### PR TITLE
[QT-669] Automatically synchronize git hooks on make invocation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -163,7 +163,14 @@ prep: check-go-version
 	@GOARCH= GOOS= $(GO_CMD) generate $(MAIN_PACKAGES)
 	@GOARCH= GOOS= cd api && $(GO_CMD) generate $(API_PACKAGES)
 	@GOARCH= GOOS= cd sdk && $(GO_CMD) generate $(SDK_PACKAGES)
+
+# Git doesn't allow us to store shared hooks in .git. Instead, we make sure they're up-to-date
+# whenever a make target is invoked.
+.PHONY: hooks
+hooks:
 	@if [ -d .git/hooks ]; then cp .hooks/* .git/hooks/; fi
+
+-include hooks # Make sure they're always up-to-date
 
 # bootstrap the build by generating any necessary code and downloading additional tools that may
 # be used by devs.
@@ -380,4 +387,4 @@ ci-copywriteheaders:
 
 .PHONY: all-packages
 all-packages:
-	@echo $(ALL_PACKAGES) | tr ' ' '\n' 
+	@echo $(ALL_PACKAGES) | tr ' ' '\n'

--- a/builtin/credential/aws/client.go
+++ b/builtin/credential/aws/client.go
@@ -219,7 +219,6 @@ func (b *backend) clientEC2(ctx context.Context, s logical.Storage, region, acco
 	// Create an AWS config object using a chain of providers
 	var awsConfig *aws.Config
 	awsConfig, err = b.getClientConfig(ctx, s, region, stsRole, accountID, "ec2")
-
 	if err != nil {
 		return nil, err
 	}
@@ -279,7 +278,6 @@ func (b *backend) clientIAM(ctx context.Context, s logical.Storage, region, acco
 	// Create an AWS config object using a chain of providers
 	var awsConfig *aws.Config
 	awsConfig, err = b.getClientConfig(ctx, s, region, stsRole, accountID, "iam")
-
 	if err != nil {
 		return nil, err
 	}

--- a/builtin/credential/aws/path_config_client_test.go
+++ b/builtin/credential/aws/path_config_client_test.go
@@ -98,7 +98,6 @@ func TestBackend_pathConfigClient(t *testing.T) {
 		Data:      data,
 		Storage:   storage,
 	})
-
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/builtin/credential/aws/path_role_test.go
+++ b/builtin/credential/aws/path_role_test.go
@@ -304,7 +304,6 @@ func TestBackend_pathIam(t *testing.T) {
 		Data:      data,
 		Storage:   storage,
 	})
-
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/builtin/logical/aws/backend_test.go
+++ b/builtin/logical/aws/backend_test.go
@@ -297,7 +297,6 @@ func createRole(t *testing.T, roleName, awsAccountID string, policyARNs []string
 			RoleName:  aws.String(roleName), // Required
 		}
 		_, err = svc.AttachRolePolicy(attachment)
-
 		if err != nil {
 			t.Fatalf("AWS AttachRolePolicy failed: %v", err)
 		}
@@ -465,7 +464,6 @@ func deleteTestRole(roleName string) error {
 
 	log.Printf("[INFO] AWS DeleteRole: %s", roleName)
 	_, err = svc.DeleteRole(params)
-
 	if err != nil {
 		log.Printf("[WARN] AWS DeleteRole failed: %v", err)
 		return err

--- a/builtin/logical/aws/secret_access_keys.go
+++ b/builtin/logical/aws/secret_access_keys.go
@@ -397,7 +397,6 @@ func (b *backend) secretAccessKeysCreate(
 			Tags:     tags,
 			UserName: &username,
 		})
-
 		if err != nil {
 			return logical.ErrorResponse("Error adding tags to user: %s", err), awsutil.CheckAWSError(err)
 		}

--- a/builtin/plugin/v5/backend.go
+++ b/builtin/plugin/v5/backend.go
@@ -80,7 +80,6 @@ func (b *backend) reloadBackend(ctx context.Context, storage logical.Storage) er
 	err = b.Backend.Initialize(ctx, &logical.InitializationRequest{
 		Storage: storage,
 	})
-
 	if err != nil {
 		return err
 	}

--- a/command/agentproxyshared/auth/oci/oci.go
+++ b/command/agentproxyshared/auth/oci/oci.go
@@ -165,7 +165,6 @@ func (a *ociMethod) Authenticate(context.Context, *api.Client) (string, http.Hea
 	signer := common.DefaultRequestSigner(a.configurationProvider)
 
 	err = signer.Sign(request)
-
 	if err != nil {
 		return "", nil, nil, fmt.Errorf("error signing authentication request: %w", err)
 	}

--- a/command/kv_metadata_put_test.go
+++ b/command/kv_metadata_put_test.go
@@ -145,7 +145,6 @@ func TestKvMetadataPutCommand_CustomMetadata(t *testing.T) {
 	}
 
 	metadata, err = client.Logical().Read(metaFullPath)
-
 	if err != nil {
 		t.Fatalf("Metadata read error: %#v", err)
 	}

--- a/helper/pgpkeys/encrypt_decrypt.go
+++ b/helper/pgpkeys/encrypt_decrypt.go
@@ -56,7 +56,6 @@ func GetFingerprints(pgpKeys []string, entities []*openpgp.Entity) ([]string, er
 	if entities == nil {
 		var err error
 		entities, err = GetEntities(pgpKeys)
-
 		if err != nil {
 			return nil, err
 		}

--- a/physical/dynamodb/dynamodb.go
+++ b/physical/dynamodb/dynamodb.go
@@ -529,7 +529,6 @@ func (d *DynamoDBBackend) batchWriteRequests(requests []*dynamodb.WriteRequest) 
 			output, err = d.client.BatchWriteItem(&dynamodb.BatchWriteItemInput{
 				RequestItems: batch,
 			})
-
 			if err != nil {
 				break
 			}

--- a/physical/foundationdb/foundationdb.go
+++ b/physical/foundationdb/foundationdb.go
@@ -451,7 +451,6 @@ func (f *FDBBackend) Put(ctx context.Context, entry *physical.Entry) error {
 
 		return nil, nil
 	})
-
 	if err != nil {
 		return fmt.Errorf("put failed for item %s: %w", entry.Key, err)
 	}
@@ -509,7 +508,6 @@ func (f *FDBBackend) Delete(ctx context.Context, key string) error {
 
 		return nil, nil
 	})
-
 	if err != nil {
 		return fmt.Errorf("delete failed for item %s: %w", key, err)
 	}

--- a/physical/raft/raft_test.go
+++ b/physical/raft/raft_test.go
@@ -143,7 +143,6 @@ func compareDBs(t *testing.T, boltDB1, boltDB2 *bolt.DB, dataOnly bool) error {
 
 		return nil
 	})
-
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/physical/zookeeper/zookeeper_test.go
+++ b/physical/zookeeper/zookeeper_test.go
@@ -29,7 +29,6 @@ func TestZooKeeperBackend(t *testing.T) {
 	randPath := fmt.Sprintf("/vault-%d", time.Now().Unix())
 	acl := zk.WorldACL(zk.PermAll)
 	_, err = client.Create(randPath, []byte("hi"), int32(0), acl)
-
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -73,7 +72,6 @@ func TestZooKeeperHABackend(t *testing.T) {
 	randPath := fmt.Sprintf("/vault-ha-%d", time.Now().Unix())
 	acl := zk.WorldACL(zk.PermAll)
 	_, err = client.Create(randPath, []byte("hi"), int32(0), acl)
-
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/sdk/helper/certutil/helpers.go
+++ b/sdk/helper/certutil/helpers.go
@@ -1284,7 +1284,6 @@ func signCertificate(data *CreationBundle, randReader io.Reader) (*ParsedCertBun
 	}
 
 	certBytes, err = x509.CreateCertificate(randReader, certTemplate, caCert, data.CSR.PublicKey, data.SigningBundle.PrivateKey)
-
 	if err != nil {
 		return nil, errutil.InternalError{Err: fmt.Sprintf("unable to create certificate: %s", err)}
 	}

--- a/sdk/helper/docker/testhelpers.go
+++ b/sdk/helper/docker/testhelpers.go
@@ -320,7 +320,6 @@ func (d *Runner) StartNewService(ctx context.Context, addSuffix, forceLocalAddr 
 		config = c
 		return nil
 	}, bo)
-
 	if err != nil {
 		if !d.RunOptions.DoNotAutoRemove {
 			cleanup()

--- a/vault/external_tests/kv/kv_patch_test.go
+++ b/vault/external_tests/kv/kv_patch_test.go
@@ -149,7 +149,6 @@ func TestKV_Patch_Audit(t *testing.T) {
 	resp, err = kvRequestWithRetry(t, func() (interface{}, error) {
 		return c.Logical().JSONMergePatch(context.Background(), "kv/data/foo", patchData)
 	})
-
 	if err != nil {
 		t.Fatalf("patch request failed, err: %#v, resp: %#v\n", err, resp)
 	}
@@ -210,7 +209,6 @@ func TestKV_Patch_RootToken(t *testing.T) {
 
 		return client.Logical().Write("kv/data/foo", data)
 	})
-
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -224,7 +222,6 @@ func TestKV_Patch_RootToken(t *testing.T) {
 		}
 		return client.Logical().JSONMergePatch(context.Background(), "kv/data/foo", data)
 	})
-
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/vault/identity_store_aliases_test.go
+++ b/vault/identity_store_aliases_test.go
@@ -642,7 +642,6 @@ func TestIdentityStore_AliasMove_DuplicateAccessor(t *testing.T) {
 	aliasReq.Data = updateData
 	aliasReq.Path = "entity-alias/id/" + alias2ID
 	resp, err = is.HandleRequest(ctx, aliasReq)
-
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -715,7 +714,6 @@ func TestIdentityStore_AliasUpdate_DuplicateAccessor(t *testing.T) {
 	aliasReq.Data = updateData
 	aliasReq.Path = "entity-alias/id/" + alias2ID
 	resp, err = is.HandleRequest(ctx, aliasReq)
-
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -769,7 +767,6 @@ func TestIdentityStore_AliasCreate_DuplicateAccessor(t *testing.T) {
 
 	// This will try to create a new alias with the same accessor and entity
 	resp, err = is.HandleRequest(ctx, aliasReq)
-
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -700,7 +700,6 @@ func (c *Core) handleCancelableRequest(ctx context.Context, req *logical.Request
 			requestBodyToken = token.(string)
 			if IsSSCToken(token.(string)) {
 				token, err = c.CheckSSCToken(ctx, token.(string), c.isLoginRequest(ctx, req), c.perfStandby)
-
 				// If we receive an error from CheckSSCToken, we can assume the token is bad somehow, and the client
 				// should receive a 403 bad token error like they do for all other invalid tokens, unless the error
 				// specifies that we should forward the request or retry the request.

--- a/vault/version_store.go
+++ b/vault/version_store.go
@@ -45,7 +45,6 @@ func (c *Core) storeVersionEntry(ctx context.Context, vaultVersion *VaultVersion
 	if force {
 		// avoid storage lookup and write immediately
 		err = c.barrier.Put(ctx, newEntry)
-
 		if err != nil {
 			return false, err
 		}
@@ -63,7 +62,6 @@ func (c *Core) storeVersionEntry(ctx context.Context, vaultVersion *VaultVersion
 	}
 
 	err = c.barrier.Put(ctx, newEntry)
-
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
Git doesn’t allow hooks to be in-repo which prevents branch specific hooks. To get around this we’ve historically copied our hooks from .hooks into .git/hooks when running make prep in vault and vault-enterprise.

That sort of works but has the following issues:
  * If you hooks call into files in-repo and they are modified between branches you have to re-sync to resolve it
  * Remembering to sync the hooks is cumbersome

We can’t exactly get around the first issue. It’s always possible that if you change branches and don’t update your hooks you could run into this problem if you try to commit without updating them. But we can make it less likely to fail by:

  * Always syncing the hooks whenever make is called
  * Updating the files in the hooks on all maintained branches to be consistent