### PR TITLE
bump hds and ember-flight-icons

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -254,8 +254,8 @@
     ]
   },
   "dependencies": {
-    "@hashicorp/design-system-components": "^3.4.0",
-    "@hashicorp/ember-flight-icons": "^4.0.5",
+    "@hashicorp/design-system-components": "^3.6.0",
+    "@hashicorp/ember-flight-icons": "^4.1.0",
     "handlebars": "4.7.7",
     "highlight.js": "^10.4.1",
     "node-notifier": "^8.0.1",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -6234,19 +6234,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hashicorp/design-system-components@npm:^3.4.0":
-  version: 3.4.0
-  resolution: "@hashicorp/design-system-components@npm:3.4.0"
+"@hashicorp/design-system-components@npm:^3.6.0":
+  version: 3.6.0
+  resolution: "@hashicorp/design-system-components@npm:3.6.0"
   dependencies:
     "@ember/render-modifiers": ^2.0.5
     "@ember/string": ^3.1.1
     "@ember/test-waiters": ^3.1.0
-    "@hashicorp/design-system-tokens": ^1.9.0
-    "@hashicorp/ember-flight-icons": ^4.0.5
+    "@hashicorp/design-system-tokens": ^1.11.0
+    "@hashicorp/ember-flight-icons": ^4.1.0
     dialog-polyfill: ^0.5.6
     ember-a11y-refocus: ^3.0.2
     ember-auto-import: ^2.6.3
-    ember-cached-decorator-polyfill: ^1.0.2
     ember-cli-babel: ^8.2.0
     ember-cli-htmlbars: ^6.3.0
     ember-cli-sass: ^11.0.1
@@ -6260,34 +6259,34 @@ __metadata:
     prismjs: ^1.29.0
     sass: ^1.69.5
     tippy.js: ^6.3.7
-  checksum: a206648f67d84849069264a25dd32cd6af0608853018925400958f89c1b590b037408ab38e616c9f8ba9bcc08955c50820c80f5a137164023f30858e472a9008
+  checksum: 88b8fb49a5ba00c36e5f2bbd668ada48647cc0d400f8ce1394da7e6b33905323a6813d9a78f23d69f5c1478bde66621e84253fc27e8560230d95754211d3724f
   languageName: node
   linkType: hard
 
-"@hashicorp/design-system-tokens@npm:^1.9.0":
-  version: 1.9.0
-  resolution: "@hashicorp/design-system-tokens@npm:1.9.0"
-  checksum: 72da214205dfca9e49726745e18f8a19674d36d656bd2e4ff3fec42b2ce06fbbba0ad673e6ec2333128e1b9bf67bfac2e4dd792ea37a1534a5040e6a4481855e
+"@hashicorp/design-system-tokens@npm:^1.11.0":
+  version: 1.11.0
+  resolution: "@hashicorp/design-system-tokens@npm:1.11.0"
+  checksum: 56e929fdc8899147a25ec654585657ab88c87d454da1ae0431bbb5fd3d052259df02052eea80975a10ef8f036127c062355d45471db1188f778f25d530343fc3
   languageName: node
   linkType: hard
 
-"@hashicorp/ember-flight-icons@npm:^4.0.5":
-  version: 4.0.5
-  resolution: "@hashicorp/ember-flight-icons@npm:4.0.5"
+"@hashicorp/ember-flight-icons@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "@hashicorp/ember-flight-icons@npm:4.1.0"
   dependencies:
-    "@hashicorp/flight-icons": ^2.24.0
+    "@hashicorp/flight-icons": ^3.0.0
     ember-auto-import: ^2.6.3
     ember-cli-babel: ^8.2.0
     ember-cli-htmlbars: ^6.3.0
     ember-get-config: ^2.1.1
-  checksum: 68ed79595fdb7ed2cd9c33260c14f780a358eee9952f228897051f5994daa9e2a366b8f5c9992a2511c9ea0a79a5fefb1ac4e1068707bb8115708f3a91b60af6
+  checksum: f40f9180a2b52b81165f22ded44e201f88f68fa2c0931aba41755835ac37cc69ec56fc58b7a38550e904de719a33bad51f94d8c10531bad1191ecbccacefb959
   languageName: node
   linkType: hard
 
-"@hashicorp/flight-icons@npm:^2.24.0":
-  version: 2.24.0
-  resolution: "@hashicorp/flight-icons@npm:2.24.0"
-  checksum: f226e4e4aed2256680a0fd29bfeac215dc9a224f8ce7b532a64cc30917a2739d34e50e84f70d40b05193e5cb2fbbb603b7870d4a0da09c6335c7f94bfb6e18df
+"@hashicorp/flight-icons@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@hashicorp/flight-icons@npm:3.0.0"
+  checksum: 02e0b7c99471469c41f735e874a098d14108280d12132525c54310a7327f259ab4deb6d2e1adba2e7d71ed592e41da95ea59882b5b0bde8fae5d292fe9b1130e
   languageName: node
   linkType: hard
 
@@ -14290,22 +14289,6 @@ __metadata:
   peerDependencies:
     ember-source: ^3.13.0 || ^4.0.0
   checksum: b2589490d897da9f560abc1858c2090fc027a54267dfaa5780ee376e00cec1183b84400df9125f6c25bd7d2b465818d63abb98bb07b3eec0a18b3206a918b804
-  languageName: node
-  linkType: hard
-
-"ember-cached-decorator-polyfill@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "ember-cached-decorator-polyfill@npm:1.0.2"
-  dependencies:
-    "@embroider/macros": ^1.8.3
-    "@glimmer/tracking": ^1.1.2
-    babel-import-util: ^1.2.2
-    ember-cache-primitive-polyfill: ^1.0.1
-    ember-cli-babel: ^7.26.11
-    ember-cli-babel-plugin-helpers: ^1.1.1
-  peerDependencies:
-    ember-source: ^3.13.0 || ^4.0.0 || >= 5.0.0
-  checksum: bbfaeafdf89a7ab834d85502829d604e3eb439cb154652b21683492e3e59a918bbaf49d39703f1a896016521d7cf03dc05e89cf5cf06de88fd1489b8e00ef8bb
   languageName: node
   linkType: hard
 
@@ -27947,8 +27930,8 @@ __metadata:
     "@ember/test-waiters": ^3.1.0
     "@glimmer/component": ^1.1.2
     "@glimmer/tracking": ^1.1.2
-    "@hashicorp/design-system-components": ^3.4.0
-    "@hashicorp/ember-flight-icons": ^4.0.5
+    "@hashicorp/design-system-components": ^3.6.0
+    "@hashicorp/ember-flight-icons": ^4.1.0
     "@icholy/duration": ^5.1.0
     "@lineal-viz/lineal": ^0.5.1
     "@tsconfig/ember": ^2.0.0


### PR DESCRIPTION
### :hammer_and_wrench: Description

Bumped the following HDS pacakges:
- @hashicorp/design-system-components@3.6.0
- @hashicorp/ember-flight-icons@4.1.0

This originally came up while auditing the UI to see if we needed to update any icons/colors. It looks like our icon & color usage is up to date, but we might as well update the HDS & icon dependencies to ensure we have access to all the latest ones, since we may need them for the future.

### :camera_flash: Screenshots
n/a, there should be no user-facing changes to this PR. 

### :building_construction: How to Build and Test the Change
Spin up the UI and ensure that the icons in the navigation and various pages still work.