### PR TITLE
Adjust sync config disclaimer

### DIFF
--- a/website/content/api-docs/system/secrets-sync.mdx
+++ b/website/content/api-docs/system/secrets-sync.mdx
@@ -15,7 +15,7 @@ delete operations.
 
 The `sys/sync/config` endpoint is used to set configuration parameters for the sync system as a whole.
 
-@include 'alerts/restricted-root.mdx'
+@include 'alerts/restricted-admin.mdx'
 
 | Method  | Path              |
 |:--------|:------------------|


### PR DESCRIPTION
Since the global config endpoint is now registered in the administrative namespace, the disclaimer has to be updated.