### PR TITLE
VAULT-20086 Handle potential panic

### DIFF
--- a/vault/expiration.go
+++ b/vault/expiration.go
@@ -1038,9 +1038,13 @@ func (m *ExpirationManager) revokeCommon(ctx context.Context, leaseID string, fo
 			if err != nil {
 				return err
 			}
-			// If it's a non-orphan batch token, assign the secondary index to its
-			// parent
-			indexToken = te.Parent
+			// lookupBatchTokenInternal can return nil, nil in the case of
+			// a token decrypt error. It's
+			if te != nil {
+				// If it's a non-orphan batch token, assign the secondary index to its
+				// parent
+				indexToken = te.Parent
+			}
 		default:
 			indexToken = le.ClientToken
 		}

--- a/vault/expiration.go
+++ b/vault/expiration.go
@@ -1039,7 +1039,7 @@ func (m *ExpirationManager) revokeCommon(ctx context.Context, leaseID string, fo
 				return err
 			}
 			// lookupBatchTokenInternal can return nil, nil in the case of
-			// a token decrypt error. It's
+			// a token decrypt error. We add this check to prevent nil panic.
 			if te != nil {
 				// If it's a non-orphan batch token, assign the secondary index to its
 				// parent

--- a/vault/token_store.go
+++ b/vault/token_store.go
@@ -1451,6 +1451,7 @@ func (ts *TokenStore) UseTokenByID(ctx context.Context, id string) (*logical.Tok
 }
 
 // Lookup is used to find a token given its ID. It acquires a read lock, then calls lookupInternal.
+// Note that callers must handle possible nil, nil returns from this function.
 func (ts *TokenStore) Lookup(ctx context.Context, id string) (*logical.TokenEntry, error) {
 	defer metrics.MeasureSince([]string{"token", "lookup"}, time.Now())
 	if id == "" {
@@ -1505,6 +1506,8 @@ func (ts *TokenStore) lookupBatchTokenInternal(ctx context.Context, id string) (
 
 	mEntry, err := ts.batchTokenEncryptor.Decrypt(ctx, "", eEntry)
 	if err != nil {
+		// We deliberately return nil, nil here to avoid leaking
+		// information about the decrypt failure.
 		return nil, nil
 	}
 
@@ -1522,12 +1525,16 @@ func (ts *TokenStore) lookupBatchTokenInternal(ctx context.Context, id string) (
 	return te, nil
 }
 
+// lookupBatchToken looks up a batch token and returns it if found.
+// Note that callers must handle possible nil, nil returns from this function.
 func (ts *TokenStore) lookupBatchToken(ctx context.Context, id string) (*logical.TokenEntry, error) {
 	te, err := ts.lookupBatchTokenInternal(ctx, id)
 	if err != nil {
 		return nil, err
 	}
 	if te == nil {
+		// We deliberately return nil, nil here to avoid leaking
+		// information in the case of a decrypt failure.
 		return nil, nil
 	}
 


### PR DESCRIPTION
Looking through this issue, there were two potential paths. First, we could have returned an error from the decrypt. Second, we could have kept the return as-is and handled the panic.

I opted for the second option after a bit of research/toying/deliberation. Changing the erroring of decryption of batch tokens has security impacts, and requires a lot more testing as it has the chance to be quite a disruptive refactor. While we wouldn't return nil, nil if implementing it today, in the interests of keeping impact low, I thought it best to document the behaviour and some of the motivation as well as fixing the panic, instead of refactoring an important area we're hazy about.

Resolves https://github.com/hashicorp/vault/issues/22065