### PR TITLE
Docs: audit log: `client_id`

### DIFF
--- a/website/content/docs/concepts/client-count/index.mdx
+++ b/website/content/docs/concepts/client-count/index.mdx
@@ -232,17 +232,18 @@ to say, two non-entity tokens would always be counted as two separate clients.
 
 ## Auditing clients
 
-As of Vault 1.9, the Vault Audit Log contains a `client_id` field in the request. The `client_id` field
-contains an Entity ID for requests that are made with tokens with entities, or a unique client ID for
-non-entity tokens.
+As of Vault 1.9, when the request has a non-empty `client_id` this field will be present
+in Vault Audit Log entries. The `client_id` field contains an Entity ID for requests that
+are made with tokens with entities, or a unique client ID for non-entity tokens.
 
 Consumers of the audit log will be able to distinguish between these two types of client IDs by comparing
 the value in the `client_id` with the value of the `entity_id` in the `Auth` section of the response. If
 the two values are the same, then the `client_id` is an `entity_id`. If not, then the `client_id` was
 generated from the use of a non-entity token.
 
-An empty `client_id` field in a request means that Vault did not track a client for that
-request; this can happen if the request is unauthenticated, or made with a root token or wrapped token.
+The `client_id` field will be omitted in cases where it was empty, this means that Vault did
+not track a client for that request; this can happen if the request is unauthenticated,
+or made with a root token or wrapped token.
 
 ## API and permissions
 
@@ -260,42 +261,42 @@ For the UI to be able to modify the configuration settings, it additionally need
 
 ## New clients for current month
 
-The billing period for the activity log API can be specified to include the current month 
-for the end date. For more information, please refer to the 
+The billing period for the activity log API can be specified to include the current month
+for the end date. For more information, please refer to the
 [the internal counters API docs](/vault/api-docs/system/internal-counters) documentation.
 
-When the end date is the current month, the `new_clients` counts will be an approximation of the  
-number of new clients for the month, and not an exact value. Note that the `new_clients` counts for the rest 
-of the months will be accurate. 
+When the end date is the current month, the `new_clients` counts will be an approximation of the
+number of new clients for the month, and not an exact value. Note that the `new_clients` counts for the rest
+of the months will be accurate.
 
 ### Why an approximation?
 
-The `new_clients` counts for the current month is an approximation to improve API 
+The `new_clients` counts for the current month is an approximation to improve API
 performance and make the UI usable. To give an exact value for the current month's
-new clients, client IDs need to be de-duplicated with the previous months' client IDs, 
-which is a time and i/o intensive process. 
+new clients, client IDs need to be de-duplicated with the previous months' client IDs,
+which is a time and i/o intensive process.
 
 ### Approximation details and accuracy testing results
 
 The `new_clients` approximation is calculated by using a [hyperloglog algorithm](https://en.wikipedia.org/wiki/HyperLogLog)
-to approximate the cardinality of the total number of clients within the billing period, and the cardinality 
-of the total number of clients within the billing period not including the current month. The returned value 
+to approximate the cardinality of the total number of clients within the billing period, and the cardinality
+of the total number of clients within the billing period not including the current month. The returned value
 is the difference between these two numbers.
 
 The hyperloglog library used for the cardinality estimate is [axiomhq](https://github.com/axiomhq/hyperloglog),
-with fourteen registers and the use of sparse representations, when applicable. Some accurate estimates can be found 
+with fourteen registers and the use of sparse representations, when applicable. Some accurate estimates can be found
 in this library's [README](https://github.com/axiomhq/hyperloglog#readme). These are accuracy results
-for the cardinality of the multiset, which is the total number of clients within a billing period. The accuracy 
-estimate for the number of new clients can be far lower, depending on the discrepancy between the number of 
-clients in the current month and the number of clients in the billing period. 
+for the cardinality of the multiset, which is the total number of clients within a billing period. The accuracy
+estimate for the number of new clients can be far lower, depending on the discrepancy between the number of
+clients in the current month and the number of clients in the billing period.
 
-If we call the number of clients for the current month C and the number of clients in the billing period B, we 
+If we call the number of clients for the current month C and the number of clients in the billing period B, we
 have found that in general, if C << B, the approximation can be imprecise, and the further the difference between
 C and B grows, the more imprecise the approximation will be. Furthermore, the closer C is to 0, the more imprecise
-the approximation can be. Also, the more months in the billing period, the less accurate the approximation can be. 
+the approximation can be. Also, the more months in the billing period, the less accurate the approximation can be.
 
 The maximum observed error rate ((found new clients)/(expected new clients)) with testing for 10,000 clients and under
-was 30%, with most cases yielding an error rate of 5-10%. 
+was 30%, with most cases yielding an error rate of 5-10%.
 
 A table with a few randomly selected values for C and B are listed below for the purposes of predictive analysis.
 
@@ -311,7 +312,7 @@ A table with a few randomly selected values for C and B are listed below for the
 |           400              |         6000          |      95%     |
 |           2000             |         10000         |      96%     |
 
-Some multi-month (over 2 months) and multi-segment tests are below: 
+Some multi-month (over 2 months) and multi-segment tests are below:
 
 | Current Month Clients      | Total Months' Clients | Accuracy     |
 | :---                       |    :----:             |        ---:  |


### PR DESCRIPTION
Update documentation to explain that `client_id` will not appear in audit log entries when the `client_id` was empty as part of the request being audited.

Resolves VAULT-23697

`/vault/docs/concepts/client-count#auditing-clients`

![image](https://github.com/hashicorp/vault/assets/487783/236dbac4-afc1-4ff6-9ffe-19faa73b8783)
