### PR TITLE
Update vault-plugin-secrets-openldap to v0.12.1

### DIFF
--- a/changelog/25524.txt
+++ b/changelog/25524.txt
@@ -1,0 +1,3 @@
+```release-note:change
+secrets/openldap: Update plugin to v0.12.1
+```

--- a/go.mod
+++ b/go.mod
@@ -160,7 +160,7 @@ require (
 	github.com/hashicorp/vault-plugin-secrets-kubernetes v0.7.0
 	github.com/hashicorp/vault-plugin-secrets-kv v0.17.0
 	github.com/hashicorp/vault-plugin-secrets-mongodbatlas v0.11.0
-	github.com/hashicorp/vault-plugin-secrets-openldap v0.12.0
+	github.com/hashicorp/vault-plugin-secrets-openldap v0.12.1
 	github.com/hashicorp/vault-plugin-secrets-terraform v0.7.5
 	github.com/hashicorp/vault-testing-stepwise v0.1.4
 	github.com/hashicorp/vault/api v1.12.0

--- a/go.sum
+++ b/go.sum
@@ -2566,8 +2566,8 @@ github.com/hashicorp/vault-plugin-secrets-kv v0.17.0 h1:UNYINnuymcGRT+7UA0MciYAz
 github.com/hashicorp/vault-plugin-secrets-kv v0.17.0/go.mod h1:2U8dr0BrVNIndr1lYrJ3Q92RCrJzpnDCkAmZe/JRyFo=
 github.com/hashicorp/vault-plugin-secrets-mongodbatlas v0.11.0 h1:NU7X28xzc/WBY0jMJNnan+elmKFWv/n5zbWXHfKf9/I=
 github.com/hashicorp/vault-plugin-secrets-mongodbatlas v0.11.0/go.mod h1:l6kmbSsAVTrzhsliH283dTo9LYZ4ClPMbBgEyWiUtz8=
-github.com/hashicorp/vault-plugin-secrets-openldap v0.12.0 h1:tAGJwjgu/NlHwIJeL/tVvqkWzMk/5f13eOSOSMPJiJY=
-github.com/hashicorp/vault-plugin-secrets-openldap v0.12.0/go.mod h1:9Jvrdmtc2/f4V1M33wGgtiXHdTtCC6l5pbMfInTurzc=
+github.com/hashicorp/vault-plugin-secrets-openldap v0.12.1 h1:8BSRXpPplF15ZL77vIQFi9+8zUmbVWjHpdEmkIaqVLg=
+github.com/hashicorp/vault-plugin-secrets-openldap v0.12.1/go.mod h1:epAxjKFROBOI5rUg/8UgRmQlboR4l0AMoAPP5Mx9qkI=
 github.com/hashicorp/vault-plugin-secrets-terraform v0.7.5 h1:nyhdeSdkcb5ZT0drFaW3IePL0aUmcVTzuOToG7RjHwY=
 github.com/hashicorp/vault-plugin-secrets-terraform v0.7.5/go.mod h1:mVZiKjHtll1vqOvThL6F29W1DM2DK5FerAmO7SNz/VE=
 github.com/hashicorp/vault-testing-stepwise v0.1.4 h1:Lsv1KdpQyjhvmLgKeH65FG5MmY5hMkF5LoX3xIxurjg=


### PR DESCRIPTION
This PR was generated by a GitHub Action. Full log: https://github.com/hashicorp/vault/actions/runs/7977649077