### PR TITLE
UI: Add missing auth config params

### DIFF
--- a/ui/app/components/auth-config-form/options.js
+++ b/ui/app/components/auth-config-form/options.js
@@ -30,11 +30,19 @@ export default AuthConfigComponent.extend({
     waitFor(function* () {
       const data = this.model.config.serialize();
       data.description = this.model.description;
+      data.user_lockout_config = {};
 
       // token_type should not be tuneable for the token auth method.
       if (this.model.methodType === 'token') {
         delete data.token_type;
       }
+
+      this.model.userLockoutConfig.apiParams.forEach((attr) => {
+        if (Object.keys(data).includes(attr)) {
+          data.user_lockout_config[attr] = data[attr];
+          delete data[attr];
+        }
+      });
 
       try {
         yield this.model.tune(data);

--- a/ui/app/models/auth-method.js
+++ b/ui/app/models/auth-method.js
@@ -75,12 +75,12 @@ export default class AuthMethodModel extends Model {
     if (methodType === 'token') {
       tuneAttrs = [
         'description',
-        'config.{listingVisibility,defaultLeaseTtl,maxLeaseTtl,auditNonHmacRequestKeys,auditNonHmacResponseKeys,passthroughRequestHeaders}',
+        'config.{listingVisibility,defaultLeaseTtl,maxLeaseTtl,auditNonHmacRequestKeys,auditNonHmacResponseKeys,passthroughRequestHeaders,allowedResponseHeaders,pluginVersion}',
       ];
     } else {
       tuneAttrs = [
         'description',
-        'config.{listingVisibility,defaultLeaseTtl,maxLeaseTtl,tokenType,auditNonHmacRequestKeys,auditNonHmacResponseKeys,passthroughRequestHeaders}',
+        'config.{listingVisibility,defaultLeaseTtl,maxLeaseTtl,tokenType,auditNonHmacRequestKeys,auditNonHmacResponseKeys,passthroughRequestHeaders,allowedResponseHeaders,pluginVersion}',
       ];
     }
     return expandAttributeMeta(this, tuneAttrs);
@@ -94,7 +94,7 @@ export default class AuthMethodModel extends Model {
       'accessor',
       'local',
       'sealWrap',
-      'config.{listingVisibility,defaultLeaseTtl,maxLeaseTtl,tokenType,auditNonHmacRequestKeys,auditNonHmacResponseKeys,passthroughRequestHeaders}',
+      'config.{listingVisibility,defaultLeaseTtl,maxLeaseTtl,tokenType,auditNonHmacRequestKeys,auditNonHmacResponseKeys,passthroughRequestHeaders,allowedResponseHeaders,pluginVersion}',
     ];
   }
 
@@ -107,7 +107,7 @@ export default class AuthMethodModel extends Model {
           'config.listingVisibility',
           'local',
           'sealWrap',
-          'config.{defaultLeaseTtl,maxLeaseTtl,tokenType,auditNonHmacRequestKeys,auditNonHmacResponseKeys,passthroughRequestHeaders}',
+          'config.{defaultLeaseTtl,maxLeaseTtl,tokenType,auditNonHmacRequestKeys,auditNonHmacResponseKeys,passthroughRequestHeaders,allowedResponseHeaders,pluginVersion}',
         ],
       },
     ];

--- a/ui/app/models/auth-method.js
+++ b/ui/app/models/auth-method.js
@@ -68,6 +68,16 @@ export default class AuthMethodModel extends Model {
     return this.local ? 'local' : 'replicated';
   }
 
+  userLockoutConfig = {
+    modelAttrs: [
+      'config.lockoutThreshold',
+      'config.lockoutDuration',
+      'config.lockoutCounterReset',
+      'config.lockoutDisable',
+    ],
+    apiParams: ['lockout_threshold', 'lockout_duration', 'lockout_counter_reset', 'lockout_disable'],
+  };
+
   get tuneAttrs() {
     const { methodType } = this;
     let tuneAttrs;
@@ -75,12 +85,12 @@ export default class AuthMethodModel extends Model {
     if (methodType === 'token') {
       tuneAttrs = [
         'description',
-        'config.{listingVisibility,defaultLeaseTtl,maxLeaseTtl,auditNonHmacRequestKeys,auditNonHmacResponseKeys,passthroughRequestHeaders,allowedResponseHeaders,pluginVersion}',
+        'config.{listingVisibility,defaultLeaseTtl,maxLeaseTtl,auditNonHmacRequestKeys,auditNonHmacResponseKeys,passthroughRequestHeaders,allowedResponseHeaders,pluginVersion,lockoutThreshold,lockoutDuration,lockoutCounterReset,lockoutDisable}',
       ];
     } else {
       tuneAttrs = [
         'description',
-        'config.{listingVisibility,defaultLeaseTtl,maxLeaseTtl,tokenType,auditNonHmacRequestKeys,auditNonHmacResponseKeys,passthroughRequestHeaders,allowedResponseHeaders,pluginVersion}',
+        'config.{listingVisibility,defaultLeaseTtl,maxLeaseTtl,tokenType,auditNonHmacRequestKeys,auditNonHmacResponseKeys,passthroughRequestHeaders,allowedResponseHeaders,pluginVersion,lockoutThreshold,lockoutDuration,lockoutCounterReset,lockoutDisable}',
       ];
     }
     return expandAttributeMeta(this, tuneAttrs);

--- a/ui/app/models/mount-config.js
+++ b/ui/app/models/mount-config.js
@@ -54,7 +54,7 @@ export default class MountConfigModel extends Model {
   allowedResponseHeaders;
 
   @attr('string', {
-    label: 'Token Type',
+    label: 'Token type',
     helpText:
       'The type of token that should be generated via this role. For `default-service` and `default-batch` service and batch tokens will be issued respectively, unless the auth method explicitly requests a different type.',
     possibleValues: ['default-service', 'default-batch', 'batch', 'service'],
@@ -66,4 +66,11 @@ export default class MountConfigModel extends Model {
     editType: 'stringArray',
   })
   allowedManagedKeys;
+
+  @attr('string', {
+    label: 'Plugin version',
+    subText:
+      'Specifies the semantic version of the plugin to use, e.g. "v1.0.0". If unspecified, the server will select any matching un-versioned plugin that may have been registered, the latest versioned plugin registered, or a built-in plugin in that order of precedence.',
+  })
+  pluginVersion;
 }

--- a/ui/app/models/mount-config.js
+++ b/ui/app/models/mount-config.js
@@ -73,4 +73,34 @@ export default class MountConfigModel extends Model {
       'Specifies the semantic version of the plugin to use, e.g. "v1.0.0". If unspecified, the server will select any matching un-versioned plugin that may have been registered, the latest versioned plugin registered, or a built-in plugin in that order of precedence.',
   })
   pluginVersion;
+
+  // Auth mount user lockout config params, added to user_lockout_config object in saveModel method
+  @attr('string', {
+    label: 'Lockout threshold',
+    subText: 'Specifies the number of failed login attempts after which the user is locked out, e.g. 15.',
+  })
+  lockoutThreshold;
+
+  @attr({
+    label: 'Lockout duration',
+    helperTextEnabled: 'The duration for which a user will be locked out, e.g. "5s" or "30m".',
+    editType: 'ttl',
+    helperTextDisabled: 'No lockout duration configured.',
+  })
+  lockoutDuration;
+
+  @attr({
+    label: 'Lockout counter reset',
+    helperTextEnabled:
+      'The duration after which the lockout counter is reset with no failed login attempts, e.g. "5s" or "30m".',
+    editType: 'ttl',
+    helperTextDisabled: 'No reset duration configured.',
+  })
+  lockoutCounterReset;
+
+  @attr('boolean', {
+    label: 'Disable lockout for this mount',
+    subText: 'If checked, disables the user lockout feature for this mount.',
+  })
+  lockoutDisable;
 }

--- a/ui/app/templates/components/auth-config-form/options.hbs
+++ b/ui/app/templates/components/auth-config-form/options.hbs
@@ -7,8 +7,22 @@
   <div class="box is-sideless is-fullwidth is-marginless">
     <MessageError @model={{this.model}} @errorMessage={{this.model.errorMessage}} />
     <NamespaceReminder @mode="save" @noun="Auth Method" />
+
     {{#each this.model.tuneAttrs as |attr|}}
-      <FormField data-test-field @attr={{attr}} @model={{this.model}} />
+      {{#if (not (includes attr.name this.model.userLockoutConfig.modelAttrs))}}
+        <FormField data-test-field @attr={{attr}} @model={{this.model}} />
+      {{/if}}
+    {{/each}}
+
+    <hr class="has-top-margin-xl has-bottom-margin-l has-background-gray-200" />
+    <Hds::Text::Display @tag="h2" @size="400" @weight="bold">User lockout configuration</Hds::Text::Display>
+    <Hds::Text::Body @tag="p" @size="100" @color="faint" class="has-bottom-margin-m">
+      Specifies the user lockout settings for this auth mount.
+    </Hds::Text::Body>
+    {{#each this.model.tuneAttrs as |attr|}}
+      {{#if (includes attr.name this.model.userLockoutConfig.modelAttrs)}}
+        <FormField @attr={{attr}} @model={{this.model}} />
+      {{/if}}
     {{/each}}
   </div>
   <div class="field is-grouped box is-fullwidth is-bottomless">


### PR DESCRIPTION
I wanted to make adding these parameters as nonintrusive as possible so this could be backported. There `MountConfig` model is shared between secret engine and auth mounts and the options component inherits from the auth config.... so overall there's some untangling and updating that could happen here. But again, held off so this would be a small change to add these parameters 

[allowed_response_headers](https://developer.hashicorp.com/vault/api-docs/system/auth#allowed_response_headers)
[plugin_version](https://developer.hashicorp.com/vault/api-docs/system/auth#plugin_version)
[user_lockout_config](https://developer.hashicorp.com/vault/api-docs/system/auth#user_lockout_config)