### PR TITLE
Clarify when external group membership is updated

### DIFF
--- a/website/content/docs/concepts/identity.mdx
+++ b/website/content/docs/concepts/identity.mdx
@@ -172,19 +172,26 @@ to policies on both GroupA and GroupB.
 
 ## External vs internal groups
 
-By default, the groups created in identity store are called the internal
-groups. The membership management of these groups should be carried out
-manually. A group can also be created as an external group. In this case, the
+By default, the groups created in identity store are called **internal groups**.
+The membership management of these groups should be carried out
+manually.
+
+A group can also be created as an **external group**. In this case, the
 entity membership in the group is managed semi-automatically. An external group
 serves as a mapping to a group that is outside of the identity store. External
 groups can have one (and only one) alias. This alias should map to a notion of
-a group that is outside of the identity store. For example, groups in LDAP and
-teams in GitHub. A username in LDAP belonging to a group in LDAP can get its
+a group that is outside of the identity store.
+
+For example, groups in LDAP and teams in GitHub.
+A username in LDAP belonging to a group in LDAP can get its
 entity ID added as a member of a group in Vault automatically during _logins_
 and _token renewals_. This works only if the group in Vault is an external
-group and has an alias that maps to the group in LDAP. If the user is removed
-from the group in LDAP, that change gets reflected in Vault only upon the
-subsequent login or renewal operation.
+group and has an alias that maps to the group in LDAP.
+
+~> **NOTE:** If the user is removed from the group in LDAP, the user will
+not immediately be removed from the external group in Vault. The group
+membership change will be reflected in Vault only upon the
+subsequent **login** or **renewal** operation.
 
 For information about Identity Secrets Engine, refer to [Identity Secrets Engine](/vault/docs/secrets/identity).
 


### PR DESCRIPTION
The large paragraph is hard to read and it's easy to miss crucial details around when membership in an external group will be updated.

Membership isn't updated when the configuration of the external group is changed, which can be counterintuitive.

<img width="715" alt="Screenshot 2024-02-15 at 14 06 34" src="https://github.com/hashicorp/vault/assets/9422872/87d5a22a-ddbe-47bf-9349-65e3495dc090">
