### PR TITLE
Update api docs to reflect changes brought in by replication canary and clock skew

### DIFF
--- a/website/content/api-docs/system/ha-status.mdx
+++ b/website/content/api-docs/system/ha-status.mdx
@@ -31,36 +31,45 @@ $ curl \
 {
   "Nodes": [
     {
-      "hostname": "node1",
-      "api_address": "http://10.0.0.2:8200",
-      "cluster_address": "https://10.0.0.2:8201",
       "active_node": true,
+      "api_address": "http://10.0.0.2:8200",
+      "clock_skew_ms": 0,
+      "cluster_address": "https://10.0.0.2:8201",
+      "echo_duration_ms": 0,
+      "hostname": "node1",
       "last_echo": null,
-      "version": "1.11.0",
-      "upgrade_version": "1.11.0",
+      "replication_primary_canary_age_ms": 0,
+      "version": "1.17.0",
+      "upgrade_version": "1.17.0",
       "redundancy_zone": "a"
     },
     {
-      "hostname": "node2",
+      "active_node": false,
       "api_address": "http://10.0.0.3:8200",
+      "clock_skew_ms": 0,
       "cluster_address": "https://10.0.0.3:8201",
-      "active_node": false,
-      "last_echo": "2021-11-29T10:29:09.202235-05:00",
-      "version": "1.11.0",
-      "upgrade_version": "1.11.0",
+      "echo_duration_ms": 20,
+      "hostname": "node2",
+      "last_echo": "2024-03-04T08:05:48.403148-05:00",
+      "replication_primary_canary_age_ms": 72,
+      "version": "1.17.0",
+      "upgrade_version": "1.17.0",
       "redundancy_zone": "a"
     },
     {
-      "hostname": "node3",
-      "api_address": "http://10.0.0.4:8200",
-      "cluster_address": "https://10.0.0.4:8201",
       "active_node": false,
-      "last_echo": "2021-11-29T10:29:07.402548-05:00",
-      "version": "1.11.0",
-      "upgrade_version": "1.11.0",
+      "api_address": "http://10.0.0.4:8200",
+      "clock_skew_ms": -1,
+      "cluster_address": "https://10.0.0.4:8201",
+      "echo_duration_ms": 17,
+      "hostname": "node3",
+      "last_echo": "2024-03-04T08:05:48.657318-05:00",
+      "replication_primary_canary_age_ms": 950,
+      "version": "1.17.0",
+      "upgrade_version": "1.17.0",
       "redundancy_zone": "a"
     }
   ]
 }
 ```
-Note that in the above sample response, `upgrade_version` and `redundancy_zone` are Enterprise-only fields.
+Note that in the above sample response, `upgrade_version`, `redundancy_zone`, and `replication_primary_canary_age_ms` are Enterprise-only fields.

--- a/website/content/api-docs/system/health.mdx
+++ b/website/content/api-docs/system/health.mdx
@@ -67,30 +67,6 @@ $ curl \
     http://127.0.0.1:8200/v1/sys/health
 ```
 
-### Sample response
-
-This response is only returned for a `GET` request.
-
-Note: `replication_performance_mode` and `replication_dr_mode` reflect the state of
-the active node in the cluster; if you are querying it for a standby that has
-just come up, it can take a small time for the active node to inform the
-standby of its status.
-
-```json
-{
-  "initialized": true,
-  "sealed": false,
-  "standby": false,
-  "performance_standby": false,
-  "replication_performance_mode": "disabled",
-  "replication_dr_mode": "disabled",
-  "server_time_utc": 1516639589,
-  "version": "0.9.2",
-  "cluster_name": "vault-cluster-3bd69ca2",
-  "cluster_id": "00af5aa8-c87d-b5fc-e82e-97cd8dfaf731"
-}
-```
-
 ### Sample request to customize the status code being returned
 
 ```shell-session
@@ -104,7 +80,27 @@ content-length: 364
 date: Wed, 26 Jan 2022 09:21:13 GMT
 ```
 
