### PR TITLE
UI: Ember deprecation - transition methods part 1

### DIFF
--- a/ui/app/controllers/vault/cluster/access/identity/create.js
+++ b/ui/app/controllers/vault/cluster/access/identity/create.js
@@ -4,9 +4,11 @@
  */
 
 import Controller from '@ember/controller';
+import { service } from '@ember/service';
 import { task } from 'ember-concurrency';
 
 export default Controller.extend({
+  router: service(),
   showRoute: 'vault.cluster.access.identity.show',
   showTab: 'details',
   navAfterSave: task(function* ({ saveType, model }) {
@@ -20,9 +22,9 @@ export default Controller.extend({
     };
     const routeName = listRoutes[type];
     if (!isDelete) {
-      yield this.transitionToRoute(this.showRoute, model.id, this.showTab);
+      yield this.router.transitionTo(this.showRoute, model.id, this.showTab);
       return;
     }
-    yield this.transitionToRoute(routeName);
+    yield this.router.transitionTo(routeName);
   }),
 });

--- a/ui/app/controllers/vault/cluster/access/identity/create.js
+++ b/ui/app/controllers/vault/cluster/access/identity/create.js
@@ -5,26 +5,28 @@
 
 import Controller from '@ember/controller';
 import { service } from '@ember/service';
-import { task } from 'ember-concurrency';
 
 export default Controller.extend({
   router: service(),
   showRoute: 'vault.cluster.access.identity.show',
   showTab: 'details',
-  navAfterSave: task(function* ({ saveType, model }) {
-    const isDelete = saveType === 'delete';
-    const type = model.get('identityType');
-    const listRoutes = {
-      'entity-alias': 'vault.cluster.access.identity.aliases.index',
-      'group-alias': 'vault.cluster.access.identity.aliases.index',
-      group: 'vault.cluster.access.identity.index',
-      entity: 'vault.cluster.access.identity.index',
-    };
-    const routeName = listRoutes[type];
-    if (!isDelete) {
-      yield this.router.transitionTo(this.showRoute, model.id, this.showTab);
-      return;
-    }
-    yield this.router.transitionTo(routeName);
-  }),
+
+  actions: {
+    navAfterSave({ saveType, model }) {
+      const isDelete = saveType === 'delete';
+      const type = model.identityType;
+      const listRoutes = {
+        'entity-alias': 'vault.cluster.access.identity.aliases.index',
+        'group-alias': 'vault.cluster.access.identity.aliases.index',
+        group: 'vault.cluster.access.identity.index',
+        entity: 'vault.cluster.access.identity.index',
+      };
+      if (!isDelete) {
+        this.router.transitionTo(this.showRoute, model.id, this.showTab);
+      } else {
+        const routeName = listRoutes[type];
+        this.router.transitionTo(routeName);
+      }
+    },
+  },
 });

--- a/ui/app/controllers/vault/cluster/access/leases/index.js
+++ b/ui/app/controllers/vault/cluster/access/leases/index.js
@@ -4,11 +4,13 @@
  */
 
 import Controller from '@ember/controller';
+import { service } from '@ember/service';
 
 export default Controller.extend({
+  router: service(),
   actions: {
     lookupLease(id) {
-      this.transitionToRoute('vault.cluster.access.leases.show', id);
+      this.router.transitionTo('vault.cluster.access.leases.show', id);
     },
   },
 });

--- a/ui/app/controllers/vault/cluster/access/leases/list.js
+++ b/ui/app/controllers/vault/cluster/access/leases/list.js
@@ -11,6 +11,7 @@ import { keyIsFolder } from 'core/utils/key-utils';
 
 export default Controller.extend(ListController, {
   flashMessages: service(),
+  router: service(),
   store: service(),
   clusterController: controller('vault.cluster'),
 
@@ -61,7 +62,7 @@ export default Controller.extend(ListController, {
       const fn = adapter[method];
       fn.call(adapter, prefix)
         .then(() => {
-          return this.transitionToRoute('vault.cluster.access.leases.list-root').then(() => {
+          return this.router.transitionTo('vault.cluster.access.leases.list-root').then(() => {
             this.flashMessages.success(`All of the leases under ${prefix} will be revoked.`);
           });
         })

--- a/ui/app/controllers/vault/cluster/access/leases/show.js
+++ b/ui/app/controllers/vault/cluster/access/leases/show.js
@@ -21,11 +21,12 @@ export default Controller.extend({
   }),
 
   flashMessages: service(),
+  router: service(),
 
   actions: {
     revokeLease(model) {
       return model.destroyRecord().then(() => {
-        return this.transitionToRoute('vault.cluster.access.leases.list-root');
+        return this.router.transitionTo('vault.cluster.access.leases.list-root');
       });
     },
 

--- a/ui/app/controllers/vault/cluster/access/namespaces/create.js
+++ b/ui/app/controllers/vault/cluster/access/namespaces/create.js
@@ -7,12 +7,13 @@ import { service } from '@ember/service';
 import Controller from '@ember/controller';
 export default Controller.extend({
   namespaceService: service('namespace'),
+  router: service(),
   actions: {
     onSave({ saveType }) {
       if (saveType === 'save') {
         // fetch new namespaces for the namespace picker
         this.namespaceService.findNamespacesForUser.perform();
-        return this.transitionToRoute('vault.cluster.access.namespaces.index');
+        return this.router.transitionTo('vault.cluster.access.namespaces.index');
       }
     },
   },

--- a/ui/app/controllers/vault/cluster/replication-dr-promote/index.js
+++ b/ui/app/controllers/vault/cluster/replication-dr-promote/index.js
@@ -4,13 +4,15 @@
  */
 
 import Controller from '@ember/controller';
+import { service } from '@ember/service';
 
 export default Controller.extend({
+  router: service(),
   queryParams: ['action'],
   action: '',
   actions: {
     onPromote() {
-      this.transitionToRoute('vault.cluster.replication.mode.index', 'dr');
+      this.router.transitionTo('vault.cluster.replication.mode.index', 'dr');
     },
   },
 });

--- a/ui/app/controllers/vault/cluster/settings/auth/enable.js
+++ b/ui/app/controllers/vault/cluster/settings/auth/enable.js
@@ -4,11 +4,14 @@
  */
 
 import Controller from '@ember/controller';
+import { service } from '@ember/service';
 
 export default Controller.extend({
+  router: service(),
+
   actions: {
     onMountSuccess: function (type, path) {
-      const transition = this.transitionToRoute('vault.cluster.settings.auth.configure', path);
+      const transition = this.router.transitionTo('vault.cluster.settings.auth.configure', path);
       return transition.followRedirects();
     },
   },

--- a/ui/app/mixins/cluster-route.js
+++ b/ui/app/mixins/cluster-route.js
@@ -42,9 +42,11 @@ export default Mixin.create({
         transition.targetName !== CLUSTER_INDEX &&
         !isExcluded
       ) {
-        return this.transitionTo(targetRoute, { queryParams: { redirect_to: this.router.currentURL } });
+        return this.router.transitionTo(targetRoute, {
+          queryParams: { redirect_to: this.router.currentURL },
+        });
       }
-      return this.transitionTo(targetRoute);
+      return this.router.transitionTo(targetRoute);
     }
 
     return RSVP.resolve();

--- a/ui/app/routes/vault/cluster.js
+++ b/ui/app/routes/vault/cluster.js
@@ -28,14 +28,15 @@ export const getManagedNamespace = (nsParam, root) => {
 };
 
 export default Route.extend(ModelBoundaryRoute, ClusterRoute, {
-  namespaceService: service('namespace'),
-  version: service(),
-  permissions: service(),
-  store: service(),
   auth: service(),
+  currentCluster: service(),
   customMessages: service(),
   featureFlagService: service('featureFlag'),
-  currentCluster: service(),
+  namespaceService: service('namespace'),
+  permissions: service(),
+  router: service(),
+  store: service(),
+  version: service(),
   modelTypes: computed(function () {
     return ['node', 'secret', 'secret-engine'];
   }),
@@ -69,12 +70,12 @@ export default Route.extend(ModelBoundaryRoute, ClusterRoute, {
       namespace = storage?.userRootNamespace;
       // only redirect if something other than nothing
       if (namespace) {
-        this.transitionTo({ queryParams: { namespace } });
+        this.router.transitionTo({ queryParams: { namespace } });
       }
     } else if (managedRoot !== null) {
       const managed = getManagedNamespace(namespace, managedRoot);
       if (managed !== namespace) {
-        this.transitionTo({ queryParams: { namespace: managed } });
+        this.router.transitionTo({ queryParams: { namespace: managed } });
       }
     }
     this.namespaceService.setNamespace(namespace);
@@ -126,7 +127,7 @@ export default Route.extend(ModelBoundaryRoute, ClusterRoute, {
     // Check that namespaces is enabled and if not,
     // clear the namespace by transition to this route w/o it
     if (this.namespaceService.path && !this.version.hasNamespaces) {
-      return this.transitionTo(this.routeName, { queryParams: { namespace: '' } });
+      return this.router.transitionTo(this.routeName, { queryParams: { namespace: '' } });
     }
     return this.transitionToTargetRoute(transition);
   },

--- a/ui/app/routes/vault/cluster/access/identity/merge.js
+++ b/ui/app/routes/vault/cluster/access/identity/merge.js
@@ -9,11 +9,12 @@ import { service } from '@ember/service';
 
 export default Route.extend(UnloadModelRoute, {
   store: service(),
+  router: service(),
 
   beforeModel() {
     const itemType = this.modelFor('vault.cluster.access.identity');
     if (itemType !== 'entity') {
-      return this.transitionTo('vault.cluster.access.identity');
+      return this.router.transitionTo('vault.cluster.access.identity');
     }
   },
 

--- a/ui/app/routes/vault/cluster/access/identity/show.js
+++ b/ui/app/routes/vault/cluster/access/identity/show.js
@@ -12,6 +12,7 @@ import { TABS } from 'vault/helpers/tabs-for-identity-show';
 import { service } from '@ember/service';
 
 export default Route.extend({
+  router: service(),
   store: service(),
 
   model(params) {
@@ -58,7 +59,7 @@ export default Route.extend({
   afterModel(resolvedModel) {
     const { section, model } = resolvedModel;
     if (model.get('identityType') === 'group' && model.get('type') === 'internal' && section === 'aliases') {
-      return this.transitionTo('vault.cluster.access.identity.show', model.id, 'details');
+      return this.router.transitionTo('vault.cluster.access.identity.show', model.id, 'details');
     }
   },
 

--- a/ui/app/routes/vault/cluster/access/leases/index.js
+++ b/ui/app/routes/vault/cluster/access/leases/index.js
@@ -4,16 +4,19 @@
  */
 
 import Route from '@ember/routing/route';
+import { service } from '@ember/service';
 
-export default Route.extend({
+export default class LeasesIndexRoute extends Route {
+  @service router;
+
   beforeModel(transition) {
     if (
       this.modelFor('vault.cluster.access.leases').get('canList') &&
       transition.targetName === this.routeName
     ) {
-      return this.replaceWith('vault.cluster.access.leases.list-root');
+      return this.router.replaceWith('vault.cluster.access.leases.list-root');
     } else {
       return;
     }
-  },
-});
+  }
+}

--- a/ui/app/routes/vault/cluster/access/leases/show.js
+++ b/ui/app/routes/vault/cluster/access/leases/show.js
@@ -12,15 +12,16 @@ import UnloadModelRoute from 'vault/mixins/unload-model-route';
 
 export default Route.extend(UnloadModelRoute, {
   store: service(),
+  router: service(),
 
   beforeModel() {
     const { lease_id: leaseId } = this.paramsFor(this.routeName);
     const parentKey = parentKeyForKey(leaseId);
     if (keyIsFolder(leaseId)) {
       if (parentKey) {
-        return this.transitionTo('vault.cluster.access.leases.list', parentKey);
+        return this.router.transitionTo('vault.cluster.access.leases.list', parentKey);
       } else {
-        return this.transitionTo('vault.cluster.access.leases.list-root');
+        return this.router.transitionTo('vault.cluster.access.leases.list-root');
       }
     }
   },

--- a/ui/app/routes/vault/cluster/access/method/index.js
+++ b/ui/app/routes/vault/cluster/access/method/index.js
@@ -4,12 +4,16 @@
  */
 
 import Route from '@ember/routing/route';
+import { service } from '@ember/service';
 import { tabsForAuthSection } from 'vault/helpers/tabs-for-auth-section';
-export default Route.extend({
+
+export default class AccessMethodIndexRoute extends Route {
+  @service router;
+
   beforeModel() {
     let { methodType, paths } = this.modelFor('vault.cluster.access.method');
     paths = paths ? paths.paths.filter((path) => path.navigation === true) : null;
     const activeTab = tabsForAuthSection([methodType, 'authConfig', paths])[0].routeParams;
-    return this.transitionTo(...activeTab);
-  },
-});
+    return this.router.transitionTo(...activeTab);
+  }
+}

--- a/ui/app/routes/vault/cluster/access/mfa/index.js
+++ b/ui/app/routes/vault/cluster/access/mfa/index.js
@@ -7,6 +7,7 @@ import Route from '@ember/routing/route';
 import { service } from '@ember/service';
 
 export default class MfaConfigureRoute extends Route {
+  @service router;
   @service store;
 
   beforeModel() {
@@ -14,7 +15,7 @@ export default class MfaConfigureRoute extends Route {
       .query('mfa-method', {})
       .then(() => {
         // if response then they should transition to the methods page instead of staying on the configure page.
-        this.transitionTo('vault.cluster.access.mfa.methods.index');
+        this.router.transitionTo('vault.cluster.access.mfa.methods.index');
       })
       .catch(() => {
         // stay on the landing page

--- a/ui/app/routes/vault/cluster/index.js
+++ b/ui/app/routes/vault/cluster/index.js
@@ -4,9 +4,11 @@
  */
 
 import Route from '@ember/routing/route';
+import { service } from '@ember/service';
 
-export default Route.extend({
+export default class ClusterIndexRoute extends Route {
+  @service router;
   beforeModel() {
-    return this.transitionTo('vault.cluster.dashboard');
-  },
-});
+    return this.router.transitionTo('vault.cluster.dashboard');
+  }
+}

--- a/ui/app/routes/vault/cluster/logout.js
+++ b/ui/app/routes/vault/cluster/logout.js
@@ -43,7 +43,7 @@ export default Route.extend(ModelBoundaryRoute, {
     }
     if (Ember.testing) {
       // Don't redirect on the test
-      this.replaceWith('vault.cluster.auth', { queryParams });
+      this.router.replaceWith('vault.cluster.auth', { queryParams });
     } else {
       const { cluster_name } = this.paramsFor('vault.cluster');
       location.assign(this.router.urlFor('vault.cluster.auth', cluster_name, { queryParams }));

--- a/ui/app/routes/vault/cluster/logout.js
+++ b/ui/app/routes/vault/cluster/logout.js
@@ -42,8 +42,9 @@ export default Route.extend(ModelBoundaryRoute, {
       queryParams.namespace = ns;
     }
     if (Ember.testing) {
+      // TODO: cleanup this replaceWith instance. Using router.replaceWith causes test failures
       // Don't redirect on the test
-      this.router.replaceWith('vault.cluster.auth', { queryParams });
+      this.replaceWith('vault.cluster.auth', { queryParams });
     } else {
       const { cluster_name } = this.paramsFor('vault.cluster');
       location.assign(this.router.urlFor('vault.cluster.auth', cluster_name, { queryParams }));

--- a/ui/app/routes/vault/cluster/oidc-provider.js
+++ b/ui/app/routes/vault/cluster/oidc-provider.js
@@ -73,7 +73,7 @@ export default class VaultClusterOidcProviderRoute extends Route {
     if (namespace) {
       queryParams.namespace = namespace;
     }
-    return this.transitionTo(AUTH, cluster_name, { queryParams });
+    return this.router.transitionTo(AUTH, cluster_name, { queryParams });
   }
 
   _buildUrl(urlString, params) {

--- a/ui/app/routes/vault/cluster/policies.js
+++ b/ui/app/routes/vault/cluster/policies.js
@@ -21,7 +21,7 @@ export default Route.extend(ClusterRoute, {
   model(params) {
     const policyType = params.type;
     if (!ALLOWED_TYPES.includes(policyType)) {
-      return this.transitionTo(this.routeName, ALLOWED_TYPES[0]);
+      return this.router.transitionTo(this.routeName, ALLOWED_TYPES[0]);
     }
     return {};
   },

--- a/ui/app/routes/vault/cluster/policies/create.js
+++ b/ui/app/routes/vault/cluster/policies/create.js
@@ -8,13 +8,14 @@ import Route from '@ember/routing/route';
 import UnsavedModelRoute from 'vault/mixins/unsaved-model-route';
 
 export default Route.extend(UnsavedModelRoute, {
+  router: service(),
   store: service(),
   version: service(),
 
   model() {
     const policyType = this.policyType();
     if (!this.version.hasSentinel && policyType !== 'acl') {
-      return this.transitionTo('vault.cluster.policies', policyType);
+      return this.router.transitionTo('vault.cluster.policies', policyType);
     }
     return this.store.createRecord(`policy/${policyType}`, {});
   },

--- a/ui/app/routes/vault/cluster/policy.js
+++ b/ui/app/routes/vault/cluster/policy.js
@@ -19,10 +19,10 @@ export default Route.extend(ClusterRoute, {
   model(params) {
     const policyType = params.type;
     if (!ALLOWED_TYPES.includes(policyType)) {
-      return this.transitionTo('vault.cluster.policies', ALLOWED_TYPES[0]);
+      return this.router.transitionTo('vault.cluster.policies', ALLOWED_TYPES[0]);
     }
     if (!this.version.hasSentinel && policyType !== 'acl') {
-      return this.transitionTo('vault.cluster.policies', policyType);
+      return this.router.transitionTo('vault.cluster.policies', policyType);
     }
     return {};
   },

--- a/ui/app/routes/vault/cluster/policy/index.js
+++ b/ui/app/routes/vault/cluster/policy/index.js
@@ -4,9 +4,12 @@
  */
 
 import Route from '@ember/routing/route';
+import { service } from '@ember/service';
 
-export default Route.extend({
+export default class PolicyIndexRouter extends Route {
+  @service router;
+
   beforeModel() {
-    return this.transitionTo('vault.cluster.policies', 'acl');
-  },
-});
+    return this.router.transitionTo('vault.cluster.policies', 'acl');
+  }
+}

--- a/ui/app/routes/vault/cluster/policy/show.js
+++ b/ui/app/routes/vault/cluster/policy/show.js
@@ -9,13 +9,14 @@ import UnloadModelRoute from 'vault/mixins/unload-model-route';
 import { service } from '@ember/service';
 
 export default Route.extend(UnloadModelRoute, {
+  router: service(),
   store: service(),
 
   beforeModel() {
     const params = this.paramsFor(this.routeName);
     const policyType = this.policyType();
     if (policyType === 'acl' && params.policy_name === 'root') {
-      return this.transitionTo('vault.cluster.policies', 'acl');
+      return this.router.transitionTo('vault.cluster.policies', 'acl');
     }
   },
 

--- a/ui/app/routes/vault/cluster/secrets/backend.js
+++ b/ui/app/routes/vault/cluster/secrets/backend.js
@@ -6,9 +6,10 @@
 import { service } from '@ember/service';
 import Route from '@ember/routing/route';
 export default Route.extend({
-  store: service(),
   flashMessages: service(),
+  router: service(),
   secretMountPath: service(),
+  store: service(),
   oldModel: null,
 
   model(params) {
@@ -28,7 +29,7 @@ export default Route.extend({
   afterModel(model, transition) {
     const path = model && model.get('path');
     if (transition.targetName === this.routeName) {
-      return this.replaceWith('vault.cluster.secrets.backend.list-root', path);
+      return this.router.replaceWith('vault.cluster.secrets.backend.list-root', path);
     }
   },
 });

--- a/ui/app/routes/vault/cluster/secrets/backend/actions.js
+++ b/ui/app/routes/vault/cluster/secrets/backend/actions.js
@@ -21,9 +21,9 @@ export default EditBase.extend({
     const { backend } = this.paramsFor('vault.cluster.secrets.backend');
     if (this.backendType(backend) !== 'transit') {
       if (parentKey) {
-        return this.transitionTo('vault.cluster.secrets.backend.show', parentKey);
+        return this.router.transitionTo('vault.cluster.secrets.backend.show', parentKey);
       } else {
-        return this.transitionTo('vault.cluster.secrets.backend.show-root');
+        return this.router.transitionTo('vault.cluster.secrets.backend.show-root');
       }
     }
   },

--- a/ui/app/routes/vault/cluster/secrets/backend/create.js
+++ b/ui/app/routes/vault/cluster/secrets/backend/create.js
@@ -4,13 +4,16 @@
  */
 
 import Route from '@ember/routing/route';
+import { service } from '@ember/service';
 
-export default Route.extend({
+export default class SecretsBackendCreateRoute extends Route {
+  @service router;
+
   beforeModel() {
     const { secret, initialKey } = this.paramsFor(this.routeName);
     const qp = initialKey || secret;
-    return this.transitionTo('vault.cluster.secrets.backend.create-root', {
+    return this.router.transitionTo('vault.cluster.secrets.backend.create-root', {
       queryParams: { initialKey: qp },
     });
-  },
-});
+  }
+}

--- a/ui/app/routes/vault/cluster/secrets/backend/credentials.js
+++ b/ui/app/routes/vault/cluster/secrets/backend/credentials.js
@@ -13,6 +13,7 @@ const SUPPORTED_DYNAMIC_BACKENDS = ['database', 'ssh', 'aws'];
 export default Route.extend({
   templateName: 'vault/cluster/secrets/backend/credentials',
   pathHelp: service('path-help'),
+  router: service(),
   store: service(),
 
   backendModel() {
@@ -65,7 +66,7 @@ export default Route.extend({
       dbCred = await this.getDatabaseCredential(backendPath, role, roleType);
     }
     if (!SUPPORTED_DYNAMIC_BACKENDS.includes(backendModel.get('type'))) {
-      return this.transitionTo('vault.cluster.secrets.backend.list-root', backendPath);
+      return this.router.transitionTo('vault.cluster.secrets.backend.list-root', backendPath);
     }
     return resolve({
       backendPath,

--- a/ui/app/routes/vault/cluster/secrets/backend/index.js
+++ b/ui/app/routes/vault/cluster/secrets/backend/index.js
@@ -4,9 +4,12 @@
  */
 
 import Route from '@ember/routing/route';
+import { service } from '@ember/service';
 
-export default Route.extend({
+export default class BackendIndexRoute extends Route {
+  @service router;
+
   beforeModel() {
-    return this.replaceWith('vault.cluster.secrets.backend.list-root');
-  },
-});
+    return this.router.replaceWith('vault.cluster.secrets.backend.list-root');
+  }
+}

--- a/ui/app/routes/vault/cluster/secrets/backend/secret-edit.js
+++ b/ui/app/routes/vault/cluster/secrets/backend/secret-edit.js
@@ -83,20 +83,24 @@ export default Route.extend({
       if (secretEngine.type === 'kv' && secretEngine.version === 2) {
         // if no secret param redirect to the create route
         // if secret param they are either viewing or editing secret so navigate to the details route
-        return !secret
-          ? this.router.transitionTo('vault.cluster.secrets.backend.kv.create', secretEngine.id)
-          : this.router.transitionTo(
-              'vault.cluster.secrets.backend.kv.secret.details',
-              secretEngine.id,
-              secret
-            );
+        if (!secret) {
+          this.router.transitionTo('vault.cluster.secrets.backend.kv.create', secretEngine.id);
+        } else {
+          this.router.transitionTo(
+            'vault.cluster.secrets.backend.kv.secret.details',
+            secretEngine.id,
+            secret
+          );
+        }
+        return;
       }
       if (mode === 'edit' && keyIsFolder(secret)) {
         if (parentKey) {
-          return this.router.transitionTo('vault.cluster.secrets.backend.list', encodePath(parentKey));
+          this.router.transitionTo('vault.cluster.secrets.backend.list', encodePath(parentKey));
         } else {
-          return this.router.transitionTo('vault.cluster.secrets.backend.list-root');
+          this.router.transitionTo('vault.cluster.secrets.backend.list-root');
         }
+        return;
       }
     });
   },

--- a/ui/app/routes/vault/cluster/secrets/backend/sign.js
+++ b/ui/app/routes/vault/cluster/secrets/backend/sign.js
@@ -8,6 +8,7 @@ import UnloadModel from 'vault/mixins/unload-model-route';
 import { service } from '@ember/service';
 
 export default Route.extend(UnloadModel, {
+  router: service(),
   store: service(),
   templateName: 'vault/cluster/secrets/backend/sign',
 
@@ -31,11 +32,11 @@ export default Route.extend(UnloadModel, {
     const backend = backendModel.get('id');
 
     if (backendModel.get('type') !== 'ssh') {
-      return this.transitionTo('vault.cluster.secrets.backend.list-root', backend);
+      return this.router.transitionTo('vault.cluster.secrets.backend.list-root', backend);
     }
     return this.store.queryRecord('capabilities', this.pathQuery(role, backend)).then((capabilities) => {
       if (!capabilities.get('canUpdate')) {
-        return this.transitionTo('vault.cluster.secrets.backend.list-root', backend);
+        return this.router.transitionTo('vault.cluster.secrets.backend.list-root', backend);
       }
       return this.store.createRecord('ssh-sign', {
         role: {

--- a/ui/app/routes/vault/cluster/settings/auth/configure/index.js
+++ b/ui/app/routes/vault/cluster/settings/auth/configure/index.js
@@ -4,12 +4,15 @@
  */
 
 import Route from '@ember/routing/route';
+import { service } from '@ember/service';
 import { tabsForAuthSection } from 'vault/helpers/tabs-for-auth-section';
 
-export default Route.extend({
+export default class SettingsAuthConfigureRoute extends Route {
+  @service router;
+
   beforeModel() {
     const model = this.modelFor('vault.cluster.settings.auth.configure');
     const section = tabsForAuthSection([model]).firstObject.routeParams.lastObject;
-    return this.transitionTo('vault.cluster.settings.auth.configure.section', section);
-  },
-});
+    return this.router.transitionTo('vault.cluster.settings.auth.configure.section', section);
+  }
+}

--- a/ui/app/routes/vault/cluster/settings/auth/index.js
+++ b/ui/app/routes/vault/cluster/settings/auth/index.js
@@ -4,9 +4,12 @@
  */
 
 import Route from '@ember/routing/route';
+import { service } from '@ember/service';
 
-export default Route.extend({
+export default class SettingsAuthIndexRouter extends Route {
+  @service router;
+
   beforeModel() {
-    return this.replaceWith('vault.cluster.settings.auth.enable');
-  },
-});
+    return this.router.replaceWith('vault.cluster.settings.auth.enable');
+  }
+}

--- a/ui/app/routes/vault/cluster/settings/index.js
+++ b/ui/app/routes/vault/cluster/settings/index.js
@@ -4,12 +4,15 @@
  */
 
 import Route from '@ember/routing/route';
+import { service } from '@ember/service';
 
-export default Route.extend({
-  beforeModel: function (transition) {
+export default class SettingsIndexRouter extends Route {
+  @service router;
+
+  beforeModel(transition) {
     if (transition.targetName === this.routeName) {
       transition.abort();
-      return this.replaceWith('vault.cluster.settings.mount-secret-backend');
+      return this.router.replaceWith('vault.cluster.settings.mount-secret-backend');
     }
-  },
-});
+  }
+}

--- a/ui/app/routes/vault/cluster/tools/index.js
+++ b/ui/app/routes/vault/cluster/tools/index.js
@@ -7,14 +7,16 @@ import { service } from '@ember/service';
 import Route from '@ember/routing/route';
 import { toolsActions } from 'vault/helpers/tools-actions';
 
-export default Route.extend({
-  currentCluster: service(),
+export default class ToolsIndexRouter extends Route {
+  @service currentCluster;
+  @service router;
+
   beforeModel(transition) {
     const currentCluster = this.currentCluster.cluster.name;
     const supportedActions = toolsActions();
     if (transition.targetName === this.routeName) {
       transition.abort();
-      return this.replaceWith('vault.cluster.tools.tool', currentCluster, supportedActions[0]);
+      return this.router.replaceWith('vault.cluster.tools.tool', currentCluster, supportedActions[0]);
     }
-  },
-});
+  }
+}

--- a/ui/app/templates/components/identity/popup-alias.hbs
+++ b/ui/app/templates/components/identity/popup-alias.hbs
@@ -29,7 +29,12 @@
         />
       {{/if}}
       {{#if @item.canDelete}}
-        <dd.Interactive @text="Remove" @color="critical" {{on "click" (fn (mut this.showConfirmModal) true)}} />
+        <dd.Interactive
+          @text="Remove"
+          @color="critical"
+          {{on "click" (fn (mut this.showConfirmModal) true)}}
+          data-test-popup-menu="delete"
+        />
       {{/if}}
     {{/if}}
   </Hds::Dropdown>

--- a/ui/app/templates/vault/cluster/access/identity/aliases/add.hbs
+++ b/ui/app/templates/vault/cluster/access/identity/aliases/add.hbs
@@ -14,4 +14,4 @@
   </p.levelLeft>
 </PageHeader>
 
-<Identity::EditForm @model={{this.model}} @onSave={{perform this.navAfterSave}} />
+<Identity::EditForm @model={{this.model}} @onSave={{action "navAfterSave"}} />

--- a/ui/app/templates/vault/cluster/access/identity/aliases/edit.hbs
+++ b/ui/app/templates/vault/cluster/access/identity/aliases/edit.hbs
@@ -12,4 +12,4 @@
   </p.levelLeft>
 </PageHeader>
 
-<Identity::EditForm @mode="edit" @model={{this.model}} @onSave={{perform this.navAfterSave}} />
+<Identity::EditForm @mode="edit" @model={{this.model}} @onSave={{action "navAfterSave"}} />

--- a/ui/app/templates/vault/cluster/access/identity/create.hbs
+++ b/ui/app/templates/vault/cluster/access/identity/create.hbs
@@ -11,4 +11,4 @@
     </h1>
   </p.levelLeft>
 </PageHeader>
-<Identity::EditForm @model={{this.model}} @onSave={{perform this.navAfterSave}} />
+<Identity::EditForm @model={{this.model}} @onSave={{action "navAfterSave"}} />

--- a/ui/app/templates/vault/cluster/access/identity/edit.hbs
+++ b/ui/app/templates/vault/cluster/access/identity/edit.hbs
@@ -12,4 +12,4 @@
   </p.levelLeft>
 </PageHeader>
 
-<Identity::EditForm @mode="edit" @model={{this.model}} @onSave={{perform this.navAfterSave}} />
+<Identity::EditForm @mode="edit" @model={{this.model}} @onSave={{action "navAfterSave"}} />

--- a/ui/app/templates/vault/cluster/access/identity/merge.hbs
+++ b/ui/app/templates/vault/cluster/access/identity/merge.hbs
@@ -11,4 +11,4 @@
   </p.levelLeft>
 </PageHeader>
 
-<Identity::EditForm @mode="merge" @model={{this.model}} @onSave={{perform this.navAfterSave}} />
+<Identity::EditForm @mode="merge" @model={{this.model}} @onSave={{action "navAfterSave"}} />

--- a/ui/tests/acceptance/access/identity/_shared-alias-tests.js
+++ b/ui/tests/acceptance/access/identity/_shared-alias-tests.js
@@ -3,12 +3,11 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { currentRouteName, settled } from '@ember/test-helpers';
+import { currentRouteName, find, settled } from '@ember/test-helpers';
 import page from 'vault/tests/pages/access/identity/aliases/add';
 import aliasIndexPage from 'vault/tests/pages/access/identity/aliases/index';
 import aliasShowPage from 'vault/tests/pages/access/identity/aliases/show';
 import createItemPage from 'vault/tests/pages/access/identity/create';
-import showItemPage from 'vault/tests/pages/access/identity/show';
 
 export const testAliasCRUD = async function (name, itemType, assert) {
   if (itemType === 'groups') {
@@ -18,8 +17,8 @@ export const testAliasCRUD = async function (name, itemType, assert) {
     await createItemPage.createItem(itemType);
     await settled();
   }
-  let idRow = showItemPage.rows.filterBy('hasLabel').filterBy('rowLabel', 'ID')[0];
-  const itemID = idRow.rowValue;
+
+  const itemID = find('[data-test-row-value="ID"]').textContent.trim();
   await page.visit({ item_type: itemType, id: itemID });
   await settled();
   await page.editForm.name(name).submit();
@@ -29,8 +28,7 @@ export const testAliasCRUD = async function (name, itemType, assert) {
     `${itemType}: shows a flash message`
   );
 
-  idRow = aliasShowPage.rows.filterBy('hasLabel').filterBy('rowLabel', 'ID')[0];
-  const aliasID = idRow.rowValue;
+  const aliasID = find('[data-test-row-value="ID"]').textContent.trim();
   assert.strictEqual(
     currentRouteName(),
     'vault.cluster.access.identity.aliases.show',
@@ -73,14 +71,13 @@ export const testAliasDeleteFromForm = async function (name, itemType, assert) {
     await createItemPage.createItem(itemType);
     await settled();
   }
-  let idRow = showItemPage.rows.filterBy('hasLabel').filterBy('rowLabel', 'ID')[0];
-  const itemID = idRow.rowValue;
+
+  const itemID = find('[data-test-row-value="ID"]').textContent.trim();
   await page.visit({ item_type: itemType, id: itemID });
   await settled();
   await page.editForm.name(name).submit();
   await settled();
-  idRow = aliasShowPage.rows.filterBy('hasLabel').filterBy('rowLabel', 'ID')[0];
-  const aliasID = idRow.rowValue;
+  const aliasID = find('[data-test-row-value="ID"]').textContent.trim();
   await aliasShowPage.edit();
   await settled();
   assert.strictEqual(

--- a/ui/tests/acceptance/access/identity/entities/aliases/create-test.js
+++ b/ui/tests/acceptance/access/identity/entities/aliases/create-test.js
@@ -3,14 +3,13 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { module, skip, test } from 'qunit';
+import { module, test } from 'qunit';
 import { settled } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { testAliasCRUD, testAliasDeleteFromForm } from '../../_shared-alias-tests';
 import authPage from 'vault/tests/pages/auth';
 
 module('Acceptance | /access/identity/entities/aliases/add', function (hooks) {
-  // TODO come back and figure out why this is failing.  Seems to be a race condition
   setupApplicationTest(hooks);
 
   hooks.beforeEach(async function () {
@@ -18,7 +17,7 @@ module('Acceptance | /access/identity/entities/aliases/add', function (hooks) {
     return;
   });
 
-  skip('it allows create, list, delete of an entity alias', async function (assert) {
+  test('it allows create, list, delete of an entity alias', async function (assert) {
     assert.expect(6);
     const name = `alias-${Date.now()}`;
     await testAliasCRUD(name, 'entities', assert);

--- a/ui/tests/acceptance/oidc-provider-test.js
+++ b/ui/tests/acceptance/oidc-provider-test.js
@@ -183,6 +183,8 @@ module('Acceptance | oidc provider', function (hooks) {
   test('OIDC Provider redirects to auth if current token and prompt = login', async function (assert) {
     const { providerName, callback, clientId, authMethodPath } = this.oidcSetupInformation;
     await settled();
+    await visit('/vault/dashboard');
+    assert.strictEqual(currentURL(), '/vault/dashboard', 'User is logged in before oidc login attempt');
     const url = getAuthzUrl(providerName, callback, clientId, { prompt: 'login' });
     await visit(url);
 

--- a/ui/tests/unit/mixins/cluster-route-test.js
+++ b/ui/tests/unit/mixins/cluster-route-test.js
@@ -20,7 +20,12 @@ import sinon from 'sinon';
 module('Unit | Mixin | cluster route', function () {
   function createClusterRoute(
     clusterModel = {},
-    methods = { router: {}, hasKeyData: () => false, authToken: () => null, transitionTo: () => {} }
+    methods = {
+      router: { transitionTo: () => {} },
+      hasKeyData: () => false,
+      authToken: () => null,
+      transitionTo: () => {},
+    }
   ) {
     const ClusterRouteObject = EmberObject.extend(
       ClusterRouteMixin,
@@ -132,7 +137,7 @@ module('Unit | Mixin | cluster route', function () {
     const redirectRouteURL = '/vault/secrets/secret/create';
     const subject = createClusterRoute({ needsInit: false, sealed: false });
     subject.router.currentURL = redirectRouteURL;
-    const spy = sinon.spy(subject, 'transitionTo');
+    const spy = sinon.spy(subject.router, 'transitionTo');
     subject.transitionToTargetRoute();
     assert.ok(
       spy.calledWithExactly(AUTH, { queryParams: { redirect_to: redirectRouteURL } }),
@@ -153,7 +158,7 @@ module('Unit | Mixin | cluster route', function () {
 
   test('#transitionToTargetRoute with auth target, coming from cluster route', function (assert) {
     const subject = createClusterRoute({ needsInit: false, sealed: false });
-    const spy = sinon.spy(subject, 'transitionTo');
+    const spy = sinon.spy(subject.router, 'transitionTo');
     subject.transitionToTargetRoute({ targetName: CLUSTER_INDEX });
     assert.ok(spy.calledWithExactly(AUTH), 'calls transitionTo without redirect_to');
     spy.restore();


### PR DESCRIPTION
This PR replaces `this.transitionTo` in routes and `this.transitionToRoute` in controllers everywhere except within the replication engine. That one is running into errors and is worth tackling in a separate PR. 

- [x] Enterprise tests pass locally