### PR TITLE
VAULT-23732 Update github actions to non-deprecated versions

### DIFF
--- a/.github/actions/set-up-go/action.yml
+++ b/.github/actions/set-up-go/action.yml
@@ -40,7 +40,7 @@ runs:
         else
           echo "go-version=${{ inputs.go-version }}" >> "$GITHUB_OUTPUT"
         fi
-    - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
+    - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
       with:
         go-version: ${{ steps.go-version.outputs.go-version }}
         cache: false # We use our own caching strategy
@@ -50,7 +50,7 @@ runs:
         echo "cache-path=$(go env GOMODCACHE)" >> "$GITHUB_OUTPUT"
         echo "cache-key=go-modules-${{ hashFiles('**/go.sum') }}" >> "$GITHUB_OUTPUT"
     - id: cache-modules
-      uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+      uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4.0.0
       with:
         enableCrossOsArchive: true
         lookup-only: ${{ inputs.no-restore }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -412,7 +412,7 @@ jobs:
         run: vault-auth
       - id: secrets
         name: Fetch Vault Secrets
-        uses: hashicorp/vault-action@affa6f04da5c2d55e6e115b7d1b044a6b1af8c74
+        uses: hashicorp/vault-action@9f522b85981b491eab9a52c144d15aedbd0bf371 # v2.8.0
         with:
           url: ${{ steps.vault-auth.outputs.addr }}
           caCertificate: ${{ steps.vault-auth.outputs.ca_certificate }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,7 +225,7 @@ jobs:
       - id: secrets
         name: Fetch secrets
         if: github.repository == 'hashicorp/vault-enterprise'
-        uses: hashicorp/vault-action@affa6f04da5c2d55e6e115b7d1b044a6b1af8c74
+        uses: hashicorp/vault-action@9f522b85981b491eab9a52c144d15aedbd0bf371 # v2.8.0
         with:
           url: ${{ steps.vault-auth.outputs.addr }}
           caCertificate: ${{ steps.vault-auth.outputs.ca_certificate }}
@@ -378,7 +378,7 @@ jobs:
         run: vault-auth
       - id: secrets
         name: Fetch Vault Secrets
-        uses: hashicorp/vault-action@affa6f04da5c2d55e6e115b7d1b044a6b1af8c74
+        uses: hashicorp/vault-action@9f522b85981b491eab9a52c144d15aedbd0bf371 # v2.8.0
         with:
           url: ${{ steps.vault-auth.outputs.addr }}
           caCertificate: ${{ steps.vault-auth.outputs.ca_certificate }}

--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -99,7 +99,7 @@ jobs:
       - name: Fetch Secrets
         id: secrets
         if: github.repository == 'hashicorp/vault-enterprise'
-        uses: hashicorp/vault-action@affa6f04da5c2d55e6e115b7d1b044a6b1af8c74
+        uses: hashicorp/vault-action@9f522b85981b491eab9a52c144d15aedbd0bf371 # v2.8.0
         with:
           url: ${{ steps.vault-auth.outputs.addr }}
           caCertificate: ${{ steps.vault-auth.outputs.ca_certificate }}
@@ -232,7 +232,7 @@ jobs:
       - name: Fetch Secrets
         id: secrets
         if: github.repository == 'hashicorp/vault-enterprise'
-        uses: hashicorp/vault-action@affa6f04da5c2d55e6e115b7d1b044a6b1af8c74
+        uses: hashicorp/vault-action@9f522b85981b491eab9a52c144d15aedbd0bf371 # v2.8.0
         with:
           url: ${{ steps.vault-auth.outputs.addr }}
           caCertificate: ${{ steps.vault-auth.outputs.ca_certificate }}


### PR DESCRIPTION
See also:
![image](https://github.com/hashicorp/vault/assets/1594272/c92cae6d-6a30-42b5-b970-c3ac1dcf43af)

All of these versions have Node 20+.