### PR TITLE
UI: client count minor fixes

### DIFF
--- a/ui/app/components/clients/config.hbs
+++ b/ui/app/components/clients/config.hbs
@@ -15,20 +15,40 @@
             month.
           </p>
           <div class="control is-flex has-bottom-margin-l">
-            <input
-              data-test-input="enabled"
-              type="checkbox"
-              id="enabled"
-              name="enabled"
-              class="toggle is-success is-small"
-              disabled={{@model.reportingEnabled}}
-              checked={{eq @model.enabled "On"}}
-              {{on "change" this.toggleEnabled}}
-            />
-            <label for="enabled" class="has-text-weight-bold is-size-8">
-              Data collection is
-              {{lowercase @model.enabled}}
-            </label>
+            {{#if @model.reportingEnabled}}
+              <Hds::TooltipButton
+                @text="Client tracking cannot be disabled for enterprise versions of Vault."
+                aria-label="More information about why this input is disabled"
+              >
+                <input
+                  data-test-input="enabled"
+                  type="checkbox"
+                  id="enabled"
+                  name="enabled"
+                  class="toggle is-success is-small"
+                  disabled={{true}}
+                  checked={{true}}
+                />
+                <label for="enabled" class="has-text-weight-bold is-size-8">
+                  Data collection is
+                  {{lowercase @model.enabled}}
+                </label>
+              </Hds::TooltipButton>
+            {{else}}
+              <input
+                data-test-input="enabled"
+                type="checkbox"
+                id="enabled"
+                name="enabled"
+                class="toggle is-success is-small"
+                checked={{eq @model.enabled "On"}}
+                {{on "change" this.toggleEnabled}}
+              />
+              <label for="enabled" class="has-text-weight-bold is-size-8">
+                Data collection is
+                {{lowercase @model.enabled}}
+              </label>
+            {{/if}}
           </div>
         {{else}}
           <FormField @attr={{attr}} @model={{@model}} @modelValidations={{this.validations}} />

--- a/ui/app/templates/vault/cluster/clients.hbs
+++ b/ui/app/templates/vault/cluster/clients.hbs
@@ -14,25 +14,33 @@
 <div class="tabs-container box is-bottomless is-marginless is-fullwidth is-paddingless">
   <nav class="tabs" aria-label="navigation for managing client counts">
     <ul>
-      <LinkTo @route="vault.cluster.clients.counts.overview" data-test-tab="overview">
-        Overview
-      </LinkTo>
-      <LinkTo @route="vault.cluster.clients.counts.token" data-test-tab="token">
-        Entity/Non-entity clients
-      </LinkTo>
+      <li>
+        <LinkTo @route="vault.cluster.clients.counts.overview" data-test-tab="overview">
+          Overview
+        </LinkTo>
+      </li>
+      <li>
+        <LinkTo @route="vault.cluster.clients.counts.token" data-test-tab="token">
+          Entity/Non-entity clients
+        </LinkTo>
+      </li>
       {{! * unavailable during SYNC BETA (1.16.0), planned for 1.16.1 release
-      <LinkTo @route="vault.cluster.clients.counts.sync" data-test-tab="sync">
-        Secrets sync clients
-      </LinkTo>
+      <li>
+        <LinkTo @route="vault.cluster.clients.counts.sync" data-test-tab="sync">
+          Secrets sync clients
+        </LinkTo>
+      </li>
        }}
       {{#if (or @model.config.canRead @model.canRead)}}
-        <LinkTo
-          @route="vault.cluster.clients.config"
-          @current-when="vault.cluster.clients.config vault.cluster.clients.edit"
-          data-test-tab="config"
-        >
-          Configuration
-        </LinkTo>
+        <li>
+          <LinkTo
+            @route="vault.cluster.clients.config"
+            @current-when="vault.cluster.clients.config vault.cluster.clients.edit"
+            data-test-tab="config"
+          >
+            Configuration
+          </LinkTo>
+        </li>
       {{/if}}
     </ul>
   </nav>


### PR DESCRIPTION
Small updates to the client count area:

- add tooltip to explain why the enable toggle is disabled
- wrap tab links in `li` so it doesn't violate a11y rules