### PR TITLE
Test stability: textContent issues on identity/aliases and group/aliases acceptance tests

### DIFF
--- a/ui/tests/acceptance/access/identity/_shared-alias-tests.js
+++ b/ui/tests/acceptance/access/identity/_shared-alias-tests.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { currentRouteName, find, settled } from '@ember/test-helpers';
+import { currentRouteName, find, settled, waitUntil } from '@ember/test-helpers';
 import page from 'vault/tests/pages/access/identity/aliases/add';
 import aliasIndexPage from 'vault/tests/pages/access/identity/aliases/index';
 import aliasShowPage from 'vault/tests/pages/access/identity/aliases/show';
@@ -18,7 +18,12 @@ export const testAliasCRUD = async function (name, itemType, assert) {
     await settled();
   }
 
-  const itemID = find('[data-test-row-value="ID"]').textContent.trim();
+  const itemID = await waitUntil(
+    function () {
+      return find('[data-test-row-value="ID"]').textContent.trim();
+    },
+    { timeout: 2000 }
+  );
   await page.visit({ item_type: itemType, id: itemID });
   await settled();
   await page.editForm.name(name).submit();
@@ -28,7 +33,12 @@ export const testAliasCRUD = async function (name, itemType, assert) {
     `${itemType}: shows a flash message`
   );
 
-  const aliasID = find('[data-test-row-value="ID"]').textContent.trim();
+  const aliasID = await waitUntil(
+    function () {
+      return find('[data-test-row-value="ID"]').textContent.trim();
+    },
+    { timeout: 2000 }
+  );
   assert.strictEqual(
     currentRouteName(),
     'vault.cluster.access.identity.aliases.show',
@@ -72,12 +82,22 @@ export const testAliasDeleteFromForm = async function (name, itemType, assert) {
     await settled();
   }
 
-  const itemID = find('[data-test-row-value="ID"]').textContent.trim();
+  const itemID = await waitUntil(
+    function () {
+      return find('[data-test-row-value="ID"]').textContent.trim();
+    },
+    { timeout: 2000 }
+  );
   await page.visit({ item_type: itemType, id: itemID });
   await settled();
   await page.editForm.name(name).submit();
   await settled();
-  const aliasID = find('[data-test-row-value="ID"]').textContent.trim();
+  const aliasID = await waitUntil(
+    function () {
+      return find('[data-test-row-value="ID"]').textContent.trim();
+    },
+    { timeout: 2000 }
+  );
   await aliasShowPage.edit();
   await settled();
   assert.strictEqual(

--- a/ui/tests/acceptance/access/identity/entities/aliases/create-test.js
+++ b/ui/tests/acceptance/access/identity/entities/aliases/create-test.js
@@ -7,6 +7,7 @@ import { module, test } from 'qunit';
 import { settled } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { testAliasCRUD, testAliasDeleteFromForm } from '../../_shared-alias-tests';
+import { v4 as uuidv4 } from 'uuid';
 import authPage from 'vault/tests/pages/auth';
 
 module('Acceptance | /access/identity/entities/aliases/add', function (hooks) {
@@ -19,14 +20,14 @@ module('Acceptance | /access/identity/entities/aliases/add', function (hooks) {
 
   test('it allows create, list, delete of an entity alias', async function (assert) {
     assert.expect(6);
-    const name = `alias-${Date.now()}`;
+    const name = `alias-${uuidv4()}`;
     await testAliasCRUD(name, 'entities', assert);
     await settled();
   });
 
   test('it allows delete from the edit form', async function (assert) {
     assert.expect(4);
-    const name = `alias-${Date.now()}`;
+    const name = `alias-${uuidv4()}`;
     await testAliasDeleteFromForm(name, 'entities', assert);
     await settled();
   });

--- a/ui/tests/acceptance/access/identity/groups/aliases/create-test.js
+++ b/ui/tests/acceptance/access/identity/groups/aliases/create-test.js
@@ -3,11 +3,12 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { module, skip, test } from 'qunit';
+import { module, test } from 'qunit';
 import { settled } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { testAliasCRUD, testAliasDeleteFromForm } from '../../_shared-alias-tests';
 import authPage from 'vault/tests/pages/auth';
+import { v4 as uuidv4 } from 'uuid';
 import { setRunOptions } from 'ember-a11y-testing/test-support';
 
 module('Acceptance | /access/identity/groups/aliases/add', function (hooks) {
@@ -24,18 +25,16 @@ module('Acceptance | /access/identity/groups/aliases/add', function (hooks) {
     return;
   });
 
-  skip('it allows create, list, delete of an entity alias', async function (assert) {
-    // TODO figure out what is wrong with this test
+  test('it allows create, list, delete of an entity alias', async function (assert) {
     assert.expect(6);
-    const name = `alias-${Date.now()}`;
+    const name = `alias-${uuidv4()}`;
     await testAliasCRUD(name, 'groups', assert);
     await settled();
   });
 
   test('it allows delete from the edit form', async function (assert) {
-    // TODO figure out what is wrong with this test
     assert.expect(4);
-    const name = `alias-${Date.now()}`;
+    const name = `alias-${uuidv4()}`;
     await testAliasDeleteFromForm(name, 'groups', assert);
     await settled();
   });

--- a/ui/tests/pages/access/identity/create.js
+++ b/ui/tests/pages/access/identity/create.js
@@ -9,10 +9,10 @@ import editForm from 'vault/tests/pages/components/identity/edit-form';
 export default create({
   visit: visitable('/vault/access/identity/:item_type/create'),
   editForm,
-  createItem(item_type, type) {
+  async createItem(item_type, type) {
     if (type) {
-      return this.visit({ item_type }).editForm.type(type).submit();
+      return await this.visit({ item_type }).editForm.type(type).submit();
     }
-    return this.visit({ item_type }).editForm.submit();
+    return await this.visit({ item_type }).editForm.submit();
   },
 });


### PR DESCRIPTION
After a change [here](https://github.com/hashicorp/vault/pull/25560), one test failure came through on the CI slack channel. Addressing a flake-light test failure and removing a skipped test while I was at it.

- [x] Enterprise tests pass locally.

