### PR TITLE
Lease Count Quotas: include error message in docs

### DIFF
--- a/website/content/docs/concepts/lease-count-quota-exceeded.mdx
+++ b/website/content/docs/concepts/lease-count-quota-exceeded.mdx
@@ -1,0 +1,42 @@
+---
+layout: docs
+page_title: Lease count quota exceeded
+description: |-
+  Vault Enterprise error when quota limit is reached.
+---
+
+# Lease count quota exceeded
+
+Vault returns a `429 - Too Many Requests` response if a new lease request
+violates the quota limit, to guard against [lease
+explosions](/vault/docs/concepts/lease-explosions).
+
+The error will appear as follows:
+
+```
+Error making API request.
+
+URL: PUT https://127.0.0.1:61555/v1/auth/userpass/login/foo
+Code: 429. Errors:
+
+* 1 error occurred:
+	* request path "auth/userpass/login/foo": lease count quota exceeded
+```
+
+To resolve the error:
+
+1. Check for client-side errors that result in excessive lease creation and
+   correct them.
+1. Tune your lease count quota to accommodate any expected increases in lease
+   creation. For example, due to new feature releases or an increase in users.
+
+## Tutorial
+
+Refer to [Protecting Vault with Resource
+Quotas](/vault/tutorials/operations/resource-quotas) for a
+step-by-step tutorial.
+
+## API
+
+Lease count quotas can be managed over the HTTP API. Please see
+[Lease Count Quotas API](/vault/api-docs/system/lease-count-quotas) for more details.

--- a/website/content/docs/concepts/lease-count-quota-exceeded.mdx
+++ b/website/content/docs/concepts/lease-count-quota-exceeded.mdx
@@ -9,9 +9,8 @@ description: |-
 
 Vault returns a `429 - Too Many Requests` response if a new lease request
 violates the quota limit, to guard against [lease
-explosions](/vault/docs/concepts/lease-explosions).
+explosions](/vault/docs/concepts/lease-explosions):
 
-The error will appear as follows:
 
 ```
 Error making API request.

--- a/website/content/docs/enterprise/lease-count-quotas.mdx
+++ b/website/content/docs/enterprise/lease-count-quotas.mdx
@@ -86,18 +86,25 @@ cluster through various
 [metrics](/vault/docs/internals/telemetry/metrics/core-system#quota-metrics)
 and through enabling optional audit logging.
 
-## Lease count quota exceeded
+# Lease count quota exceeded
 
-Vault returns a `429 - Too Many Requests` response if a new lease request violates the quota limit.
+Vault returns a `429 - Too Many Requests` response if a new lease request
+violates the quota limit.
 
 ```
-* lease count quota exceeded
+Error making API request.
+
+URL: PUT https://127.0.0.1:61555/v1/auth/userpass/login/foo
+Code: 429. Errors:
+
+* 1 error occurred:
+	* request path "auth/userpass/login/foo": lease count quota exceeded
 ```
 
 To resolve the error:
 
-1. Check for client-side errors that result in excessive lease creation requests
-   and correct them.
+1. Check for client-side errors that result in excessive lease creation and
+   correct them.
 1. Tune your lease count quota to accommodate any expected increases in lease
    creation. For example, due to new feature releases or an increase in users.
 

--- a/website/content/docs/enterprise/lease-count-quotas.mdx
+++ b/website/content/docs/enterprise/lease-count-quotas.mdx
@@ -16,6 +16,9 @@ additional lease creations will be forbidden for all clients until the
 an operator modifies the configured limit, or a lease has been revoked or
 expired.
 
+Lease count quotas guard against [lease
+explosions](/vault/docs/concepts/lease-explosions).
+
 ## Root tokens
 
 It is important to note that lease count quotas do not apply to the root tokens.
@@ -86,27 +89,11 @@ cluster through various
 [metrics](/vault/docs/internals/telemetry/metrics/core-system#quota-metrics)
 and through enabling optional audit logging.
 
-# Lease count quota exceeded
+## Lease count quota exceeded
 
 Vault returns a `429 - Too Many Requests` response if a new lease request
-violates the quota limit.
-
-```
-Error making API request.
-
-URL: PUT https://127.0.0.1:61555/v1/auth/userpass/login/foo
-Code: 429. Errors:
-
-* 1 error occurred:
-	* request path "auth/userpass/login/foo": lease count quota exceeded
-```
-
-To resolve the error:
-
-1. Check for client-side errors that result in excessive lease creation and
-   correct them.
-1. Tune your lease count quota to accommodate any expected increases in lease
-   creation. For example, due to new feature releases or an increase in users.
+violates the quota limit. For more information on this error, refer to [the
+error document](/vault/docs/concepts/lease-count-quota-exceeded).
 
 ## Tutorial
 

--- a/website/content/docs/enterprise/lease-count-quotas.mdx
+++ b/website/content/docs/enterprise/lease-count-quotas.mdx
@@ -86,6 +86,21 @@ cluster through various
 [metrics](/vault/docs/internals/telemetry/metrics/core-system#quota-metrics)
 and through enabling optional audit logging.
 
+## Lease count quota exceeded
+
+When the Lease Count Quota is exceeded, Vault will emit a `429 - Too Many
+Requests`, indicating that new leases are in violation of the quota.
+
+```
+* lease count quota exceeded
+```
+
+This error is a call to action to identify the root cause and either:
+
+1. Address any client-side errors leading to excessive lease creation.
+2. Properly tune the Lease Count Quota to accomodate any expected increase in
+   lease creation.
+
 ## Tutorial
 
 Refer to [Protecting Vault with Resource

--- a/website/content/docs/enterprise/lease-count-quotas.mdx
+++ b/website/content/docs/enterprise/lease-count-quotas.mdx
@@ -88,18 +88,18 @@ and through enabling optional audit logging.
 
 ## Lease count quota exceeded
 
-When the Lease Count Quota is exceeded, Vault will emit a `429 - Too Many
-Requests`, indicating that new leases are in violation of the quota.
+Vault returns a `429 - Too Many Requests` response if a new lease request violates the quota limit.
 
 ```
 * lease count quota exceeded
 ```
 
-This error is a call to action to identify the root cause and either:
+To resolve the error:
 
-1. Address any client-side errors leading to excessive lease creation.
-2. Properly tune the Lease Count Quota to accomodate any expected increase in
-   lease creation.
+1. Check for client-side errors that result in excessive lease creation requests
+   and correct them.
+1. Tune your lease count quota to accommodate any expected increases in lease
+   creation. For example, due to new feature releases or an increase in users.
 
 ## Tutorial
 

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -174,6 +174,10 @@
         "path": "concepts/lease-explosions"
       },
       {
+        "title": "Lease count quota exceeded",
+        "path": "concepts/lease-count-quota-exceeded"
+      },
+      {
         "title": "Authentication",
         "path": "concepts/auth"
       },


### PR DESCRIPTION
This PR adds a breadcrumb for any users seeing the `quota exceeded` error message to guide them on their journey.