### PR TITLE
Docs: Tranform secrets encode parameter: `expiration` added.

### DIFF
--- a/website/content/api-docs/secret/transform.mdx
+++ b/website/content/api-docs/secret/transform.mdx
@@ -1159,6 +1159,10 @@ This endpoint encodes the provided value using a named role.
 - `value` `(string: <required>)` –
   Specifies the value to be encoded.
 
+- `expiration` `(string: "")` - The precise expiration of the encoded value. If 
+  omitted, or no expiration is set then it shall never expire. The provided 
+  string must be a RFC3339 formatted time and date.
+
 - `transformation` `(string)` –
   Specifies the transformation within the role that should be used for this
   encode operation. If a single transformation exists for role, this parameter

--- a/website/content/api-docs/secret/transform.mdx
+++ b/website/content/api-docs/secret/transform.mdx
@@ -1168,7 +1168,7 @@ This endpoint encodes the provided value using a named role.
 - `expiration` `(string: "")` -
   Only applicable for tokenization transforms.
   Either [`ttl`](/vault/api-docs/secret/transform#ttl) or `expiration` may 
-  be configured but not both at the same time. Capped to the roles [`max_ttl`](/vault/api-docs/secret/transform#max_ttl) 
+  be configured but not both at the same time. Capped to the role's [`max_ttl`](/vault/api-docs/secret/transform#max_ttl) 
   value if that's set. When omitted the tokenization transforms shall never 
   expire. The provided string must be a RFC3339 formatted time and date.
 

--- a/website/content/api-docs/secret/transform.mdx
+++ b/website/content/api-docs/secret/transform.mdx
@@ -1165,9 +1165,10 @@ This endpoint encodes the provided value using a named role.
   may be skipped and will be inferred. If multiple transformations exist, one
   must be specified.
 
-- `expiration` `(string: "")` - Only applicable for tokenization transforms.
+- `expiration` `(string: "")` -
+  Only applicable for tokenization transforms.
   Either [`ttl`](/vault/api-docs/secret/transform#ttl) or `expiration` may 
-  configured but not both at the same time. Capped to the roles [`max_ttl`](/vault/api-docs/secret/transform#max_ttl) 
+  be configured but not both at the same time. Capped to the roles [`max_ttl`](/vault/api-docs/secret/transform#max_ttl) 
   value if that's set. When omitted the tokenization transforms shall never 
   expire. The provided string must be a RFC3339 formatted time and date.
 

--- a/website/content/api-docs/secret/transform.mdx
+++ b/website/content/api-docs/secret/transform.mdx
@@ -1159,17 +1159,19 @@ This endpoint encodes the provided value using a named role.
 - `value` `(string: <required>)` –
   Specifies the value to be encoded.
 
-- `expiration` `(string: "")` - The precise expiration of the encoded value. If 
-  omitted, or no expiration is set then it shall never expire. The provided 
-  string must be a RFC3339 formatted time and date.
-
 - `transformation` `(string)` –
   Specifies the transformation within the role that should be used for this
   encode operation. If a single transformation exists for role, this parameter
   may be skipped and will be inferred. If multiple transformations exist, one
   must be specified.
 
-- `ttl` `(duration "0") -
+- `expiration` `(string: "")` - Only applicable for tokenization transforms.
+  Either [`ttl`](/vault/api-docs/secret/transform#ttl) or `expiration` may 
+  configured but not both at the same time. Capped to the roles [`max_ttl`](/vault/api-docs/secret/transform#max_ttl) 
+  value if that's set. When omitted the tokenization transforms shall never 
+  expire. The provided string must be a RFC3339 formatted time and date.
+
+- `ttl` `(duration "0")` -
   Specifies the TTL of the resulting token. Only applicable for tokenization
   transformations.
 


### PR DESCRIPTION
Added missing parameter `expiration` that should be [part of API `/transform/encode`](https://developer.hashicorp.com/vault/api-docs/secret/transform#encode)

<img width="985" alt="Screenshot 2024-02-02 at 11 27 14" src="https://github.com/hashicorp/vault/assets/974854/e983009c-8645-4a4b-907b-81f4b64a2b17">

INITIAL: <img width="200" alt="Screenshot 2024-02-01 at 16 48 01" src="https://github.com/hashicorp/vault/assets/974854/e519d944-8dac-42dc-942b-3b3900445585">
