### PR TITLE
VAULT-24385 docs updates for proxy static secret caching -> ent

### DIFF
--- a/changelog/23621.txt
+++ b/changelog/23621.txt
@@ -1,3 +1,3 @@
 ```release-note:feature
-**Vault Proxy Static Secret Caching**: Adds support for static secret (KVv1 and KVv2) caching to Vault Proxy.
+**Vault Proxy Static Secret Caching (enterprise)**: Adds support for static secret (KVv1 and KVv2) caching to Vault Proxy.
 ```

--- a/website/content/docs/agent-and-proxy/proxy/caching/static-secret-caching.mdx
+++ b/website/content/docs/agent-and-proxy/proxy/caching/static-secret-caching.mdx
@@ -8,8 +8,14 @@ description: |-
 
 # Vault Proxy static secret caching
 
+@include 'alerts/enterprise-only.mdx'
+
 Use static secret caching with Vault Proxy to cache KVv1 and KVv2 secrets to
 minimize requests made to Vault and provide resilient connections for clients.
+
+Vault Proxy utilizes the Enterprise only [Vault event notification system](/vault/docs/concepts/events)
+feature for cache freshness. As a result, static secret caching can only be used
+with Vault Enterprise installations.
 
 ## Step 1: Subscribe Vault Proxy to KV events
 
@@ -17,10 +23,10 @@ Vault Proxy uses Vault events and auto-auth to monitor secret status and make
 appropriate cache updates.
 1. Enable [auto-auth](/vault/docs/agent-and-proxy/autoauth).
 1. Create an auto-auth token with permission to subscribe to KV event updates
-with the [Vault event system](/vault/docs/concepts/events). For example, to
-create a policy that grants access to static secret (KVv1 and KVv2) events,
-we need permission to subscribe to the `events` endpoint, as well as the
-`list` and `subscribe` permissions on KV secrets we want to get secrets
+with the [Vault event notification system](/vault/docs/concepts/events). For
+example, to create a policy that grants access to static secret (KVv1 and KVv2)
+events, we need permission to subscribe to the `events` endpoint, as well as
+the `list` and `subscribe` permissions on KV secrets we want to get secrets
 from:
  ```hcl
   path "sys/events/subscribe/kv*" {
@@ -80,7 +86,7 @@ success `GET` request. If the request is successful, Proxy caches the fact that
 the token was successful in addition to the result. Subsequent requests by the
 same token can then access this secret from the cache instead of Vault.
 
-Vault Proxy uses the [event system](/vault/docs/concepts/events) to keep the
+Vault Proxy uses the [event notification system](/vault/docs/concepts/events) to keep the
 cache up to date. It monitors the KV event feed for events related to any secret
 currently stored in the cache, including modification events like updates and
 deletes. When Proxy detects a change in a cached secret, it will update or

--- a/website/content/docs/agent-and-proxy/proxy/caching/static-secret-caching.mdx
+++ b/website/content/docs/agent-and-proxy/proxy/caching/static-secret-caching.mdx
@@ -25,8 +25,8 @@ appropriate cache updates.
 1. Create an auto-auth token with permission to subscribe to KV event updates
 with the [Vault event notification system](/vault/docs/concepts/events). For
 example, to create a policy that grants access to static secret (KVv1 and KVv2)
-events, we need permission to subscribe to the `events` endpoint, as well as
-the `list` and `subscribe` permissions on KV secrets we want to get secrets
+events, you need permission to subscribe to the `events` endpoint, as well as
+the `list` and `subscribe` permissions on KV secrets you want to get secrets
 from:
  ```hcl
   path "sys/events/subscribe/kv*" {

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -1171,7 +1171,12 @@
               },
               {
                 "title": "Static Secret Caching",
-                "path": "agent-and-proxy/proxy/caching/static-secret-caching"
+                "path": "agent-and-proxy/proxy/caching/static-secret-caching",
+                "badge": {
+                  "text": "ENTERPRISE",
+                  "type": "outlined",
+                  "color": "neutral"
+                }
               },
               {
                 "title": "Persistent Caching",


### PR DESCRIPTION
I added to the summary at the top the 'why' for why this is an enterprise feature, and included the badge for the nav bar.

I updated the changelog too, following the pattern I saw https://github.com/hashicorp/vault/pull/25671/files
