### PR TITLE
Add new /sys/well-known interface to get information about registered labels

### DIFF
--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -6023,9 +6023,9 @@ func (b *SystemBackend) handleWellKnownList() framework.OperationFunc {
 			}
 
 			respKeyInfo[label] = map[string]interface{}{
-				"mountPath": mountPath,
-				"mountUuid": wk.mountUUID,
-				"prefix":    wk.prefix,
+				"mount_path": mountPath,
+				"mount_uuid": wk.mountUUID,
+				"prefix":     wk.prefix,
 			}
 		}
 
@@ -6051,10 +6051,10 @@ func (b *SystemBackend) handleWellKnownRead() framework.OperationFunc {
 
 		return &logical.Response{
 			Data: map[string]interface{}{
-				"label":     label,
-				"mountPath": mountPath,
-				"mountUuid": wk.mountUUID,
-				"prefix":    wk.prefix,
+				"label":      label,
+				"mount_path": mountPath,
+				"mount_uuid": wk.mountUUID,
+				"prefix":     wk.prefix,
 			},
 		}, nil
 	}

--- a/vault/logical_system_paths.go
+++ b/vault/logical_system_paths.go
@@ -5200,3 +5200,98 @@ func (b *SystemBackend) eventPaths() []*framework.Path {
 		},
 	}
 }
+
+func (b *SystemBackend) wellKnownPaths() []*framework.Path {
+	return []*framework.Path{
+		{
+			Pattern: "well-known/?$",
+
+			DisplayAttrs: &framework.DisplayAttributes{
+				OperationPrefix: "well-known",
+				OperationVerb:   "list",
+			},
+
+			Operations: map[logical.Operation]framework.OperationHandler{
+				logical.ReadOperation: &framework.PathOperation{
+					Callback: b.handleWellKnownList(),
+					Responses: map[int][]framework.Response{
+						http.StatusOK: {{
+							Description: "OK",
+							Fields: map[string]*framework.FieldSchema{
+								"keys": {
+									Type:     framework.TypeStringSlice,
+									Required: true,
+								},
+							},
+						}},
+					},
+				},
+				logical.ListOperation: &framework.PathOperation{
+					Callback: b.handleWellKnownList(),
+					Responses: map[int][]framework.Response{
+						http.StatusOK: {{
+							Description: "OK",
+							Fields: map[string]*framework.FieldSchema{
+								"keys": {
+									Type:     framework.TypeStringSlice,
+									Required: true,
+								},
+							},
+						}},
+					},
+				},
+			},
+
+			HelpSynopsis:    strings.TrimSpace(sysHelp["well-known-list"][0]),
+			HelpDescription: strings.TrimSpace(sysHelp["well-known-list"][1]),
+		},
+		{
+			Pattern: "well-known/(?P<label>.+)",
+
+			DisplayAttrs: &framework.DisplayAttributes{
+				OperationPrefix: "well-known",
+				OperationSuffix: "label", // this endpoint duplicates /sys/policies/acl
+			},
+
+			Fields: map[string]*framework.FieldSchema{
+				"label": {
+					Type:        framework.TypeString,
+					Description: strings.TrimSpace(sysHelp["well-known-label"][0]),
+				},
+			},
+
+			Operations: map[logical.Operation]framework.OperationHandler{
+				logical.ReadOperation: &framework.PathOperation{
+					Callback: b.handleWellKnownRead(),
+					Responses: map[int][]framework.Response{
+						http.StatusOK: {{
+							Description: "OK",
+							Fields: map[string]*framework.FieldSchema{
+								"label": {
+									Type:     framework.TypeString,
+									Required: true,
+								},
+								"mountUuid": {
+									Type:     framework.TypeString,
+									Required: true,
+								},
+								"mountPath": {
+									Type:     framework.TypeString,
+									Required: true,
+								},
+								"prefix": {
+									Type:     framework.TypeString,
+									Required: true,
+								},
+							},
+						}},
+					},
+					Summary: "Retrieve the associated mount information for a registered well-known label.",
+				},
+			},
+
+			HelpSynopsis:    strings.TrimSpace(sysHelp["well-known"][0]),
+			HelpDescription: strings.TrimSpace(sysHelp["well-known"][1]),
+		},
+	}
+}

