### PR TITLE
UI: k8s auth openapi update

### DIFF
--- a/ui/app/models/auth-config/kubernetes.js
+++ b/ui/app/models/auth-config/kubernetes.js
@@ -26,6 +26,7 @@ export default AuthConfig.extend({
     helpText:
       'A service account JWT used to access the TokenReview API to validate other JWTs during login. If not set the JWT used for login will be used to access the API',
   }),
+  useAnnotationsAsAliasMetadata: attr('boolean'),
 
   pemKeys: attr({
     editType: 'stringArray',
@@ -37,7 +38,7 @@ export default AuthConfig.extend({
         default: ['kubernetesHost', 'kubernetesCaCert'],
       },
       {
-        'Kubernetes Options': ['tokenReviewerJwt', 'pemKeys'],
+        'Kubernetes Options': ['tokenReviewerJwt', 'pemKeys', 'useAnnotationsAsAliasMetadata'],
       },
     ];
     if (this.newFields) {

--- a/ui/tests/helpers/openapi/auth-model-attributes.js
+++ b/ui/tests/helpers/openapi/auth-model-attributes.js
@@ -605,6 +605,14 @@ const kubernetes = {
       label: 'Token Reviewer JWT',
       type: 'string',
     },
+    useAnnotationsAsAliasMetadata: {
+      editType: 'boolean',
+      fieldGroup: 'default',
+      helpText:
+        'Use annotations from the client token\'s associated service account as alias metadata for the Vault entity. Only annotations with the prefix "vault.hashicorp.com/alias-metadata-" will be used. Note that Vault will need permission to read service accounts from the Kubernetes API.',
+      label: 'Use annotations of JWT service account as alias metadata',
+      type: 'boolean',
+    },
   },
   role: {
     name: {


### PR DESCRIPTION
This PR adds a new Kubernetes config param, `use_annotations_as_alias_metadata`. This was caught via one of the OpenAPI tests. 

The new param was added in [this PR](https://github.com/hashicorp/vault-plugin-auth-kubernetes/pull/226) and Vault is updated to consume the new version in [this PR](https://github.com/hashicorp/vault/pull/25207) 

Config form has param:
<img width="1521" alt="Screenshot 2024-02-05 at 11 47 26" src="https://github.com/hashicorp/vault/assets/82459713/2a5fbd4c-70ab-45c6-a99b-da2fd193534b">
