### PR TITLE
VAULT-23938 addresses a panic when a primitive cannot be set

### DIFF
--- a/audit/hashstructure.go
+++ b/audit/hashstructure.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"reflect"
 	"time"
 
@@ -382,7 +383,7 @@ func (w *hashWalker) Primitive(v reflect.Value) error {
 	default:
 		// If the value cannot be set, return early
 		if !setV.CanSet() {
-			return nil
+			return fmt.Errorf("unable to set unaddressable value of type %v", setV.Type())
 		}
 
 		// For custom type definitions, a conversion is necessary to avoid panic

--- a/audit/hashstructure.go
+++ b/audit/hashstructure.go
@@ -11,10 +11,11 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-secure-stdlib/strutil"
-	"github.com/hashicorp/vault/sdk/helper/wrapping"
-	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/mitchellh/copystructure"
 	"github.com/mitchellh/reflectwalk"
+
+	"github.com/hashicorp/vault/sdk/helper/wrapping"
+	"github.com/hashicorp/vault/sdk/logical"
 )
 
 // HashString hashes the given opaque string and returns it
@@ -381,6 +382,9 @@ func (w *hashWalker) Primitive(v reflect.Value) error {
 		s.Slice(si, si+1).Index(0).Set(resultVal)
 	default:
 		// Otherwise, we should be addressable
+		if !setV.CanSet() {
+			return nil
+		}
 		setV.Set(resultVal)
 	}
 

--- a/audit/hashstructure.go
+++ b/audit/hashstructure.go
@@ -11,11 +11,10 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-secure-stdlib/strutil"
-	"github.com/mitchellh/copystructure"
-	"github.com/mitchellh/reflectwalk"
-
 	"github.com/hashicorp/vault/sdk/helper/wrapping"
 	"github.com/hashicorp/vault/sdk/logical"
+	"github.com/mitchellh/copystructure"
+	"github.com/mitchellh/reflectwalk"
 )
 
 // HashString hashes the given opaque string and returns it
@@ -381,7 +380,7 @@ func (w *hashWalker) Primitive(v reflect.Value) error {
 		si := int(w.csKey[len(w.cs)-1].Int())
 		s.Slice(si, si+1).Index(0).Set(resultVal)
 	default:
-		// If the value is cannot be set, return early
+		// If the value cannot be set, return early
 		if !setV.CanSet() {
 			return nil
 		}

--- a/audit/hashstructure.go
+++ b/audit/hashstructure.go
@@ -381,10 +381,10 @@ func (w *hashWalker) Primitive(v reflect.Value) error {
 		si := int(w.csKey[len(w.cs)-1].Int())
 		s.Slice(si, si+1).Index(0).Set(resultVal)
 	default:
-		// Otherwise, we should be addressable
 		if !setV.CanSet() {
 			return nil
 		}
+		// Otherwise, we should be addressable
 		setV.Set(resultVal)
 	}
 

--- a/audit/hashstructure.go
+++ b/audit/hashstructure.go
@@ -381,9 +381,16 @@ func (w *hashWalker) Primitive(v reflect.Value) error {
 		si := int(w.csKey[len(w.cs)-1].Int())
 		s.Slice(si, si+1).Index(0).Set(resultVal)
 	default:
+		// If the value is cannot be set, return early
 		if !setV.CanSet() {
 			return nil
 		}
+
+		// For custom type definitions, a conversion is necessary to avoid panic
+		if setV.Type() != resultVal.Type() {
+			resultVal = resultVal.Convert(setV.Type())
+		}
+
 		// Otherwise, we should be addressable
 		setV.Set(resultVal)
 	}

--- a/audit/hashstructure_test.go
+++ b/audit/hashstructure_test.go
@@ -393,7 +393,8 @@ func TestHashWalker_TimeStructs(t *testing.T) {
 	}
 }
 
