### PR TITLE
Add `use_csr_serial_number` option to PKI role

### DIFF
--- a/builtin/logical/pki/issuing/issue_common.go
+++ b/builtin/logical/pki/issuing/issue_common.go
@@ -106,7 +106,7 @@ func GenerateCreationBundle(b logical.SystemView, role *RoleEntry, entityInfo En
 		ridSerialNumber = cb.GetSerialNumber()
 
 		// only take serial number from CSR if one was not supplied via API
-		if ridSerialNumber == "" && csr != nil {
+		if role.UseCSRSerialNumber && ridSerialNumber == "" && csr != nil {
 			ridSerialNumber = csr.Subject.SerialNumber
 		}
 

--- a/builtin/logical/pki/issuing/roles.go
+++ b/builtin/logical/pki/issuing/roles.go
@@ -53,6 +53,7 @@ type RoleEntry struct {
 	EmailProtectionFlag           bool          `json:"email_protection_flag"`
 	UseCSRCommonName              bool          `json:"use_csr_common_name"`
 	UseCSRSANs                    bool          `json:"use_csr_sans"`
+	UseCSRSerialNumber            bool          `json:"use_csr_serial_number"`
 	KeyType                       string        `json:"key_type"`
 	KeyBits                       int           `json:"key_bits"`
 	UsePSS                        bool          `json:"use_pss"`
@@ -113,6 +114,7 @@ func (r *RoleEntry) ToResponseData() map[string]interface{} {
 		"email_protection_flag":              r.EmailProtectionFlag,
 		"use_csr_common_name":                r.UseCSRCommonName,
 		"use_csr_sans":                       r.UseCSRSANs,
+		"use_csr_serial_number":              r.UseCSRSerialNumber,
 		"key_type":                           r.KeyType,
 		"key_bits":                           r.KeyBits,
 		"signature_bits":                     r.SignatureBits,
@@ -374,6 +376,7 @@ func SignVerbatimRoleWithOpts(opts ...RoleModifier) *RoleEntry {
 		KeyType:                   "any",
 		UseCSRCommonName:          true,
 		UseCSRSANs:                true,
+		UseCSRSerialNumber:        true,
 		AllowedOtherSANs:          []string{"*"},
 		AllowedSerialNumbers:      []string{"*"},
 		AllowedURISANs:            []string{"*"},

--- a/builtin/logical/pki/path_issue_sign.go
+++ b/builtin/logical/pki/path_issue_sign.go
@@ -438,6 +438,9 @@ func (b *backend) pathIssueSignCert(ctx context.Context, req *logical.Request, d
 		if role.UseCSRSANs && data.Get("alt_names").(string) != "" {
 			resp.AddWarning("the alt_names field was provided but the role is set with \"use_csr_sans\" set to true")
 		}
+		if role.UseCSRSerialNumber && data.Get("serial_number").(string) != "" {
+			resp.AddWarning("the serial_number field was provided but the role is set with \"use_csr_serial_number\" set to true")
+		}
 	}
 
 	resp = addWarnings(resp, warnings)

--- a/builtin/logical/pki/path_roles.go
+++ b/builtin/logical/pki/path_roles.go
@@ -278,6 +278,13 @@ include the Common Name (cn); use use_csr_common_name
 for that. Defaults to true.`,
 		},
 
+		"use_csr_serial_number": {
+			Type:     framework.TypeBool,
+			Required: true,
+			Description: `If set, when used with a signing profile,
+the serial number from the CSR's subject will be used. Defaults to true.`,
+		},
+
 		"ou": {
 			Type: framework.TypeCommaStringSlice,
 			Description: `If set, OU (OrganizationalUnit) will be set to
@@ -674,6 +681,17 @@ for that. Defaults to true.`,
 				},
 			},
 
+			"use_csr_serial_number": {
+				Type:    framework.TypeBool,
+				Default: true,
+				Description: `If set, when used with a signing profile,
+the serial number from the CSR's subject will be used. Defaults to true.`,
+				DisplayAttrs: &framework.DisplayAttributes{
+					Name:  "Use CSR Subject Serial Number",
+					Value: true,
+				},
+			},
+
 			"ou": {
 				Type: framework.TypeCommaStringSlice,
 				Description: `If set, OU (OrganizationalUnit) will be set to
@@ -962,6 +980,7 @@ func (b *backend) pathRoleCreate(ctx context.Context, req *logical.Request, data
 		UsePSS:                        data.Get("use_pss").(bool),
 		UseCSRCommonName:              data.Get("use_csr_common_name").(bool),
 		UseCSRSANs:                    data.Get("use_csr_sans").(bool),
+		UseCSRSerialNumber:            data.Get("use_csr_serial_number").(bool),
 		KeyUsage:                      data.Get("key_usage").([]string),
 		ExtKeyUsage:                   data.Get("ext_key_usage").([]string),
 		ExtKeyUsageOIDs:               data.Get("ext_key_usage_oids").([]string),
@@ -1162,6 +1181,7 @@ func (b *backend) pathRolePatch(ctx context.Context, req *logical.Request, data 
 		UsePSS:                        getWithExplicitDefault(data, "use_pss", oldEntry.UsePSS).(bool),
 		UseCSRCommonName:              getWithExplicitDefault(data, "use_csr_common_name", oldEntry.UseCSRCommonName).(bool),
 		UseCSRSANs:                    getWithExplicitDefault(data, "use_csr_sans", oldEntry.UseCSRSANs).(bool),
+		UseCSRSerialNumber:            getWithExplicitDefault(data, "use_csr_serial_number", oldEntry.UseCSRSerialNumber).(bool),
 		KeyUsage:                      getWithExplicitDefault(data, "key_usage", oldEntry.KeyUsage).([]string),
 		ExtKeyUsage:                   getWithExplicitDefault(data, "ext_key_usage", oldEntry.ExtKeyUsage).([]string),
 		ExtKeyUsageOIDs:               getWithExplicitDefault(data, "ext_key_usage_oids", oldEntry.ExtKeyUsageOIDs).([]string),

--- a/builtin/logical/pki/path_roles_test.go
+++ b/builtin/logical/pki/path_roles_test.go
@@ -880,6 +880,11 @@ func TestPki_RolePatch(t *testing.T) {
 			Patched: true,
 		},
 		{
+			Field:   "use_csr_serial_number",
+			Before:  false,
+			Patched: true,
+		},
+		{
 			Field:   "ou",
 			Before:  []string{"crypto"},
 			Patched: []string{"cryptosec"},

--- a/changelog/25709.txt
+++ b/changelog/25709.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+COMPONENT: Add `use_csr_serial_number` to PKI roles
+```


### PR DESCRIPTION
Fixes #25708

Currently on `/pki/sign/:name`, the other fields that can have their values taken from the CSR, namely SANs and `common_name`, have a `use_csr_*` option to control whether or not they take their values from the CSR. `serial_number` is also taken from the CN in the CSR, but there is currently no way to ignore the `serial_number` in the CSR.

This PR adds the `use_csr_serial_number` PKI role parameter which controls whether or not the `serial_number` is taken from the CSR. It defaults to true so that the previous behaviour is kept. If a `serial_number` is provided in the JSON data, then that takes precedence over the value in the CSR.