### PR TITLE
Replace all service injects with updated import syntax

### DIFF
--- a/ui/app/adapters/application.js
+++ b/ui/app/adapters/application.js
@@ -5,7 +5,7 @@
 
 import AdapterError from '@ember-data/adapter/error';
 import RESTAdapter from '@ember-data/adapter/rest';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { assign } from '@ember/polyfills';
 import { set } from '@ember/object';
 import RSVP from 'rsvp';

--- a/ui/app/adapters/cluster.js
+++ b/ui/app/adapters/cluster.js
@@ -4,7 +4,7 @@
  */
 
 import AdapterError from '@ember-data/adapter/error';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { hash, resolve } from 'rsvp';
 import { assert } from '@ember/debug';
 import { pluralize } from 'ember-inflector';

--- a/ui/app/adapters/generated-item-list.js
+++ b/ui/app/adapters/generated-item-list.js
@@ -6,7 +6,7 @@
 import { assign } from '@ember/polyfills';
 import ApplicationAdapter from './application';
 import { task } from 'ember-concurrency';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default ApplicationAdapter.extend({
   store: service(),

--- a/ui/app/adapters/keymgmt/key.js
+++ b/ui/app/adapters/keymgmt/key.js
@@ -6,7 +6,7 @@
 import ApplicationAdapter from '../application';
 import { encodePath } from 'vault/utils/path-encoding-helpers';
 import ControlGroupError from '../../lib/control-group-error';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 function pickKeys(obj, picklist) {
   const data = {};

--- a/ui/app/adapters/ldap/role.js
+++ b/ui/app/adapters/ldap/role.js
@@ -5,7 +5,7 @@
 
 import NamedPathAdapter from 'vault/adapters/named-path';
 import { encodePath } from 'vault/utils/path-encoding-helpers';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import AdapterError from '@ember-data/adapter/error';
 
 export default class LdapRoleAdapter extends NamedPathAdapter {

--- a/ui/app/adapters/role-jwt.js
+++ b/ui/app/adapters/role-jwt.js
@@ -4,7 +4,7 @@
  */
 
 import ApplicationAdapter from './application';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { encodePath } from 'vault/utils/path-encoding-helpers';
 
 export default ApplicationAdapter.extend({

--- a/ui/app/adapters/role-saml.js
+++ b/ui/app/adapters/role-saml.js
@@ -4,7 +4,7 @@
  */
 
 import ApplicationAdapter from './application';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { encodePath } from 'vault/utils/path-encoding-helpers';
 import { v4 as uuidv4 } from 'uuid';
 

--- a/ui/app/components/auth-config-form/config.js
+++ b/ui/app/components/auth-config-form/config.js
@@ -4,7 +4,7 @@
  */
 
 import AdapterError from '@ember-data/adapter/error';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@ember/component';
 import { task } from 'ember-concurrency';
 import { waitFor } from '@ember/test-waiters';

--- a/ui/app/components/auth-config-form/options.js
+++ b/ui/app/components/auth-config-form/options.js
@@ -5,7 +5,7 @@
 
 import AdapterError from '@ember-data/adapter/error';
 import AuthConfigComponent from './config';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { task } from 'ember-concurrency';
 import { waitFor } from '@ember/test-waiters';
 

--- a/ui/app/components/auth-form.js
+++ b/ui/app/components/auth-form.js
@@ -5,7 +5,7 @@
 
 import Ember from 'ember';
 import { next } from '@ember/runloop';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { match, alias, or } from '@ember/object/computed';
 import { dasherize } from '@ember/string';
 import Component from '@ember/component';

--- a/ui/app/components/auth-jwt.js
+++ b/ui/app/components/auth-jwt.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 // ARG NOTE: Once you remove outer-html after glimmerizing you can remove the outer-html component
 import Component from './outer-html';
 import { task, timeout, waitForEvent } from 'ember-concurrency';

--- a/ui/app/components/auth-saml.js
+++ b/ui/app/components/auth-saml.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { task, timeout, waitForEvent } from 'ember-concurrency';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';

--- a/ui/app/components/clients/attribution.js
+++ b/ui/app/components/clients/attribution.js
@@ -6,7 +6,7 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { parseAPITimestamp } from 'core/utils/date-formatters';
 import { format, isSameMonth } from 'date-fns';
 

--- a/ui/app/components/clients/config.js
+++ b/ui/app/components/clients/config.js
@@ -17,7 +17,7 @@
 
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { task } from 'ember-concurrency';
 

--- a/ui/app/components/console/ui-panel.js
+++ b/ui/app/components/console/ui-panel.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { alias, or } from '@ember/object/computed';
 import Component from '@ember/component';
 import { getOwner } from '@ember/application';

--- a/ui/app/components/control-group-success.js
+++ b/ui/app/components/control-group-success.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@ember/component';
 import { task } from 'ember-concurrency';
 

--- a/ui/app/components/control-group.js
+++ b/ui/app/components/control-group.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { alias, or } from '@ember/object/computed';
 import Component from '@ember/component';
 import { computed } from '@ember/object';

--- a/ui/app/components/dashboard/client-count-card.js
+++ b/ui/app/components/dashboard/client-count-card.js
@@ -9,7 +9,7 @@ import timestamp from 'core/utils/timestamp';
 import { task } from 'ember-concurrency';
 import { waitFor } from '@ember/test-waiters';
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 /**
  * @module DashboardClientCountCard

--- a/ui/app/components/dashboard/quick-actions-card.js
+++ b/ui/app/components/dashboard/quick-actions-card.js
@@ -6,7 +6,7 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { pathIsDirectory } from 'kv/utils/kv-breadcrumbs';
 /**
  * @module DashboardQuickActionsCard

--- a/ui/app/components/dashboard/vault-version-title.js
+++ b/ui/app/components/dashboard/vault-version-title.js
@@ -4,7 +4,7 @@
  */
 
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 /**
  * @module DashboardVaultVersionTitle

--- a/ui/app/components/database-connection.js
+++ b/ui/app/components/database-connection.js
@@ -4,7 +4,7 @@
  */
 
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 

--- a/ui/app/components/database-role-edit.js
+++ b/ui/app/components/database-role-edit.js
@@ -4,7 +4,7 @@
  */
 
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 

--- a/ui/app/components/generate-credentials.js
+++ b/ui/app/components/generate-credentials.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { computed, set } from '@ember/object';
 import Component from '@ember/component';
 

--- a/ui/app/components/generated-item-list.js
+++ b/ui/app/components/generated-item-list.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { getOwner } from '@ember/application';

--- a/ui/app/components/generated-item.js
+++ b/ui/app/components/generated-item.js
@@ -4,7 +4,7 @@
  */
 
 import AdapterError from '@ember-data/adapter/error';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 import { task } from 'ember-concurrency';

--- a/ui/app/components/get-credentials-card.js
+++ b/ui/app/components/get-credentials-card.js
@@ -26,7 +26,7 @@
  */
 
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 

--- a/ui/app/components/identity/_popup-base.js
+++ b/ui/app/components/identity/_popup-base.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { assert } from '@ember/debug';
 import Component from '@ember/component';
 

--- a/ui/app/components/identity/edit-form.js
+++ b/ui/app/components/identity/edit-form.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 import { task } from 'ember-concurrency';

--- a/ui/app/components/identity/item-details.js
+++ b/ui/app/components/identity/item-details.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@ember/component';
 
 export default Component.extend({

--- a/ui/app/components/identity/lookup-input.js
+++ b/ui/app/components/identity/lookup-input.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@ember/component';
 import { task } from 'ember-concurrency';
 import { underscore } from 'vault/helpers/underscore';

--- a/ui/app/components/keymgmt/distribute.js
+++ b/ui/app/components/keymgmt/distribute.js
@@ -5,7 +5,7 @@
 
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { KEY_TYPES } from '../../models/keymgmt/key';
 import { task } from 'ember-concurrency';

--- a/ui/app/components/keymgmt/key-edit.js
+++ b/ui/app/components/keymgmt/key-edit.js
@@ -4,7 +4,7 @@
  */
 
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { task } from 'ember-concurrency';

--- a/ui/app/components/keymgmt/provider-edit.js
+++ b/ui/app/components/keymgmt/provider-edit.js
@@ -4,7 +4,7 @@
  */
 
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { task } from 'ember-concurrency';

--- a/ui/app/components/license-banners.js
+++ b/ui/app/components/license-banners.js
@@ -6,7 +6,7 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import isAfter from 'date-fns/isAfter';
 import differenceInDays from 'date-fns/differenceInDays';
 import localStorage from 'vault/lib/local-storage';

--- a/ui/app/components/link-status.js
+++ b/ui/app/components/link-status.js
@@ -4,7 +4,7 @@
  */
 
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 /**
  * @module LinkStatus

--- a/ui/app/components/logo-edition.js
+++ b/ui/app/components/logo-edition.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@ember/component';
 
 /**

--- a/ui/app/components/mfa/method-form.js
+++ b/ui/app/components/mfa/method-form.js
@@ -6,7 +6,7 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { task } from 'ember-concurrency';
 
 /**

--- a/ui/app/components/mfa/mfa-form.js
+++ b/ui/app/components/mfa/mfa-form.js
@@ -4,7 +4,7 @@
  */
 
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { action, set } from '@ember/object';
 import { task, timeout } from 'ember-concurrency';

--- a/ui/app/components/mfa/mfa-login-enforcement-form.js
+++ b/ui/app/components/mfa/mfa-login-enforcement-form.js
@@ -7,7 +7,7 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { A } from '@ember/array';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { task } from 'ember-concurrency';
 import handleHasManySelection from 'core/utils/search-select-has-many';
 

--- a/ui/app/components/mfa/mfa-login-enforcement-header.js
+++ b/ui/app/components/mfa/mfa-login-enforcement-header.js
@@ -5,7 +5,7 @@
 
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 
 /**

--- a/ui/app/components/mfa/mfa-setup-step-one.js
+++ b/ui/app/components/mfa/mfa-setup-step-one.js
@@ -4,7 +4,7 @@
  */
 
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 

--- a/ui/app/components/mfa/mfa-setup-step-two.js
+++ b/ui/app/components/mfa/mfa-setup-step-two.js
@@ -4,7 +4,7 @@
  */
 
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 
 /**

--- a/ui/app/components/modal-form/oidc-assignment-template.js
+++ b/ui/app/components/modal-form/oidc-assignment-template.js
@@ -5,7 +5,7 @@
 
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 /**

--- a/ui/app/components/modal-form/policy-template.js
+++ b/ui/app/components/modal-form/policy-template.js
@@ -5,7 +5,7 @@
 
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 /**

--- a/ui/app/components/mount-accessor-select.js
+++ b/ui/app/components/mount-accessor-select.js
@@ -4,7 +4,7 @@
  */
 
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { task } from 'ember-concurrency';
 import { action } from '@ember/object';
 

--- a/ui/app/components/mount-backend-form.js
+++ b/ui/app/components/mount-backend-form.js
@@ -5,7 +5,7 @@
 
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { task } from 'ember-concurrency';
 import { waitFor } from '@ember/test-waiters';

--- a/ui/app/components/mount-backend/type-form.js
+++ b/ui/app/components/mount-backend/type-form.js
@@ -4,7 +4,7 @@
  */
 
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { allMethods, methods } from 'vault/helpers/mountable-auth-methods';
 import { allEngines, mountableEngines } from 'vault/helpers/mountable-secret-engines';
 

--- a/ui/app/components/namespace-link.js
+++ b/ui/app/components/namespace-link.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { alias } from '@ember/object/computed';
 import Component from '@ember/component';
 import { computed } from '@ember/object';

--- a/ui/app/components/namespace-picker.js
+++ b/ui/app/components/namespace-picker.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { alias, gt } from '@ember/object/computed';
 import Component from '@ember/component';
 import { computed } from '@ember/object';

--- a/ui/app/components/not-found.js
+++ b/ui/app/components/not-found.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 
 /**

--- a/ui/app/components/oidc/assignment-form.js
+++ b/ui/app/components/oidc/assignment-form.js
@@ -5,7 +5,7 @@
 
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { task } from 'ember-concurrency';
 import { tracked } from '@glimmer/tracking';
 

--- a/ui/app/components/oidc/client-form.js
+++ b/ui/app/components/oidc/client-form.js
@@ -5,7 +5,7 @@
 
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { task } from 'ember-concurrency';
 /**

--- a/ui/app/components/oidc/key-form.js
+++ b/ui/app/components/oidc/key-form.js
@@ -5,7 +5,7 @@
 
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { task } from 'ember-concurrency';
 

--- a/ui/app/components/oidc/provider-form.js
+++ b/ui/app/components/oidc/provider-form.js
@@ -5,7 +5,7 @@
 
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { task } from 'ember-concurrency';
 import parseURL from 'core/utils/parse-url';

--- a/ui/app/components/oidc/scope-form.js
+++ b/ui/app/components/oidc/scope-form.js
@@ -7,7 +7,7 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { task } from 'ember-concurrency';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 /**
  * @module OidcScopeForm

--- a/ui/app/components/policy-form.js
+++ b/ui/app/components/policy-form.js
@@ -5,7 +5,7 @@
 
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { task } from 'ember-concurrency';
 import trimRight from 'vault/utils/trim-right';
 import { tracked } from '@glimmer/tracking';

--- a/ui/app/components/raft-join.js
+++ b/ui/app/components/raft-join.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 /**
  * @module RaftJoin

--- a/ui/app/components/raft-storage-overview.js
+++ b/ui/app/components/raft-storage-overview.js
@@ -6,7 +6,7 @@
 import Component from '@ember/component';
 import { getOwner } from '@ember/application';
 import config from '../config/environment';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default Component.extend({
   flashMessages: service(),

--- a/ui/app/components/raft-storage-restore.js
+++ b/ui/app/components/raft-storage-restore.js
@@ -6,7 +6,7 @@
 import Component from '@ember/component';
 import { task } from 'ember-concurrency';
 import { getOwner } from '@ember/application';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { alias } from '@ember/object/computed';
 import { AbortController } from 'fetch';
 

--- a/ui/app/components/role-edit.js
+++ b/ui/app/components/role-edit.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { or } from '@ember/object/computed';
 import { isBlank } from '@ember/utils';
 import { task, waitForEvent } from 'ember-concurrency';

--- a/ui/app/components/secret-create-or-update.js
+++ b/ui/app/components/secret-create-or-update.js
@@ -31,7 +31,7 @@ import ControlGroupError from 'vault/lib/control-group-error';
 import Ember from 'ember';
 import keys from 'core/utils/key-codes';
 import { action, set } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { isBlank, isNone } from '@ember/utils';
 import { task, waitForEvent } from 'ember-concurrency';

--- a/ui/app/components/secret-edit-toolbar.js
+++ b/ui/app/components/secret-edit-toolbar.js
@@ -36,7 +36,7 @@
 /* eslint ember/no-computed-properties-in-native-classes: 'warn' */
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { task } from 'ember-concurrency';
 import { waitFor } from '@ember/test-waiters';

--- a/ui/app/components/secret-edit.js
+++ b/ui/app/components/secret-edit.js
@@ -23,7 +23,7 @@
  * @param {boolean} preferAdvancedEdit - property set from the controller of show/edit/create route passed in through secret-edit-layout
  */
 
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';

--- a/ui/app/components/secret-list/database-list-item.js
+++ b/ui/app/components/secret-list/database-list-item.js
@@ -17,7 +17,7 @@
 
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 
 export default class DatabaseListItem extends Component {

--- a/ui/app/components/sidebar/frame.js
+++ b/ui/app/components/sidebar/frame.js
@@ -4,7 +4,7 @@
  */
 
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { inject as controller } from '@ember/controller';
 
 export default class SidebarNavComponent extends Component {

--- a/ui/app/components/sidebar/nav/cluster.js
+++ b/ui/app/components/sidebar/nav/cluster.js
@@ -4,7 +4,7 @@
  */
 
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class SidebarNavClusterComponent extends Component {
   @service currentCluster;

--- a/ui/app/components/sidebar/user-menu.js
+++ b/ui/app/components/sidebar/user-menu.js
@@ -4,7 +4,7 @@
  */
 
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { later } from '@ember/runloop';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';

--- a/ui/app/components/token-expire-warning.js
+++ b/ui/app/components/token-expire-warning.js
@@ -4,7 +4,7 @@
  */
 
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { later } from '@ember/runloop';
 import { task } from 'ember-concurrency';

--- a/ui/app/components/tool-actions-form.js
+++ b/ui/app/components/tool-actions-form.js
@@ -5,7 +5,7 @@
 
 import { match } from '@ember/object/computed';
 import { assign } from '@ember/polyfills';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@ember/component';
 import { setProperties, computed, set } from '@ember/object';
 import { addSeconds, parseISO } from 'date-fns';

--- a/ui/app/components/transform-edit-base.js
+++ b/ui/app/components/transform-edit-base.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { or } from '@ember/object/computed';
 import { isBlank } from '@ember/utils';
 import Component from '@ember/component';

--- a/ui/app/components/transform-role-edit.js
+++ b/ui/app/components/transform-role-edit.js
@@ -4,7 +4,7 @@
  */
 
 import TransformBase, { addToList, removeFromList } from './transform-edit-base';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default TransformBase.extend({
   flashMessages: service(),

--- a/ui/app/components/transformation-edit.js
+++ b/ui/app/components/transformation-edit.js
@@ -4,7 +4,7 @@
  */
 
 import TransformBase, { addToList, removeFromList } from './transform-edit-base';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default TransformBase.extend({
   flashMessages: service(),

--- a/ui/app/components/transit-edit.js
+++ b/ui/app/components/transit-edit.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { or } from '@ember/object/computed';
 import { isBlank } from '@ember/utils';
 import Component from '@ember/component';

--- a/ui/app/components/transit-key-actions.js
+++ b/ui/app/components/transit-key-actions.js
@@ -6,7 +6,7 @@
 import { assign } from '@ember/polyfills';
 import { copy } from 'ember-copy';
 import { assert } from '@ember/debug';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@ember/component';
 import { set, get, computed } from '@ember/object';
 import { encodeString } from 'vault/utils/b64';

--- a/ui/app/components/ui-wizard.js
+++ b/ui/app/components/ui-wizard.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { alias, or } from '@ember/object/computed';
 import Component from '@ember/component';
 import { matchesState } from 'xstate';

--- a/ui/app/components/wizard-content.js
+++ b/ui/app/components/wizard-content.js
@@ -4,7 +4,7 @@
  */
 
 import { alias, reads } from '@ember/object/computed';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 import { FEATURE_MACHINE_STEPS, INIT_STEPS } from 'vault/helpers/wizard-constants';

--- a/ui/app/components/wizard/features-selection.js
+++ b/ui/app/components/wizard/features-selection.js
@@ -4,7 +4,7 @@
  */
 
 import { or, not } from '@ember/object/computed';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 import { FEATURE_MACHINE_TIME } from 'vault/helpers/wizard-constants';

--- a/ui/app/components/wizard/mounts-wizard.js
+++ b/ui/app/components/wizard/mounts-wizard.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { alias, equal } from '@ember/object/computed';
 import Component from '@ember/component';
 import { computed } from '@ember/object';

--- a/ui/app/controllers/application.js
+++ b/ui/app/controllers/application.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Controller from '@ember/controller';
 import config from '../config/environment';
 

--- a/ui/app/controllers/vault/cluster.js
+++ b/ui/app/controllers/vault/cluster.js
@@ -4,7 +4,7 @@
  */
 
 /* eslint-disable ember/no-observers */
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { alias } from '@ember/object/computed';
 import Controller from '@ember/controller';
 import { observer } from '@ember/object';

--- a/ui/app/controllers/vault/cluster/access/identity/index.js
+++ b/ui/app/controllers/vault/cluster/access/identity/index.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Controller from '@ember/controller';
 import ListController from 'core/mixins/list-controller';
 

--- a/ui/app/controllers/vault/cluster/access/leases/list.js
+++ b/ui/app/controllers/vault/cluster/access/leases/list.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { computed } from '@ember/object';
 import Controller, { inject as controller } from '@ember/controller';
 import ListController from 'core/mixins/list-controller';

--- a/ui/app/controllers/vault/cluster/access/leases/show.js
+++ b/ui/app/controllers/vault/cluster/access/leases/show.js
@@ -4,7 +4,7 @@
  */
 
 import { next } from '@ember/runloop';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { computed } from '@ember/object';
 import Controller, { inject as controller } from '@ember/controller';
 

--- a/ui/app/controllers/vault/cluster/access/methods.js
+++ b/ui/app/controllers/vault/cluster/access/methods.js
@@ -5,7 +5,7 @@
 
 import Controller from '@ember/controller';
 import { dropTask } from 'ember-concurrency';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 

--- a/ui/app/controllers/vault/cluster/access/mfa/enforcements/enforcement/index.js
+++ b/ui/app/controllers/vault/cluster/access/mfa/enforcements/enforcement/index.js
@@ -6,7 +6,7 @@
 import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class MfaLoginEnforcementIndexController extends Controller {
   @service router;

--- a/ui/app/controllers/vault/cluster/access/mfa/methods/create.js
+++ b/ui/app/controllers/vault/cluster/access/mfa/methods/create.js
@@ -4,7 +4,7 @@
  */
 
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { capitalize } from '@ember/string';

--- a/ui/app/controllers/vault/cluster/access/mfa/methods/method/index.js
+++ b/ui/app/controllers/vault/cluster/access/mfa/methods/method/index.js
@@ -4,7 +4,7 @@
  */
 
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 
 export default class MfaMethodController extends Controller {

--- a/ui/app/controllers/vault/cluster/access/namespaces/create.js
+++ b/ui/app/controllers/vault/cluster/access/namespaces/create.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Controller from '@ember/controller';
 export default Controller.extend({
   namespaceService: service('namespace'),

--- a/ui/app/controllers/vault/cluster/access/namespaces/index.js
+++ b/ui/app/controllers/vault/cluster/access/namespaces/index.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { alias } from '@ember/object/computed';
 import Controller from '@ember/controller';
 export default Controller.extend({

--- a/ui/app/controllers/vault/cluster/access/oidc.js
+++ b/ui/app/controllers/vault/cluster/access/oidc.js
@@ -4,7 +4,7 @@
  */
 
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 export default class OidcConfigureController extends Controller {

--- a/ui/app/controllers/vault/cluster/access/oidc/assignments/assignment/details.js
+++ b/ui/app/controllers/vault/cluster/access/oidc/assignments/assignment/details.js
@@ -5,7 +5,7 @@
 
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class OidcAssignmentDetailsController extends Controller {
   @service router;

--- a/ui/app/controllers/vault/cluster/access/oidc/clients/client.js
+++ b/ui/app/controllers/vault/cluster/access/oidc/clients/client.js
@@ -4,7 +4,7 @@
  */
 
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 export default class OidcClientController extends Controller {

--- a/ui/app/controllers/vault/cluster/access/oidc/clients/client/details.js
+++ b/ui/app/controllers/vault/cluster/access/oidc/clients/client/details.js
@@ -5,7 +5,7 @@
 
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class OidcClientDetailsController extends Controller {
   @service router;

--- a/ui/app/controllers/vault/cluster/access/oidc/keys/key.js
+++ b/ui/app/controllers/vault/cluster/access/oidc/keys/key.js
@@ -4,7 +4,7 @@
  */
 
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 export default class OidcKeyController extends Controller {

--- a/ui/app/controllers/vault/cluster/access/oidc/keys/key/details.js
+++ b/ui/app/controllers/vault/cluster/access/oidc/keys/key/details.js
@@ -5,7 +5,7 @@
 
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { task } from 'ember-concurrency';
 import { waitFor } from '@ember/test-waiters';
 

--- a/ui/app/controllers/vault/cluster/access/oidc/providers/provider.js
+++ b/ui/app/controllers/vault/cluster/access/oidc/providers/provider.js
@@ -4,7 +4,7 @@
  */
 
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 export default class OidcProviderController extends Controller {

--- a/ui/app/controllers/vault/cluster/access/oidc/providers/provider/details.js
+++ b/ui/app/controllers/vault/cluster/access/oidc/providers/provider/details.js
@@ -5,7 +5,7 @@
 
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class OidcProviderDetailsController extends Controller {
   @service router;

--- a/ui/app/controllers/vault/cluster/access/oidc/scopes/scope/details.js
+++ b/ui/app/controllers/vault/cluster/access/oidc/scopes/scope/details.js
@@ -5,7 +5,7 @@
 
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class OidcScopeDetailsController extends Controller {
   @service router;

--- a/ui/app/controllers/vault/cluster/auth.js
+++ b/ui/app/controllers/vault/cluster/auth.js
@@ -2,7 +2,7 @@
  * Copyright (c) HashiCorp, Inc.
  * SPDX-License-Identifier: BUSL-1.1
  */
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { alias } from '@ember/object/computed';
 import Controller, { inject as controller } from '@ember/controller';
 import { task, timeout } from 'ember-concurrency';

--- a/ui/app/controllers/vault/cluster/mfa-setup.js
+++ b/ui/app/controllers/vault/cluster/mfa-setup.js
@@ -4,7 +4,7 @@
  */
 
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 

--- a/ui/app/controllers/vault/cluster/policies/index.js
+++ b/ui/app/controllers/vault/cluster/policies/index.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { computed } from '@ember/object';
 import Controller from '@ember/controller';
 

--- a/ui/app/controllers/vault/cluster/policy/edit.js
+++ b/ui/app/controllers/vault/cluster/policy/edit.js
@@ -5,7 +5,7 @@
 
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class PolicyEditController extends Controller {
   @service router;

--- a/ui/app/controllers/vault/cluster/secrets/backend/list.js
+++ b/ui/app/controllers/vault/cluster/secrets/backend/list.js
@@ -5,7 +5,7 @@
 
 import { or } from '@ember/object/computed';
 import { computed } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Controller from '@ember/controller';
 import BackendCrumbMixin from 'vault/mixins/backend-crumb';
 import WithNavToNearestAncestor from 'vault/mixins/with-nav-to-nearest-ancestor';

--- a/ui/app/controllers/vault/cluster/secrets/backend/sign.js
+++ b/ui/app/controllers/vault/cluster/secrets/backend/sign.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Controller from '@ember/controller';
 import { set } from '@ember/object';
 

--- a/ui/app/controllers/vault/cluster/secrets/backends.js
+++ b/ui/app/controllers/vault/cluster/secrets/backends.js
@@ -4,7 +4,7 @@
  */
 /* eslint ember/no-computed-properties-in-native-classes: 'warn' */
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { filterBy } from '@ember/object/computed';

--- a/ui/app/controllers/vault/cluster/settings.js
+++ b/ui/app/controllers/vault/cluster/settings.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Controller from '@ember/controller';
 export default Controller.extend({
   namespaceService: service('namespace'),

--- a/ui/app/controllers/vault/cluster/settings/configure-secret-backend.js
+++ b/ui/app/controllers/vault/cluster/settings/configure-secret-backend.js
@@ -4,7 +4,7 @@
  */
 
 import { isPresent } from '@ember/utils';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Controller from '@ember/controller';
 
 const CONFIG_ATTRS = {

--- a/ui/app/controllers/vault/cluster/settings/mount-secret-backend.js
+++ b/ui/app/controllers/vault/cluster/settings/mount-secret-backend.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Controller from '@ember/controller';
 import { supportedSecretBackends } from 'vault/helpers/supported-secret-backends';
 import { allEngines } from 'vault/helpers/mountable-secret-engines';

--- a/ui/app/controllers/vault/cluster/settings/seal.js
+++ b/ui/app/controllers/vault/cluster/settings/seal.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Controller from '@ember/controller';
 
 export default Controller.extend({

--- a/ui/app/controllers/vault/cluster/unseal.js
+++ b/ui/app/controllers/vault/cluster/unseal.js
@@ -4,7 +4,7 @@
  */
 
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default Controller.extend({
   router: service(),

--- a/ui/app/helpers/has-permission.js
+++ b/ui/app/helpers/has-permission.js
@@ -5,7 +5,7 @@
 
 /* eslint-disable ember/no-observers */
 import Helper from '@ember/component/helper';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { observer } from '@ember/object';
 
 export default Helper.extend({

--- a/ui/app/helpers/nav-to-route.js
+++ b/ui/app/helpers/nav-to-route.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Helper from '@ember/component/helper';
 
 export default Helper.extend({

--- a/ui/app/helpers/route-params-for.js
+++ b/ui/app/helpers/route-params-for.js
@@ -4,7 +4,7 @@
  */
 
 import Helper from '@ember/component/helper';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default Helper.extend({
   permissions: service(),

--- a/ui/app/mixins/cluster-route.js
+++ b/ui/app/mixins/cluster-route.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Mixin from '@ember/object/mixin';
 import RSVP from 'rsvp';
 import {

--- a/ui/app/models/auth-method.js
+++ b/ui/app/models/auth-method.js
@@ -6,7 +6,7 @@
 import Model, { belongsTo, hasMany, attr } from '@ember-data/model';
 import { alias } from '@ember/object/computed'; // eslint-disable-line
 import { computed } from '@ember/object'; // eslint-disable-line
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import fieldToAttrs, { expandAttributeMeta } from 'vault/utils/field-to-attrs';
 import apiPath from 'vault/utils/api-path';
 import attachCapabilities from 'vault/lib/attach-capabilities';

--- a/ui/app/models/cluster.js
+++ b/ui/app/models/cluster.js
@@ -4,7 +4,7 @@
  */
 
 import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { get } from '@ember/object';
 
 export default class ClusterModel extends Model {

--- a/ui/app/models/keymgmt/provider.js
+++ b/ui/app/models/keymgmt/provider.js
@@ -8,7 +8,7 @@ import { tracked } from '@glimmer/tracking';
 import { expandAttributeMeta } from 'vault/utils/field-to-attrs';
 import { withModelValidations } from 'vault/decorators/model-validations';
 import lazyCapabilities, { apiPath } from 'vault/macros/lazy-capabilities';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 const CRED_PROPS = {
   azurekeyvault: ['client_id', 'client_secret', 'tenant_id'],

--- a/ui/app/models/mfa-login-enforcement.js
+++ b/ui/app/models/mfa-login-enforcement.js
@@ -9,7 +9,7 @@ import PromiseProxyMixin from '@ember/object/promise-proxy-mixin';
 import { methods } from 'vault/helpers/mountable-auth-methods';
 import { withModelValidations } from 'vault/decorators/model-validations';
 import { isPresent } from '@ember/utils';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 const validations = {
   name: [{ type: 'presence', message: 'Name is required' }],

--- a/ui/app/models/pki/action.js
+++ b/ui/app/models/pki/action.js
@@ -4,7 +4,7 @@
  */
 
 import Model, { attr } from '@ember-data/model';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import lazyCapabilities, { apiPath } from 'vault/macros/lazy-capabilities';
 import { withFormFields } from 'vault/decorators/model-form-fields';

--- a/ui/app/models/pki/key.js
+++ b/ui/app/models/pki/key.js
@@ -4,7 +4,7 @@
  */
 
 import Model, { attr } from '@ember-data/model';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import lazyCapabilities, { apiPath } from 'vault/macros/lazy-capabilities';
 import { withFormFields } from 'vault/decorators/model-form-fields';
 import { withModelValidations } from 'vault/decorators/model-validations';

--- a/ui/app/routes/application.js
+++ b/ui/app/routes/application.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Route from '@ember/routing/route';
 import ControlGroupError from 'vault/lib/control-group-error';
 

--- a/ui/app/routes/vault.js
+++ b/ui/app/routes/vault.js
@@ -5,7 +5,7 @@
 
 import { later } from '@ember/runloop';
 import { Promise } from 'rsvp';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Route from '@ember/routing/route';
 import Ember from 'ember';
 

--- a/ui/app/routes/vault/cluster.js
+++ b/ui/app/routes/vault/cluster.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { computed } from '@ember/object';
 import { reject } from 'rsvp';
 import Route from '@ember/routing/route';

--- a/ui/app/routes/vault/cluster/access/control-group-accessor.js
+++ b/ui/app/routes/vault/cluster/access/control-group-accessor.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Route from '@ember/routing/route';
 import UnloadModel from 'vault/mixins/unload-model-route';
 

--- a/ui/app/routes/vault/cluster/access/control-groups-configure.js
+++ b/ui/app/routes/vault/cluster/access/control-groups-configure.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Route from '@ember/routing/route';
 import UnloadModel from 'vault/mixins/unload-model-route';
 

--- a/ui/app/routes/vault/cluster/access/control-groups.js
+++ b/ui/app/routes/vault/cluster/access/control-groups.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Route from '@ember/routing/route';
 import UnloadModel from 'vault/mixins/unload-model-route';
 

--- a/ui/app/routes/vault/cluster/access/identity/aliases/add.js
+++ b/ui/app/routes/vault/cluster/access/identity/aliases/add.js
@@ -5,7 +5,7 @@
 
 import Route from '@ember/routing/route';
 import UnsavedModelRoute from 'vault/mixins/unsaved-model-route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default Route.extend(UnsavedModelRoute, {
   store: service(),

--- a/ui/app/routes/vault/cluster/access/identity/aliases/edit.js
+++ b/ui/app/routes/vault/cluster/access/identity/aliases/edit.js
@@ -5,7 +5,7 @@
 
 import Route from '@ember/routing/route';
 import UnsavedModelRoute from 'vault/mixins/unsaved-model-route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default Route.extend(UnsavedModelRoute, {
   store: service(),

--- a/ui/app/routes/vault/cluster/access/identity/aliases/index.js
+++ b/ui/app/routes/vault/cluster/access/identity/aliases/index.js
@@ -5,7 +5,7 @@
 
 import Route from '@ember/routing/route';
 import ListRoute from 'core/mixins/list-route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default Route.extend(ListRoute, {
   store: service(),

--- a/ui/app/routes/vault/cluster/access/identity/aliases/show.js
+++ b/ui/app/routes/vault/cluster/access/identity/aliases/show.js
@@ -8,7 +8,7 @@ import { hash } from 'rsvp';
 import { set } from '@ember/object';
 import Route from '@ember/routing/route';
 import { TABS } from 'vault/helpers/tabs-for-identity-show';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default Route.extend({
   store: service(),

--- a/ui/app/routes/vault/cluster/access/identity/create.js
+++ b/ui/app/routes/vault/cluster/access/identity/create.js
@@ -5,7 +5,7 @@
 
 import Route from '@ember/routing/route';
 import UnsavedModelRoute from 'vault/mixins/unsaved-model-route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default Route.extend(UnsavedModelRoute, {
   store: service(),

--- a/ui/app/routes/vault/cluster/access/identity/edit.js
+++ b/ui/app/routes/vault/cluster/access/identity/edit.js
@@ -5,7 +5,7 @@
 
 import Route from '@ember/routing/route';
 import UnsavedModelRoute from 'vault/mixins/unsaved-model-route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default Route.extend(UnsavedModelRoute, {
   store: service(),

--- a/ui/app/routes/vault/cluster/access/identity/index.js
+++ b/ui/app/routes/vault/cluster/access/identity/index.js
@@ -5,7 +5,7 @@
 
 import Route from '@ember/routing/route';
 import ListRoute from 'core/mixins/list-route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default Route.extend(ListRoute, {
   store: service(),

--- a/ui/app/routes/vault/cluster/access/identity/merge.js
+++ b/ui/app/routes/vault/cluster/access/identity/merge.js
@@ -5,7 +5,7 @@
 
 import Route from '@ember/routing/route';
 import UnloadModelRoute from 'vault/mixins/unload-model-route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default Route.extend(UnloadModelRoute, {
   store: service(),

--- a/ui/app/routes/vault/cluster/access/identity/show.js
+++ b/ui/app/routes/vault/cluster/access/identity/show.js
@@ -9,7 +9,7 @@ import { hash } from 'rsvp';
 import { set } from '@ember/object';
 import Route from '@ember/routing/route';
 import { TABS } from 'vault/helpers/tabs-for-identity-show';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default Route.extend({
   store: service(),

--- a/ui/app/routes/vault/cluster/access/leases.js
+++ b/ui/app/routes/vault/cluster/access/leases.js
@@ -5,7 +5,7 @@
 
 import Route from '@ember/routing/route';
 import ClusterRoute from 'vault/mixins/cluster-route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default Route.extend(ClusterRoute, {
   store: service(),

--- a/ui/app/routes/vault/cluster/access/leases/list.js
+++ b/ui/app/routes/vault/cluster/access/leases/list.js
@@ -6,7 +6,7 @@
 import { set } from '@ember/object';
 import { hash } from 'rsvp';
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default Route.extend({
   store: service(),

--- a/ui/app/routes/vault/cluster/access/leases/show.js
+++ b/ui/app/routes/vault/cluster/access/leases/show.js
@@ -6,7 +6,7 @@
 import { hash } from 'rsvp';
 import { set } from '@ember/object';
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { keyIsFolder, parentKeyForKey } from 'core/utils/key-utils';
 import UnloadModelRoute from 'vault/mixins/unload-model-route';
 

--- a/ui/app/routes/vault/cluster/access/method.js
+++ b/ui/app/routes/vault/cluster/access/method.js
@@ -6,7 +6,7 @@
 import AdapterError from '@ember-data/adapter/error';
 import { set } from '@ember/object';
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default Route.extend({
   store: service(),

--- a/ui/app/routes/vault/cluster/access/method/item.js
+++ b/ui/app/routes/vault/cluster/access/method/item.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Route from '@ember/routing/route';
 import { singularize } from 'ember-inflector';
 

--- a/ui/app/routes/vault/cluster/access/method/item/create.js
+++ b/ui/app/routes/vault/cluster/access/method/item/create.js
@@ -6,7 +6,7 @@
 import Route from '@ember/routing/route';
 import UnsavedModelRoute from 'vault/mixins/unsaved-model-route';
 import { singularize } from 'ember-inflector';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default Route.extend(UnsavedModelRoute, {
   store: service(),

--- a/ui/app/routes/vault/cluster/access/method/item/edit.js
+++ b/ui/app/routes/vault/cluster/access/method/item/edit.js
@@ -6,7 +6,7 @@
 import Route from '@ember/routing/route';
 import UnsavedModelRoute from 'vault/mixins/unsaved-model-route';
 import { singularize } from 'ember-inflector';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default Route.extend(UnsavedModelRoute, {
   store: service(),

--- a/ui/app/routes/vault/cluster/access/method/item/list.js
+++ b/ui/app/routes/vault/cluster/access/method/item/list.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Route from '@ember/routing/route';
 import { singularize } from 'ember-inflector';
 import ListRoute from 'vault/mixins/list-route';

--- a/ui/app/routes/vault/cluster/access/method/item/show.js
+++ b/ui/app/routes/vault/cluster/access/method/item/show.js
@@ -4,7 +4,7 @@
  */
 
 import { singularize } from 'ember-inflector';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Route from '@ember/routing/route';
 
 export default Route.extend({

--- a/ui/app/routes/vault/cluster/access/methods.js
+++ b/ui/app/routes/vault/cluster/access/methods.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class VaultClusterAccessMethodsRoute extends Route {
   @service store;

--- a/ui/app/routes/vault/cluster/access/mfa/enforcements/create.js
+++ b/ui/app/routes/vault/cluster/access/mfa/enforcements/create.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class MfaLoginEnforcementCreateRoute extends Route {
   @service store;

--- a/ui/app/routes/vault/cluster/access/mfa/enforcements/enforcement.js
+++ b/ui/app/routes/vault/cluster/access/mfa/enforcements/enforcement.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class MfaLoginEnforcementRoute extends Route {
   @service store;

--- a/ui/app/routes/vault/cluster/access/mfa/enforcements/index.js
+++ b/ui/app/routes/vault/cluster/access/mfa/enforcements/index.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class MfaEnforcementsRoute extends Route {
   @service store;

--- a/ui/app/routes/vault/cluster/access/mfa/index.js
+++ b/ui/app/routes/vault/cluster/access/mfa/index.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class MfaConfigureRoute extends Route {
   @service store;

--- a/ui/app/routes/vault/cluster/access/mfa/methods/index.js
+++ b/ui/app/routes/vault/cluster/access/mfa/methods/index.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class MfaMethodsRoute extends Route {
   @service store;

--- a/ui/app/routes/vault/cluster/access/mfa/methods/method.js
+++ b/ui/app/routes/vault/cluster/access/mfa/methods/method.js
@@ -5,7 +5,7 @@
 
 import Route from '@ember/routing/route';
 import { hash } from 'rsvp';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class MfaMethodRoute extends Route {
   @service store;

--- a/ui/app/routes/vault/cluster/access/namespaces/create.js
+++ b/ui/app/routes/vault/cluster/access/namespaces/create.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Route from '@ember/routing/route';
 import UnloadModel from 'vault/mixins/unload-model-route';
 

--- a/ui/app/routes/vault/cluster/access/namespaces/index.js
+++ b/ui/app/routes/vault/cluster/access/namespaces/index.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Route from '@ember/routing/route';
 import UnloadModel from 'vault/mixins/unload-model-route';
 

--- a/ui/app/routes/vault/cluster/access/oidc/assignments/assignment.js
+++ b/ui/app/routes/vault/cluster/access/oidc/assignments/assignment.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class OidcAssignmentRoute extends Route {
   @service store;

--- a/ui/app/routes/vault/cluster/access/oidc/assignments/create.js
+++ b/ui/app/routes/vault/cluster/access/oidc/assignments/create.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class OidcAssignmentsCreateRoute extends Route {
   @service store;

--- a/ui/app/routes/vault/cluster/access/oidc/assignments/index.js
+++ b/ui/app/routes/vault/cluster/access/oidc/assignments/index.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class OidcAssignmentsRoute extends Route {
   @service store;

--- a/ui/app/routes/vault/cluster/access/oidc/clients/client.js
+++ b/ui/app/routes/vault/cluster/access/oidc/clients/client.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class OidcClientRoute extends Route {
   @service store;

--- a/ui/app/routes/vault/cluster/access/oidc/clients/client/providers.js
+++ b/ui/app/routes/vault/cluster/access/oidc/clients/client/providers.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class OidcClientProvidersRoute extends Route {
   @service store;

--- a/ui/app/routes/vault/cluster/access/oidc/clients/create.js
+++ b/ui/app/routes/vault/cluster/access/oidc/clients/create.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class OidcClientsCreateRoute extends Route {
   @service store;

--- a/ui/app/routes/vault/cluster/access/oidc/clients/index.js
+++ b/ui/app/routes/vault/cluster/access/oidc/clients/index.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 export default class OidcClientsRoute extends Route {
   @service store;
   @service router;

--- a/ui/app/routes/vault/cluster/access/oidc/index.js
+++ b/ui/app/routes/vault/cluster/access/oidc/index.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class OidcConfigureRoute extends Route {
   @service store;

--- a/ui/app/routes/vault/cluster/access/oidc/keys/create.js
+++ b/ui/app/routes/vault/cluster/access/oidc/keys/create.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class OidcKeysCreateRoute extends Route {
   @service store;

--- a/ui/app/routes/vault/cluster/access/oidc/keys/index.js
+++ b/ui/app/routes/vault/cluster/access/oidc/keys/index.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class OidcKeysRoute extends Route {
   @service store;

--- a/ui/app/routes/vault/cluster/access/oidc/keys/key.js
+++ b/ui/app/routes/vault/cluster/access/oidc/keys/key.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class OidcKeyRoute extends Route {
   @service store;

--- a/ui/app/routes/vault/cluster/access/oidc/keys/key/clients.js
+++ b/ui/app/routes/vault/cluster/access/oidc/keys/key/clients.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class OidcKeyClientsRoute extends Route {
   @service store;

--- a/ui/app/routes/vault/cluster/access/oidc/providers/create.js
+++ b/ui/app/routes/vault/cluster/access/oidc/providers/create.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class OidcProvidersCreateRoute extends Route {
   @service store;

--- a/ui/app/routes/vault/cluster/access/oidc/providers/index.js
+++ b/ui/app/routes/vault/cluster/access/oidc/providers/index.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class OidcProvidersRoute extends Route {
   @service store;

--- a/ui/app/routes/vault/cluster/access/oidc/providers/provider.js
+++ b/ui/app/routes/vault/cluster/access/oidc/providers/provider.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class OidcProviderRoute extends Route {
   @service store;

--- a/ui/app/routes/vault/cluster/access/oidc/providers/provider/clients.js
+++ b/ui/app/routes/vault/cluster/access/oidc/providers/provider/clients.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class OidcProviderClientsRoute extends Route {
   @service store;

--- a/ui/app/routes/vault/cluster/access/oidc/scopes/create.js
+++ b/ui/app/routes/vault/cluster/access/oidc/scopes/create.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class OidcScopesCreateRoute extends Route {
   @service store;

--- a/ui/app/routes/vault/cluster/access/oidc/scopes/index.js
+++ b/ui/app/routes/vault/cluster/access/oidc/scopes/index.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class OidcScopesRoute extends Route {
   @service store;

--- a/ui/app/routes/vault/cluster/access/oidc/scopes/scope.js
+++ b/ui/app/routes/vault/cluster/access/oidc/scopes/scope.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class OidcScopeRoute extends Route {
   @service store;

--- a/ui/app/routes/vault/cluster/auth.js
+++ b/ui/app/routes/vault/cluster/auth.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import ClusterRouteBase from './cluster-route-base';
 import config from 'vault/config/environment';
 

--- a/ui/app/routes/vault/cluster/clients.ts
+++ b/ui/app/routes/vault/cluster/clients.ts
@@ -5,7 +5,7 @@
 
 import Route from '@ember/routing/route';
 import { hash } from 'rsvp';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 import type StoreService from 'vault/services/store';
 import type ClientsConfigModel from 'vault/models/clients/config';

--- a/ui/app/routes/vault/cluster/clients/config.js
+++ b/ui/app/routes/vault/cluster/clients/config.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ConfigRoute extends Route {
   @service store;

--- a/ui/app/routes/vault/cluster/clients/counts.ts
+++ b/ui/app/routes/vault/cluster/clients/counts.ts
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import timestamp from 'core/utils/timestamp';
 import { getUnixTime } from 'date-fns';
 

--- a/ui/app/routes/vault/cluster/clients/counts/index.ts
+++ b/ui/app/routes/vault/cluster/clients/counts/index.ts
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 import type RouterService from '@ember/routing/router-service';
 

--- a/ui/app/routes/vault/cluster/clients/edit.js
+++ b/ui/app/routes/vault/cluster/clients/edit.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default Route.extend({
   store: service(),

--- a/ui/app/routes/vault/cluster/clients/index.js
+++ b/ui/app/routes/vault/cluster/clients/index.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ClientsIndexRoute extends Route {
   @service router;

--- a/ui/app/routes/vault/cluster/dashboard.js
+++ b/ui/app/routes/vault/cluster/dashboard.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { hash } from 'rsvp';
 // eslint-disable-next-line ember/no-mixins
 import ClusterRoute from 'vault/mixins/cluster-route';

--- a/ui/app/routes/vault/cluster/license.js
+++ b/ui/app/routes/vault/cluster/license.js
@@ -5,7 +5,7 @@
 
 import Route from '@ember/routing/route';
 import ClusterRoute from 'vault/mixins/cluster-route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default Route.extend(ClusterRoute, {
   store: service(),

--- a/ui/app/routes/vault/cluster/logout.js
+++ b/ui/app/routes/vault/cluster/logout.js
@@ -5,7 +5,7 @@
 
 import Ember from 'ember';
 import { computed } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Route from '@ember/routing/route';
 import ModelBoundaryRoute from 'vault/mixins/model-boundary-route';
 

--- a/ui/app/routes/vault/cluster/oidc-provider.js
+++ b/ui/app/routes/vault/cluster/oidc-provider.js
@@ -5,7 +5,7 @@
 
 import Ember from 'ember';
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 const AUTH = 'vault.cluster.auth';
 const PROVIDER = 'vault.cluster.oidc-provider';

--- a/ui/app/routes/vault/cluster/policies.js
+++ b/ui/app/routes/vault/cluster/policies.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Route from '@ember/routing/route';
 import ClusterRoute from 'vault/mixins/cluster-route';
 

--- a/ui/app/routes/vault/cluster/policies/create.js
+++ b/ui/app/routes/vault/cluster/policies/create.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Route from '@ember/routing/route';
 import UnsavedModelRoute from 'vault/mixins/unsaved-model-route';
 

--- a/ui/app/routes/vault/cluster/policies/index.js
+++ b/ui/app/routes/vault/cluster/policies/index.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Route from '@ember/routing/route';
 import ClusterRoute from 'vault/mixins/cluster-route';
 import ListRoute from 'core/mixins/list-route';

--- a/ui/app/routes/vault/cluster/policy.js
+++ b/ui/app/routes/vault/cluster/policy.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Route from '@ember/routing/route';
 import ClusterRoute from 'vault/mixins/cluster-route';
 

--- a/ui/app/routes/vault/cluster/policy/show.js
+++ b/ui/app/routes/vault/cluster/policy/show.js
@@ -6,7 +6,7 @@
 import { hash } from 'rsvp';
 import Route from '@ember/routing/route';
 import UnloadModelRoute from 'vault/mixins/unload-model-route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default Route.extend(UnloadModelRoute, {
   store: service(),

--- a/ui/app/routes/vault/cluster/redirect.js
+++ b/ui/app/routes/vault/cluster/redirect.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { AUTH, CLUSTER } from 'vault/lib/route-paths';
 
 export default class VaultClusterRedirectRoute extends Route {

--- a/ui/app/routes/vault/cluster/replication-dr-promote/details.js
+++ b/ui/app/routes/vault/cluster/replication-dr-promote/details.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Base from '../cluster-route-base';
 
 export default Base.extend({

--- a/ui/app/routes/vault/cluster/replication-dr-promote/index.js
+++ b/ui/app/routes/vault/cluster/replication-dr-promote/index.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Base from '../cluster-route-base';
 
 export default Base.extend({

--- a/ui/app/routes/vault/cluster/secrets/backend.js
+++ b/ui/app/routes/vault/cluster/secrets/backend.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Route from '@ember/routing/route';
 export default Route.extend({
   store: service(),

--- a/ui/app/routes/vault/cluster/secrets/backend/configuration.js
+++ b/ui/app/routes/vault/cluster/secrets/backend/configuration.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Route from '@ember/routing/route';
 
 export default Route.extend({

--- a/ui/app/routes/vault/cluster/secrets/backend/create-root.js
+++ b/ui/app/routes/vault/cluster/secrets/backend/create-root.js
@@ -4,7 +4,7 @@
  */
 
 import { hash } from 'rsvp';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import EditBase from './secret-edit';
 
 const secretModel = (store, backend, key) => {

--- a/ui/app/routes/vault/cluster/secrets/backend/credentials.js
+++ b/ui/app/routes/vault/cluster/secrets/backend/credentials.js
@@ -5,7 +5,7 @@
 
 import { resolve } from 'rsvp';
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import ControlGroupError from 'vault/lib/control-group-error';
 
 const SUPPORTED_DYNAMIC_BACKENDS = ['database', 'ssh', 'aws'];

--- a/ui/app/routes/vault/cluster/secrets/backend/list.js
+++ b/ui/app/routes/vault/cluster/secrets/backend/list.js
@@ -8,7 +8,7 @@ import { hash } from 'rsvp';
 import Route from '@ember/routing/route';
 import { supportedSecretBackends } from 'vault/helpers/supported-secret-backends';
 import { allEngines, isAddonEngine } from 'vault/helpers/mountable-secret-engines';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { normalizePath } from 'vault/utils/path-encoding-helpers';
 import { assert } from '@ember/debug';
 import { pathIsDirectory } from 'kv/utils/kv-breadcrumbs';

--- a/ui/app/routes/vault/cluster/secrets/backend/overview.js
+++ b/ui/app/routes/vault/cluster/secrets/backend/overview.js
@@ -5,7 +5,7 @@
 
 import Route from '@ember/routing/route';
 import { hash } from 'rsvp';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default Route.extend({
   store: service(),

--- a/ui/app/routes/vault/cluster/secrets/backend/secret-edit.js
+++ b/ui/app/routes/vault/cluster/secrets/backend/secret-edit.js
@@ -6,7 +6,7 @@
 import { set } from '@ember/object';
 import Ember from 'ember';
 import { resolve } from 'rsvp';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Route from '@ember/routing/route';
 import { encodePath, normalizePath } from 'vault/utils/path-encoding-helpers';
 import { keyIsFolder, parentKeyForKey } from 'core/utils/key-utils';

--- a/ui/app/routes/vault/cluster/secrets/backend/sign.js
+++ b/ui/app/routes/vault/cluster/secrets/backend/sign.js
@@ -5,7 +5,7 @@
 
 import Route from '@ember/routing/route';
 import UnloadModel from 'vault/mixins/unload-model-route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default Route.extend(UnloadModel, {
   store: service(),

--- a/ui/app/routes/vault/cluster/secrets/backends.js
+++ b/ui/app/routes/vault/cluster/secrets/backends.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default Route.extend({
   store: service(),

--- a/ui/app/routes/vault/cluster/settings/auth/configure.js
+++ b/ui/app/routes/vault/cluster/settings/auth/configure.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default Route.extend({
   store: service(),

--- a/ui/app/routes/vault/cluster/settings/auth/configure/section.js
+++ b/ui/app/routes/vault/cluster/settings/auth/configure/section.js
@@ -4,7 +4,7 @@
  */
 
 import AdapterError from '@ember-data/adapter/error';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { set } from '@ember/object';
 import Route from '@ember/routing/route';
 import RSVP from 'rsvp';

--- a/ui/app/routes/vault/cluster/settings/auth/enable.js
+++ b/ui/app/routes/vault/cluster/settings/auth/enable.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class VaultClusterSettingsAuthEnableRoute extends Route {
   @service store;

--- a/ui/app/routes/vault/cluster/settings/configure-secret-backend.js
+++ b/ui/app/routes/vault/cluster/settings/configure-secret-backend.js
@@ -6,7 +6,7 @@
 import AdapterError from '@ember-data/adapter/error';
 import { set } from '@ember/object';
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 const CONFIGURABLE_BACKEND_TYPES = ['aws', 'ssh'];
 
 export default Route.extend({

--- a/ui/app/routes/vault/cluster/settings/mount-secret-backend.js
+++ b/ui/app/routes/vault/cluster/settings/mount-secret-backend.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class VaultClusterSettingsMountSecretBackendRoute extends Route {
   @service store;

--- a/ui/app/routes/vault/cluster/settings/seal.js
+++ b/ui/app/routes/vault/cluster/settings/seal.js
@@ -5,7 +5,7 @@
 
 import { hash } from 'rsvp';
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default Route.extend({
   store: service(),

--- a/ui/app/routes/vault/cluster/storage.js
+++ b/ui/app/routes/vault/cluster/storage.js
@@ -5,7 +5,7 @@
 
 import Route from '@ember/routing/route';
 import ClusterRoute from 'vault/mixins/cluster-route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default Route.extend(ClusterRoute, {
   store: service(),

--- a/ui/app/routes/vault/cluster/tools/index.js
+++ b/ui/app/routes/vault/cluster/tools/index.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Route from '@ember/routing/route';
 import { toolsActions } from 'vault/helpers/tools-actions';
 

--- a/ui/lib/config-ui/addon/components/messages/page/create-and-edit-message-form.js
+++ b/ui/lib/config-ui/addon/components/messages/page/create-and-edit-message-form.js
@@ -7,7 +7,7 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { task, timeout } from 'ember-concurrency';
 import errorMessage from 'vault/utils/error-message';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import Ember from 'ember';
 import { isAfter } from 'date-fns';

--- a/ui/lib/config-ui/addon/components/messages/page/details.js
+++ b/ui/lib/config-ui/addon/components/messages/page/details.js
@@ -4,7 +4,7 @@
  */
 
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import errorMessage from 'vault/utils/error-message';
 

--- a/ui/lib/config-ui/addon/components/messages/page/list.js
+++ b/ui/lib/config-ui/addon/components/messages/page/list.js
@@ -4,7 +4,7 @@
  */
 
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { task } from 'ember-concurrency';
 import { dateFormat } from 'core/helpers/date-format';
 import { action } from '@ember/object';

--- a/ui/lib/config-ui/addon/routes/messages/create.js
+++ b/ui/lib/config-ui/addon/routes/messages/create.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class MessagesCreateRoute extends Route {
   @service store;

--- a/ui/lib/config-ui/addon/routes/messages/index.js
+++ b/ui/lib/config-ui/addon/routes/messages/index.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { hash } from 'rsvp';
 
 export default class MessagesRoute extends Route {

--- a/ui/lib/config-ui/addon/routes/messages/message/edit.js
+++ b/ui/lib/config-ui/addon/routes/messages/message/edit.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { hash } from 'rsvp';
 
 export default class MessagesMessageEditRoute extends Route {

--- a/ui/lib/core/addon/components/download-button.js
+++ b/ui/lib/core/addon/components/download-button.js
@@ -5,7 +5,7 @@
 
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import errorMessage from 'vault/utils/error-message';
 import timestamp from 'vault/utils/timestamp';
 import { tracked } from '@glimmer/tracking';

--- a/ui/lib/core/addon/components/edit-form.js
+++ b/ui/lib/core/addon/components/edit-form.js
@@ -4,7 +4,7 @@
  */
 
 import AdapterError from '@ember-data/adapter/error';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@ember/component';
 import { task } from 'ember-concurrency';
 import layout from '../templates/components/edit-form';

--- a/ui/lib/core/addon/components/info-table-item-array.js
+++ b/ui/lib/core/addon/components/info-table-item-array.js
@@ -5,7 +5,7 @@
 
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 
 /**

--- a/ui/lib/core/addon/components/linked-block.js
+++ b/ui/lib/core/addon/components/linked-block.js
@@ -4,7 +4,7 @@
  */
 
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { encodePath } from 'vault/utils/path-encoding-helpers';
 

--- a/ui/lib/core/addon/components/list-item.js
+++ b/ui/lib/core/addon/components/list-item.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@ember/component';
 import { task } from 'ember-concurrency';
 import { computed } from '@ember/object';

--- a/ui/lib/core/addon/components/namespace-reminder.js
+++ b/ui/lib/core/addon/components/namespace-reminder.js
@@ -4,7 +4,7 @@
  */
 
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class NamespaceReminder extends Component {
   @service namespace;

--- a/ui/lib/core/addon/components/navigate-input.js
+++ b/ui/lib/core/addon/components/navigate-input.js
@@ -5,7 +5,7 @@
 
 import Ember from 'ember';
 import { debounce, later } from '@ember/runloop';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { guidFor } from '@ember/object/internals';
 import Component from '@glimmer/component';

--- a/ui/lib/core/addon/components/replication-mode-summary.js
+++ b/ui/lib/core/addon/components/replication-mode-summary.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { equal } from '@ember/object/computed';
 import { get, computed } from '@ember/object';
 import Component from '@ember/component';

--- a/ui/lib/core/addon/components/replication-page.js
+++ b/ui/lib/core/addon/components/replication-page.js
@@ -6,7 +6,7 @@
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 import layout from '../templates/components/replication-page';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { task } from 'ember-concurrency';
 
 /**

--- a/ui/lib/core/addon/components/search-select-with-modal.js
+++ b/ui/lib/core/addon/components/search-select-with-modal.js
@@ -4,7 +4,7 @@
  */
 
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { task } from 'ember-concurrency';

--- a/ui/lib/core/addon/components/search-select.js
+++ b/ui/lib/core/addon/components/search-select.js
@@ -4,7 +4,7 @@
  */
 
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { task } from 'ember-concurrency';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';

--- a/ui/lib/core/addon/components/secret-list-header-tab.js
+++ b/ui/lib/core/addon/components/secret-list-header-tab.js
@@ -24,7 +24,7 @@
  */
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class SecretListHeaderTab extends Component {
   @service store;

--- a/ui/lib/core/addon/decorators/confirm-leave.js
+++ b/ui/lib/core/addon/decorators/confirm-leave.js
@@ -5,7 +5,7 @@
 
 import { action } from '@ember/object';
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Ember from 'ember';
 
 /**

--- a/ui/lib/core/addon/helpers/has-feature.js
+++ b/ui/lib/core/addon/helpers/has-feature.js
@@ -4,7 +4,7 @@
  */
 
 /* eslint-disable ember/no-observers */
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { assert } from '@ember/debug';
 import Helper from '@ember/component/helper';
 import { observer } from '@ember/object';

--- a/ui/lib/core/addon/helpers/is-active-route.js
+++ b/ui/lib/core/addon/helpers/is-active-route.js
@@ -4,7 +4,7 @@
  */
 
 /* eslint-disable ember/no-observers */
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { isArray } from '@ember/array';
 import Helper from '@ember/component/helper';
 import { observer } from '@ember/object';

--- a/ui/lib/core/addon/helpers/set-flash-message.js
+++ b/ui/lib/core/addon/helpers/set-flash-message.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Helper from '@ember/component/helper';
 
 export default Helper.extend({

--- a/ui/lib/core/addon/mixins/replication-actions.js
+++ b/ui/lib/core/addon/mixins/replication-actions.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { or } from '@ember/object/computed';
 import { isPresent } from '@ember/utils';
 import Mixin from '@ember/object/mixin';

--- a/ui/lib/kmip/addon/components/header-scope.js
+++ b/ui/lib/kmip/addon/components/header-scope.js
@@ -4,7 +4,7 @@
  */
 
 import Component from '@ember/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import layout from '../templates/components/header-scope';
 
 export default Component.extend({

--- a/ui/lib/kmip/addon/components/kmip-breadcrumb.js
+++ b/ui/lib/kmip/addon/components/kmip-breadcrumb.js
@@ -4,7 +4,7 @@
  */
 
 import Component from '@ember/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import layout from '../templates/components/kmip-breadcrumb';
 import { or } from '@ember/object/computed';
 

--- a/ui/lib/kmip/addon/controllers/credentials/show.js
+++ b/ui/lib/kmip/addon/controllers/credentials/show.js
@@ -4,7 +4,7 @@
  */
 
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 
 export default class CredentialsShowController extends Controller {

--- a/ui/lib/kmip/addon/controllers/role.js
+++ b/ui/lib/kmip/addon/controllers/role.js
@@ -4,7 +4,7 @@
  */
 
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 
 export default class RoleController extends Controller {

--- a/ui/lib/kmip/addon/routes/configuration.js
+++ b/ui/lib/kmip/addon/routes/configuration.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import UnloadModel from 'vault/mixins/unload-model-route';
 
 export default Route.extend(UnloadModel, {

--- a/ui/lib/kmip/addon/routes/configure.js
+++ b/ui/lib/kmip/addon/routes/configure.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default Route.extend({
   store: service(),

--- a/ui/lib/kmip/addon/routes/credentials/generate.js
+++ b/ui/lib/kmip/addon/routes/credentials/generate.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default Route.extend({
   store: service(),

--- a/ui/lib/kmip/addon/routes/credentials/index.js
+++ b/ui/lib/kmip/addon/routes/credentials/index.js
@@ -5,7 +5,7 @@
 
 import Route from '@ember/routing/route';
 import ListRoute from 'core/mixins/list-route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default Route.extend(ListRoute, {
   store: service(),

--- a/ui/lib/kmip/addon/routes/credentials/show.js
+++ b/ui/lib/kmip/addon/routes/credentials/show.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default Route.extend({
   store: service(),

--- a/ui/lib/kmip/addon/routes/role.js
+++ b/ui/lib/kmip/addon/routes/role.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class KmipRoleRoute extends Route {
   @service store;

--- a/ui/lib/kmip/addon/routes/role/edit.js
+++ b/ui/lib/kmip/addon/routes/role/edit.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default Route.extend({
   store: service(),

--- a/ui/lib/kmip/addon/routes/scope/roles.js
+++ b/ui/lib/kmip/addon/routes/scope/roles.js
@@ -5,7 +5,7 @@
 
 import Route from '@ember/routing/route';
 import ListRoute from 'core/mixins/list-route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default Route.extend(ListRoute, {
   store: service(),

--- a/ui/lib/kmip/addon/routes/scope/roles/create.js
+++ b/ui/lib/kmip/addon/routes/scope/roles/create.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default Route.extend({
   store: service(),

--- a/ui/lib/kmip/addon/routes/scopes/create.js
+++ b/ui/lib/kmip/addon/routes/scopes/create.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default Route.extend({
   store: service(),

--- a/ui/lib/kmip/addon/routes/scopes/index.js
+++ b/ui/lib/kmip/addon/routes/scopes/index.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import ListRoute from 'core/mixins/list-route';
 
 export default Route.extend(ListRoute, {

--- a/ui/lib/kubernetes/addon/components/page/configure.js
+++ b/ui/lib/kubernetes/addon/components/page/configure.js
@@ -4,7 +4,7 @@
  */
 
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { task } from 'ember-concurrency';

--- a/ui/lib/kubernetes/addon/components/page/credentials.js
+++ b/ui/lib/kubernetes/addon/components/page/credentials.js
@@ -4,7 +4,7 @@
  */
 
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { task } from 'ember-concurrency';

--- a/ui/lib/kubernetes/addon/components/page/overview.js
+++ b/ui/lib/kubernetes/addon/components/page/overview.js
@@ -4,7 +4,7 @@
  */
 
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 

--- a/ui/lib/kubernetes/addon/components/page/role/create-and-edit.js
+++ b/ui/lib/kubernetes/addon/components/page/role/create-and-edit.js
@@ -4,7 +4,7 @@
  */
 
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { task } from 'ember-concurrency';

--- a/ui/lib/kubernetes/addon/components/page/role/details.js
+++ b/ui/lib/kubernetes/addon/components/page/role/details.js
@@ -5,7 +5,7 @@
 
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import errorMessage from 'vault/utils/error-message';
 
 /**

--- a/ui/lib/kubernetes/addon/components/page/roles.js
+++ b/ui/lib/kubernetes/addon/components/page/roles.js
@@ -4,7 +4,7 @@
  */
 
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { getOwner } from '@ember/application';
 import errorMessage from 'vault/utils/error-message';

--- a/ui/lib/kubernetes/addon/routes/configuration.js
+++ b/ui/lib/kubernetes/addon/routes/configuration.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { withConfig } from 'core/decorators/fetch-secrets-engine-config';
 
 @withConfig('kubernetes/config')

--- a/ui/lib/kubernetes/addon/routes/configure.js
+++ b/ui/lib/kubernetes/addon/routes/configure.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { withConfig } from 'core/decorators/fetch-secrets-engine-config';
 
 @withConfig('kubernetes/config')

--- a/ui/lib/kubernetes/addon/routes/error.js
+++ b/ui/lib/kubernetes/addon/routes/error.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class KubernetesErrorRoute extends Route {
   @service secretMountPath;

--- a/ui/lib/kubernetes/addon/routes/index.js
+++ b/ui/lib/kubernetes/addon/routes/index.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class KubernetesRoute extends Route {
   @service router;

--- a/ui/lib/kubernetes/addon/routes/overview.js
+++ b/ui/lib/kubernetes/addon/routes/overview.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { withConfig } from 'core/decorators/fetch-secrets-engine-config';
 import { hash } from 'rsvp';
 

--- a/ui/lib/kubernetes/addon/routes/roles/create.js
+++ b/ui/lib/kubernetes/addon/routes/roles/create.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class KubernetesRolesCreateRoute extends Route {
   @service store;

--- a/ui/lib/kubernetes/addon/routes/roles/index.js
+++ b/ui/lib/kubernetes/addon/routes/roles/index.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { withConfig } from 'core/decorators/fetch-secrets-engine-config';
 import { hash } from 'rsvp';
 

--- a/ui/lib/kubernetes/addon/routes/roles/role/credentials.js
+++ b/ui/lib/kubernetes/addon/routes/roles/role/credentials.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 export default class KubernetesRoleCredentialsRoute extends Route {
   @service secretMountPath;
 

--- a/ui/lib/kubernetes/addon/routes/roles/role/details.js
+++ b/ui/lib/kubernetes/addon/routes/roles/role/details.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class KubernetesRoleDetailsRoute extends Route {
   @service store;

--- a/ui/lib/kubernetes/addon/routes/roles/role/edit.js
+++ b/ui/lib/kubernetes/addon/routes/roles/role/edit.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class KubernetesRoleEditRoute extends Route {
   @service store;

--- a/ui/lib/kubernetes/addon/routes/roles/role/index.js
+++ b/ui/lib/kubernetes/addon/routes/roles/role/index.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class KubernetesRoleRoute extends Route {
   @service router;

--- a/ui/lib/kv/addon/components/kv-list-filter.js
+++ b/ui/lib/kv/addon/components/kv-list-filter.js
@@ -5,7 +5,7 @@
 
 import Ember from 'ember';
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import keys from 'core/utils/key-codes';
 import { keyIsFolder, parentKeyForKey, keyWithoutParentKey } from 'core/utils/key-utils';

--- a/ui/lib/kv/addon/components/page/list.js
+++ b/ui/lib/kv/addon/components/page/list.js
@@ -4,7 +4,7 @@
  */
 
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { getOwner } from '@ember/application';

--- a/ui/lib/kv/addon/components/page/secret/details.js
+++ b/ui/lib/kv/addon/components/page/secret/details.js
@@ -7,7 +7,7 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { next } from '@ember/runloop';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { task } from 'ember-concurrency';
 import { waitFor } from '@ember/test-waiters';
 import { isDeleted } from 'kv/utils/kv-deleted';

--- a/ui/lib/kv/addon/components/page/secret/edit.js
+++ b/ui/lib/kv/addon/components/page/secret/edit.js
@@ -7,7 +7,7 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { task } from 'ember-concurrency';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import errorMessage from 'vault/utils/error-message';
 import { isAdvancedSecret } from 'core/utils/advanced-secret';
 

--- a/ui/lib/kv/addon/components/page/secret/metadata/details.js
+++ b/ui/lib/kv/addon/components/page/secret/metadata/details.js
@@ -5,7 +5,7 @@
 
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 /**
  * @module KvSecretMetadataDetails renders the details view for kv/metadata.

--- a/ui/lib/kv/addon/components/page/secret/metadata/edit.js
+++ b/ui/lib/kv/addon/components/page/secret/metadata/edit.js
@@ -4,7 +4,7 @@
  */
 
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { task } from 'ember-concurrency';
 import { tracked } from '@glimmer/tracking';
 import errorMessage from 'vault/utils/error-message';

--- a/ui/lib/kv/addon/components/page/secret/metadata/version-diff.js
+++ b/ui/lib/kv/addon/components/page/secret/metadata/version-diff.js
@@ -5,7 +5,7 @@
 
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { kvDataPath } from 'vault/utils/kv-path';
 

--- a/ui/lib/kv/addon/components/page/secret/paths.js
+++ b/ui/lib/kv/addon/components/page/secret/paths.js
@@ -4,7 +4,7 @@
  */
 
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { kvMetadataPath, kvDataPath } from 'vault/utils/kv-path';
 import { encodePath } from 'vault/utils/path-encoding-helpers';
 

--- a/ui/lib/kv/addon/components/page/secrets/create.js
+++ b/ui/lib/kv/addon/components/page/secrets/create.js
@@ -7,7 +7,7 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { task } from 'ember-concurrency';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { pathIsFromDirectory } from 'kv/utils/kv-breadcrumbs';
 import errorMessage from 'vault/utils/error-message';
 

--- a/ui/lib/kv/addon/routes/configuration.js
+++ b/ui/lib/kv/addon/routes/configuration.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { hash } from 'rsvp';
 
 export default class KvConfigurationRoute extends Route {

--- a/ui/lib/kv/addon/routes/create.js
+++ b/ui/lib/kv/addon/routes/create.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { hash } from 'rsvp';
 import { withConfirmLeave } from 'core/decorators/confirm-leave';
 import { breadcrumbsForSecret } from 'kv/utils/kv-breadcrumbs';

--- a/ui/lib/kv/addon/routes/error.js
+++ b/ui/lib/kv/addon/routes/error.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class KvErrorRoute extends Route {
   @service secretMountPath;

--- a/ui/lib/kv/addon/routes/index.js
+++ b/ui/lib/kv/addon/routes/index.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class KvRoute extends Route {
   @service router;

--- a/ui/lib/kv/addon/routes/list-directory.js
+++ b/ui/lib/kv/addon/routes/list-directory.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { hash } from 'rsvp';
 import { normalizePath } from 'vault/utils/path-encoding-helpers';
 import { breadcrumbsForSecret } from 'kv/utils/kv-breadcrumbs';

--- a/ui/lib/kv/addon/routes/secret.js
+++ b/ui/lib/kv/addon/routes/secret.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { hash } from 'rsvp';
 import { action } from '@ember/object';
 

--- a/ui/lib/kv/addon/routes/secret/details.js
+++ b/ui/lib/kv/addon/routes/secret/details.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { hash } from 'rsvp';
 
 export default class KvSecretDetailsRoute extends Route {

--- a/ui/lib/kv/addon/routes/secret/details/edit.js
+++ b/ui/lib/kv/addon/routes/secret/details/edit.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { hash } from 'rsvp';
 import { withConfirmLeave } from 'core/decorators/confirm-leave';
 import { breadcrumbsForSecret } from 'kv/utils/kv-breadcrumbs';

--- a/ui/lib/kv/addon/routes/secret/index.js
+++ b/ui/lib/kv/addon/routes/secret/index.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class SecretIndex extends Route {
   @service router;

--- a/ui/lib/ldap/addon/components/accounts-checked-out.ts
+++ b/ui/lib/ldap/addon/components/accounts-checked-out.ts
@@ -5,7 +5,7 @@
 
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { task } from 'ember-concurrency';
 import { waitFor } from '@ember/test-waiters';
 import errorMessage from 'vault/utils/error-message';

--- a/ui/lib/ldap/addon/components/page/configuration.ts
+++ b/ui/lib/ldap/addon/components/page/configuration.ts
@@ -4,7 +4,7 @@
  */
 
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { task } from 'ember-concurrency';
 import { waitFor } from '@ember/test-waiters';
 import errorMessage from 'vault/utils/error-message';

--- a/ui/lib/ldap/addon/components/page/configure.ts
+++ b/ui/lib/ldap/addon/components/page/configure.ts
@@ -6,7 +6,7 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { task } from 'ember-concurrency';
 import { waitFor } from '@ember/test-waiters';
 import errorMessage from 'vault/utils/error-message';

--- a/ui/lib/ldap/addon/components/page/libraries.ts
+++ b/ui/lib/ldap/addon/components/page/libraries.ts
@@ -5,7 +5,7 @@
 
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { getOwner } from '@ember/application';
 import errorMessage from 'vault/utils/error-message';

--- a/ui/lib/ldap/addon/components/page/library/create-and-edit.ts
+++ b/ui/lib/ldap/addon/components/page/library/create-and-edit.ts
@@ -6,7 +6,7 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { task } from 'ember-concurrency';
 import { waitFor } from '@ember/test-waiters';
 import errorMessage from 'vault/utils/error-message';

--- a/ui/lib/ldap/addon/components/page/library/details.ts
+++ b/ui/lib/ldap/addon/components/page/library/details.ts
@@ -5,7 +5,7 @@
 
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import errorMessage from 'vault/utils/error-message';
 
 import type LdapLibraryModel from 'vault/models/ldap/library';

--- a/ui/lib/ldap/addon/components/page/library/details/accounts.ts
+++ b/ui/lib/ldap/addon/components/page/library/details/accounts.ts
@@ -5,7 +5,7 @@
 
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 
 import type FlashMessageService from 'vault/services/flash-messages';

--- a/ui/lib/ldap/addon/components/page/overview.ts
+++ b/ui/lib/ldap/addon/components/page/overview.ts
@@ -5,7 +5,7 @@
 
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 
 import type LdapLibraryModel from 'vault/models/ldap/library';

--- a/ui/lib/ldap/addon/components/page/role/create-and-edit.ts
+++ b/ui/lib/ldap/addon/components/page/role/create-and-edit.ts
@@ -6,7 +6,7 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { task } from 'ember-concurrency';
 import { waitFor } from '@ember/test-waiters';
 import errorMessage from 'vault/utils/error-message';

--- a/ui/lib/ldap/addon/components/page/role/details.ts
+++ b/ui/lib/ldap/addon/components/page/role/details.ts
@@ -5,7 +5,7 @@
 
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import errorMessage from 'vault/utils/error-message';
 import { task } from 'ember-concurrency';
 import { waitFor } from '@ember/test-waiters';

--- a/ui/lib/ldap/addon/components/page/roles.ts
+++ b/ui/lib/ldap/addon/components/page/roles.ts
@@ -4,7 +4,7 @@
  */
 
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { getOwner } from '@ember/application';
 import errorMessage from 'vault/utils/error-message';

--- a/ui/lib/ldap/addon/routes/configuration.ts
+++ b/ui/lib/ldap/addon/routes/configuration.ts
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { withConfig } from 'core/decorators/fetch-secrets-engine-config';
 
 import type Store from '@ember-data/store';

--- a/ui/lib/ldap/addon/routes/configure.ts
+++ b/ui/lib/ldap/addon/routes/configure.ts
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { withConfig } from 'core/decorators/fetch-secrets-engine-config';
 
 import type Store from '@ember-data/store';

--- a/ui/lib/ldap/addon/routes/error.ts
+++ b/ui/lib/ldap/addon/routes/error.ts
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 import type Transition from '@ember/routing/transition';
 import type AdapterError from 'ember-data/adapter'; // eslint-disable-line ember/use-ember-data-rfc-395-imports

--- a/ui/lib/ldap/addon/routes/libraries/create.ts
+++ b/ui/lib/ldap/addon/routes/libraries/create.ts
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 import type Store from '@ember-data/store';
 import type SecretMountPath from 'vault/services/secret-mount-path';

--- a/ui/lib/ldap/addon/routes/libraries/index.ts
+++ b/ui/lib/ldap/addon/routes/libraries/index.ts
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { withConfig } from 'core/decorators/fetch-secrets-engine-config';
 import { hash } from 'rsvp';
 

--- a/ui/lib/ldap/addon/routes/libraries/library.ts
+++ b/ui/lib/ldap/addon/routes/libraries/library.ts
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 import type Store from '@ember-data/store';
 import type SecretMountPath from 'vault/services/secret-mount-path';

--- a/ui/lib/ldap/addon/routes/libraries/library/check-out.ts
+++ b/ui/lib/ldap/addon/routes/libraries/library/check-out.ts
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import errorMessage from 'vault/utils/error-message';
 

--- a/ui/lib/ldap/addon/routes/libraries/library/details/index.ts
+++ b/ui/lib/ldap/addon/routes/libraries/library/details/index.ts
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 import type RouterService from '@ember/routing/router-service';
 

--- a/ui/lib/ldap/addon/routes/libraries/library/index.ts
+++ b/ui/lib/ldap/addon/routes/libraries/library/index.ts
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 import type RouterService from '@ember/routing/router-service';
 

--- a/ui/lib/ldap/addon/routes/overview.ts
+++ b/ui/lib/ldap/addon/routes/overview.ts
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { withConfig } from 'core/decorators/fetch-secrets-engine-config';
 import { hash } from 'rsvp';
 

--- a/ui/lib/ldap/addon/routes/roles/create.ts
+++ b/ui/lib/ldap/addon/routes/roles/create.ts
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 import type Store from '@ember-data/store';
 import type SecretMountPath from 'vault/services/secret-mount-path';

--- a/ui/lib/ldap/addon/routes/roles/index.ts
+++ b/ui/lib/ldap/addon/routes/roles/index.ts
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { withConfig } from 'core/decorators/fetch-secrets-engine-config';
 import { hash } from 'rsvp';
 

--- a/ui/lib/ldap/addon/routes/roles/role.ts
+++ b/ui/lib/ldap/addon/routes/roles/role.ts
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 import type Store from '@ember-data/store';
 import type SecretMountPath from 'vault/services/secret-mount-path';

--- a/ui/lib/ldap/addon/routes/roles/role/credentials.ts
+++ b/ui/lib/ldap/addon/routes/roles/role/credentials.ts
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 import type Store from '@ember-data/store';
 import type LdapRoleModel from 'vault/models/ldap/role';

--- a/ui/lib/ldap/addon/routes/roles/role/index.ts
+++ b/ui/lib/ldap/addon/routes/roles/role/index.ts
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 import type RouterService from '@ember/routing/router-service';
 

--- a/ui/lib/open-api-explorer/addon/components/swagger-ui.js
+++ b/ui/lib/open-api-explorer/addon/components/swagger-ui.js
@@ -4,7 +4,7 @@
  */
 
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import parseURL from 'core/utils/parse-url';

--- a/ui/lib/open-api-explorer/addon/routes/index.js
+++ b/ui/lib/open-api-explorer/addon/routes/index.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class OpenApiExplorerIndex extends Route {
   @service flashMessages;

--- a/ui/lib/pki/addon/components/page/pki-configuration-details.ts
+++ b/ui/lib/pki/addon/components/page/pki-configuration-details.ts
@@ -4,7 +4,7 @@
  */
 
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import errorMessage from 'vault/utils/error-message';

--- a/ui/lib/pki/addon/components/page/pki-configuration-edit.ts
+++ b/ui/lib/pki/addon/components/page/pki-configuration-edit.ts
@@ -5,7 +5,7 @@
 
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { task } from 'ember-concurrency';
 import { waitFor } from '@ember/test-waiters';

--- a/ui/lib/pki/addon/components/page/pki-configure-create.ts
+++ b/ui/lib/pki/addon/components/page/pki-configure-create.ts
@@ -4,7 +4,7 @@
  */
 
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import type Store from '@ember-data/store';
 import type Router from '@ember/routing/router';

--- a/ui/lib/pki/addon/components/page/pki-issuer-edit.ts
+++ b/ui/lib/pki/addon/components/page/pki-issuer-edit.ts
@@ -5,7 +5,7 @@
 
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { task } from 'ember-concurrency';
 import { waitFor } from '@ember/test-waiters';

--- a/ui/lib/pki/addon/components/page/pki-issuer-rotate-root.ts
+++ b/ui/lib/pki/addon/components/page/pki-issuer-rotate-root.ts
@@ -4,7 +4,7 @@
  */
 
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { waitFor } from '@ember/test-waiters';

--- a/ui/lib/pki/addon/components/page/pki-key-details.ts
+++ b/ui/lib/pki/addon/components/page/pki-key-details.ts
@@ -5,7 +5,7 @@
 
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import errorMessage from 'vault/utils/error-message';
 import type RouterService from '@ember/routing/router-service';
 import type FlashMessageService from 'vault/services/flash-messages';

--- a/ui/lib/pki/addon/components/page/pki-overview.ts
+++ b/ui/lib/pki/addon/components/page/pki-overview.ts
@@ -6,7 +6,7 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import type Store from '@ember-data/store';
 import type RouterService from '@ember/routing/router-service';
 import type PkiIssuerModel from 'vault/models/pki/issuer';

--- a/ui/lib/pki/addon/components/page/pki-role-details.ts
+++ b/ui/lib/pki/addon/components/page/pki-role-details.ts
@@ -5,7 +5,7 @@
 
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import errorMessage from 'vault/utils/error-message';
 import type SecretMountPath from 'vault/services/secret-mount-path';
 import type FlashMessageService from 'vault/services/flash-messages';

--- a/ui/lib/pki/addon/components/page/pki-tidy-status.ts
+++ b/ui/lib/pki/addon/components/page/pki-tidy-status.ts
@@ -5,7 +5,7 @@
 
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { task } from 'ember-concurrency';
 import { waitFor } from '@ember/test-waiters';
 import errorMessage from 'vault/utils/error-message';

--- a/ui/lib/pki/addon/components/pki-generate-csr.ts
+++ b/ui/lib/pki/addon/components/pki-generate-csr.ts
@@ -5,7 +5,7 @@
 
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { task } from 'ember-concurrency';
 import { waitFor } from '@ember/test-waiters';

--- a/ui/lib/pki/addon/components/pki-import-pem-bundle.ts
+++ b/ui/lib/pki/addon/components/pki-import-pem-bundle.ts
@@ -5,7 +5,7 @@
 
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { task } from 'ember-concurrency';
 import { tracked } from '@glimmer/tracking';
 import { waitFor } from '@ember/test-waiters';

--- a/ui/lib/pki/addon/components/pki-issuer-cross-sign.js
+++ b/ui/lib/pki/addon/components/pki-issuer-cross-sign.js
@@ -6,7 +6,7 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { task } from 'ember-concurrency';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import errorMessage from 'vault/utils/error-message';
 import { waitFor } from '@ember/test-waiters';

--- a/ui/lib/pki/addon/components/pki-key-form.ts
+++ b/ui/lib/pki/addon/components/pki-key-form.ts
@@ -4,7 +4,7 @@
  */
 
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { task } from 'ember-concurrency';
 import { tracked } from '@glimmer/tracking';
 import { waitFor } from '@ember/test-waiters';

--- a/ui/lib/pki/addon/components/pki-key-import.ts
+++ b/ui/lib/pki/addon/components/pki-key-import.ts
@@ -8,7 +8,7 @@ import { action } from '@ember/object';
 import { task } from 'ember-concurrency';
 import { tracked } from '@glimmer/tracking';
 import { waitFor } from '@ember/test-waiters';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import trimRight from 'vault/utils/trim-right';
 import errorMessage from 'vault/utils/error-message';
 import type PkiKeyModel from 'vault/models/pki/key';

--- a/ui/lib/pki/addon/components/pki-role-form.ts
+++ b/ui/lib/pki/addon/components/pki-role-form.ts
@@ -4,7 +4,7 @@
  */
 
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { task } from 'ember-concurrency';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';

--- a/ui/lib/pki/addon/components/pki-tidy-form.ts
+++ b/ui/lib/pki/addon/components/pki-tidy-form.ts
@@ -6,7 +6,7 @@
 import Component from '@glimmer/component';
 import errorMessage from 'vault/utils/error-message';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { task } from 'ember-concurrency';
 import { waitFor } from '@ember/test-waiters';
 import { tracked } from '@glimmer/tracking';

--- a/ui/lib/pki/addon/controllers/tidy/index.js
+++ b/ui/lib/pki/addon/controllers/tidy/index.js
@@ -6,7 +6,7 @@ import Ember from 'ember';
 import Controller from '@ember/controller';
 import { task, timeout } from 'ember-concurrency';
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 const POLL_INTERVAL_MS = 5000;
 

--- a/ui/lib/pki/addon/decorators/check-issuers.js
+++ b/ui/lib/pki/addon/decorators/check-issuers.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 /**
  * the overview, roles, issuers, certificates, and key routes all need to be aware of the whether there is a config for the engine

--- a/ui/lib/pki/addon/routes/application.js
+++ b/ui/lib/pki/addon/routes/application.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { hash } from 'rsvp';
 
 export default class PkiRoute extends Route {

--- a/ui/lib/pki/addon/routes/certificates/certificate/details.js
+++ b/ui/lib/pki/addon/routes/certificates/certificate/details.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class PkiCertificateDetailsRoute extends Route {
   @service store;

--- a/ui/lib/pki/addon/routes/certificates/index.js
+++ b/ui/lib/pki/addon/routes/certificates/index.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { withConfig } from 'pki/decorators/check-issuers';
 import { hash } from 'rsvp';
 import { getCliMessage } from 'pki/routes/overview';

--- a/ui/lib/pki/addon/routes/configuration.js
+++ b/ui/lib/pki/addon/routes/configuration.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { hash } from 'rsvp';
 
 export default class PkiConfigurationRoute extends Route {

--- a/ui/lib/pki/addon/routes/configuration/create.js
+++ b/ui/lib/pki/addon/routes/configuration/create.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { withConfirmLeave } from 'core/decorators/confirm-leave';
 import { hash } from 'rsvp';
 

--- a/ui/lib/pki/addon/routes/configuration/edit.js
+++ b/ui/lib/pki/addon/routes/configuration/edit.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { withConfirmLeave } from 'core/decorators/confirm-leave';
 
 @withConfirmLeave('model.config', ['model.urls', 'model.crl'])

--- a/ui/lib/pki/addon/routes/configuration/index.js
+++ b/ui/lib/pki/addon/routes/configuration/index.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { withConfig } from 'pki/decorators/check-issuers';
 import { hash } from 'rsvp';
 import { PKI_DEFAULT_EMPTY_STATE_MSG } from 'pki/routes/overview';

--- a/ui/lib/pki/addon/routes/error.js
+++ b/ui/lib/pki/addon/routes/error.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class PkiRolesErrorRoute extends Route {
   @service secretMountPath;

--- a/ui/lib/pki/addon/routes/index.js
+++ b/ui/lib/pki/addon/routes/index.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class PkiRoute extends Route {
   @service router;

--- a/ui/lib/pki/addon/routes/issuers/generate-intermediate.js
+++ b/ui/lib/pki/addon/routes/issuers/generate-intermediate.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { withConfirmLeave } from 'core/decorators/confirm-leave';
 
 @withConfirmLeave()

--- a/ui/lib/pki/addon/routes/issuers/generate-root.js
+++ b/ui/lib/pki/addon/routes/issuers/generate-root.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { withConfirmLeave } from 'core/decorators/confirm-leave';
 
 @withConfirmLeave()

--- a/ui/lib/pki/addon/routes/issuers/import.js
+++ b/ui/lib/pki/addon/routes/issuers/import.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { withConfirmLeave } from 'core/decorators/confirm-leave';
 
 @withConfirmLeave()

--- a/ui/lib/pki/addon/routes/issuers/index.js
+++ b/ui/lib/pki/addon/routes/issuers/index.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class PkiIssuersListRoute extends Route {
   @service store;

--- a/ui/lib/pki/addon/routes/issuers/issuer.js
+++ b/ui/lib/pki/addon/routes/issuers/issuer.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class PkiIssuerIndexRoute extends Route {
   @service store;

--- a/ui/lib/pki/addon/routes/issuers/issuer/cross-sign.js
+++ b/ui/lib/pki/addon/routes/issuers/issuer/cross-sign.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { withConfirmLeave } from 'core/decorators/confirm-leave';
 
 @withConfirmLeave()

--- a/ui/lib/pki/addon/routes/issuers/issuer/details.js
+++ b/ui/lib/pki/addon/routes/issuers/issuer/details.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { verifyCertificates } from 'vault/utils/parse-pki-cert';
 import { hash } from 'rsvp';
 

--- a/ui/lib/pki/addon/routes/issuers/issuer/edit.js
+++ b/ui/lib/pki/addon/routes/issuers/issuer/edit.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { withConfirmLeave } from 'core/decorators/confirm-leave';
 
 @withConfirmLeave()

--- a/ui/lib/pki/addon/routes/issuers/issuer/rotate-root.js
+++ b/ui/lib/pki/addon/routes/issuers/issuer/rotate-root.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { hash } from 'rsvp';
 import { parseCertificate } from 'vault/utils/parse-pki-cert';
 import camelizeKeys from 'vault/utils/camelize-object-keys';

--- a/ui/lib/pki/addon/routes/keys/create.js
+++ b/ui/lib/pki/addon/routes/keys/create.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { withConfirmLeave } from 'core/decorators/confirm-leave';
 
 @withConfirmLeave()

--- a/ui/lib/pki/addon/routes/keys/import.js
+++ b/ui/lib/pki/addon/routes/keys/import.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { withConfirmLeave } from 'core/decorators/confirm-leave';
 
 @withConfirmLeave()

--- a/ui/lib/pki/addon/routes/keys/index.js
+++ b/ui/lib/pki/addon/routes/keys/index.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { withConfig } from 'pki/decorators/check-issuers';
 import { hash } from 'rsvp';
 import { PKI_DEFAULT_EMPTY_STATE_MSG } from 'pki/routes/overview';

--- a/ui/lib/pki/addon/routes/keys/key.js
+++ b/ui/lib/pki/addon/routes/keys/key.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class PkiKeyRoute extends Route {
   @service secretMountPath;

--- a/ui/lib/pki/addon/routes/keys/key/details.js
+++ b/ui/lib/pki/addon/routes/keys/key/details.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class PkiKeyDetailsRoute extends Route {
   @service secretMountPath;

--- a/ui/lib/pki/addon/routes/keys/key/edit.js
+++ b/ui/lib/pki/addon/routes/keys/key/edit.js
@@ -5,7 +5,7 @@
 
 import { withConfirmLeave } from 'core/decorators/confirm-leave';
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 @withConfirmLeave()
 export default class PkiKeyEditRoute extends Route {

--- a/ui/lib/pki/addon/routes/overview.js
+++ b/ui/lib/pki/addon/routes/overview.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { withConfig } from 'pki/decorators/check-issuers';
 import { hash } from 'rsvp';
 

--- a/ui/lib/pki/addon/routes/roles/create.js
+++ b/ui/lib/pki/addon/routes/roles/create.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { withConfirmLeave } from 'core/decorators/confirm-leave';
 import { hash } from 'rsvp';
 

--- a/ui/lib/pki/addon/routes/roles/index.js
+++ b/ui/lib/pki/addon/routes/roles/index.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { withConfig } from 'pki/decorators/check-issuers';
 import { hash } from 'rsvp';
 import { getCliMessage } from 'pki/routes/overview';

--- a/ui/lib/pki/addon/routes/roles/role/details.js
+++ b/ui/lib/pki/addon/routes/roles/role/details.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class RolesRoleDetailsRoute extends Route {
   @service store;

--- a/ui/lib/pki/addon/routes/roles/role/edit.js
+++ b/ui/lib/pki/addon/routes/roles/role/edit.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { withConfirmLeave } from 'core/decorators/confirm-leave';
 import { hash } from 'rsvp';
 

--- a/ui/lib/pki/addon/routes/roles/role/generate.js
+++ b/ui/lib/pki/addon/routes/roles/role/generate.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { withConfirmLeave } from 'core/decorators/confirm-leave';
 
 withConfirmLeave();

--- a/ui/lib/pki/addon/routes/roles/role/sign.js
+++ b/ui/lib/pki/addon/routes/roles/role/sign.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { withConfirmLeave } from 'core/decorators/confirm-leave';
 
 withConfirmLeave();

--- a/ui/lib/pki/addon/routes/tidy.js
+++ b/ui/lib/pki/addon/routes/tidy.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { withConfig } from 'pki/decorators/check-issuers';
 import { hash } from 'rsvp';
 

--- a/ui/lib/pki/addon/routes/tidy/auto/configure.js
+++ b/ui/lib/pki/addon/routes/tidy/auto/configure.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { withConfirmLeave } from 'core/decorators/confirm-leave';
 
 @withConfirmLeave()

--- a/ui/lib/pki/addon/routes/tidy/index.js
+++ b/ui/lib/pki/addon/routes/tidy/index.js
@@ -6,7 +6,7 @@
 import Route from '@ember/routing/route';
 import { PKI_DEFAULT_EMPTY_STATE_MSG } from '../overview';
 import { hash } from 'rsvp';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import timestamp from 'core/utils/timestamp';
 
 export default class PkiTidyIndexRoute extends Route {

--- a/ui/lib/pki/addon/routes/tidy/manual.js
+++ b/ui/lib/pki/addon/routes/tidy/manual.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { withConfirmLeave } from 'core/decorators/confirm-leave';
 
 @withConfirmLeave()

--- a/ui/lib/replication/addon/components/path-filter-config-list.js
+++ b/ui/lib/replication/addon/components/path-filter-config-list.js
@@ -5,7 +5,7 @@
 
 import Component from '@ember/component';
 import { set, computed } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { readOnly } from '@ember/object/computed';
 import { task, timeout } from 'ember-concurrency';
 

--- a/ui/lib/replication/addon/components/replication-summary.js
+++ b/ui/lib/replication/addon/components/replication-summary.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { alias } from '@ember/object/computed';
 import { computed } from '@ember/object';
 import Component from '@ember/component';

--- a/ui/lib/replication/addon/controllers/application.js
+++ b/ui/lib/replication/addon/controllers/application.js
@@ -5,7 +5,7 @@
 
 import { isPresent } from '@ember/utils';
 import { alias } from '@ember/object/computed';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Controller from '@ember/controller';
 import { copy } from 'ember-copy';
 import { resolve } from 'rsvp';

--- a/ui/lib/replication/addon/controllers/mode/secondaries/config-edit.js
+++ b/ui/lib/replication/addon/controllers/mode/secondaries/config-edit.js
@@ -4,7 +4,7 @@
  */
 
 import { alias } from '@ember/object/computed';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Controller from '@ember/controller';
 
 export default Controller.extend({

--- a/ui/lib/replication/addon/controllers/mode/secondaries/config-show.js
+++ b/ui/lib/replication/addon/controllers/mode/secondaries/config-show.js
@@ -4,7 +4,7 @@
  */
 
 import { alias } from '@ember/object/computed';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Controller from '@ember/controller';
 
 export default Controller.extend({

--- a/ui/lib/replication/addon/controllers/replication-mode.js
+++ b/ui/lib/replication/addon/controllers/replication-mode.js
@@ -4,7 +4,7 @@
  */
 
 import { alias } from '@ember/object/computed';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Controller from '@ember/controller';
 import { task, timeout } from 'ember-concurrency';
 

--- a/ui/lib/replication/addon/routes/application.js
+++ b/ui/lib/replication/addon/routes/application.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { setProperties } from '@ember/object';
 import { hash } from 'rsvp';
 import Route from '@ember/routing/route';

--- a/ui/lib/replication/addon/routes/index.js
+++ b/ui/lib/replication/addon/routes/index.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Route from '@ember/routing/route';
 
 export default Route.extend({

--- a/ui/lib/replication/addon/routes/mode.js
+++ b/ui/lib/replication/addon/routes/mode.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { hash } from 'rsvp';
 import { setProperties } from '@ember/object';
 import Route from '@ember/routing/route';

--- a/ui/lib/replication/addon/routes/mode/index.js
+++ b/ui/lib/replication/addon/routes/mode/index.js
@@ -6,7 +6,7 @@
 import { setProperties } from '@ember/object';
 import { hash } from 'rsvp';
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default Route.extend({
   store: service(),

--- a/ui/lib/replication/addon/routes/mode/manage.js
+++ b/ui/lib/replication/addon/routes/mode/manage.js
@@ -5,7 +5,7 @@
 
 import { camelize } from '@ember/string';
 import { all } from 'rsvp';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Route from '@ember/routing/route';
 import { replicationActionForMode } from 'replication/helpers/replication-action-for-mode';
 

--- a/ui/lib/replication/addon/routes/mode/secondaries.js
+++ b/ui/lib/replication/addon/routes/mode/secondaries.js
@@ -6,7 +6,7 @@
 import { setProperties } from '@ember/object';
 import { hash } from 'rsvp';
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default Route.extend({
   store: service(),

--- a/ui/lib/replication/addon/routes/mode/secondaries/config-create.js
+++ b/ui/lib/replication/addon/routes/mode/secondaries/config-create.js
@@ -4,7 +4,7 @@
  */
 
 import { hash } from 'rsvp';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Base from '../../replication-base';
 
 export default Base.extend({

--- a/ui/lib/replication/addon/routes/replication-base.js
+++ b/ui/lib/replication/addon/routes/replication-base.js
@@ -4,7 +4,7 @@
  */
 
 import { alias } from '@ember/object/computed';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Route from '@ember/routing/route';
 import UnloadModelRouteMixin from 'vault/mixins/unload-model-route';
 

--- a/ui/lib/sync/addon/components/secrets/destination-header.ts
+++ b/ui/lib/sync/addon/components/secrets/destination-header.ts
@@ -5,7 +5,7 @@
 
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import errorMessage from 'vault/utils/error-message';
 
 import type SyncDestinationModel from 'vault/models/sync/destination';

--- a/ui/lib/sync/addon/components/secrets/landing-cta.ts
+++ b/ui/lib/sync/addon/components/secrets/landing-cta.ts
@@ -4,7 +4,7 @@
  */
 
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 import type VersionService from 'vault/services/version';
 

--- a/ui/lib/sync/addon/components/secrets/page/destinations/create-and-edit.ts
+++ b/ui/lib/sync/addon/components/secrets/page/destinations/create-and-edit.ts
@@ -8,7 +8,7 @@ import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { task } from 'ember-concurrency';
 import { waitFor } from '@ember/test-waiters';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import errorMessage from 'vault/utils/error-message';
 
 import type SyncDestinationModel from 'vault/models/sync/destination';

--- a/ui/lib/sync/addon/components/sync-header.ts
+++ b/ui/lib/sync/addon/components/sync-header.ts
@@ -4,7 +4,7 @@
  */
 
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 import type VersionService from 'vault/services/version';
 import type { Breadcrumb } from 'vault/vault/app-types';

--- a/ui/lib/sync/addon/routes/index.ts
+++ b/ui/lib/sync/addon/routes/index.ts
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 import type RouterService from '@ember/routing/router-service';
 

--- a/ui/lib/sync/addon/routes/secrets/destinations/create/destination.ts
+++ b/ui/lib/sync/addon/routes/secrets/destinations/create/destination.ts
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 import type StoreService from 'vault/services/store';
 

--- a/ui/lib/sync/addon/routes/secrets/destinations/destination.ts
+++ b/ui/lib/sync/addon/routes/secrets/destinations/destination.ts
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 import type Store from '@ember-data/store';
 

--- a/ui/lib/sync/addon/routes/secrets/destinations/destination/index.ts
+++ b/ui/lib/sync/addon/routes/secrets/destinations/destination/index.ts
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 import type RouterService from '@ember/routing/router-service';
 

--- a/ui/lib/sync/addon/routes/secrets/destinations/destination/secrets.ts
+++ b/ui/lib/sync/addon/routes/secrets/destinations/destination/secrets.ts
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { hash } from 'rsvp';
 
 import type StoreService from 'vault/services/store';

--- a/ui/lib/sync/addon/routes/secrets/destinations/index.ts
+++ b/ui/lib/sync/addon/routes/secrets/destinations/index.ts
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { hash } from 'rsvp';
 
 import type StoreService from 'vault/services/store';

--- a/ui/lib/sync/addon/routes/secrets/overview.ts
+++ b/ui/lib/sync/addon/routes/secrets/overview.ts
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { hash } from 'rsvp';
 
 import type StoreService from 'vault/services/store';

--- a/ui/tests/unit/decorators/fetch-secrets-engine-config-test.js
+++ b/ui/tests/unit/decorators/fetch-secrets-engine-config-test.js
@@ -9,7 +9,7 @@ import sinon from 'sinon';
 import Route from '@ember/routing/route';
 import { withConfig } from 'core/decorators/fetch-secrets-engine-config';
 import { setupMirage } from 'ember-cli-mirage/test-support';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { Response } from 'miragejs';
 
 module('Unit | Decorators | fetch-secrets-engine-config', function (hooks) {


### PR DESCRIPTION
Waiting for 1.17.x branch

Came across this while scanning updates in Ember versions. I was surprised to see this had been convention since Ember-cli 4.1.x. 

- [Ember docs with example](https://guides.emberjs.com/release/services/#toc_accessing-services)
- [Ember release note for 4.1.x](https://blog.emberjs.com/ember-4-1-released/). 

While not required, making these imports consistent helps the team stick to the most recent syntax as we copy/paste along.
- [ ] Enterprise test pass locally