### PR TITLE
docs/vault-secrets-operator: supported openshift versions and OperatorHub options

### DIFF
--- a/website/content/docs/platform/k8s/vso/index.mdx
+++ b/website/content/docs/platform/k8s/vso/index.mdx
@@ -42,7 +42,7 @@ The Vault Secrets Operator has been tested successfully in the following hosted 
 - Amazon Elastic Kubernetes Service (EKS)
 - Google Kubernetes Engine (GKE)
 - Microsoft Azure Kubernetes Service (AKS)
-- Red Hat OpenShift
+- [Red Hat OpenShift](/vault/docs/platform/k8s/vso/openshift)<sup>CERTIFIED</sup>
 
 Basic integration tests are available in the project repository.
 Please report any issues [here](https://github.com/hashicorp/vault-secrets-operator/issues).

--- a/website/content/docs/platform/k8s/vso/openshift.mdx
+++ b/website/content/docs/platform/k8s/vso/openshift.mdx
@@ -7,13 +7,22 @@ description: >-
 
 # Run the Vault Secrets Operator on OpenShift
 
-The Vault Secrets Operator may be installed on OpenShift clusters via the embedded OperatorHub or the Helm chart.
+The Vault Secrets Operator may be installed on OpenShift clusters via the embedded OperatorHub or the Helm chart. OpenShift versions 4.12 and later are supported.
 
 ## OperatorHub
 
 The Vault Secrets Operator is certified by Red Hat and therefore included in the [OperatorHub section](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.2/html/operators/olm-understanding-operatorhub) of an OpenShift cluster's web console.
 
 Navigate to the OperatorHub page of your OpenShift cluster and search for `Vault Secrets Operator`, then follow the instructions to install.
+
+### Options
+
+Set the following environment variables [on the subscription](https://access.redhat.com/solutions/5761251) to customize the operator's behavior.
+
+- [VSO_CLIENT_CACHE_PERSISTENCE_MODEL](/vault/docs/platform/k8s/vso/helm#v-controller-manager-clientcache-persistencemodel)
+- [VSO_CLIENT_CACHE_SIZE](/vault/docs/platform/k8s/vso/helm#v-controller-manager-clientcache-cachesize)
+- [VSO_MAX_CONCURRENT_RECONCILES](/vault/docs/platform/k8s/vso/helm#v-controller-manager-maxconcurrentreconciles)
+- [VSO_GLOBAL_TRANSFORMATION_OPTIONS](/vault/docs/platform/k8s/vso/helm#v-controller-manager-globaltransformationoptions)
 
 ## Helm chart
 

--- a/website/content/docs/platform/k8s/vso/openshift.mdx
+++ b/website/content/docs/platform/k8s/vso/openshift.mdx
@@ -17,7 +17,7 @@ Navigate to the OperatorHub page of your OpenShift cluster and search for `Vault
 
 ### Options
 
-Set the following environment variables [on the subscription](https://access.redhat.com/solutions/5761251) to customize the operator's behavior.
+Set the following environment variables [on the subscription](https://access.redhat.com/solutions/5761251) to customize the Kubernetes Operator behavior.
 
 - [VSO_CLIENT_CACHE_PERSISTENCE_MODEL](/vault/docs/platform/k8s/vso/helm#v-controller-manager-clientcache-persistencemodel)
 - [VSO_CLIENT_CACHE_SIZE](/vault/docs/platform/k8s/vso/helm#v-controller-manager-clientcache-cachesize)


### PR DESCRIPTION
State the supported OpenShift versions in our docs, and mention the customization options for an operator installed from OperatorHub.

Changed pages:
- https://vault-iaeunj1p1-hashicorp.vercel.app/vault/docs/platform/k8s/vso#supported-kubernetes-distributions
- https://vault-iaeunj1p1-hashicorp.vercel.app/vault/docs/platform/k8s/vso/openshift