### PR TITLE
fix 1.16 upgrade guide

### DIFF
--- a/website/content/docs/release-notes/1.16.0.mdx
+++ b/website/content/docs/release-notes/1.16.0.mdx
@@ -16,7 +16,7 @@ description: |-
 | Version         | Issue                                                                                                                                                                                                                             |
 |-----------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | 1.16.0+         | [Existing clusters do not show the current Vault version in UI by default](/vault/docs/upgrading/upgrade-to-1.16.x#default-policy-changes)                                                                                                                |
-| 1.16.0+         | [Default LCQ enabled when upgrading pre-1.9](/vault/docs/upgrading/upgrade-to-1.16.x#default-lcq-pre-1.9-upgrade)
+| 1.16.0+         | [Default LCQ enabled when upgrading pre-1.9](/vault/docs/upgrading/upgrade-to-1.16.x#default-lcq-pre-1.9-upgrade) |
 
 
 ## Feature deprecations and EOL

--- a/website/content/docs/upgrading/upgrade-to-1.16.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.16.x.mdx
@@ -15,5 +15,6 @@ Vault 1.15. **Please read carefully**.
 ## Known issues and workarounds
 
 @include 'known-issues/1_16-default-policy-needs-to-be-updated.mdx'
+
 @include 'known-issues/1_16-default-lcq-pre-1_9-upgrade.mdx'
 


### PR DESCRIPTION
Some formatting issues were introduced in the rebase shuffle for https://github.com/hashicorp/vault/commit/8f9e884beebfa660a946dc7a464882438091705e

This PR addresses those to fix the upgrade guide.

Note that the breaking change has not yet been backported, so it will be manually fixed in the backport PR (https://github.com/hashicorp/vault/pull/25590) before merging.