### PR TITLE
Remove Ember polyfill Assign -- attempt 2

### DIFF
--- a/ui/app/adapters/application.js
+++ b/ui/app/adapters/application.js
@@ -6,7 +6,6 @@
 import AdapterError from '@ember-data/adapter/error';
 import RESTAdapter from '@ember-data/adapter/rest';
 import { service } from '@ember/service';
-import { assign } from '@ember/polyfills';
 import { set } from '@ember/object';
 import RSVP from 'rsvp';
 import config from '../config/environment';
@@ -53,7 +52,7 @@ export default RESTAdapter.extend({
     if (namespace && !NAMESPACE_ROOT_URLS.some((str) => url.includes(str))) {
       headers['X-Vault-Namespace'] = namespace;
     }
-    options.headers = assign(options.headers || {}, headers);
+    options.headers = Object.assign(options.headers || {}, headers);
   },
 
   _preRequest(url, options, method) {

--- a/ui/app/adapters/auth-method.js
+++ b/ui/app/adapters/auth-method.js
@@ -4,7 +4,6 @@
  */
 
 import AdapterError from '@ember-data/adapter/error';
-import { assign } from '@ember/polyfills';
 import { set } from '@ember/object';
 import ApplicationAdapter from './application';
 import { encodePath } from 'vault/utils/path-encoding-helpers';
@@ -55,7 +54,7 @@ export default ApplicationAdapter.extend({
       // ember data doesn't like 204s if it's not a DELETE
       data.config.id = path; // config relationship needs an id so use path for now
       return {
-        data: assign({}, data, { path: path + '/', id: path }),
+        data: { ...data, path: path + '/', id: path },
       };
     });
   },

--- a/ui/app/adapters/database/role.js
+++ b/ui/app/adapters/database/role.js
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { assign } from '@ember/polyfills';
 import { assert } from '@ember/debug';
 import ControlGroupError from 'vault/lib/control-group-error';
 import ApplicationAdapter from '../application';
@@ -97,7 +96,7 @@ export default ApplicationAdapter.extend({
           type,
         };
 
-        resp.data = assign({}, successful.data);
+        resp.data = { ...successful.data };
 
         return resp;
       }
@@ -130,13 +129,13 @@ export default ApplicationAdapter.extend({
         dynamicRoles = dynamicResp.value.data.keys;
       }
 
-      resp.data = assign(
-        {},
-        resp.data,
-        { keys: [...staticRoles, ...dynamicRoles] },
-        { backend },
-        { staticRoles, dynamicRoles }
-      );
+      resp.data = {
+        ...resp.data,
+        keys: [...staticRoles, ...dynamicRoles],
+        backend,
+        staticRoles,
+        dynamicRoles,
+      };
 
       return resp;
     });
@@ -170,7 +169,7 @@ export default ApplicationAdapter.extend({
     return this.ajax(this.urlFor(backend, id, roleType), 'POST', { data }).then(() => {
       // ember data doesn't like 204s if it's not a DELETE
       return {
-        data: assign({}, data, { id }),
+        data: { ...data, ...id },
       };
     });
   },

--- a/ui/app/adapters/generated-item-list.js
+++ b/ui/app/adapters/generated-item-list.js
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { assign } from '@ember/polyfills';
 import ApplicationAdapter from './application';
 import { task } from 'ember-concurrency';
 import { service } from '@ember/service';
@@ -34,7 +33,7 @@ export default ApplicationAdapter.extend({
         id,
         method: id,
       };
-      return assign({}, resp, data);
+      return { ...resp, ...data };
     });
   }),
 

--- a/ui/app/adapters/pki/role.js
+++ b/ui/app/adapters/pki/role.js
@@ -4,7 +4,6 @@
  */
 
 import ApplicationAdapter from '../application';
-import { assign } from '@ember/polyfills';
 import { encodePath } from 'vault/utils/path-encoding-helpers';
 
 export default class PkiRoleAdapter extends ApplicationAdapter {
@@ -56,7 +55,7 @@ export default class PkiRoleAdapter extends ApplicationAdapter {
         backend,
       };
 
-      return assign({}, resp, data);
+      return { ...resp, ...data };
     });
   }
 

