### PR TITLE
Add clarification to quota docs regarding parent ns access

### DIFF
--- a/website/content/api-docs/system/lease-count-quotas.mdx
+++ b/website/content/api-docs/system/lease-count-quotas.mdx
@@ -45,7 +45,12 @@ millions of leases in an automated way, it is recommended to space out the creat
   quota can have "moving" effects. For example, updating `namespace1` to
   `namespace1/auth/userpass` moves this quota from being a namespace quota to a
   namespace-specific mount quota. Non-global quotas are not inherited by child
-  namespaces.
+  namespaces. Quotas cannot be created or modified in parent or sibling namespaces.
+  **Note, namespaces are supported in Enterprise only**.
+- `max_leases` `(int: 0)` - Maximum number of leases allowed by the quota rule.
+- `role` `(string: "")` - If set on a quota where `path` is set to an auth mount with a
+- `max_leases` `(int: 0)` - Maximum number of leases allowed by the quota rule.
+- `role` `(string: "")` - If set on a quota where `path` is set to an auth mount with a
 - `max_leases` `(int: 0)` - Maximum number of leases allowed by the quota rule.
 - `role` `(string: "")` - If set on a quota where `path` is set to an auth mount with a
   concept of roles (such as `/auth/approle/`), this will make the quota restrict login
@@ -79,6 +84,7 @@ $ curl \
 ## Delete a lease count quota
 
 A lease count quota can be deleted by `name`.
+Quotas that exist in a parent or a sibling namespace cannot be deleted.
 
 | Method   | Path                            |
 | :------- | :------------------------------ |
@@ -131,8 +137,10 @@ $ curl \
 
 ## List lease count quotas
 
-This endpoint returns a list of all the lease count quotas. A 404 response will
-be returned if no lease count quota has been created.
+This endpoint returns a list of all the lease count quotas across all namespaces.
+The global visibility differs from the restricted access enforced when modifying
+and deleting rate limit quotas within parent or sibling namespaces. A 404
+response will be returned if no lease count quota has been created.
 
 | Method | Path                      |
 | :----- | :------------------------ |

--- a/website/content/api-docs/system/lease-count-quotas.mdx
+++ b/website/content/api-docs/system/lease-count-quotas.mdx
@@ -138,9 +138,9 @@ $ curl \
 ## List lease count quotas
 
 This endpoint returns a list of all the lease count quotas across all namespaces.
-The global visibility differs from the restricted access enforced when modifying
-and deleting rate limit quotas within parent or sibling namespaces. A 404
-response will be returned if no lease count quota has been created.
+Note that this level of access differs from creating, updating, and deleting
+quotas which restricts access to parent and sibling namespaces. A 404 response
+will be returned if no lease count quota has been created.
 
 | Method | Path                      |
 | :----- | :------------------------ |

--- a/website/content/api-docs/system/rate-limit-quotas.mdx
+++ b/website/content/api-docs/system/rate-limit-quotas.mdx
@@ -134,9 +134,9 @@ $ curl \
 
 ## List rate limit quotas
 
-This endpoint returns a list of all the rate limit quotas across all namespaces.
-The global visibility differs from the restricted access enforced when modifying
-and deleting rate limit quotas within parent or sibling namespaces.
+This endpoint returns a list of all the lease count quotas across all namespaces.
+Note that this level of access differs from creating, updating, and deleting
+quotas which restricts access to parent and sibling namespaces.
 
 | Method | Path                     |
 | :----- | :----------------------- |

--- a/website/content/api-docs/system/rate-limit-quotas.mdx
+++ b/website/content/api-docs/system/rate-limit-quotas.mdx
@@ -35,7 +35,8 @@ the mount to restrict more specific API paths.
   an existing quota can have "moving" effects. For example, updating `namespace1` to
   `namespace1/auth/userpass` moves this quota from being a namespace quota to a
   namespace specific mount quota. Non-global quotas are not inherited by child
-  namespaces. **Note, namespaces are supported in Enterprise only**.
+  namespaces. Quotas cannot be created or modified in parent or sibling namespaces.
+  **Note, namespaces are supported in Enterprise only**.
 - `rate` `(float: 0.0)` - The maximum number of requests in a given interval to
   be allowed by the quota rule. The `rate` must be positive.
 - `interval` `(string: "")` - The duration to enforce rate limiting for (default `"1s"`).
@@ -75,6 +76,7 @@ $ curl \
 ## Delete a rate limit quota
 
 A rate limit quota can be deleted by `name`.
+Quotas that exist in a parent or a sibling namespace cannot be deleted.
 
 | Method   | Path                           |
 | :------- | :----------------------------- |
@@ -92,6 +94,9 @@ $ curl \
 ## Get a rate limit quota
 
 A rate limit quota can be retrieved by `name`.
+A quota can be read from any namespace. This behavior differs
+from modifying and deleting quotas which is not allowed within parent
+or sibling namespaces.
 
 | Method | Path                           |
 | :----- | :----------------------------- |
@@ -129,7 +134,9 @@ $ curl \
 
 ## List rate limit quotas
 
-This endpoint returns a list of all the rate limit quotas.
+This endpoint returns a list of all the rate limit quotas across all namespaces.
+The global visibility differs from the restricted access enforced when modifying
+and deleting rate limit quotas within parent or sibling namespaces.
 
 | Method | Path                     |
 | :----- | :----------------------- |


### PR DESCRIPTION
Creating, updating, and deleting quotas within a parent or sibling namespace is not allowed. Reading and listing, however, is. This PR introduces a few small documentation changes to clarify this difference for both rate limit and lease count quota API endpoints.