### PR TITLE
[QT-670] ci: install gosimports

### DIFF
--- a/.github/actions/install-external-tools/action.yml
+++ b/.github/actions/install-external-tools/action.yml
@@ -15,6 +15,7 @@ runs:
       with:
         version: v1.25.0 # This should match the version in tools/tool.sh
     - uses: ./.github/actions/set-up-gofumpt
+    - uses: ./.github/actions/set-up-gosimports
     - uses: ./.github/actions/set-up-gotestsum
     - uses: ./.github/actions/set-up-misspell
     - uses: ./.github/actions/set-up-staticcheck

--- a/.github/actions/set-up-gosimports/action.yml
+++ b/.github/actions/set-up-gosimports/action.yml
@@ -1,0 +1,63 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+---
+name: Set up gosimports from Github releases
+description: Set up gosimports from Github releases
+
+inputs:
+  destination:
+    description: "Where to install the gosimports binary (default: $HOME/bin/gosimports)"
+    type: boolean
+    default: "$HOME/bin/gosimports"
+  version:
+    description: "The version to install (default: latest)"
+    type: string
+    default: Latest
+
+outputs:
+  destination:
+    description: Where the installed gosimports binary is
+    value: ${{ steps.install.outputs.destination }}
+  destination-dir:
+    description: The directory where the installed gosimports binary is
+    value: ${{ steps.install.outputs.destination-dir }}
+  version:
+    description: The installed version of gosimports
+    value: ${{ steps.install.outputs.version }}
+
+runs:
+  using: composite
+  steps:
+    - id: install
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        VERSION=$(gh release list -R rinchsan/gosimports --exclude-drafts --exclude-pre-releases | grep ${{ inputs.version }} | cut -f1)
+
+        mkdir -p $(dirname ${{ inputs.destination }})
+        DESTINATION="$(readlink -f "${{ inputs.destination }}")"
+        DESTINATION_DIR="$(dirname "$DESTINATION")"
+        echo "$DESTINATION_DIR" >> "$GITHUB_PATH"
+
+        {
+          echo "destination=$DESTINATION"
+          echo "version=$VERSION"
+          echo "destination-dir=$DESTINATION_DIR"
+        } | tee -a "$GITHUB_OUTPUT"
+
+        ARCH="$(echo "$RUNNER_ARCH" | tr '[:upper:]' '[:lower:]')"
+        OS="$(echo "$RUNNER_OS" | tr '[:upper:]' '[:lower:]')"
+        if [ "$ARCH" = "x64" ]; then
+          export ARCH="amd64"
+        fi
+        if [ "$OS" = "macos" ]; then
+          export OS="darwin"
+        fi
+
+        mkdir -p tmp
+        gh release download "$VERSION" -p "gosimports_*_${OS}_${ARCH}.tar.gz" -O tmp/gosimports.tgz -R rinchsan/gosimports
+        pushd tmp && tar -xvf gosimports.tgz && popd
+        mv tmp/gosimports "$DESTINATION"
+        rm -rf tmp

--- a/tools/tools.sh
+++ b/tools/tools.sh
@@ -40,13 +40,13 @@ install_external() {
     github.com/favadi/protoc-go-inject-tag@latest
     github.com/golangci/misspell/cmd/misspell@latest
     github.com/golangci/revgrep/cmd/revgrep@latest
+    github.com/rinchsan/gosimports/cmd/gosimports@latest
     golang.org/x/tools/cmd/goimports@latest
     google.golang.org/protobuf/cmd/protoc-gen-go@latest
     google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
     gotest.tools/gotestsum@latest
     honnef.co/go/tools/cmd/staticcheck@latest
     mvdan.cc/gofumpt@latest
-    github.com/rinchsan/gosimports/cmd/gosimports@latest
   )
 
   echo "==> Installing external tools..."
@@ -66,6 +66,7 @@ check_external() {
     buf
     gofumpt
     goimports
+    gosimports
     gotestsum
     misspell
     protoc-gen-go
@@ -73,7 +74,6 @@ check_external() {
     protoc-go-inject-tag
     revgrep
     staticcheck
-    gosimports
   )
 
   echo "==> Checking for external tools..."


### PR DESCRIPTION
https://github.com/hashicorp/vault/pull/25383 added gosimports to the list of external tools that are required. The precheck for some linting workflows fail because we didn't add a corresponding workflow to install them.