### PR TITLE
Initialize license in command_testonly for enterprise

### DIFF
--- a/command/command_testonly/server_testonly_test.go
+++ b/command/command_testonly/server_testonly_test.go
@@ -19,6 +19,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func init() {
+	if signed := os.Getenv("VAULT_LICENSE_CI"); signed != "" {
+		os.Setenv(command.EnvVaultLicense, signed)
+	}
+}
+
 const (
 	baseHCL = `
 		backend "inmem" { }


### PR DESCRIPTION
While introducing the new `testonly` package for testing Request Limiter reloads, we didn't initialize a license. As a result, the test fails in CI with the following error:

> Error initializing core: license check failed: no autoloaded license provided. Licenses can be obtained at https://vaultproject.io/trial
>    server_testonly_test.go:142: timeout

I wasn't able to reproduce locally because I have my vault license environment variable set!

This PR fixes the issue by setting `EnvVaultLicense` with the contents of the CI License.