### PR TITLE
VAULT-24013: Audit regression attempting to recover from panic

### DIFF
--- a/audit/entry_formatter.go
+++ b/audit/entry_formatter.go
@@ -117,10 +117,14 @@ func (f *EntryFormatter) Process(ctx context.Context, e *eventlogger.Event) (_ *
 			"error", r,
 			"stacktrace", string(debug.Stack()))
 
-		// TODO: PW: Is this error detailed enough? we will see a lot of these
-		// vs. a single one like before... :(
+		// TODO: PW: We could potentially see a lot of these errors returned from
+		// an entry formatter in every pipeline that processed the event.
+		// So for a single request or response attempt via the broker, we might
+		// have a load of warnings (errors) returned.
+		// Do we want to add an ID to the message (audit device path AKA mount path)?
+
 		// Ensure that we add this error onto any pre-existing error that was being returned.
-		retErr = multierror.Append(retErr, fmt.Errorf("panic generating audit log")).ErrorOrNil()
+		retErr = multierror.Append(retErr, fmt.Errorf("%s: panic generating audit log", op)).ErrorOrNil()
 	}()
 
 	// Take a copy of the event data before we modify anything.

--- a/audit/entry_formatter.go
+++ b/audit/entry_formatter.go
@@ -8,11 +8,15 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"reflect"
+	"runtime/debug"
 	"strings"
 	"time"
 
 	"github.com/go-jose/go-jose/v3/jwt"
 	"github.com/hashicorp/eventlogger"
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/vault/helper/namespace"
 	"github.com/hashicorp/vault/internal/observability/event"
 	"github.com/hashicorp/vault/sdk/helper/jsonutil"
