### PR TITLE
Fix data race with readable paths in our tests

### DIFF
--- a/command/agentproxyshared/cache/static_secret_capability_manager_test.go
+++ b/command/agentproxyshared/cache/static_secret_capability_manager_test.go
@@ -299,9 +299,12 @@ func TestSubmitWorkUpdatesIndex(t *testing.T) {
 
 	newIndex, err := sscm.leaseCache.db.GetCapabilitiesIndex(cachememdb.IndexNameID, indexId)
 	require.Nil(t, err)
+	newIndex.IndexLock.RLock()
+	readablePaths := newIndex.ReadablePaths
+	newIndex.IndexLock.RUnlock()
 	require.Equal(t, map[string]struct{}{
 		"auth/token/lookup-self": {},
-	}, newIndex.ReadablePaths)
+	}, readablePaths)
 
 	// Forcefully stop any remaining workers
 	sscm.workerPool.Stop()
@@ -413,9 +416,12 @@ func TestSubmitWorkUpdatesAllIndexes(t *testing.T) {
 
 	newIndex, err := sscm.leaseCache.db.GetCapabilitiesIndex(cachememdb.IndexNameID, indexId)
 	require.Nil(t, err)
+	newIndex.IndexLock.RLock()
+	readablePaths := newIndex.ReadablePaths
+	newIndex.IndexLock.RUnlock()
 	require.Equal(t, map[string]struct{}{
 		"auth/token/lookup-self": {},
-	}, newIndex.ReadablePaths)
+	}, readablePaths)
 
 	// For this, we expect the token to have been deleted
 	newPathIndex1, err := sscm.leaseCache.db.Get(cachememdb.IndexNameID, pathIndexId1)

--- a/command/agentproxyshared/cache/static_secret_capability_manager_test.go
+++ b/command/agentproxyshared/cache/static_secret_capability_manager_test.go
@@ -300,11 +300,10 @@ func TestSubmitWorkUpdatesIndex(t *testing.T) {
 	newIndex, err := sscm.leaseCache.db.GetCapabilitiesIndex(cachememdb.IndexNameID, indexId)
 	require.Nil(t, err)
 	newIndex.IndexLock.RLock()
-	readablePaths := newIndex.ReadablePaths
-	newIndex.IndexLock.RUnlock()
 	require.Equal(t, map[string]struct{}{
 		"auth/token/lookup-self": {},
-	}, readablePaths)
+	}, newIndex.ReadablePaths)
+	newIndex.IndexLock.RUnlock()
 
 	// Forcefully stop any remaining workers
 	sscm.workerPool.Stop()
@@ -417,11 +416,10 @@ func TestSubmitWorkUpdatesAllIndexes(t *testing.T) {
 	newIndex, err := sscm.leaseCache.db.GetCapabilitiesIndex(cachememdb.IndexNameID, indexId)
 	require.Nil(t, err)
 	newIndex.IndexLock.RLock()
-	readablePaths := newIndex.ReadablePaths
-	newIndex.IndexLock.RUnlock()
 	require.Equal(t, map[string]struct{}{
 		"auth/token/lookup-self": {},
-	}, readablePaths)
+	}, newIndex.ReadablePaths)
+	newIndex.IndexLock.RUnlock()
 
 	// For this, we expect the token to have been deleted
 	newPathIndex1, err := sscm.leaseCache.db.Get(cachememdb.IndexNameID, pathIndexId1)


### PR DESCRIPTION
This seems to be contained to tests. Everywhere else in the code, access to this method is blocked by a lock, we simply didn't consult the lock in the tests. That's now fixed.