### PR TITLE
Backport Flaky Control Group Test Fix to 1.15.x

### DIFF
--- a/ui/tests/acceptance/enterprise-control-groups-test.js
+++ b/ui/tests/acceptance/enterprise-control-groups-test.js
@@ -130,6 +130,11 @@ module('Acceptance | Enterprise | control groups', function (hooks) {
       await waitUntil(() => currentRouteName() === 'vault.cluster.access.control-group-accessor'),
       'redirects to access control group route'
     );
+    // without waiting for a settled state before test teardown there was an occasional async request leak causing failures
+    // the queryRecord method in the capabilities adapter was seemingly resolving after the store was destroyed
+    // "Error: Async Request leaks detected. Add a breakpoint here and set store.generateStackTracesForTrackedRequests = true; to inspect traces for leak origins"
+    // this should allow the pending request to resolve before tear down
+    await settled();
   });
 
   const workflow = async (assert, context, shouldStoreToken) => {


### PR DESCRIPTION
Backport of #23911 to fix flaky control group test

I wasn't able to reproduce the issue we're seeing in CI locally, but saw that the fix merged into 1.16 was not backported so figured that's worth a shot. 