### PR TITLE
WIP: KV v2, Revert disable json toggle when complex secret.

### DIFF
--- a/ui/lib/kv/addon/components/page/secret/details.hbs
+++ b/ui/lib/kv/addon/components/page/secret/details.hbs
@@ -109,7 +109,7 @@
 
 {{#if (or @secret.isSecretDeleted (not this.emptyState))}}
   <div class="info-table-row-header">
-    <div class="info-table-row thead {{if @secret.showAsJson 'is-shadowless'}} ">
+    <div class="info-table-row thead {{if this.showJsonView 'is-shadowless'}} ">
       {{#unless this.hideHeaders}}
         <div class="th column is-one-quarter">
           Key
@@ -138,7 +138,7 @@
   </EmptyState>
 {{else}}
   <KvDataFields
-    @showJson={{or @secret.showAsJson this.secretDataIsAdvanced}}
+    @showJson={{this.showJsonView}}
     @obscureJson={{this.secretDataIsAdvanced}}
     @secret={{@secret}}
     @modelValidations={{this.modelValidations}}

--- a/ui/lib/kv/addon/components/page/secret/details.hbs
+++ b/ui/lib/kv/addon/components/page/secret/details.hbs
@@ -56,9 +56,9 @@
     {{#unless this.emptyState}}
       <Toggle
         @name="json"
-        @checked={{or this.showJsonView this.secretDataIsAdvanced}}
-        @onChange={{fn (mut this.showJsonView)}}
-        @disabled={{this.secretDataIsAdvanced}}
+        @checked={{@secret.showAsJson}}
+        @onChange={{fn (mut @secret.showAsJson)}}
+        {{! do not disable the ability for users to toggle from json to non-json view regardless of secrets shape }}
       >
         <span class="has-text-grey">JSON</span>
       </Toggle>
@@ -109,7 +109,7 @@
 
 {{#if (or @secret.isSecretDeleted (not this.emptyState))}}
   <div class="info-table-row-header">
-    <div class="info-table-row thead {{if this.showJsonView 'is-shadowless'}} ">
+    <div class="info-table-row thead {{if @secret.showAsJson 'is-shadowless'}} ">
       {{#unless this.hideHeaders}}
         <div class="th column is-one-quarter">
           Key
@@ -138,7 +138,7 @@
   </EmptyState>
 {{else}}
   <KvDataFields
-    @showJson={{or this.showJsonView this.secretDataIsAdvanced}}
+    @showJson={{or @secret.showAsJson this.secretDataIsAdvanced}}
     @obscureJson={{this.secretDataIsAdvanced}}
     @secret={{@secret}}
     @modelValidations={{this.modelValidations}}

--- a/ui/lib/kv/addon/components/page/secret/details.hbs
+++ b/ui/lib/kv/addon/components/page/secret/details.hbs
@@ -56,8 +56,8 @@
     {{#unless this.emptyState}}
       <Toggle
         @name="json"
-        @checked={{@secret.showAsJson}}
-        @onChange={{fn (mut @secret.showAsJson)}}
+        @checked={{this.showJsonView}}
+        @onChange={{fn (mut this.showJsonView)}}
         {{! do not disable the ability for users to toggle from json to non-json view regardless of secrets shape }}
       >
         <span class="has-text-grey">JSON</span>

--- a/ui/lib/kv/addon/components/page/secret/edit.hbs
+++ b/ui/lib/kv/addon/components/page/secret/edit.hbs
@@ -5,12 +5,7 @@
 
 <KvPageHeader @breadcrumbs={{@breadcrumbs}} @pageTitle="Create New Version">
   <:toolbarFilters>
-    <Toggle
-      @name="json"
-      @checked={{or this.showJsonView this.secretDataIsAdvanced}}
-      @onChange={{fn (mut this.showJsonView)}}
-      @disabled={{this.secretDataIsAdvanced}}
-    >
+    <Toggle @name="json" @checked={{this.showJsonView}} @onChange={{fn (mut this.showJsonView)}}>
       <span class="has-text-grey">JSON</span>
     </Toggle>
   </:toolbarFilters>


### PR DESCRIPTION
WIP

Remove the disable JSON toggle when KV v2 secret is complex, added by this PR #24290. Requested by community, see issue #24839.

TODO:
- [ ] team approval
- [ ] update tests
- [ ] Changelog
- [ ] Enterprise test pass locally.