### PR TITLE
Remove deprecated "mulitple" from page object

### DIFF
--- a/ui/tests/acceptance/settings/auth/configure/section-test.js
+++ b/ui/tests/acceptance/settings/auth/configure/section-test.js
@@ -37,7 +37,7 @@ module('Acceptance | settings/auth/configure/section', function (hooks) {
     const section = 'options';
     await enablePage.enable(type, path);
     await page.visit({ path, section });
-    await page.fillInTextarea('description', 'This is AppRole!');
+    await fillIn('[data-test-input="description"]', 'This is Approle!');
     assert
       .dom('[data-test-input="config.tokenType"]')
       .hasValue('default-service', 'as default the token type selected is default-service.');

--- a/ui/tests/pages/components/form-field.js
+++ b/ui/tests/pages/components/form-field.js
@@ -11,25 +11,21 @@ import {
   isPresent,
   collection,
   fillable,
-  text,
   triggerable,
 } from 'ember-cli-page-object';
 
 export default {
   hasStringList: isPresent('[data-test-component=string-list]'),
-  hasSearchSelect: isPresent('[data-test-component=search-select]'),
   hasTextFile: isPresent('[data-test-component=text-file]'),
   hasTTLPicker: isPresent('[data-test-toggle-input="Foo"]'),
   hasJSONEditor: isPresent('[data-test-component="code-mirror-modifier"]'),
   hasJSONClearButton: isPresent('[data-test-json-clear-button]'),
-  hasSelect: isPresent('select'),
   hasInput: isPresent('input'),
   hasCheckbox: isPresent('input[type=checkbox]'),
   hasTextarea: isPresent('textarea'),
   hasMaskedInput: isPresent('[data-test-masked-input]'),
   hasTooltip: isPresent('[data-test-component=info-tooltip]'),
   tooltipTrigger: focusable('[data-test-tool-tip-trigger]'),
-  tooltipContent: text('[data-test-help-text]'),
   hasRadio: isPresent('[data-test-radio-input]'),
   radioButtons: collection('input[type=radio]', {
     select: clickable(),
@@ -39,8 +35,7 @@ export default {
   fields: collection('[data-test-field]', {
     clickLabel: clickable('label'),
     toggleTtl: clickable('[data-test-toggle-input="Foo"]'),
-    for: attribute('for', 'label', { multiple: true }),
-    labelText: text('label', { multiple: true }),
+    labelText: collection('label'),
     input: fillable('input'),
     ttlTime: fillable('[data-test-ttl-value]'),
     select: fillable('select'),
@@ -49,23 +44,8 @@ export default {
     inputValue: value('input'),
     textareaValue: value('textarea'),
     inputChecked: attribute('checked', 'input[type=checkbox]'),
-    selectValue: value('select'),
   }),
   selectRadioInput: async function (value) {
     return this.radioButtons.filterBy('id', value)[0].select();
-  },
-  fillInTextarea: async function (name, value) {
-    return this.fields
-      .filter((field) => {
-        return field.for.includes(name);
-      })[0]
-      .textarea(value);
-  },
-  fillIn: async function (name, value) {
-    return this.fields
-      .filter((field) => {
-        return field.for.includes(name);
-      })[0]
-      .input(value);
   },
 };

--- a/ui/tests/pages/components/search-select.js
+++ b/ui/tests/pages/components/search-select.js
@@ -6,7 +6,6 @@
 import { isPresent, collection, text, clickable } from 'ember-cli-page-object';
 
 export default {
-  hasSearchSelect: isPresent('[data-test-component=search-select]'),
   hasTrigger: isPresent('.ember-power-select-trigger'),
   hasLabel: isPresent('[data-test-field-label]'),
   labelText: text('[data-test-field-label]'),


### PR DESCRIPTION
Removed [multiple](https://ember-cli-page-object.js.org/docs/v1.17.x/deprecations#multiple) from ember-cli-page-object. This is part of the process to upgrade ember-cli-page-object from 1.17.x to 2.x.x. More investigation needed to allow us to upgrade to 2.x.x even with this removal. I attempted to bump versions and hit errors.

I also scanned the form-field and search-select page object files and remove selectors that we were no longer using.

- [x] Enterprise tests pass locally.