### PR TITLE
UI: Skip OpenAPI call for unmanaged auth methods

### DIFF
--- a/changelog/25364.txt
+++ b/changelog/25364.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: remove unnecessary OpenAPI calls for unmanaged auth methods
+```

--- a/ui/app/routes/vault/cluster/access/method.js
+++ b/ui/app/routes/vault/cluster/access/method.js
@@ -22,7 +22,7 @@ export default Route.extend({
         set(error, 'httpStatus', 404);
         throw error;
       }
-      const supportManaged = supportedManagedAuthBackends().map((backend) => backend.type);
+      const supportManaged = supportedManagedAuthBackends();
       if (!supportManaged.includes(model.methodType)) {
         // do not fetch path-help for unmanaged auth types
         model.set('paths', {

--- a/ui/app/routes/vault/cluster/access/method.js
+++ b/ui/app/routes/vault/cluster/access/method.js
@@ -7,6 +7,7 @@ import AdapterError from '@ember-data/adapter/error';
 import { set } from '@ember/object';
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
+import { supportedManagedAuthBackends } from 'vault/helpers/supported-managed-auth-backends';
 
 export default Route.extend({
   store: service(),
@@ -20,6 +21,15 @@ export default Route.extend({
         const error = new AdapterError();
         set(error, 'httpStatus', 404);
         throw error;
+      }
+      const supportManaged = supportedManagedAuthBackends().map((backend) => backend.type);
+      if (!supportManaged.includes(model.methodType)) {
+        // do not fetch path-help for unmanaged auth types
+        model.set('paths', {
+          apiPath: model.apiPath,
+          paths: [],
+        });
+        return model;
       }
       return this.pathHelp.getPaths(model.apiPath, path).then((paths) => {
         model.set('paths', paths);


### PR DESCRIPTION
This PR skips the OpenAPI call on auth methods which are not managed in the UI.  Resolves #24160