### PR TITLE
Update vault-plugin-secrets-mongodbatlas to v0.11.0

### DIFF
--- a/changelog/25253.txt
+++ b/changelog/25253.txt
@@ -1,0 +1,3 @@
+```release-note:change
+secrets/mongodbatlas: Update plugin to v0.11.0
+```

--- a/go.mod
+++ b/go.mod
@@ -153,7 +153,7 @@ require (
 	github.com/hashicorp/vault-plugin-secrets-gcpkms v0.16.0
 	github.com/hashicorp/vault-plugin-secrets-kubernetes v0.7.0
 	github.com/hashicorp/vault-plugin-secrets-kv v0.16.2
-	github.com/hashicorp/vault-plugin-secrets-mongodbatlas v0.10.2
+	github.com/hashicorp/vault-plugin-secrets-mongodbatlas v0.11.0
 	github.com/hashicorp/vault-plugin-secrets-openldap v0.12.0
 	github.com/hashicorp/vault-plugin-secrets-terraform v0.7.3
 	github.com/hashicorp/vault-testing-stepwise v0.1.4

--- a/go.sum
+++ b/go.sum
@@ -2559,8 +2559,8 @@ github.com/hashicorp/vault-plugin-secrets-kubernetes v0.7.0 h1:IRsrGZyYjecQrAvpK
 github.com/hashicorp/vault-plugin-secrets-kubernetes v0.7.0/go.mod h1:StJ4o4D+ChaQ3lKzaWB5CAGDx62ONP9pDFr7iK8i9HU=
 github.com/hashicorp/vault-plugin-secrets-kv v0.16.2 h1:HdluNBrYGEEAJ1IrP3/T5RRgha16VGRlAisAlSB2hvI=
 github.com/hashicorp/vault-plugin-secrets-kv v0.16.2/go.mod h1:oJwVConr6pkDIIO8q8OO3FP5WtWj/iSWuhiPVdKt67E=
-github.com/hashicorp/vault-plugin-secrets-mongodbatlas v0.10.2 h1:5eFlzhFXoSe+ntm26wromhtLbPjTCdXcdwpMv7wFeHk=
-github.com/hashicorp/vault-plugin-secrets-mongodbatlas v0.10.2/go.mod h1:OdXvez+GH0XBSRS7gxbS8B1rLUPb8bGk+bDVyEaAzI8=
+github.com/hashicorp/vault-plugin-secrets-mongodbatlas v0.11.0 h1:NU7X28xzc/WBY0jMJNnan+elmKFWv/n5zbWXHfKf9/I=
+github.com/hashicorp/vault-plugin-secrets-mongodbatlas v0.11.0/go.mod h1:l6kmbSsAVTrzhsliH283dTo9LYZ4ClPMbBgEyWiUtz8=
 github.com/hashicorp/vault-plugin-secrets-openldap v0.12.0 h1:tAGJwjgu/NlHwIJeL/tVvqkWzMk/5f13eOSOSMPJiJY=
 github.com/hashicorp/vault-plugin-secrets-openldap v0.12.0/go.mod h1:9Jvrdmtc2/f4V1M33wGgtiXHdTtCC6l5pbMfInTurzc=
 github.com/hashicorp/vault-plugin-secrets-terraform v0.7.3 h1:k5jCx6laFvQHvrQod+TSHSoDqF3ZSIlQB4Yzj6koz0I=


### PR DESCRIPTION
This PR was generated by a GitHub Action. Full log: https://github.com/hashicorp/vault/actions/runs/7818119667