### PR TITLE
Docs: New plugins pinned versions APIs

### DIFF
--- a/website/content/api-docs/system/plugins-pins.mdx
+++ b/website/content/api-docs/system/plugins-pins.mdx
@@ -7,9 +7,11 @@ description: The `/sys/plugins/pins` endpoint is used to manage pinned plugin ve
 # `/sys/plugins/pins`
 
 Use the `/sys/plugins/pins` endpoint to read, create, update, and delete pinned
-plugin versions in Vault's catalog. When a pinned version is in effect, all
-plugins that Vault starts of a specific name and type will use the specified
-version, even if the mount is configured with a different specific version.
+plugin versions in your Vault catalog.
+
+When you pin a plugin version, Vault starts all instances of that name and type
+with the configured version, even if the mount was originally configured with a
+different version.
 
 Plugin versions must be registered before being pinned, and a version pin must be
 deleted before that plugin version can be deleted. Note that pinning a version

--- a/website/content/api-docs/system/plugins-pins.mdx
+++ b/website/content/api-docs/system/plugins-pins.mdx
@@ -35,8 +35,8 @@ Create a pinned version for a plugin with the given type and name.
 - `type` `(string: <required>)` – Path parameter specifying the target plugin
   type for the pinned version. May be "auth", "database", or "secret".
 
-- `name` `(string: <required>)` – Specifies the name of the plugin to create a
-  pinned version for. This is part of the request URL.
+- `name` `(string: <required>)` – Path parameter specifying the plugin name for
+  the pinned version.
 
 - `version` `(string: <required>)` - Specifies the semantic version of the plugin
   to pin. Cannot be a builtin version, and must already exist in the catalog.

--- a/website/content/api-docs/system/plugins-pins.mdx
+++ b/website/content/api-docs/system/plugins-pins.mdx
@@ -138,8 +138,8 @@ Delete any pinned version for a plugin with the given type and name.
 
 ### Parameters
 
-- `type` `(string: <required>)` – Specifies the type of plugin. May be "auth",
-  "database", or "secret". This is part of the request URL.
+- `type` `(string: <required>)` – Path parameter specifying the target plugin
+  type for the pinned version. May be "auth", "database", or "secret".
 
 - `name` `(string: <required>)` – Specifies the name of the plugin. This is
   part of the request URL.

--- a/website/content/api-docs/system/plugins-pins.mdx
+++ b/website/content/api-docs/system/plugins-pins.mdx
@@ -32,9 +32,8 @@ Create a pinned version for a plugin with the given type and name.
 
 ### Parameters
 
-- `type` `(string: <required>)` – Specifies the type of plugin to create a pinned
-  version for. May be "auth", "database", or "secret". This is part of the request
-  URL.
+- `type` `(string: <required>)` – Path parameter specifying the target plugin
+  type for the pinned version. May be "auth", "database", or "secret".
 
 - `name` `(string: <required>)` – Specifies the name of the plugin to create a
   pinned version for. This is part of the request URL.

--- a/website/content/api-docs/system/plugins-pins.mdx
+++ b/website/content/api-docs/system/plugins-pins.mdx
@@ -13,11 +13,14 @@ When you pin a plugin version, Vault starts all instances of that name and type
 with the configured version, even if the mount was originally configured with a
 different version.
 
-Plugin versions must be registered before being pinned, and a version pin must be
-deleted before that plugin version can be deleted. Note that pinning a version
-only updates Vault's configuration. Plugins already in use must be
-[reloaded](/vault/api-docs/system/plugins-reload) before a newly pinned version
-takes effect.
+<Note tile="Behavioral notes">
+
+- You must register a plugin version before pinning it.
+- You must delete a pin before deleting the associated plugin version.
+- You must [reload](/vault/api-docs/system/plugins-reload) any plugins currently
+  in use for the pinned version to take effect.
+
+</Note>
 
 ## Create/update pinned version
 

--- a/website/content/api-docs/system/plugins-pins.mdx
+++ b/website/content/api-docs/system/plugins-pins.mdx
@@ -9,7 +9,7 @@ description: The `/sys/plugins/pins` endpoint is used to manage pinned plugin ve
 Use the `/sys/plugins/pins` endpoint to read, create, update, and delete pinned
 plugin versions in Vault's catalog. When a pinned version is in effect, all
 plugins that Vault starts of a specific name and type will use the specified
