### PR TITLE
[QT-669] Automatically synchronize git hooks on make invocation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -163,7 +163,14 @@ prep: check-go-version
 	@GOARCH= GOOS= $(GO_CMD) generate $(MAIN_PACKAGES)
 	@GOARCH= GOOS= cd api && $(GO_CMD) generate $(API_PACKAGES)
 	@GOARCH= GOOS= cd sdk && $(GO_CMD) generate $(SDK_PACKAGES)
+
+# Git doesn't allow us to store shared hooks in .git. Instead, we make sure they're up-to-date
+# whenever a make target is invoked.
+.PHONY: hooks
+hooks:
 	@if [ -d .git/hooks ]; then cp .hooks/* .git/hooks/; fi
+
+-include hooks # Make sure they're always up-to-date
 
 # bootstrap the build by generating any necessary code and downloading additional tools that may
 # be used by devs.
@@ -378,4 +385,4 @@ ci-copywriteheaders:
 
 .PHONY: all-packages
 all-packages:
-	@echo $(ALL_PACKAGES) | tr ' ' '\n' 
+	@echo $(ALL_PACKAGES) | tr ' ' '\n'


### PR DESCRIPTION
Git doesn’t allow hooks to be in-repo which prevents branch specific hooks. To get around this we’ve historically copied our hooks from .hooks into .git/hooks when running `make prep`.

That sort of works but has the following issues:
  * If your hooks call into files in-repo and they are modified between branches you have to re-sync to resolve it
  * Remembering to sync the hooks is cumbersome

We can’t exactly get around the first issue. It’s always possible that if you change branches and don’t update your hooks you could run into this problem if you try to commit without updating them. But we can make it less likely to fail by:

  * Always syncing the hooks whenever make is called
  * Updating the files in the hooks on all maintained branches to be consistent