### PR TITLE
Sync Associations ID Format

### DIFF
--- a/ui/app/adapters/sync/association.js
+++ b/ui/app/adapters/sync/association.js
@@ -82,7 +82,7 @@ export default class SyncAssociationAdapter extends ApplicationAdapter {
       });
       return {
         ...association,
-        id: `${data.mount}/${data.secret_name}`,
+        id: `${data.mount}/${data.secret_name}/${data.sub_key}`,
         destinationName: resp.data.store_name,
         destinationType: resp.data.store_type,
       };

--- a/ui/app/adapters/sync/association.js
+++ b/ui/app/adapters/sync/association.js
@@ -76,13 +76,15 @@ export default class SyncAssociationAdapter extends ApplicationAdapter {
     );
     const url = this.buildURL(modelName, null, snapshot);
     const data = snapshot.serialize();
+    const serializer = store.serializerFor('sync/association');
+
     return this.ajax(url, 'POST', { data }).then((resp) => {
       const association = Object.values(resp.data.associated_secrets).find((association) => {
         return association.mount === data.mount && association.secret_name === data.secret_name;
       });
       return {
         ...association,
-        id: `${data.mount}/${data.secret_name}/${data.sub_key}`,
+        id: serializer.generateId(association),
         destinationName: resp.data.store_name,
         destinationType: resp.data.store_type,
       };

--- a/ui/app/serializers/sync/association.js
+++ b/ui/app/serializers/sync/association.js
@@ -21,7 +21,7 @@ export default class SyncAssociationSerializer extends ApplicationSerializer {
       const secrets = [];
       for (const key in associated_secrets) {
         const data = associated_secrets[key];
-        data.id = `${data.mount}/${data.secret_name}`;
+        data.id = `${data.mount}/${data.secret_name}/${data.sub_key}`;
         const association = {
           destinationName: store_name,
           destinationType: store_type,

--- a/ui/app/serializers/sync/association.js
+++ b/ui/app/serializers/sync/association.js
@@ -15,13 +15,21 @@ export default class SyncAssociationSerializer extends ApplicationSerializer {
     subKey: { serialize: false },
   };
 
+  generateId(data) {
+    let id = `${data.mount}/${data.secret_name}`;
+    if (data.sub_key) {
+      id += `/${data.sub_key}`;
+    }
+    return id;
+  }
+
   extractLazyPaginatedData(payload) {
     if (payload) {
       const { store_name, store_type, associated_secrets } = payload.data;
       const secrets = [];
       for (const key in associated_secrets) {
         const data = associated_secrets[key];
-        data.id = `${data.mount}/${data.secret_name}/${data.sub_key}`;
+        data.id = this.generateId(data);
         const association = {
           destinationName: store_name,
           destinationType: store_type,

--- a/ui/tests/acceptance/sync/secrets/destination-test.js
+++ b/ui/tests/acceptance/sync/secrets/destination-test.js
@@ -129,4 +129,11 @@ module('Acceptance | sync | destination', function (hooks) {
       'Does no redirect when navigating to destination route other than edit or sync'
     );
   });
+
+  test('it should render correct number of associations in list for sub keys', async function (assert) {
+    this.server.db.syncDestinations.update({ granularity: 'secret-key' });
+
+    await visit('vault/sync/secrets/destinations/vercel-project/destination-vercel/secrets');
+    assert.dom('[data-test-list-item]').exists({ count: 3 }, 'Sub key associations render in list');
+  });
 });

--- a/ui/tests/integration/components/sync/secrets/page/destinations/destination/sync-test.js
+++ b/ui/tests/integration/components/sync/secrets/page/destinations/destination/sync-test.js
@@ -77,7 +77,7 @@ module('Integration | Component | sync | Secrets::Page::Destinations::Destinatio
       const data = JSON.parse(req.requestBody);
       const expected = { mount: 'my-kv', secret_name: 'my-secret' };
       assert.deepEqual(data, expected, 'Sync request made with mount and secret name');
-      return { data: { associated_secrets: {} } };
+      return { data: { associated_secrets: { 'my-kv_12345': data } } };
     });
 
     assert.dom(submit).isDisabled('Submit button is disabled when mount is not selected');


### PR DESCRIPTION
This PR fixes an issue where association records with secret-key granularity were being loaded with duplicate ids and only one of the associations would render in the list.

![image](https://github.com/hashicorp/vault/assets/24611656/ddcbe82c-f369-4c02-8736-7ded390f5f84)
_Notice in the list that the total count in the pagination bar is 2 but only one list item is displayed_