### PR TITLE
UI: Remove leading slash from kv version 2 secret path

### DIFF
--- a/changelog/25874.txt
+++ b/changelog/25874.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: remove leading slash from KV version 2 secret paths
+```

--- a/ui/app/utils/kv-path.ts
+++ b/ui/app/utils/kv-path.ts
@@ -8,10 +8,13 @@
  * Additional methods for building URLs for other KV-V2 actions
  */
 
+import { sanitizeStart } from 'core/utils/sanitize-path';
 import { encodePath } from 'vault/utils/path-encoding-helpers';
 
-function buildKvPath(backend: string, path: string, type: string, version?: number | string) {
-  const url = `${encodePath(backend)}/${type}/${encodePath(path)}`;
+// only exported for testing
+export function buildKvPath(backend: string, path: string, type: string, version?: number | string) {
+  const sanitizedPath = sanitizeStart(path); // removing leading slashes
+  const url = `${encodePath(backend)}/${type}/${encodePath(sanitizedPath)}`;
   return version ? `${url}?version=${version}` : url;
 }
 

--- a/ui/lib/core/app/utils/sanitize-path.js
+++ b/ui/lib/core/app/utils/sanitize-path.js
@@ -3,4 +3,4 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-export { ensureTrailingSlash, sanitizePath, getRelativePath } from 'core/utils/sanitize-path';
+export { ensureTrailingSlash, sanitizePath, sanitizeStart, getRelativePath } from 'core/utils/sanitize-path';

--- a/ui/tests/unit/utils/kv-path-test.js
+++ b/ui/tests/unit/utils/kv-path-test.js
@@ -3,10 +3,28 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { kvDataPath, kvDestroyPath, kvMetadataPath, kvUndeletePath } from 'vault/utils/kv-path';
+import { buildKvPath, kvDataPath, kvDestroyPath, kvMetadataPath, kvUndeletePath } from 'vault/utils/kv-path';
 import { module, test } from 'qunit';
 
 module('Unit | Utility | kv-path utils', function () {
+  test('buildKvPath encodes and sanitizes path', function (assert) {
+    assert.expect(4);
+
+    assert.strictEqual(
+      buildKvPath('my-backend', '//my-secret/hello ', 'metadata'),
+      'my-backend/metadata/my-secret/hello'
+    );
+    assert.strictEqual(
+      buildKvPath('my-backend', 'my-secret/hello ', 'data'),
+      'my-backend/data/my-secret/hello'
+    );
+    assert.strictEqual(
+      buildKvPath('kv?engine', 'my-secret hello ', 'data'),
+      'kv%3Fengine/data/my-secret%20hello'
+    );
+    assert.strictEqual(buildKvPath('kv-engine', 'foo', 'data', 2), 'kv-engine/data/foo?version=2');
+  });
+
   module('kvDataPath', function () {
     [
       {


### PR DESCRIPTION
Typically we avoid sanitizing in the UI to minimize data manipulation, however we decided to strip secret paths of the leading slash to copy CLI functionality. 

```
 vault kv put -mount=kv /my-secret foo=my-long-passcode
== Secret Path ==
kv/data/my-secret

======= Metadata =======
Key                Value
---                -----
created_time       2024-03-11T16:59:42.502882Z
custom_metadata    <nil>
deletion_time      n/a
destroyed          false
version            1
⇒ vault kv put -mount=kv //my-secret foo=my-long-passcode
== Secret Path ==
kv/data/my-secret

======= Metadata =======
Key                Value
---                -----
created_time       2024-03-11T17:00:01.047652Z
custom_metadata    <nil>
deletion_time      n/a
destroyed          false
version            2
