### PR TITLE
Default Lease Count Quota: Document pre-1.9 upgrades

### DIFF
--- a/website/content/docs/release-notes/1.16.0.mdx
+++ b/website/content/docs/release-notes/1.16.0.mdx
@@ -16,6 +16,7 @@ description: |-
 | Version         | Issue                                                                                                                                                                                                                             |
 |-----------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | 1.16.0+         | [Existing clusters do not show the current Vault version in UI by default](/vault/docs/upgrading/upgrade-to-1.16.x#default-policy-changes)                                                                                                                |
+| 1.16.0+         | [Default LCQ enabled when upgrading pre-1.9](/vault/docs/upgrading/upgrade-to-1.16.x#default-lcq-pre-1.9-upgrade)
 
 
 ## Feature deprecations and EOL

--- a/website/content/docs/upgrading/upgrade-to-1.16.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.16.x.mdx
@@ -15,4 +15,5 @@ Vault 1.15. **Please read carefully**.
 ## Known issues and workarounds
 
 @include 'known-issues/1_16-default-policy-needs-to-be-updated.mdx'
+@include 'known-issues/1_16-default-lcq-pre-1_9-upgrade.mdx'
 

--- a/website/content/partials/known-issues/1_16-default-lcq-pre-1_9-upgrade.mdx
+++ b/website/content/partials/known-issues/1_16-default-lcq-pre-1_9-upgrade.mdx
@@ -1,0 +1,46 @@
+### Default lease count quota enabled when upgrading from Vault versions before 1.9
+
+#### Affected versions
+
+- 1.16+
+
+#### Issue
+
+Vault began tracking version history as of version 1.9. As of version 1.16, new
+Vault installs automatically enable a lease count quota by consulting the
+version history. If the version history is empty on upgrade, Vault assumes the
+upgrade is a new install and automatically enables a default lease count quota.
+
+Before you upgrade Vault from a version prior to 1.9 to versions 1.16+,
+you should check the current number of unexpired leases via the
+[`vault.expire.num_leases`](/vault/docs/internals/telemetry#token-identity-and-lease-metrics)
+metric.
+
+If the number of unexpired leases is below the [default lease count
+quota](/vault/docs/enterprise/lease-count-quotas#default-lease-count-quota),
+value of 300000 no extra steps are required.
+
+If the number of unexpired leases is greater than the default threshold of
+300000, there is a two step workaround to safely upgrade without the default
+lease count quota:
+
+1. Upgrade to any Vault version prior to 1.16 (between 1.9 and 1.15) to populate the
+   version store.
+2. Upgrade to Vault version 1.16+.
+
+You can review, modify, and delete the global default quota with the
+[`/sys/quotas/lease-count/default`](/vault/api-docs/system/lease-count-quotas)
+endpoint:
+
+```shell-session
+$ vault read sys/quotas/lease-count/default
+$ vault delete sys/quotas/lease-count/default
+$ vault write sys/quotas/lease-count/default max_leases=<# of max leases>
+```
+
+Refer to [Protecting Vault with Resource
+Quotas](/vault/tutorials/operations/resource-quotas) for a step-by-step tutorial
+on quota tuning.
+
+Refer to [Lease Explosions](/vault/docs/concepts/lease-explosions) for more
+information on lease management.

--- a/website/content/partials/known-issues/1_16-default-lcq-pre-1_9-upgrade.mdx
+++ b/website/content/partials/known-issues/1_16-default-lcq-pre-1_9-upgrade.mdx
@@ -8,8 +8,8 @@
 
 Vault began tracking version history as of version 1.9. As of version 1.16, new
 Vault installs automatically enable a lease count quota by consulting the
-version history. If the version history is empty on upgrade, Vault assumes the
-upgrade is a new install and automatically enables a default lease count quota.
+version history. If the version history is empty on upgrade, Vault treats the
+upgrade as a new install and automatically enables a default lease count quota.
 
 Before you upgrade Vault from a version prior to 1.9 to versions 1.16+,
 you should check the current number of unexpired leases via the
@@ -28,7 +28,8 @@ lease count quota:
    version store.
 2. Upgrade to Vault version 1.16+.
 
-You can review, modify, and delete the global default quota with the
+You can review, modify, and delete the global default quota at any point with
+the
 [`/sys/quotas/lease-count/default`](/vault/api-docs/system/lease-count-quotas)
 endpoint:
 


### PR DESCRIPTION
Default Lease Count Quotas are enabled for new clusters by consulting Vault's
past versions.

However, the version store was introduced in 1.9. As a result, upgrading from a
version prior to 1.9 enables the Default Lease Count Quota.

Added a Known Issue to the upgrade doc.