### PR TITLE
New kafka event plugin

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -59,6 +59,7 @@ require (
 	github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf
 	github.com/denisenkom/go-mssqldb v0.12.3
 	github.com/docker/docker v25.0.2+incompatible
+	github.com/docker/go-connections v0.4.0
 	github.com/duosecurity/duo_api_golang v0.0.0-20190308151101-6c680f768e74
 	github.com/dustin/go-humanize v1.0.1
 	github.com/fatih/color v1.16.0
@@ -208,6 +209,7 @@ require (
 	github.com/ryanuber/columnize v2.1.2+incompatible
 	github.com/ryanuber/go-glob v1.0.0
 	github.com/sasha-s/go-deadlock v0.2.0
+	github.com/segmentio/kafka-go v0.4.47
 	github.com/sethvargo/go-limiter v0.7.1
 	github.com/shirou/gopsutil/v3 v3.22.6
 	github.com/stretchr/testify v1.8.4
@@ -341,7 +343,6 @@ require (
 	github.com/dimchansky/utfbom v1.1.1 // indirect
 	github.com/distribution/reference v0.5.0 // indirect
 	github.com/docker/cli v25.0.1+incompatible // indirect
-	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/dsnet/compress v0.0.2-0.20210315054119-f66993602bf5 // indirect
 	github.com/dvsekhvalnov/jose2go v1.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -3262,6 +3262,8 @@ github.com/seccomp/libseccomp-golang v0.9.2-0.20210429002308-3879420cc921/go.mod
 github.com/seccomp/libseccomp-golang v0.9.2-0.20220502022130-f33da4d89646/go.mod h1:JA8cRccbGaA1s33RQf7Y1+q9gHmZX1yB/z9WDN1C6fg=
 github.com/segmentio/fasthash v1.0.3 h1:EI9+KE1EwvMLBWwjpRDc+fEM+prwxDYbslddQGtrmhM=
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
+github.com/segmentio/kafka-go v0.4.47 h1:IqziR4pA3vrZq7YdRxaT3w1/5fvIH5qpCwstUanQQB0=
+github.com/segmentio/kafka-go v0.4.47/go.mod h1:HjF6XbOKh0Pjlkr5GVZxt6CsjjwnmhVOfURM5KMd8qg=
 github.com/sergi/go-diff v1.1.0 h1:we8PVUC3FE2uYfodKH/nBHMSetSfHDR6scGdBi+erh0=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/sethvargo/go-limiter v0.7.1 h1:wWNhTj0pxjyJ7wuJHpRJpYwJn+bUnjYfw2a85eu5w9U=

--- a/plugins/event/event_subscription_plugin.go
+++ b/plugins/event/event_subscription_plugin.go
@@ -28,12 +28,6 @@ type SubscriptionPlugin interface {
 	Close(ctx context.Context) error
 }
 
-type Request struct {
-	Subscribe   *SubscribeRequest
-	Unsubscribe *UnsubscribeRequest
-	Event       *SendRequest
-}
-
 type SubscribeRequest struct {
 	SubscriptionID   string
 	Config           map[string]interface{}

--- a/plugins/event/kafka/kafka.go
+++ b/plugins/event/kafka/kafka.go
@@ -1,0 +1,272 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package kafka
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/hashicorp/vault/plugins/event"
+	"github.com/hashicorp/vault/version"
+	"github.com/mitchellh/mapstructure"
+	"github.com/segmentio/kafka-go"
+	"github.com/segmentio/kafka-go/sasl"
+	"github.com/segmentio/kafka-go/sasl/plain"
+	"github.com/segmentio/kafka-go/sasl/scram"
+)
+
+var (
+	_ event.Factory            = New
+	_ event.SubscriptionPlugin = (*kafkaPlugin)(nil)
+)
+
+const pluginName = "kafka"
+
+// ErrAddressesRequired is returned if the addresses field is empty.
+var ErrAddressesRequired = errors.New("must specify at least one address")
+
+// New returns a new instance of the Kafka plugin backend.
+func New(_ context.Context) (event.SubscriptionPlugin, error) {
+	return &kafkaPlugin{
+		clients: map[string]*kafkaClient{},
+	}, nil
+}
+
+type kafkaPlugin struct {
+	clientLock sync.RWMutex
+	clients    map[string]*kafkaClient
+}
+
+type kafkaClient struct {
+	w      *kafka.Writer
+	config *kafkaConfig
+}
+
+type kafkaConfig struct {
+	event.SubscribeConfigDefaults
+
+	Topic string `mapstructure:"topic"` // Kafka topic to write to.
+
+	Addresses []string `mapstructure:"addresses"` // Kafka broker addresses.
+	ClientID  string   `mapstructure:"client_id"` // Client identifier, only used as metadata.
+
+	Balancer        string `mapstructure:"balancer"`          // Client side load balancing algorithm. Defaults to "round_robin".
+	RequiredAcks    string `mapstructure:"required_acks"`     // Required acks from the broker. Defaults to "none".
+	Async           bool   `mapstructure:"async"`             // Fire-and-forget on the client side; incompatible with requiring acks.
+	AutoCreateTopic bool   `mapstructure:"auto_create_topic"` // Create the event topic on the broker if it doesn't exist.
+
+	BatchSize    int           `mapstructure:"batch_size"`    // Maximum number of messages to batch.
+	BatchBytes   int64         `mapstructure:"batch_bytes"`   // Maximum size of a batch.
+	BatchTimeout time.Duration `mapstructure:"batch_timeout"` // Maximum time to wait for a batch to fill.
+
+	CAPem         string `mapstructure:"ca_pem"`          // PEM encoded CA certificate.
+	TLSServerName string `mapstructure:"tls_server_name"` // ServerName to verify for TLS connections.
+	TLSSkipVerify bool   `mapstructure:"tls_skip_verify"` // Set to skip server cert verification.
+	TLSDisabled   bool   `mapstructure:"tls_disabled"`    // Set for PLAINTEXT listeners. Default assumes SSL listeners.
+
+	SASLType string `mapstructure:"sasl_type"` // SASL (auth) mechanism type.
+	Username string `mapstructure:"username"`  // SASL username.
+	Password string `mapstructure:"password"`  // SASL password.
+}
+
+func newClient(kconfig *kafkaConfig) (*kafkaClient, error) {
+	var balancer kafka.Balancer
+	switch kconfig.Balancer {
+	case "round_robin":
+		balancer = &kafka.RoundRobin{}
+	case "hash":
+		balancer = &kafka.Hash{}
+	case "least_bytes":
+		balancer = &kafka.LeastBytes{}
+	}
+
+	var requiredAcks kafka.RequiredAcks
+	switch kconfig.RequiredAcks {
+	case "none":
+		requiredAcks = kafka.RequireNone
+	case "one":
+		requiredAcks = kafka.RequireOne
+	case "all":
+		requiredAcks = kafka.RequireAll
+	}
+
+	var sasl sasl.Mechanism
+	var err error
+	// TODO: support more SASL types.
+	switch kconfig.SASLType {
+	case "plain":
+		sasl = &plain.Mechanism{Username: kconfig.Username, Password: kconfig.Password}
+	case "scram_sha256":
+		sasl, err = scram.Mechanism(scram.SHA256, kconfig.Username, kconfig.Password)
+	case "scram_sha512":
+		sasl, err = scram.Mechanism(scram.SHA512, kconfig.Username, kconfig.Password)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	clientID := "vault.hashicorp.com"
+	if kconfig.ClientID != "" {
+		clientID = kconfig.ClientID
+	}
+
+	var tlsConfig *tls.Config
+	if !kconfig.TLSDisabled {
+		var certPool *x509.CertPool
+		if kconfig.CAPem != "" {
+			certPool = x509.NewCertPool()
+			ok := certPool.AppendCertsFromPEM([]byte(kconfig.CAPem))
+			if !ok {
+				return nil, errors.New("failed to parse any certificates from ca_pem contents")
+			}
+		}
+
+		tlsConfig = &tls.Config{
+			// TODO: support client cert auth.
+			RootCAs:            certPool,
+			ServerName:         kconfig.TLSServerName,
+			InsecureSkipVerify: kconfig.TLSSkipVerify,
+		}
+	}
+
+	writer := &kafka.Writer{
+		Addr: kafka.TCP(kconfig.Addresses...),
+
+		// TODO: writers could be shared by multiple subscriptions if they have
+		// the same config except for the topic, and we instead set the topic
+		// on individual messages. Sharing clients more broadly would improve
+		// performance for the client side load balancing algorithms if users
+		// set up multiple subscriptions to the same kafka cluster.
+		Topic: kconfig.Topic,
+
+		Balancer:               balancer,
+		RequiredAcks:           requiredAcks,
+		Async:                  kconfig.Async,
+		AllowAutoTopicCreation: kconfig.AutoCreateTopic,
+
+		BatchSize:    kconfig.BatchSize,
+		BatchBytes:   kconfig.BatchBytes,
+		BatchTimeout: kconfig.BatchTimeout,
+
+		MaxAttempts:     kconfig.GetRetries() + 1,
+		WriteBackoffMin: kconfig.GetRetryMinBackoff(),
+		WriteBackoffMax: kconfig.GetRetryMaxBackoff(),
+
+		Transport: &kafka.Transport{
+			ClientID: clientID,
+			SASL:     sasl,
+			TLS:      tlsConfig,
+		},
+	}
+
+	return &kafkaClient{
+		w:      writer,
+		config: kconfig,
+	}, nil
+}
+
+func (k *kafkaPlugin) Subscribe(_ context.Context, request *event.SubscribeRequest) error {
+	var cfg kafkaConfig
+	err := mapstructure.Decode(request.Config, &cfg)
+	if err != nil {
+		return err
+	}
+	if len(cfg.Addresses) == 0 {
+		return ErrAddressesRequired
+	}
+
+	k.clientLock.Lock()
+	defer k.clientLock.Unlock()
+
+	if _, ok := k.clients[request.SubscriptionID]; ok {
+		k.killClientWithLock(request.SubscriptionID)
+	}
+
+	client, err := newClient(&cfg)
+	if err != nil {
+		return err
+	}
+
+	// TODO: Handle ValidateConnection param.
+
+	k.clients[request.SubscriptionID] = client
+	return nil
+}
+
+func (k *kafkaPlugin) killClient(subscriptionID string) error {
+	k.clientLock.Lock()
+	defer k.clientLock.Unlock()
+	return k.killClientWithLock(subscriptionID)
+}
+
+func (k *kafkaPlugin) killClientWithLock(subscriptionID string) error {
+	client, ok := k.clients[subscriptionID]
+	if !ok {
+		return nil
+	}
+
+	delete(k.clients, subscriptionID)
+
+	return client.w.Close()
+}
+
+func (k *kafkaPlugin) getClient(subscriptionID string) (*kafkaClient, error) {
+	k.clientLock.RLock()
+	defer k.clientLock.RUnlock()
+	client, ok := k.clients[subscriptionID]
+	if !ok {
+		return nil, fmt.Errorf("invalid subscription_id")
+	}
+
+	return client, nil
+}
+
+func (k *kafkaPlugin) Send(ctx context.Context, send *event.SendRequest) error {
+	client, err := k.getClient(send.SubscriptionID)
+	if err != nil {
+		return err
+	}
+
+	backoff := client.config.NewRetryBackoff()
+	return backoff.Retry(func() error {
+		return client.w.WriteMessages(ctx, kafka.Message{
+			// TODO: Validate that this key is a sensible choice. It puts all
+			// messages for a subscription in the same partition.
+			Key:   []byte(send.SubscriptionID),
+			Value: []byte(send.EventJSON),
+		})
+	})
+}
+
+func (k *kafkaPlugin) Unsubscribe(_ context.Context, request *event.UnsubscribeRequest) error {
+	return k.killClient(request.SubscriptionID)
+}
+
+func (k *kafkaPlugin) PluginMetadata() *event.PluginMetadata {
+	return &event.PluginMetadata{
+		Name:    pluginName,
+		Version: version.GetVersion().Version,
+	}
+}
+
+func (k *kafkaPlugin) Close(_ context.Context) error {
+	k.clientLock.Lock()
+	defer k.clientLock.Unlock()
+	var subscriptions []string
+	for k := range k.clients {
+		subscriptions = append(subscriptions, k)
+	}
+
+	var err error
+	for _, subscription := range subscriptions {
+		err = errors.Join(err, k.killClientWithLock(subscription))
+	}
+
+	return err
+}

--- a/plugins/event/kafka/kafka_test.go
+++ b/plugins/event/kafka/kafka_test.go
@@ -1,0 +1,151 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package kafka
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/docker/go-connections/nat"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/vault/plugins/event"
+	"github.com/hashicorp/vault/sdk/helper/docker"
+	"github.com/segmentio/kafka-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestKafka_SendOneMessage tests the basic happy path with a dev single-node
+// Kafka cluster within a docker container.
+func TestKafka_SendOneMessage(t *testing.T) {
+	addr := prepapreKafkaTestContainer(t)
+
+	ctx := context.Background()
+	plugin, err := New(ctx)
+	require.NoError(t, err)
+
+	subID, err := uuid.GenerateUUID()
+	require.NoError(t, err)
+
+	err = plugin.Subscribe(ctx, &event.SubscribeRequest{
+		SubscriptionID: subID,
+		Config: map[string]interface{}{
+			"addresses":         []string{addr},
+			"topic":             "test-topic",
+			"auto_create_topic": true,
+			"tls_disabled":      true,
+		},
+	})
+	require.NoError(t, err)
+
+	// Re-subscribe - should not error.
+	err = plugin.Subscribe(ctx, &event.SubscribeRequest{
+		SubscriptionID: subID + "2",
+		Config: map[string]interface{}{
+			"addresses":         []string{addr},
+			"topic":             "test-topic",
+			"auto_create_topic": true,
+			"tls_disabled":      true,
+		},
+	})
+	require.NoError(t, err)
+
+	err = plugin.Send(ctx, &event.SendRequest{
+		SubscriptionID: subID,
+		EventJSON:      "{}",
+	})
+	require.NoError(t, err)
+
+	// Now read the event back from kafka.
+	reader := kafka.NewReader(kafka.ReaderConfig{
+		Brokers: []string{addr},
+		Topic:   "test-topic",
+	})
+
+	msg, err := reader.ReadMessage(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("{}"), msg.Value)
+
+	err = plugin.Unsubscribe(ctx, &event.UnsubscribeRequest{
+		SubscriptionID: subID,
+	})
+	require.NoError(t, err)
+}
+
+func prepapreKafkaTestContainer(t *testing.T) string {
+	// The cluster advertises its own address to clients, so we need to find a
+	// host port to provide as config input _before_ starting the container.
+	hostPort := findFreePort(t)
+
+	// Configure a single node dev container which will act as both the controller
+	// and the broker.
+	runner, err := docker.NewServiceRunner(docker.RunOptions{
+		ImageRepo:     "bitnami/kafka",
+		ImageTag:      "3.3.2",
+		ContainerName: "kafka",
+		Ports:         []string{"9092/tcp"},
+		PortBindings: nat.PortMap{
+			"9092/tcp": []nat.PortBinding{{
+				HostIP:   "127.0.0.1",
+				HostPort: strconv.Itoa(hostPort),
+			}},
+		},
+		Env: []string{
+			"KAFKA_CFG_NODE_ID=0",
+			"KAFKA_CFG_PROCESS_ROLES=controller,broker",
+			"KAFKA_CFG_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093",
+			fmt.Sprintf("KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://localhost:%d", hostPort),
+			"KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT",
+			"KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=0@localhost:9093",
+			"KAFKA_CFG_CONTROLLER_LISTENER_NAMES=CONTROLLER",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	svc, err := runner.StartService(context.Background(), func(ctx context.Context, host string, port int) (docker.ServiceConfig, error) {
+		var connected bool
+		for i := 0; i < 100; i++ {
+			conn, err := kafka.DialLeader(ctx, "tcp", fmt.Sprintf("%s:%d", host, port), "test-topic", 0)
+			if err == nil {
+				connected = true
+				conn.Close()
+				break
+			}
+			time.Sleep(100 * time.Millisecond)
+		}
+
+		if !connected {
+			return nil, errors.New("failed to connect to kafka")
+		}
+
+		return docker.NewServiceHostPort(host, port), nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(svc.Cleanup)
+
+	return svc.Config.Address()
+}
+
+func findFreePort(t *testing.T) int {
+	t.Helper()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := ln.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return ln.Addr().(*net.TCPAddr).Port
+}

--- a/plugins/event/sqs/sqs.go
+++ b/plugins/event/sqs/sqs.go
@@ -13,7 +13,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/sqs"
 	"github.com/hashicorp/go-secure-stdlib/awsutil"
 	"github.com/hashicorp/vault/plugins/event"
-	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/hashicorp/vault/version"
 	"github.com/mitchellh/mapstructure"
 )
@@ -215,12 +214,6 @@ func (s *sqsBackend) Unsubscribe(_ context.Context, request *event.UnsubscribeRe
 func (s *sqsBackend) PluginMetadata() *event.PluginMetadata {
 	return &event.PluginMetadata{
 		Name:    pluginName,
-		Version: version.GetVersion().Version,
-	}
-}
-
-func (s *sqsBackend) PluginVersion() logical.PluginVersion {
-	return logical.PluginVersion{
 		Version: version.GetVersion().Version,
 	}
 }


### PR DESCRIPTION
Adds a new Kafka event plugin that satisfies the events plugin interface alongside the SQS plugin. There are quite a few config options but most of them are fairly directly threaded through to the underlying client library.

There are a few Go Kafka libraries to choose from. Segment's own readme has a pretty good run down of why I chose theirs: https://github.com/segmentio/kafka-go/blob/b2b17ac6021f0cc12ff5c4e57e155f141a2fabd4/README.md#L3-L31

There are a few remaining todo items around, but I don't think all of them are necessarily required for the first cut:
* More auth type support
* Support for the ValidateConnection option
* Validating the current event key choice
* Retries/error reporting
* More intelligent client caching/sharing