### PR TITLE
Minor improvements to test cluster libraries

### DIFF
--- a/changelog/25329.txt
+++ b/changelog/25329.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+sdk/helper/testcluster: add some new helpers, improve some error messages.
+```

--- a/helper/testhelpers/testhelpers.go
+++ b/helper/testhelpers/testhelpers.go
@@ -433,30 +433,6 @@ func RekeyCluster(t testing.T, cluster *vault.TestCluster, recovery bool) [][]by
 	return newKeys
 }
 
-func RaftClusterJoinNodes(t testing.T, cluster *vault.TestCluster) {
-	leader := cluster.Cores[0]
-
-	leaderInfos := []*raft.LeaderJoinInfo{
-		{
-			LeaderAPIAddr: leader.Client.Address(),
-			TLSConfig:     leader.TLSConfig(),
-		},
-	}
-
-	// Join followers
-	for i := 1; i < len(cluster.Cores); i++ {
-		core := cluster.Cores[i]
-		_, err := core.JoinRaftCluster(namespace.RootContext(context.Background()), leaderInfos, false)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		cluster.UnsealCore(t, core)
-	}
-
-	WaitForNCoresUnsealed(t, cluster, len(cluster.Cores))
-}
-
 // HardcodedServerAddressProvider is a ServerAddressProvider that uses
 // a hardcoded map of raft node addresses.
 //

--- a/sdk/helper/testcluster/replication.go
+++ b/sdk/helper/testcluster/replication.go
@@ -42,12 +42,12 @@ func EnablePerfPrimary(ctx context.Context, pri VaultCluster) error {
 	client := pri.Nodes()[0].APIClient()
 	_, err := client.Logical().WriteWithContext(ctx, "sys/replication/performance/primary/enable", nil)
 	if err != nil {
-		return err
+		return fmt.Errorf("error enabling perf primary: %w", err)
 	}
 
 	err = WaitForPerfReplicationState(ctx, pri, consts.ReplicationPerformancePrimary)
 	if err != nil {
-		return err
+		return fmt.Errorf("error waiting for perf primary to have the correct state: %w", err)
 	}
 	return WaitForActiveNodeAndPerfStandbys(ctx, pri)
 }
@@ -108,6 +108,10 @@ func EnablePerformanceSecondary(ctx context.Context, perfToken string, pri, sec 
 }
 
 func WaitForMatchingMerkleRoots(ctx context.Context, endpoint string, pri, sec VaultCluster) error {
+	return WaitForMatchingMerkleRootsClients(ctx, endpoint, pri.Nodes()[0].APIClient(), sec.Nodes()[0].APIClient())
+}
+
+func WaitForMatchingMerkleRootsClients(ctx context.Context, endpoint string, pri, sec *api.Client) error {
 	getRoot := func(mode string, cli *api.Client) (string, error) {
 		status, err := cli.Logical().Read(endpoint + "status")
 		if err != nil {
@@ -122,16 +126,19 @@ func WaitForMatchingMerkleRoots(ctx context.Context, endpoint string, pri, sec V
 		return status.Data["merkle_root"].(string), nil
 	}
 
-	secClient := sec.Nodes()[0].APIClient()
-	priClient := pri.Nodes()[0].APIClient()
-	for i := 0; i < 30; i++ {
-		secRoot, err := getRoot("secondary", secClient)
+	var priRoot, secRoot string
+	var err error
+	genRet := func() error {
+		return fmt.Errorf("unequal merkle roots, pri=%s sec=%s, err=%w", priRoot, secRoot, err)
+	}
+	for ctx.Err() == nil {
+		secRoot, err = getRoot("secondary", sec)
 		if err != nil {
-			return err
+			return genRet()
 		}
-		priRoot, err := getRoot("primary", priClient)
+		priRoot, err = getRoot("primary", pri)
 		if err != nil {
-			return err
+			return genRet()
 		}
 
 		if reflect.DeepEqual(priRoot, secRoot) {
@@ -281,15 +288,18 @@ func WaitForPerfReplicationWorking(ctx context.Context, pri, sec VaultCluster) e
 
 func SetupTwoClusterPerfReplication(ctx context.Context, pri, sec VaultCluster) error {
 	if err := EnablePerfPrimary(ctx, pri); err != nil {
-		return err
+		return fmt.Errorf("failed to enable perf primary: %w", err)
 	}
 	perfToken, err := GetPerformanceToken(pri, sec.ClusterID(), "")
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to get performance token from perf primary: %w", err)
 	}
 
 	_, err = EnablePerformanceSecondary(ctx, perfToken, pri, sec, false, false)
-	return err
+	if err != nil {
+		return fmt.Errorf("failed to enable perf secondary: %w", err)
+	}
+	return nil
 }
 
 // PassiveWaitForActiveNodeAndPerfStandbys should be used instead of

--- a/sdk/helper/testcluster/util.go
+++ b/sdk/helper/testcluster/util.go
@@ -302,12 +302,12 @@ func WaitForActiveNodeAndPerfStandbys(ctx context.Context, cluster VaultCluster)
 			Local: true,
 		})
 		if err == nil {
-			return fmt.Errorf("unable to mount kv engine: %w", err)
+			break
 		}
 		time.Sleep(1 * time.Second)
 	}
 	if err != nil {
-		return fmt.Errorf("unable to mount KV engine: %v", err)
+		return fmt.Errorf("unable to mount KV engine: %w", err)
 	}
 	path := mountPoint + "/waitforactivenodeandperfstandbys"
 	var standbys, actives int64

--- a/sdk/helper/testcluster/util.go
+++ b/sdk/helper/testcluster/util.go
@@ -281,7 +281,7 @@ func WaitForActiveNodeAndPerfStandbys(ctx context.Context, cluster VaultCluster)
 	// this call to WaitForActiveNode by reworking the logic in this method.
 	leaderIdx, err := WaitForActiveNode(ctx, cluster)
 	if err != nil {
-		return err
+		return fmt.Errorf("did not find leader: %w", err)
 	}
 
 	if len(cluster.Nodes()) == 1 {
@@ -302,7 +302,7 @@ func WaitForActiveNodeAndPerfStandbys(ctx context.Context, cluster VaultCluster)
 			Local: true,
 		})
 		if err == nil {
-			break
+			return fmt.Errorf("unable to mount kv engine: %w", err)
 		}
 		time.Sleep(1 * time.Second)
 	}
@@ -381,9 +381,17 @@ func WaitForActiveNodeAndPerfStandbys(ctx context.Context, cluster VaultCluster)
 		time.Sleep(time.Second)
 	}
 	if err != nil {
-		return fmt.Errorf("unable to unmount KV engine on primary")
+		return fmt.Errorf("unable to unmount KV engine: %w", err)
 	}
 	return nil
+}
+
+func Clients(vc VaultCluster) []*api.Client {
+	var ret []*api.Client
+	for _, n := range vc.Nodes() {
+		ret = append(ret, n.APIClient())
+	}
+	return ret
 }
 
 type GenerateRootKind int

--- a/vault/testing.go
+++ b/vault/testing.go
@@ -717,6 +717,9 @@ type TestCluster struct {
 
 func (c *TestCluster) SetRootToken(token string) {
 	c.RootToken = token
+	for _, c := range c.Cores {
+		c.Client.SetToken(token)
+	}
 }
 
 func (c *TestCluster) Start() {


### PR DESCRIPTION
Add WaitForMatchingMerkleRootsClients and Clients to sdk testcluster.  Fix internal TestCluster.SetRootToken, which wasn't updating the builtin clients' token.  Improve some error messages.