### PR TITLE
Add test data file to fix ent-only unit test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,9 +55,8 @@ Vagrantfile
 !.release/ci.hcl
 !.release/security-scan.hcl
 !.release/linux/package/etc/vault.d/vault.hcl
-!command/agent/config/test-fixtures/*.hcl
-!command/server/test-fixtures/**/*.hcl
 !enos/**/*.hcl
+!**/test-fixtures/**/*.hcl
 !**/testdata/*.hcl
 
 # Enos

--- a/command/test-fixtures/config.hcl
+++ b/command/test-fixtures/config.hcl
@@ -1,0 +1,4 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+token_helper = "foo"


### PR DESCRIPTION
Fixes ent-only test `Test_loadGCPCredentialsFile ` following on from https://github.com/hashicorp/vault/pull/25744.