### PR TITLE
Update docs for VSO v0.5.2

### DIFF
--- a/website/content/docs/platform/k8s/vso/api-reference.mdx
+++ b/website/content/docs/platform/k8s/vso/api-reference.mdx
@@ -608,6 +608,7 @@ _Appears in:_
 | `allowStaticCreds` _boolean_ | AllowStaticCreds should be set when syncing credentials that are periodically rotated by the Vault server, rather than created upon request. These secrets are sometimes referred to as "static roles", or "static credentials", with a request path that contains "static-creds". |
 | `rolloutRestartTargets` _[RolloutRestartTarget](#rolloutrestarttarget) array_ | RolloutRestartTargets should be configured whenever the application(s) consuming the Vault secret does not support dynamically reloading a rotated secret. In that case one, or more RolloutRestartTarget(s) can be configured here. The Operator will trigger a "rollout-restart" for each target whenever the Vault secret changes between reconciliation events. See RolloutRestartTarget for more details. |
 | `destination` _[Destination](#destination)_ | Destination provides configuration necessary for syncing the Vault secret to Kubernetes. |
+| `refreshAfter` _string_ | RefreshAfter a period of time for VSO to sync the source secret data, in duration notation e.g. 30s, 1m, 24h. This value only needs to be set when syncing from a secret's engine that does not provide a lease TTL in its response. The value should be within the secret engine's configured ttl or max_ttl. The source secret's lease duration takes precedence over this configuration when it is greater than 0. |
 
 
 

--- a/website/content/docs/platform/k8s/vso/helm.mdx
+++ b/website/content/docs/platform/k8s/vso/helm.mdx
@@ -11,7 +11,7 @@ The chart is customizable using
 [Helm configuration values](https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing).
 
 <!-- DO NOT EDIT. The docs below are generated automatically. To change, edit
-                  the vault-secrets-operator repo's values.yaml: file commit=12d914f6ad83b28d56bc629cde6cbfd5ce1475f0 -->
+                  the vault-secrets-operator repo's values.yaml: file commit=787f43ac8f6e9a8c57e9a5d1f915fe2ec04abd6c -->
 <!-- codegen: start -->
 
 ## Top-Level Stanzas
@@ -123,9 +123,12 @@ Use these links to navigate to a particular top-level stanza.
 
       - `repository` ((#v-controller-manager-image-repository)) (`string: hashicorp/vault-secrets-operator`)
 
-      - `tag` ((#v-controller-manager-image-tag)) (`string: 0.5.1`)
+      - `tag` ((#v-controller-manager-image-tag)) (`string: 0.5.2`)
 
-    - `globalTransformationOptions` ((#v-controller-manager-globaltransformationoptions)) (`array<string>: ""`) - Global secret transformation options.
+    - `globalTransformationOptions` ((#v-controller-manager-globaltransformationoptions)) - Global secret transformation options. In addition to the boolean options
+      below, these options may be set via the
+      `VSO_GLOBAL_TRANSFORMATION_OPTIONS` environment variable as a
+      comma-separated list. Valid values are: `exclude-raw`
 
       - `excludeRaw` ((#v-controller-manager-globaltransformationoptions-excluderaw)) (`boolean: false`) - excludeRaw directs the operator to prevent _raw secret data being stored
         in the destination K8s Secret.

--- a/website/content/docs/platform/k8s/vso/installation.mdx
+++ b/website/content/docs/platform/k8s/vso/installation.mdx
@@ -31,13 +31,13 @@ $ helm repo add hashicorp https://helm.releases.hashicorp.com
 ```shell-session
 $ helm search repo hashicorp/vault-secrets-operator
 NAME           	CHART VERSION	APP VERSION	DESCRIPTION
-hashicorp/vault-secrets-operator	0.5.1       	0.5.1     	Official HashiCorp Vault Secrets Operator Chart
+hashicorp/vault-secrets-operator	0.5.2       	0.5.2     	Official HashiCorp Vault Secrets Operator Chart
 ```
 
 Then install the Operator:
 
 ```shell-session
-$ helm install --version 0.5.1 --create-namespace --namespace vault-secrets-operator vault-secrets-operator hashicorp/vault-secrets-operator
+$ helm install --version 0.5.2 --create-namespace --namespace vault-secrets-operator vault-secrets-operator hashicorp/vault-secrets-operator
 ```
 
 ## Upgrading using Helm
@@ -65,10 +65,10 @@ $ helm show crds --version <TARGET_VSO_VERSION> hashicorp/vault-secrets-operator
 $ helm upgrade --version <TARGET_VSO_VERSION> --namespace vault-secrets-operator vault-secrets-operator hashicorp/vault-secrets-operator
 ```
 
-For example, if you are upgrading to VSO 0.5.1:
+For example, if you are upgrading to VSO 0.5.2:
 ```shell-session
-$ helm show crds --version 0.5.1 hashicorp/vault-secrets-operator | kubectl apply -f -
-$ helm upgrade --version 0.5.1 --namespace vault-secrets-operator vault-secrets-operator hashicorp/vault-secrets-operator
+$ helm show crds --version 0.5.2 hashicorp/vault-secrets-operator | kubectl apply -f -
+$ helm upgrade --version 0.5.2 --namespace vault-secrets-operator vault-secrets-operator hashicorp/vault-secrets-operator
 ```
 
 ## Updating CRDs when using Helm
@@ -83,9 +83,9 @@ To update the VSO CRDs, replace `<TARGET_VSO_VERSION>` with the VSO version you 
 $ helm show crds --version <TARGET_VSO_VERSION> hashicorp/vault-secrets-operator | kubectl apply -f -
 ```
 
-For example, if you are upgrading to VSO 0.5.1:
+For example, if you are upgrading to VSO 0.5.2:
 ```shell-session
-$ helm show crds --version 0.5.1 hashicorp/vault-secrets-operator | kubectl apply -f -
+$ helm show crds --version 0.5.2 hashicorp/vault-secrets-operator | kubectl apply -f -
 
 customresourcedefinition.apiextensions.k8s.io/hcpauths.secrets.hashicorp.com created
 customresourcedefinition.apiextensions.k8s.io/hcpvaultsecretsapps.secrets.hashicorp.com created
@@ -112,9 +112,9 @@ You can install and update your installation using `kustomize` which allows you 
 
 To install using Kustomize, download and untar/unzip the latest release from the [Releases Page](https://github.com/hashicorp/vault-secrets-operator/releases).
 ```shell-session
-$ wget -q https://github.com/hashicorp/vault-secrets-operator/archive/refs/tags/v0.5.1.tar.gz
-$ tar -zxf v0.5.1.tar.gz
-$ cd vault-secrets-operator-0.5.1/
+$ wget -q https://github.com/hashicorp/vault-secrets-operator/archive/refs/tags/v0.5.2.tar.gz
+$ tar -zxf v0.5.2.tar.gz
+$ cd vault-secrets-operator-0.5.2/
 ```
 
 Next install using `kustomize build`:

--- a/website/content/docs/platform/k8s/vso/openshift.mdx
+++ b/website/content/docs/platform/k8s/vso/openshift.mdx
@@ -32,7 +32,7 @@ The Vault Secrets Operator may also be installed in OpenShift using the Helm cha
 $ helm install vault-secrets-operator hashicorp/vault-secrets-operator \
   --create-namespace \
   --namespace vault-secrets-operator \
-  --version 0.5.1 \
+  --version 0.5.2 \
   --values values.yaml
 ```
 
@@ -65,7 +65,7 @@ controller:
   manager:
     image:
       repository: registry.connect.redhat.com/hashicorp/vault-secrets-operator
-      tag: 0.5.1-ubi
+      tag: 0.5.2-ubi
     resources:
       limits:
         memory: 256Mi


### PR DESCRIPTION
Docs update for the VSO [v0.5.2](https://github.com/hashicorp/vault-secrets-operator/milestone/21) release.