### PR TITLE
Only warn if failing to persist encryption counts due to timeout

### DIFF
--- a/vault/core.go
+++ b/vault/core.go
@@ -3719,6 +3719,8 @@ func (c *Core) checkBarrierAutoRotate(ctx context.Context) {
 			lf := c.logger.Error
 			if strings.HasSuffix(err.Error(), "context canceled") {
 				lf = c.logger.Debug
+			} else if strings.HasSuffix(err.Error(), "context deadline exceeded") {
+				lf = c.logger.Warn
 			}
 			lf("error in barrier auto rotation", "error", err)
 			return


### PR DESCRIPTION
VAULT-23782.  If we timeout writing encryption counts, we log as an error, but if it's purely in the persist path and not rotate path, it's not that serious.