### PR TITLE
VAULT-24450: Make Audit Filtering 'Enterprise Only' in documentation

### DIFF
--- a/website/content/docs/concepts/filtering.mdx
+++ b/website/content/docs/concepts/filtering.mdx
@@ -7,6 +7,8 @@ description: >-
 
 # Filter expressions in Vault
 
+<EnterpriseAlert product="vault" />
+
 Filter expressions use matching operators and selector values to parse
 out important or relevant information. In some situations, you can use filter
 expressions to control how Vault processes results.

--- a/website/content/docs/enterprise/audit/filtering.mdx
+++ b/website/content/docs/enterprise/audit/filtering.mdx
@@ -2,26 +2,28 @@
 layout: docs
 page_title: Filter syntax for audit results
 description: >-
-  Learn about the behavior and syntax for filtering audit data.
+  Learn about the behavior and syntax for filtering audit data in Vault Enterprise.
 ---
 
 # Filter syntax for audit results
 
+<EnterpriseAlert product="vault" />
+
 As of Vault 1.16.0, you can enable audit devices with a `filter` option to limit
 the audit entries written to a particular audit log and fine-tune your auditing
-process. 
+process.
 
 <Warning title="Proceed with caution">
 
   Filtering audit logs is an advanced feature. Exclusively enabling filtered
   devices without configuring an audit fallback may lead to gaps in your audit
   logs.
-  
+
   **Always** test your audit configuration in a non-production environment
   before deploying filters to production. And make sure to read the
   [Vault security model](/vault/docs/internals/security) and
   [filtering overview](/vault/docs/concepts/filtering) to familiarize yourself
-  with Vault auditing and filtering basics before enabling filtered audit 
+  with Vault auditing and filtering basics before enabling filtered audit
   devices.
 
 </Warning>
@@ -32,7 +34,7 @@ audit entries that match the filter are written to the audit log for the device.
 
 When you enable filtered audit devices, the behavior of any existing audit
 device and the behavior of new audit devices that **do not** use filters remain
-unchanged. 
+unchanged.
 
 ## Fallback auditing devices
 
@@ -70,7 +72,7 @@ Vault emits a
 
 If you enable filtering **without** a fallback device, Vault emits a
 [fallback 'miss' metric](/vault/docs/internals/telemetry/metrics/audit#vault-audit-fallback-miss)
-metric anytime an audit entry would have been written to the fallback so you can
+metric anytime an audit entry would have been written to the fallback device, so you can
 track how many auditable events you have lost.
 
 ## Audit device limitations
@@ -88,7 +90,7 @@ By default, Vault sends a test message to the audit device when you enable it.
 Depending on how you configure your filters, the default test message may fail
 the predicate expression and not write to the new device.
 
-You can determine whether the test message should appear in the sink for the 
+You can determine whether the test message should appear in the sink for the
 newly enabled audit device based on the following property
 table, which are common to all default test messages.
 

--- a/website/content/partials/audit-options-common.mdx
+++ b/website/content/partials/audit-options-common.mdx
@@ -1,11 +1,11 @@
 - `elide_list_responses` `(bool: false)` - See [Eliding list response
 bodies](/vault/docs/audit#eliding-list-response-bodies).
 
-- `fallback` `(bool: false)` - Indicates whether the audit device is the
+- `fallback` `(bool: false)` - (**Enterprise only**) Indicates whether the audit device is the
 fallback for filtering purposes. **Vault only supports one fallback audit
 device at a time**.
 
-- `filter` `(string: "")` - Sets an optional string used to filter the audit
+- `filter` `(string: "")` - (**Enterprise only**) Sets an optional string used to filter the audit
 entries logged by the audit device.  See the [filtering](/vault/docs/concepts/filtering/audit)
 section of the auditing overview for more information.
 

--- a/website/content/partials/telemetry-metrics/vault/audit/fallback_miss.mdx
+++ b/website/content/partials/telemetry-metrics/vault/audit/fallback_miss.mdx
@@ -1,5 +1,5 @@
 ### vault.audit.fallback.miss ((#vault-audit-fallback_miss))
 
-| Metric type | Value  | Description                                                                            |
-|-------------|--------|----------------------------------------------------------------------------------------|
-| counter     | number | Number of times Vault filtered out an audit entry such that no devices were written to |
+| Metric type | Value  | Description                                                                                                  |
+|-------------|--------|--------------------------------------------------------------------------------------------------------------|
+| counter     | number | Number of times Vault filtered out an audit entry such that no devices were written to (**Enterprise only**) |

--- a/website/content/partials/telemetry-metrics/vault/audit/fallback_success.mdx
+++ b/website/content/partials/telemetry-metrics/vault/audit/fallback_success.mdx
@@ -1,5 +1,5 @@
 ### vault.audit.fallback.success ((#vault-audit-fallback_failure))
 
-| Metric type | Value  | Description                                              |
-|-------------|--------|----------------------------------------------------------|
-| counter     | number | Number of times the fallback audit device was written to |
+| Metric type | Value  | Description                                                                    |
+|-------------|--------|--------------------------------------------------------------------------------|
+| counter     | number | Number of times the fallback audit device was written to (**Enterprise only**) |

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -290,16 +290,12 @@
       },
       {
         "title": "Filtering",
-        "routes": [
-          {
-            "title": "Overview",
-            "path": "concepts/filtering"
-          },
-          {
-            "title": "Audit Filtering",
-            "path": "concepts/filtering/audit"
-          }
-        ]
+        "path": "concepts/filtering",
+        "badge": {
+          "text": "ENTERPRISE",
+          "type": "outlined",
+          "color": "neutral"
+        }
       },
       {
         "title": "Request Limiter",
@@ -2745,6 +2741,15 @@
       {
         "title": "Eventual Consistency",
         "path": "enterprise/consistency"
+      },
+      {
+        "title": "Audit",
+        "routes": [
+          {
+            "title": "Audit Filtering",
+            "path": "enterprise/audit/filtering"
+          }
+        ]
       },
       {
         "title": "Control Groups",


### PR DESCRIPTION
Q: Is there a nice way to mark metrics or cmd options as 'Ent only' in the way we do in the nav bar with the badge?
