### PR TITLE
fix "Vault as a service" reference in namespace docs

### DIFF
--- a/website/content/docs/enterprise/namespaces/index.mdx
+++ b/website/content/docs/enterprise/namespaces/index.mdx
@@ -14,7 +14,7 @@ organization operate within isolated environments known as **tenants**.
 
 Multi-tenant environments have the following implementation challenges:
 
-- **Tenant isolation**. Teams within a Visualization as a Service (VaaS)
+- **Tenant isolation**. Teams within a Vault as a Service (VaaS)
   environment require strong isolation for their policies, secrets, and
   identities. Tenant isolation may also be required due to organizational
   security and privacy requirements or to address compliance regulations like


### PR DESCRIPTION
There is a reference in the third sentence on this page, https://developer.hashicorp.com/vault/docs/enterprise/namespaces, to "Visualization as a Service".

I suspect that this is a typo, and that the original author meant to write "Vault as a Service". This would reflect the "Vault as a service" reference in the first sentence, and fit better with the page's context and content.