-### Sample response
+### Sample response - CE active node
+
+```json
+{
+  "clock_skew_ms": 0,
+  "cluster_id": "995f749a-9bc3-fbe0-a185-ccba6999fc73",
+  "cluster_name": "vault-cluster-e65c0563",
+  "echo_duration_ms": 0,
+  "enterprise": false,
+  "initialized": true,
+  "performance_standby": false,
+  "replication_dr_mode": "disabled",
+  "replication_performance_mode": "disabled",
+  "sealed": false,
+  "server_time_utc": 1709559327,
+  "standby": false,
+  "version": "1.16.0-rc2"
+}
+```
+
+### Sample response - Enterprise active node
 
 This response is only returned for a `GET` request.
 
@@ -115,17 +111,26 @@ standby of its status.
 
 ```json
 {
+  "clock_skew_ms": 0,
+  "cluster_id": "e278ff10-60da-4248-0b0a-dd174d22172d",
+  "cluster_name": "vault-cluster-88b4e092",
+  "echo_duration_ms": 0,
+  "enterprise": true,
   "initialized": true,
-  "sealed": false,
-  "standby": false,
+  "last_wal": 362,
+  "license": {
+    "expiry_time": "2024-08-03T23:59:59Z",
+    "state": "autoloaded",
+    "terminated": false
+  },
   "performance_standby": false,
+  "replication_dr_mode": "disabled",
   "replication_performance_mode": "disabled",
-  "replication_dr_mode": "secondary",
-  "server_time_utc": 1643188873,
-  "version": "1.9.0+prem",
-  "cluster_name": "SECONDARY",
-  "cluster_id": "d2fbb13b-0830-70a3-4751-57b6b6d95d01",
-  "last_wal":13,
-  "license":{"state":"none","expiry_time":"","terminated":false}
+  "replication_primary_canary_age_ms": 0,
+  "sealed": false,
+  "server_time_utc": 1709558830,
+  "standby": false,
+  "version": "1.17.0-beta1+ent"
+
 }
 ```

--- a/website/content/api-docs/system/replication/index.mdx
+++ b/website/content/api-docs/system/replication/index.mdx
@@ -113,38 +113,60 @@ performance primary and DR primary node, it will look something like:
 {
   "data": {
     "dr": {
-      "cluster_id": "f2c21cb5-523f-617b-20ac-c913d9154ba6",
-      "known_secondaries": ["3"],
-      "last_wal": 291,
-      "merkle_root": "38543b95d44132138003939addbaf94125ec184e",
+      "cluster_id": "eef2a5ab-51e2-1c05-407c-8b4dc8d09ebf",
+      "corrupted_merkle_tree": false,
+      "known_secondaries": [
+        "4ca6b639-046b-5bb1-8043-6788ddf09121"
+      ],
+      "last_corruption_check_epoch": "-62135596800",
+      "last_dr_wal": 223,
+      "last_reindex_epoch": "0",
+      "last_wal": 223,
+      "merkle_root": "2494830f1a1c304829b5742a232d39b5457bce9a",
       "mode": "primary",
       "primary_cluster_addr": "",
       "secondaries": [
         {
-          "api_address": "https://127.0.0.1:49264",
-          "cluster_address": "https://127.0.0.1:49267",
+          "api_address": "https://127.0.0.1:65531",
+          "clock_skew_ms": "0",
+          "cluster_address": "https://127.0.0.1:65534",
           "connection_status": "connected",
-          "last_heartbeat": "2020-06-10T15:40:47-07:00",
-          "node_id": "3"
+          "last_heartbeat": "2024-03-04T10:05:56-05:00",
+          "last_heartbeat_duration_ms": "0",
+          "node_id": "4ca6b639-046b-5bb1-8043-6788ddf09121",
+          "replication_primary_canary_age_ms": "696"
         }
-      ]
+      ],
+      "ssct_generation_counter": 0,
+      "state": "running"
     },
     "performance": {
-      "cluster_id": "1598d434-dfec-1f48-f019-3d22a8075bf9",
-      "known_secondaries": ["2"],
-      "last_wal": 291,
-      "merkle_root": "43f40fc775b40cc76cd5d7e289b2e6eaf4ba138c",
+      "cluster_id": "00616ea0-3094-5017-29f9-644f3633f0da",
+      "corrupted_merkle_tree": false,
+      "known_secondaries": [
+        "cd0463e0-a37f-7421-345e-aad53007479f"
+      ],
+      "last_corruption_check_epoch": "-62135596800",
+      "last_performance_wal": 223,
+      "last_reindex_epoch": "0",
+      "last_wal": 223,
+      "merkle_root": "7b75cf69bb9a862913b0de2478164e046d242e0f",
       "mode": "primary",
       "primary_cluster_addr": "",
       "secondaries": [
         {
-          "api_address": "https://127.0.0.1:49253",
-          "cluster_address": "https://127.0.0.1:49256",
+          "api_address": "https://127.0.0.1:49155",
+          "clock_skew_ms": "0",
+          "cluster_address": "https://127.0.0.1:49160",
           "connection_status": "connected",
-          "last_heartbeat": "2020-06-10T15:40:46-07:00",
-          "node_id": "2"
+          "last_heartbeat": "2024-03-04T10:05:56-05:00",
+          "last_heartbeat_duration_ms": "0",
+          "node_id": "cd0463e0-a37f-7421-345e-aad53007479f",
+          "replication_primary_canary_age_ms": "660"
         }
-      ]
+      ],
+      "ssct_generation_counter": 0,
+      "state": "running"
     }
   }
 }
