### PR TITLE
[QT-683] only create artifact metadata on changes that build artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -381,12 +381,14 @@ jobs:
               ]
             }
       - uses: hashicorp/actions-generate-metadata@v1
+        if: needs.artifacts.result == 'success' # create build metadata if we successfully created artifacts
         id: generate-metadata-file
         with:
           version: ${{ needs.setup.outputs.vault-version-metadata }}
           product: ${{ needs.setup.outputs.vault-binary-name }}
       # Use actions/upload-artifact @3.x until https://hashicorp.atlassian.net/browse/HREL-99 is resolved
       - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+        if: steps.generate-metadata-file.outcome == 'success' # upload our metadata if we created it
         with:
           name: metadata.json
           path: ${{ steps.generate-metadata-file.outputs.filepath }}


### PR DESCRIPTION
On docs only changes, or any other changes where we don’t build artifacts, we need to skip building a metadata file so that the prepare workflow can short circuit before attempting to notarize, sign, and upload artifacts.