### PR TITLE
core/login: fix potential deadlock for failed logins when user lockout is enabled

### DIFF
--- a/changelog/25697.txt
+++ b/changelog/25697.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core/login: Fixed a potential deadlock when a login fails and user lockout is enabled.
+```

--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -2440,6 +2440,8 @@ func (c *Core) LocalGetUserFailedLoginInfo(ctx context.Context, userKey FailedLo
 // LocalUpdateUserFailedLoginInfo updates the failed login information for a user based on alias name and mountAccessor
 func (c *Core) LocalUpdateUserFailedLoginInfo(ctx context.Context, userKey FailedLoginUser, failedLoginInfo *FailedLoginInfo, deleteEntry bool) error {
 	c.userFailedLoginInfoLock.Lock()
+	defer c.userFailedLoginInfoLock.Unlock()
+
 	switch deleteEntry {
 	case false:
 		// update entry in the map
@@ -2482,7 +2484,6 @@ func (c *Core) LocalUpdateUserFailedLoginInfo(ctx context.Context, userKey Faile
 		// delete the entry from the map, if no key exists it is no-op
 		delete(c.userFailedLoginInfo, userKey)
 	}
-	c.userFailedLoginInfoLock.Unlock()
 	return nil
 }
 


### PR DESCRIPTION
Semgrep found an instance in user lockout request handling where we can return without unlocking due to an error.