### PR TITLE
Don't load SQS events backend by default (for now)

### DIFF
--- a/command/commands.go
+++ b/command/commands.go
@@ -54,7 +54,6 @@ import (
 	physSwift "github.com/hashicorp/vault/physical/swift"
 	physZooKeeper "github.com/hashicorp/vault/physical/zookeeper"
 	"github.com/hashicorp/vault/plugins/event"
-	"github.com/hashicorp/vault/plugins/event/sqs"
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/hashicorp/vault/sdk/physical"
 	physFile "github.com/hashicorp/vault/sdk/physical/file"
@@ -176,9 +175,7 @@ var (
 		"plugin": plugin.Factory,
 	}
 
-	eventBackends = map[string]event.Factory{
-		"sqs": sqs.New,
-	}
+	eventBackends = map[string]event.Factory{}
 
 	logicalBackends = map[string]logical.Factory{
 		"plugin":   plugin.Factory,


### PR DESCRIPTION
This is not going to be enabled in 1.16, so we can remove it from the default list of backends.

This removes about 600 KB of dead code from the
binary.

We can add this back in when the rest of the
event plugin endpoints are merged.