### PR TITLE
Docs: Fix SQL Server EKM Provider KEK rotation instructions

### DIFF
--- a/website/content/docs/platform/mssql/installation.mdx
+++ b/website/content/docs/platform/mssql/installation.mdx
@@ -221,38 +221,5 @@ installation.
 
 ## Key rotation
 
-Both the database encryption key and Vault Transit's asymmetric key can be rotated independently.
-
-To rotate the database encryption key, you can execute the
-[following SQL query](https://docs.microsoft.com/en-us/sql/t-sql/statements/alter-database-encryption-key-transact-sql?view=azuresqldb-current)
-in Microsoft SQL Server Management Studio:
-
-```sql
-USE TestTDE;
-GO
-
-ALTER DATABASE ENCRYPTION KEY
-REGENERATE WITH ALGORITHM = AES_256;
-GO
-
-SELECT * FROM sys.dm_database_encryption_keys;
-```
-
-To rotate the asymmetric key in Vault's Transit, you can use the standard
-[`/rotate`](/vault/api-docs/secret/transit#rotate-key) endpoint:
-
-```shell-session
-$ vault write -f transit/keys/ekm-encryption-key/rotate
-```
-
-After rotating the Vault asymmetric key, you can force SQL Server to re-encrypt the database encryption
-key with the newest version of the Vault key with:
-
-```sql
-USE TestTDE;
-GO
-
-ALTER DATABASE ENCRYPTION KEY
-ENCRYPTION BY SERVER ASYMMETRIC KEY TransitVaultAsymmetric;
-GO
-```
+See [key rotation](/vault/docs/platform/mssql/rotation) for guidance on rotating
+the encryption keys.

--- a/website/content/docs/platform/mssql/rotation.mdx
+++ b/website/content/docs/platform/mssql/rotation.mdx
@@ -1,0 +1,64 @@
+---
+layout: docs
+page_title: Rotating encryption keys with the Vault EKM Provider
+description: Steps to rotate the symmetric Database Encryption Key (DEK) and the
+asymmetric Key Encryption Key (KEK) when using the Vault EKM Provider for Microsoft
+SQL Server.
+---
+
+# Key rotation
+
+Both the database encryption key and Vault Transit's asymmetric key can be rotated independently.
+
+## Database encryption key (DEK) rotation
+
+To rotate the database encryption key, you can execute the
+[following SQL query](https://docs.microsoft.com/en-us/sql/t-sql/statements/alter-database-encryption-key-transact-sql?view=azuresqldb-current)
+in Microsoft SQL Server Management Studio:
+
+```sql
+USE TestTDE;
+GO
+
+ALTER DATABASE ENCRYPTION KEY
+REGENERATE WITH ALGORITHM = AES_256;
+GO
+
+SELECT * FROM sys.dm_database_encryption_keys;
+```
+
+## Key encryption key (KEK) rotation
+
+To rotate the asymmetric key in Vault's Transit, you can use the standard
+[`/rotate`](/vault/api-docs/secret/transit#rotate-key) endpoint:
+
+```shell-session
+$ vault write -f transit/keys/ekm-encryption-key/rotate
+```
+
+After rotating the Vault asymmetric key, you can force SQL Server to re-encrypt the database encryption
+key with the newest version of the Vault key by creating a new asymmetric key:
+
+```sql
+use master;
+GO
+
+CREATE ASYMMETRIC KEY TransitVaultAsymmetricV2
+FROM PROVIDER TransitVaultProvider
+WITH CREATION_DISPOSITION = OPEN_EXISTING,
+PROVIDER_KEY_NAME = 'ekm-encryption-key';
+
+
+CREATE CREDENTIAL TransitVaultTDECredentialsV2
+    WITH IDENTITY = '<approle-role-id>',
+    SECRET = '<approle-secret-id>'
+FOR CRYPTOGRAPHIC PROVIDER TransitVaultProvider;
+GO
+
+CREATE LOGIN TransitVaultTDELoginV2 FROM ASYMMETRIC KEY TransitVaultAsymmetricV2;
+
+use TestTDE;
+go
+
+ALTER DATABASE ENCRYPTION KEY ENCRYPTION BY SERVER ASYMMETRIC KEY TransitVaultAsymmetricV2;
+```

--- a/website/content/docs/platform/mssql/rotation.mdx
+++ b/website/content/docs/platform/mssql/rotation.mdx
@@ -1,9 +1,7 @@
 ---
 layout: docs
 page_title: Rotating encryption keys with the Vault EKM Provider
-description: Steps to rotate the symmetric Database Encryption Key (DEK) and the
-asymmetric Key Encryption Key (KEK) when using the Vault EKM Provider for Microsoft
-SQL Server.
+description: Steps to rotate the symmetric Database Encryption Key (DEK) and the asymmetric Key Encryption Key (KEK) when using the Vault EKM Provider for Microsoft SQL Server.
 ---
 
 # Key rotation

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -2093,6 +2093,10 @@
             "path": "platform/mssql/configuration"
           },
           {
+            "title": "Key Rotation",
+            "path": "platform/mssql/rotation"
+          },
+          {
             "title": "Upgrading",
             "path": "platform/mssql/upgrading"
           },


### PR DESCRIPTION
Fixes the KEK rotation instructions to ensure the old KEK can be fully decommissioned from the Vault transit mount (via min decrypt version) after rotating.

Also creates a dedicated page for key rotation to make it easier to discover in the sidebar, rather than hidden at the bottom of a long installation page.