### PR TITLE
Ui: update overview metric to total secrets instead of associations

### DIFF
--- a/ui/lib/sync/addon/components/secrets/page/overview.hbs
+++ b/ui/lib/sync/addon/components/secrets/page/overview.hbs
@@ -158,7 +158,7 @@
        --}}
       class="is-flex-half"
     >
-      <h2 class="title is-2 has-font-weight-normal has-top-margin-m" data-test-overview-card-content="total vault secrets">
+      <h2 class="title is-2 has-font-weight-normal has-top-margin-m" data-test-overview-card-content="Total secrets">
         {{or @totalVaultSecrets "None"}}
       </h2>
     </OverviewCard>

--- a/ui/lib/sync/addon/components/secrets/page/overview.hbs
+++ b/ui/lib/sync/addon/components/secrets/page/overview.hbs
@@ -149,21 +149,17 @@
       </h2>
     </OverviewCard>
     <OverviewCard
-      @cardTitle="Total sync associations"
-      @subText="The number of secrets with a configured sync destination. One secret synced to two unique destinations will count as two associations."
+      @cardTitle="Total secrets"
+      @subText="The total number of secrets synced from Vault."
       {{!-- * sync clients are unavailable during SYNC BETA (1.16.0), planned for 1.16.1 release 
-      @subText="Total sync associations that count towards client count"
       @actionText="View billing" 
       @actionTo="clientCountOverview"
       @actionExternal={{true}}
        --}}
       class="is-flex-half"
     >
-      <h2
-        class="title is-2 has-font-weight-normal has-top-margin-m"
-        data-test-overview-card-content="Total sync associations"
-      >
-        {{or @totalAssociations "None"}}
+      <h2 class="title is-2 has-font-weight-normal has-top-margin-m" data-test-overview-card-content="total vault secrets">
+        {{or @totalVaultSecrets "None"}}
       </h2>
     </OverviewCard>
   </div>

--- a/ui/lib/sync/addon/templates/secrets/overview.hbs
+++ b/ui/lib/sync/addon/templates/secrets/overview.hbs
@@ -5,5 +5,5 @@
 
 <Secrets::Page::Overview
   @destinations={{this.model.destinations}}
-  @totalAssociations={{this.model.associations.total_associations}}
+  @totalVaultSecrets={{this.model.associations.total_secrets}}
 />

--- a/ui/mirage/handlers/sync.js
+++ b/ui/mirage/handlers/sync.js
@@ -189,23 +189,25 @@ export default function (server) {
   });
   // associations
   server.get('/sys/sync/associations', (schema) => {
-    const records = schema.db.syncAssociations.where({});
-    if (!records.length) {
+    const associations = schema.db.syncAssociations.where({});
+    if (!associations.length) {
       return new Response(404, {}, { errors: [] });
     }
-    // for now we only care about the total_associations value
+
+    const secrets = associations.reduce((secrets, association) => {
+      const secretPath = `${association.mount}/${association.secret_name}`;
+      if (!secrets.includes(secretPath)) {
+        secrets.push(secretPath);
+      }
+      return secrets;
+    }, []);
+
     return {
       data: {
         key_info: {},
         keys: [],
-        total_associations: records.length,
-        total_secrets: records.reduce((secrets, association) => {
-          const secretPath = `${association.mount}/${association.secret_name}`;
-          if (!secrets.includes(secretPath)) {
-            secrets.push(secretPath);
-          }
-          return secrets;
-        }, []),
+        total_associations: associations.length, // link between a secret and a destination
+        total_secrets: secrets.length, // number of secrets synced from vault (one secret can be synced to multiple destinations)
       },
     };
   });

--- a/ui/tests/integration/components/sync/secrets/page/overview-test.js
+++ b/ui/tests/integration/components/sync/secrets/page/overview-test.js
@@ -143,9 +143,8 @@ module('Integration | Component | sync | Page::Overview', function (hooks) {
         count: '6',
       },
       {
-        cardTitle: 'total vault secrets',
-        subText:
-          'The number of secrets with a configured sync destination. One secret synced to two unique destinations will count as two associations.',
+        cardTitle: 'Total secrets',
+        subText: 'The total number of secrets synced from Vault.',
         // actionText: 'View billing',
         count: '7',
       },
@@ -155,7 +154,7 @@ module('Integration | Component | sync | Page::Overview', function (hooks) {
       assert.dom(title(cardTitle)).hasText(cardTitle, 'Overview card title renders');
       assert.dom(description(cardTitle)).hasText(subText, 'Destinations overview card description renders');
       assert.dom(content(cardTitle)).hasText(count, 'Total count renders');
-      if (cardTitle === 'total vault secrets') return; // uncomment 'actionText' above and this return after SYNC BETA
+      if (cardTitle === 'Total secrets') return; // uncomment 'actionText' above and this return after SYNC BETA
       assert.dom(action(cardTitle)).hasText(actionText, 'Card action renders');
     });
   });

--- a/ui/tests/integration/components/sync/secrets/page/overview-test.js
+++ b/ui/tests/integration/components/sync/secrets/page/overview-test.js
@@ -43,7 +43,7 @@ module('Integration | Component | sync | Page::Overview', function (hooks) {
     this.destinations = await store.query('sync/destination', {});
 
     await render(
-      hbs`<Secrets::Page::Overview @destinations={{this.destinations}} @totalAssociations={{7}} />`,
+      hbs`<Secrets::Page::Overview @destinations={{this.destinations}} @totalVaultSecrets={{7}} />`,
       {
         owner: this.engine,
       }
@@ -143,7 +143,7 @@ module('Integration | Component | sync | Page::Overview', function (hooks) {
         count: '6',
       },
       {
-        cardTitle: 'Total sync associations',
+        cardTitle: 'total vault secrets',
         subText:
           'The number of secrets with a configured sync destination. One secret synced to two unique destinations will count as two associations.',
         // actionText: 'View billing',
@@ -155,7 +155,7 @@ module('Integration | Component | sync | Page::Overview', function (hooks) {
       assert.dom(title(cardTitle)).hasText(cardTitle, 'Overview card title renders');
       assert.dom(description(cardTitle)).hasText(subText, 'Destinations overview card description renders');
       assert.dom(content(cardTitle)).hasText(count, 'Total count renders');
-      if (cardTitle === 'Total sync associations') return; // uncomment 'actionText' above and this return after SYNC BETA
+      if (cardTitle === 'total vault secrets') return; // uncomment 'actionText' above and this return after SYNC BETA
       assert.dom(action(cardTitle)).hasText(actionText, 'Card action renders');
     });
   });


### PR DESCRIPTION
For the beta release `Total secrets` is a more useful metric for users because this number will likely correlate to the sync client count. `Associations` formally contributed to the client count number, but for now is a somewhat confusing count as it refers to the link between a secret and a destination. We're considering adding it back to the overview when the sync billing is live after design has time to consider the best way to display all of the counts.

<img width="1235" alt="Screenshot 2024-02-22 at 3 08 02 PM" src="https://github.com/hashicorp/vault/assets/68122737/83da65f2-ec4d-484a-8164-51fee846429c">
