### PR TITLE
Restructuring suggestion - UI customer messages

### DIFF
--- a/website/content/docs/ui/custom-messages.mdx
+++ b/website/content/docs/ui/custom-messages.mdx
@@ -33,8 +33,24 @@ Use custom banners and modals in the Vault UI to share system-wide alerts for al
 
 - **You must have Vault 1.16.0 or higher installed**.
 - **You must have permission to call the `sys/config/ui/custom-message` endpoint**:
-  - To **create or edit messages** you must have `read`, `list`, and `create` permissions.
+  - To **create or edit messages** you must have `read`, `list`, and `create`
+    permissions.
+  
+   ```hcl
+   path "sys/config/ui/custom-message" {
+      capabilities = [ "read", "list", "create" ]
+   }
+   ```
+
   - To **delete messages** you must have `list` and `delete` permissions.
+
+   ```hcl
+   path "sys/config/ui/custom-message" {
+      capabilities = [ "list", "delete" ]
+   }
+   ```
+
+
 
 ## Add a custom message
 

--- a/website/content/docs/ui/custom-messages.mdx
+++ b/website/content/docs/ui/custom-messages.mdx
@@ -33,22 +33,8 @@ Use custom banners and modals in the Vault UI to share system-wide alerts for al
 
 - **You must have Vault 1.16.0 or higher installed**.
 - **You must have permission to call the `sys/config/ui/custom-message` endpoint**:
-  - To **create or edit messages** you must have `read`, `list`, and `create`
-    permissions.
-  
-   ```hcl
-   path "sys/config/ui/custom-message" {
-      capabilities = [ "read", "list", "create" ]
-   }
-   ```
-
+  - To **create or edit messages** you must have `read`, `list`, and `create` permissions.
   - To **delete messages** you must have `list` and `delete` permissions.
-
-   ```hcl
-   path "sys/config/ui/custom-message" {
-      capabilities = [ "list", "delete" ]
-   }
-   ```
 
 ## Add a custom message
 

--- a/website/content/docs/ui/custom-messages.mdx
+++ b/website/content/docs/ui/custom-messages.mdx
@@ -50,8 +50,6 @@ Use custom banners and modals in the Vault UI to share system-wide alerts for al
    }
    ```
 
-
-
 ## Add a custom message
 
 1. Navigate to the **Settings** section in the Vault UI sidebar and select "Custom

--- a/website/content/docs/ui/index.mdx
+++ b/website/content/docs/ui/index.mdx
@@ -35,12 +35,9 @@ listener "tcp" {
 
 </CodeBlockConfig>
 
-In this case, the UI is accessible at the following URL from any machine on the
-subnet (provided no network firewalls are in place): `https://10.0.1.35:8200/ui`
-
-It is also accessible at any DNS entry that resolves to that IP address, such as
-the Consul service address (if using Consul):
-`https://vault.service.consul:8200/ui`
+The Vault UI is also accessible at any DNS entry that resolves to the configured
+IP address. For example, if you use Consul, you could configure a Consul service
+address for the Vault UI as `https://vault.service.consul:8200/ui`.
 
 <Note>
 

--- a/website/content/docs/ui/index.mdx
+++ b/website/content/docs/ui/index.mdx
@@ -16,7 +16,9 @@ option in the Vault server configuration. The UI runs on the same port as the
 Vault listener. As such, you must configure at least one `listener` stanza in
 order to access the UI.
 
-**Example:**
+For example, the following configuration block enables the UI at
+`https://10.0.1.35:8200/ui` for any machine on the same subnet as long as there
+are no network firewalls in place that explicitly block communication:
 
 <CodeBlockConfig hideClipboard>
 

--- a/website/content/docs/ui/index.mdx
+++ b/website/content/docs/ui/index.mdx
@@ -41,7 +41,7 @@ The Vault UI is also accessible at any DNS entry that resolves to the configured
 IP address. For example, if you use Consul, you could configure a Consul service
 address for the Vault UI as `https://vault.service.consul:8200/ui`.
 
-<Note>
+<Note title="UI enabled in dev mode by default">
 
 When you start the Vault server in dev mode, Vault UI is automatically enabled
 and ready to use.

--- a/website/content/docs/ui/index.mdx
+++ b/website/content/docs/ui/index.mdx
@@ -1,0 +1,56 @@
+---
+layout: docs
+page_title: Vault UI
+description: Interact with Vault using the UI.
+---
+
+# Vault UI
+
+Vault features a web-based user interface (UI) that enables you to unseal,
+authenticate, manage policies and secrets engines.
+
+## Server configuration
+
+To activate the UI, define the [`ui` stanza](/vault/docs/configuration/ui)
+option in the Vault server configuration. The UI runs on the same port as the
+Vault listener. As such, you must configure at least one `listener` stanza in
+order to access the UI.
+
+**Example:**
+
+<CodeBlockConfig hideClipboard>
+
+```hcl
+ui = true
+
+listener "tcp" {
+  address = "10.0.1.35:8200"
+
+  # If bound to localhost, the Vault UI is only
+  # accessible from the local machine!
+  # address = "127.0.0.1:8200"
+}
+# ...
+```
+
+</CodeBlockConfig>
+
+In this case, the UI is accessible at the following URL from any machine on the
+subnet (provided no network firewalls are in place): `https://10.0.1.35:8200/ui`
+
+It is also accessible at any DNS entry that resolves to that IP address, such as
+the Consul service address (if using Consul):
+`https://vault.service.consul:8200/ui`
+
+<Note>
+
+When you start the Vault server in dev mode, Vault UI is automatically enabled
+and ready to use.
+
+</Note>
+
+
+## Tutorial
+
+Refer to the [UI quick start](/vault/tutorials/getting-started-ui) tutorials to
+get familiar with Vault UI.

--- a/website/content/docs/ui/index.mdx
+++ b/website/content/docs/ui/index.mdx
@@ -44,7 +44,7 @@ address for the Vault UI as `https://vault.service.consul:8200/ui`.
 <Note title="UI enabled in dev mode by default">
 
 When you start the Vault server in dev mode, Vault UI is automatically enabled
-and ready to use.
+at `http://127.0.0.1:8200/ui` and ready to use.
 
 </Note>
 

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -1036,6 +1036,19 @@
     ]
   },
   {
+    "title": "Vault UI",
+    "routes": [
+      {
+        "title": "Overview",
+        "path": "ui"
+      },
+      {
+        "title": "Custom Messages",
+        "path": "ui/custom-messages"
+      }
+    ]
+  },
+  {
     "title": "Vault Agent and Vault Proxy",
     "routes": [
       {
@@ -1222,15 +1235,6 @@
             "path": "agent-and-proxy/agent/versions"
           }
         ]
-      }
-    ]
-  },
-  {
-    "title": "Vault UI",
-    "routes": [
-      {
-        "title": "Custom Messages",
-        "path": "ui/custom-messages"
       }
     ]
   },


### PR DESCRIPTION
This PR includes suggestion for https://github.com/hashicorp/vault/pull/25435

Changes:

- Navigation --> moved "Vault UI" immediately after CLI (before the Vault Agent docs)
- Instead of creating `custom-messages` folder, add `custom-messages.mdx` under the `ui` folder
- Added an overview page (`index.mdx`) which covers the server configuration and add a link to tutorials

![image](https://github.com/hashicorp/vault/assets/7660718/6655d41c-5dec-4c99-ad8f-f69763662bb0)
