### PR TITLE
UI: Fix openAPI test for JWT

### DIFF
--- a/ui/app/models/auth-config/jwt.js
+++ b/ui/app/models/auth-config/jwt.js
@@ -41,6 +41,11 @@ export default AuthConfig.extend({
     label: 'JWKS URL',
   }),
 
+  jwksPairs: attr({
+    label: 'JWKS pairs',
+    // This attribute is not shown in the UI
+  }),
+
   oidcResponseMode: attr('string', {
     label: 'OIDC response mode',
   }),

--- a/ui/app/models/auth-config/jwt.js
+++ b/ui/app/models/auth-config/jwt.js
@@ -37,14 +37,6 @@ export default AuthConfig.extend({
     editType: 'file',
   }),
 
-  jwksPairs: attr('jwksPair', {
-    editType: 'kv',
-    keyPlaceholder: 'JWKS URL',
-    valuePlaceholder: 'JWKS CA PEM',
-    label: 'JWKS pairs',
-    allowWhiteSpace: true,
-  }),
-
   jwksUrl: attr('string', {
     label: 'JWKS URL',
   }),
@@ -79,7 +71,6 @@ export default AuthConfig.extend({
           'defaultRole',
           'jwksCaPem',
           'jwksUrl',
-          'jwksPairs',
           'oidcResponseMode',
           'oidcResponseTypes',
         ],

--- a/ui/app/models/auth-config/jwt.js
+++ b/ui/app/models/auth-config/jwt.js
@@ -37,6 +37,14 @@ export default AuthConfig.extend({
     editType: 'file',
   }),
 
+  jwksPairs: attr('jwksPair', {
+    editType: 'kv',
+    keyPlaceholder: 'JWKS URL',
+    valuePlaceholder: 'JWKS CA PEM',
+    label: 'JWKS pairs',
+    allowWhiteSpace: true,
+  }),
+
   jwksUrl: attr('string', {
     label: 'JWKS URL',
   }),
@@ -71,6 +79,7 @@ export default AuthConfig.extend({
           'defaultRole',
           'jwksCaPem',
           'jwksUrl',
+          'jwksPairs',
           'oidcResponseMode',
           'oidcResponseTypes',
         ],

--- a/ui/tests/helpers/openapi/auth-model-attributes.js
+++ b/ui/tests/helpers/openapi/auth-model-attributes.js
@@ -489,6 +489,12 @@ const jwt = {
       fieldGroup: 'default',
       type: 'string',
     },
+    jwksPairs: {
+      editType: 'objectArray',
+      fieldGroup: 'default',
+      helpText:
+        'Set of JWKS Url and CA certificate (or chain of certificates) pairs. CA certificates must be in PEM format. Cannot be used with "jwks_url" or "jwks_ca_pem".',
+    },
     jwksUrl: {
       editType: 'string',
       helpText:


### PR DESCRIPTION
This PR fixes the test that alerts us to a new JWT config attribute. As follow-on work, we need to handle the new attribute (which is of a new type, `objectArray`). 