### PR TITLE
Audit: Extracted SSCT related auditing code to formatter node

### DIFF
--- a/audit/entry_formatter.go
+++ b/audit/entry_formatter.go
@@ -107,6 +107,13 @@ func (f *EntryFormatter) Process(ctx context.Context, e *eventlogger.Event) (*ev
 		data.Request.Headers = adjustedHeaders
 	}
 
+	// If the request contains a Server-Side Consistency Token (SSCT), and we
+	// have an auth response, overwrite the existing client token with the SSCT,
+	// so that the SSCT appears in the audit log for this entry.
+	if data.Request != nil && data.Request.InboundSSCToken != "" && data.Auth != nil {
+		data.Auth.ClientToken = data.Request.InboundSSCToken
+	}
+
 	var result []byte
 
 	switch a.Subtype {

--- a/changelog/25443.txt
+++ b/changelog/25443.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+audit: Resolve potential race condition when auditing entries which use SSCT.
+```

--- a/vault/audit_broker.go
+++ b/vault/audit_broker.go
@@ -209,25 +209,15 @@ func (a *AuditBroker) GetHash(ctx context.Context, name string, input string) (s
 // LogRequest is used to ensure all the audit backends have an opportunity to
 // log the given request and that *at least one* succeeds.
 func (a *AuditBroker) LogRequest(ctx context.Context, in *logical.LogInput) (ret error) {
+	a.RLock()
+	defer a.RUnlock()
+
 	// If no backends are registered then we have no devices to log the request.
 	if len(a.backends) < 1 {
 		return nil
 	}
 
 	defer metrics.MeasureSince([]string{"audit", "log_request"}, time.Now())
-
-	a.RLock()
-	defer a.RUnlock()
-
-	if in.Request.InboundSSCToken != "" {
-		if in.Auth != nil {
-			reqAuthToken := in.Auth.ClientToken
-			in.Auth.ClientToken = in.Request.InboundSSCToken
-			defer func() {
-				in.Auth.ClientToken = reqAuthToken
-			}()
-		}
-	}
 
 	var retErr *multierror.Error
 
@@ -243,11 +233,6 @@ func (a *AuditBroker) LogRequest(ctx context.Context, in *logical.LogInput) (ret
 			failure = 1.0
 		}
 		metrics.IncrCounter([]string{"audit", "log_request_failure"}, failure)
-	}()
-
-	headers := in.Request.Headers
-	defer func() {
-		in.Request.Headers = headers
 	}()
 
 	e, err := audit.NewEvent(audit.RequestType)
@@ -299,21 +284,15 @@ func (a *AuditBroker) LogRequest(ctx context.Context, in *logical.LogInput) (ret
 // LogResponse is used to ensure all the audit backends have an opportunity to
 // log the given response and that *at least one* succeeds.
 func (a *AuditBroker) LogResponse(ctx context.Context, in *logical.LogInput) (ret error) {
+	a.RLock()
+	defer a.RUnlock()
+
 	// If no backends are registered then we have no devices to send audit entries to.
 	if len(a.backends) < 1 {
 		return nil
 	}
 
 	defer metrics.MeasureSince([]string{"audit", "log_response"}, time.Now())
-
-	a.RLock()
-	defer a.RUnlock()
-
-	if in.Request.InboundSSCToken != "" && in.Auth != nil {
-		reqAuthToken := in.Auth.ClientToken
-		in.Auth.ClientToken = in.Request.InboundSSCToken
-		defer func() { in.Auth.ClientToken = reqAuthToken }()
-	}
 
 	var retErr *multierror.Error
 
@@ -329,11 +308,6 @@ func (a *AuditBroker) LogResponse(ctx context.Context, in *logical.LogInput) (re
 			failure = 1.0
 		}
 		metrics.IncrCounter([]string{"audit", "log_response_failure"}, failure)
-	}()
-
-	headers := in.Request.Headers
-	defer func() {
-		in.Request.Headers = headers
 	}()
 
 	e, err := audit.NewEvent(audit.ResponseType)


### PR DESCRIPTION
This PR addresses a potential race condition which occurred when an SSCT is present in the auth related audit entry.

It removes some unrequired code which captured the current headers, and moves the logic for updating the client token with the SSCT to the entry formatter which deals with a cloned version of the input.

Previous race detection occurred in `command/agentproxyshared/auth TestAuthHandler`