### PR TITLE
Remove remaining imports of the console runCommands

### DIFF
--- a/ui/tests/acceptance/auth-list-test.js
+++ b/ui/tests/acceptance/auth-list-test.js
@@ -13,7 +13,7 @@ import authPage from 'vault/tests/pages/auth';
 import enablePage from 'vault/tests/pages/settings/auth/enable';
 import { allSupportedAuthBackends, supportedAuthBackends } from 'vault/helpers/supported-auth-backends';
 import { supportedManagedAuthBackends } from 'vault/helpers/supported-managed-auth-backends';
-import { deleteAuthCmd, mountAuthCmd, runCmd } from 'vault/tests/helpers/commands';
+import { deleteAuthCmd, mountAuthCmd, runCmd, createNS } from 'vault/tests/helpers/commands';
 
 const SELECTORS = {
   backendLink: (path) => `[data-test-auth-backend-link="${path}"]`,
@@ -152,7 +152,8 @@ module('Acceptance | auth backend list', function (hooks) {
 
   test('enterprise: token config within namespace', async function (assert) {
     const ns = 'ns-wxyz';
-    await runCmd(`write sys/namespaces/${ns} -f`);
+    await runCmd(createNS(ns), false);
+    await settled();
     await authPage.loginNs(ns);
     // go directly to token configure route
     await visit('/vault/settings/auth/configure/token/options');

--- a/ui/tests/acceptance/enterprise-control-groups-test.js
+++ b/ui/tests/acceptance/enterprise-control-groups-test.js
@@ -16,6 +16,7 @@ import controlGroupSuccess from 'vault/tests/pages/components/control-group-succ
 import { writeSecret } from 'vault/tests/helpers/kv/kv-run-commands';
 import authPage from 'vault/tests/pages/auth';
 import { setRunOptions } from 'ember-a11y-testing/test-support';
+import { runCmd } from 'vault/tests/helpers/commands';
 
 const consoleComponent = create(consoleClass);
 const authFormComponent = create(authForm);
@@ -83,7 +84,7 @@ module('Acceptance | Enterprise | control groups', function (hooks) {
     await visit('/vault/secrets');
     await consoleComponent.toggle();
     await settled();
-    await consoleComponent.runCommands([
+    await runCmd([
       //enable kv-v1 mount and write a secret
       'write sys/mounts/kv type=kv',
       'write kv/foo bar=baz',
@@ -101,13 +102,13 @@ module('Acceptance | Enterprise | control groups', function (hooks) {
     await settled();
     const userpassAccessor = consoleComponent.lastTextOutput;
 
-    await consoleComponent.runCommands([
+    await runCmd([
       // lookup entity id for our authorizer
       `write -field=id identity/lookup/entity name=${ADMIN_USER}`,
     ]);
     await settled();
     const authorizerEntityId = consoleComponent.lastTextOutput;
-    await consoleComponent.runCommands([
+    await runCmd([
       // create alias for authorizor and add them to the managers group
       `write identity/alias mount_accessor=${userpassAccessor} entity_id=${authorizerEntityId} name=${ADMIN_USER}`,
       `write identity/group name=managers member_entity_ids=${authorizerEntityId} policies=authorizer`,
@@ -123,10 +124,7 @@ module('Acceptance | Enterprise | control groups', function (hooks) {
   };
 
   test('for v2 secrets it redirects you if you try to navigate to a Control Group restricted path', async function (assert) {
-    await consoleComponent.runCommands([
-      'write sys/mounts/kv-v2-mount type=kv-v2',
-      'delete kv-v2-mount/metadata/foo',
-    ]);
+    await runCmd(['write sys/mounts/kv-v2-mount type=kv-v2', 'delete kv-v2-mount/metadata/foo']);
     await writeSecret('kv-v2-mount', 'foo', 'bar', 'baz');
     await settled();
     await setupControlGroup(this);
@@ -222,7 +220,7 @@ module('Acceptance | Enterprise | control groups', function (hooks) {
     await settled();
     await consoleComponent.toggle();
     await settled();
-    await consoleComponent.runCommands('read kv/foo');
+    await runCmd('read kv/foo');
     await settled();
     const output = consoleComponent.lastLogOutput;
     assert.ok(output.includes('A Control Group was encountered at kv/foo'));

--- a/ui/tests/acceptance/enterprise-namespaces-test.js
+++ b/ui/tests/acceptance/enterprise-namespaces-test.js
@@ -6,14 +6,9 @@
 import { click, settled, visit, fillIn, currentURL } from '@ember/test-helpers';
 import { module, test, skip } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
-import { create } from 'ember-cli-page-object';
-import consoleClass from 'vault/tests/pages/components/console/ui-panel';
+import { runCmd, createNS } from 'vault/tests/helpers/commands';
 import authPage from 'vault/tests/pages/auth';
 import logout from 'vault/tests/pages/logout';
-
-const shell = create(consoleClass);
-
-const createNS = (name) => shell.runCommands(`write sys/namespaces/${name} -force`);
 
 module('Acceptance | Enterprise | namespaces', function (hooks) {
   setupApplicationTest(hooks);
@@ -24,9 +19,8 @@ module('Acceptance | Enterprise | namespaces', function (hooks) {
 
   test('it clears namespaces when you log out', async function (assert) {
     const ns = 'foo';
-    await createNS(ns);
-    await shell.runCommands(`write -field=client_token auth/token/create policies=default`);
-    const token = shell.lastLogOutput;
+    await runCmd(createNS(ns), false);
+    const token = await runCmd(`write -field=client_token auth/token/create policies=default`);
     await logout.visit();
     await authPage.login(token);
     await click('[data-test-namespace-toggle]');
@@ -45,7 +39,7 @@ module('Acceptance | Enterprise | namespaces', function (hooks) {
 
     const nses = ['beep', 'boop', 'bop'];
     for (const [i, ns] of nses.entries()) {
-      await createNS(ns);
+      await runCmd(createNS(ns), false);
       await settled();
       // the namespace path will include all of the namespaces up to this point
       const targetNamespace = nses.slice(0, i + 1).join('/');

--- a/ui/tests/integration/components/auth-form-test.js
+++ b/ui/tests/integration/components/auth-form-test.js
@@ -43,6 +43,7 @@ module('Integration | Component | auth form', function (hooks) {
   hooks.beforeEach(function () {
     this.owner.register('service:router', routerService);
     this.router = this.owner.lookup('service:router');
+    this.onSuccess = sinon.spy();
   });
 
   const CSP_ERR_TEXT = `Error This is a standby Vault node but can't communicate with the active node via request forwarding. Sign in at the active node to use the Vault UI.`;
@@ -232,7 +233,9 @@ module('Integration | Component | auth form', function (hooks) {
     const wrappedToken = '54321';
     this.set('wrappedToken', wrappedToken);
     this.set('cluster', EmberObject.create({}));
-    await render(hbs`<AuthForm @cluster={{this.cluster}} @wrappedToken={{this.wrappedToken}} />`);
+    await render(
+      hbs`<AuthForm @cluster={{this.cluster}} @wrappedToken={{this.wrappedToken}} @onSuccess={{this.onSuccess}} />`
+    );
     later(() => cancelTimers(), 50);
     await settled();
     assert.strictEqual(


### PR DESCRIPTION
Building off of PR #25226, this PR removes the remaining cases of console runCommands imports. The only component still using the runCommands is the console ui component test. Moving forward it should be easier for devs to understand the correct pattern.