### PR TITLE
Import Mirage Handlers in Tests

### DIFF
--- a/ui/tests/acceptance/chroot-namespace-test.js
+++ b/ui/tests/acceptance/chroot-namespace-test.js
@@ -8,7 +8,7 @@ import { setupApplicationTest } from 'ember-qunit';
 import { currentRouteName } from '@ember/test-helpers';
 import authPage from 'vault/tests/pages/auth';
 import { setupMirage } from 'ember-cli-mirage/test-support';
-import ENV from 'vault/config/environment';
+import chrootNamespaceHandlers from 'vault/mirage/handlers/chroot-namespace';
 import { createTokenCmd, runCmd, tokenWithPolicyCmd } from '../helpers/commands';
 
 const navLink = (title) => `[data-test-sidebar-nav-link="${title}"]`;
@@ -19,11 +19,8 @@ module('Acceptance | chroot-namespace enterprise ui', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  hooks.before(function () {
-    ENV['ember-cli-mirage'].handler = 'chrootNamespace';
-  });
-  hooks.after(function () {
-    ENV['ember-cli-mirage'].handler = null;
+  hooks.beforeEach(function () {
+    chrootNamespaceHandlers(this.server);
   });
 
   test('it should render normally when chroot namespace exists', async function (assert) {

--- a/ui/tests/acceptance/client-dashboard-test.js
+++ b/ui/tests/acceptance/client-dashboard-test.js
@@ -10,7 +10,7 @@ import { setupApplicationTest } from 'ember-qunit';
 import authPage from 'vault/tests/pages/auth';
 import { addMonths, formatRFC3339, startOfMonth, subMonths } from 'date-fns';
 import { setupMirage } from 'ember-cli-mirage/test-support';
-import ENV from 'vault/config/environment';
+import clientsHandlers from 'vault/mirage/handlers/clients';
 import { SELECTORS, overrideResponse } from '../helpers/clients';
 import { create } from 'ember-cli-page-object';
 import ss from 'vault/tests/pages/components/search-select';
@@ -33,16 +33,15 @@ module('Acceptance | client counts dashboard tab', function (hooks) {
 
   hooks.before(function () {
     sinon.stub(timestamp, 'now').callsFake(() => STATIC_NOW);
-    ENV['ember-cli-mirage'].handler = 'clients';
   });
 
   hooks.beforeEach(function () {
+    clientsHandlers(this.server);
     this.store = this.owner.lookup('service:store');
   });
 
   hooks.after(function () {
     timestamp.now.restore();
-    ENV['ember-cli-mirage'].handler = null;
   });
 
   hooks.beforeEach(function () {

--- a/ui/tests/acceptance/dashboard-test.js
+++ b/ui/tests/acceptance/dashboard-test.js
@@ -23,7 +23,7 @@ import { deleteEngineCmd } from 'vault/tests/helpers/commands';
 import authPage from 'vault/tests/pages/auth';
 import mountSecrets from 'vault/tests/pages/settings/mount-secret-backend';
 import consoleClass from 'vault/tests/pages/components/console/ui-panel';
-import ENV from 'vault/config/environment';
+import clientsHandlers from 'vault/mirage/handlers/clients';
 import { formatNumber } from 'core/helpers/format-number';
 import { pollCluster } from 'vault/tests/helpers/poll-cluster';
 import { disableReplication } from 'vault/tests/helpers/replication';
@@ -383,18 +383,11 @@ module('Acceptance | landing page dashboard', function (hooks) {
   });
 
   module('client counts card enterprise', function (hooks) {
-    hooks.before(async function () {
-      ENV['ember-cli-mirage'].handler = 'clients';
-    });
-
     hooks.beforeEach(async function () {
+      clientsHandlers(this.server);
       this.store = this.owner.lookup('service:store');
 
       await authPage.login();
-    });
-
-    hooks.after(function () {
-      ENV['ember-cli-mirage'].handler = null;
     });
 
     test('shows the client count card for enterprise', async function (assert) {

--- a/ui/tests/acceptance/mfa-login-enforcement-test.js
+++ b/ui/tests/acceptance/mfa-login-enforcement-test.js
@@ -8,20 +8,15 @@ import { setupApplicationTest } from 'ember-qunit';
 import { click, currentRouteName, fillIn, visit } from '@ember/test-helpers';
 import authPage from 'vault/tests/pages/auth';
 import { setupMirage } from 'ember-cli-mirage/test-support';
-import ENV from 'vault/config/environment';
+import mfaConfigHandlers from 'vault/mirage/handlers/mfa-config';
 
 module('Acceptance | mfa-login-enforcement', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  hooks.before(function () {
-    ENV['ember-cli-mirage'].handler = 'mfaConfig';
-  });
   hooks.beforeEach(function () {
+    mfaConfigHandlers(this.server);
     return authPage.login();
-  });
-  hooks.after(function () {
-    ENV['ember-cli-mirage'].handler = null;
   });
 
   test('it should send the correct data when creating an enforcement', async function (assert) {

--- a/ui/tests/acceptance/mfa-login-test.js
+++ b/ui/tests/acceptance/mfa-login-test.js
@@ -7,17 +7,14 @@ import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { click, currentRouteName, fillIn, visit, waitUntil, find } from '@ember/test-helpers';
 import { setupMirage } from 'ember-cli-mirage/test-support';
-import ENV from 'vault/config/environment';
-import { validationHandler } from '../../mirage/handlers/mfa-login';
+import mfaLoginHandler, { validationHandler } from '../../mirage/handlers/mfa-login';
 
 module('Acceptance | mfa-login', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  hooks.before(function () {
-    ENV['ember-cli-mirage'].handler = 'mfaLogin';
-  });
   hooks.beforeEach(function () {
+    mfaLoginHandler(this.server);
     this.auth = this.owner.lookup('service:auth');
     this.select = async (select = 0, option = 1) => {
       const selector = `[data-test-mfa-select="${select}"]`;
@@ -29,9 +26,6 @@ module('Acceptance | mfa-login', function (hooks) {
   hooks.afterEach(function () {
     // Manually clear token after each so that future tests don't get into a weird state
     this.auth.deleteCurrentToken();
-  });
-  hooks.after(function () {
-    ENV['ember-cli-mirage'].handler = null;
   });
 
   const login = async (user) => {

--- a/ui/tests/acceptance/mfa-method-test.js
+++ b/ui/tests/acceptance/mfa-method-test.js
@@ -8,7 +8,7 @@ import { setupApplicationTest } from 'ember-qunit';
 import { click, currentRouteName, currentURL, fillIn, visit } from '@ember/test-helpers';
 import authPage from 'vault/tests/pages/auth';
 import { setupMirage } from 'ember-cli-mirage/test-support';
-import ENV from 'vault/config/environment';
+import mfaConfigHandler from 'vault/mirage/handlers/mfa-config';
 import { Response } from 'miragejs';
 import { underscore } from '@ember/string';
 
@@ -16,10 +16,8 @@ module('Acceptance | mfa-method', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  hooks.before(function () {
-    ENV['ember-cli-mirage'].handler = 'mfaConfig';
-  });
   hooks.beforeEach(async function () {
+    mfaConfigHandler(this.server);
     this.store = this.owner.lookup('service:store');
     this.getMethods = () =>
       ['Totp', 'Duo', 'Okta', 'Pingid'].reduce((methods, type) => {
@@ -27,9 +25,6 @@ module('Acceptance | mfa-method', function (hooks) {
         return methods;
       }, []);
     return authPage.login();
-  });
-  hooks.after(function () {
-    ENV['ember-cli-mirage'].handler = null;
   });
 
   test('it should display landing page when no methods exist', async function (assert) {

--- a/ui/tests/acceptance/oidc-config/clients-assignments-test.js
+++ b/ui/tests/acceptance/oidc-config/clients-assignments-test.js
@@ -7,7 +7,7 @@ import { module, test } from 'qunit';
 import { visit, currentURL, click, fillIn, findAll, currentRouteName } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
-import ENV from 'vault/config/environment';
+import oidcConfigHandlers from 'vault/mirage/handlers/oidc-config';
 import authPage from 'vault/tests/pages/auth';
 import { create } from 'ember-cli-page-object';
 import { clickTrigger } from 'ember-power-select/test-support/helpers';
@@ -29,17 +29,10 @@ module('Acceptance | oidc-config clients and assignments', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  hooks.before(function () {
-    ENV['ember-cli-mirage'].handler = 'oidcConfig';
-  });
-
   hooks.beforeEach(function () {
+    oidcConfigHandlers(this.server);
     this.store = this.owner.lookup('service:store');
     return authPage.login();
-  });
-
-  hooks.after(function () {
-    ENV['ember-cli-mirage'].handler = null;
   });
 
   test('it renders only allow_all when no assignments are configured', async function (assert) {

--- a/ui/tests/acceptance/oidc-config/clients-keys-test.js
+++ b/ui/tests/acceptance/oidc-config/clients-keys-test.js
@@ -7,7 +7,7 @@ import { module, test } from 'qunit';
 import { visit, click, fillIn, findAll, currentRouteName } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
-import ENV from 'vault/config/environment';
+import oidcConfigHandlers from 'vault/mirage/handlers/oidc-config';
 import authPage from 'vault/tests/pages/auth';
 import { create } from 'ember-cli-page-object';
 import { clickTrigger, selectChoose } from 'ember-power-select/test-support/helpers';
@@ -32,17 +32,10 @@ module('Acceptance | oidc-config clients and keys', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  hooks.before(function () {
-    ENV['ember-cli-mirage'].handler = 'oidcConfig';
-  });
-
   hooks.beforeEach(function () {
+    oidcConfigHandlers(this.server);
     this.store = this.owner.lookup('service:store');
     return authPage.login();
-  });
-
-  hooks.after(function () {
-    ENV['ember-cli-mirage'].handler = null;
   });
 
   test('it creates a key, signs a client and edits key access to only that client', async function (assert) {

--- a/ui/tests/acceptance/oidc-config/providers-scopes-test.js
+++ b/ui/tests/acceptance/oidc-config/providers-scopes-test.js
@@ -7,7 +7,7 @@ import { module, test } from 'qunit';
 import { visit, currentURL, click, fillIn, findAll, currentRouteName } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
-import ENV from 'vault/config/environment';
+import oidcConfigHandlers from 'vault/mirage/handlers/oidc-config';
 import authPage from 'vault/tests/pages/auth';
 import { create } from 'ember-cli-page-object';
 import { clickTrigger, selectChoose } from 'ember-power-select/test-support/helpers';
@@ -34,19 +34,12 @@ module('Acceptance |  oidc-config providers and scopes', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  hooks.before(function () {
-    ENV['ember-cli-mirage'].handler = 'oidcConfig';
-  });
-
   hooks.beforeEach(function () {
+    oidcConfigHandlers(this.server);
     this.store = this.owner.lookup('service:store');
     // mock client list so OIDC BASE URL does not redirect to landing call-to-action image
     this.server.get('/identity/oidc/client', () => overrideMirageResponse(null, CLIENT_LIST_RESPONSE));
     return authPage.login();
-  });
-
-  hooks.after(function () {
-    ENV['ember-cli-mirage'].handler = null;
   });
 
   // LIST SCOPES EMPTY

--- a/ui/tests/acceptance/reduced-disclosure-test.js
+++ b/ui/tests/acceptance/reduced-disclosure-test.js
@@ -11,7 +11,7 @@ import authPage from 'vault/tests/pages/auth';
 import { createTokenCmd, runCmd, tokenWithPolicyCmd } from 'vault/tests/helpers/commands';
 import { pollCluster } from 'vault/tests/helpers/poll-cluster';
 import VAULT_KEYS from 'vault/tests/helpers/vault-keys';
-import ENV from 'vault/config/environment';
+import reducedDisclosureHandlers from 'vault/mirage/handlers/reduced-disclosure';
 import { overrideResponse } from 'vault/tests/helpers/clients';
 
 const { unsealKeys } = VAULT_KEYS;
@@ -24,17 +24,12 @@ module('Acceptance | reduced disclosure test', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  hooks.before(function () {
-    ENV['ember-cli-mirage'].handler = 'reducedDisclosure';
-  });
   hooks.beforeEach(function () {
+    reducedDisclosureHandlers(this.server);
     this.unsealCount = 0;
     this.sealed = false;
     this.versionSvc = this.owner.lookup('service:version');
     return authPage.logout();
-  });
-  hooks.after(function () {
-    ENV['ember-cli-mirage'].handler = null;
   });
 
   test('login works when reduced disclosure enabled', async function (assert) {

--- a/ui/tests/acceptance/secrets/backend/database/workflow-test.js
+++ b/ui/tests/acceptance/secrets/backend/database/workflow-test.js
@@ -10,7 +10,7 @@ import { click, currentURL, fillIn, visit } from '@ember/test-helpers';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { create } from 'ember-cli-page-object';
 
-import ENV from 'vault/config/environment';
+import databaseHandlers from 'vault/mirage/handlers/database';
 import { setupApplicationTest } from 'vault/tests/helpers';
 import authPage from 'vault/tests/pages/auth';
 import flashMessage from 'vault/tests/pages/components/flash-message';
@@ -60,14 +60,8 @@ module('Acceptance | database workflow', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  hooks.before(function () {
-    ENV['ember-cli-mirage'].handler = 'database';
-  });
-  hooks.after(function () {
-    ENV['ember-cli-mirage'].handler = null;
-  });
-
   hooks.beforeEach(async function () {
+    databaseHandlers(this.server);
     this.backend = `db-workflow-${uuidv4()}`;
     this.store = this.owner.lookup('service:store');
     await authPage.login();

--- a/ui/tests/acceptance/secrets/backend/kubernetes/configuration-test.js
+++ b/ui/tests/acceptance/secrets/backend/kubernetes/configuration-test.js
@@ -7,7 +7,7 @@ import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import kubernetesScenario from 'vault/mirage/scenarios/kubernetes';
-import ENV from 'vault/config/environment';
+import kubernetesHandlers from 'vault/mirage/handlers/kubernetes';
 import authPage from 'vault/tests/pages/auth';
 import { visit, click, currentRouteName } from '@ember/test-helpers';
 import { Response } from 'miragejs';
@@ -16,11 +16,8 @@ module('Acceptance | kubernetes | configuration', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  hooks.before(function () {
-    ENV['ember-cli-mirage'].handler = 'kubernetes';
-  });
-
   hooks.beforeEach(function () {
+    kubernetesHandlers(this.server);
     kubernetesScenario(this.server);
     this.visitConfiguration = () => {
       return visit('/vault/secrets/kubernetes/kubernetes/configuration');
@@ -29,10 +26,6 @@ module('Acceptance | kubernetes | configuration', function (hooks) {
       assert.strictEqual(currentRouteName(), `vault.cluster.secrets.backend.kubernetes.${route}`, message);
     };
     return authPage.login();
-  });
-
-  hooks.after(function () {
-    ENV['ember-cli-mirage'].handler = null;
   });
 
   test('it should transition to configure page on Edit Configuration click from toolbar', async function (assert) {

--- a/ui/tests/acceptance/secrets/backend/kubernetes/credentials-test.js
+++ b/ui/tests/acceptance/secrets/backend/kubernetes/credentials-test.js
@@ -7,7 +7,7 @@ import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import kubernetesScenario from 'vault/mirage/scenarios/kubernetes';
-import ENV from 'vault/config/environment';
+import kubernetesHandlers from 'vault/mirage/handlers/kubernetes';
 import authPage from 'vault/tests/pages/auth';
 import { fillIn, visit, click, currentRouteName } from '@ember/test-helpers';
 
@@ -15,10 +15,8 @@ module('Acceptance | kubernetes | credentials', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  hooks.before(function () {
-    ENV['ember-cli-mirage'].handler = 'kubernetes';
-  });
   hooks.beforeEach(function () {
+    kubernetesHandlers(this.server);
     kubernetesScenario(this.server);
     this.visitRoleCredentials = () => {
       return visit('/vault/secrets/kubernetes/kubernetes/roles/role-0/credentials');
@@ -27,9 +25,6 @@ module('Acceptance | kubernetes | credentials', function (hooks) {
       assert.strictEqual(currentRouteName(), `vault.cluster.secrets.backend.kubernetes.${route}`, message);
     };
     return authPage.login();
-  });
-  hooks.after(function () {
-    ENV['ember-cli-mirage'].handler = null;
   });
 
   test('it should have correct breadcrumb links in credentials view', async function (assert) {

--- a/ui/tests/acceptance/secrets/backend/kubernetes/overview-test.js
+++ b/ui/tests/acceptance/secrets/backend/kubernetes/overview-test.js
@@ -7,7 +7,7 @@ import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import kubernetesScenario from 'vault/mirage/scenarios/kubernetes';
-import ENV from 'vault/config/environment';
+import kubernetesHandlers from 'vault/mirage/handlers/kubernetes';
 import authPage from 'vault/tests/pages/auth';
 import { visit, click, currentRouteName } from '@ember/test-helpers';
 import { selectChoose } from 'ember-power-select/test-support';
@@ -17,10 +17,8 @@ module('Acceptance | kubernetes | overview', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  hooks.before(function () {
-    ENV['ember-cli-mirage'].handler = 'kubernetes';
-  });
   hooks.beforeEach(function () {
+    kubernetesHandlers(this.server);
     this.createScenario = (shouldConfigureRoles = true) =>
       shouldConfigureRoles ? kubernetesScenario(this.server) : kubernetesScenario(this.server, false);
 
@@ -31,9 +29,6 @@ module('Acceptance | kubernetes | overview', function (hooks) {
       assert.strictEqual(currentRouteName(), `vault.cluster.secrets.backend.kubernetes.${route}`, message);
     };
     return authPage.login();
-  });
-  hooks.after(function () {
-    ENV['ember-cli-mirage'].handler = null;
   });
 
   test('it should transition to configuration page during empty state', async function (assert) {

--- a/ui/tests/acceptance/secrets/backend/kubernetes/roles-test.js
+++ b/ui/tests/acceptance/secrets/backend/kubernetes/roles-test.js
@@ -7,7 +7,7 @@ import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import kubernetesScenario from 'vault/mirage/scenarios/kubernetes';
-import ENV from 'vault/config/environment';
+import kubernetesHandlers from 'vault/mirage/handlers/kubernetes';
 import authPage from 'vault/tests/pages/auth';
 import { fillIn, visit, currentURL, click, currentRouteName } from '@ember/test-helpers';
 import { setRunOptions } from 'ember-a11y-testing/test-support';
@@ -16,10 +16,8 @@ module('Acceptance | kubernetes | roles', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  hooks.before(function () {
-    ENV['ember-cli-mirage'].handler = 'kubernetes';
-  });
   hooks.beforeEach(function () {
+    kubernetesHandlers(this.server);
     kubernetesScenario(this.server);
     this.visitRoles = () => {
       return visit('/vault/secrets/kubernetes/kubernetes/roles');
@@ -28,9 +26,6 @@ module('Acceptance | kubernetes | roles', function (hooks) {
       assert.strictEqual(currentRouteName(), `vault.cluster.secrets.backend.kubernetes.${route}`, message);
     };
     return authPage.login();
-  });
-  hooks.after(function () {
-    ENV['ember-cli-mirage'].handler = null;
   });
 
   test('it should filter roles', async function (assert) {

--- a/ui/tests/acceptance/secrets/backend/ldap/libraries-test.js
+++ b/ui/tests/acceptance/secrets/backend/ldap/libraries-test.js
@@ -7,7 +7,7 @@ import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import ldapMirageScenario from 'vault/mirage/scenarios/ldap';
-import ENV from 'vault/config/environment';
+import ldapHandlers from 'vault/mirage/handlers/ldap';
 import authPage from 'vault/tests/pages/auth';
 import { click } from '@ember/test-helpers';
 import { isURL, visitURL } from 'vault/tests/helpers/ldap';
@@ -17,18 +17,11 @@ module('Acceptance | ldap | libraries', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  hooks.before(function () {
-    ENV['ember-cli-mirage'].handler = 'ldap';
-  });
-
   hooks.beforeEach(async function () {
+    ldapHandlers(this.server);
     ldapMirageScenario(this.server);
     await authPage.login();
     return visitURL('libraries');
-  });
-
-  hooks.after(function () {
-    ENV['ember-cli-mirage'].handler = null;
   });
 
   test('it should transition to create library route on toolbar link click', async function (assert) {

--- a/ui/tests/acceptance/secrets/backend/ldap/overview-test.js
+++ b/ui/tests/acceptance/secrets/backend/ldap/overview-test.js
@@ -7,7 +7,7 @@ import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import ldapMirageScenario from 'vault/mirage/scenarios/ldap';
-import ENV from 'vault/config/environment';
+import ldapHandlers from 'vault/mirage/handlers/ldap';
 import authPage from 'vault/tests/pages/auth';
 import { click, fillIn, visit } from '@ember/test-helpers';
 import { selectChoose } from 'ember-power-select/test-support';
@@ -17,16 +17,9 @@ module('Acceptance | ldap | overview', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  hooks.before(function () {
-    ENV['ember-cli-mirage'].handler = 'ldap';
-  });
-
   hooks.beforeEach(async function () {
+    ldapHandlers(this.server);
     return authPage.login();
-  });
-
-  hooks.after(function () {
-    ENV['ember-cli-mirage'].handler = null;
   });
 
   test('it should transition to ldap overview on mount success', async function (assert) {

--- a/ui/tests/acceptance/secrets/backend/ldap/roles-test.js
+++ b/ui/tests/acceptance/secrets/backend/ldap/roles-test.js
@@ -7,7 +7,7 @@ import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import ldapMirageScenario from 'vault/mirage/scenarios/ldap';
-import ENV from 'vault/config/environment';
+import ldapHandlers from 'vault/mirage/handlers/ldap';
 import authPage from 'vault/tests/pages/auth';
 import { click, fillIn } from '@ember/test-helpers';
 import { isURL, visitURL } from 'vault/tests/helpers/ldap';
@@ -17,18 +17,11 @@ module('Acceptance | ldap | roles', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  hooks.before(function () {
-    ENV['ember-cli-mirage'].handler = 'ldap';
-  });
-
   hooks.beforeEach(async function () {
+    ldapHandlers(this.server);
     ldapMirageScenario(this.server);
     await authPage.login();
     return visitURL('roles');
-  });
-
-  hooks.after(function () {
-    ENV['ember-cli-mirage'].handler = null;
   });
 
   test('it should transition to create role route on toolbar link click', async function (assert) {

--- a/ui/tests/integration/components/oidc/assignment-form-test.js
+++ b/ui/tests/integration/components/oidc/assignment-form-test.js
@@ -8,7 +8,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render, fillIn, click, findAll } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
-import ENV from 'vault/config/environment';
+import oidcConfigHandlers from 'vault/mirage/handlers/oidc-config';
 import { overrideMirageResponse } from 'vault/tests/helpers/oidc-config';
 import { setRunOptions } from 'ember-a11y-testing/test-support';
 
@@ -16,15 +16,8 @@ module('Integration | Component | oidc/assignment-form', function (hooks) {
   setupRenderingTest(hooks);
   setupMirage(hooks);
 
-  hooks.before(function () {
-    ENV['ember-cli-mirage'].handler = 'oidcConfig';
-  });
-
-  hooks.after(function () {
-    ENV['ember-cli-mirage'].handler = null;
-  });
-
   hooks.beforeEach(function () {
+    oidcConfigHandlers(this.server);
     this.store = this.owner.lookup('service:store');
     this.server.post('/sys/capabilities-self', () => {});
     setRunOptions({

--- a/ui/tests/integration/components/oidc/client-form-test.js
+++ b/ui/tests/integration/components/oidc/client-form-test.js
@@ -11,7 +11,7 @@ import { create } from 'ember-cli-page-object';
 import { clickTrigger } from 'ember-power-select/test-support/helpers';
 import ss from 'vault/tests/pages/components/search-select';
 import { setupMirage } from 'ember-cli-mirage/test-support';
-import ENV from 'vault/config/environment';
+import oidcConfigHandlers from 'vault/mirage/handlers/oidc-config';
 import {
   OIDC_BASE_URL,
   SELECTORS,
@@ -26,15 +26,8 @@ module('Integration | Component | oidc/client-form', function (hooks) {
   setupRenderingTest(hooks);
   setupMirage(hooks);
 
-  hooks.before(function () {
-    ENV['ember-cli-mirage'].handler = 'oidcConfig';
-  });
-
-  hooks.after(function () {
-    ENV['ember-cli-mirage'].handler = null;
-  });
-
   hooks.beforeEach(function () {
+    oidcConfigHandlers(this.server);
     this.store = this.owner.lookup('service:store');
     this.server.post('/sys/capabilities-self', () => {});
     this.server.get('/identity/oidc/key', () => {

--- a/ui/tests/integration/components/oidc/key-form-test.js
+++ b/ui/tests/integration/components/oidc/key-form-test.js
@@ -8,7 +8,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render, fillIn, click, findAll } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
-import ENV from 'vault/config/environment';
+import oidcConfigHandlers from 'vault/mirage/handlers/oidc-config';
 import {
   OIDC_BASE_URL,
   CLIENT_LIST_RESPONSE,
@@ -22,15 +22,8 @@ module('Integration | Component | oidc/key-form', function (hooks) {
   setupRenderingTest(hooks);
   setupMirage(hooks);
 
-  hooks.before(function () {
-    ENV['ember-cli-mirage'].handler = 'oidcConfig';
-  });
-
-  hooks.after(function () {
-    ENV['ember-cli-mirage'].handler = null;
-  });
-
   hooks.beforeEach(function () {
+    oidcConfigHandlers(this.server);
     this.store = this.owner.lookup('service:store');
     this.server.get('/identity/oidc/client', () => overrideMirageResponse(null, CLIENT_LIST_RESPONSE));
     setRunOptions({

--- a/ui/tests/integration/components/oidc/provider-form-test.js
+++ b/ui/tests/integration/components/oidc/provider-form-test.js
@@ -8,7 +8,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render, fillIn, click, findAll } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
-import ENV from 'vault/config/environment';
+import oidcConfigHandlers from 'vault/mirage/handlers/oidc-config';
 import {
   SELECTORS,
   OIDC_BASE_URL,
@@ -25,15 +25,8 @@ module('Integration | Component | oidc/provider-form', function (hooks) {
   setupRenderingTest(hooks);
   setupMirage(hooks);
 
-  hooks.before(function () {
-    ENV['ember-cli-mirage'].handler = 'oidcConfig';
-  });
-
-  hooks.after(function () {
-    ENV['ember-cli-mirage'].handler = null;
-  });
-
   hooks.beforeEach(function () {
+    oidcConfigHandlers(this.server);
     this.store = this.owner.lookup('service:store');
     this.server.get('/identity/oidc/scope', () => {
       return {


### PR DESCRIPTION
After moving to `ember-exam` and running tests in parallel there have been some cases where a test that required mirage would fail and looking at the logs it was using a different set of request handlers than what it should. The old pattern to use mirage handlers in tests was to globally define it in the environment which is no longer viable since tests are running at the same time and that would override the handlers used in other tests.

This PR removes all instances of globally setting the mirage handler in tests and updates to import the required handle directly into the test for use. 