### PR TITLE
identity: skip oidc default key generation on read-only storage error for local mounts

### DIFF
--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -1649,8 +1649,10 @@ func (b *SystemBackend) handleMount(ctx context.Context, req *logical.Request, d
 			if !errors.Is(err, logical.ErrReadOnly) {
 				return nil, fmt.Errorf("failed to generate default key: %w", err)
 			}
-			b.Logger().Warn("skipping default OIDC key generation for local mount",
-				"name", logicalType, "path", path)
+			if local {
+				b.Logger().Warn("skipping default OIDC key generation for local mount",
+					"name", logicalType, "path", path)
+			}
 		}
 	}
 
@@ -2475,8 +2477,10 @@ func (b *SystemBackend) handleTuneWriteCommon(ctx context.Context, path string, 
 					mountEntry.Config.IdentityTokenKey = oldVal
 					return nil, fmt.Errorf("failed to generate default key: %w", err)
 				}
-				b.Logger().Warn("skipping default OIDC key generation for local mount",
-					"name", mountEntry.Type, "path", mountEntry.Path)
+				if mountEntry.Local {
+					b.Logger().Warn("skipping default OIDC key generation for local mount",
+						"name", mountEntry.Type, "path", path)
+				}
 			}
 		}
 
@@ -3281,8 +3285,10 @@ func (b *SystemBackend) handleEnableAuth(ctx context.Context, req *logical.Reque
 			if !errors.Is(err, logical.ErrReadOnly) {
 				return nil, fmt.Errorf("failed to generate default key: %w", err)
 			}
-			b.Logger().Warn("skipping default OIDC key generation for local mount",
-				"name", logicalType, "path", path)
+			if local {
+				b.Logger().Warn("skipping default OIDC key generation for local mount",
+					"name", logicalType, "path", path)
+			}
 		}
 	}
 

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -1646,12 +1646,11 @@ func (b *SystemBackend) handleMount(ctx context.Context, req *logical.Request, d
 	if config.usingOIDCDefaultKey() && logicalType != mountTypeKV {
 		err := identityStore.lazyGenerateDefaultKey(ctx, storage)
 		if err != nil {
-			if !errors.Is(err, logical.ErrReadOnly) {
-				return nil, fmt.Errorf("failed to generate default key: %w", err)
-			}
-			if local {
+			if local && errors.Is(err, logical.ErrReadOnly) {
 				b.Logger().Warn("skipping default OIDC key generation for local mount",
 					"name", logicalType, "path", path)
+			} else {
+				return nil, fmt.Errorf("failed to generate default key: %w", err)
 			}
 		}
 	}
@@ -2473,13 +2472,12 @@ func (b *SystemBackend) handleTuneWriteCommon(ctx context.Context, path string, 
 		if mountEntry.Config.usingOIDCDefaultKey() {
 			err := identityStore.lazyGenerateDefaultKey(ctx, storage)
 			if err != nil {
-				if !errors.Is(err, logical.ErrReadOnly) {
-					mountEntry.Config.IdentityTokenKey = oldVal
-					return nil, fmt.Errorf("failed to generate default key: %w", err)
-				}
-				if mountEntry.Local {
+				if mountEntry.Local && errors.Is(err, logical.ErrReadOnly) {
 					b.Logger().Warn("skipping default OIDC key generation for local mount",
 						"name", mountEntry.Type, "path", path)
+				} else {
+					mountEntry.Config.IdentityTokenKey = oldVal
+					return nil, fmt.Errorf("failed to generate default key: %w", err)
 				}
 			}
 		}
@@ -3282,12 +3280,11 @@ func (b *SystemBackend) handleEnableAuth(ctx context.Context, req *logical.Reque
 	if config.usingOIDCDefaultKey() {
 		err := identityStore.lazyGenerateDefaultKey(ctx, storage)
 		if err != nil {
-			if !errors.Is(err, logical.ErrReadOnly) {
-				return nil, fmt.Errorf("failed to generate default key: %w", err)
-			}
-			if local {
+			if local && errors.Is(err, logical.ErrReadOnly) {
 				b.Logger().Warn("skipping default OIDC key generation for local mount",
 					"name", logicalType, "path", path)
+			} else {
+				return nil, fmt.Errorf("failed to generate default key: %w", err)
 			}
 		}
 	}


### PR DESCRIPTION
This PR fixes enterprise tests that were encountering read-only storage errors for local-only mounts. The local-only mounts were trying to generate the OIDC default key which involves a storage write. We will simply log a warning and allow the local-only mount to be created for now.

This approach has an edge case where plugin workload identity would not work if:
- The local-only mount was the first mount ever enabled in Vault
- No identity token roles have been created
- No OIDC provider clients have been created

I'm going to think on a better solution for this. In the meantime, this PR fixes the tests.