### PR TITLE
Request Limiter Reload tests

### DIFF
--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -162,7 +162,7 @@ jobs:
           # tack on various extra test packages to the `go list`
           TESTONLY_PACKAGES=$(go list -tags=testonly "${TESTONLY_DIRS[@]}" \
                                 ./vault/external_tests/{kv,token,*replication-perf*} \
-                                ./vault/)
+                                ./vault/ | xargs)
 
           # disable glob expansion
           shopt -u nullglob

--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -145,7 +145,8 @@ jobs:
               --partitions "${{ inputs.total-runners }}" \
               --timing-files 'test-results/go-test/*.json' > matrix.json
           )
-      - name: Build matrix for tests tagged with testonly
+      - name: Build up list of testonly packages
+        id: list-testonly
         if: ${{ inputs.testonly }}
         env:
           GOPRIVATE: github.com/hashicorp/*
@@ -153,15 +154,30 @@ jobs:
           set -exo pipefail
           # enable glob expansion
           shopt -s nullglob
+
+          # `go list` lumps together quoted arguments, so we need an array to please the shellchecker
+          TESTONLY_DIRS=( $(find . -type d -name "*_testonly*") )
+
+          # tack on various extra to the `go list`
+          TESTONLY_PACKAGES=$(go list -tags=testonly "${TESTONLY_DIRS[@]}" \
+                                ./vault/external_tests/{kv,token,*replication-perf*} \
+                                ./vault/)
+
+          # disable glob expansion
+          shopt -u nullglob
+          echo "packages=$TESTONLY_PACKAGES" >> "$GITHUB_OUTPUT"
+      - name: Build matrix for tests tagged with testonly
+        if: ${{ inputs.testonly }}
+        env:
+          GOPRIVATE: github.com/hashicorp/*
+        run: |
           # testonly tagged tests need an additional tag to be included
           # also running some extra tests for sanity checking with the testonly build tag
           (
-            go list -tags=testonly ./vault/external_tests/{kv,token,*replication-perf*,*testonly*} ./vault/ | gotestsum tool ci-matrix --debug \
+            echo "${{ steps.list-testonly.output.packages }}"| gotestsum tool ci-matrix --debug \
               --partitions "${{ inputs.total-runners }}" \
               --timing-files 'test-results/go-test/*.json' > matrix.json
           )
-          # disable glob expansion
-          shopt -u nullglob
       - name: Capture list of binary tests
         if: inputs.binary-tests
         id: list-binary-tests

--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -145,8 +145,7 @@ jobs:
               --partitions "${{ inputs.total-runners }}" \
               --timing-files 'test-results/go-test/*.json' > matrix.json
           )
-      - name: Build up list of testonly packages
-        id: list-testonly
+      - name: Build matrix for tests tagged with testonly
         if: ${{ inputs.testonly }}
         env:
           GOPRIVATE: github.com/hashicorp/*
@@ -154,33 +153,15 @@ jobs:
           set -exo pipefail
           # enable glob expansion
           shopt -s nullglob
-
-          # `go list` lumps together quoted arguments, so we need an array to please the shellchecker
-          TESTONLY_DIRS=()
-          while IFS='' read -r line; do
-            TESTONLY_DIRS+=("$line");
-          done < <(find . -type d -name "*_testonly*")
-
-          # tack on various extra test packages to the `go list`
-          TESTONLY_PACKAGES=$(go list -tags=testonly "${TESTONLY_DIRS[@]}" \
-                                ./vault/external_tests/{kv,token,*replication-perf*} \
-                                ./vault/ | xargs)
-
-          # disable glob expansion
-          shopt -u nullglob
-          echo "packages=$TESTONLY_PACKAGES" >> "$GITHUB_OUTPUT"
-      - name: Build matrix for tests tagged with testonly
-        if: ${{ inputs.testonly }}
-        env:
-          GOPRIVATE: github.com/hashicorp/*
-        run: |
           # testonly tagged tests need an additional tag to be included
           # also running some extra tests for sanity checking with the testonly build tag
           (
-            echo "${{ steps.list-testonly.outputs.packages }}"| gotestsum tool ci-matrix --debug \
+            go list -tags=testonly ./vault/external_tests/{kv,token,*replication-perf*,*testonly*} ./command/*testonly* ./vault/ | gotestsum tool ci-matrix --debug \
               --partitions "${{ inputs.total-runners }}" \
               --timing-files 'test-results/go-test/*.json' > matrix.json
           )
+          # disable glob expansion
+          shopt -u nullglob
       - name: Capture list of binary tests
         if: inputs.binary-tests
         id: list-binary-tests

--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -157,7 +157,9 @@ jobs:
 
           # `go list` lumps together quoted arguments, so we need an array to please the shellchecker
           TESTONLY_DIRS=()
-          IFS=" " read -r -a TESTONLY_DIRS <<< "$(find . -type d -name "*_testonly")"
+          while IFS='' read -r line; do
+            TESTONLY_DIRS+=("$line");
+          done < <(find . -type d -name "*_testonly*")
 
           # tack on various extra test packages to the `go list`
           TESTONLY_PACKAGES=$(go list -tags=testonly "${TESTONLY_DIRS[@]}" \

--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -156,7 +156,8 @@ jobs:
           shopt -s nullglob
 
           # `go list` lumps together quoted arguments, so we need an array to please the shellchecker
-          TESTONLY_DIRS=( $(find . -type d -name "*_testonly*") )
+          TESTONLY_DIRS=()
+          IFS=" " read -r -a TESTONLY_DIRS <<< "$(find . -type d -name "*_testonly")"
 
           # tack on various extra test packages to the `go list`
           TESTONLY_PACKAGES=$(go list -tags=testonly "${TESTONLY_DIRS[@]}" \

--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -158,7 +158,7 @@ jobs:
           # `go list` lumps together quoted arguments, so we need an array to please the shellchecker
           TESTONLY_DIRS=( $(find . -type d -name "*_testonly*") )
 
-          # tack on various extra to the `go list`
+          # tack on various extra test packages to the `go list`
           TESTONLY_PACKAGES=$(go list -tags=testonly "${TESTONLY_DIRS[@]}" \
                                 ./vault/external_tests/{kv,token,*replication-perf*} \
                                 ./vault/)

--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -174,7 +174,7 @@ jobs:
           # testonly tagged tests need an additional tag to be included
           # also running some extra tests for sanity checking with the testonly build tag
           (
-            echo "${{ steps.list-testonly.output.packages }}"| gotestsum tool ci-matrix --debug \
+            echo "${{ steps.list-testonly.outputs.packages }}"| gotestsum tool ci-matrix --debug \
               --partitions "${{ inputs.total-runners }}" \
               --timing-files 'test-results/go-test/*.json' > matrix.json
           )

--- a/command/command_testonly/server_testonly_test.go
+++ b/command/command_testonly/server_testonly_test.go
@@ -201,7 +201,6 @@ func TestServer_ReloadRequestLimiter(t *testing.T) {
 				t.Fatalf("test timed out")
 			}
 
-			// Verify that the test-case is
 			verifyLimiters(t, tc.expectedResponse)
 		})
 	}

--- a/command/command_testonly/server_testonly_test.go
+++ b/command/command_testonly/server_testonly_test.go
@@ -1,0 +1,216 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+//go:build testonly
+
+// NOTE: we can't use this with HSM. We can't set testing mode on and it's not
+// safe to use env vars since that provides an attack vector in the real world.
+//
+// The server tests have a go-metrics/exp manager race condition :(.
+
+package command_testonly
+
+import (
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/vault/api"
+	"github.com/hashicorp/vault/command"
+	"github.com/hashicorp/vault/limits"
+	"github.com/hashicorp/vault/vault"
+	"github.com/mitchellh/mapstructure"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	baseHCL = `
+		backend "inmem" { }
+		disable_mlock = true
+		listener "tcp" {
+			address     = "127.0.0.1:8209"
+			tls_disable = "true"
+		}
+		api_addr = "http://127.0.0.1:8209"
+	`
+	requestLimiterDisableHCL = `
+  request_limiter {
+	disable = true
+  }
+`
+	requestLimiterEnableHCL = `
+  request_limiter {
+	disable = false
+  }
+`
+)
+
+// TestServer_ReloadRequestLimiter tests a series of reloads and state
+// transitions between RequestLimiter enable and disable.
+func TestServer_ReloadRequestLimiter(t *testing.T) {
+	t.Parallel()
+
+	enabledResponse := &vault.RequestLimiterResponse{
+		GlobalDisabled:   false,
+		ListenerDisabled: false,
+		Limiters: map[string]*vault.LimiterStatus{
+			limits.WriteLimiter: {
+				Enabled: true,
+				Flags:   limits.DefaultLimiterFlags[limits.WriteLimiter],
+			},
+			limits.SpecialPathLimiter: {
+				Enabled: true,
+				Flags:   limits.DefaultLimiterFlags[limits.SpecialPathLimiter],
+			},
+		},
+	}
+
+	disabledResponse := &vault.RequestLimiterResponse{
+		GlobalDisabled:   true,
+		ListenerDisabled: false,
+		Limiters: map[string]*vault.LimiterStatus{
+			limits.WriteLimiter: {
+				Enabled: false,
+			},
+			limits.SpecialPathLimiter: {
+				Enabled: false,
+			},
+		},
+	}
+
+	cases := []struct {
+		name        string
+		configAfter string
+		disabled    bool
+	}{
+		{
+			"enable after default",
+			baseHCL + requestLimiterEnableHCL,
+			false,
+		},
+		{
+			"enable after enable",
+			baseHCL + requestLimiterEnableHCL,
+			false,
+		},
+		{
+			"disable after enable",
+			baseHCL + requestLimiterDisableHCL,
+			true,
+		},
+		{
+			"default after disable",
+			baseHCL,
+			false,
+		},
+		{
+			"default after default",
+			baseHCL,
+			false,
+		},
+		{
+			"disable after default",
+			baseHCL + requestLimiterDisableHCL,
+			true,
+		},
+		{
+			"disable after disable",
+			baseHCL + requestLimiterDisableHCL,
+			true,
+		},
+	}
+
+	ui, srv := command.TestServerCommand(t)
+
+	f, err := os.CreateTemp(t.TempDir(), "")
+	require.NoErrorf(t, err, "error creating temp dir: %v", err)
+
+	_, err = f.WriteString(baseHCL)
+	require.NoErrorf(t, err, "cannot write temp file contents")
+
+	configPath := f.Name()
+
+	var output string
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		code := srv.Run([]string{"-config", configPath})
+		output = ui.ErrorWriter.String() + ui.OutputWriter.String()
+		require.Equal(t, 0, code, output)
+	}()
+
+	select {
+	case <-srv.StartedCh():
+	case <-time.After(5 * time.Second):
+		t.Fatalf("timeout")
+	}
+	defer func() {
+		srv.ShutdownCh <- struct{}{}
+		wg.Wait()
+	}()
+
+	err = f.Close()
+	require.NoErrorf(t, err, "unable to close temp file")
+
+	// create a client and unseal vault
+	cli, err := srv.Client()
+	require.NoError(t, err)
+	require.NoError(t, cli.SetAddress("http://127.0.0.1:8209"))
+	initResp, err := cli.Sys().Init(&api.InitRequest{SecretShares: 1, SecretThreshold: 1})
+	require.NoError(t, err)
+	_, err = cli.Sys().Unseal(initResp.Keys[0])
+	require.NoError(t, err)
+	cli.SetToken(initResp.RootToken)
+
+	output = ui.ErrorWriter.String() + ui.OutputWriter.String()
+	require.Contains(t, output, "Request Limiter: enabled")
+
+	verifyLimiters := func(t *testing.T, expectedDisabled bool) {
+		t.Helper()
+		statusResp, err := cli.Logical().Read("/sys/internal/request-limiter/status")
+		require.NoError(t, err)
+		require.NotNil(t, statusResp)
+
+		limitersResp, ok := statusResp.Data["request_limiter"]
+		require.True(t, ok)
+		require.NotNil(t, limitersResp)
+
+		var limiters *vault.RequestLimiterResponse
+		err = mapstructure.Decode(limitersResp, &limiters)
+		require.NoError(t, err)
+		require.NotNil(t, limiters)
+
+		switch expectedDisabled {
+		case true:
+			require.Equal(t, disabledResponse, limiters)
+		default:
+			require.Equal(t, enabledResponse, limiters)
+		}
+	}
+
+	verifyLimiters(t, false)
+
+	for _, tc := range cases {
+		tc := tc
+		// Check that we default on
+		t.Run(tc.name, func(t *testing.T) {
+			// write the new contents and reload the server
+			f, err = os.OpenFile(configPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o644)
+			require.NoError(t, err)
+			defer f.Close()
+
+			_, err = f.WriteString(tc.configAfter)
+			require.NoErrorf(t, err, "cannot write temp file contents")
+
+			srv.SighupCh <- struct{}{}
+			select {
+			case <-srv.ReloadedCh():
+			case <-time.After(5 * time.Second):
+				t.Fatalf("test timed out")
+			}
+			verifyLimiters(t, tc.disabled)
+		})
+	}
+}

--- a/command/command_testonly/server_testonly_test.go
+++ b/command/command_testonly/server_testonly_test.go
@@ -3,11 +3,6 @@
 
 //go:build testonly
 
-// NOTE: we can't use this with HSM. We can't set testing mode on and it's not
-// safe to use env vars since that provides an attack vector in the real world.
-//
-// The server tests have a go-metrics/exp manager race condition :(.
-
 package command_testonly
 
 import (

--- a/command/server_test.go
+++ b/command/server_test.go
@@ -22,11 +22,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/cli"
 	"github.com/hashicorp/vault/command/server"
 	"github.com/hashicorp/vault/helper/testhelpers/corehelpers"
 	"github.com/hashicorp/vault/internalshared/configutil"
-	"github.com/hashicorp/vault/sdk/physical"
 	physInmem "github.com/hashicorp/vault/sdk/physical/inmem"
 	"github.com/hashicorp/vault/vault"
 	"github.com/hashicorp/vault/vault/seal"
@@ -96,29 +94,6 @@ cloud {
 }
 `
 )
-
-func testServerCommand(tb testing.TB) (*cli.MockUi, *ServerCommand) {
-	tb.Helper()
-
-	ui := cli.NewMockUi()
-	return ui, &ServerCommand{
-		BaseCommand: &BaseCommand{
-			UI: ui,
-		},
-		ShutdownCh: MakeShutdownCh(),
-		SighupCh:   MakeSighupCh(),
-		SigUSR2Ch:  MakeSigUSR2Ch(),
-		PhysicalBackends: map[string]physical.Factory{
-			"inmem":    physInmem.NewInmem,
-			"inmem_ha": physInmem.NewInmemHA,
-		},
-
-		// These prevent us from random sleep guessing...
-		startedCh:         make(chan struct{}, 5),
-		reloadedCh:        make(chan struct{}, 5),
-		licenseReloadedCh: make(chan error),
-	}
-}
 
 func TestServer_ReloadListener(t *testing.T) {
 	t.Parallel()

--- a/command/server_util.go
+++ b/command/server_util.go
@@ -1,0 +1,48 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package command
+
+import (
+	"testing"
+
+	"github.com/hashicorp/cli"
+	"github.com/hashicorp/vault/sdk/physical"
+	physInmem "github.com/hashicorp/vault/sdk/physical/inmem"
+)
+
+func TestServerCommand(tb testing.TB) (*cli.MockUi, *ServerCommand) {
+	tb.Helper()
+	return testServerCommand(tb)
+}
+
+func (c *ServerCommand) StartedCh() chan struct{} {
+	return c.startedCh
+}
+
+func (c *ServerCommand) ReloadedCh() chan struct{} {
+	return c.reloadedCh
+}
+
+func testServerCommand(tb testing.TB) (*cli.MockUi, *ServerCommand) {
+	tb.Helper()
+
+	ui := cli.NewMockUi()
+	return ui, &ServerCommand{
+		BaseCommand: &BaseCommand{
+			UI: ui,
+		},
+		ShutdownCh: MakeShutdownCh(),
+		SighupCh:   MakeSighupCh(),
+		SigUSR2Ch:  MakeSigUSR2Ch(),
+		PhysicalBackends: map[string]physical.Factory{
+			"inmem":    physInmem.NewInmem,
+			"inmem_ha": physInmem.NewInmemHA,
+		},
+
+		// These prevent us from random sleep guessing...
+		startedCh:         make(chan struct{}, 5),
+		reloadedCh:        make(chan struct{}, 5),
+		licenseReloadedCh: make(chan error),
+	}
+}

--- a/http/handler.go
+++ b/http/handler.go
@@ -919,6 +919,7 @@ func acquireLimiterListener(core *vault.Core, rawReq *http.Request, r *logical.R
 	if disableRequestLimiter != nil {
 		disable = disableRequestLimiter.(bool)
 	}
+	r.RequestLimiterDisabled = disable
 	if disable {
 		return &limits.RequestListener{}, true
 	}

--- a/limits/limiter.go
+++ b/limits/limiter.go
@@ -105,7 +105,7 @@ func concurrencyChanger(limit int) int {
 }
 
 var DefaultLimiterFlags = map[string]LimiterFlags{
-	// WriteLimiter defaults flags have a less conservative MinLimit to prevent
+	// WriteLimiter default flags have a less conservative MinLimit to prevent
 	// over-optimizing the request latency, which would result in
 	// under-utilization and client starvation.
 	WriteLimiter: {

--- a/sdk/logical/request.go
+++ b/sdk/logical/request.go
@@ -255,6 +255,9 @@ type Request struct {
 
 	// Name of the chroot namespace for the listener that the request was made against
 	ChrootNamespace string `json:"chroot_namespace,omitempty"`
+
+	// RequestLimiterDisabled tells whether the request context has Request Limiter applied.
+	RequestLimiterDisabled bool `json:"request_limiter_disabled,omitempty"`
 }
 
 // Clone returns a deep copy (almost) of the request.

--- a/vault/core.go
+++ b/vault/core.go
@@ -725,6 +725,8 @@ func (c *Core) EchoDuration() time.Duration {
 }
 
 func (c *Core) GetRequestLimiter(key string) *limits.RequestLimiter {
+	c.limiterRegistryLock.Lock()
+	defer c.limiterRegistryLock.Unlock()
 	return c.limiterRegistry.GetLimiter(key)
 }
 

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -226,6 +226,10 @@ func NewSystemBackend(core *Core, logger log.Logger, config *logical.BackendConf
 	b.Backend.Paths = append(b.Backend.Paths, b.experimentPaths()...)
 	b.Backend.Paths = append(b.Backend.Paths, b.introspectionPaths()...)
 
+	if requestLimiterRead := b.requestLimiterReadPath(); requestLimiterRead != nil {
+		b.Backend.Paths = append(b.Backend.Paths, b.requestLimiterReadPath())
+	}
+
 	if core.rawEnabled {
 		b.Backend.Paths = append(b.Backend.Paths, b.rawPaths()...)
 	}

--- a/vault/logical_system_limits.go
+++ b/vault/logical_system_limits.go
@@ -1,0 +1,12 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+//go:build !testonly
+
+package vault
+
+import (
+	"github.com/hashicorp/vault/sdk/framework"
+)
+
+func (b *SystemBackend) requestLimiterReadPath() *framework.Path { return nil }

--- a/vault/logical_system_limits_testonly.go
+++ b/vault/logical_system_limits_testonly.go
@@ -14,20 +14,28 @@ import (
 	"github.com/hashicorp/vault/sdk/logical"
 )
 
+// RequestLimiterResponse is a struct for marshalling Request Limiter status responses.
 type RequestLimiterResponse struct {
 	GlobalDisabled   bool                      `json:"global_disabled" mapstructure:"global_disabled"`
 	ListenerDisabled bool                      `json:"listener_disabled" mapstructure:"listener_disabled"`
 	Limiters         map[string]*LimiterStatus `json:"types" mapstructure:"types"`
 }
 
+// LimiterStatus holds the per-limiter status and flags for testing.
 type LimiterStatus struct {
 	Enabled bool                `json:"enabled" mapstructure:"enabled"`
 	Flags   limits.LimiterFlags `json:"flags,omitempty" mapstructure:"flags,omitempty"`
 }
 
+const readRequestLimiterHelpText = `
+Read the current status of the request limiter.
+`
+
 func (b *SystemBackend) requestLimiterReadPath() *framework.Path {
 	return &framework.Path{
-		Pattern: "internal/request-limiter/status$",
+		Pattern:         "internal/request-limiter/status$",
+		HelpDescription: readRequestLimiterHelpText,
+		HelpSynopsis:    readRequestLimiterHelpText,
 		Operations: map[logical.Operation]framework.OperationHandler{
 			logical.ReadOperation: &framework.PathOperation{
 				Callback: b.handleReadRequestLimiter,

--- a/vault/logical_system_limits_testonly.go
+++ b/vault/logical_system_limits_testonly.go
@@ -1,0 +1,80 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+//go:build testonly
+
+package vault
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/vault/limits"
+	"github.com/hashicorp/vault/sdk/framework"
+	"github.com/hashicorp/vault/sdk/logical"
+)
+
+type RequestLimiterResponse struct {
+	GlobalDisabled   bool                      `json:"global_disabled" mapstructure:"global_disabled"`
+	ListenerDisabled bool                      `json:"listener_disabled" mapstructure:"listener_disabled"`
+	Limiters         map[string]*LimiterStatus `json:"types" mapstructure:"types"`
+}
+
+type LimiterStatus struct {
+	Enabled bool                `json:"enabled" mapstructure:"enabled"`
+	Flags   limits.LimiterFlags `json:"flags,omitempty" mapstructure:"flags,omitempty"`
+}
+
+func (b *SystemBackend) requestLimiterReadPath() *framework.Path {
+	return &framework.Path{
+		Pattern: "internal/request-limiter/status$",
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.ReadOperation: &framework.PathOperation{
+				Callback: b.handleReadRequestLimiter,
+				DisplayAttrs: &framework.DisplayAttributes{
+					OperationVerb:   "read",
+					OperationSuffix: "verbosity-level-for",
+				},
+				Responses: map[int][]framework.Response{
+					http.StatusOK: {{
+						Description: "OK",
+					}},
+				},
+				Summary: "Read the current status of the request limiter.",
+			},
+		},
+	}
+}
+
+// handleReadRequestLimiter returns the enabled Request Limiter status for this node.
+func (b *SystemBackend) handleReadRequestLimiter(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	resp := &RequestLimiterResponse{
+		Limiters: make(map[string]*LimiterStatus),
+	}
+
+	b.Core.limiterRegistryLock.Lock()
+	registry := b.Core.limiterRegistry
+	b.Core.limiterRegistryLock.Unlock()
+
+	resp.GlobalDisabled = !registry.Enabled
+	resp.ListenerDisabled = req.RequestLimiterDisabled
+	enabled := !(resp.GlobalDisabled || resp.ListenerDisabled)
+
+	for name := range limits.DefaultLimiterFlags {
+		var flags limits.LimiterFlags
+		if requestLimiter := b.Core.GetRequestLimiter(name); requestLimiter != nil && enabled {
+			flags = requestLimiter.Flags
+		}
+
+		resp.Limiters[name] = &LimiterStatus{
+			Enabled: enabled,
+			Flags:   flags,
+		}
+	}
+
+	return &logical.Response{
+		Data: map[string]interface{}{
+			"request_limiter": resp,
+		},
+	}, nil
+}


### PR DESCRIPTION
This PR introduces a new `testonly` endpoint for introspecting the RequestLimiter state. It makes use of the endpoint to verify that changes to the `request_limiter` config are honored across reload.

In the future, we may choose to make the `sys/internal/request-limiter/status` endpoint available in normal binaries, but this is an expedient way to expose the status for testing without having to rush the design.

In order to re-use as much of the existing `command` package utility funcionality as possible without introducing sprawling code changes, I introduced a new `server_util.go` and exported some fields via accessors.

The tests shook out a couple of bugs (including a deadlock 😅 and lack of locking around the core `limiterRegistry` state).

This resolves VAULT-23584.