### PR TITLE
Make encryption persistence timeout configurable via env var

### DIFF
--- a/changelog/25636.txt
+++ b/changelog/25636.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+core: make the best effort timeout for encryption count tracking persistence configurable via an environment variable.
+```

--- a/vault/barrier_aes_gcm.go
+++ b/vault/barrier_aes_gcm.go
@@ -20,6 +20,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/hashicorp/go-secure-stdlib/parseutil"
+
 	"github.com/armon/go-metrics"
 	"github.com/hashicorp/go-secure-stdlib/strutil"
 	"github.com/hashicorp/vault/sdk/helper/jsonutil"
@@ -122,7 +124,7 @@ func NewAESGCMBarrier(physical physical.Backend) (*AESGCMBarrier, error) {
 	keyringTimeout := defaultKeyringTimeout
 	keyringTimeoutStr := os.Getenv(bestEffortKeyringTimeoutOverride)
 	if keyringTimeoutStr != "" {
-		t, err := time.ParseDuration(keyringTimeoutStr)
+		t, err := parseutil.ParseDurationSecond(keyringTimeoutStr)
 		if err != nil {
 			return nil, err
 		}

--- a/website/content/docs/internals/rotation.mdx
+++ b/website/content/docs/internals/rotation.mdx
@@ -73,3 +73,11 @@ Operators can estimate the number of encryptions by summing the following:
 - The `vault.token.creation` metric where the `token_type` label is `batch`.
 - The `merkle.flushDirty.num_pages` metric.
 - The WAL index.
+
+Vault periodically persists the number of encryptions to support rotation. 
+This save operation has a 1 second timeout to prevent impact to performance
+if Vault is under heavy load.  Because persisting encryptions involves the
+seal backend (if seal wrap is enabled), some seals (such as HSMs) may take
+regularly longer than 1 second to respond.  If this is the case, operators
+may override that timeout by setting the environment variable 
+`VAULT_ENCRYPTION_COUNT_PERSIST_TIMEOUT` to a larger value, such as "5s".


### PR DESCRIPTION
Adds VAULT_ENCRYPTION_COUNT_PERSIST_TIMEOUT, which overrides the default 1
second best effort timeout for encryption count tracking, as some customers
have slower HSMs that don't respond within 1 second.