### PR TITLE
Updated Database secret engine API docs - root_credentials_rotate_statements

### DIFF
--- a/website/content/api-docs/secret/databases/index.mdx
+++ b/website/content/api-docs/secret/databases/index.mdx
@@ -46,7 +46,7 @@ list of additional parameters.
 - `allowed_roles` `(list: [])` - List of the roles allowed to use this connection.
   Defaults to empty (no roles), if contains a `*` any role can use this connection.
 
-- `root_rotation_statements` `(list: [])` - Specifies the database statements to be
+- `root_credentials_rotate_statements` `(list: [])` - Specifies the database statements to be
   executed to rotate the root user's credentials. See the plugin's API page for more
   information on support and formatting for this parameter.
 


### PR DESCRIPTION
Updated Database secret engine API docs to use root_credentials_rotate_statements instead of root_rotation_statements