### PR TITLE
Sync Overview Table Copy Updates

### DIFF
--- a/ui/lib/sync/addon/components/secrets/page/overview.hbs
+++ b/ui/lib/sync/addon/components/secrets/page/overview.hbs
@@ -60,7 +60,16 @@
         <:head as |H|>
           <H.Tr>
             <H.Th>Sync destination</H.Th>
-            <H.Th @align="right"># of secrets</H.Th>
+            <H.Th @align="right">
+              # of external secrets
+              <Hds::TooltipButton
+                @text="# of secrets created at the destination"
+                aria-label="More information"
+                class="is-v-centered"
+              >
+                <FlightIcon @name="info" />
+              </Hds::TooltipButton>
+            </H.Th>
             <H.Th @align="right">Last updated</H.Th>
             <H.Th @align="right">Actions</H.Th>
           </H.Tr>

--- a/ui/tests/integration/components/sync/secrets/page/overview-test.js
+++ b/ui/tests/integration/components/sync/secrets/page/overview-test.js
@@ -96,10 +96,10 @@ module('Integration | Component | sync | Page::Overview', function (hooks) {
     assert.dom(badge(2)).hasText('1 Unsynced', 'Unsynced badge renders');
     assert.dom(badge(2)).hasClass('hds-badge--color-neutral', 'Correct color renders for unsynced badge');
 
-    assert.dom(total(0)).hasText('1', '# of secrets renders');
+    assert.dom(total(0)).hasText('1', '# of external secrets renders');
     assert.dom(updated(0)).hasText(updatedDate, 'Last updated datetime renders');
 
-    assert.dom(total(1)).hasText('0', '# of secrets render for destination with no associations');
+    assert.dom(total(1)).hasText('0', '# of external secrets renders for destination with no associations');
     assert
       .dom(updated(1))
       .hasText('—', 'Last updated placeholder renders for destination with no associations');


### PR DESCRIPTION
This PR updates the copy for the sync overview table secrets column header to reflect that the value represents the external secrets number after the addition of the granularity level on destinations allowing sub keys to be synced within a Vault secret.