@@ -162,40 +184,62 @@ performance secondary and DR primary node, it will look something like:
 {
   "data": {
     "dr": {
-      "cluster_id": "e4bfa800-002e-7b6d-14c2-617855ece02f",
-      "known_secondaries": ["4"],
-      "last_wal": 455,
-      "merkle_root": "cdcf796619240ce19dd8af30fa700f64c8006e3d",
+      "cluster_id": "8cfe8fd1-c7b7-c301-5aa8-3131d66d53ea",
+      "corrupted_merkle_tree": false,
+      "known_secondaries": [
+        "79f5e0b2-6420-fdcd-5f53-3a1745f3d979"
+      ],
+      "last_corruption_check_epoch": "-62135596800",
+      "last_dr_wal": 145,
+      "last_reindex_epoch": "0",
+      "last_wal": 145,
+      "merkle_root": "29a9794b2e7f1d39cb4ef3976566c02e740b72c2",
       "mode": "primary",
       "primary_cluster_addr": "",
       "secondaries": [
         {
-          "api_address": "https://127.0.0.1:49277",
-          "cluster_address": "https://127.0.0.1:49281",
+          "api_address": "https://127.0.0.1:49167",
+          "clock_skew_ms": "-1",
+          "cluster_address": "https://127.0.0.1:49170",
           "connection_status": "connected",
-          "last_heartbeat": "2020-06-10T15:40:46-07:00",
-          "node_id": "4"
+          "last_heartbeat": "2024-03-04T10:05:56-05:00",
+          "last_heartbeat_duration_ms": "2",
+          "node_id": "79f5e0b2-6420-fdcd-5f53-3a1745f3d979",
+          "replication_primary_canary_age_ms": "454"
         }
-      ]
+      ],
+      "ssct_generation_counter": 0,
+      "state": "running"
     },
     "performance": {
-      "cluster_id": "1598d434-dfec-1f48-f019-3d22a8075bf9",
-      "known_primary_cluster_addrs": ["https://127.0.0.1:8201"],
-      "last_remote_wal": 291,
-      "merkle_root": "43f40fc775b40cc76cd5d7e289b2e6eaf4ba138c",
+      "cluster_id": "00616ea0-3094-5017-29f9-644f3633f0da",
+      "connection_state": "ready",
       "corrupted_merkle_tree": false,
-      "last_corruption_check_epoch": "1694456090",
+      "known_primary_cluster_addrs": [
+        "https://127.0.0.1:65524",
+        "https://127.0.0.1:65525",
+        "https://127.0.0.1:65526"
+      ],
+      "last_corruption_check_epoch": "-62135596800",
+      "last_reindex_epoch": "1709564740",
+      "last_remote_wal": 223,
+      "last_start": "2024-03-04T10:05:48-05:00",
+      "merkle_root": "7b75cf69bb9a862913b0de2478164e046d242e0f",
       "mode": "secondary",
       "primaries": [
         {
-          "api_address": "https://127.0.0.1:49244",
-          "cluster_address": "https://127.0.0.1:8201",
+          "api_address": "https://127.0.0.1:65521",
+          "clock_skew_ms": "0",
+          "cluster_address": "https://127.0.0.1:65524",
           "connection_status": "connected",
-          "last_heartbeat": "2020-06-10T15:40:46-07:00"
+          "last_heartbeat": "2024-03-04T10:05:56-05:00",
+          "last_heartbeat_duration_ms": "0",
+          "replication_primary_canary_age_ms": "660"
         }
       ],
-      "primary_cluster_addr": "https://127.0.0.1:8201",
-      "secondary_id": "2",
+      "primary_cluster_addr": "https://127.0.0.1:65524",
+      "secondary_id": "cd0463e0-a37f-7421-345e-aad53007479f",
+      "ssct_generation_counter": 0,
       "state": "stream-wals"
     }
   }

