### PR TITLE
Secrets Sync Demo Feedback

### DIFF
--- a/ui/lib/sync/addon/components/secrets/destination-header.hbs
+++ b/ui/lib/sync/addon/components/secrets/destination-header.hbs
@@ -52,6 +52,18 @@
 </div>
 
 <Toolbar>
+  {{#if @refreshList}}
+    <ToolbarFilters>
+      <Hds::Button
+        @text="Refresh list"
+        @icon="reload"
+        @color="secondary"
+        class="toolbar-button"
+        data-test-refresh-list
+        {{on "click" @refreshList}}
+      />
+    </ToolbarFilters>
+  {{/if}}
   <ToolbarActions>
     {{#if @destination.canDelete}}
       <Hds::Button

--- a/ui/lib/sync/addon/components/secrets/page/destinations/destination/secrets.hbs
+++ b/ui/lib/sync/addon/components/secrets/page/destinations/destination/secrets.hbs
@@ -3,7 +3,7 @@
   SPDX-License-Identifier: BUSL-1.1
 ~}}
 
-<Secrets::DestinationHeader @destination={{@destination}} />
+<Secrets::DestinationHeader @destination={{@destination}} @refreshList={{this.refreshRoute}} />
 
 {{#if @associations.meta.filteredTotal}}
   <div class="has-bottom-margin-s">

--- a/ui/lib/sync/addon/components/secrets/page/destinations/destination/secrets.ts
+++ b/ui/lib/sync/addon/components/secrets/page/destinations/destination/secrets.ts
@@ -36,6 +36,17 @@ export default class SyncSecretsDestinationsPageComponent extends Component<Args
   }
 
   @action
+  refreshRoute() {
+    // refresh route to update displayed secrets
+    this.store.clearDataset('sync/association');
+    this.router.transitionTo(
+      'vault.cluster.sync.secrets.destinations.destination.secrets',
+      this.args.destination.type,
+      this.args.destination.name
+    );
+  }
+
+  @action
   async update(association: SyncAssociationModel, operation: string) {
     try {
       await association.save({ adapterOptions: { action: operation } });
@@ -44,13 +55,7 @@ export default class SyncSecretsDestinationsPageComponent extends Component<Args
     } catch (error) {
       this.flashMessages.danger(`Sync operation error: \n ${errorMessage(error)}`);
     } finally {
-      // refresh route to update displayed secrets
-      this.store.clearDataset('sync/association');
-      this.router.transitionTo(
-        'vault.cluster.sync.secrets.destinations.destination.secrets',
-        this.args.destination.type,
-        this.args.destination.name
-      );
+      this.refreshRoute();
     }
   }
 }

--- a/ui/lib/sync/addon/components/secrets/page/destinations/destination/sync.ts
+++ b/ui/lib/sync/addon/components/secrets/page/destinations/destination/sync.ts
@@ -91,6 +91,8 @@ export default class DestinationSyncPageComponent extends Component<Args> {
       });
       await association.save({ adapterOptions: { action: 'set' } });
       this.syncedSecret = this.secretPath;
+      // reset the secret path to help make it clear that the sync was successful
+      this.secretPath = '';
     } catch (error) {
       this.error = `Sync operation error: \n ${errorMessage(error)}`;
     }

--- a/ui/tests/helpers/sync/sync-selectors.js
+++ b/ui/tests/helpers/sync/sync-selectors.js
@@ -18,6 +18,7 @@ export const PAGE = {
       name: '[data-test-association-name]',
       status: '[data-test-association-status]',
       updated: '[data-test-association-updated]',
+      refresh: '[data-test-refresh-list]',
       menu: {
         sync: '[data-test-association-action="sync"]',
         view: '[data-test-association-action="view"]',

--- a/ui/tests/integration/components/sync/secrets/destination-header-test.js
+++ b/ui/tests/integration/components/sync/secrets/destination-header-test.js
@@ -99,4 +99,19 @@ module('Integration | Component | sync | Secrets::DestinationHeader', function (
       .dom(`${PAGE.destinations.deleteBanner} ${PAGE.icon('alert-diamond')}`)
       .exists('banner renders critical icon');
   });
+
+  test('it should render refresh list button', async function (assert) {
+    assert.expect(1);
+
+    this.refreshList = () => assert.ok(true, 'Refresh list callback fires');
+
+    await render(
+      hbs`<Secrets::DestinationHeader @destination={{this.destination}} @refreshList={{this.refreshList}} />`,
+      {
+        owner: this.engine,
+      }
+    );
+
+    await click(PAGE.associations.list.refresh);
+  });
 });

--- a/ui/tests/integration/components/sync/secrets/page/destinations/destination/sync-test.js
+++ b/ui/tests/integration/components/sync/secrets/page/destinations/destination/sync-test.js
@@ -70,7 +70,7 @@ module('Integration | Component | sync | Secrets::Page::Destinations::Destinatio
   });
 
   test('it should sync secret', async function (assert) {
-    assert.expect(7);
+    assert.expect(9);
 
     const { type, name } = this.destination;
     this.server.post(`/sys/sync/destinations/${type}/${name}/associations/set`, (schema, req) => {
@@ -88,6 +88,8 @@ module('Integration | Component | sync | Secrets::Page::Destinations::Destinatio
     await click(searchSelect.option(1));
     await click(submit);
     assert.dom(cancel).hasText('View synced secrets', 'view secrets tertiary renders');
+    assert.dom(kvSuggestion.input).hasNoValue('Secret path is unset after submit success');
+    assert.dom(submit).isDisabled('Submit button is disabled');
     assert
       .dom(successMessage)
       .includesText('Sync operation successfully initiated for my-secret.', 'Success banner renders');


### PR DESCRIPTION
This PR addresses feedback that came out of a demo run with the UI.

- Clear secret path after successful sync submission. The feedback was that it wasn't completely clear if the submission was successful which led to users click the submit button numerous times.

https://github.com/hashicorp/vault/assets/24611656/95e6e187-7a12-4dcd-9ebd-5efa48ab0953

- Added refresh list button to destination secrets view. Since the backend needs to reach out to the destination to sync the secret, a user may view the list before the operation is complete and the synced secret does not appear in the list.

![image](https://github.com/hashicorp/vault/assets/24611656/24acd498-ca2f-417a-bf2d-13ffb2e4ae58)

