### PR TITLE
VAULT-24362: Updated 'known issues' to include audit panic

### DIFF
--- a/website/content/docs/upgrading/upgrade-to-1.15.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.15.x.mdx
@@ -72,3 +72,5 @@ option.
 @include 'known-issues/1_15_openldap-rotate-credentials.mdx'
 
 @include 'known-issues/perf-secondary-many-mounts-deadlock.mdx'
+
+@include 'known-issues/1_15-audit-panic-handling-with-eventlogger.mdx'

--- a/website/content/partials/known-issues/1_15-audit-panic-handling-with-eventlogger.mdx
+++ b/website/content/partials/known-issues/1_15-audit-panic-handling-with-eventlogger.mdx
@@ -1,0 +1,25 @@
+### Audit fails to recover from panics when formatting audit entries
+
+#### Affected versions
+
+- 1.15.0 - 1.15.5
+
+#### Issue
+
+The new underlying event framework for auditing causes Vault to incorrectly
+attempt to handle panics if they occur during the formatting of audit entries.
+
+This will cause the Vault server to stop running.
+
+The issue with audit devices not handling panics is fixed as a patch release in Vault `1.15.6`.
+
+#### Workaround
+
+Set the `VAULT_AUDIT_DISABLE_EVENTLOGGER` environment variable to `true` to
+disable the new underlying event framework and restart Vault:
+
+```shell-session
+$ export VAULT_AUDIT_DISABLE_EVENTLOGGER=true
+```
+
+On startup, Vault reverts to the audit behavior used in `1.14.x`.

--- a/website/content/partials/known-issues/1_15-audit-panic-handling-with-eventlogger.mdx
+++ b/website/content/partials/known-issues/1_15-audit-panic-handling-with-eventlogger.mdx
@@ -6,12 +6,11 @@
 
 #### Issue
 
-The new underlying event framework for auditing causes Vault to incorrectly
-attempt to handle panics if they occur during the formatting of audit entries.
+Due to an issue in the new event framework, Vault tries to resolve panics that
+occur when formatting audit entries. Vault cannot resolve the panic correctly,
+which results in the server terminating unexpectedly.
 
-This will cause the Vault server to stop running.
-
-The issue with audit devices not handling panics is fixed as a patch release in Vault `1.15.6`.
+The panic issue was resolved in `1.15.6`.
 
 #### Workaround
 


### PR DESCRIPTION
`vault/docs/upgrading/upgrade-to-1.15.x#audit-fails-to-recover-from-panics-when-formatting-audit-entries`