--- a/website/content/api-docs/system/replication/replication-dr.mdx
+++ b/website/content/api-docs/system/replication/replication-dr.mdx
@@ -36,22 +36,32 @@ primary, it will look something like:
 ```json
 {
   "data": {
-    "cluster_id": "d4095d41-3aee-8791-c421-9bc7f88f7c3e",
-    "known_secondaries": ["3"],
+    "cluster_id": "eef2a5ab-51e2-1c05-407c-8b4dc8d09ebf",
     "corrupted_merkle_tree": false,
-    "last_corruption_check_epoch": "1694456090",
-    "last_wal": 241,
-    "merkle_root": "56794a98e52598f35974024fba6691f047e772e9",
+    "known_secondaries": [
+      "4ca6b639-046b-5bb1-8043-6788ddf09121"
+    ],
+    "last_corruption_check_epoch": "-62135596800",
+    "last_dr_wal": 223,
+    "last_reindex_epoch": "0",
+    "last_wal": 223,
+    "merkle_root": "2494830f1a1c304829b5742a232d39b5457bce9a",
     "mode": "primary",
+    "primary_cluster_addr": "",
     "secondaries": [
       {
-        "api_address": "https://127.0.0.1:49264",
-        "cluster_address": "https://127.0.0.1:49267",
+        "api_address": "https://127.0.0.1:65531",
+        "clock_skew_ms": "0",
+        "cluster_address": "https://127.0.0.1:65534",
         "connection_status": "connected",
-        "last_heartbeat": "2020-06-10T15:40:47-07:00",
-        "node_id": "3"
+        "last_heartbeat": "2024-03-04T10:05:56-05:00",
+        "last_heartbeat_duration_ms": "0",
+        "node_id": "4ca6b639-046b-5bb1-8043-6788ddf09121",
+        "replication_primary_canary_age_ms": "696"
       }
-    ]
+    ],
+    "ssct_generation_counter": 0,
+    "state": "running"
   }
 }
 ```
