### PR TITLE
Audit: Removed unused code

### DIFF
--- a/audit/types.go
+++ b/audit/types.go
@@ -5,7 +5,6 @@ package audit
 
 import (
 	"context"
-	"io"
 	"time"
 
 	"github.com/hashicorp/go-bexpr"
@@ -76,15 +75,6 @@ type Formatter interface {
 	FormatResponse(context.Context, *logical.LogInput) (*ResponseEntry, error)
 }
 
-// Writer is an interface that provides a way to write request and response audit entries.
-// Formatters write their output to an io.Writer.
-type Writer interface {
-	// WriteRequest writes the request entry to the writer or returns an error.
-	WriteRequest(io.Writer, *RequestEntry) error
-	// WriteResponse writes the response entry to the writer or returns an error.
-	WriteResponse(io.Writer, *ResponseEntry) error
-}
-
 // HeaderFormatter is an interface defining the methods of the
 // vault.AuditedHeadersConfig structure needed in this package.
 type HeaderFormatter interface {
@@ -100,13 +90,6 @@ type EntryFormatter struct {
 	headerFormatter HeaderFormatter
 	config          FormatterConfig
 	prefix          string
-}
-
-// EntryFormatterWriter should be used to format and write out audit requests and responses.
-type EntryFormatterWriter struct {
-	Formatter
-	Writer
-	config FormatterConfig
 }
 
 // FormatterConfig is used to provide basic configuration to a formatter.


### PR DESCRIPTION
`EntryFormatterWriter` and the `Writer` interface are no longer required.

They were maintained during `1.15.x` as we allowed customers a way to revert to non-eventlogger audit behaviour, but this flag has been removed.