### PR TITLE
Disable Request Limiter by default

### DIFF
--- a/changelog/25095.txt
+++ b/changelog/25095.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-limits: Introduce a reloadable disable configuration for the Request Limiter.
+limits: Introduce a reloadable opt-in configuration for the Request Limiter.
 ```

--- a/command/command_testonly/server_testonly_test.go
+++ b/command/command_testonly/server_testonly_test.go
@@ -86,31 +86,6 @@ func TestServer_ReloadRequestLimiter(t *testing.T) {
 		expectedResponse *vault.RequestLimiterResponse
 	}{
 		{
-			"enable after default",
-			baseHCL + requestLimiterEnableHCL,
-			enabledResponse,
-		},
-		{
-			"enable after enable",
-			baseHCL + requestLimiterEnableHCL,
-			enabledResponse,
-		},
-		{
-			"disable after enable",
-			baseHCL + requestLimiterDisableHCL,
-			disabledResponse,
-		},
-		{
-			"default after disable",
-			baseHCL,
-			enabledResponse,
-		},
-		{
-			"default after default",
-			baseHCL,
-			enabledResponse,
-		},
-		{
 			"disable after default",
 			baseHCL + requestLimiterDisableHCL,
 			disabledResponse,
@@ -119,6 +94,31 @@ func TestServer_ReloadRequestLimiter(t *testing.T) {
 			"disable after disable",
 			baseHCL + requestLimiterDisableHCL,
 			disabledResponse,
+		},
+		{
+			"enable after disable",
+			baseHCL + requestLimiterEnableHCL,
+			enabledResponse,
+		},
+		{
+			"default after enable",
+			baseHCL,
+			disabledResponse,
+		},
+		{
+			"default after default",
+			baseHCL,
+			disabledResponse,
+		},
+		{
+			"enable after default",
+			baseHCL + requestLimiterEnableHCL,
+			enabledResponse,
+		},
+		{
+			"enable after enable",
+			baseHCL + requestLimiterEnableHCL,
+			enabledResponse,
 		},
 	}
 
@@ -166,7 +166,7 @@ func TestServer_ReloadRequestLimiter(t *testing.T) {
 	cli.SetToken(initResp.RootToken)
 
 	output = ui.ErrorWriter.String() + ui.OutputWriter.String()
-	require.Contains(t, output, "Request Limiter: enabled")
+	require.Contains(t, output, "Request Limiter: disabled")
 
 	verifyLimiters := func(t *testing.T, expectedResponse *vault.RequestLimiterResponse) {
 		t.Helper()
@@ -187,8 +187,8 @@ func TestServer_ReloadRequestLimiter(t *testing.T) {
 		require.Equal(t, expectedResponse, limiters)
 	}
 
-	// Start off with default enabled
-	verifyLimiters(t, enabledResponse)
+	// Start off with default disabled
+	verifyLimiters(t, disabledResponse)
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/command/server.go
+++ b/command/server.go
@@ -1441,9 +1441,9 @@ func (c *ServerCommand) Run(args []string) int {
 	info["administrative namespace"] = config.AdministrativeNamespacePath
 
 	infoKeys = append(infoKeys, "request limiter")
-	info["request limiter"] = "enabled"
-	if config.RequestLimiter != nil && config.RequestLimiter.Disable {
-		info["request limiter"] = "disabled"
+	info["request limiter"] = "disabled"
+	if config.RequestLimiter != nil && !config.RequestLimiter.Disable {
+		info["request limiter"] = "enabled"
 	}
 
 	sort.Strings(infoKeys)
@@ -3120,6 +3120,8 @@ func createCoreConfig(c *ServerCommand, config *server.Config, backend physical.
 
 	if config.RequestLimiter != nil {
 		coreConfig.DisableRequestLimiter = config.RequestLimiter.Disable
+	} else {
+		coreConfig.DisableRequestLimiter = true
 	}
 
 	if c.flagDev {

--- a/command/server/config_util_test.go
+++ b/command/server/config_util_test.go
@@ -112,7 +112,7 @@ request_limiter {
 			name: "invalid disable",
 			inConfig: `
 request_limiter {
-	disable = "whywouldyoudothis"
+	disable = "people make mistakes"
 }`,
 			outErr: true,
 		},

--- a/internalshared/configutil/request_limiter.go
+++ b/internalshared/configutil/request_limiter.go
@@ -28,7 +28,7 @@ func (r *RequestLimiter) GoString() string {
 }
 
 var DefaultRequestLimiter = &RequestLimiter{
-	Disable: false,
+	Disable: true,
 }
 
 func parseRequestLimiter(result *SharedConfig, list *ast.ObjectList) error {
@@ -45,14 +45,13 @@ func parseRequestLimiter(result *SharedConfig, list *ast.ObjectList) error {
 		return multierror.Prefix(err, "request_limiter:")
 	}
 
+	result.RequestLimiter.Disable = true
 	if result.RequestLimiter.DisableRaw != nil {
 		var err error
 		if result.RequestLimiter.Disable, err = parseutil.ParseBool(result.RequestLimiter.DisableRaw); err != nil {
 			return err
 		}
 		result.RequestLimiter.DisableRaw = nil
-	} else {
-		result.RequestLimiter.Disable = false
 	}
 
 	return nil

--- a/vault/core.go
+++ b/vault/core.go
@@ -1317,9 +1317,8 @@ func NewCore(conf *CoreConfig) (*Core, error) {
 
 	c.limiterRegistry = conf.LimiterRegistry
 	c.limiterRegistryLock.Lock()
-	if conf.DisableRequestLimiter {
-		c.limiterRegistry.Disable()
-	} else {
+	c.limiterRegistry.Disable()
+	if !conf.DisableRequestLimiter {
 		c.limiterRegistry.Enable()
 	}
 	c.limiterRegistryLock.Unlock()
@@ -4112,7 +4111,7 @@ func (c *Core) ReloadRequestLimiter() {
 		return
 	}
 
-	disable := false
+	disable := true
 	requestLimiterConfig := conf.(*server.Config).RequestLimiter
 	if requestLimiterConfig != nil {
 		disable = requestLimiterConfig.Disable


### PR DESCRIPTION
This PR flips the logic for the Request Limiter, setting it to default disabled.

We allow users to turn on the global Request Limiter, but leave the Listener configuration as a "disable per Listener".