@@ -64,21 +74,34 @@ secondary, it will look something like:
 ```json
 {
   "data": {
-    "cluster_id": "d4095d41-3aee-8791-c421-9bc7f88f7c3e",
-    "known_primary_cluster_addrs": ["https://127.0.0.1:8201"],
-    "last_remote_wal": 241,
-    "merkle_root": "56794a98e52598f35974024fba6691f047e772e9",
+    "cluster_id": "eef2a5ab-51e2-1c05-407c-8b4dc8d09ebf",
+    "connection_state": "ready",
+    "corrupted_merkle_tree": false,
+    "known_primary_cluster_addrs": [
+      "https://127.0.0.1:65524",
+      "https://127.0.0.1:65525",
+      "https://127.0.0.1:65526"
+    ],
+    "last_corruption_check_epoch": "-62135596800",
+    "last_reindex_epoch": "1709564746",
+    "last_remote_wal": 223,
+    "last_start": "2024-03-04T10:05:46-05:00",
+    "merkle_root": "2494830f1a1c304829b5742a232d39b5457bce9a",
     "mode": "secondary",
     "primaries": [
       {
-        "api_address": "https://127.0.0.1:49244",
-        "cluster_address": "https://127.0.0.1:8201",
+        "api_address": "https://127.0.0.1:65521",
+        "clock_skew_ms": "0",
+        "cluster_address": "https://127.0.0.1:65524",
         "connection_status": "connected",
-        "last_heartbeat": "2020-06-10T15:40:46-07:00"
+        "last_heartbeat": "2024-03-04T10:05:56-05:00",
+        "last_heartbeat_duration_ms": "0",
+        "replication_primary_canary_age_ms": "697"
       }
     ],
-    "primary_cluster_addr": "https://127.0.0.1:8201",
-    "secondary_id": "3",
+    "primary_cluster_addr": "https://127.0.0.1:65524",
+    "secondary_id": "4ca6b639-046b-5bb1-8043-6788ddf09121",
+    "ssct_generation_counter": 0,
     "state": "stream-wals"
   }
 }

--- a/website/content/api-docs/system/replication/replication-performance.mdx
+++ b/website/content/api-docs/system/replication/replication-performance.mdx
@@ -36,22 +36,32 @@ primary, it will look something like:
 ```json
 {
   "data": {
-    "cluster_id": "d4095d41-3aee-8791-c421-9bc7f88f7c3e",
-    "known_secondaries": ["2"],
-    "last_wal": 87,
-    "merkle_root": "c31e40f6ff02f32c37b70e6a4d58732ac812abf0",
+    "cluster_id": "00616ea0-3094-5017-29f9-644f3633f0da",
     "corrupted_merkle_tree": false,
-    "last_corruption_check_epoch": "1694456090",
+    "known_secondaries": [
+      "cd0463e0-a37f-7421-345e-aad53007479f"
+    ],
+    "last_corruption_check_epoch": "-62135596800",
+    "last_performance_wal": 223,
+    "last_reindex_epoch": "0",
+    "last_wal": 223,
+    "merkle_root": "7b75cf69bb9a862913b0de2478164e046d242e0f",
     "mode": "primary",
+    "primary_cluster_addr": "",
     "secondaries": [
       {
-        "api_address": "https://127.0.0.1:49264",
-        "cluster_address": "https://127.0.0.1:49267",
+        "api_address": "https://127.0.0.1:49155",
+        "clock_skew_ms": "0",
+        "cluster_address": "https://127.0.0.1:49160",
         "connection_status": "connected",
-        "last_heartbeat": "2020-06-10T15:40:47-07:00",
-        "node_id": "2"
+        "last_heartbeat": "2024-03-04T10:05:56-05:00",
+        "last_heartbeat_duration_ms": "0",
+        "node_id": "cd0463e0-a37f-7421-345e-aad53007479f",
+        "replication_primary_canary_age_ms": "660"
       }
-    ]
+    ],
+    "ssct_generation_counter": 0,
+    "state": "running"
   }
 }
 ```
@@ -64,21 +74,34 @@ secondary, it will look something like:
 ```json
 {
   "data": {
-    "cluster_id": "06dcf957-6630-44ae-bdd9-117d5f4d70d7",
-    "known_primary_cluster_addrs": ["https://127.0.0.1:8201"],
-    "last_remote_wal": 87,
-    "merkle_root": "c31e40f6ff02f32c37b70e6a4d58732ac812abf0",
+    "cluster_id": "00616ea0-3094-5017-29f9-644f3633f0da",
+    "connection_state": "ready",
+    "corrupted_merkle_tree": false,
+    "known_primary_cluster_addrs": [
+      "https://127.0.0.1:65524",
+      "https://127.0.0.1:65525",
+      "https://127.0.0.1:65526"
+    ],
+    "last_corruption_check_epoch": "-62135596800",
+    "last_reindex_epoch": "1709564740",
+    "last_remote_wal": 223,
+    "last_start": "2024-03-04T10:05:48-05:00",
+    "merkle_root": "7b75cf69bb9a862913b0de2478164e046d242e0f",
     "mode": "secondary",
     "primaries": [
       {
-        "api_address": "https://127.0.0.1:49244",
-        "cluster_address": "https://127.0.0.1:8201",
+        "api_address": "https://127.0.0.1:65521",
+        "clock_skew_ms": "0",
+        "cluster_address": "https://127.0.0.1:65524",
         "connection_status": "connected",
-        "last_heartbeat": "2020-06-10T15:40:46-07:00"
+        "last_heartbeat": "2024-03-04T10:05:56-05:00",
+        "last_heartbeat_duration_ms": "0",
+        "replication_primary_canary_age_ms": "660"
       }
     ],
-    "primary_cluster_addr": "https://127.0.0.1:8201",
-    "secondary_id": "2",
+    "primary_cluster_addr": "https://127.0.0.1:65524",
+    "secondary_id": "cd0463e0-a37f-7421-345e-aad53007479f",
+    "ssct_generation_counter": 0,
     "state": "stream-wals"
   }
 }


### PR DESCRIPTION
There are also some additional undocumented-until-now fields introduced previously that are unrelated, e.g. last_reindex_epoch and last_start and ssct_generation_counter.