### PR TITLE
ci: always trigger slack notification for any failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -275,7 +275,13 @@ jobs:
       - if: |
           always() &&
           needs.setup.outputs.workflow-trigger == 'push' &&
-          steps.status.outputs.result != 'success'
+          (
+            needs.test-go.result == 'failure' ||
+            needs.test-go-race.result == 'failure' ||
+            needs.test-go-race.outputs.data-race-result == 'failure' ||
+            needs.test-go-testonly.result == 'failure' ||
+            needs.test-ui.result == 'failure'
+          )
         name: Notify build failures in Slack
         uses: slackapi/slack-github-action@6c661ce58804a1a20f6dc5fbee7f0381b469e001 # v1.25.0
         # We intentionally aren't using the following here since it's from an internal repo


### PR DESCRIPTION
Don't rely on the pass/fail result of the CI workflow for notifications. We do this to ensure we notify Slack on failures but still allow for merging.