@@ -28,19 +32,24 @@ var (
 
 // EntryFormatter should be used to format audit requests and responses.
 type EntryFormatter struct {
-	salter          Salter
-	headerFormatter HeaderFormatter
 	config          FormatterConfig
+	salter          Salter
+	logger          hclog.Logger
+	headerFormatter HeaderFormatter
 	prefix          string
 }
 
 // NewEntryFormatter should be used to create an EntryFormatter.
 // Accepted options: WithHeaderFormatter, WithPrefix.
-func NewEntryFormatter(config FormatterConfig, salter Salter, opt ...Option) (*EntryFormatter, error) {
+func NewEntryFormatter(config FormatterConfig, salter Salter, logger hclog.Logger, opt ...Option) (*EntryFormatter, error) {
 	const op = "audit.NewEntryFormatter"
 
 	if salter == nil {
 		return nil, fmt.Errorf("%s: cannot create a new audit formatter with nil salter: %w", op, event.ErrInvalidParameter)
+	}
+
+	if logger == nil || reflect.ValueOf(logger).IsNil() {
+		return nil, fmt.Errorf("%s: cannot create a new audit formatter with nil logger: %w", op, event.ErrInvalidParameter)
 	}
 
 	// We need to ensure that the format isn't just some default empty string.
@@ -54,8 +63,9 @@ func NewEntryFormatter(config FormatterConfig, salter Salter, opt ...Option) (*E
 	}
 
 	return &EntryFormatter{
-		salter:          salter,
 		config:          config,
+		salter:          salter,
+		logger:          logger,
 		headerFormatter: opts.withHeaderFormatter,
 		prefix:          opts.withPrefix,
 	}, nil
@@ -73,7 +83,7 @@ func (*EntryFormatter) Type() eventlogger.NodeType {
 
 // Process will attempt to parse the incoming event data into a corresponding
 // audit Request/Response which is serialized to JSON/JSONx and stored within the event.
-func (f *EntryFormatter) Process(ctx context.Context, e *eventlogger.Event) (*eventlogger.Event, error) {
+func (f *EntryFormatter) Process(ctx context.Context, e *eventlogger.Event) (_ *eventlogger.Event, retErr error) {
 	const op = "audit.(EntryFormatter).Process"
 
 	select {
@@ -94,6 +104,24 @@ func (f *EntryFormatter) Process(ctx context.Context, e *eventlogger.Event) (*ev
 	if a.Data == nil {
 		return nil, fmt.Errorf("%s: cannot audit event (%s) with no data: %w", op, a.Subtype, event.ErrInvalidParameter)
 	}
+
+	// Handle panics
+	defer func() {
+		r := recover()
+		if r == nil {
+			return
+		}
+
+		f.logger.Error("panic during logging",
+			"request_path", a.Data.Request.Path,
+			"error", r,
+			"stacktrace", string(debug.Stack()))
+
+		// TODO: PW: Is this error detailed enough? we will see a lot of these
+		// vs. a single one like before... :(
+		// Ensure that we add this error onto any pre-existing error that was being returned.
+		retErr = multierror.Append(retErr, fmt.Errorf("panic generating audit log")).ErrorOrNil()
+	}()
 
 	// Take a copy of the event data before we modify anything.
 	data, err := a.Data.Clone()

--- a/audit/entry_formatter.go
+++ b/audit/entry_formatter.go
@@ -121,13 +121,9 @@ func (f *EntryFormatter) Process(ctx context.Context, e *eventlogger.Event) (_ *
 
 		f.logger.Error("panic during logging",
 			"request_path", a.Data.Request.Path,
+			"audit_device_path", f.name,
 			"error", r,
 			"stacktrace", string(debug.Stack()))
-
-		// TODO: PW: We could potentially see a lot of these errors returned from
-		// an entry formatter in every pipeline that processed the event.
-		// So for a single request or response attempt via the broker, we might
-		// have a load of warnings (errors) returned.
 
 		// Ensure that we add this error onto any pre-existing error that was being returned.
 		retErr = multierror.Append(retErr, fmt.Errorf("%s: panic generating audit log: %q", op, f.name)).ErrorOrNil()

--- a/audit/entry_formatter_test.go
+++ b/audit/entry_formatter_test.go
@@ -1063,7 +1063,6 @@ func TestEntryFormatter_Process_NoMutation(t *testing.T) {
 // which will currently cause a panic when a response is formatted due to the
 // underlying hashing that is done with reflectwalk.
 func TestEntryFormatter_Process_Panic(t *testing.T) {
-	// get a bad input...
 	t.Parallel()
 
 	// Create the formatter node.

--- a/audit/types.go
+++ b/audit/types.go
@@ -6,6 +6,7 @@ package audit
 import (
 	"context"
 
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/vault/internal/observability/event"
 	"github.com/hashicorp/vault/sdk/helper/salt"
 	"github.com/hashicorp/vault/sdk/logical"
@@ -231,6 +232,9 @@ type BackendConfig struct {
 
 	// MountPath is the path where this Backend is mounted
 	MountPath string
+
+	// Logger is used to emit log messages usually captured in the server logs.
+	Logger hclog.Logger
 }
 
 // Factory is the factory function to create an audit backend.

--- a/builtin/audit/file/backend.go
+++ b/builtin/audit/file/backend.go
@@ -12,9 +12,8 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"github.com/hashicorp/go-hclog"
-
 	"github.com/hashicorp/eventlogger"
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-secure-stdlib/parseutil"
 	"github.com/hashicorp/vault/audit"
 	"github.com/hashicorp/vault/internal/observability/event"

--- a/builtin/audit/file/backend.go
+++ b/builtin/audit/file/backend.go
@@ -123,7 +123,7 @@ func Factory(_ context.Context, conf *audit.BackendConfig, headersConfig audit.H
 		audit.WithPrefix(conf.Config["prefix"]),
 	}
 
-	err = b.configureFormatterNode(cfg, conf.Logger, formatterOpts...)
+	err = b.configureFormatterNode(conf.MountPath, cfg, conf.Logger, formatterOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("%s: error configuring formatter node: %w", op, err)
 	}
@@ -250,7 +250,7 @@ func (b *Backend) configureFilterNode(filter string) error {
 }
 
 // configureFormatterNode is used to configure a formatter node and associated ID on the Backend.
-func (b *Backend) configureFormatterNode(formatConfig audit.FormatterConfig, logger hclog.Logger, opts ...audit.Option) error {
+func (b *Backend) configureFormatterNode(name string, formatConfig audit.FormatterConfig, logger hclog.Logger, opts ...audit.Option) error {
 	const op = "file.(Backend).configureFormatterNode"
 
 	formatterNodeID, err := event.GenerateNodeID()
@@ -258,7 +258,7 @@ func (b *Backend) configureFormatterNode(formatConfig audit.FormatterConfig, log
 		return fmt.Errorf("%s: error generating random NodeID for formatter node: %w", op, err)
 	}
 
-	formatterNode, err := audit.NewEntryFormatter(formatConfig, b, logger, opts...)
+	formatterNode, err := audit.NewEntryFormatter(name, formatConfig, b, logger, opts...)
 	if err != nil {
 		return fmt.Errorf("%s: error creating formatter: %w", op, err)
 	}

--- a/builtin/audit/file/backend.go
+++ b/builtin/audit/file/backend.go
@@ -6,10 +6,13 @@ package file
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
+
+	"github.com/hashicorp/go-hclog"
 
 	"github.com/hashicorp/eventlogger"
 	"github.com/hashicorp/go-secure-stdlib/parseutil"
@@ -48,8 +51,13 @@ func Factory(_ context.Context, conf *audit.BackendConfig, headersConfig audit.H
 	if conf.SaltConfig == nil {
 		return nil, fmt.Errorf("%s: nil salt config", op)
 	}
+
 	if conf.SaltView == nil {
 		return nil, fmt.Errorf("%s: nil salt view", op)
+	}
+
+	if conf.Logger == nil || reflect.ValueOf(conf.Logger).IsNil() {
+		return nil, fmt.Errorf("%s: nil logger", op)
 	}
 
 	// The config options 'fallback' and 'filter' are mutually exclusive, a fallback
@@ -115,7 +123,7 @@ func Factory(_ context.Context, conf *audit.BackendConfig, headersConfig audit.H
 		audit.WithPrefix(conf.Config["prefix"]),
 	}
 
-	err = b.configureFormatterNode(cfg, formatterOpts...)
+	err = b.configureFormatterNode(cfg, conf.Logger, formatterOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("%s: error configuring formatter node: %w", op, err)
 	}
@@ -242,7 +250,7 @@ func (b *Backend) configureFilterNode(filter string) error {
 }
 
 // configureFormatterNode is used to configure a formatter node and associated ID on the Backend.
-func (b *Backend) configureFormatterNode(formatConfig audit.FormatterConfig, opts ...audit.Option) error {
+func (b *Backend) configureFormatterNode(formatConfig audit.FormatterConfig, logger hclog.Logger, opts ...audit.Option) error {
 	const op = "file.(Backend).configureFormatterNode"
 
 	formatterNodeID, err := event.GenerateNodeID()
@@ -250,7 +258,7 @@ func (b *Backend) configureFormatterNode(formatConfig audit.FormatterConfig, opt
 		return fmt.Errorf("%s: error generating random NodeID for formatter node: %w", op, err)
 	}
 
-	formatterNode, err := audit.NewEntryFormatter(formatConfig, b, opts...)
+	formatterNode, err := audit.NewEntryFormatter(formatConfig, b, logger, opts...)
 	if err != nil {
 		return fmt.Errorf("%s: error creating formatter: %w", op, err)
 	}

--- a/builtin/audit/file/backend_test.go
+++ b/builtin/audit/file/backend_test.go
@@ -325,7 +325,7 @@ func TestBackend_configureFormatterNode(t *testing.T) {
 	formatConfig, err := audit.NewFormatterConfig()
 	require.NoError(t, err)
 
-	err = b.configureFormatterNode(formatConfig, hclog.NewNullLogger())
+	err = b.configureFormatterNode("juan", formatConfig, hclog.NewNullLogger())
 
 	require.NoError(t, err)
 	require.Len(t, b.nodeIDList, 1)
@@ -490,7 +490,7 @@ func TestBackend_configureFilterFormatterSink(t *testing.T) {
 	err = b.configureFilterNode("path == bar")
 	require.NoError(t, err)
 
-	err = b.configureFormatterNode(formatConfig, hclog.NewNullLogger())
+	err = b.configureFormatterNode("juan", formatConfig, hclog.NewNullLogger())
 	require.NoError(t, err)
 
 	err = b.configureSinkNode("foo", "/tmp/foo", "0777", "json")

--- a/builtin/audit/file/backend_test.go
+++ b/builtin/audit/file/backend_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/eventlogger"
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/vault/audit"
 	"github.com/hashicorp/vault/internal/observability/event"
 	"github.com/hashicorp/vault/sdk/helper/salt"
@@ -37,6 +38,7 @@ func TestAuditFile_fileModeNew(t *testing.T) {
 		MountPath:  "foo/bar",
 		SaltConfig: &salt.Config{},
 		SaltView:   &logical.InmemStorage{},
+		Logger:     hclog.NewNullLogger(),
 	}
 	_, err = Factory(context.Background(), backendConfig, nil)
 	require.NoError(t, err)
@@ -68,6 +70,7 @@ func TestAuditFile_fileModeExisting(t *testing.T) {
 		MountPath:  "foo/bar",
 		SaltConfig: &salt.Config{},
 		SaltView:   &logical.InmemStorage{},
+		Logger:     hclog.NewNullLogger(),
 	}
 
 	_, err = Factory(context.Background(), backendConfig, nil)
@@ -101,6 +104,7 @@ func TestAuditFile_fileMode0000(t *testing.T) {
 		MountPath:  "foo/bar",
 		SaltConfig: &salt.Config{},
 		SaltView:   &logical.InmemStorage{},
+		Logger:     hclog.NewNullLogger(),
 	}
 
 	_, err = Factory(context.Background(), backendConfig, nil)
@@ -129,6 +133,7 @@ func TestAuditFile_EventLogger_fileModeNew(t *testing.T) {
 		MountPath:  "foo/bar",
 		SaltConfig: &salt.Config{},
 		SaltView:   &logical.InmemStorage{},
+		Logger:     hclog.NewNullLogger(),
 	}
 
 	_, err = Factory(context.Background(), backendConfig, nil)
@@ -320,7 +325,7 @@ func TestBackend_configureFormatterNode(t *testing.T) {
 	formatConfig, err := audit.NewFormatterConfig()
 	require.NoError(t, err)
 
-	err = b.configureFormatterNode(formatConfig)
+	err = b.configureFormatterNode(formatConfig, hclog.NewNullLogger())
 
 	require.NoError(t, err)
 	require.Len(t, b.nodeIDList, 1)
@@ -485,7 +490,7 @@ func TestBackend_configureFilterFormatterSink(t *testing.T) {
 	err = b.configureFilterNode("path == bar")
 	require.NoError(t, err)
 
-	err = b.configureFormatterNode(formatConfig)
+	err = b.configureFormatterNode(formatConfig, hclog.NewNullLogger())
 	require.NoError(t, err)
 
 	err = b.configureSinkNode("foo", "/tmp/foo", "0777", "json")
@@ -533,11 +538,22 @@ func TestBackend_Factory_Conf(t *testing.T) {
 			isErrorExpected:      true,
 			expectedErrorMessage: "file.Factory: nil salt view",
 		},
+		"nil-logger": {
+			backendConfig: &audit.BackendConfig{
+				MountPath:  "discard",
+				SaltConfig: &salt.Config{},
+				SaltView:   &logical.InmemStorage{},
+				Logger:     nil,
+			},
+			isErrorExpected:      true,
+			expectedErrorMessage: "file.Factory: nil logger",
+		},
 		"fallback-device-with-filter": {
 			backendConfig: &audit.BackendConfig{
 				MountPath:  "discard",
 				SaltConfig: &salt.Config{},
 				SaltView:   &logical.InmemStorage{},
+				Logger:     hclog.NewNullLogger(),
 				Config: map[string]string{
 					"fallback":  "true",
 					"file_path": discard,
@@ -552,6 +568,7 @@ func TestBackend_Factory_Conf(t *testing.T) {
 				MountPath:  "discard",
 				SaltConfig: &salt.Config{},
 				SaltView:   &logical.InmemStorage{},
+				Logger:     hclog.NewNullLogger(),
 				Config: map[string]string{
 					"fallback":  "false",
 					"file_path": discard,
@@ -598,6 +615,7 @@ func TestBackend_IsFallback(t *testing.T) {
 				MountPath:  "discard",
 				SaltConfig: &salt.Config{},
 				SaltView:   &logical.InmemStorage{},
+				Logger:     hclog.NewNullLogger(),
 				Config: map[string]string{
 					"fallback":  "true",
 					"file_path": discard,
@@ -610,6 +628,7 @@ func TestBackend_IsFallback(t *testing.T) {
 				MountPath:  "discard",
 				SaltConfig: &salt.Config{},
 				SaltView:   &logical.InmemStorage{},
+				Logger:     hclog.NewNullLogger(),
 				Config: map[string]string{
 					"fallback":  "false",
 					"file_path": discard,

--- a/builtin/audit/socket/backend.go
+++ b/builtin/audit/socket/backend.go
@@ -103,7 +103,7 @@ func Factory(_ context.Context, conf *audit.BackendConfig, headersConfig audit.H
 		audit.WithPrefix(conf.Config["prefix"]),
 	}
 
-	err = b.configureFormatterNode(cfg, conf.Logger, opts...)
+	err = b.configureFormatterNode(conf.MountPath, cfg, conf.Logger, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("%s: error configuring formatter node: %w", op, err)
 	}
@@ -231,7 +231,7 @@ func (b *Backend) configureFilterNode(filter string) error {
 }
 
 // configureFormatterNode is used to configure a formatter node and associated ID on the Backend.
-func (b *Backend) configureFormatterNode(formatConfig audit.FormatterConfig, logger hclog.Logger, opts ...audit.Option) error {
+func (b *Backend) configureFormatterNode(name string, formatConfig audit.FormatterConfig, logger hclog.Logger, opts ...audit.Option) error {
 	const op = "socket.(Backend).configureFormatterNode"
 
 	formatterNodeID, err := event.GenerateNodeID()
@@ -239,7 +239,7 @@ func (b *Backend) configureFormatterNode(formatConfig audit.FormatterConfig, log
 		return fmt.Errorf("%s: error generating random NodeID for formatter node: %w", op, err)
 	}
 
-	formatterNode, err := audit.NewEntryFormatter(formatConfig, b, logger, opts...)
+	formatterNode, err := audit.NewEntryFormatter(name, formatConfig, b, logger, opts...)
 	if err != nil {
 		return fmt.Errorf("%s: error creating formatter: %w", op, err)
 	}

--- a/builtin/audit/socket/backend.go
+++ b/builtin/audit/socket/backend.go
@@ -6,11 +6,13 @@ package socket
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"strconv"
 	"strings"
 	"sync"
 
 	"github.com/hashicorp/eventlogger"
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-secure-stdlib/parseutil"
 	"github.com/hashicorp/vault/audit"
 	"github.com/hashicorp/vault/internal/observability/event"
@@ -41,6 +43,10 @@ func Factory(_ context.Context, conf *audit.BackendConfig, headersConfig audit.H
 
 	if conf.SaltView == nil {
 		return nil, fmt.Errorf("%s: nil salt view", op)
+	}
+
+	if conf.Logger == nil || reflect.ValueOf(conf.Logger).IsNil() {
+		return nil, fmt.Errorf("%s: nil logger", op)
 	}
 
 	address, ok := conf.Config["address"]
@@ -97,7 +103,7 @@ func Factory(_ context.Context, conf *audit.BackendConfig, headersConfig audit.H
 		audit.WithPrefix(conf.Config["prefix"]),
 	}
 
-	err = b.configureFormatterNode(cfg, opts...)
+	err = b.configureFormatterNode(cfg, conf.Logger, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("%s: error configuring formatter node: %w", op, err)
 	}
@@ -225,7 +231,7 @@ func (b *Backend) configureFilterNode(filter string) error {
 }
 
 // configureFormatterNode is used to configure a formatter node and associated ID on the Backend.
-func (b *Backend) configureFormatterNode(formatConfig audit.FormatterConfig, opts ...audit.Option) error {
+func (b *Backend) configureFormatterNode(formatConfig audit.FormatterConfig, logger hclog.Logger, opts ...audit.Option) error {
 	const op = "socket.(Backend).configureFormatterNode"
 
 	formatterNodeID, err := event.GenerateNodeID()
@@ -233,7 +239,7 @@ func (b *Backend) configureFormatterNode(formatConfig audit.FormatterConfig, opt
 		return fmt.Errorf("%s: error generating random NodeID for formatter node: %w", op, err)
 	}
 
-	formatterNode, err := audit.NewEntryFormatter(formatConfig, b, opts...)
+	formatterNode, err := audit.NewEntryFormatter(formatConfig, b, logger, opts...)
 	if err != nil {
 		return fmt.Errorf("%s: error creating formatter: %w", op, err)
 	}

--- a/builtin/audit/socket/backend_test.go
+++ b/builtin/audit/socket/backend_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/eventlogger"
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/vault/audit"
 	"github.com/hashicorp/vault/internal/observability/event"
 	"github.com/hashicorp/vault/sdk/helper/salt"
@@ -196,7 +197,7 @@ func TestBackend_configureFormatterNode(t *testing.T) {
 	formatConfig, err := audit.NewFormatterConfig()
 	require.NoError(t, err)
 
-	err = b.configureFormatterNode(formatConfig)
+	err = b.configureFormatterNode(formatConfig, hclog.NewNullLogger())
 
 	require.NoError(t, err)
 	require.Len(t, b.nodeIDList, 1)
@@ -317,7 +318,7 @@ func TestBackend_configureFilterFormatterSink(t *testing.T) {
 	err = b.configureFilterNode("mount_type == kv")
 	require.NoError(t, err)
 
-	err = b.configureFormatterNode(formatConfig)
+	err = b.configureFormatterNode(formatConfig, hclog.NewNullLogger())
 	require.NoError(t, err)
 
 	err = b.configureSinkNode("foo", "https://hashicorp.com", "json")
@@ -365,11 +366,22 @@ func TestBackend_Factory_Conf(t *testing.T) {
 			isErrorExpected:      true,
 			expectedErrorMessage: "socket.Factory: nil salt view",
 		},
+		"nil-logger": {
+			backendConfig: &audit.BackendConfig{
+				MountPath:  "discard",
+				SaltConfig: &salt.Config{},
+				SaltView:   &logical.InmemStorage{},
+				Logger:     nil,
+			},
+			isErrorExpected:      true,
+			expectedErrorMessage: "socket.Factory: nil logger",
+		},
 		"no-address": {
 			backendConfig: &audit.BackendConfig{
 				MountPath:  "discard",
 				SaltConfig: &salt.Config{},
 				SaltView:   &logical.InmemStorage{},
+				Logger:     hclog.NewNullLogger(),
 				Config:     map[string]string{},
 			},
 			isErrorExpected:      true,
@@ -380,6 +392,7 @@ func TestBackend_Factory_Conf(t *testing.T) {
 				MountPath:  "discard",
 				SaltConfig: &salt.Config{},
 				SaltView:   &logical.InmemStorage{},
+				Logger:     hclog.NewNullLogger(),
 				Config: map[string]string{
 					"address": "",
 				},
@@ -392,6 +405,7 @@ func TestBackend_Factory_Conf(t *testing.T) {
 				MountPath:  "discard",
 				SaltConfig: &salt.Config{},
 				SaltView:   &logical.InmemStorage{},
+				Logger:     hclog.NewNullLogger(),
 				Config: map[string]string{
 					"address": "    ",
 				},
@@ -404,6 +418,7 @@ func TestBackend_Factory_Conf(t *testing.T) {
 				MountPath:  "discard",
 				SaltConfig: &salt.Config{},
 				SaltView:   &logical.InmemStorage{},
+				Logger:     hclog.NewNullLogger(),
 				Config: map[string]string{
 					"address":       "hashicorp.com",
 					"write_timeout": "5s",
@@ -416,6 +431,7 @@ func TestBackend_Factory_Conf(t *testing.T) {
 				MountPath:  "discard",
 				SaltConfig: &salt.Config{},
 				SaltView:   &logical.InmemStorage{},
+				Logger:     hclog.NewNullLogger(),
 				Config: map[string]string{
 					"address":       "hashicorp.com",
 					"write_timeout": "qwerty",
@@ -429,6 +445,7 @@ func TestBackend_Factory_Conf(t *testing.T) {
 				MountPath:  "discard",
 				SaltConfig: &salt.Config{},
 				SaltView:   &logical.InmemStorage{},
+				Logger:     hclog.NewNullLogger(),
 				Config: map[string]string{
 					"address":       "hashicorp.com",
 					"write_timeout": "5s",
@@ -443,6 +460,7 @@ func TestBackend_Factory_Conf(t *testing.T) {
 				MountPath:  "discard",
 				SaltConfig: &salt.Config{},
 				SaltView:   &logical.InmemStorage{},
+				Logger:     hclog.NewNullLogger(),
 				Config: map[string]string{
 					"address":       "hashicorp.com",
 					"write_timeout": "2s",
@@ -491,6 +509,7 @@ func TestBackend_IsFallback(t *testing.T) {
 				MountPath:  "qwerty",
 				SaltConfig: &salt.Config{},
 				SaltView:   &logical.InmemStorage{},
+				Logger:     hclog.NewNullLogger(),
 				Config: map[string]string{
 					"fallback":      "true",
 					"address":       "hashicorp.com",
@@ -504,6 +523,7 @@ func TestBackend_IsFallback(t *testing.T) {
 				MountPath:  "qwerty",
 				SaltConfig: &salt.Config{},
 				SaltView:   &logical.InmemStorage{},
+				Logger:     hclog.NewNullLogger(),
 				Config: map[string]string{
 					"fallback":      "false",
 					"address":       "hashicorp.com",

--- a/builtin/audit/socket/backend_test.go
+++ b/builtin/audit/socket/backend_test.go
@@ -197,7 +197,7 @@ func TestBackend_configureFormatterNode(t *testing.T) {
 	formatConfig, err := audit.NewFormatterConfig()
 	require.NoError(t, err)
 
-	err = b.configureFormatterNode(formatConfig, hclog.NewNullLogger())
+	err = b.configureFormatterNode("juan", formatConfig, hclog.NewNullLogger())
 
 	require.NoError(t, err)
 	require.Len(t, b.nodeIDList, 1)
@@ -318,7 +318,7 @@ func TestBackend_configureFilterFormatterSink(t *testing.T) {
 	err = b.configureFilterNode("mount_type == kv")
 	require.NoError(t, err)
 
-	err = b.configureFormatterNode(formatConfig, hclog.NewNullLogger())
+	err = b.configureFormatterNode("juan", formatConfig, hclog.NewNullLogger())
 	require.NoError(t, err)
 
 	err = b.configureSinkNode("foo", "https://hashicorp.com", "json")

--- a/builtin/audit/syslog/backend.go
+++ b/builtin/audit/syslog/backend.go
@@ -100,7 +100,7 @@ func Factory(_ context.Context, conf *audit.BackendConfig, headersConfig audit.H
 		audit.WithPrefix(conf.Config["prefix"]),
 	}
 
-	err = b.configureFormatterNode(cfg, conf.Logger, formatterOpts...)
+	err = b.configureFormatterNode(conf.MountPath, cfg, conf.Logger, formatterOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("%s: error configuring formatter node: %w", op, err)
 	}
@@ -222,7 +222,7 @@ func (b *Backend) configureFilterNode(filter string) error {
 }
 
 // configureFormatterNode is used to configure a formatter node and associated ID on the Backend.
-func (b *Backend) configureFormatterNode(formatConfig audit.FormatterConfig, logger hclog.Logger, opts ...audit.Option) error {
+func (b *Backend) configureFormatterNode(name string, formatConfig audit.FormatterConfig, logger hclog.Logger, opts ...audit.Option) error {
 	const op = "syslog.(Backend).configureFormatterNode"
 
 	formatterNodeID, err := event.GenerateNodeID()
@@ -230,7 +230,7 @@ func (b *Backend) configureFormatterNode(formatConfig audit.FormatterConfig, log
 		return fmt.Errorf("%s: error generating random NodeID for formatter node: %w", op, err)
 	}
 
-	formatterNode, err := audit.NewEntryFormatter(formatConfig, b, logger, opts...)
+	formatterNode, err := audit.NewEntryFormatter(name, formatConfig, b, logger, opts...)
 	if err != nil {
 		return fmt.Errorf("%s: error creating formatter: %w", op, err)
 	}

--- a/builtin/audit/syslog/backend.go
+++ b/builtin/audit/syslog/backend.go
@@ -6,13 +6,14 @@ package syslog
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"strconv"
 	"strings"
 	"sync"
 
 	"github.com/hashicorp/eventlogger"
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-secure-stdlib/parseutil"
-	gsyslog "github.com/hashicorp/go-syslog"
 	"github.com/hashicorp/vault/audit"
 	"github.com/hashicorp/vault/internal/observability/event"
 	"github.com/hashicorp/vault/sdk/helper/salt"
@@ -24,7 +25,6 @@ var _ audit.Backend = (*Backend)(nil)
 // Backend is the audit backend for the syslog-based audit store.
 type Backend struct {
 	fallback   bool
-	logger     gsyslog.Syslogger
 	name       string
 	nodeIDList []eventlogger.NodeID
 	nodeMap    map[eventlogger.NodeID]eventlogger.Node
@@ -43,6 +43,10 @@ func Factory(_ context.Context, conf *audit.BackendConfig, headersConfig audit.H
 
 	if conf.SaltView == nil {
 		return nil, fmt.Errorf("%s: nil salt view", op)
+	}
+
+	if conf.Logger == nil || reflect.ValueOf(conf.Logger).IsNil() {
+		return nil, fmt.Errorf("%s: nil logger", op)
 	}
 
 	// Get facility or default to AUTH
@@ -72,15 +76,8 @@ func Factory(_ context.Context, conf *audit.BackendConfig, headersConfig audit.H
 		return nil, fmt.Errorf("%s: cannot configure a fallback device with a filter: %w", op, event.ErrInvalidParameter)
 	}
 
-	// Get the logger
-	logger, err := gsyslog.NewLogger(gsyslog.LOG_INFO, facility, tag)
-	if err != nil {
-		return nil, fmt.Errorf("%s: cannot create logger: %w", op, err)
-	}
-
 	b := &Backend{
 		fallback:   fallback,
-		logger:     logger,
 		name:       conf.MountPath,
 		saltConfig: conf.SaltConfig,
 		saltView:   conf.SaltView,
@@ -103,7 +100,7 @@ func Factory(_ context.Context, conf *audit.BackendConfig, headersConfig audit.H
 		audit.WithPrefix(conf.Config["prefix"]),
 	}
 
-	err = b.configureFormatterNode(cfg, formatterOpts...)
+	err = b.configureFormatterNode(cfg, conf.Logger, formatterOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("%s: error configuring formatter node: %w", op, err)
 	}
@@ -225,7 +222,7 @@ func (b *Backend) configureFilterNode(filter string) error {
 }
 
 // configureFormatterNode is used to configure a formatter node and associated ID on the Backend.
-func (b *Backend) configureFormatterNode(formatConfig audit.FormatterConfig, opts ...audit.Option) error {
+func (b *Backend) configureFormatterNode(formatConfig audit.FormatterConfig, logger hclog.Logger, opts ...audit.Option) error {
 	const op = "syslog.(Backend).configureFormatterNode"
 
 	formatterNodeID, err := event.GenerateNodeID()
@@ -233,7 +230,7 @@ func (b *Backend) configureFormatterNode(formatConfig audit.FormatterConfig, opt
 		return fmt.Errorf("%s: error generating random NodeID for formatter node: %w", op, err)
 	}
 
-	formatterNode, err := audit.NewEntryFormatter(formatConfig, b, opts...)
+	formatterNode, err := audit.NewEntryFormatter(formatConfig, b, logger, opts...)
 	if err != nil {
 		return fmt.Errorf("%s: error creating formatter: %w", op, err)
 	}

--- a/builtin/audit/syslog/backend_test.go
+++ b/builtin/audit/syslog/backend_test.go
@@ -198,7 +198,7 @@ func TestBackend_configureFormatterNode(t *testing.T) {
 	formatConfig, err := audit.NewFormatterConfig()
 	require.NoError(t, err)
 
-	err = b.configureFormatterNode(formatConfig, hclog.NewNullLogger())
+	err = b.configureFormatterNode("juan", formatConfig, hclog.NewNullLogger())
 
 	require.NoError(t, err)
 	require.Len(t, b.nodeIDList, 1)
@@ -301,7 +301,7 @@ func TestBackend_configureFilterFormatterSink(t *testing.T) {
 	err = b.configureFilterNode("mount_type == kv")
 	require.NoError(t, err)
 
-	err = b.configureFormatterNode(formatConfig, hclog.NewNullLogger())
+	err = b.configureFormatterNode("juan", formatConfig, hclog.NewNullLogger())
 	require.NoError(t, err)
 
 	err = b.configureSinkNode("foo", "json")

--- a/builtin/audit/syslog/backend_test.go
+++ b/builtin/audit/syslog/backend_test.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"testing"
 
+	"github.com/hashicorp/go-hclog"
+
 	"github.com/hashicorp/eventlogger"
 	"github.com/hashicorp/vault/audit"
 	"github.com/hashicorp/vault/internal/observability/event"
@@ -196,7 +198,7 @@ func TestBackend_configureFormatterNode(t *testing.T) {
 	formatConfig, err := audit.NewFormatterConfig()
 	require.NoError(t, err)
 
-	err = b.configureFormatterNode(formatConfig)
+	err = b.configureFormatterNode(formatConfig, hclog.NewNullLogger())
 
 	require.NoError(t, err)
 	require.Len(t, b.nodeIDList, 1)
@@ -299,7 +301,7 @@ func TestBackend_configureFilterFormatterSink(t *testing.T) {
 	err = b.configureFilterNode("mount_type == kv")
 	require.NoError(t, err)
 
-	err = b.configureFormatterNode(formatConfig)
+	err = b.configureFormatterNode(formatConfig, hclog.NewNullLogger())
 	require.NoError(t, err)
 
 	err = b.configureSinkNode("foo", "json")
@@ -352,6 +354,7 @@ func TestBackend_Factory_Conf(t *testing.T) {
 				MountPath:  "discard",
 				SaltConfig: &salt.Config{},
 				SaltView:   &logical.InmemStorage{},
+				Logger:     hclog.NewNullLogger(),
 				Config: map[string]string{
 					"fallback": "false",
 					"filter":   "mount_type == kv",
@@ -364,6 +367,7 @@ func TestBackend_Factory_Conf(t *testing.T) {
 				MountPath:  "discard",
 				SaltConfig: &salt.Config{},
 				SaltView:   &logical.InmemStorage{},
+				Logger:     hclog.NewNullLogger(),
 				Config: map[string]string{
 					"fallback": "true",
 					"filter":   "mount_type == kv",
@@ -410,6 +414,7 @@ func TestBackend_IsFallback(t *testing.T) {
 				MountPath:  "qwerty",
 				SaltConfig: &salt.Config{},
 				SaltView:   &logical.InmemStorage{},
+				Logger:     hclog.NewNullLogger(),
 				Config: map[string]string{
 					"fallback": "true",
 				},
@@ -421,6 +426,7 @@ func TestBackend_IsFallback(t *testing.T) {
 				MountPath:  "qwerty",
 				SaltConfig: &salt.Config{},
 				SaltView:   &logical.InmemStorage{},
+				Logger:     hclog.NewNullLogger(),
 				Config: map[string]string{
 					"fallback": "false",
 				},

--- a/changelog/25605.txt
+++ b/changelog/25605.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+audit: Handle a potential panic while formatting audit entries for an audit log
+```

--- a/helper/testhelpers/corehelpers/corehelpers.go
+++ b/helper/testhelpers/corehelpers/corehelpers.go
@@ -217,7 +217,11 @@ func (m *mockBuiltinRegistry) DeprecationStatus(name string, pluginType consts.P
 }
 
 func TestNoopAudit(t testing.T, path string, config map[string]string, opts ...audit.Option) *NoopAudit {
-	cfg := &audit.BackendConfig{Config: config, MountPath: path}
+	cfg := &audit.BackendConfig{
+		Config:    config,
+		MountPath: path,
+		Logger:    NewTestLogger(t),
+	}
 	n, err := NewNoopAudit(cfg, opts...)
 	if err != nil {
 		t.Fatal(err)
@@ -265,7 +269,7 @@ func NewNoopAudit(config *audit.BackendConfig, opts ...audit.Option) (*NoopAudit
 		return nil, fmt.Errorf("error generating random NodeID for formatter node: %w", err)
 	}
 
-	formatterNode, err := audit.NewEntryFormatter(cfg, noopBackend, opts...)
+	formatterNode, err := audit.NewEntryFormatter(config.MountPath, cfg, noopBackend, config.Logger, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("error creating formatter: %w", err)
 	}

--- a/vault/audit.go
+++ b/vault/audit.go
@@ -516,6 +516,7 @@ func (c *Core) newAuditBackend(ctx context.Context, entry *MountEntry, view logi
 		HMACType: "hmac-sha256",
 		Location: salt.DefaultLocation,
 	}
+	auditLogger := c.baseLogger.Named("audit")
 
 	be, err := f(
 		ctx, &audit.BackendConfig{
@@ -523,6 +524,7 @@ func (c *Core) newAuditBackend(ctx context.Context, entry *MountEntry, view logi
 			SaltConfig: saltConfig,
 			Config:     conf,
 			MountPath:  entry.Path,
+			Logger:     auditLogger,
 		},
 		c.auditedHeaders)
 	if err != nil {
@@ -531,8 +533,6 @@ func (c *Core) newAuditBackend(ctx context.Context, entry *MountEntry, view logi
 	if be == nil {
 		return nil, fmt.Errorf("nil backend returned from %q factory function", entry.Type)
 	}
-
-	auditLogger := c.baseLogger.Named("audit")
 
 	switch entry.Type {
 	case "file":

--- a/vault/audit_broker.go
+++ b/vault/audit_broker.go
@@ -218,9 +218,11 @@ func (a *AuditBroker) LogRequest(ctx context.Context, in *logical.LogInput) (ret
 
 	defer metrics.MeasureSince([]string{"audit", "log_request"}, time.Now())
 	defer func() {
+		metricVal := float32(0.0)
 		if ret != nil {
-			metrics.IncrCounter([]string{"audit", "log_request_failure"}, 1.0)
+			metricVal = 1.0
 		}
+		metrics.IncrCounter([]string{"audit", "log_request_failure"}, metricVal)
 	}()
 
 	var retErr *multierror.Error
@@ -284,9 +286,11 @@ func (a *AuditBroker) LogResponse(ctx context.Context, in *logical.LogInput) (re
 
 	defer metrics.MeasureSince([]string{"audit", "log_response"}, time.Now())
 	defer func() {
+		metricVal := float32(0.0)
 		if ret != nil {
-			metrics.IncrCounter([]string{"audit", "log_response_failure"}, 1.0)
+			metricVal = 1.0
 		}
+		metrics.IncrCounter([]string{"audit", "log_response_failure"}, metricVal)
 	}()
 
 	var retErr *multierror.Error

--- a/vault/audit_broker_test.go
+++ b/vault/audit_broker_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/eventlogger"
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/vault/audit"
 	"github.com/hashicorp/vault/builtin/audit/file"
 	"github.com/hashicorp/vault/builtin/audit/syslog"
@@ -41,6 +42,7 @@ func testAuditBackend(t *testing.T, path string, config map[string]string) audit
 			HMAC:     sha256.New,
 			HMACType: "hmac-sha256",
 		},
+		Logger:    corehelpers.NewTestLogger(t),
 		Config:    config,
 		MountPath: path,
 	}
@@ -283,6 +285,7 @@ func BenchmarkAuditBroker_File_Request_DevNull(b *testing.B) {
 		MountPath:  "test",
 		SaltConfig: &salt.Config{},
 		SaltView:   &logical.InmemStorage{},
+		Logger:     hclog.NewNullLogger(),
 	}
 
 	sink, err := file.Factory(context.Background(), backendConfig, nil)


### PR DESCRIPTION
This PR fixes a regression in recovering Vault when audit related code panics. It appeared with the introduction of the go-eventlogger.

The changes involve continuing to handle the metrics updates in the audit broker, but making an entry formatter node responsible for handling panics that occur during formatting of the audit entry.

Addresses: https://github.com/hashicorp/vault/issues/16462