### PR TITLE
api: do not require sudo for GetAuth wrapper

### DIFF
--- a/api/sys_auth.go
+++ b/api/sys_auth.go
@@ -20,7 +20,9 @@ func (c *Sys) GetAuthWithContext(ctx context.Context, path string) (*AuthMount, 
 	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
 	defer cancelFunc()
 
-	r := c.c.NewRequest(http.MethodGet, fmt.Sprintf("/v1/sys/auth/%s", path))
+	// use `sys/mounts/auth/:path` so we don't require sudo permissions
+	// historically, `sys/auth` doesn't require sudo, so we don't require it here either
+	r := c.c.NewRequest(http.MethodGet, fmt.Sprintf("/v1/sys/mounts/auth/%s", path))
 
 	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err != nil {

--- a/changelog/25968.txt
+++ b/changelog/25968.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+api: Do not require sudo for API wrapper functions GetAuth and GetAuthWithContext
+```

--- a/website/content/api-docs/system/auth.mdx
+++ b/website/content/api-docs/system/auth.mdx
@@ -187,6 +187,11 @@ $ curl \
 ## Read auth method configuration
 
 This endpoints returns the configuration of the auth method at the given path.
+_This endpoint requires `sudo` capability on the final path, but the same
+functionality can be achieved without `sudo` via `sys/mounts/auth/[auth-path]`._
+
+- **`sudo` required** – This endpoint requires `sudo` capability in addition to
+  any path-specific capabilities.
 
 | Method | Path              |
 | :----- | :---------------- |
@@ -260,7 +265,7 @@ $ curl \
 
 ## Read auth method tuning
 
-- This endpoint reads the given auth path's configuration. This endpoint requires
+This endpoint reads the given auth path's configuration. _This endpoint requires
 `sudo` capability on the final path, but the same functionality can be achieved
 without `sudo` via `sys/mounts/auth/[auth-path]/tune`._
 


### PR DESCRIPTION
This PR proposes the following changes
- remove sudo requirement for GetAuthWithContext and GetAuth API wrapper methods
- add the missing sudo requirement to the API docs for `sys/auth/:path`

This should allow the TFVP to use the API wrapper and remove the `sudo` requirement for managing auth methods.

See
- https://github.com/hashicorp/terraform-provider-vault/pull/2145#issuecomment-1999443231