### PR TITLE
Added sync telemetry doc

### DIFF
--- a/website/content/docs/internals/telemetry/metrics/all.mdx
+++ b/website/content/docs/internals/telemetry/metrics/all.mdx
@@ -682,6 +682,10 @@ alphabetic order by name.
 
 @include 'telemetry-metrics/vault/secret/lease/creation.mdx'
 
+@include 'telemetry-metrics/vault/secrets-sync/destinations.mdx'
+
+@include 'telemetry-metrics/vault/secrets-sync/associations.mdx'
+
 @include 'telemetry-metrics/vault/spanner/delete.mdx'
 
 @include 'telemetry-metrics/vault/spanner/get.mdx'

--- a/website/content/docs/internals/telemetry/metrics/secrets-sync.mdx
+++ b/website/content/docs/internals/telemetry/metrics/secrets-sync.mdx
@@ -1,0 +1,16 @@
+---
+layout: docs
+page_title: "Telemetry reference: Secrets Sync metrics"
+description: >-
+  Technical reference for secrets sync related telemetry values.
+---
+
+# Secrets Sync telemetry
+
+Secrets Sync telemetry provides general information about configured sync resources and usage.
+
+## Default metrics
+
+@include 'telemetry-metrics/vault/secrets-sync/destinations.mdx'
+
+@include 'telemetry-metrics/vault/secrets-sync/associations.mdx'

--- a/website/content/partials/telemetry-metrics/vault/secrets-sync/associations.mdx
+++ b/website/content/partials/telemetry-metrics/vault/secrets-sync/associations.mdx
@@ -1,0 +1,5 @@
+### vault.secrets-sync.associations.count ((#vault-secrets-sync-associations))
+
+Metric type | Value    | Description
+----------- | -------- | -----------
+gauge       | number   | Total number of associations across all namespaces for each destination type

--- a/website/content/partials/telemetry-metrics/vault/secrets-sync/destinations.mdx
+++ b/website/content/partials/telemetry-metrics/vault/secrets-sync/destinations.mdx
@@ -1,0 +1,5 @@
+### vault.secrets-sync.destinations.count ((#vault-secrets-sync-destinations))
+
+Metric type | Value    | Description
+----------- | -------- | -----------
+gauge       | number   | Total number of destinations across all namespaces for each destination type

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -112,6 +112,10 @@
                 "path": "internals/telemetry/metrics/raft"
               },
               {
+                "title": "Secrets Sync metrics",
+                "path": "internals/telemetry/metrics/secrets-sync"
+              },
+              {
                 "title": "Secrets metrics",
                 "path": "internals/telemetry/metrics/secrets"
               },


### PR DESCRIPTION
Metrics on the `sys/metrics` endpoints have this format:
```
(...)
      {
        "Labels": {
          "destination-type": "all"
        },
        "Name": "vault.secrets-sync.associations.count",
        "Value": 15
      },
      {
        "Labels": {
          "destination-type": "gcm-sm"
        },
        "Name": "vault.secrets-sync.associations.count",
        "Value": 10
      },
      {
        "Labels": {
          "destination-type": "azure-kv"
        },
        "Name": "vault.secrets-sync.associations.count",
        "Value": 5
      },
      {
        "Labels": {
          "destination-type": "all"
        },
        "Name": "vault.secrets-sync.destinations.count",
        "Value": 3
      },
      {
        "Labels": {
          "destination-type": "gcp-sm"
        },
        "Name": "vault.secrets-sync.destinations.count",
        "Value": 2
      },
      {
        "Labels": {
          "destination-type": "azure-kv"
        },
        "Name": "vault.secrets-sync.destinations.count",
        "Value": 1
      },
(...)
```