### PR TITLE
Added new "Invalid Token" Error Message

### DIFF
--- a/changelog/25953.txt
+++ b/changelog/25953.txt
@@ -1,0 +1,4 @@
+```release-note:change
+core: return an additional "invalid token" error message in 403 response when the provided request token is expired,
+exceeded the number of uses, or is a bogus value
+```

--- a/sdk/logical/error.go
+++ b/sdk/logical/error.go
@@ -23,6 +23,9 @@ var (
 	// ErrPermissionDenied is returned if the client is not authorized
 	ErrPermissionDenied = errors.New("permission denied")
 
+	// ErrInvalidToken is returned if the token is revoked, expired, or non-existent
+	ErrInvalidToken = errors.New("invalid token")
+
 	// ErrInvalidCredentials is returned when the provided credentials are incorrect
 	// This is used internally for user lockout purposes. This is not seen externally.
 	// The status code returned does not change because of this error

--- a/vault/core_test.go
+++ b/vault/core_test.go
@@ -1175,7 +1175,7 @@ func TestCore_HandleRequest_InvalidToken(t *testing.T) {
 	if err == nil || !errwrap.Contains(err, logical.ErrPermissionDenied.Error()) {
 		t.Fatalf("err: %v", err)
 	}
-	if resp.Data["error"] != "permission denied" {
+	if !strings.Contains(resp.Data["error"].(string), "permission denied") {
 		t.Fatalf("bad: %#v", resp)
 	}
 }
@@ -1251,6 +1251,26 @@ func TestCore_HandleRequest_RootPath_WithSudo(t *testing.T) {
 	}
 }
 
+// TestCore_HandleRequest_TokenErrInvalidToken checks that a request made
+// with a non-existent token will return the "permission denied" and "invalid token" error
+func TestCore_HandleRequest_TokenErrInvalidToken(t *testing.T) {
+	c, _, _ := TestCoreUnsealed(t)
+
+	req := &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "secret/test",
+		Data: map[string]interface{}{
+			"foo":   "bar",
+			"lease": "1h",
+		},
+		ClientToken: "bogus",
+	}
+	resp, err := c.HandleRequest(namespace.RootContext(nil), req)
+	if err == nil || !errwrap.Contains(err, logical.ErrInvalidToken.Error()) || !errwrap.Contains(err, logical.ErrPermissionDenied.Error()) {
+		t.Fatalf("err: %v, resp: %v", err, resp)
+	}
+}
+
 // Check that standard permissions work
 func TestCore_HandleRequest_PermissionDenied(t *testing.T) {
 	c, _, root := TestCoreUnsealed(t)
@@ -1267,6 +1287,69 @@ func TestCore_HandleRequest_PermissionDenied(t *testing.T) {
 	}
 	resp, err := c.HandleRequest(namespace.RootContext(nil), req)
 	if err == nil || !errwrap.Contains(err, logical.ErrPermissionDenied.Error()) {
+		t.Fatalf("err: %v, resp: %v", err, resp)
+	}
+}
+
+// TestCore_RevokedToken_InvalidTokenError checks that a request
+// returns an "invalid token" and a "permission denied" error when a token
+// that has been revoked is used in a request
+func TestCore_RevokedToken_InvalidTokenError(t *testing.T) {
+	c, _, root := TestCoreUnsealed(t)
+
+	// Set the 'test' policy object to permit access to sys/policy
+	req := &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "sys/policy/test", // root protected!
+		Data: map[string]interface{}{
+			"rules": `path "sys/policy" { policy = "sudo" }`,
+		},
+		ClientToken: root,
+	}
+	resp, err := c.HandleRequest(namespace.RootContext(nil), req)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if resp != nil && (resp.IsError() || len(resp.Data) > 0) {
+		t.Fatalf("bad: %#v", resp)
+	}
+
+	// Child token (non-root) but with 'test' policy should have access
+	testMakeServiceTokenViaCore(t, c, root, "child", "", []string{"test"})
+	req = &logical.Request{
+		Operation:   logical.ReadOperation,
+		Path:        "sys/policy", // root protected!
+		ClientToken: "child",
+	}
+	resp, err = c.HandleRequest(namespace.RootContext(nil), req)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if resp == nil {
+		t.Fatalf("bad: %#v", resp)
+	}
+
+	// Revoke the token
+	req = &logical.Request{
+		ClientToken: root,
+		Operation:   logical.UpdateOperation,
+		Path:        "auth/token/revoke",
+		Data: map[string]interface{}{
+			"token": "child",
+		},
+	}
+	resp, err = c.HandleRequest(namespace.RootContext(nil), req)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	req = &logical.Request{
+		Operation:   logical.ReadOperation,
+		Path:        "sys/policy", // root protected!
+		ClientToken: "child",
+	}
+	_, err = c.HandleRequest(namespace.RootContext(nil), req)
+	if err == nil || !errwrap.Contains(err, logical.ErrPermissionDenied.Error()) || !errwrap.Contains(err, logical.ErrInvalidToken.Error()) {
 		t.Fatalf("err: %v, resp: %v", err, resp)
 	}
 }

--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -248,7 +248,7 @@ func (c *Core) fetchACLTokenEntryAndEntity(ctx context.Context, req *logical.Req
 
 	// Ensure the token is valid
 	if te == nil {
-		return nil, nil, nil, nil, logical.ErrPermissionDenied
+		return nil, nil, nil, nil, multierror.Append(logical.ErrPermissionDenied, logical.ErrInvalidToken)
 	}
 
 	// CIDR checks bind all tokens except non-expiring root tokens
@@ -627,6 +627,9 @@ func (c *Core) handleCancelableRequest(ctx context.Context, req *logical.Request
 
 	err = c.PopulateTokenEntry(ctx, req)
 	if err != nil {
+		if errwrap.Contains(err, logical.ErrPermissionDenied.Error()) {
+			return nil, multierror.Append(err, logical.ErrInvalidToken)
+		}
 		return nil, err
 	}
 
@@ -1025,7 +1028,7 @@ func (c *Core) handleRequest(ctx context.Context, req *logical.Request) (retResp
 		}
 		if te == nil {
 			// Token has been revoked by this point
-			retErr = multierror.Append(retErr, logical.ErrPermissionDenied)
+			retErr = multierror.Append(retErr, logical.ErrPermissionDenied, logical.ErrInvalidToken)
 			return nil, nil, retErr
 		}
 		if te.NumUses == tokenRevocationPending {


### PR DESCRIPTION
Adds the "Invalid Token" error message to the error response whenever (1) the token is revoked (2) the token does not exist, (3) the token lease is expired, (4) the token is some hocus value.

We've decided to add this value to the error message instead of replace it essentially allows all other subsystems to work as it was working previously, but adds an extra layer of information for Agent and Proxy to use when identifying when to retrigger auto auth.

Link to ENT Pr: https://github.com/hashicorp/vault-enterprise/pull/5588
closes https://github.com/hashicorp/vault-enterprise/pull/5588