### PR TITLE
ci: remove re-runs logic for failed tests on release branches

### DIFF
--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -407,17 +407,6 @@ jobs:
             package_parallelism="-p 2"
           fi
 
-          # On a release branch, add a flag to rerun failed tests
-          # shellcheck disable=SC2193 # can get false positive for this comparision
-          if [[  "${{ github.base_ref }}" == release/* ]] || [[  -z "${{ github.base_ref }}" && "${{ github.ref_name }}" == release/* ]]
-          then
-            # TODO remove this extra condition once 1.15 is about to released GA
-            if [[  "${{ github.base_ref }}" != release/1.15* ]] || [[  -z "${{ github.base_ref }}" && "${{ github.ref_name }}" != release/1.15* ]]
-            then
-              RERUN_FAILS="--rerun-fails"
-            fi
-          fi
-
           VAULT_TEST_LOG_DIR='${{ steps.metadata.outputs.go-test-log-dir-absolute }}'
           export VAULT_TEST_LOG_DIR
           mkdir -p "$VAULT_TEST_LOG_DIR"
@@ -427,7 +416,6 @@ jobs:
               --junitfile '${{ steps.metadata.outputs.gotestsum-junitfile }}' \
               --jsonfile '${{ steps.metadata.outputs.gotestsum-jsonfile }}' \
               --jsonfile-timing-events '${{ steps.metadata.outputs.gotestsum-timing-events }}' \
-              $RERUN_FAILS \
               --packages "$packages" \
               -- \
               $package_parallelism \


### PR DESCRIPTION
This is change we ought to make for a few reasons:
* Release branches are the code we actually to ship to end users. As such, release branches ought to be the most well tested and verified of the bunch. The current behavior allows papering over test failures on `release/1.14.x` and `release/1.16.x` by having `gotestsum` silently re-run them for us. While this might make it easier to merge changes, it introduces a vector where actual bugs that might be unearthed by our testing are silently hidden and we're lured into a false sense of quality and correctness.
* Due to the logic that's already present, `release/1.15.x` and has had this behavior for a while now. This change would only introduce it for `release/1.16.x`, which is very new and hasn't diverged much from `main`, and `release/1.14.x`. There's hardly a better time to rip the band-aid off than now, as two of the release branches are fairly stable at this point.
* Turning this on for `release/1.14.x` might mean more manual test retries as that branch has had retries enabled for some time. This behavior for that branch is the most risky to me, but we can always revert this behavior if it becomes too much of a burden.