### PR TITLE
Adding org, org_unit to certificate entity alias metadata

### DIFF
--- a/builtin/credential/cert/backend_test.go
+++ b/builtin/credential/cert/backend_test.go
@@ -1421,7 +1421,7 @@ func TestBackend_organizationalUnit_singleCert(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error testing connection state: %v", err)
 	}
-	ca, err := ioutil.ReadFile("test-fixtures/root/rootcawoucert.pem")
+	ca, err := os.ReadFile("test-fixtures/root/rootcawoucert.pem")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -1434,6 +1434,10 @@ func TestBackend_organizationalUnit_singleCert(t *testing.T) {
 			testAccStepLogin(t, connState),
 			testAccStepCert(t, "web", ca, "foo", allowed{organizational_units: "engineering,finance"}, false),
 			testAccStepLogin(t, connState),
+			testAccStepLoginWithMetadata(t, connState, "web", map[string]string{}, false),
+			testAccStepSetConfig(t, config{EnableIdentityAliasMetadata: true}, connState),
+			testAccStepReadConfig(t, config{EnableIdentityAliasMetadata: true}, connState),
+			testAccStepLoginWithMetadata(t, connState, "web", map[string]string{}, true),
 			testAccStepCert(t, "web", ca, "foo", allowed{organizational_units: "foo"}, false),
 			testAccStepLoginInvalid(t, connState),
 		},
@@ -1808,6 +1812,8 @@ func testAccStepLoginWithMetadata(t *testing.T, connState tls.ConnectionState, c
 			// Check for fixed metadata too
 			metadata["cert_name"] = certName
 			metadata["common_name"] = connState.PeerCertificates[0].Subject.CommonName
+			metadata["org"] = fmt.Sprint(connState.PeerCertificates[0].Subject.Organization)
+			metadata["org_unit"] = fmt.Sprint(connState.PeerCertificates[0].Subject.OrganizationalUnit)
 			metadata["serial_number"] = connState.PeerCertificates[0].SerialNumber.String()
 			metadata["subject_key_id"] = certutil.GetHexFormatted(connState.PeerCertificates[0].SubjectKeyId, ":")
 			metadata["authority_key_id"] = certutil.GetHexFormatted(connState.PeerCertificates[0].AuthorityKeyId, ":")

--- a/builtin/credential/cert/path_login.go
+++ b/builtin/credential/cert/path_login.go
@@ -143,6 +143,8 @@ func (b *backend) pathLogin(ctx context.Context, req *logical.Request, data *fra
 	metadata := map[string]string{
 		"cert_name":        matched.Entry.Name,
 		"common_name":      clientCerts[0].Subject.CommonName,
+		"org":              fmt.Sprint(clientCerts[0].Subject.Organization),
+		"org_unit":         fmt.Sprint(clientCerts[0].Subject.OrganizationalUnit),
 		"serial_number":    clientCerts[0].SerialNumber.String(),
 		"subject_key_id":   certutil.GetHexFormatted(clientCerts[0].SubjectKeyId, ":"),
 		"authority_key_id": certutil.GetHexFormatted(clientCerts[0].AuthorityKeyId, ":"),


### PR DESCRIPTION
Certificate metadata added to {{identity.entity.aliases..metadata...}} is missing org and org unit.

These standard oids cannot be queried via the cert extensions mechanism as they are not extensions.

The reason for adding this information is that there's an org_unit matching mechanism in the certificate role, and consequently it would be convenient to write templated policies with org_unit in them.