### PR TITLE
UI: Ember Deprecation - Remove A import from ember/array

### DIFF
--- a/ui/app/components/mfa/mfa-login-enforcement-form.js
+++ b/ui/app/components/mfa/mfa-login-enforcement-form.js
@@ -6,7 +6,6 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
-import { A } from '@ember/array';
 import { service } from '@ember/service';
 import { task } from 'ember-concurrency';
 import handleHasManySelection from 'core/utils/search-select-has-many';
@@ -41,14 +40,14 @@ export default class MfaLoginEnforcementForm extends Component {
   searchSelectOptions = null;
 
   @tracked name;
-  @tracked targets = A([]);
+  @tracked targets = [];
   @tracked selectedTargetType = 'accessor';
   @tracked selectedTargetValue = null;
   @tracked searchSelect = {
     options: [],
     selected: [],
   };
-  @tracked authMethods = A([]);
+  @tracked authMethods = [];
   @tracked modelErrors;
 
   constructor() {

--- a/ui/app/components/tool-actions-form.js
+++ b/ui/app/components/tool-actions-form.js
@@ -8,13 +8,12 @@ import { service } from '@ember/service';
 import Component from '@ember/component';
 import { setProperties, computed, set } from '@ember/object';
 import { addSeconds, parseISO } from 'date-fns';
-import { A } from '@ember/array';
 import { capitalize } from '@ember/string';
 
 const DEFAULTS = {
   token: null,
   rewrap_token: null,
-  errors: A(),
+  errors: null,
   wrap_info: null,
   creation_time: null,
   creation_ttl: null,

--- a/ui/app/transforms/array.js
+++ b/ui/app/transforms/array.js
@@ -4,7 +4,7 @@
  */
 
 import Transform from '@ember-data/serializer/transform';
-import { isArray, A } from '@ember/array';
+import { isArray } from '@ember/array';
 /*
   This should go inside a globally available place for all apps
 
@@ -13,16 +13,16 @@ import { isArray, A } from '@ember/array';
 export default class ArrayTransform extends Transform {
   deserialize(value) {
     if (isArray(value)) {
-      return A(value);
+      return [...value];
     } else {
-      return A();
+      return [];
     }
   }
   serialize(value) {
     if (isArray(value)) {
-      return A(value);
+      return [...value];
     } else {
-      return A();
+      return [];
     }
   }
 }

--- a/ui/lib/core/addon/components/replication-actions.js
+++ b/ui/lib/core/addon/components/replication-actions.js
@@ -7,13 +7,12 @@ import { alias } from '@ember/object/computed';
 import Component from '@ember/component';
 import ReplicationActions from 'core/mixins/replication-actions';
 import layout from '../templates/components/replication-actions';
-import { A } from '@ember/array';
 
 const DEFAULTS = {
   token: null,
   primary_api_addr: null,
   primary_cluster_addr: null,
-  errors: A(),
+  errors: null,
   id: null,
   force: false,
 };

--- a/ui/lib/core/addon/components/shamir/flow.js
+++ b/ui/lib/core/addon/components/shamir/flow.js
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { A } from '@ember/array';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import { camelize } from '@ember/string';
@@ -44,7 +43,7 @@ import { tracked } from '@glimmer/tracking';
  */
 export default class ShamirFlowComponent extends Component {
   @service store;
-  @tracked errors = A();
+  @tracked errors = [];
   @tracked attemptResponse = null;
 
   get action() {

--- a/ui/lib/core/addon/components/shamir/flow.js
+++ b/ui/lib/core/addon/components/shamir/flow.js
@@ -43,7 +43,7 @@ import { tracked } from '@glimmer/tracking';
  */
 export default class ShamirFlowComponent extends Component {
   @service store;
-  @tracked errors = [];
+  @tracked errors = null;
   @tracked attemptResponse = null;
 
   get action() {

--- a/ui/lib/replication/addon/components/replication-summary.js
+++ b/ui/lib/replication/addon/components/replication-summary.js
@@ -10,13 +10,12 @@ import Component from '@ember/component';
 import decodeConfigFromJWT from 'replication/utils/decode-config-from-jwt';
 import ReplicationActions from 'core/mixins/replication-actions';
 import { task } from 'ember-concurrency';
-import { A } from '@ember/array';
 
 const DEFAULTS = {
   token: null,
   id: null,
   loading: false,
-  errors: A(),
+  errors: null,
   primary_api_addr: null,
   primary_cluster_addr: null,
   ca_file: null,

--- a/ui/types/ember-cli-flash/services/flash-messages.d.ts
+++ b/ui/types/ember-cli-flash/services/flash-messages.d.ts
@@ -6,7 +6,6 @@
 declare module 'ember-cli-flash/services/flash-messages' {
   import Service from '@ember/service';
   import FlashObject from 'ember-cli-flash/flash/object';
-  import { A } from '@ember/array';
 
   type Partial<T> = { [K in keyof T]?: T[K] };
 
@@ -31,7 +30,7 @@ declare module 'ember-cli-flash/services/flash-messages' {
   }
 
   class FlashMessageService extends Service {
-    queue: A<FlashObject>;
+    queue: FlashObject[];
     success: FlashFunction;
     warning: FlashFunction;
     info: FlashFunction;


### PR DESCRIPTION
[Ember-Data 4.12](https://api.emberjs.com/ember-data/4.12/classes/CurrentDeprecations/properties/DEPRECATE_A_USAGE?anchor=DEPRECATE_A_USAGE) deprecated the use of `A()`, on ember-data ArrayLike class, so this PR removes `A()` instances. filterBy was already replaced in a [prior PR](https://github.com/hashicorp/vault/pull/25674)

- [x] Ent tests pass locally