### PR TITLE
VAULT-24439: Make sys/config/ui/custom-messages enterprise paths

### DIFF
--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -192,7 +192,6 @@ func NewSystemBackend(core *Core, logger log.Logger, config *logical.BackendConf
 
 	b.Backend.Paths = append(b.Backend.Paths, entPaths(b)...)
 	b.Backend.Paths = append(b.Backend.Paths, b.configPaths()...)
-	b.Backend.Paths = append(b.Backend.Paths, b.uiCustomMessagePaths()...)
 	b.Backend.Paths = append(b.Backend.Paths, b.rekeyPaths()...)
 	b.Backend.Paths = append(b.Backend.Paths, b.sealPaths()...)
 	b.Backend.Paths = append(b.Backend.Paths, b.statusPaths()...)

--- a/website/content/api-docs/system/config-ui-custom-messages.mdx
+++ b/website/content/api-docs/system/config-ui-custom-messages.mdx
@@ -6,6 +6,8 @@ description: The '/sys/config/ui/custom-messages' endpoint configures the custom
 
 # `/sys/config/ui/custom-messages`
 
+@include 'alerts/enterprise-only.mdx'
+
 The `/sys/config/ui/custom-messages` endpoint is used to list, create, read, update, or delete custom messages.
 
 ## List custom messages

--- a/website/content/api-docs/system/internal-ui-authenticated-messages.mdx
+++ b/website/content/api-docs/system/internal-ui-authenticated-messages.mdx
@@ -10,9 +10,8 @@ description: >-
 The `/sys/internal/ui/authenticated-messages` endpoint is used by the UI to
 retrieve the active post-login custom messages so that it can display them.
 
-The ability to create and maintain custom messages is reserved for the Vault
-Enterprise edition. In the community edition, this path simply returns an
-empty result.
+You must install Vault Enterprise 1.16.0 or higher to create custom messages
+that can be retrieved using this endpoint.
 
 When retrieving custom messages, the results will include active messages from
 the current namespace along with custom messages that exist all of the ancestral

--- a/website/content/api-docs/system/internal-ui-authenticated-messages.mdx
+++ b/website/content/api-docs/system/internal-ui-authenticated-messages.mdx
@@ -10,6 +10,10 @@ description: >-
 The `/sys/internal/ui/authenticated-messages` endpoint is used by the UI to
 retrieve the active post-login custom messages so that it can display them.
 
+The ability to create and maintain custom messages is reserved for the Vault
+Enterprise edition. In the community edition, this path simply returns an
+empty result.
+
 When retrieving custom messages, the results will include active messages from
 the current namespace along with custom messages that exist all of the ancestral
 namespaces up to and including the root namespace.

--- a/website/content/api-docs/system/internal-ui-unauthenticated-messages.mdx
+++ b/website/content/api-docs/system/internal-ui-unauthenticated-messages.mdx
@@ -10,9 +10,8 @@ description: >-
 The `/sys/internal/ui/unauthenticated-messages` endpoint is used by the UI to
 retrieve the active pre-login custom messages so that it can display them.
 
-The ability to create and maintain custom messages is reserved for the Vault
-Enterprise edition. In the community edition, this path simply returns an
-empty result.
+You must install Vault Enterprise 1.16.0 or higher to create custom messages
+that can be retrieved using this endpoint.
 
 When retrieving custom messages, the results will include active messages from
 the current namespace along with custom messages that exist all of the ancestral

--- a/website/content/api-docs/system/internal-ui-unauthenticated-messages.mdx
+++ b/website/content/api-docs/system/internal-ui-unauthenticated-messages.mdx
@@ -10,6 +10,10 @@ description: >-
 The `/sys/internal/ui/unauthenticated-messages` endpoint is used by the UI to
 retrieve the active pre-login custom messages so that it can display them.
 
+The ability to create and maintain custom messages is reserved for the Vault
+Enterprise edition. In the community edition, this path simply returns an
+empty result.
+
 When retrieving custom messages, the results will include active messages from
 the current namespace along with custom messages that exist all of the ancestral
 namespaces up to and including the root namespace.

--- a/website/data/api-docs-nav-data.json
+++ b/website/data/api-docs-nav-data.json
@@ -440,7 +440,12 @@
       },
       {
         "title": "<code>/sys/config/ui/custom-messages</code>",
-        "path": "system/config-ui-custom-messages"
+        "path": "system/config-ui-custom-messages",
+        "badge": {
+          "text": "ENT",
+          "type": "outlined",
+          "color": "neutral"
+        }
       },
       {
         "title": "<code>/sys/config/ui/headers</code>",


### PR DESCRIPTION
This change contains the code change to remove the `sys/config/ui/custom-messages` paths from the community edition in commit b374b78.

The remaining commits contain documentation changes.