### PR TITLE
Hide Sync Destination Actions When Purging

### DIFF
--- a/ui/app/models/sync/destination.js
+++ b/ui/app/models/sync/destination.js
@@ -54,12 +54,12 @@ export default class SyncDestinationModel extends Model {
     return this.destinationPath.get('canDelete') !== false;
   }
   get canEdit() {
-    return this.destinationPath.get('canUpdate') !== false;
+    return this.destinationPath.get('canUpdate') !== false && !this.purgeInitiatedAt;
   }
   get canRead() {
     return this.destinationPath.get('canRead') !== false;
   }
   get canSync() {
-    return this.setAssociationPath.get('canUpdate') !== false;
+    return this.setAssociationPath.get('canUpdate') !== false && !this.purgeInitiatedAt;
   }
 }

--- a/ui/lib/sync/addon/routes/secrets/destinations/destination.ts
+++ b/ui/lib/sync/addon/routes/secrets/destinations/destination.ts
@@ -8,6 +8,7 @@ import { inject as service } from '@ember/service';
 
 import type Store from '@ember-data/store';
 import type RouterService from '@ember/routing/router-service';
+import type FlashMessageService from 'vault/services/flash-messages';
 import type Transition from '@ember/routing/transition';
 import type SyncDestinationModel from 'vault/models/sync/destination';
 
@@ -19,6 +20,7 @@ interface RouteParams {
 export default class SyncSecretsDestinationsDestinationRoute extends Route {
   @service declare readonly store: Store;
   @service declare readonly router: RouterService;
+  @service declare readonly flashMessages: FlashMessageService;
 
   model(params: RouteParams) {
     const { name, type } = params;
@@ -33,6 +35,10 @@ export default class SyncSecretsDestinationsDestinationRoute extends Route {
     const baseRoute = 'vault.cluster.sync.secrets.destinations.destination';
     const routes = [`${baseRoute}.edit`, `${baseRoute}.sync`];
     if (routes.includes(transition.to.name) && model.purgeInitiatedAt) {
+      // const target = transition.to.name.
+      // this.flashMessages.info('Actions are ')
+      const action = transition.to.localName === 'edit' ? 'Editing a destination' : 'Syncing secrets';
+      this.flashMessages.info(`${action} is not permitted once a purge has been initiated.`);
       this.router.replaceWith('vault.cluster.sync.secrets.destinations.destination.secrets');
     }
   }

--- a/ui/lib/sync/addon/routes/secrets/destinations/destination.ts
+++ b/ui/lib/sync/addon/routes/secrets/destinations/destination.ts
@@ -7,6 +7,9 @@ import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 
 import type Store from '@ember-data/store';
+import type RouterService from '@ember/routing/router-service';
+import type Transition from '@ember/routing/transition';
+import type SyncDestinationModel from 'vault/models/sync/destination';
 
 interface RouteParams {
   name: string;
@@ -15,9 +18,22 @@ interface RouteParams {
 
 export default class SyncSecretsDestinationsDestinationRoute extends Route {
   @service declare readonly store: Store;
+  @service declare readonly router: RouterService;
 
   model(params: RouteParams) {
     const { name, type } = params;
     return this.store.findRecord(`sync/destinations/${type}`, name);
+  }
+
+  afterModel(model: SyncDestinationModel, transition: Transition) {
+    // handles the case where the user attempts to perform actions on a destination when a purge has been initiated
+    // editing is available from the list view and syncing secrets is available from the overview
+    // the list endpoint does not return the full model so we don't have access to purgeInitiatedAt to disable or hide the actions
+    // if transitioning from either of the mentioned routes and a purge has been initiated redirect to the secrets view
+    const baseRoute = 'vault.cluster.sync.secrets.destinations.destination';
+    const routes = [`${baseRoute}.edit`, `${baseRoute}.sync`];
+    if (routes.includes(transition.to.name) && model.purgeInitiatedAt) {
+      this.router.replaceWith('vault.cluster.sync.secrets.destinations.destination.secrets');
+    }
   }
 }

--- a/ui/tests/integration/components/sync/secrets/destination-header-test.js
+++ b/ui/tests/integration/components/sync/secrets/destination-header-test.js
@@ -70,8 +70,8 @@ module('Integration | Component | sync | Secrets::DestinationHeader', function (
     );
   });
 
-  test('it should render delete progress banner', async function (assert) {
-    assert.expect(2);
+  test('it should render delete progress banner and hide actions', async function (assert) {
+    assert.expect(5);
     this.destination.set('purgeInitiatedAt', '2024-01-09T16:54:28.463879');
     await settled();
     assert
@@ -82,6 +82,9 @@ module('Integration | Component | sync | Secrets::DestinationHeader', function (
     assert
       .dom(`${PAGE.destinations.deleteBanner} ${PAGE.icon('loading-static')}`)
       .exists('banner renders loading icon');
+    assert.dom(PAGE.toolbar('Sync secrets')).doesNotExist('Sync action is hidden');
+    assert.dom(PAGE.toolbar('Edit destination')).doesNotExist('Edit action is hidden');
+    assert.dom('.toolbar-separator').doesNotExist('Divider is hidden when only delete action is available');
   });
 
   test('it should render delete error banner', async function (assert) {

--- a/ui/types/vault/models/sync/destination.d.ts
+++ b/ui/types/vault/models/sync/destination.d.ts
@@ -8,6 +8,10 @@ import type { WithFormFieldsAndValidationsModel } from 'vault/app-types';
 export default interface SyncDestinationModel extends WithFormFieldsAndValidationsModel {
   name: string;
   type: string;
+  secretNameTemplate: string;
+  purgeInitiatedAt: string;
+  purgeError: string;
+
   get icon(): string;
   get typeDisplayName(): string;
   get maskedParams(): string[];
@@ -37,4 +41,10 @@ export default interface SyncDestinationModel extends WithFormFieldsAndValidatio
   projectId?: string;
   teamId?: string;
   deploymentEnvironments?: array;
+
+  get canCreate(): boolean;
+  get canDelete(): boolean;
+  get canEdit(): boolean;
+  get canRead(): boolean;
+  get canSync(): boolean;
 }


### PR DESCRIPTION
If a purge has been initiated for a destination the user is unable to edit the destination config or sync secrets. This PR hides those actions from the destination view and adds a redirect if attempting to access the route. 