--- a/vault/logical_system_paths.go
+++ b/vault/logical_system_paths.go
@@ -5271,11 +5271,11 @@ func (b *SystemBackend) wellKnownPaths() []*framework.Path {
 									Type:     framework.TypeString,
 									Required: true,
 								},
-								"mountUuid": {
+								"mount_uuid": {
 									Type:     framework.TypeString,
 									Required: true,
 								},
-								"mountPath": {
+								"mount_path": {
 									Type:     framework.TypeString,
 									Required: true,
 								},

--- a/vault/logical_system_paths.go
+++ b/vault/logical_system_paths.go
@@ -5250,7 +5250,7 @@ func (b *SystemBackend) wellKnownPaths() []*framework.Path {
 
 			DisplayAttrs: &framework.DisplayAttributes{
 				OperationPrefix: "well-known",
-				OperationSuffix: "label", // this endpoint duplicates /sys/policies/acl
+				OperationSuffix: "label",
 			},
 
 			Fields: map[string]*framework.FieldSchema{

--- a/vault/logical_system_test.go
+++ b/vault/logical_system_test.go
@@ -7025,6 +7025,7 @@ func TestGetSealStatus_RedactionSettings(t *testing.T) {
 	assert.Empty(t, resp.ClusterName)
 }
 
+// TestWellKnownSysApi verifies the GET/LIST endpoints of /sys/well-known and /sys/well-known/<label>
 func TestWellKnownSysApi(t *testing.T) {
 	c, _, _ := TestCoreUnsealed(t)
 	b := c.systemBackend

--- a/vault/logical_system_test.go
+++ b/vault/logical_system_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/hashicorp/go-hclog"
 	wrapping "github.com/hashicorp/go-kms-wrapping/v2"
 	aeadwrapper "github.com/hashicorp/go-kms-wrapping/wrappers/aead/v2"
+	"github.com/hashicorp/go-uuid"
 	credUserpass "github.com/hashicorp/vault/builtin/credential/userpass"
 	"github.com/hashicorp/vault/helper/builtinplugins"
 	"github.com/hashicorp/vault/helper/experiments"
@@ -7023,3 +7024,52 @@ func TestGetSealStatus_RedactionSettings(t *testing.T) {
 	assert.Empty(t, resp.BuildDate)
 	assert.Empty(t, resp.ClusterName)
 }
+
+func TestWellKnownSysApi(t *testing.T) {
+	c, _, _ := TestCoreUnsealed(t)
+	b := c.systemBackend
+
+	myUuid, err := uuid.GenerateUUID()
+	require.NoError(t, err, "failed generating uuid")
+
+	err = c.WellKnownRedirects.TryRegister(context.Background(), c, myUuid, "mylabel1", "test-path/foo1")
+	require.NoError(t, err, "failed registering well-known redirect 1")
+
+	err = c.WellKnownRedirects.TryRegister(context.Background(), c, myUuid, "mylabel2", "test-path/foo2")
+	require.NoError(t, err, "failed registering well-known redirect 2")
+
+	// Test LIST operation
+	req := logical.TestRequest(t, logical.ListOperation, "well-known")
+	resp, err := b.HandleRequest(namespace.RootContext(nil), req)
+	require.NoError(t, err, "failed list well-known request")
+	require.NotNil(t, resp, "response from list well-known request was nil")
+
+	require.Contains(t, resp.Data["keys"], "mylabel1")
+	require.Contains(t, resp.Data["keys"], "mylabel2")
+	require.Len(t, resp.Data["keys"], 2)
+
+	keyInfo := resp.Data["key_info"].(map[string]interface{})
+	keyInfoLabel1 := keyInfo["mylabel1"].(map[string]interface{})
+	require.Equal(t, myUuid, keyInfoLabel1["mountUuid"])
+	require.Equal(t, "test-path/foo1", keyInfoLabel1["prefix"])
+
+	keyInfoLabel2 := keyInfo["mylabel2"].(map[string]interface{})
+	require.Equal(t, myUuid, keyInfoLabel2["mountUuid"])
+	require.Equal(t, "test-path/foo2", keyInfoLabel2["prefix"])
+
+	// Test GET operation
+	req = logical.TestRequest(t, logical.ReadOperation, "well-known/mylabel1")
+	resp, err = b.HandleRequest(namespace.RootContext(nil), req)
+	require.NoError(t, err, "failed get well-known request")
+	require.NotNil(t, resp, "response from get well-known request was nil")
+
+	require.Equal(t, myUuid, resp.Data["mountUuid"])
+	require.Equal(t, "test-path/foo1", resp.Data["prefix"])
+
+	// Test GET operation on unknown label
+	req = logical.TestRequest(t, logical.ReadOperation, "well-known/mylabel1-unknown")
+	resp, err = b.HandleRequest(namespace.RootContext(nil), req)
+	require.NoError(t, err, "failed get well-known request")
+	require.Nil(t, resp, "response from unknown should have been nil was %v", resp)
+}
+

--- a/vault/logical_system_test.go
+++ b/vault/logical_system_test.go
@@ -7073,4 +7073,3 @@ func TestWellKnownSysApi(t *testing.T) {
 	require.NoError(t, err, "failed get well-known request")
 	require.Nil(t, resp, "response from unknown should have been nil was %v", resp)
 }
-

--- a/vault/logical_system_test.go
+++ b/vault/logical_system_test.go
@@ -7051,11 +7051,11 @@ func TestWellKnownSysApi(t *testing.T) {
 
 	keyInfo := resp.Data["key_info"].(map[string]interface{})
 	keyInfoLabel1 := keyInfo["mylabel1"].(map[string]interface{})
-	require.Equal(t, myUuid, keyInfoLabel1["mountUuid"])
+	require.Equal(t, myUuid, keyInfoLabel1["mount_uuid"])
 	require.Equal(t, "test-path/foo1", keyInfoLabel1["prefix"])
 
 	keyInfoLabel2 := keyInfo["mylabel2"].(map[string]interface{})
-	require.Equal(t, myUuid, keyInfoLabel2["mountUuid"])
+	require.Equal(t, myUuid, keyInfoLabel2["mount_uuid"])
 	require.Equal(t, "test-path/foo2", keyInfoLabel2["prefix"])
 
 	// Test GET operation
@@ -7064,7 +7064,7 @@ func TestWellKnownSysApi(t *testing.T) {
 	require.NoError(t, err, "failed get well-known request")
 	require.NotNil(t, resp, "response from get well-known request was nil")
 
-	require.Equal(t, myUuid, resp.Data["mountUuid"])
+	require.Equal(t, myUuid, resp.Data["mount_uuid"])
 	require.Equal(t, "test-path/foo1", resp.Data["prefix"])
 
 	// Test GET operation on unknown label

--- a/website/content/api-docs/system/well-known.mdx
+++ b/website/content/api-docs/system/well-known.mdx
@@ -31,13 +31,13 @@ $ curl \
 {
   "key_info": {
     "est/cacerts": {
-      "mountPath": "ns1/pki_int/",
-      "mountUuid": "fc9d3ee4-ae92-4e3e-c0e1-a1fdb3e3b8cf",
+      "mount_path": "ns1/pki_int/",
+      "mount_uuid": "fc9d3ee4-ae92-4e3e-c0e1-a1fdb3e3b8cf",
       "prefix": "est/cacerts"
     }
-  }
+  },
   "keys": [
-    "est/cacerts",
+    "est/cacerts"
   ]
 }
 ```
@@ -68,8 +68,8 @@ $ curl \
 ```json
 {
   "label": "est/cacerts",
-  "mountPath": "ns1/pki_int/",
-  "mountUuid": "fc9d3ee4-ae92-4e3e-c0e1-a1fdb3e3b8cf",
+  "mount_path": "ns1/pki_int/",
+  "mount_uuid": "fc9d3ee4-ae92-4e3e-c0e1-a1fdb3e3b8cf",
   "prefix": "est/cacerts"
 }
 ```

--- a/website/content/api-docs/system/well-known.mdx
+++ b/website/content/api-docs/system/well-known.mdx
@@ -1,0 +1,75 @@
+---
+layout: api
+page_title: /sys/well-known - HTTP API
+description: The `/sys/well-known` endpoint is used to list and read registered .well-known labels in Vault.
+---
+
+# `/sys/well-known`
+
+The `/sys/well-known` endpoint is used to list and read the registered labels within the server's .well-known/ path prefix
+
+## List well-known
+
+This endpoint lists all registered labels.
+
+| Method | Path              |
+|:-------|:------------------|
+| `GET`  | `/sys/well-known` |
+| `LIST` | `/sys/well-known` |
+
+### Sample request
+
+```shell-session
+$ curl \
+    --header "X-Vault-Token: ..." \
+    http://127.0.0.1:8200/v1/sys/well-known
+```
+
+### Sample response
+
+```json
+{
+  "key_info": {
+    "est/cacerts": {
+      "mountPath": "ns1/pki_int/",
+      "mountUuid": "fc9d3ee4-ae92-4e3e-c0e1-a1fdb3e3b8cf",
+      "prefix": "est/cacerts"
+    }
+  }
+  "keys": [
+    "est/cacerts",
+  ]
+}
+```
+
+## Read well-known
+
+This endpoint retrieves the information around a specific registered label
+
+| Method | Path                     |
+| :----- |:-------------------------|
+| `GET`  | `/sys/well-known/:label` |
+
+### Parameters
+
+- `label` `(string: <required>)` – Specifies the registered label to lookup
+  This is specified as part of the request URL.
+
+### Sample request
+
+```shell-session
+$ curl \
+    --header "X-Vault-Token: ..." \
+    http://127.0.0.1:8200/v1/sys/well-known/est/cacerts
+```
+
+### Sample response
+
+```json
+{
+  "label": "est/cacerts",
+  "mountPath": "ns1/pki_int/",
+  "mountUuid": "fc9d3ee4-ae92-4e3e-c0e1-a1fdb3e3b8cf",
+  "prefix": "est/cacerts"
+}
+```

--- a/website/content/api-docs/system/well-known.mdx
+++ b/website/content/api-docs/system/well-known.mdx
@@ -6,11 +6,11 @@ description: The `/sys/well-known` endpoint is used to list and read registered 
 
 # `/sys/well-known`
 
-The `/sys/well-known` endpoint is used to list and read the registered labels within the server's .well-known/ path prefix
+Use the `/sys/well-known` endpoint to list and read registered labels on the `.well-known/` path prefix for your Vault instance.
 
 ## List well-known
 
-This endpoint lists all registered labels.
+List all registered labels.
 
 | Method | Path              |
 |:-------|:------------------|
@@ -44,7 +44,7 @@ $ curl \
 
 ## Read well-known
 
-This endpoint retrieves the information around a specific registered label
+Retrieve information for the specified label.
 
 | Method | Path                     |
 | :----- |:-------------------------|
@@ -52,8 +52,7 @@ This endpoint retrieves the information around a specific registered label
 
 ### Parameters
 
-- `label` `(string: <required>)` – Specifies the registered label to lookup
-  This is specified as part of the request URL.
+- `label` `(string: <required>)` – URL path parameter specifying the registered label to fetch.
 
 ### Sample request
 

--- a/website/data/api-docs-nav-data.json
+++ b/website/data/api-docs-nav-data.json
@@ -757,6 +757,10 @@
         "path": "system/version-history"
       },
       {
+        "title": "<code>/sys/well-known</code>",
+        "path": "system/well-known"
+      },
+      {
         "title": "<code>/sys/wrapping/lookup</code>",
         "path": "system/wrapping-lookup"
       },


### PR DESCRIPTION
 - Add new interfaces LIST/GET /sys/well-known which will provide a list of keys which are registered labels within the /.well-known space on the local server, along with a detailed info map for each
 - Add GET /sys/well-known/<label> to get details on a specific registered label
 - Add api-docs and tests for the new API endpoints

VAULT-24499