### PR TITLE
vault-23135 - fix modify storage keys ending with .temp causes overwr…

### DIFF
--- a/changelog/25395.txt
+++ b/changelog/25395.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+storage/file: Fixing spuriously deleting storage keys ending with .temp
+```

--- a/sdk/physical/file/file_test.go
+++ b/sdk/physical/file/file_test.go
@@ -242,11 +242,7 @@ func TestFileBackend(t *testing.T) {
 }
 
 func TestFileBackendCreateTempKey(t *testing.T) {
-	dir, err := ioutil.TempDir("", "vault")
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	logger := logging.NewVaultLogger(log.Debug)
 

--- a/sdk/physical/file/file_test.go
+++ b/sdk/physical/file/file_test.go
@@ -240,3 +240,58 @@ func TestFileBackend(t *testing.T) {
 
 	physical.ExerciseBackend_ListPrefix(t, b)
 }
+
+func TestFileBackendCreateTempKey(t *testing.T) {
+	dir, err := ioutil.TempDir("", "vault")
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	defer os.RemoveAll(dir)
+
+	logger := logging.NewVaultLogger(log.Debug)
+
+	b, err := NewFileBackend(map[string]string{
+		"path": dir,
+	}, logger)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	temp := &physical.Entry{Key: "example.temp", Value: []byte("tempfoo")}
+	err = b.Put(context.Background(), temp)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	nonTemp := &physical.Entry{Key: "example", Value: []byte("foobar")}
+	err = b.Put(context.Background(), nonTemp)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	vals, err := b.List(context.Background(), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(vals) != 2 || vals[0] == vals[1] {
+		t.Fatalf("bad: %v", vals)
+	}
+	for _, val := range vals {
+		if val != "example.temp" && val != "example" {
+			t.Fatalf("bad val: %v", val)
+		}
+	}
+	out, err := b.Get(context.Background(), "example")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !reflect.DeepEqual(out, nonTemp) {
+		t.Fatalf("bad: %v expected: %v", out, nonTemp)
+	}
+	out, err = b.Get(context.Background(), "example.temp")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !reflect.DeepEqual(out, temp) {
+		t.Fatalf("bad: %v expected: %v", out, temp)
+	}
+}


### PR DESCRIPTION
Addresses https://github.com/hashicorp/vault/issues/23135

Instead of hardcoded `.temp` suffix, randomize the suffix to make sure it is not overwriting an existing file.