### PR TITLE
Sync Associations ID Bug

### DIFF
--- a/ui/app/adapters/sync/association.js
+++ b/ui/app/adapters/sync/association.js
@@ -77,10 +77,12 @@ export default class SyncAssociationAdapter extends ApplicationAdapter {
     const url = this.buildURL(modelName, null, snapshot);
     const data = snapshot.serialize();
     return this.ajax(url, 'POST', { data }).then((resp) => {
-      const id = `${data.mount}/${data.secret_name}`;
+      const association = Object.values(resp.data.associated_secrets).find((association) => {
+        return association.mount === data.mount && association.secret_name === data.secret_name;
+      });
       return {
-        ...resp.data.associated_secrets[id],
-        id,
+        ...association,
+        id: `${data.mount}/${data.secret_name}`,
         destinationName: resp.data.store_name,
         destinationType: resp.data.store_type,
       };

--- a/ui/app/serializers/sync/association.js
+++ b/ui/app/serializers/sync/association.js
@@ -21,7 +21,7 @@ export default class SyncAssociationSerializer extends ApplicationSerializer {
       const secrets = [];
       for (const key in associated_secrets) {
         const data = associated_secrets[key];
-        data.id = key;
+        data.id = `${data.mount}/${data.secret_name}`;
         const association = {
           destinationName: store_name,
           destinationType: store_type,

--- a/ui/mirage/handlers/sync.js
+++ b/ui/mirage/handlers/sync.js
@@ -14,7 +14,7 @@ export const associationsResponse = (schema, req) => {
   const records = schema.db.syncAssociations.where({ type, name });
   const associations = records.length
     ? records.reduce((associations, association) => {
-        const key = `${association.mount}/${association.secret_name}`;
+        const key = `${association.mount}_12345/${association.secret_name}`;
         delete association.type;
         delete association.name;
         associations[key] = association;
@@ -26,21 +26,21 @@ export const associationsResponse = (schema, req) => {
   // are added to the association response but they are not individual associations
   // the secret itself is still a single association
   const subKeys = {
-    'my-kv/my-granular-secret/foo': {
+    'my-kv_12345/my-granular-secret/foo': {
       mount: 'my-kv',
       secret_name: 'my-granular-secret',
       sync_status: 'SYNCED',
       updated_at: '2023-09-20T10:51:53.961861096-04:00',
       sub_key: 'foo',
     },
-    'my-kv/my-granular-secret/bar': {
+    'my-kv_12345/my-granular-secret/bar': {
       mount: 'my-kv',
       secret_name: 'my-granular-secret',
       sync_status: 'SYNCED',
       updated_at: '2023-09-20T10:51:53.961861096-04:00',
       sub_key: 'bar',
     },
-    'my-kv/my-granular-secret/baz': {
+    'my-kv_12345/my-granular-secret/baz': {
       mount: 'my-kv',
       secret_name: 'my-granular-secret',
       sync_status: 'SYNCED',

--- a/ui/tests/unit/serializers/sync/associations-test.js
+++ b/ui/tests/unit/serializers/sync/associations-test.js
@@ -26,8 +26,8 @@ module('Unit | Serializer | sync | association', function (hooks) {
     const payload = {
       data: {
         associated_secrets: {
-          'foo/bar': associations[0],
-          'test/my-secret': associations[1],
+          'foo_12345/bar': associations[0],
+          'test_12345/my-secret': associations[1],
         },
         store_name: destinationName,
         store_type: destinationType,
@@ -46,13 +46,13 @@ module('Unit | Serializer | sync | association', function (hooks) {
     const payload = {
       data: {
         associated_secrets: {
-          'foo/bar': {
+          'foo_12345/bar': {
             mount: 'foo',
             secret_name: 'bar',
             sync_status: 'SYNCED',
             updated_at: '2023-09-20T10:51:53.961861096-04:00',
           },
-          'bar/baz': {
+          'bar_12345/baz': {
             mount: 'bar',
             secret_name: 'baz',
             sync_status: 'UNSYNCED',
@@ -69,13 +69,13 @@ module('Unit | Serializer | sync | association', function (hooks) {
       type: 'aws-sm',
       associationCount: 2,
       status: '1 Unsynced',
-      lastUpdated: new Date(payload.data.associated_secrets['bar/baz'].updated_at),
+      lastUpdated: new Date(payload.data.associated_secrets['bar_12345/baz'].updated_at),
     };
     let normalized = this.serializer.normalizeFetchByDestinations(payload);
 
     assert.deepEqual(normalized, expected, 'Response is normalized from fetchByDestinations request');
 
-    payload.data.associated_secrets['bar/baz'].sync_status = 'SYNCED';
+    payload.data.associated_secrets['bar_12345/baz'].sync_status = 'SYNCED';
     normalized = this.serializer.normalizeFetchByDestinations(payload);
 
     assert.strictEqual(


### PR DESCRIPTION
The ID for sync associations was not being consistently set which was causing Ember Data to throw an error alerting the mismatch. This PR updates it to a consistent format.

![image](https://github.com/hashicorp/vault/assets/24611656/8d9c0d55-27fb-46c7-8798-7fdc41934816)
