### PR TITLE
Extra information about how to escape an @ as the first char in kv value

### DIFF
--- a/website/content/docs/commands/index.mdx
+++ b/website/content/docs/commands/index.mdx
@@ -214,8 +214,8 @@ Or specify the contents of a file as a value:
 $ vault kv put secret/password value=@data.txt
 ```
 
-If you intend the value supplied to begin with an `@` character, then escaping
-using a `\` will instruct Vault not to attempt to parse the value as a file location:
+To use values that begin with an `@` character, escape the character with a
+backslash (`\`) to keep Vault from parsing the value as a file location:
 
 ```shell-session
 $ vault login -method userpass username="mitchellh" password="\@foo"

--- a/website/content/docs/commands/index.mdx
+++ b/website/content/docs/commands/index.mdx
@@ -214,6 +214,13 @@ Or specify the contents of a file as a value:
 $ vault kv put secret/password value=@data.txt
 ```
 
+If you intend the value supplied to begin with an `@` character, then escaping
+using a `\` will instruct Vault not to attempt to parse the value as a file location:
+
+```shell-session
+$ vault login -method userpass username="mitchellh" password="\@foo"
+```
+
 Note that if an argument is supplied in a @key=value format, Vault will treat that as a
 kv pair with the key being `@key`, not a file called `key=value`. This also means that Vault
 does not support filenames with `=` in them.
@@ -272,8 +279,8 @@ this file at any time to "logout" of Vault.
 
 The CLI reads the following environment variables to set behavioral defaults.
 This can alleviate the need to repetitively type a flag. Flags always take
-precedence over the environment variables. Each of the following environment 
-variables must be set on the Vault process.  In Vault 1.13+, all environment 
+precedence over the environment variables. Each of the following environment
+variables must be set on the Vault process.  In Vault 1.13+, all environment
 variables available to the Vault process will be logged during startup.
 
 ### `VAULT_TOKEN`


### PR DESCRIPTION
See: https://developer.hashicorp.com/vault/docs/commands#files

The Vault CLI interprets `@` as the first part of a value or as an entire k/v pair to mean it should parse the contents of the file location following the symbol.

This has caused issues for users that intend to supply a value beginning with `@` (the literal character), this PR updates the commands documentation to give users a hint as to how they should deal with that situation.

For an example of this causing friction please see: https://github.com/hashicorp/vault/issues/25787.