### PR TITLE
UI: add deletion_allowed to transform, add tokenization transform type

### DIFF
--- a/changelog/25436.txt
+++ b/changelog/25436.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: Add `deletion_allowed` param to transformations and include `tokenization` as a type option
+```

--- a/ui/app/adapters/transform.js
+++ b/ui/app/adapters/transform.js
@@ -11,11 +11,11 @@ import { encodePath } from 'vault/utils/path-encoding-helpers';
 export default ApplicationAdapter.extend({
   namespace: 'v1',
 
-  createOrUpdate(store, type, snapshot) {
-    const { backend, name } = snapshot.record;
-    const serializer = store.serializerFor(type.modelName);
+  createOrUpdate(store, { modelName }, snapshot) {
+    const { backend, name, type } = snapshot.record;
+    const serializer = store.serializerFor(modelName);
     const data = serializer.serialize(snapshot);
-    const url = this.urlForTransformations(backend, name);
+    const url = this.urlForTransformations(backend, name, type);
 
     return this.ajax(url, 'POST', { data }).then((resp) => {
       const response = resp || {};
@@ -41,11 +41,11 @@ export default ApplicationAdapter.extend({
     return 'transform';
   },
 
-  urlForTransformations(backend, id) {
-    let url = `${this.buildURL()}/${encodePath(backend)}/transformation`;
-    if (id) {
-      url = url + '/' + encodePath(id);
-    }
+  urlForTransformations(backend, id, type) {
+    const base = `${this.buildURL()}/${encodePath(backend)}`;
+    // when type exists, transformations is plural
+    const url = type ? `${base}/transformations/${type}` : `${base}/transformation`;
+    if (id) return `${url}/${encodePath(id)}`;
     return url;
   },
 

--- a/ui/app/adapters/transform.js
+++ b/ui/app/adapters/transform.js
@@ -62,7 +62,7 @@ export default ApplicationAdapter.extend({
     const queryAjax = this.ajax(this.urlForTransformations(backend, id), 'GET', this.optionsForQuery(id));
 
     return allSettled([queryAjax]).then((results) => {
-      // query result 404d, so throw the adapterError
+      // query result 404, so throw the adapterError
       if (!results[0].value) {
         throw results[0].reason;
       }

--- a/ui/app/models/transform.js
+++ b/ui/app/models/transform.js
@@ -111,7 +111,7 @@ export default Model.extend({
   max_ttl: attr({
     editType: 'ttl',
     defaultValue: '0',
-    label: 'Maximum TTL of a token',
+    label: 'Maximum TTL (time-to-live) of a token',
     helperTextDisabled: 'If "0" or unspecified, tokens may have no expiration.',
   }),
 

--- a/ui/app/models/transform.js
+++ b/ui/app/models/transform.js
@@ -8,8 +8,7 @@ import { computed } from '@ember/object';
 import lazyCapabilities, { apiPath } from 'vault/macros/lazy-capabilities';
 import { expandAttributeMeta } from 'vault/utils/field-to-attrs';
 
-// these arrays define the order in which the fields will be displayed
-// see
+// these arrays define the order in which the fields will be displayed, see:
 // https://developer.hashicorp.com/vault/api-docs/secret/transform#create-update-transformation-deprecated-1-6
 const TYPES = [
   {

--- a/ui/tests/unit/adapters/transform-test.js
+++ b/ui/tests/unit/adapters/transform-test.js
@@ -1,0 +1,95 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+
+const TRANSFORM_TYPES = ['fpe', 'masking', 'tokenization'];
+module('Unit | Adapter | transform', function (hooks) {
+  setupTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(function () {
+    this.store = this.owner.lookup('service:store');
+    this.backend = 'my-transform-engine';
+    this.name = 'my-transform';
+  });
+
+  hooks.afterEach(function () {
+    this.store.unloadAll('transform');
+  });
+
+  test('it should make request to correct endpoint when querying all records', async function (assert) {
+    assert.expect(2);
+    this.server.get(`${this.backend}/transformation`, (schema, req) => {
+      assert.ok(true, 'GET request made to correct endpoint when querying record');
+      assert.propEqual(req.queryParams, { list: 'true' }, 'query params include list: true');
+      return { data: { key_info: {}, keys: [] } };
+    });
+    await this.store.adapterFor('transform').query();
+  });
+
+  test('it should make request to correct endpoint when querying a record', async function (assert) {
+    assert.expect(1);
+    this.server.get(`${this.backend}/transformation/${this.name}`, () => {
+      assert.ok(true, 'GET request made to correct endpoint when querying record');
+      return { data: { backend: this.backend, name: this.name } };
+    });
+    await this.store.queryRecord('transform', { backend: this.backend, id: this.name });
+  });
+
+  test('it should make request to correct endpoint when creating new record', async function (assert) {
+    assert.expect(3);
+
+    for (const type of TRANSFORM_TYPES) {
+      const name = `transform-${type}-test`;
+      this.server.post(`${this.backend}/transformations/${type}/${name}`, () => {
+        assert.ok(true, `POST request made to transformations/${type}/:name creating a record`);
+        return { data: { backend: this.backend, name, type } };
+      });
+      const record = this.store.createRecord('transform', { backend: this.backend, name, type });
+      await record.save();
+    }
+  });
+
+  test('it should make request to correct endpoint when updating record', async function (assert) {
+    assert.expect(3);
+    for (const type of TRANSFORM_TYPES) {
+      const name = `transform-${type}-test`;
+      this.server.post(`${this.backend}/transformations/${type}/${name}`, () => {
+        assert.ok(true, `POST request made to transformations/${type}/:name endpoint`);
+      });
+      this.store.pushPayload('transform', {
+        modelName: 'transform',
+        backend: this.backend,
+        id: name,
+        type,
+        name,
+      });
+      const record = this.store.peekRecord('transform', name);
+      await record.save();
+    }
+  });
+
+  test('it should make request to correct endpoint when deleting record', async function (assert) {
+    assert.expect(3);
+    for (const type of TRANSFORM_TYPES) {
+      const name = `transform-${type}-test`;
+      this.server.delete(`${this.backend}/transformation/${name}`, () => {
+        assert.ok(true, `type: ${type} - DELETE request to transformation/:name endpoint`);
+      });
+      this.store.pushPayload('transform', {
+        modelName: 'transform',
+        backend: this.backend,
+        id: name,
+        type,
+        name,
+      });
+      const record = this.store.peekRecord('transform', name);
+      await record.destroyRecord();
+    }
+  });
+});

--- a/ui/tests/unit/adapters/transform-test.js
+++ b/ui/tests/unit/adapters/transform-test.js
@@ -29,7 +29,7 @@ module('Unit | Adapter | transform', function (hooks) {
       assert.propEqual(req.queryParams, { list: 'true' }, 'query params include list: true');
       return { data: { key_info: {}, keys: [] } };
     });
-    await this.store.adapterFor('transform').query();
+    await this.store.query('transform', { backend: this.backend });
   });
 
   test('it should make request to correct endpoint when querying a record', async function (assert) {


### PR DESCRIPTION

In 1.6 general requests to `/transform` (without `:type`) as part of the URL was deprecated [docs](https://developer.hashicorp.com/vault/api-docs/secret/transform#create-update-transformation-deprecated-1-6)

 I decided against glimmerizing for backportability since this will go back to every supported release. Changes in this PR include:
- adds `deletion_allowed` to all transform types
- adds the third type, `tokenization` and associated [params](https://developer.hashicorp.com/vault/api-docs/secret/transform#create-update-tokenization-transformation)
- each transform type makes a request to the specific `:type` endpoint (e.g.`/transform/transformations/fpe/:name`

### enterprise tests ✅ 
<img width="1326" alt="Screenshot 2024-02-14 at 4 00 01 PM" src="https://github.com/hashicorp/vault/assets/68122737/8dc13b2b-ce36-4110-b004-218d40859558">


### 📷 

![transform](https://github.com/hashicorp/vault/assets/68122737/d0db63b9-9020-4b82-a0a5-746c57dffc8e)
