### PR TITLE
Sync UI: Remove beta tags, and reveal sync client count billing tab

### DIFF
--- a/ui/app/components/clients/attribution.hbs
+++ b/ui/app/components/clients/attribution.hbs
@@ -89,13 +89,6 @@
     </M.Header>
     <M.Body>
       <p class="has-bottom-margin-s">
-        This export will include the namespace path, authentication method path, and the associated total, entity, and
-        non-entity clients for the
-        {{if this.formattedEndDate "date range" "month"}}
-        below.
-      </p>
-      {{!--  * SYNC BETA (1.16.0) - beta removal planned for 1.16.1 release, replace copy above with the following
-      <p class="has-bottom-margin-s">
         This export will include the namespace path, mount path and associated total, entity, non-entity and secrets sync
         clients for the
         {{if this.formattedEndDate "date range" "month"}}
@@ -107,7 +100,6 @@
         for secrets sync clients is the KV v2 engine path and for entity/non-entity clients is the corresponding
         authentication method path.
       </p>
-       --}}
       <p class="has-bottom-margin-s is-subtitle-gray">SELECTED DATE {{if this.formattedEndDate " RANGE"}}</p>
       <p class="has-bottom-margin-s" data-test-export-date-range>
         {{this.formattedStartDate}}

--- a/ui/app/components/clients/attribution.js
+++ b/ui/app/components/clients/attribution.js
@@ -48,7 +48,7 @@ export default class Attribution extends Component {
   attributionLegend = [
     { key: 'entity_clients', label: 'entity clients' },
     { key: 'non_entity_clients', label: 'non-entity clients' },
-    // { key: 'secret_syncs', label: 'secrets sync clients' }, * unavailable during SYNC BETA (1.16.0), planned for 1.16.1 release
+    { key: 'secret_syncs', label: 'secrets sync clients' },
   ];
 
   get formattedStartDate() {
@@ -125,15 +125,11 @@ export default class Attribution extends Component {
     }
   }
 
-  // secrets_syncs unavailable during SYNC BETA (1.16.0), planned for 1.16.1 release
-  // the three necessary CSV changes to add sync data are commented below
-
   destructureCountsToArray(object) {
     // destructure the namespace object  {label: 'some-namespace', entity_clients: 171, non_entity_clients: 20, secret_syncs: 10, clients: 201}
     // to get integers for CSV file
-    // (1) SYNC BETA - add `secrets_syncs to destructured and returned object below
-    const { clients, entity_clients, non_entity_clients } = object;
-    return [clients, entity_clients, non_entity_clients];
+    const { clients, entity_clients, non_entity_clients, secret_syncs } = object;
+    return [clients, entity_clients, non_entity_clients, secret_syncs];
   }
 
   constructCsvRow(namespaceColumn, mountColumn = null, totalColumns, newColumns = null) {
@@ -165,11 +161,13 @@ export default class Attribution extends Component {
       'Total clients',
       'Entity clients',
       'Non-entity clients',
-      // 'Secrets sync clients', * (2) SYNC BETA - add 'Secrets sync clients' as the last element of csvHeader
+      'Secrets sync clients',
     ];
 
     if (newAttribution) {
-      csvHeader.push('Total new clients, New entity clients, New non-entity clients'); // * (3) add 'New secrets sync clients' as last string pushed here
+      csvHeader.push(
+        'Total new clients, New entity clients, New non-entity clients, New secrets sync clients'
+      );
     }
 
     totalAttribution.forEach((totalClientsObject) => {

--- a/ui/app/components/clients/charts/line.hbs
+++ b/ui/app/components/clients/charts/line.hbs
@@ -7,7 +7,7 @@
     <div class="lineal-chart" data-test-chart={{@chartTitle}}>
       <Lineal::Fluid as |width|>
         {{#let
-          (scale-time domain=this.timeDomain range=(array 0 width) nice=true)
+          (scale-point domain=this.xDomain range=(array 0 width) padding=0.2)
           (scale-linear domain=this.yDomain range=(array this.chartHeight 0) nice=true)
           (scale-linear range=(array 0 this.chartHeight))
           as |xScale yScale tooltipScale|

--- a/ui/app/components/clients/charts/line.ts
+++ b/ui/app/components/clients/charts/line.ts
@@ -90,11 +90,11 @@ export default class LineChart extends Component<Args> {
     // if max is <=4, hardcode 4 which is the y-axis tickCount so y-axes are not decimals
     return [0, max <= 4 ? 4 : max];
   }
-  get timeDomain() {
-    // assume data is sorted by time
-    const firstTime = this.data[0]?.x;
-    const lastTime = this.data[this.data.length - 1]?.x;
-    return [firstTime, lastTime];
+
+  get xDomain() {
+    // these values are date objects but are already in chronological order so we use scale-point (instead of scale-time)
+    // which calculates the x-scale based on the number of data points
+    return this.data.map((d) => d.x);
   }
 
   get upgradeByMonthYear(): UpgradeByMonth {

--- a/ui/app/components/clients/page/sync.ts
+++ b/ui/app/components/clients/page/sync.ts
@@ -8,5 +8,5 @@ import ActivityComponent from '../activity';
 export default class SyncComponent extends ActivityComponent {
   title = 'Secrets sync usage';
   description =
-    'This data can be used to understand how many secrets sync clients have been used for this date range. A secret with a configured sync destination would qualify as a unique and active client.';
+    'This data can be used to understand how many secrets sync clients have been used for this date range. Each Vault secret that is synced to at least one destination counts as one Vault client.';
 }

--- a/ui/app/components/clients/running-total.hbs
+++ b/ui/app/components/clients/running-total.hbs
@@ -6,8 +6,7 @@
 {{#if (gt @byMonthActivityData.length 1)}}
   <Clients::ChartContainer
     @title="Vault client counts"
-    {{! * add "secrets sync" clients to list here - unavailable during SYNC BETA (1.16.0), planned for 1.16.1 release }}
-    @description="The total clients in the specified date range. This includes entity and non-entity clients. The total client count number is an important consideration for Vault billing."
+    @description="The total clients in the specified date range. This includes entity, non-entity, and secrets sync clients. The total client count number is an important consideration for Vault billing."
     @timestamp={{@responseTimestamp}}
     @hasChartData={{true}}
     data-test-chart="running total"
@@ -30,15 +29,13 @@
             @size="m"
             data-test-chart-stat="running total entity"
           />
-          {{!--  * unavailable during SYNC BETA (1.16.0), planned for 1.16.1 release
           <StatText
             @label="Secrets sync clients"
             @value={{@runningTotals.secret_syncs}}
             @size="m"
             class="has-left-margin-l"
             data-test-chart-stat="running total sync"
-          /> 
-          --}}
+          />
         </div>
       </div>
       <StatText
@@ -80,11 +77,9 @@
           <div class="single-month-breakdown-nonentity">
             <StatText @label="Non-entity clients" @value={{singleMonthData.new_clients.non_entity_clients}} @size="m" />
           </div>
-          {{!-- * unavailable during SYNC BETA (1.16.0), planned for 1.16.1 release
           <div class="single-month-breakdown-sync">
             <StatText @label="Secrets sync clients" @value={{singleMonthData.new_clients.secret_syncs}} @size="m" />
           </div>
-           --}}
         </div>
         <div class="single-month-stats" data-test-total>
           <div class="single-month-section-title">
@@ -101,11 +96,9 @@
           <div class="single-month-breakdown-nonentity">
             <StatText @label="Non-entity clients" @value={{singleMonthData.non_entity_clients}} @size="m" />
           </div>
-          {{!-- * unavailable during SYNC BETA (1.16.0), planned for 1.16.1 release
           <div class="single-month-breakdown-sync">
             <StatText @label="Secrets sync clients" @value={{singleMonthData.secret_syncs}} @size="m" />
           </div>
-           --}}
         </div>
       </div>
     {{else}}

--- a/ui/app/components/clients/usage-stats.hbs
+++ b/ui/app/components/clients/usage-stats.hbs
@@ -47,7 +47,6 @@
         data-test-stat-text="non-entity-clients"
       />
     </div>
-    {{!-- * unavailable during SYNC BETA (1.16.0), planned for 1.16.1 release
     {{#if (gte @totalUsageCounts.secret_syncs 0)}}
       <div class="column">
         <StatText
@@ -60,6 +59,5 @@
         />
       </div>
     {{/if}}
-     --}}
   </div>
 </div>

--- a/ui/app/components/sidebar/nav/cluster.hbs
+++ b/ui/app/components/sidebar/nav/cluster.hbs
@@ -16,7 +16,7 @@
   <Nav.Link
     @route="vault.cluster.sync"
     @text="Secrets Sync"
-    @badge={{if this.version.isEnterprise "Beta" "Enterprise"}}
+    @badge={{unless this.version.isEnterprise "Enterprise"}}
     data-test-sidebar-nav-link="Secrets Sync"
   />
   {{#if (has-permission "access")}}

--- a/ui/app/router.js
+++ b/ui/app/router.js
@@ -29,7 +29,7 @@ Router.map(function () {
       this.route('clients', function () {
         this.route('counts', function () {
           this.route('overview');
-          // this.route('sync'); * unavailable during SYNC BETA (1.16.0), planned for 1.16.1 release
+          this.route('sync');
           this.route('token');
         });
         this.route('config');

--- a/ui/app/styles/core/charts.scss
+++ b/ui/app/styles/core/charts.scss
@@ -321,11 +321,6 @@ p.data-details {
     margin-right: $spacing-48;
   }
 
-  .legend {
-    grid-column-start: 2;
-    grid-row-start: 4;
-  }
-
   .timestamp {
     grid-column-start: 1;
     grid-row-start: 4;

--- a/ui/app/templates/vault/cluster/clients.hbs
+++ b/ui/app/templates/vault/cluster/clients.hbs
@@ -24,13 +24,11 @@
           Entity/Non-entity clients
         </LinkTo>
       </li>
-      {{! * unavailable during SYNC BETA (1.16.0), planned for 1.16.1 release
       <li>
         <LinkTo @route="vault.cluster.clients.counts.sync" data-test-tab="sync">
           Secrets sync clients
         </LinkTo>
       </li>
-       }}
       {{#if (or @model.config.canRead @model.canRead)}}
         <li>
           <LinkTo

--- a/ui/lib/sync/addon/components/secrets/page/overview.hbs
+++ b/ui/lib/sync/addon/components/secrets/page/overview.hbs
@@ -150,12 +150,10 @@
     </OverviewCard>
     <OverviewCard
       @cardTitle="Total secrets"
-      @subText="The total number of secrets synced from Vault."
-      {{!-- * sync clients are unavailable during SYNC BETA (1.16.0), planned for 1.16.1 release 
-      @actionText="View billing" 
+      @subText="The total number of secrets that have been synced from Vault. One secret will be counted as one sync client."
+      @actionText="View billing"
       @actionTo="clientCountOverview"
       @actionExternal={{true}}
-       --}}
       class="is-flex-half"
     >
       <h2 class="title is-2 has-font-weight-normal has-top-margin-m" data-test-overview-card-content="Total secrets">

--- a/ui/lib/sync/addon/components/sync-header.hbs
+++ b/ui/lib/sync/addon/components/sync-header.hbs
@@ -17,9 +17,6 @@
       {{#if this.version.isCommunity}}
         <Hds::Badge @text="Enterprise feature" @color="highlight" @size="large" />
       {{/if}}
-      {{#if this.version.isEnterprise}}
-        <Hds::Badge @text="Beta" @color="highlight" @size="large" />
-      {{/if}}
     </h1>
   </p.levelLeft>
 

--- a/ui/tests/acceptance/clients/counts/overview-test.js
+++ b/ui/tests/acceptance/clients/counts/overview-test.js
@@ -184,10 +184,9 @@ module('Acceptance | clients | overview', function (hooks) {
         `${formatNumber([topNamespace.non_entity_clients])}`,
         'total non-entity clients is accurate'
       );
-    // * unavailable during SYNC BETA (1.16.0), planned for 1.16.1 release
-    // assert
-    //   .dom(SELECTORS.charts.statTextValue('Secrets sync clients'))
-    //   .includesText(`${formatNumber([topNamespace.secret_syncs])}`, 'total sync clients is accurate');
+    assert
+      .dom(SELECTORS.charts.statTextValue('Secrets sync clients'))
+      .includesText(`${formatNumber([topNamespace.secret_syncs])}`, 'total sync clients is accurate');
     assert
       .dom('[data-test-attribution-clients] p')
       .includesText(`${formatNumber([topMount.clients])}`, 'top attribution clients accurate');
@@ -205,10 +204,9 @@ module('Acceptance | clients | overview', function (hooks) {
     assert
       .dom(SELECTORS.charts.statTextValue('Non-entity clients'))
       .includesText(`${formatNumber([topMount.non_entity_clients])}`, 'total non-entity clients is accurate');
-    // * unavailable during SYNC BETA (1.16.0), planned for 1.16.1 release
-    // assert
-    //   .dom(SELECTORS.charts.statTextValue('Secrets sync clients'))
-    //   .includesText(`${formatNumber([topMount.secret_syncs])}`, 'total sync clients is accurate');
+    assert
+      .dom(SELECTORS.charts.statTextValue('Secrets sync clients'))
+      .includesText(`${formatNumber([topMount.secret_syncs])}`, 'total sync clients is accurate');
     assert.dom(SELECTORS.attributionBlock).doesNotExist('Does not show attribution block');
 
     await click('#namespace-search-select [data-test-selected-list-button="delete"]');
@@ -226,13 +224,12 @@ module('Acceptance | clients | overview', function (hooks) {
         `${formatNumber([formatNumber([response.total.non_entity_clients])])}`,
         'total non-entity clients is back to unfiltered value'
       );
-    // * unavailable during SYNC BETA (1.16.0), planned for 1.16.1 release
-    // assert
-    //   .dom(SELECTORS.charts.statTextValue('Secrets sync clients'))
-    //   .hasTextContaining(
-    //     `${formatNumber([formatNumber([response.total.secret_syncs])])}`,
-    //     'total sync clients is back to unfiltered value'
-    //   );
+    assert
+      .dom(SELECTORS.charts.statTextValue('Secrets sync clients'))
+      .hasTextContaining(
+        `${formatNumber([formatNumber([response.total.secret_syncs])])}`,
+        'total sync clients is back to unfiltered value'
+      );
     assert
       .dom('[data-test-attribution-clients]')
       .hasTextContaining(

--- a/ui/tests/integration/components/clients/page/sync-test.js
+++ b/ui/tests/integration/components/clients/page/sync-test.js
@@ -113,7 +113,7 @@ module('Integration | Component | clients | Clients::Page::Sync', function (hook
     assert
       .dom(usageStats)
       .hasText(
-        `Secrets sync usage This data can be used to understand how many secrets sync clients have been used for this date range. A secret with a configured sync destination would qualify as a unique and active client. Total sync clients ${total}`,
+        `Secrets sync usage This data can be used to understand how many secrets sync clients have been used for this date range. Each Vault secret that is synced to at least one destination counts as one Vault client. Total sync clients ${total}`,
         'renders sync stats instead of chart'
       );
     assert.dom(syncTab.total).doesNotExist('total sync counts does not exist');

--- a/ui/tests/integration/components/clients/running-total-test.js
+++ b/ui/tests/integration/components/clients/running-total-test.js
@@ -161,7 +161,7 @@ module('Integration | Component | clients/running-total', function (hooks) {
       />
     `);
     assert.dom(ts.charts.lineChart).doesNotExist('line chart does not render');
-    assert.dom(statTextValue()).exists({ count: 6 }, 'renders 6 stat text containers'); // after SYNC BETA update to 8
+    assert.dom(statTextValue()).exists({ count: 8 }, 'renders 6 stat text containers');
     assert
       .dom(`[data-test-new] ${statTextValue('New clients')}`)
       .hasText(`${expectedNewClients}`, `renders correct total new clients: ${expectedNewClients}`);

--- a/ui/tests/integration/components/clients/running-total-test.js
+++ b/ui/tests/integration/components/clients/running-total-test.js
@@ -57,7 +57,7 @@ module('Integration | Component | clients/running-total', function (hooks) {
   test('it renders with full monthly activity data', async function (assert) {
     const expectedTotalEntity = formatNumber([this.totalUsageCounts.entity_clients]);
     const expectedTotalNonEntity = formatNumber([this.totalUsageCounts.non_entity_clients]);
-    // const expectedTotalSync = formatNumber([this.totalUsageCounts.secret_syncs]);
+    const expectedTotalSync = formatNumber([this.totalUsageCounts.secret_syncs]);
 
     await render(hbs`
       <Clients::RunningTotal
@@ -80,10 +80,9 @@ module('Integration | Component | clients/running-total', function (hooks) {
         `${expectedTotalNonEntity}`,
         `renders correct total nonentity average ${expectedTotalNonEntity}`
       );
-    // * unavailable during SYNC BETA (1.16.0), planned for 1.16.1 release
-    // assert
-    //   .dom(ts.charts.statTextValue('Secrets sync clients'))
-    //   .hasText(`${expectedTotalSync}`, `renders correct total sync ${expectedTotalSync}`);
+    assert
+      .dom(ts.charts.statTextValue('Secrets sync clients'))
+      .hasText(`${expectedTotalSync}`, `renders correct total sync ${expectedTotalSync}`);
 
     // assert line chart is correct
     findAll(ts.charts.line.xAxisLabel).forEach((e, i) => {
@@ -112,7 +111,7 @@ module('Integration | Component | clients/running-total', function (hooks) {
     );
     const expectedTotalEntity = formatNumber([this.totalUsageCounts.entity_clients]);
     const expectedTotalNonEntity = formatNumber([this.totalUsageCounts.non_entity_clients]);
-    // const expectedTotalSync = formatNumber([this.totalUsageCounts.secret_syncs]);
+    const expectedTotalSync = formatNumber([this.totalUsageCounts.secret_syncs]);
 
     await render(hbs`
       <Clients::RunningTotal
@@ -134,10 +133,9 @@ module('Integration | Component | clients/running-total', function (hooks) {
         `${expectedTotalNonEntity}`,
         `renders correct total nonentity average ${expectedTotalNonEntity}`
       );
-    // * unavailable during SYNC BETA (1.16.0), planned for 1.16.1 release
-    // assert
-    //   .dom(ts.charts.statTextValue('Secrets sync clients'))
-    //   .hasText(`${expectedTotalSync}`, `renders correct total sync ${expectedTotalSync}`);
+    assert
+      .dom(ts.charts.statTextValue('Secrets sync clients'))
+      .hasText(`${expectedTotalSync}`, `renders correct total sync ${expectedTotalSync}`);
   });
 
   test('it renders with single historical month data', async function (assert) {
@@ -147,11 +145,11 @@ module('Integration | Component | clients/running-total', function (hooks) {
     const expectedTotalClients = formatNumber([singleMonth.clients]);
     const expectedTotalEntity = formatNumber([singleMonth.entity_clients]);
     const expectedTotalNonEntity = formatNumber([singleMonth.non_entity_clients]);
-    // const expectedTotalSync = formatNumber([singleMonth.secret_syncs]);
+    const expectedTotalSync = formatNumber([singleMonth.secret_syncs]);
     const expectedNewClients = formatNumber([singleMonthNew.clients]);
     const expectedNewEntity = formatNumber([singleMonthNew.entity_clients]);
     const expectedNewNonEntity = formatNumber([singleMonthNew.non_entity_clients]);
-    // const expectedNewSyncs = formatNumber([singleMonthNew.secret_syncs]);
+    const expectedNewSyncs = formatNumber([singleMonthNew.secret_syncs]);
     const { statTextValue } = ts.charts;
 
     await render(hbs`
@@ -173,10 +171,9 @@ module('Integration | Component | clients/running-total', function (hooks) {
     assert
       .dom(`[data-test-new] ${statTextValue('Non-entity clients')}`)
       .hasText(`${expectedNewNonEntity}`, `renders correct total new non-entity: ${expectedNewNonEntity}`);
-    // * unavailable during SYNC BETA (1.16.0), planned for 1.16.1 release
-    // assert
-    //   .dom(`[data-test-new] ${statTextValue('Secrets sync clients')}`)
-    //   .hasText(`${expectedNewSyncs}`, `renders correct total new non-entity: ${expectedNewSyncs}`);
+    assert
+      .dom(`[data-test-new] ${statTextValue('Secrets sync clients')}`)
+      .hasText(`${expectedNewSyncs}`, `renders correct total new non-entity: ${expectedNewSyncs}`);
     assert
       .dom(`[data-test-total] ${statTextValue('Total monthly clients')}`)
       .hasText(`${expectedTotalClients}`, `renders correct total clients: ${expectedTotalClients}`);
@@ -186,9 +183,8 @@ module('Integration | Component | clients/running-total', function (hooks) {
     assert
       .dom(`[data-test-total] ${statTextValue('Non-entity clients')}`)
       .hasText(`${expectedTotalNonEntity}`, `renders correct total non-entity: ${expectedTotalNonEntity}`);
-    // * unavailable during SYNC BETA (1.16.0), planned for 1.16.1 release
-    // assert
-    //   .dom(`[data-test-total] ${statTextValue('Secrets sync clients')}`)
-    //   .hasText(`${expectedTotalSync}`, `renders correct total sync: ${expectedTotalSync}`);
+    assert
+      .dom(`[data-test-total] ${statTextValue('Secrets sync clients')}`)
+      .hasText(`${expectedTotalSync}`, `renders correct total sync: ${expectedTotalSync}`);
   });
 });

--- a/ui/tests/integration/components/clients/usage-stats-test.js
+++ b/ui/tests/integration/components/clients/usage-stats-test.js
@@ -60,7 +60,7 @@ module('Integration | Component | clients/usage-stats', function (hooks) {
 
     await render(hbs`<Clients::UsageStats @totalUsageCounts={{this.counts}} />`);
 
-    assert.dom('[data-test-stat-text]').exists({ count: 3 }, 'Renders 3 Stat texts'); // after SYNC BETA update to 4
+    assert.dom('[data-test-stat-text]').exists({ count: 4 }, 'Renders 3 Stat texts');
     assert
       .dom('[data-test-stat-text="total-clients"] .stat-value')
       .hasText('22', 'Total clients shows passed value');

--- a/ui/tests/integration/components/clients/usage-stats-test.js
+++ b/ui/tests/integration/components/clients/usage-stats-test.js
@@ -70,9 +70,8 @@ module('Integration | Component | clients/usage-stats', function (hooks) {
     assert
       .dom('[data-test-stat-text="non-entity-clients"] .stat-value')
       .hasText('10', 'non entity clients shows passed value');
-    // * unavailable during SYNC BETA (1.16.0), planned for 1.16.1 release
-    // assert
-    //   .dom('[data-test-stat-text="secret-syncs"] .stat-value')
-    //   .hasText('5', 'secrets sync clients shows passed value');
+    assert
+      .dom('[data-test-stat-text="secret-syncs"] .stat-value')
+      .hasText('5', 'secrets sync clients shows passed value');
   });
 });

--- a/ui/tests/integration/components/sidebar/nav/cluster-test.js
+++ b/ui/tests/integration/components/sidebar/nav/cluster-test.js
@@ -79,13 +79,8 @@ module('Integration | Component | sidebar-nav-cluster', function (hooks) {
       .dom('[data-test-sidebar-nav-link]')
       .exists({ count: links.length }, 'Correct number of links render');
     links.forEach((link) => {
-      if (link === 'Secrets Sync') return;
       assert.dom(`[data-test-sidebar-nav-link="${link}"]`).hasText(link, `${link} link renders`);
     });
-    // after SYNC BETA - remove assertion below and return on line 82
-    assert
-      .dom('[data-test-sidebar-nav-link="Secrets Sync"]')
-      .hasText('Secrets Sync Beta', 'Secrets Sync nav link includes beta tag');
   });
 
   test('it should hide enterprise related links in child namespace', async function (assert) {

--- a/ui/tests/integration/components/sync/secrets/page/destinations-test.js
+++ b/ui/tests/integration/components/sync/secrets/page/destinations-test.js
@@ -70,7 +70,7 @@ module('Integration | Component | sync | Page::Destinations', function (hooks) {
   test('it should render header and tabs', async function (assert) {
     await this.renderComponent();
     assert.dom(breadcrumb).includesText('Secrets Sync', 'Breadcrumb renders');
-    assert.dom(title).hasText('Secrets Sync Beta', 'Page title renders');
+    assert.dom(title).hasText('Secrets Sync', 'Page title renders');
     assert.dom(tab('Overview')).exists('Overview tab renders');
     assert.dom(tab('Destinations')).exists('Destinations tab renders');
   });

--- a/ui/tests/integration/components/sync/secrets/page/overview-test.js
+++ b/ui/tests/integration/components/sync/secrets/page/overview-test.js
@@ -144,8 +144,9 @@ module('Integration | Component | sync | Page::Overview', function (hooks) {
       },
       {
         cardTitle: 'Total secrets',
-        subText: 'The total number of secrets synced from Vault.',
-        // actionText: 'View billing',
+        subText:
+          'The total number of secrets that have been synced from Vault. One secret will be counted as one sync client.',
+        actionText: 'View billing',
         count: '7',
       },
     ];
@@ -154,7 +155,6 @@ module('Integration | Component | sync | Page::Overview', function (hooks) {
       assert.dom(title(cardTitle)).hasText(cardTitle, 'Overview card title renders');
       assert.dom(description(cardTitle)).hasText(subText, 'Destinations overview card description renders');
       assert.dom(content(cardTitle)).hasText(count, 'Total count renders');
-      if (cardTitle === 'Total secrets') return; // uncomment 'actionText' above and this return after SYNC BETA
       assert.dom(action(cardTitle)).hasText(actionText, 'Card action renders');
     });
   });

--- a/ui/tests/integration/components/sync/secrets/page/overview-test.js
+++ b/ui/tests/integration/components/sync/secrets/page/overview-test.js
@@ -61,13 +61,13 @@ module('Integration | Component | sync | Page::Overview', function (hooks) {
   test('it should render landing cta component for enterprise', async function (assert) {
     this.set('destinations', []);
     await settled();
-    assert.dom(title).hasText('Secrets Sync Beta', 'Page title renders');
+    assert.dom(title).hasText('Secrets Sync', 'Page title renders');
     assert.dom(cta.button).hasText('Create first destination', 'CTA action renders');
     assert.dom(cta.summary).exists('CTA renders');
   });
 
   test('it should render header, tabs and toolbar for overview state', async function (assert) {
-    assert.dom(title).hasText('Secrets Sync Beta', 'Page title renders');
+    assert.dom(title).hasText('Secrets Sync', 'Page title renders');
     assert.dom(breadcrumb).exists({ count: 1 }, 'Correct number of breadcrumbs render');
     assert.dom(breadcrumb).includesText('Secrets Sync', 'Top level breadcrumb renders');
     assert.dom(cta.button).doesNotExist('CTA does not render');

--- a/ui/tests/integration/components/sync/sync-header-test.js
+++ b/ui/tests/integration/components/sync/sync-header-test.js
@@ -41,11 +41,11 @@ module('Integration | Component | sync | SyncHeader', function (hooks) {
 
   test('it should just render title for enterprise version', async function (assert) {
     await this.renderComponent();
-    assert.dom(title).hasText('Secrets Sync Beta');
+    assert.dom(title).hasText('Secrets Sync');
   });
 
   test('it should render title and promotional enterprise badge for community version', async function (assert) {
-    this.version.type = 'community';
+    this.version.type = null;
     await this.renderComponent();
     assert.dom(title).hasText('Secrets Sync Enterprise feature');
   });


### PR DESCRIPTION
This PR reverts https://github.com/hashicorp/vault/pull/25170 by revealing the sync billing tab and removing `Beta` tags in the UI.

<img width="1300" alt="Screenshot 2024-02-27 at 10 37 51 AM" src="https://github.com/hashicorp/vault/assets/68122737/e741eeaf-e70f-4495-b8e3-1a08c3ab48c8">

## empty state for sync billing tab

<img width="1014" alt="Screenshot 2024-02-27 at 10 38 40 AM" src="https://github.com/hashicorp/vault/assets/68122737/8a26daab-26a7-4f40-88ed-232f3c77aeb0">

## with mock data
<img width="1985" alt="Screenshot 2024-02-27 at 11 00 23 AM" src="https://github.com/hashicorp/vault/assets/68122737/79d8fefe-380f-4b61-b6ed-ec43523e5c9f">

