### PR TITLE
Sync Destination Edit Bug

### DIFF
--- a/ui/lib/sync/addon/components/secrets/page/destinations/create-and-edit.ts
+++ b/ui/lib/sync/addon/components/secrets/page/destinations/create-and-edit.ts
@@ -75,14 +75,13 @@ export default class DestinationsCreateForm extends Component<Args> {
         if (destination.dirtyType as unknown as string) {
           const verb = destination.isNew ? 'created' : 'updated';
           yield destination.save();
+          this.flashMessages.success(`Successfully ${verb} the destination ${destination.name}`);
           // when saving a record the server returns all credentials as ******
           // Ember Data observes this as a change, marks the model as dirty and the field will be returned from changedAttributes
           // if the user then attempts to update the record the credential will get overwritten with the masked placeholder value
           // since the record will be fetched from the details route we can safely unload it to avoid the aforementioned issue
           destination.unloadRecord();
-          this.flashMessages.success(`Successfully ${verb} the destination ${destination.name}`);
           this.store.clearDataset('sync/destination');
-          this.store.unloadAll('sync/destination');
         }
         this.router.transitionTo(
           'vault.cluster.sync.secrets.destinations.destination.details',

--- a/ui/lib/sync/addon/components/secrets/page/destinations/create-and-edit.ts
+++ b/ui/lib/sync/addon/components/secrets/page/destinations/create-and-edit.ts
@@ -71,10 +71,19 @@ export default class DestinationsCreateForm extends Component<Args> {
 
     if (isValid) {
       try {
-        const verb = destination.isNew ? 'created' : 'updated';
-        yield destination.save();
-        this.flashMessages.success(`Successfully ${verb} the destination ${destination.name}`);
-        this.store.clearDataset('sync/destination');
+        // we only want to save if there are changes
+        if (destination.dirtyType as unknown as string) {
+          const verb = destination.isNew ? 'created' : 'updated';
+          yield destination.save();
+          // when saving a record the server returns all credentials as ******
+          // Ember Data observes this as a change, marks the model as dirty and the field will be returned from changedAttributes
+          // if the user then attempts to update the record the credential will get overwritten with the masked placeholder value
+          // since the record will be fetched from the details route we can safely unload it to avoid the aforementioned issue
+          destination.unloadRecord();
+          this.flashMessages.success(`Successfully ${verb} the destination ${destination.name}`);
+          this.store.clearDataset('sync/destination');
+          this.store.unloadAll('sync/destination');
+        }
         this.router.transitionTo(
           'vault.cluster.sync.secrets.destinations.destination.details',
           destination.type,

--- a/ui/tests/helpers/general-selectors.js
+++ b/ui/tests/helpers/general-selectors.js
@@ -44,6 +44,7 @@ export const SELECTORS = {
   infoRowValue: (label) => `[data-test-value-div="${label}"]`,
   inputByAttr: (attr) => `[data-test-input="${attr}"]`,
   fieldByAttr: (attr) => `[data-test-field="${attr}"]`,
+  enableField: (attr) => `[data-test-enable-field="${attr}"] button`,
   validation: (attr) => `[data-test-field-validation=${attr}]`,
   validationWarning: (attr) => `[data-test-validation-warning=${attr}]`,
   messageError: '[data-test-message-error]',


### PR DESCRIPTION
This PR fixes an issue with editing a sync destination and credential fields being overwritten with masked placeholder values. Since the server always returns credentials as `*****`, when a user would input a value and save, the model was being marked as dirty. If the model was saved again, the credential(s) would be returned from `changedAttributes` and the masked value would be sent in the `PATCH` request. To work around this, the model is now unloaded after save success since it is fetched when transitioning to the details route.