### PR TITLE
[DOCS] Add enterprise badge

### DIFF
--- a/website/content/docs/configuration/replication.mdx
+++ b/website/content/docs/configuration/replication.mdx
@@ -7,6 +7,8 @@ description: |-
 
 # `replication` stanza
 
+@include 'alerts/enterprise-only.mdx'
+
 The `replication` stanza specifies various parameters for tuning replication related values.
 
 ```hcl

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -352,6 +352,11 @@
       },
       {
         "title": "<code>replication</code>",
+        "badge": {
+          "text": "ENTERPRISE",
+          "type": "outlined",
+          "color": "neutral"
+        },
         "path": "configuration/replication"
       },
       {


### PR DESCRIPTION
🧵 [Reported via Slack](https://hashicorp.slack.com/archives/C012RTGJR1V/p1709139139031729)

🔍 [Deploy preview](https://vault-c4cphqzst-hashicorp.vercel.app/vault/docs/configuration/replication)

This PR adds the ENTERPRISE badge to the [replication](https://developer.hashicorp.com/vault/docs/configuration/replication) doc which was missing. 


![image](https://github.com/hashicorp/vault/assets/7660718/4e6d4e36-1d3d-4b14-8998-5bc9459e02d6)
