### PR TITLE
Seal HA Improvements, CE side

### DIFF
--- a/changelog/25171.txt
+++ b/changelog/25171.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+core (enterprise): Improve seal unwrap performance when in degraded mode with one or more unhealthy seals.
+```

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -5420,6 +5420,7 @@ type SealBackendStatusResponse struct {
 	Healthy        bool                `json:"healthy"`
 	UnhealthySince string              `json:"unhealthy_since,omitempty"`
 	Backends       []SealBackendStatus `json:"backends"`
+	FullyWrapped   bool                `json:"fully_wrapped"`
 }
 
 func (core *Core) GetSealStatus(ctx context.Context, lock bool) (*SealStatusResponse, error) {
@@ -5545,6 +5546,13 @@ func (c *Core) GetSealBackendStatus(ctx context.Context) (*SealBackendStatusResp
 		}
 		r.Healthy = true
 	}
+
+	pps, err := GetPartiallySealWrappedPaths(ctx, c.physical)
+	if err != nil {
+		return nil, fmt.Errorf("could not list partially seal wrapped values: %w", err)
+	}
+	genInfo := c.seal.GetAccess().GetSealGenerationInfo()
+	r.FullyWrapped = genInfo.IsRewrapped() && len(pps) == 0
 	return &r, nil
 }
 


### PR DESCRIPTION
Two changes:
- Add a fully_wrapped field to seal-backend-status
- Always attempt to find an in common wrapper, not just in the case a
blobInfo contains only one entry.  If none can be found, warn.