### PR TITLE
openapi: Fix response fields for rekey operations

### DIFF
--- a/changelog/25509.txt
+++ b/changelog/25509.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+openapi: Fixing response fields for rekey operations
+```

--- a/vault/logical_system_paths.go
+++ b/vault/logical_system_paths.go
@@ -739,12 +739,12 @@ func (b *SystemBackend) configPaths() []*framework.Path {
 
 func (b *SystemBackend) rekeyPaths() []*framework.Path {
 	respFields := map[string]*framework.FieldSchema{
-		"nounce": {
+		"nonce": {
 			Type:     framework.TypeString,
 			Required: true,
 		},
 		"started": {
-			Type:     framework.TypeString,
+			Type:     framework.TypeBool,
 			Required: true,
 		},
 		"t": {
@@ -984,7 +984,7 @@ func (b *SystemBackend) rekeyPaths() []*framework.Path {
 						http.StatusOK: {{
 							Description: "OK",
 							Fields: map[string]*framework.FieldSchema{
-								"nounce": {
+								"nonce": {
 									Type:     framework.TypeString,
 									Required: true,
 								},
@@ -992,7 +992,7 @@ func (b *SystemBackend) rekeyPaths() []*framework.Path {
 									Type: framework.TypeBool,
 								},
 								"started": {
-									Type: framework.TypeString,
+									Type: framework.TypeBool,
 								},
 								"t": {
 									Type: framework.TypeInt,
@@ -1061,12 +1061,12 @@ func (b *SystemBackend) rekeyPaths() []*framework.Path {
 						http.StatusOK: {{
 							Description: "OK",
 							Fields: map[string]*framework.FieldSchema{
-								"nounce": {
+								"nonce": {
 									Type:     framework.TypeString,
 									Required: true,
 								},
 								"started": {
-									Type:     framework.TypeString,
+									Type:     framework.TypeBool,
 									Required: true,
 								},
 								"t": {
@@ -1094,12 +1094,12 @@ func (b *SystemBackend) rekeyPaths() []*framework.Path {
 						http.StatusOK: {{
 							Description: "OK",
 							Fields: map[string]*framework.FieldSchema{
-								"nounce": {
+								"nonce": {
 									Type:     framework.TypeString,
 									Required: true,
 								},
 								"started": {
-									Type:     framework.TypeString,
+									Type:     framework.TypeBool,
 									Required: true,
 								},
 								"t": {
@@ -1128,7 +1128,7 @@ func (b *SystemBackend) rekeyPaths() []*framework.Path {
 						http.StatusOK: {{
 							Description: "OK",
 							Fields: map[string]*framework.FieldSchema{
-								"nounce": {
+								"nonce": {
 									Type:     framework.TypeString,
 									Required: true,
 								},


### PR DESCRIPTION
Fixing the response fields to match the correct names and types declared in `http/sys_rekey.go`:

https://github.com/hashicorp/vault/blob/633dae1a6a6f11e4e64f42bb385838454f555523/http/sys_rekey.go#L369-L371

Fixing this and releasing the corresponding `openapi.json` should resolve https://github.com/hashicorp/vault-client-go/issues/251