### PR TITLE
Fix duplication of OpenAPI operation ids in sys/well-known list apis

### DIFF
--- a/vault/logical_system_paths.go
+++ b/vault/logical_system_paths.go
@@ -5206,14 +5206,14 @@ func (b *SystemBackend) wellKnownPaths() []*framework.Path {
 		{
 			Pattern: "well-known/?$",
 
-			DisplayAttrs: &framework.DisplayAttributes{
-				OperationPrefix: "well-known",
-				OperationVerb:   "list",
-			},
-
 			Operations: map[logical.Operation]framework.OperationHandler{
 				logical.ReadOperation: &framework.PathOperation{
 					Callback: b.handleWellKnownList(),
+					DisplayAttrs: &framework.DisplayAttributes{
+						OperationPrefix: "well-known",
+						OperationVerb:   "list",
+						OperationSuffix: "labels-2",
+					},
 					Responses: map[int][]framework.Response{
 						http.StatusOK: {{
 							Description: "OK",
@@ -5228,6 +5228,11 @@ func (b *SystemBackend) wellKnownPaths() []*framework.Path {
 				},
 				logical.ListOperation: &framework.PathOperation{
 					Callback: b.handleWellKnownList(),
+					DisplayAttrs: &framework.DisplayAttributes{
+						OperationPrefix: "well-known",
+						OperationVerb:   "list",
+						OperationSuffix: "labels",
+					},
 					Responses: map[int][]framework.Response{
 						http.StatusOK: {{
 							Description: "OK",


### PR DESCRIPTION
 - The `well-known-list` operation id was duplicated across different API endpoints, for the `sys/well-known` list operations, GET and LIST verbs.
 - Separate each endpoint operation id so the LIST version uses `well-known-list-labels` and the GET version uses `well-known-list-labels2`

