### PR TITLE
Remove Enterprise Label from Sync Acceptance Test Module Names

### DIFF
--- a/ui/tests/acceptance/sync/secrets/destination-test.js
+++ b/ui/tests/acceptance/sync/secrets/destination-test.js
@@ -12,7 +12,8 @@ import authPage from 'vault/tests/pages/auth';
 import { click, visit, currentURL, fillIn } from '@ember/test-helpers';
 import { PAGE as ts } from 'vault/tests/helpers/sync/sync-selectors';
 
-module('Acceptance | enterprise | sync | destination', function (hooks) {
+// sync is an enterprise feature but since mirage is used the enterprise label has been intentionally omitted from the module name
+module('Acceptance | sync | destination', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 

--- a/ui/tests/acceptance/sync/secrets/destinations-test.js
+++ b/ui/tests/acceptance/sync/secrets/destinations-test.js
@@ -12,7 +12,8 @@ import authPage from 'vault/tests/pages/auth';
 import { click, visit, fillIn, currentURL, currentRouteName } from '@ember/test-helpers';
 import { PAGE as ts } from 'vault/tests/helpers/sync/sync-selectors';
 
-module('Acceptance | enterprise | sync | destinations', function (hooks) {
+// sync is an enterprise feature but since mirage is used the enterprise label has been intentionally omitted from the module name
+module('Acceptance | sync | destinations', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 

--- a/ui/tests/acceptance/sync/secrets/overview-test.js
+++ b/ui/tests/acceptance/sync/secrets/overview-test.js
@@ -12,7 +12,8 @@ import authPage from 'vault/tests/pages/auth';
 import { click } from '@ember/test-helpers';
 import { PAGE as ts } from 'vault/tests/helpers/sync/sync-selectors';
 
-module('Acceptance | enterprise | sync | destination', function (hooks) {
+// sync is an enterprise feature but since mirage is used the enterprise label has been intentionally omitted from the module name
+module('Acceptance | sync | destination', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 


### PR DESCRIPTION
Since mirage is used for all of the sync related requests in acceptance tests, this PR removes the enterprise label from the module names so that the tests will run on PR's in the community repo.