### PR TITLE
Test stability: seal & unseal

### DIFF
--- a/ui/app/controllers/vault/cluster/settings/seal.js
+++ b/ui/app/controllers/vault/cluster/settings/seal.js
@@ -10,6 +10,7 @@ export default Controller.extend({
   auth: service(),
   router: service(),
   version: service(),
+  store: service(),
 
   actions: {
     seal() {
@@ -17,7 +18,7 @@ export default Controller.extend({
         .adapterFor('cluster')
         .seal()
         .then(() => {
-          this.model.cluster.get('leaderNode').set('sealed', true);
+          this.store.peekAll('cluster')[0].reload();
           this.auth.deleteCurrentToken();
           // Reset version so it doesn't show on footer
           this.version.version = null;

--- a/ui/app/controllers/vault/cluster/unseal.js
+++ b/ui/app/controllers/vault/cluster/unseal.js
@@ -11,12 +11,6 @@ export default Controller.extend({
   showLicenseError: false,
 
   actions: {
-    transitionToCluster() {
-      return this.model.reload().then(() => {
-        return this.router.transitionTo('vault.cluster', this.model.name);
-      });
-    },
-
     reloadCluster() {
       return this.model.reload();
     },

--- a/ui/app/templates/vault/cluster/unseal.hbs
+++ b/ui/app/templates/vault/cluster/unseal.hbs
@@ -60,7 +60,7 @@
             @buttonText="Unseal"
             @onLicenseError={{action "handleLicenseError"}}
             @checkComplete={{action "isUnsealed"}}
-            @onShamirSuccess={{action "transitionToCluster"}}
+            @onShamirSuccess={{transition-to "vault.cluster" this.model.name}}
             class="has-top-margin-m"
           />
         {{/if}}

--- a/ui/tests/helpers/poll-cluster.js
+++ b/ui/tests/helpers/poll-cluster.js
@@ -7,6 +7,6 @@ import { settled } from '@ember/test-helpers';
 
 export async function pollCluster(owner) {
   const store = owner.lookup('service:store');
-  await store.peekAll('cluster').firstObject.reload();
+  await store.peekAll('cluster')[0].reload();
   await settled();
 }


### PR DESCRIPTION
Pulling in changes from the Ember data upgrade branch that improve test stability. The firstObject is going to be deprecated so removing that as well.

- [ ] Enterprise test passed locally.