--- a/ui/app/adapters/policy.js
+++ b/ui/app/adapters/policy.js
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { assign } from '@ember/polyfills';
 import ApplicationAdapter from './application';
 
 export default ApplicationAdapter.extend({
@@ -21,7 +20,7 @@ export default ApplicationAdapter.extend({
     return this.ajax(this.buildURL(type.modelName, name), 'PUT', { data }).then(() => {
       // doing this to make it like a Vault response - ember data doesn't like 204s if it's not a DELETE
       return {
-        data: assign({}, this.serialize(snapshot), { id: name }),
+        data: { ...this.serialize(snapshot), id: name },
       };
     });
   },

--- a/ui/app/adapters/role-ssh.js
+++ b/ui/app/adapters/role-ssh.js
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { assign } from '@ember/polyfills';
 import { resolve, allSettled } from 'rsvp';
 import ApplicationAdapter from './application';
 import { encodePath } from 'vault/utils/path-encoding-helpers';
@@ -81,9 +80,9 @@ export default ApplicationAdapter.extend({
       results.forEach((result) => {
         if (result.value) {
           if (result.value.data.roles) {
-            resp.data = assign({}, resp.data, { zero_address_roles: result.value.data.roles });
+            resp.data = { ...resp.data, zero_address_roles: result.value.data.roles };
           } else {
-            resp.data = assign({}, resp.data, result.value.data);
+            resp.data = { ...resp.data, ...result.value.data };
           }
         }
       });

--- a/ui/app/adapters/secret-engine.js
+++ b/ui/app/adapters/secret-engine.js
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { assign } from '@ember/polyfills';
 import ApplicationAdapter from './application';
 import { encodePath } from 'vault/utils/path-encoding-helpers';
 import { splitObject } from 'vault/helpers/split-object';
@@ -76,13 +75,13 @@ export default ApplicationAdapter.extend({
         // we do not handle the error here because we want the secret-engine to mount successfully and to continue the flow.
       }
       return {
-        data: assign({}, data, { path: path + '/', id: path }),
+        data: { ...data, path: path + '/', id: path },
       };
     } else {
       return this.ajax(this.url(path), 'POST', { data }).then(() => {
         // ember data doesn't like 204s if it's not a DELETE
         return {
-          data: assign({}, data, { path: path + '/', id: path }),
+          data: { ...data, path: path + '/', id: path },
         };
       });
     }

--- a/ui/app/adapters/transform.js
+++ b/ui/app/adapters/transform.js
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { assign } from '@ember/polyfills';
 import { allSettled } from 'rsvp';
 import ApplicationAdapter from './application';
 import { encodePath } from 'vault/utils/path-encoding-helpers';
@@ -85,7 +84,7 @@ export default ApplicationAdapter.extend({
             };
             delete d.templates;
           }
-          resp.data = assign({}, resp.data, d);
+          resp.data = { ...resp.data, ...d };
         }
       });
       return resp;

--- a/ui/app/components/tool-actions-form.js
+++ b/ui/app/components/tool-actions-form.js
@@ -4,7 +4,6 @@
  */
 
 import { match } from '@ember/object/computed';
-import { assign } from '@ember/polyfills';
 import { service } from '@ember/service';
 import Component from '@ember/component';
 import { setProperties, computed, set } from '@ember/object';
@@ -91,12 +90,12 @@ export default Component.extend(DEFAULTS, {
         Renewable: resp.renewable ? 'Yes' : 'No',
         'Lease Duration': resp.lease_duration || 'None',
       };
-      props = assign({}, props, { unwrap_data: secret }, { details: details });
+      props = { ...props, unwrap_data: secret, details: details };
     }
-    props = assign({}, props, secret);
+    props = { ...props, ...secret };
     if (resp && resp.wrap_info) {
       const keyName = action === 'rewrap' ? 'rewrap_token' : 'token';
-      props = assign({}, props, { [keyName]: resp.wrap_info.token });
+      props = { ...props, [keyName]: resp.wrap_info.token };
     }
     setProperties(this, props);
     this.flashMessages.success(`${capitalize(action)} was successful.`);

--- a/ui/app/components/transit-key-actions.js
+++ b/ui/app/components/transit-key-actions.js
@@ -121,7 +121,7 @@ export default class TransitKeyActions extends Component {
       }
     }
     if (options.wrapTTL) {
-      this.props = { ...this.props, ...{ wrappedToken: resp.wrap_info.token } };
+      this.props = { ...this.props, wrappedToken: resp.wrap_info.token };
     }
     this.isModalActive = true;
     // verify doesn't trigger a success message

--- a/ui/app/serializers/application.js
+++ b/ui/app/serializers/application.js
@@ -5,7 +5,6 @@
 
 import JSONSerializer from '@ember-data/serializer/json';
 import { isNone, isBlank } from '@ember/utils';
-import { assign } from '@ember/polyfills';
 import { decamelize } from '@ember/string';
 
 export default JSONSerializer.extend({
@@ -30,7 +29,7 @@ export default JSONSerializer.extend({
       });
       return models;
     }
-    assign(payload, payload.data);
+    Object.assign(payload, payload.data);
     delete payload.data;
     return payload;
   },

--- a/ui/app/serializers/cluster.js
+++ b/ui/app/serializers/cluster.js
@@ -4,7 +4,6 @@
  */
 
 import RESTSerializer, { EmbeddedRecordsMixin } from '@ember-data/serializer/rest';
-import { assign } from '@ember/polyfills';
 import { decamelize } from '@ember/string';
 import IdentityManager from '../utils/identity-manager';
 
@@ -49,7 +48,7 @@ export default RESTSerializer.extend(EmbeddedRecordsMixin, {
   normalizeResponse(store, primaryModelClass, payload, id, requestType) {
     // FIXME when multiple clusters lands
     const transformedPayload = {
-      clusters: assign({ id: '1' }, payload.data || payload),
+      clusters: Object.assign({ id: '1' }, payload.data || payload),
     };
 
     return this._super(store, primaryModelClass, transformedPayload, id, requestType);

--- a/ui/app/serializers/config.js
+++ b/ui/app/serializers/config.js
@@ -4,7 +4,6 @@
  */
 
 import RESTSerializer from '@ember-data/serializer/rest';
-import { assign } from '@ember/polyfills';
 import { decamelize } from '@ember/string';
 
 export default RESTSerializer.extend({
@@ -14,7 +13,7 @@ export default RESTSerializer.extend({
 
   normalizeAll(payload) {
     if (payload.data) {
-      const data = assign({}, payload, payload.data);
+      const data = { ...payload, ...payload.data };
       return [data];
     }
     return [payload];

--- a/ui/app/serializers/identity/_base.js
+++ b/ui/app/serializers/identity/_base.js
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { assign } from '@ember/polyfills';
 import ApplicationSerializer from '../application';
 
 export default ApplicationSerializer.extend({
@@ -19,7 +18,7 @@ export default ApplicationSerializer.extend({
         return model;
       });
     }
-    assign(payload, payload.data);
+    Object.assign(payload, payload.data);
     delete payload.data;
     return payload;
   },

--- a/ui/app/serializers/node.js
+++ b/ui/app/serializers/node.js
@@ -4,7 +4,6 @@
  */
 
 import RESTSerializer, { EmbeddedRecordsMixin } from '@ember-data/serializer/rest';
-import { assign } from '@ember/polyfills';
 import { decamelize } from '@ember/string';
 
 export default RESTSerializer.extend(EmbeddedRecordsMixin, {
@@ -25,7 +24,7 @@ export default RESTSerializer.extend(EmbeddedRecordsMixin, {
 
   nodeFromObject(name, payload) {
     const nodeObj = payload.nodes[name];
-    return assign(nodeObj, {
+    return Object.assign(nodeObj, {
       name,
       id: name,
     });
@@ -34,7 +33,7 @@ export default RESTSerializer.extend(EmbeddedRecordsMixin, {
   normalizeResponse(store, primaryModelClass, payload, id, requestType) {
     const nodes = payload.nodes
       ? Object.keys(payload.nodes).map((name) => this.nodeFromObject(name, payload))
-      : [assign(payload, { id: '1' })];
+      : [Object.assign(payload, { id: '1' })];
 
     const transformedPayload = { nodes: nodes };
 

--- a/ui/app/serializers/secret-engine.js
+++ b/ui/app/serializers/secret-engine.js
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { assign } from '@ember/polyfills';
 import ApplicationSerializer from './application';
 import { EmbeddedRecordsMixin } from '@ember-data/serializer/rest';
 
@@ -34,7 +33,7 @@ export default ApplicationSerializer.extend(EmbeddedRecordsMixin, {
     }
 
     if (struct.data) {
-      struct = assign({}, struct, struct.data);
+      struct = { ...struct, ...struct.data };
       delete struct.data;
     }
     // strip the trailing slash off of the path so we

--- a/ui/app/serializers/ssh.js
+++ b/ui/app/serializers/ssh.js
@@ -5,7 +5,6 @@
 
 import RESTSerializer from '@ember-data/serializer/rest';
 import { isNone, isBlank } from '@ember/utils';
-import { assign } from '@ember/polyfills';
 import { decamelize } from '@ember/string';
 
 export default RESTSerializer.extend({
@@ -25,7 +24,7 @@ export default RESTSerializer.extend({
   },
 
   normalizeItems(payload) {
-    assign(payload, payload.data);
+    Object.assign(payload, payload.data);
     delete payload.data;
     return payload;
   },

--- a/ui/app/serializers/transit-key.js
+++ b/ui/app/serializers/transit-key.js
@@ -4,7 +4,6 @@
  */
 
 import RESTSerializer from '@ember-data/serializer/rest';
-import { assign } from '@ember/polyfills';
 import { decamelize } from '@ember/string';
 
 export default RESTSerializer.extend({
@@ -19,7 +18,7 @@ export default RESTSerializer.extend({
       const secrets = payload.data.keys.map((secret) => ({ name: secret, backend: payload.backend }));
       return secrets;
     }
-    assign(payload, payload.data);
+    Object.assign(payload, payload.data);
     delete payload.data;
     // timestamps for these two are in seconds...
     if (

--- a/ui/app/services/path-help.js
+++ b/ui/app/services/path-help.js
@@ -12,7 +12,6 @@ import Model from '@ember-data/model';
 import Service from '@ember/service';
 import { encodePath } from 'vault/utils/path-encoding-helpers';
 import { getOwner } from '@ember/application';
-import { assign } from '@ember/polyfills';
 import { expandOpenApiProps, combineAttributes } from 'vault/utils/openapi-to-attrs';
 import fieldToAttrs from 'vault/utils/field-to-attrs';
 import { resolve, reject } from 'rsvp';
@@ -183,7 +182,7 @@ export default Service.extend({
       }
       // put url params (e.g. {name}, {role})
       // at the front of the props list
-      const newProps = assign({}, paramProp, props);
+      const newProps = { ...paramProp, ...props };
       return expandOpenApiProps(newProps);
     });
   },

--- a/ui/app/utils/openapi-to-attrs.js
+++ b/ui/app/utils/openapi-to-attrs.js
@@ -4,7 +4,6 @@
  */
 
 import { attr } from '@ember-data/model';
-import { assign } from '@ember/polyfills';
 import { camelize, capitalize } from '@ember/string';
 
 export const expandOpenApiProps = function (props) {
@@ -90,7 +89,7 @@ export const combineAttributes = function (oldAttrs, newProps) {
   if (oldAttrs) {
     oldAttrs.forEach(function (value, name) {
       if (newProps[name]) {
-        newAttrs[name] = attr(newProps[name].type, assign({}, newProps[name], value.options));
+        newAttrs[name] = attr(newProps[name].type, { ...newProps[name], ...value.options });
       } else {
         newAttrs[name] = attr(value.type, value.options);
       }

--- a/ui/tests/integration/components/replication-dashboard-test.js
+++ b/ui/tests/integration/components/replication-dashboard-test.js
@@ -6,7 +6,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
-import { assign } from '@ember/polyfills';
 import hbs from 'htmlbars-inline-precompile';
 
 const REPLICATION_DETAILS = {
@@ -116,7 +115,7 @@ module('Integration | Component | replication-dashboard', function (hooks) {
         IS_REINDEXING.reindex_building_progress,
         'shows the reindexing progress inside the alert banner'
       );
-    const reindexingInProgress = assign({}, IS_REINDEXING, { reindex_building_progress: 152721 });
+    const reindexingInProgress = { ...IS_REINDEXING, reindex_building_progress: 152721 };
     this.set('replicationDetails', reindexingInProgress);
     assert
       .dom('[data-test-reindexing-progress]')

--- a/ui/tests/integration/components/transit-key-actions-test.js
+++ b/ui/tests/integration/components/transit-key-actions-test.js
@@ -5,7 +5,6 @@
 
 import { run } from '@ember/runloop';
 import { resolve } from 'rsvp';
-import { assign } from '@ember/polyfills';
 import Service from '@ember/service';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
@@ -25,12 +24,12 @@ const storeStub = Service.extend({
       keyAction(action, { backend, id, payload }, options) {
         self.set('callArgs', { action, backend, id, payload });
         self.set('callArgsOptions', options);
-        const rootResp = assign({}, self.get('rootKeyActionReturnVal'));
+        const rootResp = { ...self.get('rootKeyActionReturnVal') };
         const resp =
           Object.keys(rootResp).length > 0
             ? rootResp
             : {
-                data: assign({}, self.get('keyActionReturnVal')),
+                data: { ...self.get('keyActionReturnVal') },
               };
         return resolve(resp);
       },
@@ -105,7 +104,7 @@ module('Integration | Component | transit key actions', function (hooks) {
   async function doEncrypt(assert, actions = [], keyattrs = {}) {
     const keyDefaults = { backend: 'transit', id: 'akey', supportedActions: ['encrypt'].concat(actions) };
 
-    const key = assign({}, keyDefaults, keyattrs);
+    const key = { ...keyDefaults, ...keyattrs };
     this.set('key', key);
     this.set('selectedAction', 'encrypt');
     this.set('storeService.keyActionReturnVal', { ciphertext: 'secret' });
@@ -156,7 +155,7 @@ module('Integration | Component | transit key actions', function (hooks) {
   test('it shows key version selection', async function (assert) {
     const keyDefaults = { backend: 'transit', id: 'akey', supportedActions: ['encrypt'].concat([]) };
     const keyattrs = { keysForEncryption: [3, 2, 1], latestVersion: 3 };
-    const key = assign({}, keyDefaults, keyattrs);
+    const key = { ...keyDefaults, ...keyattrs };
     this.set('key', key);
     this.set('storeService.keyActionReturnVal', { ciphertext: 'secret' });
     await render(hbs`
@@ -185,7 +184,7 @@ module('Integration | Component | transit key actions', function (hooks) {
   test('it hides key version selection', async function (assert) {
     const keyDefaults = { backend: 'transit', id: 'akey', supportedActions: ['encrypt'].concat([]) };
     const keyattrs = { keysForEncryption: [1] };
-    const key = assign({}, keyDefaults, keyattrs);
+    const key = { ...keyDefaults, ...keyattrs };
     this.set('key', key);
     this.set('storeService.keyActionReturnVal', { ciphertext: 'secret' });
     await render(hbs`

--- a/ui/tests/unit/mixins/cluster-route-test.js
+++ b/ui/tests/unit/mixins/cluster-route-test.js
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { assign } from '@ember/polyfills';
 import EmberObject from '@ember/object';
 import ClusterRouteMixin from 'vault/mixins/cluster-route';
 import {
@@ -25,7 +24,7 @@ module('Unit | Mixin | cluster route', function () {
   ) {
     const ClusterRouteObject = EmberObject.extend(
       ClusterRouteMixin,
-      assign(methods, { clusterModel: () => clusterModel })
+      Object.assign(methods, { clusterModel: () => clusterModel })
     );
     return ClusterRouteObject.create();
   }


### PR DESCRIPTION
Previous PR borked due to CI things, easiest route was to redo. 

Can compare with [previous PR](https://github.com/hashicorp/vault/pull/25132/files) which was already approved.

------------------------------------------------------------------
`Assign` from [Ember](https://deprecations.emberjs.com/v4.x/#toc_ember-polyfills-deprecate-assign) is deprecated in Ember 5. Here is a snippet of what it was:

```
function assign(target) {
    (true && !(false) && (0, _debug.deprecate)('Use of `assign` has been deprecated. Please use `Object.assign` or the spread operator instead.', false, {
      id: 'ember-polyfills.deprecate-assign',
      until: '5.0.0',
      url: 'https://deprecations.emberjs.com/v4.x/#toc_ember-polyfills-deprecate-assign',
      for: 'ember-source',
      since: {
        available: '4.0.0',
        enabled: '4.0.0'
      }
    }));

    for (var _len = arguments.length, rest = new Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
      rest[_key - 1] = arguments[_key];
    }

    return Object.assign(target, ...rest);
}
```

**Note:** We decided that because Spread creates a new object whereas Object.assign does not, we are using Object.assign when a new Object was not created and Spread when a new object was explicitly created. See Stack overflow discussion [here](https://stackoverflow.com/questions/32925460/object-spread-vs-object-assign).

```
return assign({}, resp, data); // use spread
return assign(resp, data); // use Object assign
```

- [x] Enterprise pass X2 runs in a row.