### PR TITLE
UI: Add socket.io v4.5.4 to resolutions

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -126,7 +126,7 @@
     "ember-a11y-testing": "^5.2.1",
     "ember-auto-import": "2.6.3",
     "ember-basic-dropdown": "6.0.1",
-    "ember-cli": "~4.12.1",
+    "ember-cli": "~4.12.2",
     "ember-cli-autoprefixer": "^0.8.1",
     "ember-cli-babel": "^7.26.11",
     "ember-cli-content-security-policy": "2.0.3",
@@ -213,6 +213,7 @@
   },
   "resolutions": {
     "cryptiles": "^4.1.2",
+    "socket-io": "^4.6.2",
     "eslint-utils": "^1.4.1",
     "ember-basic-dropdown": "6.0.1",
     "growl": "^1.10.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -228,7 +228,8 @@
     "underscore": "^1.12.1",
     "trim": "^0.0.3",
     "xmlhttprequest-ssl": "^1.6.2",
-    "@embroider/macros": "^1.0.0"
+    "@embroider/macros": "^1.0.0",
+    "socket-io": "^4.6.2"
   },
   "engines": {
     "node": "18"

--- a/ui/package.json
+++ b/ui/package.json
@@ -126,7 +126,7 @@
     "ember-a11y-testing": "^5.2.1",
     "ember-auto-import": "2.6.3",
     "ember-basic-dropdown": "6.0.1",
-    "ember-cli": "~4.12.2",
+    "ember-cli": "~4.12.1",
     "ember-cli-autoprefixer": "^0.8.1",
     "ember-cli-babel": "^7.26.11",
     "ember-cli-content-security-policy": "2.0.3",
@@ -213,7 +213,6 @@
   },
   "resolutions": {
     "cryptiles": "^4.1.2",
-    "socket-io": "^4.6.2",
     "eslint-utils": "^1.4.1",
     "ember-basic-dropdown": "6.0.1",
     "growl": "^1.10.0",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -15027,9 +15027,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ember-cli@npm:~4.12.2":
-  version: 4.12.2
-  resolution: "ember-cli@npm:4.12.2"
+"ember-cli@npm:~4.12.1":
+  version: 4.12.1
+  resolution: "ember-cli@npm:4.12.1"
   dependencies:
     "@babel/core": ^7.21.0
     "@babel/plugin-transform-modules-amd": ^7.20.11
@@ -15126,7 +15126,7 @@ __metadata:
     yam: ^1.0.0
   bin:
     ember: bin/ember
-  checksum: 9b0fbf59cf7e513841efb0f16cedccc0f10f08eb34011002e7b0e34370042149c2f5f033ef07ed155f90518bb966a83d3bd1823c99b206304068b4562c9bfa01
+  checksum: 3e6066637211d98994b44b85b33070cc4614f6f1500eebfdc64886880300602a49220b788c4359548d6f305c47844b18ef5bbe0b64d4d61d6865811a15a712b0
   languageName: node
   linkType: hard
 
@@ -27880,7 +27880,7 @@ __metadata:
     ember-a11y-testing: ^5.2.1
     ember-auto-import: 2.6.3
     ember-basic-dropdown: 6.0.1
-    ember-cli: ~4.12.2
+    ember-cli: ~4.12.1
     ember-cli-autoprefixer: ^0.8.1
     ember-cli-babel: ^7.26.11
     ember-cli-content-security-policy: 2.0.3

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -15027,9 +15027,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ember-cli@npm:~4.12.1":
-  version: 4.12.1
-  resolution: "ember-cli@npm:4.12.1"
+"ember-cli@npm:~4.12.2":
+  version: 4.12.2
+  resolution: "ember-cli@npm:4.12.2"
   dependencies:
     "@babel/core": ^7.21.0
     "@babel/plugin-transform-modules-amd": ^7.20.11
@@ -15126,7 +15126,7 @@ __metadata:
     yam: ^1.0.0
   bin:
     ember: bin/ember
-  checksum: 3e6066637211d98994b44b85b33070cc4614f6f1500eebfdc64886880300602a49220b788c4359548d6f305c47844b18ef5bbe0b64d4d61d6865811a15a712b0
+  checksum: 9b0fbf59cf7e513841efb0f16cedccc0f10f08eb34011002e7b0e34370042149c2f5f033ef07ed155f90518bb966a83d3bd1823c99b206304068b4562c9bfa01
   languageName: node
   linkType: hard
 
@@ -27880,7 +27880,7 @@ __metadata:
     ember-a11y-testing: ^5.2.1
     ember-auto-import: 2.6.3
     ember-basic-dropdown: 6.0.1
-    ember-cli: ~4.12.1
+    ember-cli: ~4.12.2
     ember-cli-autoprefixer: ^0.8.1
     ember-cli-babel: ^7.26.11
     ember-cli-content-security-policy: 2.0.3


### PR DESCRIPTION
Trace of `socket.io-parser` vulnerability: 
```sh
⇒ yarn why socket.io-parser           
└─ socket.io@npm:4.5.2
   └─ socket.io-parser@npm:4.2.1 (via npm:~4.2.0)
⇒ yarn why socket.io
└─ testem@npm:3.10.1
   └─ socket.io@npm:4.5.2 (via npm:^4.1.2)
⇒ yarn why testem
└─ ember-cli@npm:4.12.1
   └─ testem@npm:3.10.1 (via npm:^3.10.1)
```

[socket.io](https://github.com/socketio/socket.io/blob/4.6.2/package.json#L54) version `4.6.2` has the desired `socket.io-parser` version ~4.2.4 (we want >= 4.2.3 ) 

the latest release of [testem](https://github.com/testem/testem/releases) only goes up to `socket.io: 4.5.4` (see package.json [here](https://github.com/testem/testem/compare/v3.11.0...v3.12.0#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R48)) and so there isn't an `ember-cli` version available that has the package version we want. Resolved by pinning the `socket.io` version in the `resolutions` block.