-version.
+version, even if the mount is configured with a different specific version.
 
 Plugin versions must be registered before being pinned, and a version pin must be
 deleted before that plugin version can be deleted. Note that pinning a version

--- a/website/content/api-docs/system/plugins-pins.mdx
+++ b/website/content/api-docs/system/plugins-pins.mdx
@@ -93,7 +93,7 @@ $ curl \
 
 ## Read pinned version
 
-This endpoint reads the pinned version for a plugin with the given type and name.
+Read the pinned version for a plugin with the given type and name.
 
 | Method | Path                            |
 | :----- | :------------------------------ |

--- a/website/content/api-docs/system/plugins-pins.mdx
+++ b/website/content/api-docs/system/plugins-pins.mdx
@@ -1,0 +1,150 @@
+---
+layout: api
+page_title: /sys/plugins/pins - HTTP API
+description: The `/sys/plugins/pins` endpoint is used to manage pinned plugin versions.
+---
+
+# `/sys/plugins/pins`
+
+Use the `/sys/plugins/pins` endpoint to read, create, update, and delete pinned
+plugin versions in Vault's catalog. When a pinned version is in effect, all
+plugins that Vault starts of a specific name and type will use the specified
+version.
+
+Plugin versions must be registered before being pinned, and a version pin must be
+deleted before that plugin version can be deleted. Note that pinning a version
+only updates Vault's configuration. Plugins already in use must be
+[reloaded](/vault/api-docs/system/plugins-reload) before a newly pinned version
+takes effect.
+
+## Create/update pinned version
+
+This endpoint creates a pinned version for a plugin with the given type and name.
+
+| Method | Path                            |
+| :----- | :------------------------------ |
+| `POST` | `/sys/plugins/pins/:type/:name` |
+
+### Parameters
+
+- `type` `(string: <required>)` – Specifies the type of plugin to create a pinned
+  version for. May be "auth", "database", or "secret". This is part of the request
+  URL.
+
+- `name` `(string: <required>)` – Specifies the name of the plugin to create a
+  pinned version for. This is part of the request URL.
+
+- `version` `(string: <required>)` - Specifies the semantic version of the plugin
+  to pin. Cannot be a builtin version, and must already exist in the catalog.
+
+### Sample payload
+
+```json
+{
+  "version": "v1.0.0"
+}
+```
+
+### Sample request
+
+```shell-session
+$ curl \
+    --header "X-Vault-Token: ..." \
+    --request POST \
+    --data @payload.json \
+    http://127.0.0.1:8200/v1/sys/plugins/pins/auth/github
+```
+
+## List pinned versions
+
+This endpoint lists all pinned versions.
+
+| Method | Path                |
+| :----- | :------------------ |
+| `GET`  | `/sys/plugins/pins` |
+
+### Sample request
+
+```shell-session
+$ curl \
+    --header "X-Vault-Token: ..." \
+    http://127.0.0.1:8200/v1/sys/plugins/pins
+```
+
+### Sample response
+
+```json
+{
+    "data": {
+        "pinned_versions": [
+            {
+                "name": "github",
+                "type": "auth",
+                "version": "v1.0.0"
+            }
+        ]
+    }
+}
+```
+
+## Read pinned version
+
+This endpoint reads the pinned version for a plugin with the given type and name.
+
+| Method | Path                            |
+| :----- | :------------------------------ |
+| `GET`  | `/sys/plugins/pins/:type/:name` |
+
+### Parameters
+
+- `type` `(string: <required>)` – Specifies the type of plugin. May be "auth",
+  "database", or "secret". This is part of the request URL.
+
+- `name` `(string: <required>)` – Specifies the name of the plugin. This is
+  part of the request URL.
+
+### Sample request
+
+```shell-session
+$ curl \
+    --header "X-Vault-Token: ..." \
+    --request GET \
+    http://127.0.0.1:8200/v1/sys/plugins/pins/auth/github
+```
+
+### Sample response
+
+```json
+{
+    "data": {
+        "name": "github",
+        "type": "auth",
+        "version": "v1.0.0"
+    }
+}
+```
+
+## Delete pinned version
+
+This endpoint deletes any pinned version for a plugin with the given type and name.
+
+| Method   | Path                           |
+| :------- | :----------------------------- |
+| `DELETE` | `/sys/plugins/pins/:type/:name |
+
+### Parameters
+
+- `type` `(string: <required>)` – Specifies the type of plugin. May be "auth",
+  "database", or "secret". This is part of the request URL.
+
+- `name` `(string: <required>)` – Specifies the name of the plugin. This is
+  part of the request URL.
+
+### Sample request
+
+```shell-session
+$ curl \
+    --header "X-Vault-Token: ..." \
+    --request DELETE \
+    http://127.0.0.1:8200/v1/sys/plugins/pins/auth/github
+```

--- a/website/content/api-docs/system/plugins-pins.mdx
+++ b/website/content/api-docs/system/plugins-pins.mdx
@@ -101,8 +101,8 @@ Read the pinned version for a plugin with the given type and name.
 
 ### Parameters
 
-- `type` `(string: <required>)` – Specifies the type of plugin. May be "auth",
-  "database", or "secret". This is part of the request URL.
+- `type` `(string: <required>)` – Path parameter specifying the target plugin
+  type for the pinned version. May be "auth", "database", or "secret".
 
 - `name` `(string: <required>)` – Specifies the name of the plugin. This is
   part of the request URL.

--- a/website/content/api-docs/system/plugins-pins.mdx
+++ b/website/content/api-docs/system/plugins-pins.mdx
@@ -104,8 +104,8 @@ Read the pinned version for a plugin with the given type and name.
 - `type` `(string: <required>)` – Path parameter specifying the target plugin
   type for the pinned version. May be "auth", "database", or "secret".
 
-- `name` `(string: <required>)` – Specifies the name of the plugin. This is
-  part of the request URL.
+- `name` `(string: <required>)` – Path parameter specifying the plugin name for
+  the pinned version.
 
 ### Sample request
 

--- a/website/content/api-docs/system/plugins-pins.mdx
+++ b/website/content/api-docs/system/plugins-pins.mdx
@@ -130,7 +130,7 @@ $ curl \
 
 ## Delete pinned version
 
-This endpoint deletes any pinned version for a plugin with the given type and name.
+Delete any pinned version for a plugin with the given type and name.
 
 | Method   | Path                           |
 | :------- | :----------------------------- |

--- a/website/content/api-docs/system/plugins-pins.mdx
+++ b/website/content/api-docs/system/plugins-pins.mdx
@@ -24,7 +24,7 @@ different version.
 
 ## Create/update pinned version
 
-This endpoint creates a pinned version for a plugin with the given type and name.
+Create a pinned version for a plugin with the given type and name.
 
 | Method | Path                            |
 | :----- | :------------------------------ |

--- a/website/content/api-docs/system/plugins-pins.mdx
+++ b/website/content/api-docs/system/plugins-pins.mdx
@@ -141,8 +141,8 @@ Delete any pinned version for a plugin with the given type and name.
 - `type` `(string: <required>)` – Path parameter specifying the target plugin
   type for the pinned version. May be "auth", "database", or "secret".
 
-- `name` `(string: <required>)` – Specifies the name of the plugin. This is
-  part of the request URL.
+- `name` `(string: <required>)` – Path parameter specifying the plugin name for
+  the pinned version.
 
 ### Sample request
 

--- a/website/content/api-docs/system/plugins-pins.mdx
+++ b/website/content/api-docs/system/plugins-pins.mdx
@@ -39,7 +39,7 @@ Create a pinned version for a plugin with the given type and name.
   the pinned version.
 
 - `version` `(string: <required>)` - Specifies the semantic version of the plugin
-  to pin. Cannot be a builtin version, and must already exist in the catalog.
+  to pin. Cannot be a builtin version and must already exist in the catalog.
 
 ### Sample payload
 

--- a/website/data/api-docs-nav-data.json
+++ b/website/data/api-docs-nav-data.json
@@ -614,12 +614,16 @@
         "path": "system/namespaces"
       },
       {
-        "title": "<code>/sys/plugins/reload</code>",
-        "path": "system/plugins-reload"
-      },
-      {
         "title": "<code>/sys/plugins/catalog</code>",
         "path": "system/plugins-catalog"
+      },
+      {
+        "title": "<code>/sys/plugins/pins</code>",
+        "path": "system/plugins-pins"
+      },
+      {
+        "title": "<code>/sys/plugins/reload</code>",
+        "path": "system/plugins-reload"
       },
       {
         "title": "<code>/sys/plugins/runtimes/catalog</code>",


### PR DESCRIPTION
API docs for the new plugin version pinning API. I haven't planned it yet, but if there's any usage documentation it will follow in a separate PR.