### PR TITLE
PSA-714 - update ubi-minimal to 8.9 for security fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,7 +74,7 @@ CMD ["server", "-dev"]
 
 
 ## UBI DOCKERFILE ##
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8 as ubi
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9 as ubi
 
 ARG BIN_NAME
 # PRODUCT_VERSION is the version built dist/$TARGETOS/$TARGETARCH/$BIN_NAME,


### PR DESCRIPTION
Fixes CVE's in sqlite and gnutls packages.