### PR TITLE
UI: Control group flaky enterprise test fix attempt 1.14.x

### DIFF
--- a/ui/app/adapters/capabilities.js
+++ b/ui/app/adapters/capabilities.js
@@ -12,7 +12,7 @@ export default ApplicationAdapter.extend({
     return 'capabilities-self';
   },
 
-  findRecord(store, type, id) {
+  async findRecord(store, type, id) {
     return this.ajax(this.buildURL(type), 'POST', { data: { paths: [id] } }).catch((e) => {
       if (e instanceof AdapterError) {
         set(e, 'policyPath', 'sys/capabilities-self');

--- a/ui/app/adapters/control-group.js
+++ b/ui/app/adapters/control-group.js
@@ -10,7 +10,7 @@ export default ApplicationAdapter.extend({
     return 'control-group';
   },
 
-  findRecord(store, type, id) {
+  async findRecord(store, type, id) {
     const baseUrl = this.buildURL(type.modelName);
     return this.ajax(`${baseUrl}/request`, 'POST', {
       data: {


### PR DESCRIPTION
This is to resolve this error: 
<img width="1105" alt="Screenshot 2024-02-15 at 9 49 17 AM" src="https://github.com/hashicorp/vault/assets/68122737/20701cc5-3568-4970-bc54-44d8fc69206b">

which displayed locally as:
```
Async Request leaks detected. Add a breakpoint here and set store.generateStackTracesForTrackedRequests = true;to inspect traces for leak origins 
```

This error also stopped failing after this fix. But hard to know if it's related
<img width="1101" alt="Screenshot 2024-02-15 at 9 53 51 AM" src="https://github.com/hashicorp/vault/assets/68122737/9cddb0ec-528b-4848-8f2e-ec1728e6f352">
