### PR TITLE
remove _ from server info

### DIFF
--- a/command/server.go
+++ b/command/server.go
@@ -1439,8 +1439,8 @@ func (c *ServerCommand) Run(args []string) int {
 
 	requestLimiterStatus := entGetRequestLimiterStatus(coreConfig)
 	if requestLimiterStatus != "" {
-		infoKeys = append(infoKeys, "request_limiter")
-		info["request_limiter"] = requestLimiterStatus
+		infoKeys = append(infoKeys, "request limiter")
+		info["request limiter"] = requestLimiterStatus
 	}
 
 	infoKeys = append(infoKeys, "administrative namespace")


### PR DESCRIPTION
This is a cosmetic change to make the info key on server start more in line with existing info keys: space separated strings.

This change will break the [pre-existing test](https://github.com/hashicorp/vault-enterprise/pull/5528) on enterprise, so I'm going to manually merge these together to prevent disruption.