### PR TITLE
Fix test to be less flacky

### DIFF
--- a/builtin/logical/pki/cert_util_test.go
+++ b/builtin/logical/pki/cert_util_test.go
@@ -638,11 +638,10 @@ func testParseCertificateToFields(t *testing.T, issueTime time.Time, tt *parseCe
 			require.NoError(t, err)
 
 			diff := expectedTTL - actualTTL
-			if diff < 0 {
-				diff = -diff
-			}
-			require.LessOrEqual(t, diff, 1*time.Second,
-				"ttl must be at most 1s off, want: %s got: %s", tt.wantFields["ttl"], fields["ttl"])
+			require.GreaterOrEqual(t, diff, 0,
+				"ttl should be, if off, smaller than expected want: %s got: %s", tt.wantFields["ttl"], fields["ttl"])
+			require.LessOrEqual(t, diff, 30*time.Second, // Test can be slow, allow more off in the other direction
+				"ttl must be at most 30s off, want: %s got: %s", tt.wantFields["ttl"], fields["ttl"])
 			delete(fields, "ttl")
 			delete(tt.wantFields, "ttl")
 		}

--- a/builtin/logical/pki/cert_util_test.go
+++ b/builtin/logical/pki/cert_util_test.go
@@ -638,7 +638,7 @@ func testParseCertificateToFields(t *testing.T, issueTime time.Time, tt *parseCe
 			require.NoError(t, err)
 
 			diff := expectedTTL - actualTTL
-			require.GreaterOrEqual(t, diff, 0,
+			require.LessOrEqual(t, actualTTL, expectedTTL, // NotAfter is generated before NotBefore so the time.Now of notBefore may be later, shrinking our calculated TTL during very slow tests
 				"ttl should be, if off, smaller than expected want: %s got: %s", tt.wantFields["ttl"], fields["ttl"])
 			require.LessOrEqual(t, diff, 30*time.Second, // Test can be slow, allow more off in the other direction
 				"ttl must be at most 30s off, want: %s got: %s", tt.wantFields["ttl"], fields["ttl"])


### PR DESCRIPTION
Allow remarkably long time for certificate generation due to slowness of night-ci runners.