### PR TITLE
UI: Fix capability path for custom messages

### DIFF
--- a/ui/app/models/config-ui/message.js
+++ b/ui/app/models/config-ui/message.js
@@ -131,17 +131,18 @@ export default class MessageModel extends Model {
 
   // capabilities
   @lazyCapabilities(apiPath`sys/config/ui/custom-messages`) customMessagesPath;
+  @lazyCapabilities(apiPath`sys/config/ui/custom-messages/${'id'}`, 'id') customMessagePath;
 
   get canCreateCustomMessages() {
     return this.customMessagesPath.get('canCreate') !== false;
   }
   get canReadCustomMessages() {
-    return this.customMessagesPath.get('canRead') !== false;
+    return this.customMessagePath.get('canRead') !== false;
   }
   get canEditCustomMessages() {
-    return this.customMessagesPath.get('canUpdate') !== false;
+    return this.customMessagePath.get('canUpdate') !== false;
   }
   get canDeleteCustomMessages() {
-    return this.customMessagesPath.get('canDelete') !== false;
+    return this.customMessagePath.get('canDelete') !== false;
   }
 }


### PR DESCRIPTION
While writing the docs for custom messages, I noticed that the capabilities path wasn't correct for update, delete, and read. Update, delete, and read require the path to be "sys/config/ui/custom-messages/:id"

```
 # create
path "sys/config/ui/custom-messages" {
    capabilities = ["list", "create"]
}

path "sys/config/ui/custom-messages/:id" {
    capabilities = ["read"]
}
```

```
# edit 
path "sys/config/ui/custom-messages" {
    capabilities = ["list"]
}

path "sys/config/ui/custom-messages/:id" {
    capabilities = ["read", "update"]
}
```

```
 # delete
path "sys/config/ui/custom-messages" {
    capabilities = ["list"]
}

path "sys/config/ui/custom-messages/:id" {
    capabilities = ["delete"]
} 
```
