### PR TITLE
UI: Redirect after logging in from token expiry

### DIFF
--- a/changelog/25335.txt
+++ b/changelog/25335.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: redirect back to current route after reauthentication when token expires
+```

--- a/ui/app/components/token-expire-warning.hbs
+++ b/ui/app/components/token-expire-warning.hbs
@@ -10,7 +10,13 @@
       Your auth token expired on
       {{date-format @expirationDate "MMMM do yyyy, h:mm:ss a"}}. You will need to re-authenticate.
     </A.Description>
-    <A.Link::Standalone @icon="arrow-right" @iconPosition="trailing" @text="Reauthenticate" @route="vault.cluster.logout" />
+    <A.Link::Standalone
+      @icon="arrow-right"
+      @iconPosition="trailing"
+      @text="Reauthenticate"
+      @route="vault.cluster.logout"
+      @query={{this.queryParams}}
+    />
   </Hds::Alert>
 {{else}}
   <section class="section">

--- a/ui/app/components/token-expire-warning.js
+++ b/ui/app/components/token-expire-warning.js
@@ -36,6 +36,11 @@ export default class TokenExpireWarning extends Component {
     yield this.handleRenew();
   }
 
+  get queryParams() {
+    // Bring user back to current page after login
+    return { redirect_to: this.router.currentURL };
+  }
+
   get showWarning() {
     const currentRoute = this.router.currentRouteName;
     if ('vault.cluster.oidc-provider' === currentRoute) {


### PR DESCRIPTION
Adds a redirect back to the current URL if the user's token expires and they click "reauthenticate". 

This PR fixes #10963