### PR TITLE
Secret sync modal language and link change

### DIFF
--- a/ui/lib/sync/addon/components/secrets/page/overview.hbs
+++ b/ui/lib/sync/addon/components/secrets/page/overview.hbs
@@ -180,7 +180,7 @@
 {{#if this.showActivateSecretsSyncModal}}
   <Hds::Modal @onClose={{fn (mut this.showActivateSecretsSyncModal) false}} data-test-secrets-sync-opt-in-modal as |M|>
     <M.Header @icon="alert-triangle">
-      Enable secrets sync feature
+      Enable Secrets sync feature
     </M.Header>
     <M.Body>
       <p class="has-bottom-margin-m">

--- a/ui/lib/sync/addon/components/secrets/page/overview.hbs
+++ b/ui/lib/sync/addon/components/secrets/page/overview.hbs
@@ -185,7 +185,10 @@
     <M.Body>
       <p class="has-bottom-margin-m">
         By enabling the Secret Sync feature you may incur additional costs. Please review our
-        <DocLink @path="/hcp/docs/vault/client">documentation</DocLink>
+        <Hds::Link::Inline
+          @isHrefExternal={{true}}
+          @href={{doc-link "/hcp/docs/vault/client"}}
+        >documentation</Hds::Link::Inline>
         to learn more.
       </p>
       <Hds::Form::Checkbox::Field {{on "change" this.onDocsConfirmChange}} data-test-opt-in-check as |F|>

--- a/ui/lib/sync/addon/components/secrets/page/overview.hbs
+++ b/ui/lib/sync/addon/components/secrets/page/overview.hbs
@@ -184,9 +184,9 @@
     </M.Header>
     <M.Body>
       <p class="has-bottom-margin-m">
-        Before using this feature, we want to make sure you’ve carefully read the document around the billing and client
-        count impact.
-        <DocLink @path="/vault/docs/sync">Docs here.</DocLink>
+        By enabling the Secret Sync feature you may incur additional costs. Please review our
+        <DocLink @path="/hcp/docs/vault/client">documentation</DocLink>
+        to learn more.
       </p>
       <Hds::Form::Checkbox::Field {{on "change" this.onDocsConfirmChange}} data-test-opt-in-check as |F|>
         <F.Label>I've read the above linked document</F.Label>

--- a/ui/lib/sync/addon/components/secrets/page/overview.hbs
+++ b/ui/lib/sync/addon/components/secrets/page/overview.hbs
@@ -184,7 +184,7 @@
     </M.Header>
     <M.Body>
       <p class="has-bottom-margin-m">
-        By enabling the Secret Sync feature you may incur additional costs. Please review our
+        By enabling the Secrets sync feature you may incur additional costs. Please review our
         <Hds::Link::Inline
           @isHrefExternal={{true}}
           @href={{doc-link "/hcp/docs/vault/client"}}

--- a/ui/lib/sync/addon/components/secrets/page/overview.hbs
+++ b/ui/lib/sync/addon/components/secrets/page/overview.hbs
@@ -5,7 +5,7 @@
 
 {{#unless this.isActivated}}
   <Hds::Alert @type="inline" @color="warning" data-test-secrets-sync-opt-in-banner as |A|>
-    <A.Title>Enable secrets sync feature</A.Title>
+    <A.Title>Enable Secrets Sync feature</A.Title>
     <A.Description>To use this feature, specific activation is required. Please review the feature documentation and enable
       it. If you're upgrading from beta, your previous data will be accessible after activation.</A.Description>
     <A.Button
@@ -63,7 +63,7 @@
         <Hds::Link::Standalone
           @icon="docs-link"
           @iconPosition="trailing"
-          @text="Secrets sync association API docs"
+          @text="Secrets Sync association API docs"
           @href={{doc-link "/vault/api-docs/system/secrets-sync#read-associations"}}
         />
       </EmptyState>
@@ -180,11 +180,11 @@
 {{#if this.showActivateSecretsSyncModal}}
   <Hds::Modal @onClose={{fn (mut this.showActivateSecretsSyncModal) false}} data-test-secrets-sync-opt-in-modal as |M|>
     <M.Header @icon="alert-triangle">
-      Enable Secrets sync feature
+      Enable Secrets Sync feature
     </M.Header>
     <M.Body>
       <p class="has-bottom-margin-m">
-        By enabling the Secrets sync feature you may incur additional costs. Please review our
+        By enabling the Secrets Sync feature you may incur additional costs. Please review our
         <Hds::Link::Inline
           @isHrefExternal={{true}}
           @href={{doc-link "/hcp/docs/vault/client"}}

--- a/ui/lib/sync/addon/components/secrets/page/overview.ts
+++ b/ui/lib/sync/addon/components/secrets/page/overview.ts
@@ -79,10 +79,11 @@ export default class SyncSecretsDestinationsPageComponent extends Component<Args
       yield this.store
         .adapterFor('application')
         .ajax('/v1/sys/activation-flags/secrets-sync/activate', 'POST');
-      this.showActivateSecretsSyncModal = false;
       this.router.transitionTo('vault.cluster.sync.secrets.overview');
     } catch (error) {
       this.flashMessages.danger(`Error enabling feature \n ${errorMessage(error)}`);
+    } finally {
+      this.showActivateSecretsSyncModal = false;
     }
   }
 }


### PR DESCRIPTION
New link: https://developer.hashicorp.com/hcp/docs/vault/client

And new language to modal:
![image](https://github.com/hashicorp/vault/assets/6618863/12ce6392-9a0b-4aad-94ad-c1008c2649d1)
