### PR TITLE
remove regular expression comparison in a GHA script

### DIFF
--- a/.github/scripts/changed-files.sh
+++ b/.github/scripts/changed-files.sh
@@ -35,16 +35,16 @@ if ! files="$(git diff "${base_commit}...${head_commit}" --name-only)"; then
 fi
 
 for file in $(awk -F "/" '{ print $1}' <<< "$files" | uniq); do
-  if [[ "$file" =~ "changelog" ]]; then
+  if [[ "$file" == "changelog" ]]; then
     continue
   fi
 
-  if [[ "$file" =~ "website" ]]; then
+  if [[ "$file" == "website" ]]; then
     docs_changed=true
     continue
   fi
 
-  if [[ "$file" =~ "ui" ]]; then
+  if [[ "$file" == "ui" ]]; then
     ui_changed=true
     continue
   fi


### PR DESCRIPTION
A PR could set the `ui-changes` to true even if there is no ui-changes. [Example](https://github.com/hashicorp/vault/actions/runs/7848168666/job/21418704533#step:3:3134):
```
'40330b2eada30269f09e47d20a08ad9a660b34e2'
Run ./.github/scripts/changed-files.sh pull_request 25336/merge main
  ./.github/scripts/changed-files.sh pull_request 25336/merge main
  shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
From https://github.com/hashicorp/vault
 * branch                  main       -> FETCH_HEAD
app-changed=false
docs-changed=false
ui-changed=true
files='builtin/logical/transit/backend.go
builtin/logical/transit/path_decrypt.go
builtin/logical/transit/path_encrypt.go
builtin/logical/transit/path_hmac.go
builtin/logical/transit/path_rewrap.go
builtin/logical/transit/path_sign_verify.go
changelog/25336.txt'
```