### PR TITLE
Fix typo in rate limit quota API docs

### DIFF
--- a/website/content/api-docs/system/rate-limit-quotas.mdx
+++ b/website/content/api-docs/system/rate-limit-quotas.mdx
@@ -134,7 +134,7 @@ $ curl \
 
 ## List rate limit quotas
 
-This endpoint returns a list of all the lease count quotas across all namespaces.
+This endpoint returns a list of all the rate limit quotas across all namespaces.
 Note that this level of access differs from creating, updating, and deleting
 quotas which restricts access to parent and sibling namespaces.
 


### PR DESCRIPTION
This is a followup to https://github.com/hashicorp/vault/pull/25894 in order to fix a typo.