### PR TITLE
UI: Replace list item popup menus

### DIFF
--- a/changelog/25379.txt
+++ b/changelog/25379.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: replace popup menu on list items (namespaces, auth items, KMIP, K8S, LDAP)
+```

--- a/ui/app/components/generated-item-list.js
+++ b/ui/app/components/generated-item-list.js
@@ -7,6 +7,7 @@ import { inject as service } from '@ember/service';
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { getOwner } from '@ember/application';
+import { tracked } from '@glimmer/tracking';
 
 /**
  * @module GeneratedItemList
@@ -26,6 +27,7 @@ import { getOwner } from '@ember/application';
 export default class GeneratedItemList extends Component {
   @service router;
   @service store;
+  @tracked showConfirmModal = false;
 
   get model() {
     return this.args.model || null;

--- a/ui/app/styles/components/popup-menu.scss
+++ b/ui/app/styles/components/popup-menu.scss
@@ -176,3 +176,18 @@
     }
   }
 }
+
+// Match HDS styling for namespace ink
+a.ns-dropdown-item {
+  color: var(--token-color-foreground-primary);
+  display: flex;
+  align-items: flex-start;
+  padding: 7px 9px 7px 0px;
+  border: 1px solid transparent;
+  outline-style: solid;
+  outline-color: transparent;
+  text-decoration: none;
+  &:hover {
+    color: var(--token-color-foreground-action-hover);
+  }
+}

--- a/ui/app/templates/components/generated-item-list.hbs
+++ b/ui/app/templates/components/generated-item-list.hbs
@@ -72,21 +72,36 @@
         <Icon @name="folder" class="has-text-grey-light" />{{list.item.id}}
       </Item.content>
       <Item.menu>
-        <li class="action">
-          <LinkTo @route="vault.cluster.access.method.item.show" @model={{list.item.id}} class="is-block">
-            View
-            {{singularize this.itemType}}
-          </LinkTo>
-        </li>
-        <li class="action">
-          <LinkTo @route="vault.cluster.access.method.item.edit" @model={{list.item.id}} class="is-block">
-            Edit
-            {{singularize this.itemType}}
-          </LinkTo>
-        </li>
-        <ConfirmAction
-          @isInDropdown={{true}}
-          @onConfirmAction={{action
+        <Hds::Dropdown @isInline={{true}} @listPosition="bottom-right" as |dd|>
+          <dd.ToggleIcon
+            @icon="more-horizontal"
+            @text="Overflow options"
+            @hasChevron={{false}}
+            data-test-popup-menu-trigger
+          />
+          <dd.Interactive
+            @text="View {{singularize this.itemType}}"
+            @route="vault.cluster.access.method.item.show"
+            @model={{list.item.id}}
+          />
+          <dd.Interactive
+            @text="Edit {{singularize this.itemType}}"
+            @route="vault.cluster.access.method.item.edit"
+            @model={{list.item.id}}
+          />
+          <dd.Interactive
+            @text="Delete {{singularize this.itemType}}"
+            @color="critical"
+            {{on "click" (fn (mut this.showConfirmModal) true)}}
+          />
+        </Hds::Dropdown>
+      </Item.menu>
+
+      {{#if this.showConfirmModal}}
+        <ConfirmModal
+          @color="critical"
+          @onClose={{fn (mut this.showConfirmModal) false}}
+          @onConfirm={{action
             (perform
               Item.callMethod
               "destroyRecord"
@@ -98,9 +113,8 @@
           }}
           @confirmTitle="Delete {{singularize this.itemType}}?"
           @confirmMessage="Are you sure you want to delete {{singularize this.itemType}} {{list.item.id}}?"
-          @buttonText="Delete {{singularize this.itemType}}"
         />
-      </Item.menu>
+      {{/if}}
     </ListItem>
   {{/if}}
 </ListView>

--- a/ui/app/templates/vault/cluster/access/namespaces/index.hbs
+++ b/ui/app/templates/vault/cluster/access/namespaces/index.hbs
@@ -35,31 +35,37 @@
           {{list.item.id}}
         </Item.content>
         <Item.menu>
-          {{#let (concat this.currentNamespace (if this.currentNamespace "/") list.item.id) as |targetNamespace|}}
-            {{#if (includes targetNamespace this.accessibleNamespaces)}}
-              <li class="action">
-                <NamespaceLink @targetNamespace={{targetNamespace}} @unparsed={{true}} @class="is-block">
-                  Switch to Namespace
-                </NamespaceLink>
-              </li>
-            {{/if}}
-          {{/let}}
-          <ConfirmAction
-            @isInDropdown={{true}}
-            @buttonText="Delete"
-            @confirmTitle="Delete this namespace?"
-            @confirmMessage="Any engines or mounts in this namespace will also be removed."
-            @onConfirmAction={{action
-              (perform
-                Item.callMethod
-                "destroyRecord"
-                list.item
-                (concat "Successfully deleted namespace: " list.item.id)
-                "There was an error deleting this namespace: "
-                (action "refreshNamespaceList")
-              )
-            }}
-          />
+          <Hds::Dropdown @isInline={{true}} @listPosition="bottom-right" as |dd|>
+            <dd.ToggleIcon @icon="more-horizontal" @text="More options" @hasChevron={{false}} data-test-popup-menu-trigger />
+            {{#let (concat this.currentNamespace (if this.currentNamespace "/") list.item.id) as |targetNamespace|}}
+              {{#if (includes targetNamespace this.accessibleNamespaces)}}
+                <dd.Generic>
+                  <NamespaceLink @targetNamespace={{targetNamespace}} @unparsed={{true}} @class="ns-dropdown-item">
+                    Switch to Namespace
+                  </NamespaceLink>
+                </dd.Generic>
+              {{/if}}
+            {{/let}}
+            <dd.Interactive @text="Delete" @color="critical" {{on "click" (fn (mut this.showConfirmModal) true)}} />
+          </Hds::Dropdown>
+          {{#if this.showConfirmModal}}
+            <ConfirmModal
+              @color="critical"
+              @onClose={{fn (mut this.showConfirmModal) false}}
+              @onConfirm={{action
+                (perform
+                  Item.callMethod
+                  "destroyRecord"
+                  list.item
+                  (concat "Successfully deleted namespace: " list.item.id)
+                  "There was an error deleting this namespace: "
+                  (action "refreshNamespaceList")
+                )
+              }}
+              @confirmTitle="Delete this namespace?"
+              @confirmMessage="Any engines or mounts in this namespace will also be removed."
+            />
+          {{/if}}
         </Item.menu>
       </ListItem>
     {{/if}}

--- a/ui/lib/core/addon/components/list-item.hbs
+++ b/ui/lib/core/addon/components/list-item.hbs
@@ -3,11 +3,11 @@
   SPDX-License-Identifier: BUSL-1.1
 ~}}
 
-{{#if this.componentName}}
-  {{component this.componentName item=this.item}}
-{{else if this.linkParams}}
+{{#if @componentName}}
+  {{component @componentName item=@item}}
+{{else if @linkParams}}
   <LinkedBlock
-    @params={{this.linkParams}}
+    @params={{@linkParams}}
     @queryParams={{@queryParams}}
     @linkPrefix={{@linkPrefix}}
     class="list-item-row"
@@ -25,9 +25,7 @@
       </div>
       <div class="level-right">
         <div class="level-item" data-test-list-item-popup>
-          {{yield
-            (hash callMethod=this.callMethod menu=(component "list-item/popup-menu" item=this.item hasMenu=this.hasMenu))
-          }}
+          {{yield (hash callMethod=this.callMethod menu=(component "list-item/popup-menu" item=@item hasMenu=@hasMenu))}}
         </div>
       </div>
     </div>
@@ -40,9 +38,7 @@
       </div>
       <div class="level-right">
         <div class="level-item" data-test-list-item-popup>
-          {{yield
-            (hash callMethod=this.callMethod menu=(component "list-item/popup-menu" item=this.item hasMenu=this.hasMenu))
-          }}
+          {{yield (hash callMethod=this.callMethod menu=(component "list-item/popup-menu" item=@item hasMenu=@hasMenu))}}
         </div>
       </div>
     </div>

--- a/ui/lib/core/addon/components/list-item.js
+++ b/ui/lib/core/addon/components/list-item.js
@@ -24,8 +24,8 @@ export default class ListItemComponent extends Component {
   }
 
   get link() {
-    if (!Array.isArray(this.linkParams) || !this.linkParams.length) return {};
-    const [route, ...models] = this.linkParams;
+    if (!Array.isArray(this.args.linkParams) || !this.args.linkParams.length) return {};
+    const [route, ...models] = this.args.linkParams;
     return { route, models };
   }
 }

--- a/ui/lib/core/addon/components/list-item.js
+++ b/ui/lib/core/addon/components/list-item.js
@@ -4,21 +4,13 @@
  */
 
 import { inject as service } from '@ember/service';
-import Component from '@ember/component';
+import Component from '@glimmer/component';
 import { task } from 'ember-concurrency';
-import { computed } from '@ember/object';
-import layout from '../templates/components/list-item';
 
-export default Component.extend({
-  layout,
-  flashMessages: service(),
-  tagName: '',
-  linkParams: null,
-  queryParams: null,
-  componentName: null,
-  hasMenu: true,
+export default class ListItemComponent extends Component {
+  @service flashMessages;
 
-  callMethod: task(function* (method, model, successMessage, failureMessage, successCallback = () => {}) {
+  @task *callMethod(method, model, successMessage, failureMessage, successCallback = () => {}) {
     const flash = this.flashMessages;
     try {
       yield model[method]();
@@ -29,10 +21,11 @@ export default Component.extend({
       flash.danger(failureMessage + ' ' + errString);
       model.rollbackAttributes();
     }
-  }),
-  link: computed('linkParams.[]', function () {
+  }
+
+  get link() {
     if (!Array.isArray(this.linkParams) || !this.linkParams.length) return {};
     const [route, ...models] = this.linkParams;
     return { route, models };
-  }),
-});
+  }
+}

--- a/ui/lib/core/addon/templates/components/list-item/popup-menu.hbs
+++ b/ui/lib/core/addon/templates/components/list-item/popup-menu.hbs
@@ -3,14 +3,4 @@
   SPDX-License-Identifier: BUSL-1.1
 ~}}
 
-{{#if this.hasMenu}}
-  <PopupMenu>
-    <nav class="menu">
-      <ul class="menu-list">
-        {{yield}}
-      </ul>
-    </nav>
-  </PopupMenu>
-{{else}}
-  {{yield this.item}}
-{{/if}}
+{{yield this.item}}

--- a/ui/lib/kmip/addon/templates/credentials/index.hbs
+++ b/ui/lib/kmip/addon/templates/credentials/index.hbs
@@ -79,28 +79,29 @@
               @text="Revoke credentials"
               @color="critical"
               {{on "click" (fn (mut this.showConfirmModal) true)}}
+              data-test-confirm-action-trigger
             />
           {{/if}}
         </Hds::Dropdown>
+        {{#if this.showConfirmModal}}
+          <ConfirmModal
+            @color="critical"
+            @onClose={{fn (mut this.showConfirmModal) false}}
+            @confirmTitle="Revoke this?"
+            @confirmMessage="Any client using these credentials will no longer be able to."
+            @onConfirm={{action
+              (perform
+                Item.callMethod
+                "destroyRecord"
+                list.item
+                "Successfully revoked credentials"
+                "There was an error revoking the credentials"
+                (action "refresh")
+              )
+            }}
+          />
+        {{/if}}
       </Item.menu>
-      {{#if this.showConfirmModal}}
-        <ConfirmModal
-          @color="critical"
-          @onClose={{fn (mut this.showConfirmModal) false}}
-          @confirmTitle="Revoke this?"
-          @confirmMessage="Any client using these credentials will no longer be able to."
-          @onConfirm={{action
-            (perform
-              Item.callMethod
-              "destroyRecord"
-              list.item
-              "Successfully revoked credentials"
-              "There was an error revoking the credentials"
-              (action "refresh")
-            )
-          }}
-        />
-      {{/if}}
     </ListItem>
   {{else}}
     <ListItem as |Item|>

--- a/ui/lib/kmip/addon/templates/credentials/index.hbs
+++ b/ui/lib/kmip/addon/templates/credentials/index.hbs
@@ -63,34 +63,44 @@
         <Icon @name="file-text" class="has-text-grey-light" />{{list.item.id}}
       </Item.content>
       <Item.menu>
-        <li class="action">
-          <LinkTo @route="credentials.show" @models={{array this.scope this.role list.item.id}} class="is-block">
-            View credentials
-          </LinkTo>
-        </li>
-        {{#if list.item.deletePath.isPending}}
-          <li class="action">
-            <LoadingDropdownOption />
-          </li>
-        {{else if list.item.deletePath.canDelete}}
-          <ConfirmAction
-            @isInDropdown={{true}}
-            @buttonText="Revoke credentials"
-            @confirmTitle="Revoke this?"
-            @confirmMessage="Any client using these credentials will no longer be able to."
-            @onConfirmAction={{action
-              (perform
-                Item.callMethod
-                "destroyRecord"
-                list.item
-                "Successfully revoked credentials"
-                "There was an error revoking the credentials"
-                (action "refresh")
-              )
-            }}
+        <Hds::Dropdown @isInline={{true}} @listPosition="bottom-right" as |dd|>
+          <dd.ToggleIcon @icon="more-horizontal" @text="More options" @hasChevron={{false}} data-test-popup-menu-trigger />
+          <dd.Interactive
+            @text="View credentials"
+            @route="credentials.show"
+            @models={{array this.scope this.role list.item.id}}
           />
-        {{/if}}
+          {{#if list.item.deletePath.isPending}}
+            <dd.Generic>
+              <LoadingDropdownOption />
+            </dd.Generic>
+          {{else if list.item.deletePath.canDelete}}
+            <dd.Interactive
+              @text="Revoke credentials"
+              @color="critical"
+              {{on "click" (fn (mut this.showConfirmModal) true)}}
+            />
+          {{/if}}
+        </Hds::Dropdown>
       </Item.menu>
+      {{#if this.showConfirmModal}}
+        <ConfirmModal
+          @color="critical"
+          @onClose={{fn (mut this.showConfirmModal) false}}
+          @confirmTitle="Revoke this?"
+          @confirmMessage="Any client using these credentials will no longer be able to."
+          @onConfirm={{action
+            (perform
+              Item.callMethod
+              "destroyRecord"
+              list.item
+              "Successfully revoked credentials"
+              "There was an error revoking the credentials"
+              (action "refresh")
+            )
+          }}
+        />
+      {{/if}}
     </ListItem>
   {{else}}
     <ListItem as |Item|>

--- a/ui/lib/kmip/addon/templates/scope/roles.hbs
+++ b/ui/lib/kmip/addon/templates/scope/roles.hbs
@@ -82,7 +82,12 @@
               <dd.Interactive @text="Edit role" @route="role.edit" @models={{array this.scope list.item.id}} />
             {{/if}}
             {{#if list.item.updatePath.canDelete}}
-              <dd.Interactive @text="Delete role" @color="critical" {{on "click" (fn (mut this.showConfirmModal) true)}} />
+              <dd.Interactive
+                @text="Delete role"
+                @color="critical"
+                {{on "click" (fn (mut this.showConfirmModal) true)}}
+                data-test-confirm-action-trigger
+              />
             {{/if}}
           {{/if}}
         </Hds::Dropdown>

--- a/ui/lib/kmip/addon/templates/scope/roles.hbs
+++ b/ui/lib/kmip/addon/templates/scope/roles.hbs
@@ -69,44 +69,39 @@
         <Icon @name="user" class="has-text-grey-light" />{{list.item.id}}
       </Item.content>
       <Item.menu>
-        <li class="action">
-          <LinkTo @route="credentials" @models={{array this.scope list.item.id}} class="is-block">
-            View credentials
-          </LinkTo>
-        </li>
-        <li class="action">
-          <LinkTo @route="role" @models={{array this.scope list.item.id}} class="is-block">
-            View role
-          </LinkTo>
-        </li>
-        {{#if list.item.updatePath.isPending}}
-          <li class="action">
-            <LoadingDropdownOption />
-          </li>
-        {{else}}
-          {{#if list.item.updatePath.canUpdate}}
-            <LinkTo @route="role.edit" @models={{array this.scope list.item.id}} class="is-block">
-              Edit role
-            </LinkTo>
+        <Hds::Dropdown @isInline={{true}} @listPosition="bottom-right" as |dd|>
+          <dd.ToggleIcon @icon="more-horizontal" @text="More options" @hasChevron={{false}} data-test-popup-menu-trigger />
+          <dd.Interactive @text="View credentials" @route="credentials" @models={{array this.scope list.item.id}} />
+          <dd.Interactive @text="View role" @route="role" @models={{array this.scope list.item.id}} />
+          {{#if list.item.updatePath.isPending}}
+            <dd.Generic>
+              <LoadingDropdownOption />
+            </dd.Generic>
+          {{else}}
+            {{#if list.item.updatePath.canUpdate}}
+              <dd.Interactive @text="Edit role" @route="role.edit" @models={{array this.scope list.item.id}} />
+            {{/if}}
+            {{#if list.item.updatePath.canDelete}}
+              <dd.Interactive @text="Delete role" @color="critical" {{on "click" (fn (mut this.showConfirmModal) true)}} />
+            {{/if}}
           {{/if}}
-          {{#if list.item.updatePath.canDelete}}
-            <ConfirmAction
-              @isInDropdown={{true}}
-              @buttonText="Delete role"
-              @confirmMessage="Are you sure you want to delete {{list.item.id}}?"
-              @onConfirmAction={{action
-                (perform
-                  Item.callMethod
-                  "destroyRecord"
-                  list.item
-                  (concat "Successfully deleted role " list.item.id)
-                  (concat "There was an error deleting the role " list.item.id)
-                  (action "refresh")
-                )
-              }}
-              data-test-scope-delete
-            />
-          {{/if}}
+        </Hds::Dropdown>
+        {{#if this.showConfirmModal}}
+          <ConfirmModal
+            @color="critical"
+            @confirmMessage="Are you sure you want to delete {{list.item.id}}?"
+            @onConfirm={{action
+              (perform
+                Item.callMethod
+                "destroyRecord"
+                list.item
+                (concat "Successfully deleted role " list.item.id)
+                (concat "There was an error deleting the role " list.item.id)
+                (action "refresh")
+              )
+            }}
+            @onClose={{fn (mut this.showConfirmModal) false}}
+          />
         {{/if}}
       </Item.menu>
     </ListItem>

--- a/ui/lib/kmip/addon/templates/scopes/index.hbs
+++ b/ui/lib/kmip/addon/templates/scopes/index.hbs
@@ -66,7 +66,12 @@
               <LoadingDropdownOption />
             </dd.Generic>
           {{else if list.item.updatePath.canDelete}}
-            <dd.Interactive @text="Delete scope" @color="critical" {{on "click" (fn (mut this.showConfirmModal) true)}} />
+            <dd.Interactive
+              @text="Delete scope"
+              @color="critical"
+              {{on "click" (fn (mut this.showConfirmModal) true)}}
+              data-test-confirm-action-trigger
+            />
           {{/if}}
         </Hds::Dropdown>
         {{#if this.showConfirmModal}}

--- a/ui/lib/kmip/addon/templates/scopes/index.hbs
+++ b/ui/lib/kmip/addon/templates/scopes/index.hbs
@@ -58,22 +58,24 @@
         <Icon @name="folder" class="has-text-grey-light" />{{list.item.id}}
       </Item.content>
       <Item.menu>
-        <li class="action">
-          <LinkTo @route="scope" @model={{list.item.id}} class="is-block">
-            View scope
-          </LinkTo>
-        </li>
-        {{#if list.item.updatePath.isPending}}
-          <li class="action">
-            <LoadingDropdownOption />
-          </li>
-        {{else if list.item.updatePath.canDelete}}
-          <ConfirmAction
-            @isInDropdown={{true}}
-            @buttonText="Delete scope"
+        <Hds::Dropdown @isInline={{true}} @listPosition="bottom-right" as |dd|>
+          <dd.ToggleIcon @icon="more-horizontal" @text="More options" @hasChevron={{false}} data-test-popup-menu-trigger />
+          <dd.Interactive @text="View scope" @route="scope" @model={{list.item.id}} />
+          {{#if list.item.updatePath.isPending}}
+            <dd.Generic>
+              <LoadingDropdownOption />
+            </dd.Generic>
+          {{else if list.item.updatePath.canDelete}}
+            <dd.Interactive @text="Delete scope" @color="critical" {{on "click" (fn (mut this.showConfirmModal) true)}} />
+          {{/if}}
+        </Hds::Dropdown>
+        {{#if this.showConfirmModal}}
+          <ConfirmModal
+            @color="critical"
             @confirmTitle="Delete scope {{list.item.id}}?"
             @confirmMessage="This will permanently delete this scope and all roles and credentials contained within"
-            @onConfirmAction={{action
+            @onClose={{fn (mut this.showConfirmModal) false}}
+            @onConfirm={{action
               (perform
                 Item.callMethod
                 "destroyRecord"

--- a/ui/lib/kubernetes/addon/components/page/roles.hbs
+++ b/ui/lib/kubernetes/addon/components/page/roles.hbs
@@ -37,43 +37,35 @@
           <span data-test-role={{role.name}}>{{role.name}}</span>
         </Item.content>
         <Item.menu>
-          {{#if role.rolesPath.isLoading}}
-            <li class="action">
-              <Hds::Button disabled @color="tertiary" @icon="loading" @text="loading" @isIconOnly={{true}} />
-            </li>
-          {{else}}
-            <li class="action">
-              <LinkTo
-                class="has-text-black has-text-weight-semibold"
-                data-test-details
-                @route="roles.role.details"
-                @model={{role}}
-                @disabled={{eq role.canRead false}}
-              >
-                Details
-              </LinkTo>
-            </li>
-            <li class="action">
-              <LinkTo
-                class="has-text-black has-text-weight-semibold"
-                data-test-edit
-                @route="roles.role.edit"
-                @model={{role}}
-                @disabled={{not role.canEdit}}
-              >
-                Edit
-              </LinkTo>
-            </li>
-            <ConfirmAction
-              data-test-delete
-              @isInDropdown={{true}}
-              @buttonText="Delete"
-              @confirmMessage="Deleting this role means that you’ll need to recreate it in order to generate credentials again."
-              @onConfirmAction={{fn this.onDelete role}}
-            />
+          {{#if (or role.canRead role.canEdit role.canDelete)}}
+            <Hds::Dropdown @isInline={{true}} @listPosition="bottom-right" as |dd|>
+              <dd.ToggleIcon
+                @icon="more-horizontal"
+                @text="More options"
+                @hasChevron={{false}}
+                data-test-popup-menu-trigger
+              />
+              {{#if role.canRead}}
+                <dd.Interactive @text="Details" @route="roles.role.details" @model={{role}} data-test-details />
+              {{/if}}
+              {{#if role.canEdit}}
+                <dd.Interactive @text="Edit" data-test-edit @route="roles.role.edit" @model={{role}} />
+              {{/if}}
+              {{#if role.canDelete}}
+                <dd.Interactive @text="Delete" @color="critical" {{on "click" (fn (mut this.roleToDelete) role)}} />
+              {{/if}}
+            </Hds::Dropdown>
           {{/if}}
         </Item.menu>
       </ListItem>
     {{/each}}
+    {{#if this.roleToDelete}}
+      <ConfirmModal
+        @color="critical"
+        @confirmMessage="Deleting this role means that you’ll need to recreate it in order to generate credentials again."
+        @onConfirm={{fn this.onDelete this.roleToDelete}}
+        @onClose={{fn (mut this.roleToDelete) null}}
+      />
+    {{/if}}
   </div>
 {{/if}}

--- a/ui/lib/kubernetes/addon/components/page/roles.hbs
+++ b/ui/lib/kubernetes/addon/components/page/roles.hbs
@@ -52,7 +52,12 @@
                 <dd.Interactive @text="Edit" data-test-edit @route="roles.role.edit" @model={{role}} />
               {{/if}}
               {{#if role.canDelete}}
-                <dd.Interactive @text="Delete" @color="critical" {{on "click" (fn (mut this.roleToDelete) role)}} />
+                <dd.Interactive
+                  @text="Delete"
+                  data-test-delete
+                  @color="critical"
+                  {{on "click" (fn (mut this.roleToDelete) role)}}
+                />
               {{/if}}
             </Hds::Dropdown>
           {{/if}}

--- a/ui/lib/kubernetes/addon/components/page/roles.js
+++ b/ui/lib/kubernetes/addon/components/page/roles.js
@@ -6,6 +6,7 @@
 import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
 import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
 import { getOwner } from '@ember/application';
 import errorMessage from 'vault/utils/error-message';
 
@@ -20,6 +21,7 @@ import errorMessage from 'vault/utils/error-message';
  */
 export default class RolesPageComponent extends Component {
   @service flashMessages;
+  @tracked roleToDelete = null;
 
   get mountPoint() {
     return getOwner(this).mountPoint;

--- a/ui/lib/ldap/addon/components/page/libraries.hbs
+++ b/ui/lib/ldap/addon/components/page/libraries.hbs
@@ -49,46 +49,35 @@
           <span data-test-library={{library.name}}>{{library.name}}</span>
         </Item.content>
         <Item.menu>
-          {{#if library.libraryPath.isLoading}}
-            <li class="action">
-              <Hds::Button disabled @color="tertiary" @icon="loading" @text="loading" @isIconOnly={{true}} />
-            </li>
-          {{else}}
-            <li class="action">
-              <LinkTo
-                class="has-text-black has-text-weight-semibold"
-                data-test-edit
-                @route="libraries.library.edit"
-                @model={{library}}
-                @disabled={{not library.canEdit}}
-              >
-                Edit
-              </LinkTo>
-            </li>
-            <li class="action">
-              <LinkTo
-                class="has-text-black has-text-weight-semibold"
-                data-test-details
-                @route="libraries.library.details"
-                @model={{library}}
-                @disabled={{not library.canRead}}
-              >
-                Details
-              </LinkTo>
-            </li>
-            {{#if library.canDelete}}
-              <ConfirmAction
-                data-test-delete
-                @id={{library.id}}
-                @isInDropdown={{true}}
-                @buttonText="Delete"
-                @confirmMessage="This library and associated accounts will be permanently deleted. You will not be able to recover it."
-                @onConfirmAction={{fn this.onDelete library}}
+          {{#if (or library.canRead library.canEdit library.canDelete)}}
+            <Hds::Dropdown @isInline={{true}} @listPosition="bottom-right" as |dd|>
+              <dd.ToggleIcon
+                @icon="more-horizontal"
+                @text="More options"
+                @hasChevron={{false}}
+                data-test-popup-menu-trigger
               />
-            {{/if}}
+              {{#if library.canEdit}}
+                <dd.Interactive @text="Edit" data-test-edit @route="libraries.library.edit" @model={{library}} />
+              {{/if}}
+              {{#if library.canRead}}
+                <dd.Interactive @text="Details" data-test-details @route="libraries.library.details" @model={{library}} />
+              {{/if}}
+              {{#if library.canDelete}}
+                <dd.Interactive @text="Delete" @color="critical" {{on "click" (fn (mut this.libraryToDelete) library)}} />
+              {{/if}}
+            </Hds::Dropdown>
           {{/if}}
         </Item.menu>
       </ListItem>
     {{/each}}
+    {{#if this.libraryToDelete}}
+      <ConfirmModal
+        @color="critical"
+        @confirmMessage="This library and associated accounts will be permanently deleted. You will not be able to recover it."
+        @onConfirm={{fn this.onDelete this.libraryToDelete}}
+        @onClose={{fn (mut this.libraryToDelete) false}}
+      />
+    {{/if}}
   </div>
 {{/if}}

--- a/ui/lib/ldap/addon/components/page/libraries.hbs
+++ b/ui/lib/ldap/addon/components/page/libraries.hbs
@@ -64,7 +64,12 @@
                 <dd.Interactive @text="Details" data-test-details @route="libraries.library.details" @model={{library}} />
               {{/if}}
               {{#if library.canDelete}}
-                <dd.Interactive @text="Delete" @color="critical" {{on "click" (fn (mut this.libraryToDelete) library)}} />
+                <dd.Interactive
+                  @text="Delete"
+                  data-test-delete
+                  @color="critical"
+                  {{on "click" (fn (mut this.libraryToDelete) library)}}
+                />
               {{/if}}
             </Hds::Dropdown>
           {{/if}}

--- a/ui/lib/ldap/addon/components/page/libraries.ts
+++ b/ui/lib/ldap/addon/components/page/libraries.ts
@@ -26,6 +26,7 @@ export default class LdapLibrariesPageComponent extends Component<Args> {
   @service declare readonly flashMessages: FlashMessageService;
 
   @tracked filterValue = '';
+  @tracked libraryToDelete: LdapLibraryModel | null = null;
 
   get mountPoint(): string {
     const owner = getOwner(this) as EngineOwner;

--- a/ui/lib/ldap/addon/components/page/roles.hbs
+++ b/ui/lib/ldap/addon/components/page/roles.hbs
@@ -50,69 +50,62 @@
           <Hds::Badge @text={{role.type}} data-test-role-type-badge={{role.name}} />
         </Item.content>
         <Item.menu>
-          {{#if role.rolePath.isLoading}}
-            <li class="action">
-              <Hds::Button disabled @color="tertiary" @icon="loading" @text="loading" @isIconOnly={{true}} />
-            </li>
-          {{else}}
-            <li class="action">
-              <LinkTo
-                class="has-text-black has-text-weight-semibold"
-                data-test-edit
-                @route="roles.role.edit"
-                @models={{array role.type role.name}}
-                @disabled={{not role.canEdit}}
-              >
-                Edit
-              </LinkTo>
-            </li>
-            <li class="action">
-              <LinkTo
-                class="has-text-black has-text-weight-semibold"
+          <Hds::Dropdown @isInline={{true}} @listPosition="bottom-right" as |dd|>
+            <dd.ToggleIcon @icon="more-horizontal" @text="More options" @hasChevron={{false}} data-test-popup-menu-trigger />
+            {{#if role.canEdit}}
+              <dd.Interactive @text="Edit" data-test-edit @route="roles.role.edit" @models={{array role.type role.name}} />
+            {{/if}}
+            {{#if role.canReadCreds}}
+              <dd.Interactive
+                @text="Get credentials"
                 data-test-get-creds
                 @route="roles.role.credentials"
                 @models={{array role.type role.name}}
-                @disabled={{not role.canReadCreds}}
-              >
-                Get credentials
-              </LinkTo>
-            </li>
+              />
+            {{/if}}
             {{#if role.canRotateStaticCreds}}
-              <ConfirmAction
+              <dd.Interactive
+                @text="Rotate credentials"
                 data-test-rotate-creds
-                @isInDropdown={{true}}
-                @id={{concat "rotate-" role.id}}
-                @buttonText="Rotate credentials"
-                @confirmMessage="When manually rotating credentials, the rotation period will start over."
-                @modalColor="warning"
-                @onConfirmAction={{fn this.onRotate role}}
+                @color="critical"
+                {{on "click" (fn (mut this.credsToRotate) role)}}
               />
             {{/if}}
-            <li class="action">
-              <LinkTo
-                class="has-text-black has-text-weight-semibold"
-                data-test-details
-                @route="roles.role.details"
-                {{! this will force the roles.role model hook to fire since we may only have a partial model loaded in the list view }}
-                @models={{array role.type role.name}}
-                @disabled={{not role.canRead}}
-              >
-                Details
-              </LinkTo>
-            </li>
+            <dd.Interactive
+              @text="Details"
+              data-test-details
+              @route="roles.role.details"
+              {{! this will force the roles.role model hook to fire since we may only have a partial model loaded in the list view }}
+              @models={{array role.type role.name}}
+            />
             {{#if role.canDelete}}
-              <ConfirmAction
+              <dd.Interactive
+                @text="Delete"
                 data-test-delete
-                @isInDropdown={{true}}
-                @buttonText="Delete"
-                @confirmMessage="Deleting this role means that you’ll need to recreate it in order to generate credentials again."
-                @onConfirmAction={{fn this.onDelete role}}
+                @color="critical"
+                {{on "click" (fn (mut this.roleToDelete) role)}}
               />
             {{/if}}
-          {{/if}}
+          </Hds::Dropdown>
         </Item.menu>
       </ListItem>
     {{/each}}
+
+    {{#if this.credsToRotate}}
+      <ConfirmModal
+        @confirmMessage="When manually rotating credentials, the rotation period will start over."
+        @onConfirm={{fn this.onRotate this.credsToRotate}}
+        @onClose={{fn (mut this.credsToRotate) null}}
+      />
+    {{/if}}
+    {{#if this.roleToDelete}}
+      <ConfirmModal
+        @color="critical"
+        @confirmMessage="Deleting this role means that you’ll need to recreate it in order to generate credentials again."
+        @onConfirm={{fn this.onDelete this.roleToDelete}}
+        @onClose={{fn (mut this.roleToDelete) null}}
+      />
+    {{/if}}
 
     <Hds::Pagination::Numbered
       @currentPage={{@roles.meta.currentPage}}

--- a/ui/lib/ldap/addon/components/page/roles.ts
+++ b/ui/lib/ldap/addon/components/page/roles.ts
@@ -15,6 +15,7 @@ import type FlashMessageService from 'vault/services/flash-messages';
 import type { Breadcrumb, EngineOwner } from 'vault/vault/app-types';
 import type RouterService from '@ember/routing/router-service';
 import type StoreService from 'vault/services/store';
+import { tracked } from '@glimmer/tracking';
 
 interface Args {
   roles: Array<LdapRoleModel>;
@@ -28,6 +29,9 @@ export default class LdapRolesPageComponent extends Component<Args> {
   @service declare readonly flashMessages: FlashMessageService;
   @service declare readonly router: RouterService;
   @service declare readonly store: StoreService;
+
+  @tracked credsToRotate: LdapRoleModel | null = null;
+  @tracked roleToDelete: LdapRoleModel | null = null;
 
   get mountPoint(): string {
     const owner = getOwner(this) as EngineOwner;
@@ -51,6 +55,8 @@ export default class LdapRolesPageComponent extends Component<Args> {
       this.flashMessages.success(message);
     } catch (error) {
       this.flashMessages.danger(`Error rotating credentials \n ${errorMessage(error)}`);
+    } finally {
+      this.credsToRotate = null;
     }
   }
 
@@ -64,6 +70,8 @@ export default class LdapRolesPageComponent extends Component<Args> {
       this.flashMessages.success(message);
     } catch (error) {
       this.flashMessages.danger(`Error deleting role \n ${errorMessage(error)}`);
+    } finally {
+      this.roleToDelete = null;
     }
   }
 }

--- a/ui/lib/sync/addon/components/secrets/page/destinations.hbs
+++ b/ui/lib/sync/addon/components/secrets/page/destinations.hbs
@@ -68,46 +68,57 @@
         </Item.content>
 
         <Item.menu>
-          {{#if destination.destinationPath.isLoading}}
-            <li class="action">
-              <LoadingDropdownOption />
-            </li>
-          {{else}}
-            <li>
-              <LinkTo
-                class="has-text-black has-text-weight-semibold"
-                data-test-details
-                @route="secrets.destinations.destination.details"
-                @models={{array destination.type destination.name}}
-                @disabled={{not destination.canRead}}
-              >
-                Details
-              </LinkTo>
-            </li>
-            <li>
-              <LinkTo
-                class="has-text-black has-text-weight-semibold"
-                data-test-edit
-                @route="secrets.destinations.destination.edit"
-                @models={{array destination.type destination.name}}
-                @disabled={{not destination.canEdit}}
-              >
-                Edit
-              </LinkTo>
-            </li>
-            {{#if destination.canDelete}}
-              <ConfirmAction
-                data-test-delete
-                @isInDropdown={{true}}
-                @buttonText="Delete"
-                @confirmMessage="The destination will be permanently deleted and all the secrets will be unsynced. This cannot be undone."
-                @onConfirmAction={{fn this.onDelete destination}}
+          {{#if (or destination.canRead destination.canEdit destination.canDelete)}}
+            <Hds::Dropdown @isInline={{true}} @listPosition="bottom-right" as |dd|>
+              <dd.ToggleIcon
+                @icon="more-horizontal"
+                @text="More options"
+                @hasChevron={{false}}
+                data-test-popup-menu-trigger
               />
-            {{/if}}
+              {{#if destination.destinationPath.isLoading}}
+                <dd.Generic>
+                  <LoadingDropdownOption />
+                </dd.Generic>
+              {{else}}
+                {{#if destination.canRead}}
+                  <dd.Interactive
+                    @text="Details"
+                    data-test-details
+                    @route="secrets.destinations.destination.details"
+                    @models={{array destination.type destination.name}}
+                  />
+                {{/if}}
+                {{#if destination.canEdit}}
+                  <dd.Interactive
+                    @text="Edit"
+                    data-test-edit
+                    @route="secrets.destinations.destination.edit"
+                    @models={{array destination.type destination.name}}
+                  />
+                {{/if}}
+                {{#if destination.canDelete}}
+                  <dd.Interactive
+                    @text="Delete"
+                    @color="critical"
+                    data-test-delete
+                    {{on "click" (fn (mut this.destinationToDelete) destination)}}
+                  />
+                {{/if}}
+              {{/if}}
+            </Hds::Dropdown>
           {{/if}}
         </Item.menu>
       </ListItem>
     {{/each}}
+    {{#if this.destinationToDelete}}
+      <ConfirmModal
+        @color="critical"
+        @confirmMessage="The destination will be permanently deleted and all the secrets will be unsynced. This cannot be undone."
+        @onConfirm={{fn this.onDelete this.destinationToDelete}}
+        @onClose={{fn (mut this.destinationToDelete) null}}
+      />
+    {{/if}}
     <Hds::Pagination::Numbered
       @currentPage={{@destinations.meta.currentPage}}
       @currentPageSize={{@destinations.meta.pageSize}}

--- a/ui/lib/sync/addon/components/secrets/page/destinations.ts
+++ b/ui/lib/sync/addon/components/secrets/page/destinations.ts
@@ -18,6 +18,7 @@ import type FlashMessageService from 'vault/services/flash-messages';
 import type { EngineOwner } from 'vault/vault/app-types';
 import type { SyncDestinationName, SyncDestinationType } from 'vault/vault/helpers/sync-destinations';
 import type Transition from '@ember/routing/transition';
+import { tracked } from '@glimmer/tracking';
 
 interface Args {
   destinations: Array<SyncDestinationModel>;
@@ -29,6 +30,8 @@ export default class SyncSecretsDestinationsPageComponent extends Component<Args
   @service declare readonly router: RouterService;
   @service declare readonly store: StoreService;
   @service declare readonly flashMessages: FlashMessageService;
+
+  @tracked destinationToDelete: SyncDestinationModel | null = null;
 
   // for some reason there isn't a full page refresh happening when transitioning on filter change
   // when the transition happens it causes the FilterInput component to lose focus since it can only focus on didInsert
@@ -101,6 +104,8 @@ export default class SyncSecretsDestinationsPageComponent extends Component<Args
       this.flashMessages.success(message);
     } catch (error) {
       this.flashMessages.danger(`Error deleting destination \n ${errorMessage(error)}`);
+    } finally {
+      this.destinationToDelete = null;
     }
   }
 }

--- a/ui/lib/sync/addon/components/secrets/page/destinations/destination/secrets.hbs
+++ b/ui/lib/sync/addon/components/secrets/page/destinations/destination/secrets.hbs
@@ -31,40 +31,43 @@
         </Item.content>
 
         <Item.menu>
-          {{#if (or association.setAssociationPath.isLoading association.removeAssociationPath.isLoading)}}
-            <li class="action">
-              <LoadingDropdownOption />
-            </li>
-          {{else}}
-            <li class="action">
-              <Hds::Button
-                @text="Sync now"
-                class="link is-flex-start"
-                @isFullWidth={{true}}
-                disabled={{not association.canSync}}
-                data-test-association-action="sync"
-                {{on "click" (fn this.update association "set")}}
-              />
-            </li>
-            <li>
-              <LinkToExternal
-                class="has-text-black has-text-weight-semibold"
+          <Hds::Dropdown @isInline={{true}} @listPosition="bottom-right" as |dd|>
+            <dd.ToggleIcon @icon="more-horizontal" @text="More options" @hasChevron={{false}} data-test-popup-menu-trigger />
+            {{#if (or association.setAssociationPath.isLoading association.removeAssociationPath.isLoading)}}
+              <dd.Generic>
+                <LoadingDropdownOption />
+              </dd.Generic>
+            {{else}}
+              {{#if association.canSync}}
+                <dd.Interactive
+                  @text="Sync now"
+                  data-test-association-action="sync"
+                  {{on "click" (fn this.update association "set")}}
+                />
+              {{/if}}
+              <dd.Interactive
+                @text="View secret"
                 data-test-association-action="view"
                 @route="kvSecretDetails"
                 @models={{array association.mount association.secretName}}
-              >
-                View secret
-              </LinkToExternal>
-            </li>
-            {{#if association.canUnsync}}
-              <ConfirmAction
-                data-test-association-action="unsync"
-                @isInDropdown={{true}}
-                @buttonText="Unsync"
-                @confirmMessage="This secret will be unsynced from this destination."
-                @onConfirmAction={{fn this.update association "remove"}}
+                @isRouteExternal={{true}}
               />
+              {{#if association.canUnsync}}
+                <dd.Interactive
+                  @text="Unsync"
+                  @color="critical"
+                  data-test-association-action="unsync"
+                  {{on "click" (fn (mut this.associationToUnsync) association)}}
+                />
+              {{/if}}
             {{/if}}
+          </Hds::Dropdown>
+          {{#if this.associationToUnsync}}
+            <ConfirmModal
+              @confirmMessage="This secret will be unsynced from this destination."
+              @onConfirm={{fn this.update this.associationToUnsync "remove"}}
+              @onClose={{fn (mut this.associationToUnsync) null}}
+            />
           {{/if}}
         </Item.menu>
       </ListItem>

--- a/ui/lib/sync/addon/components/secrets/page/destinations/destination/secrets.ts
+++ b/ui/lib/sync/addon/components/secrets/page/destinations/destination/secrets.ts
@@ -15,6 +15,7 @@ import type RouterService from '@ember/routing/router-service';
 import type StoreService from 'vault/services/store';
 import type FlashMessageService from 'vault/services/flash-messages';
 import type { EngineOwner } from 'vault/vault/app-types';
+import { tracked } from '@glimmer/tracking';
 
 interface Args {
   destination: SyncDestinationModel;
@@ -25,6 +26,8 @@ export default class SyncSecretsDestinationsPageComponent extends Component<Args
   @service declare readonly router: RouterService;
   @service declare readonly store: StoreService;
   @service declare readonly flashMessages: FlashMessageService;
+
+  @tracked associationToUnsync: SyncAssociationModel | null = null;
 
   get mountPoint(): string {
     const owner = getOwner(this) as EngineOwner;

--- a/ui/tests/acceptance/access/identity/entities/create-test.js
+++ b/ui/tests/acceptance/access/identity/entities/create-test.js
@@ -9,18 +9,11 @@ import { setupApplicationTest } from 'ember-qunit';
 import page from 'vault/tests/pages/access/identity/create';
 import { testCRUD, testDeleteFromForm } from '../_shared-tests';
 import authPage from 'vault/tests/pages/auth';
-import { setRunOptions } from 'ember-a11y-testing/test-support';
 
 module('Acceptance | /access/identity/entities/create', function (hooks) {
   setupApplicationTest(hooks);
 
   hooks.beforeEach(function () {
-    // Popup menu causes flakiness
-    setRunOptions({
-      rules: {
-        'color-contrast': { enabled: false },
-      },
-    });
     return authPage.login();
   });
 

--- a/ui/tests/acceptance/access/identity/groups/aliases/create-test.js
+++ b/ui/tests/acceptance/access/identity/groups/aliases/create-test.js
@@ -8,18 +8,11 @@ import { settled } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { testAliasCRUD, testAliasDeleteFromForm } from '../../_shared-alias-tests';
 import authPage from 'vault/tests/pages/auth';
-import { setRunOptions } from 'ember-a11y-testing/test-support';
 
 module('Acceptance | /access/identity/groups/aliases/add', function (hooks) {
   setupApplicationTest(hooks);
 
   hooks.beforeEach(async function () {
-    // Popup menu causes flakiness
-    setRunOptions({
-      rules: {
-        'color-contrast': { enabled: false },
-      },
-    });
     await authPage.login();
     return;
   });

--- a/ui/tests/acceptance/access/identity/groups/create-test.js
+++ b/ui/tests/acceptance/access/identity/groups/create-test.js
@@ -9,18 +9,11 @@ import { setupApplicationTest } from 'ember-qunit';
 import page from 'vault/tests/pages/access/identity/create';
 import { testCRUD, testDeleteFromForm } from '../_shared-tests';
 import authPage from 'vault/tests/pages/auth';
-import { setRunOptions } from 'ember-a11y-testing/test-support';
 
 module('Acceptance | /access/identity/groups/create', function (hooks) {
   setupApplicationTest(hooks);
 
   hooks.beforeEach(function () {
-    // Popup menu causes flakiness
-    setRunOptions({
-      rules: {
-        'color-contrast': { enabled: false },
-      },
-    });
     return authPage.login();
   });
 

--- a/ui/tests/acceptance/enterprise-kmip-test.js
+++ b/ui/tests/acceptance/enterprise-kmip-test.js
@@ -13,7 +13,6 @@ import rolesPage from 'vault/tests/pages/secrets/backend/kmip/roles';
 import credentialsPage from 'vault/tests/pages/secrets/backend/kmip/credentials';
 import mountSecrets from 'vault/tests/pages/settings/mount-secret-backend';
 import { allEngines } from 'vault/helpers/mountable-secret-engines';
-import { setRunOptions } from 'ember-a11y-testing/test-support';
 import { runCmd } from 'vault/tests/helpers/commands';
 
 const getRandomPort = () => {
@@ -316,16 +315,9 @@ module('Acceptance | Enterprise | KMIP secrets', function (hooks) {
   });
 
   test('it can revoke a credential from the list', async function (assert) {
-    // Popup menu causes flakiness
-    setRunOptions({
-      rules: {
-        'color-contrast': { enabled: false },
-      },
-    });
     const { path, scope, role } = await generateCreds();
     await credentialsPage.visit({ backend: path, scope, role });
     // revoke the credentials
-    await settled();
     await credentialsPage.listItemLinks.objectAt(0).menuToggle();
     await settled();
     await credentialsPage.delete().confirmDelete();

--- a/ui/tests/acceptance/secrets/backend/kubernetes/roles-test.js
+++ b/ui/tests/acceptance/secrets/backend/kubernetes/roles-test.js
@@ -10,7 +10,6 @@ import kubernetesScenario from 'vault/mirage/scenarios/kubernetes';
 import kubernetesHandlers from 'vault/mirage/handlers/kubernetes';
 import authPage from 'vault/tests/pages/auth';
 import { fillIn, visit, currentURL, click, currentRouteName } from '@ember/test-helpers';
-import { setRunOptions } from 'ember-a11y-testing/test-support';
 
 module('Acceptance | kubernetes | roles', function (hooks) {
   setupApplicationTest(hooks);
@@ -55,12 +54,6 @@ module('Acceptance | kubernetes | roles', function (hooks) {
   });
 
   test('it should have functional list item menu', async function (assert) {
-    // Popup menu causes flakiness
-    setRunOptions({
-      rules: {
-        'color-contrast': { enabled: false },
-      },
-    });
     assert.expect(3);
     await this.visitRoles();
     for (const action of ['details', 'edit', 'delete']) {

--- a/ui/tests/acceptance/secrets/backend/ldap/libraries-test.js
+++ b/ui/tests/acceptance/secrets/backend/ldap/libraries-test.js
@@ -11,7 +11,6 @@ import ldapHandlers from 'vault/mirage/handlers/ldap';
 import authPage from 'vault/tests/pages/auth';
 import { click } from '@ember/test-helpers';
 import { isURL, visitURL } from 'vault/tests/helpers/ldap';
-import { setRunOptions } from 'ember-a11y-testing/test-support';
 
 module('Acceptance | ldap | libraries', function (hooks) {
   setupApplicationTest(hooks);
@@ -38,12 +37,6 @@ module('Acceptance | ldap | libraries', function (hooks) {
   });
 
   test('it should transition to routes from list item action menu', async function (assert) {
-    // Popup menu causes flakiness
-    setRunOptions({
-      rules: {
-        'color-contrast': { enabled: false },
-      },
-    });
     assert.expect(2);
 
     for (const action of ['edit', 'details']) {

--- a/ui/tests/acceptance/secrets/backend/ldap/roles-test.js
+++ b/ui/tests/acceptance/secrets/backend/ldap/roles-test.js
@@ -11,7 +11,6 @@ import ldapHandlers from 'vault/mirage/handlers/ldap';
 import authPage from 'vault/tests/pages/auth';
 import { click, fillIn } from '@ember/test-helpers';
 import { isURL, visitURL } from 'vault/tests/helpers/ldap';
-import { setRunOptions } from 'ember-a11y-testing/test-support';
 
 module('Acceptance | ldap | roles', function (hooks) {
   setupApplicationTest(hooks);
@@ -45,12 +44,6 @@ module('Acceptance | ldap | roles', function (hooks) {
   });
 
   test('it should transition to routes from list item action menu', async function (assert) {
-    // Popup menu causes flakiness
-    setRunOptions({
-      rules: {
-        'color-contrast': { enabled: false },
-      },
-    });
     assert.expect(3);
 
     for (const action of ['edit', 'get-creds', 'details']) {

--- a/ui/tests/acceptance/ssh-test.js
+++ b/ui/tests/acceptance/ssh-test.js
@@ -10,7 +10,6 @@ import { v4 as uuidv4 } from 'uuid';
 
 import authPage from 'vault/tests/pages/auth';
 import enablePage from 'vault/tests/pages/settings/mount-secret-backend';
-import { setRunOptions } from 'ember-a11y-testing/test-support';
 
 module('Acceptance | ssh secret backend', function (hooks) {
   setupApplicationTest(hooks);
@@ -84,12 +83,6 @@ module('Acceptance | ssh secret backend', function (hooks) {
     },
   ];
   test('ssh backend', async function (assert) {
-    // Popup menu causes flakiness
-    setRunOptions({
-      rules: {
-        'color-contrast': { enabled: false },
-      },
-    });
     assert.expect(28);
     const sshPath = `ssh-${this.uid}`;
 

--- a/ui/tests/integration/components/kubernetes/page/roles-test.js
+++ b/ui/tests/integration/components/kubernetes/page/roles-test.js
@@ -9,6 +9,7 @@ import { setupEngine } from 'ember-engines/test-support';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { render, click } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
+import { allowAllCapabilitiesStub } from 'vault/tests/helpers/stubs';
 
 module('Integration | Component | kubernetes | Page::Roles', function (hooks) {
   setupRenderingTest(hooks);
@@ -17,6 +18,7 @@ module('Integration | Component | kubernetes | Page::Roles', function (hooks) {
 
   hooks.beforeEach(function () {
     this.store = this.owner.lookup('service:store');
+    this.server.post('/sys/capabilities-self', allowAllCapabilitiesStub(['read', 'update', 'delete']));
     this.store.pushPayload('secret-engine', {
       modelName: 'secret-engine',
       data: {
@@ -88,11 +90,6 @@ module('Integration | Component | kubernetes | Page::Roles', function (hooks) {
   });
 
   test('it should render roles list', async function (assert) {
-    this.server.post('/sys/capabilities-self', () => ({
-      data: {
-        'kubernetes/role': ['root'],
-      },
-    }));
     await this.renderComponent();
     assert.dom('[data-test-list-item-content] svg').hasClass('flight-icon-user', 'List item icon renders');
     assert


### PR DESCRIPTION
This PR updates the last of the Popup menus, which were rendered as contextual components in the `ListItem` component. Once this PR and #25366 are merged we can remove PopupMenu completely. 

**Areas impacted**
- Generated auth items (eg. userpass users) CRUD via popup menu
- Namespace CRUD via list
- KMIP items CRUD via list
- Kubernetes items CRUD via list
- LDAP items CRUD via list
- Sync items CRUD via list

<img width="1286" alt="new-k8s-role" src="https://github.com/hashicorp/vault/assets/82459713/3a81c969-38dc-4cbc-aa6a-9b6876a08247">
<img width="1286" alt="new-kmip-cred" src="https://github.com/hashicorp/vault/assets/82459713/4637134b-ab75-4585-89b0-3f6b0a162f32">
<img width="1286" alt="new-kmip-role" src="https://github.com/hashicorp/vault/assets/82459713/0a90654d-f056-4dc1-83df-53766faf9f95">
<img width="1286" alt="new-ldap-role" src="https://github.com/hashicorp/vault/assets/82459713/14b7be2a-1373-48f4-8d92-659c63623dec">
<img width="1286" alt="new-ldap-role-static" src="https://github.com/hashicorp/vault/assets/82459713/6648e8e6-641d-4e60-b48f-21af8dd46b4a">
<img width="1286" alt="new-namespaces" src="https://github.com/hashicorp/vault/assets/82459713/37ccc1b4-ccf0-49f0-a089-05606a923d7c">
<img width="1286" alt="new-sync-destination" src="https://github.com/hashicorp/vault/assets/82459713/cbfd6e84-808a-48d3-bb2c-38d9ae52b82e">
<img width="1286" alt="new-sync-secret" src="https://github.com/hashicorp/vault/assets/82459713/399f4f84-cc08-46ec-9e59-7ae21831181b">
<img width="1286" alt="new-userpass" src="https://github.com/hashicorp/vault/assets/82459713/6f265674-1027-418d-873f-4aa585796092">
<img width="1286" alt="new-kmip-scope" src="https://github.com/hashicorp/vault/assets/82459713/246d7200-b35e-42ab-8590-84a2f97522ef">
