### PR TITLE
rotation POC: detect schedule updates

### DIFF
--- a/builtin/credential/ldap/path_config.go
+++ b/builtin/credential/ldap/path_config.go
@@ -329,6 +329,8 @@ type ldapConfigEntry struct {
 	RotationSchedule string `json:"rotation_schedule"`
 	RotationWindow   int    `json:"rotation_window"`
 	TTL              int    `json:"ttl"`
+
+	rotationID string // used to track the rotation entry in the rotation manager for the root password
 }
 
 const pathConfigHelpSyn = `


### PR DESCRIPTION
this adds some code that allows the system to track rotationIDs, allowing schedules to be updated without a new config entry in the manager.