### PR TITLE
Fix a race in ToggleableWrapper (test struct)

### DIFF
--- a/vault/seal/seal_testing.go
+++ b/vault/seal/seal_testing.go
@@ -125,7 +125,7 @@ func (t *ToggleableWrapper) Encrypt(ctx context.Context, bytes []byte, opts ...w
 	return t.Wrapper.Encrypt(ctx, bytes, opts...)
 }
 
-func (t ToggleableWrapper) Decrypt(ctx context.Context, info *wrapping.BlobInfo, opts ...wrapping.Option) ([]byte, error) {
+func (t *ToggleableWrapper) Decrypt(ctx context.Context, info *wrapping.BlobInfo, opts ...wrapping.Option) ([]byte, error) {
 	t.l.RLock()
 	defer t.l.RUnlock()
 	if t.error != nil {


### PR DESCRIPTION
Should be a pointer to ToggleableWrapper, so we don't get a fresh mutex each time