### PR TITLE
release: add config to trigger SBOM creation

### DIFF
--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -174,3 +174,15 @@ event "update-ironbank" {
     on = "fail"
   }
 }
+
+event "crt-generate-sbom" {
+  depends = ["promote-production"]
+  action "crt-generate-sbom" {
+	organization = "hashicorp"
+	repository = "security-generate-release-sbom"
+	workflow = "crt-generate-sbom"
+  }
+  notification {
+	on = "fail"
+  }
+}


### PR DESCRIPTION
This should cause CRT to trigger the [crt-generate-sbom](https://github.com/hashicorp/security-generate-release-sbom/blob/main/.github/workflows/crt-generate-sbom.yml) workflow post-release. Currently that workflow just stores the SBOM as a GitHub Actions Workflow Artifact. The purpose of this change is to establish the integration between Vault and Vault Enterprise releases and our SBOM-generating workflow. Once this link is established, we will continue to work on the SBOM side of things and shouldn't need to make further changes here.

See [PSP-1992](https://hashicorp.atlassian.net/browse/PSP-1992) and related tickets for more details.

**Question for reviewer:** do I need to make a similar change in Vault Enterprise, or will this be automatically ported there as well? Thanks.

[PSP-1992]: https://hashicorp.atlassian.net/browse/PSP-1992?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