-// Test_hashWalker_Primitive_TypeDefinition assures the behaviour of hashWalker.Primitive method when dealing with non-assignable values. These used to cause a panic, so we added it to avoid future regressions.
+// Test_hashWalker_Primitive_TypeDefinition assures the behaviour of hashWalker.Primitive method when dealing with non-assignable values.
+// These used to cause a panic, so we added it to avoid future regressions.
 func Test_hashWalker_Primitive_TypeDefinition(t *testing.T) {
 	callback := func(input string) string { return "***" }
 	t.Run("simple-map", func(t *testing.T) {
@@ -407,8 +408,7 @@ func Test_hashWalker_Primitive_TypeDefinition(t *testing.T) {
 			"key": struct{ Value string }{Value: "value1"},
 		}
 		err := hashMap(callback, m, nil)
-		require.NoError(t, err)
-		require.Equal(t, "value1", m["key"].(struct{ Value string }).Value)
+		require.EqualError(t, err, "unable to set unaddressable value of type string")
 	})
 	t.Run("map-with-pointer-struct", func(t *testing.T) {
 		m := map[string]interface{}{
@@ -426,8 +426,7 @@ func Test_hashWalker_Primitive_TypeDefinition(t *testing.T) {
 			"key": S{Value: "value1"},
 		}
 		err := hashMap(callback, m, nil)
-		require.NoError(t, err)
-		require.Equal(t, "value1", m["key"].(S).Value)
+		require.EqualError(t, err, "unable to set unaddressable value of type string")
 	})
 	t.Run("map-with-pointer-struct-with-custom-type", func(t *testing.T) {
 		type Foo string

--- a/audit/hashstructure_test.go
+++ b/audit/hashstructure_test.go
@@ -430,4 +430,16 @@ func Test_hashWalker_Primitive_TypeDefinition(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "value1", m["key"].(S).Value)
 	})
+	t.Run("map-with-pointer-struct-with-custom-type", func(t *testing.T) {
+		type Foo string
+		type S struct {
+			Value Foo
+		}
+		m := map[string]interface{}{
+			"key": &S{Value: "value1"},
+		}
+		err := hashMap(callback, m, nil)
+		require.NoError(t, err)
+		require.Equal(t, Foo("***"), m["key"].(S).Value)
+	})
 }

--- a/audit/hashstructure_test.go
+++ b/audit/hashstructure_test.go
@@ -13,13 +13,12 @@ import (
 	"time"
 
 	"github.com/go-test/deep"
-	"github.com/mitchellh/copystructure"
-	"github.com/stretchr/testify/require"
-
 	"github.com/hashicorp/vault/sdk/helper/certutil"
 	"github.com/hashicorp/vault/sdk/helper/salt"
 	"github.com/hashicorp/vault/sdk/helper/wrapping"
 	"github.com/hashicorp/vault/sdk/logical"
+	"github.com/mitchellh/copystructure"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCopy_auth(t *testing.T) {

--- a/audit/hashstructure_test.go
+++ b/audit/hashstructure_test.go
@@ -13,9 +13,8 @@ import (
 	"time"
 
 	"github.com/go-test/deep"
-	"github.com/stretchr/testify/require"
-
 	"github.com/mitchellh/copystructure"
+	"github.com/stretchr/testify/require"
 
 	"github.com/hashicorp/vault/sdk/helper/certutil"
 	"github.com/hashicorp/vault/sdk/helper/salt"
@@ -395,6 +394,7 @@ func TestHashWalker_TimeStructs(t *testing.T) {
 	}
 }
 
+// Test_hashWalker_Primitive_TypeDefinition is to avoid future regression in the hashWalker.Primitive method.
 func Test_hashWalker_Primitive_TypeDefinition(t *testing.T) {
 	callback := func(input string) string { return "***" }
 	t.Run("simple-map", func(t *testing.T) {
@@ -440,6 +440,6 @@ func Test_hashWalker_Primitive_TypeDefinition(t *testing.T) {
 		}
 		err := hashMap(callback, m, nil)
 		require.NoError(t, err)
-		require.Equal(t, Foo("***"), m["key"].(S).Value)
+		require.Equal(t, Foo("***"), m["key"].(*S).Value)
 	})
 }

--- a/audit/hashstructure_test.go
+++ b/audit/hashstructure_test.go
@@ -393,7 +393,7 @@ func TestHashWalker_TimeStructs(t *testing.T) {
 	}
 }
 
-// Test_hashWalker_Primitive_TypeDefinition is to avoid future regression in the hashWalker.Primitive method.
+// Test_hashWalker_Primitive_TypeDefinition assures the behaviour of hashWalker.Primitive method when dealing with non-assignable values. These used to cause a panic, so we added it to avoid future regressions.
 func Test_hashWalker_Primitive_TypeDefinition(t *testing.T) {
 	callback := func(input string) string { return "***" }
 	t.Run("simple-map", func(t *testing.T) {

--- a/changelog/25328.txt
+++ b/changelog/25328.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+audit: Fixes a panic in hashwalker when traversing through struct values
+```

--- a/changelog/25328.txt
+++ b/changelog/25328.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-audit: Fixes a panic in hashwalker when traversing through struct values
+audit: Fixes a panic in hashwalker when encountering a non-assignable value when traversing through a struct.
 ```


### PR DESCRIPTION
## Summary

@austingebauer noticed a bug when testing the secrets sync feature with auditing enabled.

This makes a change in the `hashwalker` to fix a panic. The panic occurred when calling `Reflect.Value.Set` if the value was not addressable. This change first checks if it's settable, and returns early if not.

There's a set of test cases I added which can be used to reproduce the panic.