### PR TITLE
Cache trusted cert values, invalidating when anything changes

### DIFF
--- a/builtin/credential/cert/backend.go
+++ b/builtin/credential/cert/backend.go
@@ -68,7 +68,7 @@ type trusted struct {
 	pool          *x509.CertPool
 	trusted       []*ParsedCert
 	trustedNonCAs []*ParsedCert
-	conf          *ocsp.VerifyConfig
+	ocspConf      *ocsp.VerifyConfig
 }
 
 type backend struct {

--- a/builtin/credential/cert/path_config.go
+++ b/builtin/credential/cert/path_config.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/vault/sdk/logical"
 )
 
-const maxCacheSize = 100000
+const maxOcspCacheSize = 100000
 
 func pathConfig(b *backend) *framework.Path {
 	return &framework.Path{
@@ -36,6 +36,11 @@ func pathConfig(b *backend) *framework.Path {
 				Type:        framework.TypeInt,
 				Default:     100,
 				Description: `The size of the in memory OCSP response cache, shared by all configured certs`,
+			},
+			"role_cache_size": {
+				Type:        framework.TypeInt,
+				Default:     defaultRoleCacheSize,
+				Description: `The size of the in memory role cache`,
 			},
 		},
 
@@ -70,10 +75,17 @@ func (b *backend) pathConfigWrite(ctx context.Context, req *logical.Request, dat
 	}
 	if cacheSizeRaw, ok := data.GetOk("ocsp_cache_size"); ok {
 		cacheSize := cacheSizeRaw.(int)
-		if cacheSize < 2 || cacheSize > maxCacheSize {
-			return logical.ErrorResponse("invalid cache size, must be >= 2 and <= %d", maxCacheSize), nil
+		if cacheSize < 2 || cacheSize > maxOcspCacheSize {
+			return logical.ErrorResponse("invalid ocsp cache size, must be >= 2 and <= %d", maxOcspCacheSize), nil
 		}
 		config.OcspCacheSize = cacheSize
+	}
+	if cacheSizeRaw, ok := data.GetOk("role_cache_size"); ok {
+		cacheSize := cacheSizeRaw.(int)
+		if (cacheSize < 0 && cacheSize != -1) || cacheSize > maxRoleCacheSize {
+			return logical.ErrorResponse("invalid role cache size, must be <= %d or -1 to disable role caching", maxRoleCacheSize), nil
+		}
+		config.RoleCacheSize = cacheSize
 	}
 	if err := b.storeConfig(ctx, req.Storage, config); err != nil {
 		return nil, err
@@ -91,6 +103,7 @@ func (b *backend) pathConfigRead(ctx context.Context, req *logical.Request, d *f
 		"disable_binding":                cfg.DisableBinding,
 		"enable_identity_alias_metadata": cfg.EnableIdentityAliasMetadata,
 		"ocsp_cache_size":                cfg.OcspCacheSize,
+		"role_cache_size":                cfg.RoleCacheSize,
 	}
 
 	return &logical.Response{
@@ -119,4 +132,5 @@ type config struct {
 	DisableBinding              bool `json:"disable_binding"`
 	EnableIdentityAliasMetadata bool `json:"enable_identity_alias_metadata"`
 	OcspCacheSize               int  `json:"ocsp_cache_size"`
+	RoleCacheSize               int  `json:"role_cache_size"`
 }

--- a/builtin/credential/cert/path_crls.go
+++ b/builtin/credential/cert/path_crls.go
@@ -205,6 +205,7 @@ func (b *backend) pathCRLDelete(ctx context.Context, req *logical.Request, d *fr
 	}
 
 	delete(b.crls, name)
+	b.flushTrustedCache()
 
 	return nil, nil
 }
@@ -313,6 +314,8 @@ func (b *backend) setCRL(ctx context.Context, storage logical.Storage, certList 
 	}
 
 	b.crls[name] = crlInfo
+	b.flushTrustedCache()
+
 	return err
 }
 

--- a/builtin/credential/cert/path_crls.go
+++ b/builtin/credential/cert/path_crls.go
@@ -190,6 +190,7 @@ func (b *backend) pathCRLDelete(ctx context.Context, req *logical.Request, d *fr
 
 	b.crlUpdateMutex.Lock()
 	defer b.crlUpdateMutex.Unlock()
+	defer b.flushTrustedCache()
 
 	_, ok := b.crls[name]
 	if !ok {
@@ -205,7 +206,6 @@ func (b *backend) pathCRLDelete(ctx context.Context, req *logical.Request, d *fr
 	}
 
 	delete(b.crls, name)
-	b.flushTrustedCache()
 
 	return nil, nil
 }

--- a/builtin/credential/cert/path_login.go
+++ b/builtin/credential/cert/path_login.go
@@ -257,7 +257,7 @@ func (b *backend) verifyCredentials(ctx context.Context, req *logical.Request, d
 	}
 
 	// Load the trusted certificates and other details
-	roots, trusted, trustedNonCAs, verifyConf := b.loadTrustedCerts(ctx, req.Storage, certName)
+	roots, trusted, trustedNonCAs, verifyConf := b.getTrustedCerts(ctx, req.Storage, certName)
 
 	// Get the list of full chains matching the connection and validates the
 	// certificate itself
@@ -581,10 +581,22 @@ func (b *backend) certificateExtensionsMetadata(clientCert *x509.Certificate, co
 	return metadata
 }
 
+// getTrustedCerts is used to load all the trusted certificates from the backend, cached
+
+func (b *backend) getTrustedCerts(ctx context.Context, storage logical.Storage, certName string) (pool *x509.CertPool, trusted []*ParsedCert, trustedNonCAs []*ParsedCert, conf *ocsp.VerifyConfig) {
+	b.trustedLock.RLock()
+	if trusted, found := b.trustedCache[certName]; found {
+		b.trustedLock.RUnlock()
+		return trusted.pool, trusted.trusted, trusted.trustedNonCAs, trusted.conf
+	}
+	b.trustedLock.RUnlock()
+	return b.loadTrustedCerts(ctx, storage, certName)
+}
+
 // loadTrustedCerts is used to load all the trusted certificates from the backend
-func (b *backend) loadTrustedCerts(ctx context.Context, storage logical.Storage, certName string) (pool *x509.CertPool, trusted []*ParsedCert, trustedNonCAs []*ParsedCert, conf *ocsp.VerifyConfig) {
+func (b *backend) loadTrustedCerts(ctx context.Context, storage logical.Storage, certName string) (pool *x509.CertPool, trustedCerts []*ParsedCert, trustedNonCAs []*ParsedCert, conf *ocsp.VerifyConfig) {
 	pool = x509.NewCertPool()
-	trusted = make([]*ParsedCert, 0)
+	trustedCerts = make([]*ParsedCert, 0)
 	trustedNonCAs = make([]*ParsedCert, 0)
 
 	var names []string
@@ -592,7 +604,7 @@ func (b *backend) loadTrustedCerts(ctx context.Context, storage logical.Storage,
 		names = append(names, certName)
 	} else {
 		var err error
-		names, err = storage.List(ctx, "cert/")
+		names, err = storage.List(ctx, trustedCertPath)
 		if err != nil {
 			b.Logger().Error("failed to list trusted certs", "error", err)
 			return
@@ -601,7 +613,7 @@ func (b *backend) loadTrustedCerts(ctx context.Context, storage logical.Storage,
 
 	conf = &ocsp.VerifyConfig{}
 	for _, name := range names {
-		entry, err := b.Cert(ctx, storage, strings.TrimPrefix(name, "cert/"))
+		entry, err := b.Cert(ctx, storage, strings.TrimPrefix(name, trustedCertPath))
 		if err != nil {
 			b.Logger().Error("failed to load trusted cert", "name", name, "error", err)
 			continue
@@ -630,7 +642,7 @@ func (b *backend) loadTrustedCerts(ctx context.Context, storage logical.Storage,
 			}
 
 			// Create a ParsedCert entry
-			trusted = append(trusted, &ParsedCert{
+			trustedCerts = append(trustedCerts, &ParsedCert{
 				Entry:        entry,
 				Certificates: parsed,
 			})
@@ -645,6 +657,17 @@ func (b *backend) loadTrustedCerts(ctx context.Context, storage logical.Storage,
 			}
 			conf.QueryAllServers = conf.QueryAllServers || entry.OcspQueryAllServers
 		}
+	}
+
+	// In order not to hold the lock long, we're okay with this work getting duplicated so that only caching the value
+	// holds the lock
+	b.trustedLock.Lock()
+	defer b.trustedLock.Unlock()
+	b.trustedCache[certName] = &trusted{
+		pool:          pool,
+		trusted:       trustedCerts,
+		trustedNonCAs: trustedNonCAs,
+		conf:          conf,
 	}
 	return
 }

--- a/builtin/credential/cert/path_login.go
+++ b/builtin/credential/cert/path_login.go
@@ -587,7 +587,7 @@ func (b *backend) getTrustedCerts(ctx context.Context, storage logical.Storage, 
 	b.trustedLock.RLock()
 	if trusted, found := b.trustedCache[certName]; found {
 		b.trustedLock.RUnlock()
-		return trusted.pool, trusted.trusted, trusted.trustedNonCAs, trusted.conf
+		return trusted.pool, trusted.trusted, trusted.trustedNonCAs, trusted.ocspConf
 	}
 	b.trustedLock.RUnlock()
 	return b.loadTrustedCerts(ctx, storage, certName)
@@ -667,7 +667,7 @@ func (b *backend) loadTrustedCerts(ctx context.Context, storage logical.Storage,
 		pool:          pool,
 		trusted:       trustedCerts,
 		trustedNonCAs: trustedNonCAs,
-		conf:          conf,
+		ocspConf:      conf,
 	}
 	return
 }

--- a/builtin/credential/cert/path_login_test.go
+++ b/builtin/credential/cert/path_login_test.go
@@ -94,6 +94,10 @@ func TestCert_RoleResolve(t *testing.T) {
 			testAccStepCert(t, "web", ca, "foo", allowed{dns: "example.com"}, false),
 			testAccStepLoginWithName(t, connState, "web"),
 			testAccStepResolveRoleWithName(t, connState, "web"),
+			// Test with caching disabled
+			testAccStepSetRoleCacheSize(t, -1),
+			testAccStepLoginWithName(t, connState, "web"),
+			testAccStepResolveRoleWithName(t, connState, "web"),
 		},
 	})
 }
@@ -151,8 +155,21 @@ func TestCert_RoleResolveWithoutProvidingCertName(t *testing.T) {
 			testAccStepCert(t, "web", ca, "foo", allowed{dns: "example.com"}, false),
 			testAccStepLoginWithName(t, connState, "web"),
 			testAccStepResolveRoleWithEmptyDataMap(t, connState, "web"),
+			testAccStepSetRoleCacheSize(t, -1),
+			testAccStepLoginWithName(t, connState, "web"),
+			testAccStepResolveRoleWithEmptyDataMap(t, connState, "web"),
 		},
 	})
+}
+
+func testAccStepSetRoleCacheSize(t *testing.T, size int) logicaltest.TestStep {
+	return logicaltest.TestStep{
+		Operation: logical.UpdateOperation,
+		Path:      "config",
+		Data: map[string]interface{}{
+			"role_cache_size": size,
+		},
+	}
 }
 
 func testAccStepResolveRoleWithEmptyDataMap(t *testing.T, connState tls.ConnectionState, certName string) logicaltest.TestStep {

--- a/changelog/25421.txt
+++ b/changelog/25421.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+auth/cert: Cache trusted certs to reduce memory usage and improve performance of logins.
+```

--- a/go.mod
+++ b/go.mod
@@ -118,6 +118,7 @@ require (
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/golang-lru v1.0.2
+	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/hashicorp/hcl v1.0.1-vault-5
 	github.com/hashicorp/hcl/v2 v2.16.2
 	github.com/hashicorp/hcp-link v0.2.1

--- a/go.sum
+++ b/go.sum
@@ -2476,6 +2476,8 @@ github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/golang-lru v1.0.2 h1:dV3g9Z/unq5DpblPpw+Oqcv4dU/1omnb4Ok8iPY6p1c=
 github.com/hashicorp/golang-lru v1.0.2/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
+github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
+github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/hcl v1.0.1-vault-5 h1:kI3hhbbyzr4dldA8UdTb7ZlVVlI2DACdCfz31RPDgJM=
 github.com/hashicorp/hcl v1.0.1-vault-5/go.mod h1:XYhtn6ijBSAj6n4YqAaf7RBPS4I06AItNorpy+MoQNM=

--- a/website/content/api-docs/auth/cert.mdx
+++ b/website/content/api-docs/auth/cert.mdx
@@ -360,6 +360,8 @@ Configuration options for the method.
   `allowed_metadata_extensions` will be stored in the alias
 - `ocsp_cache_size` `(int: 100)` - The size of the OCSP response LRU cache.  Note
   that this cache is used for all configured certificates.
+- `role_cache_size` `(int: 200)` - The size of the role cache.  Use `-1` to disable 
+  role caching.
 
 ### Sample payload
 


### PR DESCRIPTION
Previously, trusted certs were loaded and parsed on every login call.  This
is both slow, and means a copy of the trusted certs is in memory per login. 
For highly concurrent use this raises Vault's memory usage unnecessarily.