### PR TITLE
UI: fix items displayed in sidenav for chroot

### DIFF
--- a/ui/app/components/sidebar/nav/cluster.js
+++ b/ui/app/components/sidebar/nav/cluster.js
@@ -18,6 +18,6 @@ export default class SidebarNavClusterComponent extends Component {
 
   get isRootNamespace() {
     // should only return true if we're in the true root namespace
-    return this.namespace.inRootNamespace && !this.currentCluster.cluster.hasChrootNamespace;
+    return this.namespace.inRootNamespace && !this.cluster?.hasChrootNamespace;
   }
 }

--- a/ui/app/components/sidebar/nav/cluster.js
+++ b/ui/app/components/sidebar/nav/cluster.js
@@ -18,6 +18,6 @@ export default class SidebarNavClusterComponent extends Component {
 
   get isRootNamespace() {
     // should only return true if we're in the true root namespace
-    return this.namespace.inRootNamespace && !this.currentCluster.hasChrootNamespace;
+    return this.namespace.inRootNamespace && !this.currentCluster.cluster.hasChrootNamespace;
   }
 }

--- a/ui/tests/acceptance/chroot-namespace-test.js
+++ b/ui/tests/acceptance/chroot-namespace-test.js
@@ -29,6 +29,21 @@ module('Acceptance | chroot-namespace enterprise ui', function (hooks) {
     assert.dom('[data-test-badge-namespace]').includesText('root', 'Shows root namespace badge');
   });
 
+  test('root-only nav items are unavailable', async function (assert) {
+    await authPage.login();
+
+    ['Dashboard', 'Secrets Engines', 'Access', 'Tools', 'Policies', 'Client Count'].forEach((nav) => {
+      assert.dom(navLink(nav)).exists(`Shows ${nav} nav item in chroot listener`);
+    });
+    ['Replication', 'Raft Storage', 'License', 'Seal Vault'].forEach((nav) => {
+      assert.dom(navLink(nav)).doesNotExist(`Does not show ${nav} nav item in chroot listener`);
+    });
+
+    // cleanup namespace
+    await authPage.login();
+    await runCmd(`delete sys/namespaces/${namespace}`);
+  });
+
   test('a user with default policy should see nav items', async function (assert) {
     await authPage.login();
     // Create namespace


### PR DESCRIPTION
Logging in as root token to chroot listener should show the same nav items as logging in as root token to a child namespace. This PR correctly calculates what to show in the main nav. 

- [x] ent tests pass