### PR TITLE
events: Wire up endpoints for subscribe/unsubscribe

### DIFF
--- a/changelog/25474.txt
+++ b/changelog/25474.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+cli: Add events subscriptions commands
+```

--- a/command/commands.go
+++ b/command/commands.go
@@ -342,7 +342,27 @@ func initCommands(ui, serverCmdUi cli.Ui, runOpts *RunOptions) map[string]cli.Co
 			}, nil
 		},
 		"events subscribe": func() (cli.Command, error) {
-			return &EventsSubscribeCommands{
+			return &EventsWebSocketCommands{
+				BaseCommand: getBaseCommand(),
+			}, nil
+		},
+		"events subscriptions create": func() (cli.Command, error) {
+			return &EventsSubscriptionCreateCommand{
+				BaseCommand: getBaseCommand(),
+			}, nil
+		},
+		"events subscriptions delete": func() (cli.Command, error) {
+			return &EventsSubscriptionDeleteCommand{
+				BaseCommand: getBaseCommand(),
+			}, nil
+		},
+		"events subscriptions get": func() (cli.Command, error) {
+			return &EventsSubscriptionGetCommand{
+				BaseCommand: getBaseCommand(),
+			}, nil
+		},
+		"events subscriptions list": func() (cli.Command, error) {
+			return &EventsSubscriptionListCommand{
 				BaseCommand: getBaseCommand(),
 			}, nil
 		},

--- a/command/events_subscriptions.go
+++ b/command/events_subscriptions.go
@@ -1,0 +1,309 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package command
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/cli"
+	"github.com/posener/complete"
+)
+
+var (
+	_ cli.Command             = (*EventsSubscriptionListCommand)(nil)
+	_ cli.Command             = (*EventsSubscriptionGetCommand)(nil)
+	_ cli.Command             = (*EventsSubscriptionCreateCommand)(nil)
+	_ cli.Command             = (*EventsSubscriptionDeleteCommand)(nil)
+	_ cli.CommandAutocomplete = (*EventsSubscriptionListCommand)(nil)
+	_ cli.CommandAutocomplete = (*EventsSubscriptionGetCommand)(nil)
+	_ cli.CommandAutocomplete = (*EventsSubscriptionCreateCommand)(nil)
+	_ cli.CommandAutocomplete = (*EventsSubscriptionDeleteCommand)(nil)
+)
+
+type EventsSubscriptionListCommand struct {
+	*BaseCommand
+}
+
+func (c *EventsSubscriptionListCommand) Synopsis() string {
+	return "List subscriptions"
+}
+
+func (c *EventsSubscriptionListCommand) Help() string {
+	helpText := `
+Usage: vault events subscriptions list
+
+  List all event subscriptions.
+` + c.Flags().Help()
+	return strings.TrimSpace(helpText)
+}
+
+func (c *EventsSubscriptionListCommand) Flags() *FlagSets {
+	return c.flagSet(FlagSetHTTP | FlagSetOutputField | FlagSetOutputFormat)
+}
+
+func (c *EventsSubscriptionListCommand) AutocompleteArgs() complete.Predictor {
+	return nil
+}
+
+func (c *EventsSubscriptionListCommand) AutocompleteFlags() complete.Flags {
+	return c.Flags().Completions()
+}
+
+func (c *EventsSubscriptionListCommand) Run(args []string) int {
+	f := c.Flags()
+
+	if err := f.Parse(args); err != nil {
+		c.UI.Error(err.Error())
+		return 1
+	}
+
+	client, err := c.Client()
+	if err != nil {
+		c.UI.Error(err.Error())
+		return 2
+	}
+
+	secret, err := client.Logical().Read("sys/events/subscriptions")
+	if err != nil {
+		c.UI.Error(err.Error())
+		return 1
+	}
+	if secret == nil || secret.Data == nil || secret.Data["subscriptions"] == nil {
+		return 0
+	}
+	switch Format(c.UI) {
+	case "table":
+		var out []string
+		out = append(out, "ID | Plugin")
+		for _, a := range secret.Data["subscriptions"].([]any) {
+			m := a.(map[string]any)
+			out = append(out, fmt.Sprintf("%s | %s", m["id"], m["plugin"]))
+		}
+		c.UI.Output(tableOutput(out, nil))
+		return 0
+	default:
+		return OutputData(c.UI, secret.Data)
+	}
+}
+
+type EventsSubscriptionGetCommand struct {
+	*BaseCommand
+}
+
+func (c *EventsSubscriptionGetCommand) Synopsis() string {
+	return "Get subscription"
+}
+
+func (c *EventsSubscriptionGetCommand) Help() string {
+	helpText := `
+Usage: vault events subscriptions get plugin id
+
+  Get details about the specified event subscription.
+` + c.Flags().Help()
+	return strings.TrimSpace(helpText)
+}
+
+func (c *EventsSubscriptionGetCommand) Flags() *FlagSets {
+	return c.flagSet(FlagSetHTTP | FlagSetOutputField | FlagSetOutputFormat)
+}
+
+func (c *EventsSubscriptionGetCommand) AutocompleteArgs() complete.Predictor {
+	return nil
+}
+
+func (c *EventsSubscriptionGetCommand) AutocompleteFlags() complete.Flags {
+	return c.Flags().Completions()
+}
+
+func (c *EventsSubscriptionGetCommand) Run(args []string) int {
+	f := c.Flags()
+
+	if err := f.Parse(args); err != nil {
+		c.UI.Error(err.Error())
+		return 1
+	}
+
+	client, err := c.Client()
+	if err != nil {
+		c.UI.Error(err.Error())
+		return 2
+	}
+
+	args = f.Args()
+	switch {
+	case len(args) < 2:
+		c.UI.Error(fmt.Sprintf("Not enough arguments (expected 2, got %d)", len(args)))
+		return 1
+	case len(args) > 2:
+		c.UI.Error(fmt.Sprintf("Too many arguments (expected 2, got %d)", len(args)))
+		return 1
+	}
+	plugin := args[0]
+	id := args[1]
+
+	secret, err := client.Logical().Read("sys/events/subscriptions/" + plugin + "/" + id)
+	if err != nil {
+		c.UI.Error(err.Error())
+		return 1
+	}
+	if secret == nil || secret.Data == nil {
+		return 0
+	}
+	return OutputData(c.UI, secret.Data)
+}
+
+type EventsSubscriptionCreateCommand struct {
+	*BaseCommand
+
+	bexprFilter string
+	config      map[string]string
+}
+
+func (c *EventsSubscriptionCreateCommand) Synopsis() string {
+	return "Create an external, push subscription to events"
+}
+
+func (c *EventsSubscriptionCreateCommand) Help() string {
+	helpText := `
+Usage: vault events subscriptions create -config=a=b [-config=c=d] [-filter=filterExpression] plugin eventType
+
+  Subscribe to events of the given event type (topic), which may be a glob
+  pattern (with "*" treated as a wildcard). The events will routed to the specified plugin, which
+  will be created with the config options.
+` + c.Flags().Help()
+	return strings.TrimSpace(helpText)
+}
+
+func (c *EventsSubscriptionCreateCommand) Flags() *FlagSets {
+	set := c.flagSet(FlagSetHTTP | FlagSetOutputField | FlagSetOutputFormat)
+	f := set.NewFlagSet("Subscribe Options")
+	f.StringVar(&StringVar{
+		Name: "filter",
+		Usage: `A boolean expression to use to filter events. Only events matching
+                the filter will be subscribed to. This is applied after any filtering
+                by event type or namespace.`,
+		Default: "",
+		Target:  &c.bexprFilter,
+	})
+	f.StringMapVar(&StringMapVar{
+		Name: "config",
+		Usage: `Map of key-value pairs to pass to the plugin. See plugin
+                documentation for specific values.`,
+		Default: map[string]string{},
+		Target:  &c.config,
+	})
+	return set
+}
+
+func (c *EventsSubscriptionCreateCommand) AutocompleteArgs() complete.Predictor {
+	return nil
+}
+
+func (c *EventsSubscriptionCreateCommand) AutocompleteFlags() complete.Flags {
+	return c.Flags().Completions()
+}
+
+func (c *EventsSubscriptionCreateCommand) Run(args []string) int {
+	f := c.Flags()
+
+	if err := f.Parse(args); err != nil {
+		c.UI.Error(err.Error())
+		return 1
+	}
+
+	args = f.Args()
+	switch {
+	case len(args) < 2:
+		c.UI.Error(fmt.Sprintf("Not enough arguments (expected 2, got %d)", len(args)))
+		return 1
+	case len(args) > 2:
+		c.UI.Error(fmt.Sprintf("Too many arguments (expected 2, got %d)", len(args)))
+		return 1
+	}
+	plugin := args[0]
+	eventType := args[1]
+
+	client, err := c.Client()
+	if err != nil {
+		c.UI.Error(err.Error())
+		return 2
+	}
+	input := map[string]interface{}{
+		"config":     c.config,
+		"plugin":     plugin,
+		"event_type": eventType,
+	}
+	if c.bexprFilter != "" {
+		input["filter"] = c.bexprFilter
+	}
+	secret, err := client.Logical().Write("sys/events/subscriptions", input)
+	if err != nil {
+		c.UI.Error(err.Error())
+		return 1
+	}
+	return OutputData(c.UI, secret.Data)
+}
+
+type EventsSubscriptionDeleteCommand struct {
+	*BaseCommand
+}
+
+func (c *EventsSubscriptionDeleteCommand) Synopsis() string {
+	return "Delete a subscription (unsubscribe)"
+}
+
+func (c *EventsSubscriptionDeleteCommand) Help() string {
+	helpText := `
+Usage: vault events subscriptions delete plugin id
+
+  Delete (unsubscribe) the specified event subscription.
+` + c.Flags().Help()
+	return strings.TrimSpace(helpText)
+}
+
+func (c *EventsSubscriptionDeleteCommand) Flags() *FlagSets {
+	return c.flagSet(FlagSetHTTP)
+}
+
+func (c *EventsSubscriptionDeleteCommand) AutocompleteArgs() complete.Predictor {
+	return nil
+}
+
+func (c *EventsSubscriptionDeleteCommand) AutocompleteFlags() complete.Flags {
+	return c.Flags().Completions()
+}
+
+func (c *EventsSubscriptionDeleteCommand) Run(args []string) int {
+	f := c.Flags()
+
+	if err := f.Parse(args); err != nil {
+		c.UI.Error(err.Error())
+		return 1
+	}
+
+	args = f.Args()
+	switch {
+	case len(args) < 2:
+		c.UI.Error(fmt.Sprintf("Not enough arguments (expected 2, got %d)", len(args)))
+		return 1
+	case len(args) > 2:
+		c.UI.Error(fmt.Sprintf("Too many arguments (expected 2, got %d)", len(args)))
+		return 1
+	}
+	plugin := args[0]
+	id := args[1]
+
+	client, err := c.Client()
+	if err != nil {
+		c.UI.Error(err.Error())
+		return 2
+	}
+	_, err = client.Logical().Delete("sys/events/subscriptions/" + plugin + "/" + id)
+	if err != nil {
+		c.UI.Error(err.Error())
+		return 1
+	}
+	return 0
+}

--- a/command/events_subscriptions_test.go
+++ b/command/events_subscriptions_test.go
@@ -10,19 +10,19 @@ import (
 	"github.com/hashicorp/cli"
 )
 
-func testEventsSubscribeCommand(tb testing.TB) (*cli.MockUi, *EventsSubscribeCommands) {
+func testEventsSubscriptionsCommand(tb testing.TB) (*cli.MockUi, *EventsSubscriptionCreateCommand) {
 	tb.Helper()
 
 	ui := cli.NewMockUi()
-	return ui, &EventsSubscribeCommands{
+	return ui, &EventsSubscriptionCreateCommand{
 		BaseCommand: &BaseCommand{
 			UI: ui,
 		},
 	}
 }
 
-// TestEventsSubscribeCommand_Run tests that the command argument parsing is working as expected.
-func TestEventsSubscribeCommand_Run(t *testing.T) {
+// TestEventsSubscriptionsCommand_Run tests that the command argument parsing is working as expected.
+func TestEventsSubscriptionsCommand_Run(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
@@ -38,8 +38,14 @@ func TestEventsSubscribeCommand_Run(t *testing.T) {
 			1,
 		},
 		{
+			"not_enough_args",
+			[]string{"foo"},
+			"Not enough arguments",
+			1,
+		},
+		{
 			"too_many_args",
-			[]string{"foo", "bar"},
+			[]string{"foo", "bar", "baz"},
 			"Too many arguments",
 			1,
 		},
@@ -54,7 +60,7 @@ func TestEventsSubscribeCommand_Run(t *testing.T) {
 			client, closer := testVaultServer(t)
 			defer closer()
 
-			ui, cmd := testEventsSubscribeCommand(t)
+			ui, cmd := testEventsSubscriptionsCommand(t)
 			cmd.client = client
 
 			code := cmd.Run(tc.args)

--- a/command/events_ws.go
+++ b/command/events_ws.go
@@ -18,22 +18,22 @@ import (
 )
 
 var (
-	_ cli.Command             = (*EventsSubscribeCommands)(nil)
-	_ cli.CommandAutocomplete = (*EventsSubscribeCommands)(nil)
+	_ cli.Command             = (*EventsWebSocketCommands)(nil)
+	_ cli.CommandAutocomplete = (*EventsWebSocketCommands)(nil)
 )
 
-type EventsSubscribeCommands struct {
+type EventsWebSocketCommands struct {
 	*BaseCommand
 
 	namespaces  []string
 	bexprFilter string
 }
 
-func (c *EventsSubscribeCommands) Synopsis() string {
-	return "Subscribe to events"
+func (c *EventsWebSocketCommands) Synopsis() string {
+	return "Subscribe to events by creating a WebSocket"
 }
 
-func (c *EventsSubscribeCommands) Help() string {
+func (c *EventsWebSocketCommands) Help() string {
 	helpText := `
 Usage: vault events subscribe [-namespaces=ns1] [-timeout=XYZs] [-filter=filterExpression] eventType
 
