### PR TITLE
Transit Active Tab

### DIFF
--- a/changelog/25614.txt
+++ b/changelog/25614.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fixes issue with no active tab when viewing transit encryption key
+```

--- a/ui/app/components/transit-edit.js
+++ b/ui/app/components/transit-edit.js
@@ -80,7 +80,7 @@ export default Component.extend(FocusOnInsertMixin, {
         'save',
         () => {
           this.hasDataChanges();
-          this.transitionToRoute(SHOW_ROUTE, keyId);
+          this.transitionToRoute(SHOW_ROUTE, keyId, { queryParams: { tab: 'details' } });
         },
         type === 'create'
       );

--- a/ui/app/templates/components/transit-form-edit.hbs
+++ b/ui/app/templates/components/transit-form-edit.hbs
@@ -100,7 +100,13 @@
         </div>
       {{/if}}
       <div class="control">
-        <Hds::Button @text="Cancel" @color="secondary" @route="vault.cluster.secrets.backend.show" @model={{@key.id}} />
+        <Hds::Button
+          @text="Cancel"
+          @color="secondary"
+          @route="vault.cluster.secrets.backend.show"
+          @model={{@key.id}}
+          @query={{hash tab="details"}}
+        />
       </div>
     </div>
     {{#if (and @key.canDelete @capabilities.canDelete)}}

--- a/ui/tests/acceptance/transit-test.js
+++ b/ui/tests/acceptance/transit-test.js
@@ -237,7 +237,11 @@ module('Acceptance | transit (flaky)', function (hooks) {
     await click('[data-test-toggle-label="Auto-rotation period"]');
     await click(SELECTORS.form('create'));
 
-    assert.strictEqual(currentURL(), `/vault/secrets/${this.path}/show/${name}`, 'it navigates to show page');
+    assert.strictEqual(
+      currentURL(),
+      `/vault/secrets/${this.path}/show/${name}?tab=details`,
+      'it navigates to show page'
+    );
     assert.dom(SELECTORS.infoRow('Auto-rotation period')).hasText('30 days');
     assert.dom(SELECTORS.infoRow('Deletion allowed')).hasText('false');
     assert.dom(SELECTORS.infoRow('Derived')).hasText('Yes');


### PR DESCRIPTION
This PR fixes an issue where transitioning from the transit edit route to the show route would result in none of the tabs being active.

![image](https://github.com/hashicorp/vault/assets/24611656/61c0b7f7-f517-49b5-af08-7109b41be705)

After fix

https://github.com/hashicorp/vault/assets/24611656/e2a56977-ac1f-4278-88a4-0fdcf11d241e

