### PR TITLE
Use new SDK and API versions for 1.16.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -157,10 +157,10 @@ require (
 	github.com/hashicorp/vault-plugin-secrets-openldap v0.12.0
 	github.com/hashicorp/vault-plugin-secrets-terraform v0.7.3
 	github.com/hashicorp/vault-testing-stepwise v0.1.4
-	github.com/hashicorp/vault/api v1.11.0
+	github.com/hashicorp/vault/api v1.12.0
 	github.com/hashicorp/vault/api/auth/approle v0.1.0
 	github.com/hashicorp/vault/api/auth/userpass v0.1.0
-	github.com/hashicorp/vault/sdk v0.10.2
+	github.com/hashicorp/vault/sdk v0.11.0
 	github.com/hashicorp/vault/vault/hcp_link/proto v0.0.0-20230201201504-b741fa893d77
 	github.com/influxdata/influxdb1-client v0.0.0-20200827194710-b269163b24ab
 	github.com/jackc/pgx/v4 v4.18.1


### PR DESCRIPTION
I'm surprised by no go.sum changes, but I did run a `go mod tidy`, and it's far from impossible.