### PR TITLE
Document known issue to release notes and upgrade guide for 1.16.0

### DIFF
--- a/website/content/docs/release-notes/1.16.0.mdx
+++ b/website/content/docs/release-notes/1.16.0.mdx
@@ -15,7 +15,7 @@ description: |-
 
 | Version         | Issue                                                                                                                                                                                                                             |
 |-----------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 1.16.0+         | [Vault UI needs a change to the default policy in order to display the version](/vault/docs/upgrading/upgrade-to-1.16.x#default-policy-changes)                                                                                                                |
+| 1.16.0+         | [Existing clusters do not show the current Vault version in UI by default](/vault/docs/upgrading/upgrade-to-1.16.x#default-policy-changes)                                                                                                                |
 
 
 ## Feature deprecations and EOL

--- a/website/content/docs/release-notes/1.16.0.mdx
+++ b/website/content/docs/release-notes/1.16.0.mdx
@@ -1,0 +1,27 @@
+---
+layout: docs
+page_title: "1.16.0 release notes"
+description: |-
+  Key updates for  Vault 1.16.0
+---
+
+# Vault 1.16.0 release notes
+
+**GA date:** 2024-02-28
+
+@include 'release-notes/intro.mdx'
+
+## Known issues and breaking changes
+
+| Version         | Issue                                                                                                                                                                                                                             |
+|-----------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 1.16.0+         | [Vault UI needs a change to the default policy in order to display the version](/vault/docs/upgrading/upgrade-to-1.16.x#default-policy-changes)                                                                                                                |
+
+
+## Feature deprecations and EOL
+
+Deprecated in 1.15 | Retired in 1.15
+------------------ | ---------------
+None | None
+
+@include 'release-notes/deprecation-note.mdx'

--- a/website/content/docs/upgrading/upgrade-to-1.16.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.16.x.mdx
@@ -1,0 +1,18 @@
+---
+layout: docs
+page_title: Upgrade to Vault 1.16.x - Guides
+description: |-
+  Deprecations, important or breaking changes, and remediation recommendations
+  for anyone upgrading to 1.16.x from Vault 1.15.x.
+---
+
+# Overview
+
+The Vault 1.16.x upgrade guide contains information on deprecations, important
+or breaking changes, and remediation recommendations for anyone upgrading from
+Vault 1.15. **Please read carefully**.
+
+## Known issues and workarounds
+
+@include 'known-issues/1_16-default-policy-needs-to-be-updated.mdx'
+

--- a/website/content/partials/known-issues/1_16-default-policy-needs-to-be-updated.mdx
+++ b/website/content/partials/known-issues/1_16-default-policy-needs-to-be-updated.mdx
@@ -2,7 +2,7 @@
 
 #### Affected versions
 
-- 1.16.0
+- 1.16+
 
 #### Issue
 

--- a/website/content/partials/known-issues/1_16-default-policy-needs-to-be-updated.mdx
+++ b/website/content/partials/known-issues/1_16-default-policy-needs-to-be-updated.mdx
@@ -1,4 +1,4 @@
-### Default policy needs to be updated in order for the version to appear in the Vault UI
+### Existing clusters do not show the current Vault version in UI by default
 
 #### Affected versions
 

--- a/website/content/partials/known-issues/1_16-default-policy-needs-to-be-updated.mdx
+++ b/website/content/partials/known-issues/1_16-default-policy-needs-to-be-updated.mdx
@@ -6,10 +6,12 @@
 
 #### Issue
 
-Since the version information in both the `sys/health` and `sys/seal-status` un-authenticated
-endpoints can now be redacted with the use of the **redact_version** TCP listener parameter,
-the Vault UI uses a new authenticated endpoint `sys/internal/ui/version` to obtain the Vault
-server's version.
+Previous versions of the Vault UI fetched version information from
+un-authenticated endpoints like `sys/health` and `sys/seal-status`. Since
+introducing the `redact_version` TCP listener parameter, version information may
+no longer be available under some configurations. As a result, the Vault UI now
+uses a new, **authenticated** endpoint (`sys/internal/ui/version`) to fetch
+version information.
 
 The following rule has been added to the **default** policy that is automatically generated on
 new Vault server.

--- a/website/content/partials/known-issues/1_16-default-policy-needs-to-be-updated.mdx
+++ b/website/content/partials/known-issues/1_16-default-policy-needs-to-be-updated.mdx
@@ -30,7 +30,8 @@ for the Vault version to be displayed in the Vault UI.
 
 No other functionality in the Vault UI is affected be this issue.
 
-To update the **default** policy, use the following commands:
+You can use the Vault CLI to update the **default** policy and allow the Vault IU to query the Vault server for version information:
+
 ```shell-session
 $ vault policy read default | cat - <<< '
 # Allow a token to look up the Vault version. This path is not subject to

--- a/website/content/partials/known-issues/1_16-default-policy-needs-to-be-updated.mdx
+++ b/website/content/partials/known-issues/1_16-default-policy-needs-to-be-updated.mdx
@@ -24,10 +24,11 @@ path "sys/internal/ui/version" {
 }
 ```
 
-However, the **default** policy in existing Vault servers is not updated automatically. It
-must be updated manually be an operator with sufficient privileges in order for the Vault
-version to be displayed in the Vault UI. No other functionality in the Vault UI is affected
-be this issue.
+However, the default policy for **existing** Vault servers does not update
+automatically during the upgrade. You must updated the policy manually in order
+for the Vault version to be displayed in the Vault UI.
+
+No other functionality in the Vault UI is affected be this issue.
 
 To update the **default** policy, use the following commands:
 ```shell-session

--- a/website/content/partials/known-issues/1_16-default-policy-needs-to-be-updated.mdx
+++ b/website/content/partials/known-issues/1_16-default-policy-needs-to-be-updated.mdx
@@ -1,0 +1,43 @@
+### Default policy needs to be updated in order for the version to appear in the Vault UI
+
+#### Affected versions
+
+- 1.16.0
+
+#### Issue
+
+Since the version information in both the `sys/health` and `sys/seal-status` un-authenticated
+endpoints can now be redacted with the use of the **redact_version** TCP listener parameter,
+the Vault UI uses a new authenticated endpoint `sys/internal/ui/version` to obtain the Vault
+server's version.
+
+The following rule has been added to the **default** policy that is automatically generated on
+new Vault server.
+
+```
+# Allow a token to look up the Vault version. This path is not subject to
+# redaction like the unauthenticated endpoints that provide the Vault version.
+path "sys/internal/ui/version" {
+    capabilities = ["read"]
+}
+```
+
+However, the **default** policy in existing Vault servers is not updated automatically. It
+must be updated manually be an operator with sufficient privileges in order for the Vault
+version to be displayed in the Vault UI. No other functionality in the Vault UI is affected
+be this issue.
+
+To update the **default** policy, use the following commands:
+```shell-session
+$ vault policy read default | cat - <<< '
+# Allow a token to look up the Vault version. This path is not subject to
+# redaction like the unauthenticated endpoints that provide the Vault version.
+path "sys/internal/ui/version" {
+    capabilities = ["read"]
+}
+' > default-policy.hcl
+$ vault policy write default ./default-policy.hcl
+```
+
+This change to the default policy will allow the Vault UI to successfully query
+the Vault server version and display it to the users.

--- a/website/content/partials/known-issues/1_16-default-policy-needs-to-be-updated.mdx
+++ b/website/content/partials/known-issues/1_16-default-policy-needs-to-be-updated.mdx
@@ -43,5 +43,3 @@ path "sys/internal/ui/version" {
 $ vault policy write default ./default-policy.hcl
 ```
 
-This change to the default policy will allow the Vault UI to successfully query
-the Vault server version and display it to the users.

--- a/website/content/partials/known-issues/1_16-default-policy-needs-to-be-updated.mdx
+++ b/website/content/partials/known-issues/1_16-default-policy-needs-to-be-updated.mdx
@@ -13,8 +13,8 @@ no longer be available under some configurations. As a result, the Vault UI now
 uses a new, **authenticated** endpoint (`sys/internal/ui/version`) to fetch
 version information.
 
-The following rule has been added to the **default** policy that is automatically generated on
-new Vault server.
+By default, all **new** Vault servers created with v1.16+ include the following rule, in the 
+automatically-generated policy:
 
 ```
 # Allow a token to look up the Vault version. This path is not subject to

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -2165,6 +2165,10 @@
         "path": "upgrading/plugins"
       },
       {
+        "title": "Upgrade to 1.16.x",
+        "path": "upgrading/upgrade-to-1.16.x"
+      },
+      {
         "title": "Upgrade to 1.15.x",
         "path": "upgrading/upgrade-to-1.15.x"
       },
@@ -2415,6 +2419,10 @@
       {
         "title": "Overview",
         "path": "release-notes"
+      },
+      {
+        "title": "1.16.0",
+        "path": "release-notes/1.16.0"
       },
       {
         "title": "1.15.0",


### PR DESCRIPTION
When upgrading a Vault server to version 1.16.0, the Vault UI will no longer be able to display the version because it is now using a different endpoint. To account for this, the **default** policy has been updated to allow access to this endpoint, but the change is not applied to an existing **default** policy. This note serves to inform the users that they need to make a small change to the **default** policy to allow the Vault UI to retrieve the version.