### PR TITLE
update HDS and ember-flight-icons

### DIFF
--- a/ui/app/components/database-connection.js
+++ b/ui/app/components/database-connection.js
@@ -7,6 +7,7 @@ import Component from '@glimmer/component';
 import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
+import { waitFor } from '@ember/test-waiters';
 
 const LIST_ROOT_ROUTE = 'vault.cluster.secrets.backend.list-root';
 const SHOW_ROUTE = 'vault.cluster.secrets.backend.show';
@@ -78,18 +79,18 @@ export default class DatabaseConnectionEdit extends Component {
   }
 
   @action
-  continueWithRotate() {
+  @waitFor
+  async continueWithRotate() {
     this.showSaveModal = false;
     const { backend, name } = this.args.model;
-    this.rotateCredentials(backend, name)
-      .then(() => {
-        this.flashMessages.success(`Successfully rotated root credentials for connection "${name}"`);
-        this.transitionToRoute(SHOW_ROUTE, name);
-      })
-      .catch((e) => {
-        this.flashMessages.danger(`Error rotating root credentials: ${e.errors}`);
-        this.transitionToRoute(SHOW_ROUTE, name);
-      });
+    try {
+      await this.rotateCredentials(backend, name);
+      this.flashMessages.success(`Successfully rotated root credentials for connection "${name}"`);
+      this.transitionToRoute(SHOW_ROUTE, name);
+    } catch (e) {
+      this.flashMessages.danger(`Error rotating root credentials: ${e.errors}`);
+      this.transitionToRoute(SHOW_ROUTE, name);
+    }
   }
 
   @action

--- a/ui/app/components/resultant-acl-banner.hbs
+++ b/ui/app/components/resultant-acl-banner.hbs
@@ -16,7 +16,7 @@
       {{this.message}}
     </A.Description>
     {{#if @isEnterprise}}
-      <A.Link::Standalone
+      <A.LinkStandalone
         @icon="arrow-right"
         @iconPosition="trailing"
         @text={{concat "Log into " this.ns " namespace"}}

--- a/ui/app/components/token-expire-warning.hbs
+++ b/ui/app/components/token-expire-warning.hbs
@@ -10,7 +10,7 @@
       Your auth token expired on
       {{date-format @expirationDate "MMMM do yyyy, h:mm:ss a"}}. You will need to re-authenticate.
     </A.Description>
-    <A.Link::Standalone
+    <A.LinkStandalone
       @icon="arrow-right"
       @iconPosition="trailing"
       @text="Reauthenticate"
@@ -46,7 +46,7 @@
             {{on "click" (perform this.renewToken)}}
             data-test-renew-token-button
           />
-          <A.Link::Standalone
+          <A.LinkStandalone
             @icon="arrow-right"
             @iconPosition="trailing"
             @color="secondary"

--- a/ui/app/templates/vault/cluster.hbs
+++ b/ui/app/templates/vault/cluster.hbs
@@ -21,7 +21,7 @@
         {{/each}}
         {{#unless (is-empty-value bannerMessage.link)}}
           {{#each-in bannerMessage.link as |title href|}}
-            <A.Link::Standalone
+            <A.LinkStandalone
               @color="secondary"
               @icon="external-link"
               @isHrefExternal={{true}}

--- a/ui/ember-cli-build.js
+++ b/ui/ember-cli-build.js
@@ -47,7 +47,8 @@ const appConfig = {
     onlyIncluded: true,
     precision: 4,
     includePaths: [
-      './node_modules/@hashicorp/design-system-components/app/styles',
+      './node_modules/@hashicorp/design-system-components/dist/styles',
+      './node_modules/@hashicorp/ember-flight-icons/dist/styles',
       './node_modules/@hashicorp/design-system-tokens/dist/products/css',
     ],
   },

--- a/ui/lib/config-ui/addon/components/messages/preview-image.hbs
+++ b/ui/lib/config-ui/addon/components/messages/preview-image.hbs
@@ -27,7 +27,7 @@
       {{/each}}
       {{#unless (is-empty-value @message.link)}}
         {{#each-in @message.link as |title href|}}
-          <A.Link::Standalone
+          <A.LinkStandalone
             @color="secondary"
             @icon="external-link"
             @isHrefExternal={{true}}

--- a/ui/lib/core/addon/components/form-field.hbs
+++ b/ui/lib/core/addon/components/form-field.hbs
@@ -59,7 +59,7 @@
     {{else if (eq @attr.options.editType "checkboxList")}}
       <Hds::Form::Checkbox::Group @name={{@attr.name}} data-test-input={{@attr.name}} as |G|>
         {{#each @attr.options.possibleValues as |option|}}
-          <G.Checkbox::Field
+          <G.CheckboxField
             class={{if this.validationError "has-error-border"}}
             checked={{includes option (get @model this.valuePath)}}
             @value={{option}}
@@ -68,7 +68,7 @@
             as |F|
           >
             <F.Label>{{option}}</F.Label>
-          </G.Checkbox::Field>
+          </G.CheckboxField>
         {{/each}}
       </Hds::Form::Checkbox::Group>
     {{else}}

--- a/ui/lib/core/addon/templates/components/replication-secondary-card.hbs
+++ b/ui/lib/core/addon/templates/components/replication-secondary-card.hbs
@@ -113,7 +113,7 @@
             @text="These addresses are used by the secondary to communicate with the primary cluster. Should always be non-zero in a functioning replication setup."
           />
           <A.Footer @hasDivider={{true}} as |F|>
-            <F.Link::Standalone
+            <F.LinkStandalone
               @icon="help"
               @text="Learn more about replication"
               @href={{doc-link "/vault/tutorials/monitoring/monitor-replication"}}

--- a/ui/lib/kmip/package.json
+++ b/ui/lib/kmip/package.json
@@ -7,7 +7,8 @@
   "dependencies": {
     "ember-cli-htmlbars": "*",
     "ember-cli-babel": "*",
-    "@hashicorp/design-system-components": "*"
+    "@hashicorp/design-system-components": "*",
+    "ember-auto-import": "*"
 
   },
   "ember-addon": {

--- a/ui/lib/kubernetes/package.json
+++ b/ui/lib/kubernetes/package.json
@@ -10,7 +10,8 @@
     "ember-concurrency": "*",
     "@ember/test-waiters": "*",
     "ember-inflector": "*",
-    "@hashicorp/design-system-components": "*"
+    "@hashicorp/design-system-components": "*",
+    "ember-auto-import": "*"
   },
   "ember-addon": {
     "paths": [

--- a/ui/lib/kv/addon/components/page/secret/details.hbs
+++ b/ui/lib/kv/addon/components/page/secret/details.hbs
@@ -33,7 +33,7 @@
           @color="secondary"
           {{on "click" (perform this.fetchSyncStatus)}}
         />
-        <A.Link::Standalone
+        <A.LinkStandalone
           @isHrefExternal={{true}}
           @icon="docs-link"
           @text="About sync statuses"

--- a/ui/lib/ldap/package.json
+++ b/ui/lib/ldap/package.json
@@ -10,6 +10,7 @@
     "ember-cli-babel": "*",
     "ember-concurrency": "*",
     "@ember/test-waiters": "*",
+    "ember-auto-import": "*",
     "ember-cli-typescript": "*",
     "@types/ember": "latest",
     "@types/ember-data": "latest",

--- a/ui/lib/pki/addon/components/page/pki-issuer-rotate-root.hbs
+++ b/ui/lib/pki/addon/components/page/pki-issuer-rotate-root.hbs
@@ -93,7 +93,7 @@
         If you’re ready, you can begin cross-signing issuers now. If not, the option to cross-sign is available when you use
         this certificate.
       </A.Description>
-      <A.Link::Standalone
+      <A.LinkStandalone
         @icon="arrow-right"
         @iconPosition="trailing"
         @text="Cross-sign issuers"

--- a/ui/lib/pki/package.json
+++ b/ui/lib/pki/package.json
@@ -8,6 +8,7 @@
     "ember-cli-babel": "*",
     "ember-cli-htmlbars": "*",
     "ember-cli-typescript": "*",
+    "ember-auto-import": "*",
     "@hashicorp/design-system-components": "*",
     "@types/ember": "latest",
     "@types/ember-data": "latest",

--- a/ui/lib/replication/package.json
+++ b/ui/lib/replication/package.json
@@ -7,7 +7,8 @@
   "dependencies": {
     "ember-cli-htmlbars": "*",
     "ember-cli-babel": "*",
-    "@hashicorp/design-system-components": "*"
+    "@hashicorp/design-system-components": "*",
+    "ember-auto-import": "*"
   },
   "ember-addon": {
     "paths": [

--- a/ui/lib/sync/package.json
+++ b/ui/lib/sync/package.json
@@ -11,6 +11,7 @@
     "ember-concurrency": "*",
     "@ember/test-waiters": "*",
     "ember-cli-typescript": "*",
+    "ember-auto-import": "*",
     "@types/ember": "latest",
     "@types/ember-data": "latest",
     "@types/ember-data__store": "latest",

--- a/ui/package.json
+++ b/ui/package.json
@@ -124,7 +124,6 @@
     "doctoc": "^2.2.0",
     "dompurify": "^3.0.2",
     "ember-a11y-testing": "^5.2.1",
-    "ember-auto-import": "^2.7.2",
     "ember-basic-dropdown": "6.0.1",
     "ember-cli": "~4.12.1",
     "ember-cli-autoprefixer": "^0.8.1",
@@ -228,7 +227,7 @@
     "underscore": "^1.12.1",
     "trim": "^0.0.3",
     "xmlhttprequest-ssl": "^1.6.2",
-    "@embroider/macros": "^1.0.0",
+    "@embroider/macros": "^1.15.0",
     "socket-io": "^4.6.2"
   },
   "engines": {
@@ -256,8 +255,10 @@
     ]
   },
   "dependencies": {
-    "@hashicorp/design-system-components": "^4.0.0",
-    "@hashicorp/ember-flight-icons": "^5.0.0",
+    "@babel/core": "^7.24.0",
+    "@hashicorp/design-system-components": "^4.1.0",
+    "@hashicorp/ember-flight-icons": "^5.0.1",
+    "ember-auto-import": "^2.7.2",
     "handlebars": "4.7.7",
     "highlight.js": "^10.4.1",
     "node-notifier": "^8.0.1",

--- a/ui/package.json
+++ b/ui/package.json
@@ -124,7 +124,7 @@
     "doctoc": "^2.2.0",
     "dompurify": "^3.0.2",
     "ember-a11y-testing": "^5.2.1",
-    "ember-auto-import": "2.6.3",
+    "ember-auto-import": "^2.7.2",
     "ember-basic-dropdown": "6.0.1",
     "ember-cli": "~4.12.1",
     "ember-cli-autoprefixer": "^0.8.1",
@@ -256,8 +256,8 @@
     ]
   },
   "dependencies": {
-    "@hashicorp/design-system-components": "^3.4.0",
-    "@hashicorp/ember-flight-icons": "^4.0.5",
+    "@hashicorp/design-system-components": "^4.0.0",
+    "@hashicorp/ember-flight-icons": "^5.0.0",
     "handlebars": "4.7.7",
     "highlight.js": "^10.4.1",
     "node-notifier": "^8.0.1",

--- a/ui/tests/integration/components/confirm-modal-test.js
+++ b/ui/tests/integration/components/confirm-modal-test.js
@@ -13,12 +13,13 @@ module('Integration | Component | confirm-modal', function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function () {
-    this.onConfirm = sinon.spy();
-    this.onClose = sinon.spy();
+    this.onConfirm = sinon.stub();
+    this.onClose = sinon.stub();
   });
 
   test('it renders a reasonable default', async function (assert) {
     await render(hbs`<ConfirmModal @onConfirm={{this.onConfirm}} @onClose={{this.onClose}} />`);
+
     assert
       .dom('[data-test-confirm-modal]')
       .hasClass('hds-modal--color-warning', 'renders warning modal color');
@@ -29,9 +30,10 @@ module('Integration | Component | confirm-modal', function (hooks) {
     assert
       .dom('[data-test-confirm-action-message]')
       .hasText('You will not be able to recover it later.', 'renders default body text');
+
     await click('[data-test-confirm-cancel-button]');
-    assert.ok(this.onClose.called, 'calls the onClose action when Cancel is clicked');
+    assert.true(this.onClose.called, 'calls the onClose action when Cancel is clicked');
     await click('[data-test-confirm-button]');
-    assert.ok(this.onConfirm.called, 'calls the onConfirm action when Confirm is clicked');
+    assert.true(this.onConfirm.called, 'calls the onConfirm action when Confirm is clicked');
   });
 });

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -5102,6 +5102,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@embroider/addon-shim@npm:^1.8.6, @embroider/addon-shim@npm:^1.8.7":
+  version: 1.8.7
+  resolution: "@embroider/addon-shim@npm:1.8.7"
+  dependencies:
+    "@embroider/shared-internals": ^2.5.1
+    broccoli-funnel: ^3.0.8
+    semver: ^7.3.8
+  checksum: 2f208adfe1f883a6e7030c2c744c1e8399aaa9423237a87e8d04195f0d2ad947a0d7e37e77232b3021e9c7bdfbc23381606e636183a7953ba952bea78eb15035
+  languageName: node
+  linkType: hard
+
 "@embroider/macros@npm:^1.0.0":
   version: 1.5.0
   resolution: "@embroider/macros@npm:1.5.0"
@@ -5178,6 +5189,23 @@ __metadata:
     semver: ^7.3.5
     typescript-memoize: ^1.0.1
   checksum: bf9f3769af5a66b6e8935257c77fe49678ef0a24ec74b397134598c16f13cd791ac2107008b0ae5dc41d94810f5e15ad318100c03bf1fcb2209a62db966cc483
+  languageName: node
+  linkType: hard
+
+"@embroider/shared-internals@npm:^2.5.1":
+  version: 2.5.2
+  resolution: "@embroider/shared-internals@npm:2.5.2"
+  dependencies:
+    babel-import-util: ^2.0.0
+    debug: ^4.3.2
+    ember-rfc176-data: ^0.3.17
+    fs-extra: ^9.1.0
+    js-string-escape: ^1.0.1
+    lodash: ^4.17.21
+    resolve-package-path: ^4.0.1
+    semver: ^7.3.5
+    typescript-memoize: ^1.0.1
+  checksum: ffa48bc708498f57482d7c1ebca44fccf46543d705a2dab698581ef5dee5f0981a9a67d7df3164940f8de1b7412f20cfd4d6204b13c2945f461660089908fe53
   languageName: node
   linkType: hard
 
@@ -5465,60 +5493,57 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hashicorp/design-system-components@npm:^3.4.0":
-  version: 3.4.0
-  resolution: "@hashicorp/design-system-components@npm:3.4.0"
+"@hashicorp/design-system-components@npm:^4.0.0":
+  version: 4.1.0
+  resolution: "@hashicorp/design-system-components@npm:4.1.0"
   dependencies:
     "@ember/render-modifiers": ^2.0.5
     "@ember/string": ^3.1.1
     "@ember/test-waiters": ^3.1.0
-    "@hashicorp/design-system-tokens": ^1.9.0
-    "@hashicorp/ember-flight-icons": ^4.0.5
-    dialog-polyfill: ^0.5.6
+    "@embroider/addon-shim": ^1.8.7
+    "@hashicorp/design-system-tokens": ^2.1.0
+    "@hashicorp/ember-flight-icons": ^5.0.1
     ember-a11y-refocus: ^3.0.2
-    ember-auto-import: ^2.6.3
-    ember-cached-decorator-polyfill: ^1.0.2
-    ember-cli-babel: ^8.2.0
-    ember-cli-htmlbars: ^6.3.0
     ember-cli-sass: ^11.0.1
     ember-composable-helpers: ^5.0.0
     ember-element-helper: ^0.8.5
     ember-focus-trap: ^1.1.0
     ember-keyboard: ^8.2.1
+    ember-modifier: ^4.1.0
     ember-stargate: ^0.4.3
     ember-style-modifier: ^3.0.1
-    ember-truth-helpers: ^3.1.1
+    ember-truth-helpers: ^4.0.3
     prismjs: ^1.29.0
     sass: ^1.69.5
     tippy.js: ^6.3.7
-  checksum: a206648f67d84849069264a25dd32cd6af0608853018925400958f89c1b590b037408ab38e616c9f8ba9bcc08955c50820c80f5a137164023f30858e472a9008
+  peerDependencies:
+    ember-source: ^3.28.0 || ^4.0.0 || ^5.3.0
+  checksum: d08ba25880985fa8343ed108f168c24449af0c64511f6d95edf6b497ec856a1524d48a7c7c86c93084ced40058f8a07b817dbb517e80fd38107087e2e9219feb
   languageName: node
   linkType: hard
 
-"@hashicorp/design-system-tokens@npm:^1.9.0":
-  version: 1.9.0
-  resolution: "@hashicorp/design-system-tokens@npm:1.9.0"
-  checksum: 72da214205dfca9e49726745e18f8a19674d36d656bd2e4ff3fec42b2ce06fbbba0ad673e6ec2333128e1b9bf67bfac2e4dd792ea37a1534a5040e6a4481855e
+"@hashicorp/design-system-tokens@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "@hashicorp/design-system-tokens@npm:2.1.0"
+  checksum: 4a30f55691267cb962f6f37733b7dc6e2c4ff09d48576c3844e3c9d8a0765bfa49252fd5c6d94434b30a6f015e0b21cd67571e814986e0457eb5a379c9976964
   languageName: node
   linkType: hard
 
-"@hashicorp/ember-flight-icons@npm:^4.0.5":
-  version: 4.0.5
-  resolution: "@hashicorp/ember-flight-icons@npm:4.0.5"
+"@hashicorp/ember-flight-icons@npm:^5.0.0, @hashicorp/ember-flight-icons@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "@hashicorp/ember-flight-icons@npm:5.0.1"
   dependencies:
-    "@hashicorp/flight-icons": ^2.24.0
-    ember-auto-import: ^2.6.3
-    ember-cli-babel: ^8.2.0
-    ember-cli-htmlbars: ^6.3.0
+    "@embroider/addon-shim": ^1.8.7
+    "@hashicorp/flight-icons": ^3.1.0
     ember-get-config: ^2.1.1
-  checksum: 68ed79595fdb7ed2cd9c33260c14f780a358eee9952f228897051f5994daa9e2a366b8f5c9992a2511c9ea0a79a5fefb1ac4e1068707bb8115708f3a91b60af6
+  checksum: b614a00c910cad32dfbf171b3d44db74bb9a31f41a16e1e9e1aed215b6300b1a8cac79f6a633ac638cd9f811055b5ea90313ca9fee5581ba8cd7a1129d2a9d3f
   languageName: node
   linkType: hard
 
-"@hashicorp/flight-icons@npm:^2.24.0":
-  version: 2.24.0
-  resolution: "@hashicorp/flight-icons@npm:2.24.0"
-  checksum: f226e4e4aed2256680a0fd29bfeac215dc9a224f8ce7b532a64cc30917a2739d34e50e84f70d40b05193e5cb2fbbb603b7870d4a0da09c6335c7f94bfb6e18df
+"@hashicorp/flight-icons@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "@hashicorp/flight-icons@npm:3.1.0"
+  checksum: 5853decb3ab2a76c505b6908420820d0fd5810466522ccdc9bb4c380efbf2173a97bbf496878712b10676b4f5117cd7e30cf8602e405d767aa14bc810a0fcabb
   languageName: node
   linkType: hard
 
@@ -12017,13 +12042,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dialog-polyfill@npm:^0.5.6":
-  version: 0.5.6
-  resolution: "dialog-polyfill@npm:0.5.6"
-  checksum: dde8d4b6a62b63b710e0d0d70b615d92ff08f3cb2b521e1f99b17e8220d9d55d0fdf9fc17fbe77b0ff1be817094e14b60c4c4bacd5456fba427ede48d2d90230
-  languageName: node
-  linkType: hard
-
 "diff-match-patch@npm:^1.0.0":
   version: 1.0.5
   resolution: "diff-match-patch@npm:1.0.5"
@@ -12356,45 +12374,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ember-auto-import@npm:2.6.3, ember-auto-import@npm:^2.5.0, ember-auto-import@npm:^2.6.3":
-  version: 2.6.3
-  resolution: "ember-auto-import@npm:2.6.3"
-  dependencies:
-    "@babel/core": ^7.16.7
-    "@babel/plugin-proposal-class-properties": ^7.16.7
-    "@babel/plugin-proposal-decorators": ^7.16.7
-    "@babel/preset-env": ^7.16.7
-    "@embroider/macros": ^1.0.0
-    "@embroider/shared-internals": ^2.0.0
-    babel-loader: ^8.0.6
-    babel-plugin-ember-modules-api-polyfill: ^3.5.0
-    babel-plugin-ember-template-compilation: ^2.0.1
-    babel-plugin-htmlbars-inline-precompile: ^5.2.1
-    babel-plugin-syntax-dynamic-import: ^6.18.0
-    broccoli-debug: ^0.6.4
-    broccoli-funnel: ^3.0.8
-    broccoli-merge-trees: ^4.2.0
-    broccoli-plugin: ^4.0.0
-    broccoli-source: ^3.0.0
-    css-loader: ^5.2.0
-    debug: ^4.3.1
-    fs-extra: ^10.0.0
-    fs-tree-diff: ^2.0.0
-    handlebars: ^4.3.1
-    js-string-escape: ^1.0.1
-    lodash: ^4.17.19
-    mini-css-extract-plugin: ^2.5.2
-    parse5: ^6.0.1
-    resolve: ^1.20.0
-    resolve-package-path: ^4.0.3
-    semver: ^7.3.4
-    style-loader: ^2.0.0
-    typescript-memoize: ^1.0.0-alpha.3
-    walk-sync: ^3.0.0
-  checksum: e42c0f9dee74c94a16c8b4d701707f457e8955ad340e68be32375ff32fba030fcaa53aa4e4fd2d482fabe0a320ceabc034520c73601c8d69caa6268093dd0f65
-  languageName: node
-  linkType: hard
-
 "ember-auto-import@npm:^2.2.4, ember-auto-import@npm:^2.6.0":
   version: 2.7.0
   resolution: "ember-auto-import@npm:2.7.0"
@@ -12475,7 +12454,46 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ember-auto-import@npm:^2.6.1, ember-auto-import@npm:^2.7.0":
+"ember-auto-import@npm:^2.5.0, ember-auto-import@npm:^2.6.3":
+  version: 2.6.3
+  resolution: "ember-auto-import@npm:2.6.3"
+  dependencies:
+    "@babel/core": ^7.16.7
+    "@babel/plugin-proposal-class-properties": ^7.16.7
+    "@babel/plugin-proposal-decorators": ^7.16.7
+    "@babel/preset-env": ^7.16.7
+    "@embroider/macros": ^1.0.0
+    "@embroider/shared-internals": ^2.0.0
+    babel-loader: ^8.0.6
+    babel-plugin-ember-modules-api-polyfill: ^3.5.0
+    babel-plugin-ember-template-compilation: ^2.0.1
+    babel-plugin-htmlbars-inline-precompile: ^5.2.1
+    babel-plugin-syntax-dynamic-import: ^6.18.0
+    broccoli-debug: ^0.6.4
+    broccoli-funnel: ^3.0.8
+    broccoli-merge-trees: ^4.2.0
+    broccoli-plugin: ^4.0.0
+    broccoli-source: ^3.0.0
+    css-loader: ^5.2.0
+    debug: ^4.3.1
+    fs-extra: ^10.0.0
+    fs-tree-diff: ^2.0.0
+    handlebars: ^4.3.1
+    js-string-escape: ^1.0.1
+    lodash: ^4.17.19
+    mini-css-extract-plugin: ^2.5.2
+    parse5: ^6.0.1
+    resolve: ^1.20.0
+    resolve-package-path: ^4.0.3
+    semver: ^7.3.4
+    style-loader: ^2.0.0
+    typescript-memoize: ^1.0.0-alpha.3
+    walk-sync: ^3.0.0
+  checksum: e42c0f9dee74c94a16c8b4d701707f457e8955ad340e68be32375ff32fba030fcaa53aa4e4fd2d482fabe0a320ceabc034520c73601c8d69caa6268093dd0f65
+  languageName: node
+  linkType: hard
+
+"ember-auto-import@npm:^2.6.1, ember-auto-import@npm:^2.7.0, ember-auto-import@npm:^2.7.2":
   version: 2.7.2
   resolution: "ember-auto-import@npm:2.7.2"
   dependencies:
@@ -12564,22 +12582,6 @@ __metadata:
   peerDependencies:
     ember-source: ^3.13.0 || ^4.0.0
   checksum: b2589490d897da9f560abc1858c2090fc027a54267dfaa5780ee376e00cec1183b84400df9125f6c25bd7d2b465818d63abb98bb07b3eec0a18b3206a918b804
-  languageName: node
-  linkType: hard
-
-"ember-cached-decorator-polyfill@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "ember-cached-decorator-polyfill@npm:1.0.2"
-  dependencies:
-    "@embroider/macros": ^1.8.3
-    "@glimmer/tracking": ^1.1.2
-    babel-import-util: ^1.2.2
-    ember-cache-primitive-polyfill: ^1.0.1
-    ember-cli-babel: ^7.26.11
-    ember-cli-babel-plugin-helpers: ^1.1.1
-  peerDependencies:
-    ember-source: ^3.13.0 || ^4.0.0 || >= 5.0.0
-  checksum: bbfaeafdf89a7ab834d85502829d604e3eb439cb154652b21683492e3e59a918bbaf49d39703f1a896016521d7cf03dc05e89cf5cf06de88fd1489b8e00ef8bb
   languageName: node
   linkType: hard
 
@@ -12891,28 +12893,6 @@ __metadata:
     silent-error: ^1.1.1
     walk-sync: ^2.2.0
   checksum: 1a0f94152ae381aed4c0300f4d8e756d60bfc4dfd1357fd49a0d36d420d65d6dc3f5761e604976f63edd11bc264959dddbd1b4c8401e9922711eafc748f4df92
-  languageName: node
-  linkType: hard
-
-"ember-cli-htmlbars@npm:^6.3.0":
-  version: 6.3.0
-  resolution: "ember-cli-htmlbars@npm:6.3.0"
-  dependencies:
-    "@ember/edition-utils": ^1.2.0
-    babel-plugin-ember-template-compilation: ^2.0.0
-    babel-plugin-htmlbars-inline-precompile: ^5.3.0
-    broccoli-debug: ^0.6.5
-    broccoli-persistent-filter: ^3.1.2
-    broccoli-plugin: ^4.0.3
-    ember-cli-version-checker: ^5.1.2
-    fs-tree-diff: ^2.0.1
-    hash-for-dep: ^1.5.1
-    heimdalljs-logger: ^0.1.10
-    js-string-escape: ^1.0.1
-    semver: ^7.3.4
-    silent-error: ^1.1.1
-    walk-sync: ^2.2.0
-  checksum: 30639ab2afd4cdf4edf677d6dfdef61865ee1be46449b123917c12a3119346f769573f55897ec3bb2a2dd05bd0e3a645ecc0090453d53545902fd21fbce3d057
   languageName: node
   linkType: hard
 
@@ -13643,6 +13623,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ember-functions-as-helper-polyfill@npm:^2.1.2":
+  version: 2.1.2
+  resolution: "ember-functions-as-helper-polyfill@npm:2.1.2"
+  dependencies:
+    ember-cli-babel: ^7.26.11
+    ember-cli-typescript: ^5.0.0
+    ember-cli-version-checker: ^5.1.2
+  peerDependencies:
+    ember-source: ^3.25.0 || >=4.0.0
+  checksum: ed1fa320d73f684501b54ecf0679fc39d9db930a192dd0caba33c41672956ac3cf686fce1db8c67c03471fbd9023bcbe1ce11cdd664ac6b2dfffaf3a76e061cc
+  languageName: node
+  linkType: hard
+
 "ember-get-config@npm:0.2.4 - 0.5.0 || ^1.0.0 || ^2.1.1, ember-get-config@npm:^1.0.2 || ^2.0.0, ember-get-config@npm:^2.1.1":
   version: 2.1.1
   resolution: "ember-get-config@npm:2.1.1"
@@ -14211,12 +14204,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ember-truth-helpers@npm:^3.0.0, ember-truth-helpers@npm:^3.1.1":
+"ember-truth-helpers@npm:^3.0.0":
   version: 3.1.1
   resolution: "ember-truth-helpers@npm:3.1.1"
   dependencies:
     ember-cli-babel: ^7.22.1
   checksum: 6f3a779ae714cec543b39ca93caa98121e65046e48929e1890aa24b2592c4e90a703148694bae9d7ca9bfc68d9ae1f7e00392f0f288158ee962aefbae1f3c0b0
+  languageName: node
+  linkType: hard
+
+"ember-truth-helpers@npm:^4.0.3":
+  version: 4.0.3
+  resolution: "ember-truth-helpers@npm:4.0.3"
+  dependencies:
+    "@embroider/addon-shim": ^1.8.6
+    ember-functions-as-helper-polyfill: ^2.1.2
+  peerDependencies:
+    ember-source: ">=3.28.0"
+  checksum: bcf81ab9848237fa336aa944a928e6894ab9fa50cf1ee37c9bd2721cba4a12728c61f08a52cb635aa9cd625c6451af5704030318e4b5a0b47ed141fe86e6f408
   languageName: node
   linkType: hard
 
@@ -24830,8 +24835,8 @@ __metadata:
     "@ember/test-waiters": ^3.1.0
     "@glimmer/component": ^1.1.2
     "@glimmer/tracking": ^1.1.2
-    "@hashicorp/design-system-components": ^3.4.0
-    "@hashicorp/ember-flight-icons": ^4.0.5
+    "@hashicorp/design-system-components": ^4.0.0
+    "@hashicorp/ember-flight-icons": ^5.0.0
     "@icholy/duration": ^5.1.0
     "@lineal-viz/lineal": ^0.5.1
     "@tsconfig/ember": ^2.0.0
@@ -24888,7 +24893,7 @@ __metadata:
     doctoc: ^2.2.0
     dompurify: ^3.0.2
     ember-a11y-testing: ^5.2.1
-    ember-auto-import: 2.6.3
+    ember-auto-import: ^2.7.2
     ember-basic-dropdown: 6.0.1
     ember-cli: ~4.12.1
     ember-cli-autoprefixer: ^0.8.1

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -266,7 +266,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/core@npm:^7.22.20":
+"@babel/core@npm:^7.22.20, @babel/core@npm:^7.24.0":
   version: 7.24.0
   resolution: "@babel/core@npm:7.24.0"
   dependencies:
@@ -5080,29 +5080,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@embroider/addon-shim@npm:^1.0.0, @embroider/addon-shim@npm:^1.2.0, @embroider/addon-shim@npm:^1.8.3":
-  version: 1.8.6
-  resolution: "@embroider/addon-shim@npm:1.8.6"
-  dependencies:
-    "@embroider/shared-internals": ^2.2.3
-    broccoli-funnel: ^3.0.8
-    semver: ^7.3.8
-  checksum: 63214fbc1b3f333b052791cdfc0c278c348dd6ca4ec2b53c96183150e3d5fe9882cdd3065853e3d6a2c964c962d718b87f2fd8a17414b53fc3a3997d5eedb30e
-  languageName: node
-  linkType: hard
-
-"@embroider/addon-shim@npm:^1.8.4":
-  version: 1.8.4
-  resolution: "@embroider/addon-shim@npm:1.8.4"
-  dependencies:
-    "@embroider/shared-internals": ^2.0.0
-    broccoli-funnel: ^3.0.8
-    semver: ^7.3.8
-  checksum: 107220e97bbd46ead81dfbbfc6cf7daa61731096a6e81b989659a9a0b29b48b3c97ebdd446b6dc0636c4be369f3744e514b7f5e5c0fdc54c1c0e026f54404cc2
-  languageName: node
-  linkType: hard
-
-"@embroider/addon-shim@npm:^1.8.6, @embroider/addon-shim@npm:^1.8.7":
+"@embroider/addon-shim@npm:^1.0.0, @embroider/addon-shim@npm:^1.2.0, @embroider/addon-shim@npm:^1.8.3, @embroider/addon-shim@npm:^1.8.4, @embroider/addon-shim@npm:^1.8.6, @embroider/addon-shim@npm:^1.8.7":
   version: 1.8.7
   resolution: "@embroider/addon-shim@npm:1.8.7"
   dependencies:
@@ -5113,23 +5091,46 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@embroider/macros@npm:^1.0.0":
-  version: 1.5.0
-  resolution: "@embroider/macros@npm:1.5.0"
+"@embroider/macros@npm:^1.15.0":
+  version: 1.15.0
+  resolution: "@embroider/macros@npm:1.15.0"
   dependencies:
-    "@embroider/shared-internals": 1.5.0
+    "@babel/core": ^7.24.0
+    "@embroider/shared-internals": 2.5.2
     assert-never: ^1.2.1
-    babel-import-util: ^1.1.0
-    ember-cli-babel: ^7.26.6
+    babel-import-util: ^2.0.0
+    ember-cli-babel: ^8.2.0
     find-up: ^5.0.0
     lodash: ^4.17.21
     resolve: ^1.20.0
     semver: ^7.3.2
-  checksum: 5e0d5f8c89b0b31199b938848bb7afc5bcd8d3501cc8bfd3ad4a531d74c4e50e8648303e8adaf690c0f0f69a61025925ce55640d93aa3d1723c820efd9cecabc
+  peerDependencies:
+    "@glint/template": ^1.0.0
+  peerDependenciesMeta:
+    "@glint/template":
+      optional: true
+  checksum: ac78c4e0d8a553a6d45476acf9248b6ccfb6499e0eb1ddc7e953e1e52cc7a491ce72d4a28defcbe29aff69ed4c32fac5a7311445400836f6427281ef378f1f83
   languageName: node
   linkType: hard
 
-"@embroider/shared-internals@npm:1.5.0, @embroider/shared-internals@npm:^1.0.0":
+"@embroider/shared-internals@npm:2.5.2, @embroider/shared-internals@npm:^2.5.1":
+  version: 2.5.2
+  resolution: "@embroider/shared-internals@npm:2.5.2"
+  dependencies:
+    babel-import-util: ^2.0.0
+    debug: ^4.3.2
+    ember-rfc176-data: ^0.3.17
+    fs-extra: ^9.1.0
+    js-string-escape: ^1.0.1
+    lodash: ^4.17.21
+    resolve-package-path: ^4.0.1
+    semver: ^7.3.5
+    typescript-memoize: ^1.0.1
+  checksum: ffa48bc708498f57482d7c1ebca44fccf46543d705a2dab698581ef5dee5f0981a9a67d7df3164940f8de1b7412f20cfd4d6204b13c2945f461660089908fe53
+  languageName: node
+  linkType: hard
+
+"@embroider/shared-internals@npm:^1.0.0":
   version: 1.5.0
   resolution: "@embroider/shared-internals@npm:1.5.0"
   dependencies:
@@ -5173,39 +5174,6 @@ __metadata:
     semver: ^7.3.5
     typescript-memoize: ^1.0.1
   checksum: 19d2754182b9e1373177843a354852c82b35d71af66edcdf0662597442062e5f5f51adbdf7a63a263ee0052064c222ff33ddb983ec3f17b68b7275de8de3680e
-  languageName: node
-  linkType: hard
-
-"@embroider/shared-internals@npm:^2.2.3":
-  version: 2.2.3
-  resolution: "@embroider/shared-internals@npm:2.2.3"
-  dependencies:
-    babel-import-util: ^1.1.0
-    ember-rfc176-data: ^0.3.17
-    fs-extra: ^9.1.0
-    js-string-escape: ^1.0.1
-    lodash: ^4.17.21
-    resolve-package-path: ^4.0.1
-    semver: ^7.3.5
-    typescript-memoize: ^1.0.1
-  checksum: bf9f3769af5a66b6e8935257c77fe49678ef0a24ec74b397134598c16f13cd791ac2107008b0ae5dc41d94810f5e15ad318100c03bf1fcb2209a62db966cc483
-  languageName: node
-  linkType: hard
-
-"@embroider/shared-internals@npm:^2.5.1":
-  version: 2.5.2
-  resolution: "@embroider/shared-internals@npm:2.5.2"
-  dependencies:
-    babel-import-util: ^2.0.0
-    debug: ^4.3.2
-    ember-rfc176-data: ^0.3.17
-    fs-extra: ^9.1.0
-    js-string-escape: ^1.0.1
-    lodash: ^4.17.21
-    resolve-package-path: ^4.0.1
-    semver: ^7.3.5
-    typescript-memoize: ^1.0.1
-  checksum: ffa48bc708498f57482d7c1ebca44fccf46543d705a2dab698581ef5dee5f0981a9a67d7df3164940f8de1b7412f20cfd4d6204b13c2945f461660089908fe53
   languageName: node
   linkType: hard
 
@@ -5493,7 +5461,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hashicorp/design-system-components@npm:^4.0.0":
+"@hashicorp/design-system-components@npm:^4.1.0":
   version: 4.1.0
   resolution: "@hashicorp/design-system-components@npm:4.1.0"
   dependencies:
@@ -5529,7 +5497,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hashicorp/ember-flight-icons@npm:^5.0.0, @hashicorp/ember-flight-icons@npm:^5.0.1":
+"@hashicorp/ember-flight-icons@npm:^5.0.1":
   version: 5.0.1
   resolution: "@hashicorp/ember-flight-icons@npm:5.0.1"
   dependencies:
@@ -24822,6 +24790,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "vault@workspace:."
   dependencies:
+    "@babel/core": ^7.24.0
     "@babel/eslint-parser": ^7.21.3
     "@babel/plugin-proposal-decorators": ^7.21.0
     "@babel/plugin-proposal-object-rest-spread": ^7.12.1
@@ -24835,8 +24804,8 @@ __metadata:
     "@ember/test-waiters": ^3.1.0
     "@glimmer/component": ^1.1.2
     "@glimmer/tracking": ^1.1.2
-    "@hashicorp/design-system-components": ^4.0.0
-    "@hashicorp/ember-flight-icons": ^5.0.0
+    "@hashicorp/design-system-components": ^4.1.0
+    "@hashicorp/ember-flight-icons": ^5.0.1
     "@icholy/duration": ^5.1.0
     "@lineal-viz/lineal": ^0.5.1
     "@tsconfig/ember": ^2.0.0


### PR DESCRIPTION
### :hammer_and_wrench: Description

Updates Vault to the latest HDS & flight-icons version by bumping the following packages:
```
"@hashicorp/design-system-components": "^4.1.0",
"@hashicorp/ember-flight-icons": "^5.0.1",
"ember-auto-import": "^2.7.2", // necessary for us to consume v2 addons, see note*
"@embroider/macros": "^1.15.0"
```

This originally came up while auditing the UI to see if we needed to update any icons/colors. It looks like our icon & color usage is up to date, but we might as well update the HDS & icon dependencies to ensure we have access to all the latest ones, since we may need them for the future.

*Note:* `@hashicorp/design-system-components @4.x` is a v2 addon. We're able to consume this addon because we're using [ember-auto-import @2.x](https://github.com/embroider-build/ember-auto-import/blob/main/docs/upgrade-guide-2.0.md#embroider-v2-addon-format-support). However, even with this version we initially encountered an odd Embroider-related error when trying to build after installing `@hashicorp/design-system-components": "^4`:
```
Cannot read properties of undefined (reading 'registerV2Addon')
```
The error was resolved by running `yarn dedupe @embroider/addon-shim --strategy highest` and moving `ember-auto-import` out of `devDependencies` and into `dependencies`. 

### 🔗 Links
[HDS release notes](https://github.com/hashicorp/design-system/releases/tag/%40hashicorp%2Fdesign-system-components%404.0.0)

### :camera_flash: Screenshots
n/a, there should be no user-facing changes to this PR. 

### :building_construction: How to Build and Test the Change
Spin up the UI and ensure that the icons in the navigation and various pages still work.