@@ -47,9 +47,9 @@ Usage: vault events subscribe [-namespaces=ns1] [-timeout=XYZs] [-filter=filterE
 	return strings.TrimSpace(helpText)
 }
 
-func (c *EventsSubscribeCommands) Flags() *FlagSets {
+func (c *EventsWebSocketCommands) Flags() *FlagSets {
 	set := c.flagSet(FlagSetHTTP)
-	f := set.NewFlagSet("Subscribe Options")
+	f := set.NewFlagSet("Subscription Options")
 	f.StringVar(&StringVar{
 		Name: "filter",
 		Usage: `A boolean expression to use to filter events. Only events matching
@@ -73,15 +73,15 @@ func (c *EventsSubscribeCommands) Flags() *FlagSets {
 	return set
 }
 
-func (c *EventsSubscribeCommands) AutocompleteArgs() complete.Predictor {
+func (c *EventsWebSocketCommands) AutocompleteArgs() complete.Predictor {
 	return nil
 }
 
-func (c *EventsSubscribeCommands) AutocompleteFlags() complete.Flags {
+func (c *EventsWebSocketCommands) AutocompleteFlags() complete.Flags {
 	return c.Flags().Completions()
 }
 
-func (c *EventsSubscribeCommands) Run(args []string) int {
+func (c *EventsWebSocketCommands) Run(args []string) int {
 	f := c.Flags()
 
 	if err := f.Parse(args); err != nil {
@@ -105,7 +105,7 @@ func (c *EventsSubscribeCommands) Run(args []string) int {
 		return 2
 	}
 
-	err = c.subscribeRequest(client, "sys/events/subscribe/"+args[0])
+	err = c.subscribeRequest(client, "sys/events/subscriptions/"+args[0])
 	if err != nil {
 		c.UI.Error(err.Error())
 		return 1
@@ -129,7 +129,7 @@ func cleanNamespaces(namespaces []string) []string {
 	return cleaned
 }
 
-func (c *EventsSubscribeCommands) subscribeRequest(client *api.Client, path string) error {
+func (c *EventsWebSocketCommands) subscribeRequest(client *api.Client, path string) error {
 	r := client.NewRequest("GET", "/v1/"+path)
 	u := r.URL
 	if u.Scheme == "http" {

--- a/command/events_ws_test.go
+++ b/command/events_ws_test.go
@@ -1,0 +1,71 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package command
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/cli"
+)
+
+func testEventWebSocketCommand(tb testing.TB) (*cli.MockUi, *EventsWebSocketCommands) {
+	tb.Helper()
+
+	ui := cli.NewMockUi()
+	return ui, &EventsWebSocketCommands{
+		BaseCommand: &BaseCommand{
+			UI: ui,
+		},
+	}
+}
+
+// TestEventsWebSocketCommand_Run tests that the command argument parsing is working as expected.
+func TestEventsWebSocketCommand_Run(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		args []string
+		out  string
+		code int
+	}{
+		{
+			"not_enough_args",
+			[]string{},
+			"Not enough arguments",
+			1,
+		},
+		{
+			"too_many_args",
+			[]string{"foo", "bar"},
+			"Too many arguments",
+			1,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			client, closer := testVaultServer(t)
+			defer closer()
+
+			ui, cmd := testEventWebSocketCommand(t)
+			cmd.client = client
+
+			code := cmd.Run(tc.args)
+			if code != tc.code {
+				t.Errorf("expected %d to be %d", code, tc.code)
+			}
+
+			combined := ui.OutputWriter.String() + ui.ErrorWriter.String()
+			if !strings.Contains(combined, tc.out) {
+				t.Errorf("expected %q to contain %q", combined, tc.out)
+			}
+		})
+	}
+}

--- a/vault/logical_system_events.go
+++ b/vault/logical_system_events.go
@@ -5,26 +5,209 @@ package vault
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
+	"github.com/hashicorp/eventlogger"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/vault/helper/namespace"
+	"github.com/hashicorp/vault/helper/syncmap"
+	"github.com/hashicorp/vault/plugins/event"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/logical"
 )
 
+type eventSubscriptions struct {
+	subscriptions *syncmap.SyncMap[string, *eventSubscription]
+}
+
+type eventSubscription struct {
+	ctx     context.Context
+	cancel  context.CancelFunc
+	id      string
+	plugin  string
+	config  map[string]interface{}
+	backend event.SubscriptionPlugin
+}
+
+func (sub *eventSubscription) ID() string {
+	return sub.id
+}
+
+func newEventSubscriptions() *eventSubscriptions {
+	return &eventSubscriptions{
+		subscriptions: syncmap.NewSyncMap[string, *eventSubscription](),
+	}
+}
+
 // handleEventsSubscribe
-func (b *SystemBackend) handleEventsSubscribe(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
-	// TODO
-	return logical.RespondWithStatusCode(nil, req, http.StatusNoContent)
+func (b *SystemBackend) handleEventsSubscribe(requestCtx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+	// TODO: check policy
+	eventTypePattern := data.Get("event_type").(string)
+	if eventTypePattern == "" {
+		return logical.ErrorResponse("event_type is required"), logical.ErrInvalidRequest
+	}
+	bexprFilter := data.Get("filter").(string)
+	plugin := data.Get("plugin").(string)
+	if plugin == "" {
+		return logical.ErrorResponse("plugin is required"), logical.ErrInvalidRequest
+	}
+	factory, ok := b.Core.eventBackends[plugin]
+	if !ok {
+		return logical.ErrorResponse("unsupported plugin type"), logical.ErrInvalidRequest
+	}
+	config := data.Get("config").(map[string]interface{})
+	if config == nil || len(config) == 0 {
+		return logical.ErrorResponse("config is required"), logical.ErrInvalidRequest
+	}
+	id, err := uuid.GenerateUUID()
+	if err != nil {
+		b.logger.Error("Error generating UUID", "error", err)
+		return logical.ErrorResponse("error generating UUID"), logical.ErrUnrecoverable
+	}
+	backend, err := factory(requestCtx)
+	if err != nil {
+		b.logger.Error("Error initializing plugin", "error", err)
+		return logical.ErrorResponse("error initializing plugin"), logical.ErrUnrecoverable
+	}
+	if err != nil {
+		b.logger.Warn("Error subscribing to events", "error", err)
+		return logical.ErrorResponse("error subscribing to events"), logical.ErrUnrecoverable
+	}
+	ns, err := namespace.FromContext(requestCtx)
+	if err != nil {
+		b.logger.Error("No namespace found", "error", err)
+		return logical.ErrorResponse("no namespace found"), logical.ErrUnrecoverable
+	}
+	ctx, ctxCancel := context.WithCancel(context.Background())
+	eventCh, eventCancel, err := b.Core.events.Subscribe(ctx, ns, eventTypePattern, bexprFilter)
+	sub := &eventSubscription{
+		ctx:     ctx,
+		id:      id,
+		plugin:  plugin,
+		config:  config,
+		backend: backend,
+	}
+	sub.cancel = func() {
+		sub.cancel = func() {} // for safety
+		ctxCancel()
+		eventCancel()
+	}
+	err = sub.backend.Subscribe(requestCtx, &event.SubscribeRequest{
+		SubscriptionID:   id,
+		Config:           config,
+		VerifyConnection: false, // TODO: read this from parameters
+	})
+	if err != nil {
+		b.logger.Warn("Error starting subscription", "error", err)
+		return logical.ErrorResponse(fmt.Sprintf("error starting subscription: %v", err)), logical.ErrUnrecoverable
+	}
+	b.eventSubscriptions.subscriptions.Put(id, sub)
+	go b.subscriptionLoop(sub, eventCh)
+	resp := &logical.Response{
+		Data: map[string]interface{}{
+			"id":     id,
+			"plugin": plugin,
+		},
+	}
+	return logical.RespondWithStatusCode(resp, req, http.StatusOK)
+}
+
+func (b *SystemBackend) unsubscribe(sub *eventSubscription) {
+	sub.cancel()
+	go func() {
+		// subscription context might have been canceled already
+		err := sub.backend.Unsubscribe(context.Background(), &event.UnsubscribeRequest{
+			SubscriptionID: sub.id,
+		})
+		if err != nil {
+			b.logger.Warn("Error unsubscribing", "subscription_id", sub.id, "error", err)
+		}
+	}()
+}
+
+func (b *SystemBackend) subscriptionLoop(sub *eventSubscription, eventCh <-chan *eventlogger.Event) {
+	doneCh := sub.ctx.Done()
+	defer b.unsubscribe(sub)
+	for {
+		select {
+		case <-doneCh:
+			return
+		case payload := <-eventCh:
+			jsonBytes, ok := payload.Format("cloudevents-json")
+			if !ok {
+				b.logger.Error("Event system is not supplying 'cloudevents-json' format")
+				return
+			}
+			err := sub.backend.Send(sub.ctx, &event.SendRequest{
+				SubscriptionID: sub.id,
+				EventJSON:      string(jsonBytes),
+			})
+			if err != nil {
+				b.logger.Warn("Error sending event", "subscription_id", sub.id, "error", err)
+				return
+			}
+		}
+	}
 }
 
 // handleEventsUnsubscribe
-func (b *SystemBackend) handleEventsUnsubscribe(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
-	// TODO
+func (b *SystemBackend) handleEventsUnsubscribe(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+	plugin := data.Get("plugin").(string)
+	id := data.Get("id").(string)
+	if plugin == "" || id == "" {
+		return logical.ErrorResponse("no subscription specified"), logical.ErrNotFound
+	}
+	sub := b.eventSubscriptions.subscriptions.Pop(id) // Pop avoids race condition
+	if sub == nil {
+		return logical.ErrorResponse("no subscription found"), logical.ErrNotFound
+	}
+	if sub.plugin != plugin {
+		b.eventSubscriptions.subscriptions.Put(id, sub)
+		return logical.ErrorResponse("wrong plugin type specified"), logical.ErrNotFound
+	}
+	b.unsubscribe(sub)
 	return logical.RespondWithStatusCode(nil, req, http.StatusNoContent)
 }
 
 // handleEventsListSubscriptions
-func (b *SystemBackend) handleEventsListSubscriptions(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
-	// TODO
-	return logical.RespondWithStatusCode(nil, req, http.StatusNoContent)
+func (b *SystemBackend) handleEventsListSubscriptions(_ context.Context, req *logical.Request, _ *framework.FieldData) (*logical.Response, error) {
+	allSubs := b.eventSubscriptions.subscriptions.Values()
+	var redactedSubs []map[string]any
+	for _, sub := range allSubs {
+		newSub := map[string]any{
+			"id":     sub.id,
+			"plugin": sub.plugin,
+		}
+		redactedSubs = append(redactedSubs, newSub)
+	}
+	resp := &logical.Response{
+		Data: map[string]interface{}{
+			"subscriptions": redactedSubs,
+		},
+	}
+	return logical.RespondWithStatusCode(resp, req, http.StatusOK)
+}
+
+// handleReadSubscription
+func (b *SystemBackend) handleEventsReadSubscription(_ context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+	plugin := data.Get("plugin").(string)
+	id := data.Get("id").(string)
+	if plugin == "" || id == "" {
+		return logical.ErrorResponse("plugin and id are required"), logical.ErrInvalidRequest
+	}
+	sub := b.eventSubscriptions.subscriptions.Get(id)
+	if sub == nil {
+		return logical.ErrorResponse("subscription not found"), logical.ErrNotFound
+	}
+	if sub.plugin != plugin {
+		return logical.ErrorResponse(fmt.Sprintf("subscription found, but with plugin %s instead of %s", sub.plugin, plugin)), logical.ErrNotFound
+	}
+	resp := &logical.Response{
+		Data: map[string]interface{}{
+			"id":     sub.id,
+			"plugin": sub.plugin,
+		},
+	}
+	return logical.RespondWithStatusCode(resp, req, http.StatusOK)
 }

--- a/vault/logical_system_events_test.go
+++ b/vault/logical_system_events_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
 package vault
 
 import (

--- a/vault/logical_system_events_test.go
+++ b/vault/logical_system_events_test.go
@@ -1,0 +1,148 @@
+package vault
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/vault/helper/namespace"
+	"github.com/hashicorp/vault/plugins/event"
+	"github.com/hashicorp/vault/sdk/logical"
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	noopLock     sync.Mutex
+	noopEvents   []string
+	unsubscribed atomic.Pointer[string]
+)
+
+type noopEventBackend struct{}
+
+func (n *noopEventBackend) Subscribe(_ context.Context, _ *event.SubscribeRequest) error {
+	return nil
+}
+
+func (n *noopEventBackend) Send(_ context.Context, request *event.SendRequest) error {
+	noopLock.Lock()
+	defer noopLock.Unlock()
+	noopEvents = append(noopEvents, request.EventJSON)
+	return nil
+}
+
+func (n *noopEventBackend) Unsubscribe(_ context.Context, req *event.UnsubscribeRequest) error {
+	unsubscribed.Store(&req.SubscriptionID)
+	return nil
+}
+
+func (n *noopEventBackend) PluginMetadata() *event.PluginMetadata {
+	return nil
+}
+
+func (n *noopEventBackend) Close(_ context.Context) error {
+	return nil
+}
+
+func noopFactory(_ context.Context) (event.SubscriptionPlugin, error) {
+	return &noopEventBackend{}, nil
+}
+
+// TestSystemBackendEvents_BasicSubscription tests that a basic subscription and send events work.
+func TestSystemBackendEvents_BasicSubscription(t *testing.T) {
+	core, _, root := TestCoreUnsealed(t)
+	core.eventBackends["noop"] = noopFactory
+	ctx := namespace.RootContext(nil)
+	req := logical.TestRequest(t, logical.UpdateOperation, "events/subscriptions")
+	req.ClientToken = root
+	req.Data["config"] = map[string]interface{}{
+		"noop": "nothing",
+	}
+	req.Data["event_type"] = "a*"
+	req.Data["plugin"] = "noop"
+	resp, err := core.systemBackend.HandleRequest(ctx, req)
+	assert.Nil(t, err)
+	assert.Equal(t, 200, resp.Data["http_status_code"])
+
+	// generate an event
+	ev, err := logical.NewEvent()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = core.events.SendEventInternal(nil, namespace.RootNamespace, nil, "abc", ev)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Eventually(t, func() bool {
+		noopLock.Lock()
+		defer noopLock.Unlock()
+		for _, e := range noopEvents {
+			if strings.Contains(e, ev.Id) {
+				return true
+			}
+		}
+		return false
+	}, 5*time.Second, 10*time.Millisecond)
+}
+
+// TestSystemBackendEvents_Unsubscribe tests that unsubscribe terminates the stream of events.
+func TestSystemBackendEvents_Unsubscribe(t *testing.T) {
+	core, _, root := TestCoreUnsealed(t)
+	core.eventBackends["noop"] = noopFactory
+	ctx := namespace.RootContext(nil)
+	req := logical.TestRequest(t, logical.UpdateOperation, "events/subscriptions")
+	req.ClientToken = root
+	req.Data["config"] = map[string]interface{}{
+		"noop": "nothing",
+	}
+	req.Data["event_type"] = "a*"
+	req.Data["plugin"] = "noop"
+	resp, err := core.systemBackend.HandleRequest(ctx, req)
+	assert.Nil(t, err)
+	assert.Equal(t, 200, resp.Data["http_status_code"])
+	raw := resp.Data["http_raw_body"].(string)
+	data := map[string]interface{}{}
+	err = json.Unmarshal([]byte(raw), &data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	subID := data["data"].(map[string]interface{})["id"].(string)
+
+	ureq := logical.TestRequest(t, logical.DeleteOperation, "events/subscriptions/noop/"+subID)
+	ureq.ClientToken = root
+	resp, err = core.systemBackend.HandleRequest(ctx, ureq)
+	assert.Nil(t, err)
+	fmt.Printf("resp = %+v\n", resp)
+	assert.Equal(t, 204, resp.Data["http_status_code"])
+	assert.Eventually(t, func() bool {
+		x := unsubscribed.Load()
+		if x == nil {
+			return false
+		}
+		return *x == subID
+	}, 5*time.Second, 10*time.Millisecond)
+
+	// make sure that we don't get an event
+	ev, err := logical.NewEvent()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = core.events.SendEventInternal(nil, namespace.RootNamespace, nil, "abc", ev)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Never(t, func() bool {
+		noopLock.Lock()
+		defer noopLock.Unlock()
+		for _, e := range noopEvents {
+			if strings.Contains(e, ev.Id) {
+				return true
+			}
+		}
+		return false
+	}, 1*time.Second, 10*time.Millisecond)
+}

--- a/vault/logical_system_paths.go
+++ b/vault/logical_system_paths.go
@@ -5100,29 +5100,56 @@ func (b *SystemBackend) eventPaths() []*framework.Path {
 	return []*framework.Path{
 		{
 			Pattern: "events/subscriptions$",
-
 			DisplayAttrs: &framework.DisplayAttributes{
 				OperationPrefix: "subscriptions",
-				OperationVerb:   "create",
 			},
-
 			Fields: map[string]*framework.FieldSchema{
+				"event_type": {
+					Type: framework.TypeString,
+				},
+				"filter": {
+					Type: framework.TypeString,
+				},
 				"config": {
-					Type:     framework.TypeMap,
-					Required: true,
+					Type: framework.TypeMap,
 					// Description: strings.TrimSpace(sysHelp["mount_accessor"][0]),
 				},
 				"plugin": {
-					Type:     framework.TypeString,
-					Required: true,
+					Type: framework.TypeString,
 				},
-				//"alias_identifier": {
-				//	Type: framework.TypeString,
-				//	// Description: strings.TrimSpace(sysHelp["alias_identifier"][0]),
-				//},
+				"list": {
+					Type: framework.TypeBool,
+				},
 			},
-
 			Operations: map[logical.Operation]framework.OperationHandler{
+				logical.ReadOperation: &framework.PathOperation{
+					Callback: b.handleEventsListSubscriptions,
+					Summary:  "",
+					Responses: map[int][]framework.Response{
+						http.StatusOK: {{
+							Description: "OK",
+							Fields: map[string]*framework.FieldSchema{
+								"subscriptions": {
+									Type: framework.TypeSlice,
+								},
+							},
+						}},
+					},
+				},
+				logical.ListOperation: &framework.PathOperation{
+					Callback: b.handleEventsListSubscriptions,
+					Summary:  "",
+					Responses: map[int][]framework.Response{
+						http.StatusOK: {{
+							Description: "OK",
+							Fields: map[string]*framework.FieldSchema{
+								"subscriptions": {
+									Type: framework.TypeSlice,
+								},
+							},
+						}},
+					},
+				},
 				logical.UpdateOperation: &framework.PathOperation{
 					Callback: b.handleEventsSubscribe,
 					Summary:  "",
@@ -5131,6 +5158,10 @@ func (b *SystemBackend) eventPaths() []*framework.Path {
 							Description: "OK",
 							Fields: map[string]*framework.FieldSchema{
 								"id": {
+									Type:     framework.TypeString,
+									Required: true,
+								},
+								"plugin": {
 									Type:     framework.TypeString,
 									Required: true,
 								},
@@ -5167,21 +5198,20 @@ func (b *SystemBackend) eventPaths() []*framework.Path {
 				//},
 			},
 			Operations: map[logical.Operation]framework.OperationHandler{
-				logical.ListOperation: &framework.PathOperation{
-					Callback: b.handleEventsListSubscriptions,
-					Summary:  "",
-					Responses: map[int][]framework.Response{
-						http.StatusNoContent: {{
-							Description: "OK",
-						}},
-					},
-				},
 				logical.ReadOperation: &framework.PathOperation{
-					Callback: b.handleEventsListSubscriptions,
+					Callback: b.handleEventsReadSubscription,
 					Summary:  "",
 					Responses: map[int][]framework.Response{
 						http.StatusNoContent: {{
 							Description: "OK",
+							Fields: map[string]*framework.FieldSchema{
+								"id": {
+									Type: framework.TypeString,
+								},
+								"plugin": {
+									Type: framework.TypeString,
+								},
+							},
 						}},
 					},
 				},


### PR DESCRIPTION
These are tied to the CLI command:

```
vault events subscriptions create ...
vault events subscriptions delete ...
```

This might be slightly confusing, as we already have, for starting up an events WebSocket:

```
vault events subscribe ...
```

I'm open to suggestion on what to name the new CLI endpoints.