### PR TITLE
Remove duplicate changelog for enterprise privileged namespace quota

### DIFF
--- a/changelog/24040.txt
+++ b/changelog/24040.txt
@@ -1,3 +1,0 @@
-```release-note:feature
-**Quotas in Privileged Namespaces**: Enable creation/update/deletion of quotas from the privileged namespace
-```


### PR DESCRIPTION
The generated changelog includes duplicate entries for an enterprise feature. Removing the CE changelog in favor of the enterprise one.

<img width="1146" alt="Screenshot 2024-02-26 at 10 50 41 AM" src="https://github.com/hashicorp/vault/assets/2160810/1f903c17-0c8a-48ed-92ba-b14ea04fe3f8">
