### PR TITLE
UI: Store user preference for KV display setting

### DIFF
--- a/ui/app/app.js
+++ b/ui/app/app.js
@@ -85,6 +85,7 @@ export default class App extends Application {
           'secret-mount-path',
           'flash-messages',
           'control-group',
+          'user-preference',
         ],
         externalRoutes: {
           secrets: 'vault.cluster.secrets.backends',

--- a/ui/app/models/kv/data.js
+++ b/ui/app/models/kv/data.js
@@ -8,6 +8,7 @@ import lazyCapabilities, { apiPath } from 'vault/macros/lazy-capabilities';
 import { withModelValidations } from 'vault/decorators/model-validations';
 import { withFormFields } from 'vault/decorators/model-form-fields';
 import { isDeleted } from 'kv/utils/kv-deleted';
+import { isAdvancedSecret } from 'core/utils/advanced-secret';
 
 /* sample response
 {
@@ -63,6 +64,10 @@ export default class KvSecretDataModel extends Model {
   @attr('number') version;
   // Set in adapter if read failed
   @attr('number') failReadErrorCode;
+
+  get isAdvanced() {
+    return isAdvancedSecret(this.secretData);
+  }
 
   // if creating a new version this value is set in the edit route's
   // model hook from metadata or secret version, pending permissions

--- a/ui/app/routes/vault/cluster/logout.js
+++ b/ui/app/routes/vault/cluster/logout.js
@@ -19,6 +19,7 @@ export default Route.extend(ModelBoundaryRoute, {
   router: service(),
   version: service(),
   customMessages: service(),
+  userPreference: service(),
 
   modelTypes: computed(function () {
     return ['secret', 'secret-engine'];
@@ -36,6 +37,7 @@ export default Route.extend(ModelBoundaryRoute, {
     this.permissions.reset();
     this.version.version = null;
     this.customMessages.clearCustomMessages();
+    this.userPreference.reset();
 
     queryParams.with = authType;
     if (ns) {

--- a/ui/app/services/user-preference.ts
+++ b/ui/app/services/user-preference.ts
@@ -1,0 +1,24 @@
+import { action } from '@ember/object';
+import Service from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+
+enum KvSecretDisplay {
+  Unset = 'unset',
+  Json = 'json',
+  KeyValue = 'keyvalue',
+}
+
+export default class UserPreferenceService extends Service {
+  @tracked kvDisplaySetting = KvSecretDisplay.Unset;
+  calculateInitialKvJson = (isAdvanced: boolean) => {
+    if (this.kvDisplaySetting === KvSecretDisplay.Unset) {
+      // if user preference is unset, show json if advanced
+      return isAdvanced;
+    }
+    // otherwise use user preference
+    return this.kvDisplaySetting === KvSecretDisplay.Json;
+  };
+  @action setKvDisplayPreference(jsonToggle: boolean) {
+    this.kvDisplaySetting = jsonToggle ? KvSecretDisplay.Json : KvSecretDisplay.KeyValue;
+  }
+}

--- a/ui/app/services/user-preference.ts
+++ b/ui/app/services/user-preference.ts
@@ -21,4 +21,9 @@ export default class UserPreferenceService extends Service {
   @action setKvDisplayPreference(jsonToggle: boolean) {
     this.kvDisplaySetting = jsonToggle ? KvSecretDisplay.Json : KvSecretDisplay.KeyValue;
   }
+
+  @action
+  reset() {
+    this.kvDisplaySetting = KvSecretDisplay.Unset;
+  }
 }

--- a/ui/lib/kv/addon/components/page/secret/details.hbs
+++ b/ui/lib/kv/addon/components/page/secret/details.hbs
@@ -54,7 +54,7 @@
 
   <:toolbarFilters>
     {{#unless this.emptyState}}
-      <Toggle @name="json" @checked={{this.showJsonView}} @onChange={{fn (mut this.showJsonView)}}>
+      <Toggle @name="json" @checked={{this.showJsonView}} @onChange={{this.toggleAdvancedEdit}}>
         <span class="has-text-grey">JSON</span>
       </Toggle>
     {{/unless}}

--- a/ui/lib/kv/addon/components/page/secret/details.js
+++ b/ui/lib/kv/addon/components/page/secret/details.js
@@ -11,7 +11,6 @@ import { inject as service } from '@ember/service';
 import { task } from 'ember-concurrency';
 import { waitFor } from '@ember/test-waiters';
 import { isDeleted } from 'kv/utils/kv-deleted';
-import { isAdvancedSecret } from 'core/utils/advanced-secret';
 
 /**
  * @module KvSecretDetails renders the key/value data of a KV secret.
@@ -33,6 +32,7 @@ export default class KvSecretDetails extends Component {
   @service flashMessages;
   @service router;
   @service store;
+  @service userPreference;
 
   @tracked showJsonView = false;
   @tracked wrappedData = null;
@@ -42,10 +42,7 @@ export default class KvSecretDetails extends Component {
     super(...arguments);
     this.fetchSyncStatus.perform();
     this.originalSecret = JSON.stringify(this.args.secret.secretData || {});
-    if (isAdvancedSecret(this.originalSecret)) {
-      // Default to JSON view if advanced
-      this.showJsonView = true;
-    }
+    this.showJsonView = this.userPreference.calculateInitialKvJson(this.args.secret.isAdvanced);
   }
 
   @action
@@ -118,6 +115,12 @@ export default class KvSecretDetails extends Component {
         )}.`
       );
     }
+  }
+
+  @action toggleAdvancedEdit() {
+    const newVal = !this.showJsonView;
+    this.showJsonView = newVal;
+    this.userPreference.setKvDisplayPreference(newVal);
   }
 
   refreshRoute() {

--- a/ui/lib/kv/addon/components/page/secret/edit.hbs
+++ b/ui/lib/kv/addon/components/page/secret/edit.hbs
@@ -5,7 +5,7 @@
 
 <KvPageHeader @breadcrumbs={{@breadcrumbs}} @pageTitle="Create New Version">
   <:toolbarFilters>
-    <Toggle @name="json" @checked={{this.showJsonView}} @onChange={{fn (mut this.showJsonView)}}>
+    <Toggle @name="json" @checked={{this.showJsonView}} @onChange={{this.toggleAdvancedEdit}}>
       <span class="has-text-grey">JSON</span>
     </Toggle>
   </:toolbarFilters>

--- a/ui/lib/kv/addon/components/page/secret/edit.js
+++ b/ui/lib/kv/addon/components/page/secret/edit.js
@@ -9,7 +9,6 @@ import { tracked } from '@glimmer/tracking';
 import { task } from 'ember-concurrency';
 import { inject as service } from '@ember/service';
 import errorMessage from 'vault/utils/error-message';
-import { isAdvancedSecret } from 'core/utils/advanced-secret';
 
 /**
  * @module KvSecretEdit is used for creating a new version of a secret
@@ -32,6 +31,7 @@ export default class KvSecretEdit extends Component {
   @service controlGroup;
   @service flashMessages;
   @service router;
+  @service userPreference;
 
   @tracked showJsonView = false;
   @tracked showDiff = false;
@@ -43,10 +43,7 @@ export default class KvSecretEdit extends Component {
   constructor() {
     super(...arguments);
     this.originalSecret = JSON.stringify(this.args.secret.secretData || {});
-    if (isAdvancedSecret(this.originalSecret)) {
-      // Default to JSON view if advanced
-      this.showJsonView = true;
-    }
+    this.showJsonView = this.userPreference.calculateInitialKvJson(this.args.secret.isAdvanced);
   }
 
   get showOldVersionAlert() {
@@ -98,6 +95,12 @@ export default class KvSecretEdit extends Component {
       this.errorMessage = message;
       this.invalidFormAlert = 'There was an error submitting this form.';
     }
+  }
+
+  @action toggleAdvancedEdit() {
+    const newVal = !this.showJsonView;
+    this.showJsonView = newVal;
+    this.userPreference.setKvDisplayPreference(newVal);
   }
 
   @action

--- a/ui/lib/kv/addon/engine.js
+++ b/ui/lib/kv/addon/engine.js
@@ -24,6 +24,7 @@ export default class KvEngine extends Engine {
       'secret-mount-path',
       'flash-messages',
       'control-group',
+      'user-preference',
     ],
     externalRoutes: ['secrets', 'syncDestination'],
   };

--- a/ui/tests/unit/services/user-preference-test.js
+++ b/ui/tests/unit/services/user-preference-test.js
@@ -1,0 +1,37 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'vault/tests/helpers';
+
+module('Unit | Service | user-preference', function (hooks) {
+  setupTest(hooks);
+
+  hooks.beforeEach(function () {
+    this.service = this.owner.lookup('service:user-preference');
+    this.service.kvDisplaySetting = 'unset';
+  });
+  hooks.afterEach(function () {
+    this.service.kvDisplaySetting = 'unset';
+  });
+
+  test('it manages the kvDisplaySetting correctly', function (assert) {
+    assert.strictEqual(this.service.kvDisplaySetting, 'unset', 'kvDisplaySetting is unset by default');
+    assert.false(
+      this.service.calculateInitialKvJson(false),
+      'inital view is not json when secret not advanced'
+    );
+    assert.true(this.service.calculateInitialKvJson(true), 'inital view is json when secret is advanced');
+    this.service.setKvDisplayPreference(true);
+    assert.strictEqual(this.service.kvDisplaySetting, 'json', 'kvDisplaySetting is set to json');
+    assert.true(this.service.calculateInitialKvJson(false), 'inital view is json due to user preference');
+    assert.true(this.service.calculateInitialKvJson(true), 'inital view is json due to user preference');
+    this.service.setKvDisplayPreference(false);
+    assert.strictEqual(this.service.kvDisplaySetting, 'keyvalue', 'kvDisplaySetting is set to keyvalue');
+    assert.false(
+      this.service.calculateInitialKvJson(false),
+      'inital view is key-value due to user preference'
+    );
+    assert.false(
+      this.service.calculateInitialKvJson(true),
+      'inital view is key-value due to user preference'
+    );
+  });
+});


### PR DESCRIPTION
This PR adds a user preference service that stores the display preference for all KV secret data in a session. Once a user has clicked the `JSON` toggle on or off, that preference will override the default behavior, which defaults to JSON view if the secret has non-string values. 

This setting will not reset when moving between secret engines. Alternative to this approach, we could instead store this data in the secret-mount-path service and have it reset when the backend is changed. However, adding this service is a nice foundation to allow making use of more user preferences in the future. 