### PR TITLE
Add additional Linux distros and Consul editions to Enos scenarios

### DIFF
--- a/.github/workflows/test-run-enos-scenario-matrix.yml
+++ b/.github/workflows/test-run-enos-scenario-matrix.yml
@@ -96,7 +96,13 @@ jobs:
       ENOS_VAR_vault_build_date: ${{ needs.metadata.outputs.build-date }}
       ENOS_VAR_vault_product_version: ${{ needs.metadata.outputs.vault-version }}
       ENOS_VAR_vault_revision: ${{ inputs.vault-revision }}
+      ENOS_VAR_consul_license_path: ./support/consul.hclic
       ENOS_VAR_vault_license_path: ./support/vault.hclic
+      ENOS_VAR_distro_version_amzn2: ${{ matrix.attributes.distro_version_amzn2 }}
+      ENOS_VAR_distro_version_leap: ${{ matrix.attributes.distro_version_leap }}
+      ENOS_VAR_distro_version_rhel: ${{ matrix.attributes.distro_version_rhel }}
+      ENOS_VAR_distro_version_sles: ${{ matrix.attributes.distro_version_sles }}
+      ENOS_VAR_distro_version_ubuntu: ${{ matrix.attributes.distro_version_ubuntu }}
       ENOS_DEBUG_DATA_ROOT_DIR: /tmp/enos-debug-data
     steps:
       - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
@@ -134,6 +140,11 @@ jobs:
       - if: contains(inputs.sample-name, 'ent')
         name: Configure Vault license
         run: echo "${{ secrets.VAULT_LICENSE }}" > ./enos/support/vault.hclic || true
+      - if: contains(matrix.scenario.id.filter, 'consul_edition:ent')
+        name: Configure Consul license
+        run: |
+          echo "matrix.scenario.id.filter: ${{ matrix.scenario.id.filter }}"
+          echo "${{ secrets.CONSUL_LICENSE }}" > ./enos/support/consul.hclic || true
       - id: launch
         name: enos scenario launch ${{ matrix.scenario.id.filter }}
         # Continue once and retry to handle occasional blips when creating infrastructure.

--- a/enos/enos-dev-scenario-pr-replication.hcl
+++ b/enos/enos-dev-scenario-pr-replication.hcl
@@ -69,13 +69,13 @@ scenario "dev_pr_replication" {
   EOF
 
   // The matrix is where we define all the baseline combinations that enos can utilize to customize
-  // your scenario. By default enos attempts to perform your command an the entire product! Most
-  // of the time you'll want to reduce that by passing in a filter.
+  // your scenario. By default enos attempts to perform your command on the entire product of these
+  // possible comginations! Most of the time you'll want to reduce that by passing in a filter.
   // Run 'enos scenario list --help' to see more about how filtering scenarios works in enos.
   matrix {
     arch              = ["amd64", "arm64"]
     artifact          = ["local", "deb", "rpm", "zip"]
-    distro            = ["ubuntu", "rhel"]
+    distro            = ["amzn2", "leap", "rhel", "sles", "ubuntu"]
     edition           = ["ent", "ent.fips1402", "ent.hsm", "ent.hsm.fips1402"]
     primary_backend   = ["consul", "raft"]
     primary_seal      = ["awskms", "pkcs11", "shamir"]
@@ -117,8 +117,8 @@ scenario "dev_pr_replication" {
   // Here we declare all of the providers that we might need for our scenario.
   providers = [
     provider.aws.default,
-    provider.enos.ubuntu,
-    provider.enos.rhel
+    provider.enos.ec2_user,
+    provider.enos.ubuntu
   ]
 
   // These are variable values that are local to our scenario. They are evaluated after external
@@ -127,7 +127,10 @@ scenario "dev_pr_replication" {
     // The enos provider uses different ssh transport configs for different distros (as
     // specified in enos-providers.hcl), and we need to be able to access both of those here.
     enos_provider = {
-      rhel   = provider.enos.rhel
+      amzn2  = provider.enos.ec2_user
+      leap   = provider.enos.ec2_user
+      rhel   = provider.enos.ec2_user
+      sles   = provider.enos.ec2_user
       ubuntu = provider.enos.ubuntu
     }
     // We install vault packages from artifactory. If you wish to use one of these variants you'll
@@ -139,7 +142,7 @@ scenario "dev_pr_replication" {
     // If you are using an ent edition, you will need a Vault license. Common convention
     // is to store it at ./support/vault.hclic, but you may change this path according
     // to your own preference.
-    vault_install_dir = matrix.artifact == "zip" ? var.vault_install_dir : global.vault_install_dir_packages[matrix.distro]
+    vault_install_dir = matrix.artifact == "zip" || matrix.artifact == "local" ? global.vault_install_dir["bundle"] : global.vault_install_dir["package"]
   }
 
   // Begin scenario steps. These are the steps we'll perform to get your cluster up and running.

--- a/enos/enos-dev-scenario-single-cluster.hcl
+++ b/enos/enos-dev-scenario-single-cluster.hcl
@@ -68,14 +68,14 @@ scenario "dev_single_cluster" {
   EOF
 
   // The matrix is where we define all the baseline combinations that enos can utilize to customize
-  // your scenario. By default enos attempts to perform your command an the entire product! Most
-  // of the time you'll want to reduce that by passing in a filter.
+  // your scenario. By default enos attempts to perform your command on the entire product of these
+  // possible comginations! Most of the time you'll want to reduce that by passing in a filter.
   // Run 'enos scenario list --help' to see more about how filtering scenarios works in enos.
   matrix {
     arch     = ["amd64", "arm64"]
     artifact = ["local", "deb", "rpm", "zip"]
     backend  = ["consul", "raft"]
-    distro   = ["ubuntu", "rhel"]
+    distro   = ["amzn2", "leap", "rhel", "sles", "ubuntu"]
     edition  = ["ce", "ent", "ent.fips1402", "ent.hsm", "ent.hsm.fips1402"]
     seal     = ["awskms", "pkcs11", "shamir"]
 
@@ -107,10 +107,12 @@ scenario "dev_single_cluster" {
   terraform     = terraform.default
 
   // Here we declare all of the providers that we might need for our scenario.
+  // There are two different configurations for the Enos provider, each specifying
+  // SSH transport configs for different Linux distros.
   providers = [
     provider.aws.default,
-    provider.enos.ubuntu,
-    provider.enos.rhel
+    provider.enos.ec2_user,
+    provider.enos.ubuntu
   ]
 
   // These are variable values that are local to our scenario. They are evaluated after external
@@ -119,7 +121,10 @@ scenario "dev_single_cluster" {
     // The enos provider uses different ssh transport configs for different distros (as
     // specified in enos-providers.hcl), and we need to be able to access both of those here.
     enos_provider = {
-      rhel   = provider.enos.rhel
+      amzn2  = provider.enos.ec2_user
+      leap   = provider.enos.ec2_user
+      rhel   = provider.enos.ec2_user
+      sles   = provider.enos.ec2_user
       ubuntu = provider.enos.ubuntu
     }
     // We install vault packages from artifactory. If you wish to use one of these variants you'll
@@ -131,7 +136,7 @@ scenario "dev_single_cluster" {
     // If you are using an ent edition, you will need a Vault license. Common convention
     // is to store it at ./support/vault.hclic, but you may change this path according
     // to your own preference.
-    vault_install_dir = matrix.artifact == "zip" ? var.vault_install_dir : global.vault_install_dir_packages[matrix.distro]
+    vault_install_dir = matrix.artifact == "zip" || matrix.artifact == "local" ? global.vault_install_dir["bundle"] : global.vault_install_dir["package"]
   }
 
   // Begin scenario steps. These are the steps we'll perform to get your cluster up and running.

--- a/enos/enos-globals.hcl
+++ b/enos/enos-globals.hcl
@@ -16,20 +16,43 @@ globals {
     "ent.hsm.fips1402" = ["ui", "enterprise", "cgo", "hsm", "fips", "fips_140_2", "ent.hsm.fips1402"]
   }
   config_modes    = ["env", "file"]
+  consul_editions = ["ce", "ent"]
   consul_versions = ["1.14.11", "1.15.7", "1.16.3", "1.17.0"]
-  distros         = ["ubuntu", "rhel"]
+  distros         = ["amzn2", "leap", "rhel", "sles", "ubuntu"]
+  # Different distros may require different packages, or use different aliases for the same package
+  distro_packages = {
+    amzn2 = ["nc"]
+    leap  = ["netcat", "openssl"]
+    rhel  = ["nc"]
+    # When installing Vault RPM packages on a SLES AMI, the openssl package provided
+    # isn't named "openssl, which rpm doesn't know how to handle. Therefore we add the
+    # "correctly" named one in our package installation before installing Vault.
+    sles   = ["netcat-openbsd", "openssl"]
+    ubuntu = ["netcat"]
+  }
   distro_version = {
-    "rhel"   = var.rhel_distro_version
-    "ubuntu" = var.ubuntu_distro_version
+    "amzn2"  = var.distro_version_amzn2
+    "leap"   = var.distro_version_leap
+    "rhel"   = var.distro_version_rhel
+    "sles"   = var.distro_version_sles
+    "ubuntu" = var.distro_version_ubuntu
   }
   editions = ["ce", "ent", "ent.fips1402", "ent.hsm", "ent.hsm.fips1402"]
-  packages = ["jq"]
-  distro_packages = {
-    ubuntu = ["netcat"]
-    rhel   = ["nc"]
+  package_manager = {
+    "amzn2"  = "yum"
+    "leap"   = "zypper"
+    "rhel"   = "yum"
+    "sles"   = "zypper"
+    "ubuntu" = "apt"
   }
+  packages = ["jq"]
   sample_attributes = {
-    aws_region = ["us-east-1", "us-west-2"]
+    aws_region            = ["us-east-1", "us-west-2"]
+    distro_version_amzn2  = ["2"]
+    distro_version_leap   = ["15.4", "15.5"]
+    distro_version_rhel   = ["8.9", "9.3"]
+    distro_version_sles   = ["v15_sp5_standard"]
+    distro_version_ubuntu = ["20.04", "22.04"]
   }
   seals = ["awskms", "pkcs11", "shamir"]
   tags = merge({
@@ -42,9 +65,9 @@ globals {
   // that use this global might not work as expected with earlier versions. Below 1.8.x is
   // not supported in any way.
   upgrade_initial_versions = ["1.11.12", "1.12.11", "1.13.11", "1.14.7", "1.15.3"]
-  vault_install_dir_packages = {
-    rhel   = "/bin"
-    ubuntu = "/usr/bin"
+  vault_install_dir = {
+    bundle  = "/opt/vault/bin"
+    package = "/usr/bin"
   }
   vault_license_path = abspath(var.vault_license_path != null ? var.vault_license_path : joinpath(path.root, "./support/vault.hclic"))
   vault_tag_key      = "Type" // enos_vault_start expects Type as the tag key

--- a/enos/enos-providers.hcl
+++ b/enos/enos-providers.hcl
@@ -5,7 +5,8 @@ provider "aws" "default" {
   region = var.aws_region
 }
 
-provider "enos" "rhel" {
+# This default SSH user is used in RHEL, Amazon Linux, SUSE, and Leap distros
+provider "enos" "ec2_user" {
   transport = {
     ssh = {
       user             = "ec2-user"
@@ -14,6 +15,7 @@ provider "enos" "rhel" {
   }
 }
 
+# This default SSH user is used in the Ubuntu distro
 provider "enos" "ubuntu" {
   transport = {
     ssh = {

--- a/enos/enos-samples-ce-build.hcl
+++ b/enos/enos-samples-ce-build.hcl
@@ -97,7 +97,7 @@ sample "build_ce_linux_arm64_rpm" {
       arch            = ["arm64"]
       artifact_source = ["crt"]
       artifact_type   = ["package"]
-      distro          = ["rhel"]
+      distro          = ["amzn2", "rhel", "sles"]
       edition         = ["ce"]
     }
   }
@@ -107,7 +107,7 @@ sample "build_ce_linux_arm64_rpm" {
       arch            = ["arm64"]
       artifact_source = ["crt"]
       artifact_type   = ["package"]
-      distro          = ["rhel"]
+      distro          = ["amzn2", "rhel", "sles"]
       edition         = ["ce"]
     }
   }
@@ -117,7 +117,7 @@ sample "build_ce_linux_arm64_rpm" {
       arch            = ["arm64"]
       artifact_source = ["crt"]
       artifact_type   = ["package"]
-      distro          = ["rhel"]
+      distro          = ["amzn2", "rhel", "sles"]
       edition         = ["ce"]
     }
   }
@@ -127,7 +127,7 @@ sample "build_ce_linux_arm64_rpm" {
       arch            = ["arm64"]
       artifact_source = ["crt"]
       artifact_type   = ["package"]
-      distro          = ["rhel"]
+      distro          = ["amzn2", "rhel", "sles"]
       edition         = ["ce"]
     }
   }
@@ -141,7 +141,7 @@ sample "build_ce_linux_amd64_rpm" {
       arch            = ["amd64"]
       artifact_source = ["crt"]
       artifact_type   = ["package"]
-      distro          = ["rhel"]
+      distro          = ["amzn2", "leap", "rhel", "sles"]
       edition         = ["ce"]
     }
   }
@@ -151,7 +151,7 @@ sample "build_ce_linux_amd64_rpm" {
       arch            = ["amd64"]
       artifact_source = ["crt"]
       artifact_type   = ["package"]
-      distro          = ["rhel"]
+      distro          = ["amzn2", "leap", "rhel", "sles"]
       edition         = ["ce"]
     }
   }
@@ -161,7 +161,7 @@ sample "build_ce_linux_amd64_rpm" {
       arch            = ["amd64"]
       artifact_source = ["crt"]
       artifact_type   = ["package"]
-      distro          = ["rhel"]
+      distro          = ["amzn2", "leap", "rhel", "sles"]
       edition         = ["ce"]
     }
   }
@@ -171,7 +171,7 @@ sample "build_ce_linux_amd64_rpm" {
       arch            = ["amd64"]
       artifact_source = ["crt"]
       artifact_type   = ["package"]
-      distro          = ["rhel"]
+      distro          = ["amzn2", "leap", "rhel", "sles"]
       edition         = ["ce"]
 
       exclude {
@@ -191,6 +191,7 @@ sample "build_ce_linux_amd64_zip" {
       arch            = ["amd64"]
       artifact_type   = ["bundle"]
       artifact_source = ["crt"]
+      distro          = ["amzn2", "ubuntu"]
       edition         = ["ce"]
     }
   }
@@ -200,6 +201,7 @@ sample "build_ce_linux_amd64_zip" {
       arch            = ["amd64"]
       artifact_type   = ["bundle"]
       artifact_source = ["crt"]
+      distro          = ["amzn2", "ubuntu"]
       edition         = ["ce"]
     }
   }
@@ -209,6 +211,7 @@ sample "build_ce_linux_amd64_zip" {
       arch            = ["amd64"]
       artifact_type   = ["bundle"]
       artifact_source = ["crt"]
+      distro          = ["amzn2", "ubuntu"]
       edition         = ["ce"]
     }
   }
@@ -218,6 +221,7 @@ sample "build_ce_linux_amd64_zip" {
       arch            = ["amd64"]
       artifact_type   = ["bundle"]
       artifact_source = ["crt"]
+      distro          = ["amzn2", "ubuntu"]
       edition         = ["ce"]
     }
   }
@@ -231,6 +235,7 @@ sample "build_ce_linux_arm64_zip" {
       arch            = ["arm64"]
       artifact_source = ["crt"]
       artifact_type   = ["bundle"]
+      distro          = ["amzn2", "ubuntu"]
       edition         = ["ce"]
     }
   }
@@ -240,6 +245,7 @@ sample "build_ce_linux_arm64_zip" {
       arch            = ["arm64"]
       artifact_source = ["crt"]
       artifact_type   = ["bundle"]
+      distro          = ["amzn2", "ubuntu"]
       edition         = ["ce"]
     }
   }
@@ -249,6 +255,7 @@ sample "build_ce_linux_arm64_zip" {
       arch            = ["arm64"]
       artifact_source = ["crt"]
       artifact_type   = ["bundle"]
+      distro          = ["amzn2", "ubuntu"]
       edition         = ["ce"]
     }
   }
@@ -258,6 +265,7 @@ sample "build_ce_linux_arm64_zip" {
       arch            = ["arm64"]
       artifact_source = ["crt"]
       artifact_type   = ["bundle"]
+      distro          = ["amzn2", "ubuntu"]
       edition         = ["ce"]
     }
   }

--- a/enos/enos-samples-ce-release.hcl
+++ b/enos/enos-samples-ce-release.hcl
@@ -97,7 +97,7 @@ sample "release_ce_linux_arm64_rpm" {
       arch            = ["arm64"]
       artifact_source = ["artifactory"]
       artifact_type   = ["package"]
-      distro          = ["rhel"]
+      distro          = ["amzn2", "rhel", "sles"]
       edition         = ["ce"]
     }
   }
@@ -107,7 +107,7 @@ sample "release_ce_linux_arm64_rpm" {
       arch            = ["arm64"]
       artifact_source = ["artifactory"]
       artifact_type   = ["package"]
-      distro          = ["rhel"]
+      distro          = ["amzn2", "rhel", "sles"]
       edition         = ["ce"]
     }
   }
@@ -117,7 +117,7 @@ sample "release_ce_linux_arm64_rpm" {
       arch            = ["arm64"]
       artifact_source = ["artifactory"]
       artifact_type   = ["package"]
-      distro          = ["rhel"]
+      distro          = ["amzn2", "rhel", "sles"]
       edition         = ["ce"]
     }
   }
@@ -127,7 +127,7 @@ sample "release_ce_linux_arm64_rpm" {
       arch            = ["arm64"]
       artifact_source = ["artifactory"]
       artifact_type   = ["package"]
-      distro          = ["rhel"]
+      distro          = ["amzn2", "rhel", "sles"]
       edition         = ["ce"]
     }
   }
@@ -141,7 +141,7 @@ sample "release_ce_linux_amd64_rpm" {
       arch            = ["amd64"]
       artifact_source = ["artifactory"]
       artifact_type   = ["package"]
-      distro          = ["rhel"]
+      distro          = ["amzn2", "leap", "rhel", "sles"]
       edition         = ["ce"]
     }
   }
@@ -151,7 +151,7 @@ sample "release_ce_linux_amd64_rpm" {
       arch            = ["amd64"]
       artifact_source = ["artifactory"]
       artifact_type   = ["package"]
-      distro          = ["rhel"]
+      distro          = ["amzn2", "leap", "rhel", "sles"]
       edition         = ["ce"]
     }
   }
@@ -161,7 +161,7 @@ sample "release_ce_linux_amd64_rpm" {
       arch            = ["amd64"]
       artifact_source = ["artifactory"]
       artifact_type   = ["package"]
-      distro          = ["rhel"]
+      distro          = ["amzn2", "leap", "rhel", "sles"]
       edition         = ["ce"]
     }
   }
@@ -171,7 +171,7 @@ sample "release_ce_linux_amd64_rpm" {
       arch            = ["amd64"]
       artifact_source = ["artifactory"]
       artifact_type   = ["package"]
-      distro          = ["rhel"]
+      distro          = ["amzn2", "leap", "rhel", "sles"]
       edition         = ["ce"]
     }
   }
@@ -185,6 +185,7 @@ sample "release_ce_linux_amd64_zip" {
       arch            = ["amd64"]
       artifact_type   = ["bundle"]
       artifact_source = ["artifactory"]
+      distro          = ["amzn2", "ubuntu"]
       edition         = ["ce"]
     }
   }
@@ -194,6 +195,7 @@ sample "release_ce_linux_amd64_zip" {
       arch            = ["amd64"]
       artifact_type   = ["bundle"]
       artifact_source = ["artifactory"]
+      distro          = ["amzn2", "ubuntu"]
       edition         = ["ce"]
     }
   }
@@ -203,6 +205,7 @@ sample "release_ce_linux_amd64_zip" {
       arch            = ["amd64"]
       artifact_type   = ["bundle"]
       artifact_source = ["artifactory"]
+      distro          = ["amzn2", "ubuntu"]
       edition         = ["ce"]
     }
   }
@@ -212,6 +215,7 @@ sample "release_ce_linux_amd64_zip" {
       arch            = ["amd64"]
       artifact_type   = ["bundle"]
       artifact_source = ["artifactory"]
+      distro          = ["amzn2", "ubuntu"]
       edition         = ["ce"]
     }
   }
@@ -225,6 +229,7 @@ sample "release_ce_linux_arm64_zip" {
       arch            = ["arm64"]
       artifact_source = ["artifactory"]
       artifact_type   = ["bundle"]
+      distro          = ["amzn2", "ubuntu"]
       edition         = ["ce"]
     }
   }
@@ -234,6 +239,7 @@ sample "release_ce_linux_arm64_zip" {
       arch            = ["arm64"]
       artifact_source = ["artifactory"]
       artifact_type   = ["bundle"]
+      distro          = ["amzn2", "ubuntu"]
       edition         = ["ce"]
     }
   }
@@ -243,6 +249,7 @@ sample "release_ce_linux_arm64_zip" {
       arch            = ["arm64"]
       artifact_source = ["artifactory"]
       artifact_type   = ["bundle"]
+      distro          = ["amzn2", "ubuntu"]
       edition         = ["ce"]
     }
   }
@@ -252,6 +259,7 @@ sample "release_ce_linux_arm64_zip" {
       arch            = ["arm64"]
       artifact_source = ["artifactory"]
       artifact_type   = ["bundle"]
+      distro          = ["amzn2", "ubuntu"]
       edition         = ["ce"]
     }
   }

--- a/enos/enos-scenario-agent.hcl
+++ b/enos/enos-scenario-agent.hcl
@@ -8,6 +8,7 @@ scenario "agent" {
     artifact_type   = global.artifact_types
     backend         = global.backends
     config_mode     = global.config_modes
+    consul_edition  = global.consul_editions
     consul_version  = global.consul_versions
     distro          = global.distros
     edition         = global.editions
@@ -30,24 +31,39 @@ scenario "agent" {
       seal    = ["pkcs11"]
       edition = ["ce", "ent", "ent.fips1402"]
     }
+
+    # arm64 AMIs are not offered for Leap 15.4
+    exclude {
+      distro = ["leap"]
+      arch   = ["arm64"]
+    }
+
+    # softhsm packages not available for leap/sles; Enos support for softhsm
+    # on amzn2 to be added later.
+    exclude {
+      seal   = ["pkcs11"]
+      distro = ["amzn2", "leap", "sles"]
+    }
   }
 
   terraform_cli = terraform_cli.default
   terraform     = terraform.default
   providers = [
     provider.aws.default,
-    provider.enos.ubuntu,
-    provider.enos.rhel
+    provider.enos.ec2_user,
+    provider.enos.ubuntu
   ]
 
   locals {
     artifact_path = matrix.artifact_source != "artifactory" ? abspath(var.vault_artifact_path) : null
     enos_provider = {
-      rhel   = provider.enos.rhel
+      amzn2  = provider.enos.ec2_user
+      leap   = provider.enos.ec2_user
+      rhel   = provider.enos.ec2_user
+      sles   = provider.enos.ec2_user
       ubuntu = provider.enos.ubuntu
     }
-    manage_service    = matrix.artifact_type == "bundle"
-    vault_install_dir = matrix.artifact_type == "bundle" ? var.vault_install_dir : global.vault_install_dir_packages[matrix.distro]
+    manage_service = matrix.artifact_type == "bundle"
   }
 
   step "get_local_metadata" {
@@ -89,9 +105,9 @@ scenario "agent" {
   }
 
   // This step reads the contents of the backend license if we're using a Consul backend and
-  // the edition is "ent".
+  // an "ent" Consul edition.
   step "read_backend_license" {
-    skip_step = matrix.backend == "raft" || var.backend_edition == "ce"
+    skip_step = matrix.backend == "raft" || matrix.consul_edition == "ce"
     module    = module.read_license
 
     variables {
@@ -169,9 +185,9 @@ scenario "agent" {
     variables {
       cluster_name    = step.create_vault_cluster_backend_targets.cluster_name
       cluster_tag_key = global.backend_tag_key
-      license         = (matrix.backend == "consul" && var.backend_edition == "ent") ? step.read_backend_license.license : null
+      license         = (matrix.backend == "consul" && matrix.consul_edition == "ent") ? step.read_backend_license.license : null
       release = {
-        edition = var.backend_edition
+        edition = matrix.consul_edition
         version = matrix.consul_version
       }
       target_hosts = step.create_vault_cluster_backend_targets.hosts
@@ -196,13 +212,13 @@ scenario "agent" {
       backend_cluster_tag_key = global.backend_tag_key
       cluster_name            = step.create_vault_cluster_targets.cluster_name
       config_mode             = matrix.config_mode
-      consul_license          = (matrix.backend == "consul" && var.backend_edition == "ent") ? step.read_backend_license.license : null
+      consul_license          = (matrix.backend == "consul" && matrix.consul_edition == "ent") ? step.read_backend_license.license : null
       consul_release = matrix.backend == "consul" ? {
-        edition = var.backend_edition
+        edition = matrix.consul_edition
         version = matrix.consul_version
       } : null
       enable_audit_devices = var.vault_enable_audit_devices
-      install_dir          = local.vault_install_dir
+      install_dir          = global.vault_install_dir[matrix.artifact_type]
       license              = matrix.edition != "ce" ? step.read_vault_license.license : null
       local_artifact_path  = local.artifact_path
       manage_service       = local.manage_service
@@ -226,7 +242,7 @@ scenario "agent" {
     variables {
       timeout           = 120 # seconds
       vault_hosts       = step.create_vault_cluster_targets.hosts
-      vault_install_dir = local.vault_install_dir
+      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
       vault_root_token  = step.create_vault_cluster.root_token
     }
   }
@@ -244,7 +260,7 @@ scenario "agent" {
     }
 
     variables {
-      vault_install_dir                = local.vault_install_dir
+      vault_install_dir                = global.vault_install_dir[matrix.artifact_type]
       vault_instances                  = step.create_vault_cluster_targets.hosts
       vault_root_token                 = step.create_vault_cluster.root_token
       vault_agent_template_destination = "/tmp/agent_output.txt"
@@ -281,7 +297,7 @@ scenario "agent" {
 
     variables {
       vault_hosts       = step.create_vault_cluster_targets.hosts
-      vault_install_dir = local.vault_install_dir
+      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
       vault_root_token  = step.create_vault_cluster.root_token
     }
   }
@@ -297,7 +313,7 @@ scenario "agent" {
     variables {
       vault_instances       = step.create_vault_cluster_targets.hosts
       vault_edition         = matrix.edition
-      vault_install_dir     = local.vault_install_dir
+      vault_install_dir     = global.vault_install_dir[matrix.artifact_type]
       vault_product_version = matrix.artifact_source == "local" ? step.get_local_metadata.version : var.vault_product_version
       vault_revision        = matrix.artifact_source == "local" ? step.get_local_metadata.revision : var.vault_revision
       vault_build_date      = matrix.artifact_source == "local" ? step.get_local_metadata.build_date : var.vault_build_date
@@ -314,7 +330,7 @@ scenario "agent" {
     }
 
     variables {
-      vault_install_dir = local.vault_install_dir
+      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
       vault_instances   = step.create_vault_cluster_targets.hosts
     }
   }
@@ -334,7 +350,7 @@ scenario "agent" {
       leader_public_ip  = step.get_vault_cluster_ips.leader_public_ip
       leader_private_ip = step.get_vault_cluster_ips.leader_private_ip
       vault_instances   = step.create_vault_cluster_targets.hosts
-      vault_install_dir = local.vault_install_dir
+      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
       vault_root_token  = step.create_vault_cluster.root_token
     }
   }
@@ -352,7 +368,7 @@ scenario "agent" {
     }
 
     variables {
-      vault_install_dir = local.vault_install_dir
+      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
       vault_instances   = step.create_vault_cluster_targets.hosts
       vault_root_token  = step.create_vault_cluster.root_token
     }
@@ -371,7 +387,7 @@ scenario "agent" {
 
     variables {
       vault_edition     = matrix.edition
-      vault_install_dir = local.vault_install_dir
+      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
       vault_instances   = step.create_vault_cluster_targets.hosts
     }
   }
@@ -389,7 +405,7 @@ scenario "agent" {
 
     variables {
       node_public_ips   = step.get_vault_cluster_ips.follower_public_ips
-      vault_install_dir = local.vault_install_dir
+      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
     }
   }
 

--- a/enos/enos-scenario-proxy.hcl
+++ b/enos/enos-scenario-proxy.hcl
@@ -8,6 +8,7 @@ scenario "proxy" {
     artifact_type   = global.artifact_types
     backend         = global.backends
     config_mode     = global.config_modes
+    consul_edition  = global.consul_editions
     consul_version  = global.consul_versions
     distro          = global.distros
     edition         = global.editions
@@ -30,24 +31,40 @@ scenario "proxy" {
       seal    = ["pkcs11"]
       edition = ["ce", "ent", "ent.fips1402"]
     }
+
+    # arm64 AMIs are not offered for Leap 15.4
+    exclude {
+      distro = ["leap"]
+      arch   = ["arm64"]
+    }
+
+    # softhsm packages not available for leap/sles; Enos support for softhsm
+    # on amzn2 to be added later.
+    exclude {
+      seal   = ["pkcs11"]
+      distro = ["amzn2", "leap", "sles"]
+    }
   }
 
   terraform_cli = terraform_cli.default
   terraform     = terraform.default
   providers = [
     provider.aws.default,
-    provider.enos.ubuntu,
-    provider.enos.rhel
+    provider.enos.ec2_user,
+    provider.enos.ubuntu
   ]
 
   locals {
     artifact_path = matrix.artifact_source != "artifactory" ? abspath(var.vault_artifact_path) : null
     enos_provider = {
-      rhel   = provider.enos.rhel
+      amzn2  = provider.enos.ec2_user
+      leap   = provider.enos.ec2_user
+      rhel   = provider.enos.ec2_user
+      sles   = provider.enos.ec2_user
       ubuntu = provider.enos.ubuntu
     }
     manage_service    = matrix.artifact_type == "bundle"
-    vault_install_dir = matrix.artifact_type == "bundle" ? var.vault_install_dir : global.vault_install_dir_packages[matrix.distro]
+    vault_install_dir = global.vault_install_dir[matrix.artifact_type]
   }
 
   step "get_local_metadata" {
@@ -89,9 +106,9 @@ scenario "proxy" {
   }
 
   // This step reads the contents of the backend license if we're using a Consul backend and
-  // the edition is "ent".
+  // an "ent" Consul edition.
   step "read_backend_license" {
-    skip_step = matrix.backend == "raft" || var.backend_edition == "ce"
+    skip_step = matrix.backend == "raft" || matrix.consul_edition == "ce"
     module    = module.read_license
 
     variables {
@@ -169,9 +186,9 @@ scenario "proxy" {
     variables {
       cluster_name    = step.create_vault_cluster_backend_targets.cluster_name
       cluster_tag_key = global.backend_tag_key
-      license         = (matrix.backend == "consul" && var.backend_edition == "ent") ? step.read_backend_license.license : null
+      license         = (matrix.backend == "consul" && matrix.consul_edition == "ent") ? step.read_backend_license.license : null
       release = {
-        edition = var.backend_edition
+        edition = matrix.consul_edition
         version = matrix.consul_version
       }
       target_hosts = step.create_vault_cluster_backend_targets.hosts
@@ -196,13 +213,13 @@ scenario "proxy" {
       backend_cluster_tag_key = global.backend_tag_key
       cluster_name            = step.create_vault_cluster_targets.cluster_name
       config_mode             = matrix.config_mode
-      consul_license          = (matrix.backend == "consul" && var.backend_edition == "ent") ? step.read_backend_license.license : null
+      consul_license          = (matrix.backend == "consul" && matrix.consul_edition == "ent") ? step.read_backend_license.license : null
       consul_release = matrix.backend == "consul" ? {
-        edition = var.backend_edition
+        edition = matrix.consul_edition
         version = matrix.consul_version
       } : null
       enable_audit_devices = var.vault_enable_audit_devices
-      install_dir          = local.vault_install_dir
+      install_dir          = global.vault_install_dir[matrix.artifact_type]
       license              = matrix.edition != "ce" ? step.read_vault_license.license : null
       local_artifact_path  = local.artifact_path
       manage_service       = local.manage_service
@@ -226,7 +243,7 @@ scenario "proxy" {
     variables {
       timeout           = 120 # seconds
       vault_hosts       = step.create_vault_cluster_targets.hosts
-      vault_install_dir = local.vault_install_dir
+      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
       vault_root_token  = step.create_vault_cluster.root_token
     }
   }
@@ -243,7 +260,7 @@ scenario "proxy" {
     }
 
     variables {
-      vault_install_dir = local.vault_install_dir
+      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
       vault_instances   = step.create_vault_cluster_targets.hosts
       vault_root_token  = step.create_vault_cluster.root_token
     }
@@ -259,7 +276,7 @@ scenario "proxy" {
 
     variables {
       vault_hosts       = step.create_vault_cluster_targets.hosts
-      vault_install_dir = local.vault_install_dir
+      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
       vault_root_token  = step.create_vault_cluster.root_token
     }
   }
@@ -275,7 +292,7 @@ scenario "proxy" {
     variables {
       vault_instances       = step.create_vault_cluster_targets.hosts
       vault_edition         = matrix.edition
-      vault_install_dir     = local.vault_install_dir
+      vault_install_dir     = global.vault_install_dir[matrix.artifact_type]
       vault_product_version = matrix.artifact_source == "local" ? step.get_local_metadata.version : var.vault_product_version
       vault_revision        = matrix.artifact_source == "local" ? step.get_local_metadata.revision : var.vault_revision
       vault_build_date      = matrix.artifact_source == "local" ? step.get_local_metadata.build_date : var.vault_build_date
@@ -292,7 +309,7 @@ scenario "proxy" {
     }
 
     variables {
-      vault_install_dir = local.vault_install_dir
+      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
       vault_instances   = step.create_vault_cluster_targets.hosts
     }
   }
@@ -312,7 +329,7 @@ scenario "proxy" {
       leader_public_ip  = step.get_vault_cluster_ips.leader_public_ip
       leader_private_ip = step.get_vault_cluster_ips.leader_private_ip
       vault_instances   = step.create_vault_cluster_targets.hosts
-      vault_install_dir = local.vault_install_dir
+      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
       vault_root_token  = step.create_vault_cluster.root_token
     }
   }
@@ -327,7 +344,7 @@ scenario "proxy" {
     }
 
     variables {
-      vault_install_dir = local.vault_install_dir
+      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
       vault_instances   = step.create_vault_cluster_targets.hosts
       vault_root_token  = step.create_vault_cluster.root_token
     }
@@ -343,7 +360,7 @@ scenario "proxy" {
 
     variables {
       vault_edition     = matrix.edition
-      vault_install_dir = local.vault_install_dir
+      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
       vault_instances   = step.create_vault_cluster_targets.hosts
     }
   }
@@ -361,7 +378,7 @@ scenario "proxy" {
 
     variables {
       node_public_ips   = step.get_vault_cluster_ips.follower_public_ips
-      vault_install_dir = local.vault_install_dir
+      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
     }
   }
 

--- a/enos/enos-scenario-smoke.hcl
+++ b/enos/enos-scenario-smoke.hcl
@@ -8,6 +8,7 @@ scenario "smoke" {
     artifact_type   = global.artifact_types
     backend         = global.backends
     config_mode     = global.config_modes
+    consul_edition  = global.consul_editions
     consul_version  = global.consul_versions
     distro          = global.distros
     edition         = global.editions
@@ -30,24 +31,39 @@ scenario "smoke" {
       seal    = ["pkcs11"]
       edition = ["ce", "ent", "ent.fips1402"]
     }
+
+    # arm64 AMIs are not offered for Leap 15.4
+    exclude {
+      distro = ["leap"]
+      arch   = ["arm64"]
+    }
+
+    # softhsm packages not available for leap/sles; Enos support for softhsm
+    # on amzn2 to be added later.
+    exclude {
+      seal   = ["pkcs11"]
+      distro = ["amzn2", "leap", "sles"]
+    }
   }
 
   terraform_cli = terraform_cli.default
   terraform     = terraform.default
   providers = [
     provider.aws.default,
-    provider.enos.ubuntu,
-    provider.enos.rhel
+    provider.enos.ec2_user,
+    provider.enos.ubuntu
   ]
 
   locals {
     artifact_path = matrix.artifact_source != "artifactory" ? abspath(var.vault_artifact_path) : null
     enos_provider = {
-      rhel   = provider.enos.rhel
+      amzn2  = provider.enos.ec2_user
+      leap   = provider.enos.ec2_user
+      rhel   = provider.enos.ec2_user
+      sles   = provider.enos.ec2_user
       ubuntu = provider.enos.ubuntu
     }
-    manage_service    = matrix.artifact_type == "bundle"
-    vault_install_dir = matrix.artifact_type == "bundle" ? var.vault_install_dir : global.vault_install_dir_packages[matrix.distro]
+    manage_service = matrix.artifact_type == "bundle"
   }
 
   step "get_local_metadata" {
@@ -89,9 +105,9 @@ scenario "smoke" {
   }
 
   // This step reads the contents of the backend license if we're using a Consul backend and
-  // the edition is "ent".
+  // an "ent" Consul edition.
   step "read_backend_license" {
-    skip_step = matrix.backend == "raft" || var.backend_edition == "ce"
+    skip_step = matrix.backend == "raft" || matrix.consul_edition == "ce"
     module    = module.read_license
 
     variables {
@@ -169,9 +185,9 @@ scenario "smoke" {
     variables {
       cluster_name    = step.create_vault_cluster_backend_targets.cluster_name
       cluster_tag_key = global.backend_tag_key
-      license         = (matrix.backend == "consul" && var.backend_edition == "ent") ? step.read_backend_license.license : null
+      license         = (matrix.backend == "consul" && matrix.consul_edition == "ent") ? step.read_backend_license.license : null
       release = {
-        edition = var.backend_edition
+        edition = matrix.consul_edition
         version = matrix.consul_version
       }
       target_hosts = step.create_vault_cluster_backend_targets.hosts
@@ -196,13 +212,13 @@ scenario "smoke" {
       backend_cluster_tag_key = global.backend_tag_key
       cluster_name            = step.create_vault_cluster_targets.cluster_name
       config_mode             = matrix.config_mode
-      consul_license          = (matrix.backend == "consul" && var.backend_edition == "ent") ? step.read_backend_license.license : null
+      consul_license          = (matrix.backend == "consul" && matrix.consul_edition == "ent") ? step.read_backend_license.license : null
       consul_release = matrix.backend == "consul" ? {
-        edition = var.backend_edition
+        edition = matrix.consul_edition
         version = matrix.consul_version
       } : null
       enable_audit_devices = var.vault_enable_audit_devices
-      install_dir          = local.vault_install_dir
+      install_dir          = global.vault_install_dir[matrix.artifact_type]
       license              = matrix.edition != "ce" ? step.read_vault_license.license : null
       local_artifact_path  = local.artifact_path
       manage_service       = local.manage_service
@@ -226,7 +242,7 @@ scenario "smoke" {
     variables {
       timeout           = 120 # seconds
       vault_hosts       = step.create_vault_cluster_targets.hosts
-      vault_install_dir = local.vault_install_dir
+      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
       vault_root_token  = step.create_vault_cluster.root_token
     }
   }
@@ -241,7 +257,7 @@ scenario "smoke" {
 
     variables {
       vault_hosts       = step.create_vault_cluster_targets.hosts
-      vault_install_dir = local.vault_install_dir
+      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
       vault_root_token  = step.create_vault_cluster.root_token
     }
   }
@@ -256,7 +272,7 @@ scenario "smoke" {
     }
 
     variables {
-      vault_install_dir = local.vault_install_dir
+      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
       leader_host       = step.get_leader_ip_for_step_down.leader_host
       vault_root_token  = step.create_vault_cluster.root_token
     }
@@ -274,7 +290,7 @@ scenario "smoke" {
     variables {
       timeout           = 120 # seconds
       vault_hosts       = step.create_vault_cluster_targets.hosts
-      vault_install_dir = local.vault_install_dir
+      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
       vault_root_token  = step.create_vault_cluster.root_token
     }
   }
@@ -289,7 +305,7 @@ scenario "smoke" {
 
     variables {
       vault_hosts       = step.create_vault_cluster_targets.hosts
-      vault_install_dir = local.vault_install_dir
+      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
       vault_root_token  = step.create_vault_cluster.root_token
     }
   }
@@ -305,7 +321,7 @@ scenario "smoke" {
     variables {
       vault_instances       = step.create_vault_cluster_targets.hosts
       vault_edition         = matrix.edition
-      vault_install_dir     = local.vault_install_dir
+      vault_install_dir     = global.vault_install_dir[matrix.artifact_type]
       vault_product_version = matrix.artifact_source == "local" ? step.get_local_metadata.version : var.vault_product_version
       vault_revision        = matrix.artifact_source == "local" ? step.get_local_metadata.revision : var.vault_revision
       vault_build_date      = matrix.artifact_source == "local" ? step.get_local_metadata.build_date : var.vault_build_date
@@ -322,7 +338,7 @@ scenario "smoke" {
     }
 
     variables {
-      vault_install_dir = local.vault_install_dir
+      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
       vault_instances   = step.create_vault_cluster_targets.hosts
     }
   }
@@ -342,7 +358,7 @@ scenario "smoke" {
       leader_public_ip  = step.get_vault_cluster_ips.leader_public_ip
       leader_private_ip = step.get_vault_cluster_ips.leader_private_ip
       vault_instances   = step.create_vault_cluster_targets.hosts
-      vault_install_dir = local.vault_install_dir
+      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
       vault_root_token  = step.create_vault_cluster.root_token
     }
   }
@@ -360,7 +376,7 @@ scenario "smoke" {
     }
 
     variables {
-      vault_install_dir = local.vault_install_dir
+      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
       vault_instances   = step.create_vault_cluster_targets.hosts
       vault_root_token  = step.create_vault_cluster.root_token
     }
@@ -379,7 +395,7 @@ scenario "smoke" {
 
     variables {
       vault_edition     = matrix.edition
-      vault_install_dir = local.vault_install_dir
+      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
       vault_instances   = step.create_vault_cluster_targets.hosts
     }
   }
@@ -397,7 +413,7 @@ scenario "smoke" {
 
     variables {
       node_public_ips   = step.get_vault_cluster_ips.follower_public_ips
-      vault_install_dir = local.vault_install_dir
+      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
     }
   }
 

--- a/enos/enos-scenario-upgrade.hcl
+++ b/enos/enos-scenario-upgrade.hcl
@@ -8,6 +8,7 @@ scenario "upgrade" {
     artifact_type   = global.artifact_types
     backend         = global.backends
     config_mode     = global.config_modes
+    consul_edition  = global.consul_editions
     consul_version  = global.consul_versions
     distro          = global.distros
     edition         = global.editions
@@ -43,24 +44,39 @@ scenario "upgrade" {
       seal    = ["pkcs11"]
       edition = ["ce", "ent", "ent.fips1402"]
     }
+
+    # arm64 AMIs are not offered for Leap 15.4
+    exclude {
+      distro = ["leap"]
+      arch   = ["arm64"]
+    }
+
+    # softhsm packages not available for leap/sles; Enos support for softhsm
+    # on amzn2 to be added later.
+    exclude {
+      seal   = ["pkcs11"]
+      distro = ["amzn2", "leap", "sles"]
+    }
   }
 
   terraform_cli = terraform_cli.default
   terraform     = terraform.default
   providers = [
     provider.aws.default,
-    provider.enos.ubuntu,
-    provider.enos.rhel
+    provider.enos.ec2_user,
+    provider.enos.ubuntu
   ]
 
   locals {
     artifact_path = matrix.artifact_source != "artifactory" ? abspath(var.vault_artifact_path) : null
     enos_provider = {
-      rhel   = provider.enos.rhel
+      amzn2  = provider.enos.ec2_user
+      leap   = provider.enos.ec2_user
+      rhel   = provider.enos.ec2_user
+      sles   = provider.enos.ec2_user
       ubuntu = provider.enos.ubuntu
     }
-    manage_service    = matrix.artifact_type == "bundle"
-    vault_install_dir = matrix.artifact_type == "bundle" ? var.vault_install_dir : global.vault_install_dir_packages[matrix.distro]
+    manage_service = matrix.artifact_type == "bundle"
   }
 
   step "get_local_metadata" {
@@ -103,9 +119,9 @@ scenario "upgrade" {
   }
 
   // This step reads the contents of the backend license if we're using a Consul backend and
-  // the edition is "ent".
+  // an "ent" Consul edition.
   step "read_backend_license" {
-    skip_step = matrix.backend == "raft" || var.backend_edition == "ce"
+    skip_step = matrix.backend == "raft" || matrix.consul_edition == "ce"
     module    = module.read_license
 
     variables {
@@ -183,9 +199,9 @@ scenario "upgrade" {
     variables {
       cluster_name    = step.create_vault_cluster_backend_targets.cluster_name
       cluster_tag_key = global.backend_tag_key
-      license         = (matrix.backend == "consul" && var.backend_edition == "ent") ? step.read_backend_license.license : null
+      license         = (matrix.backend == "consul" && matrix.consul_edition == "ent") ? step.read_backend_license.license : null
       release = {
-        edition = var.backend_edition
+        edition = matrix.consul_edition
         version = matrix.consul_version
       }
       target_hosts = step.create_vault_cluster_backend_targets.hosts
@@ -209,13 +225,13 @@ scenario "upgrade" {
       backend_cluster_tag_key = global.backend_tag_key
       cluster_name            = step.create_vault_cluster_targets.cluster_name
       config_mode             = matrix.config_mode
-      consul_license          = (matrix.backend == "consul" && var.backend_edition == "ent") ? step.read_backend_license.license : null
+      consul_license          = (matrix.backend == "consul" && matrix.consul_edition == "ent") ? step.read_backend_license.license : null
       consul_release = matrix.backend == "consul" ? {
-        edition = var.backend_edition
+        edition = matrix.consul_edition
         version = matrix.consul_version
       } : null
       enable_audit_devices = var.vault_enable_audit_devices
-      install_dir          = local.vault_install_dir
+      install_dir          = global.vault_install_dir[matrix.artifact_type]
       license              = matrix.edition != "ce" ? step.read_vault_license.license : null
       packages             = concat(global.packages, global.distro_packages[matrix.distro])
       release = {
@@ -239,7 +255,7 @@ scenario "upgrade" {
 
     variables {
       vault_hosts       = step.create_vault_cluster_targets.hosts
-      vault_install_dir = local.vault_install_dir
+      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
       vault_root_token  = step.create_vault_cluster.root_token
     }
   }
@@ -259,7 +275,7 @@ scenario "upgrade" {
       leader_public_ip  = step.get_vault_cluster_ips.leader_public_ip
       leader_private_ip = step.get_vault_cluster_ips.leader_private_ip
       vault_instances   = step.create_vault_cluster_targets.hosts
-      vault_install_dir = local.vault_install_dir
+      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
       vault_root_token  = step.create_vault_cluster.root_token
     }
   }
@@ -282,7 +298,7 @@ scenario "upgrade" {
       vault_instances           = step.create_vault_cluster_targets.hosts
       vault_local_artifact_path = local.artifact_path
       vault_artifactory_release = matrix.artifact_source == "artifactory" ? step.build_vault.vault_artifactory_release : null
-      vault_install_dir         = local.vault_install_dir
+      vault_install_dir         = global.vault_install_dir[matrix.artifact_type]
       vault_unseal_keys         = matrix.seal == "shamir" ? step.create_vault_cluster.unseal_keys_hex : null
       vault_seal_type           = matrix.seal
     }
@@ -303,7 +319,7 @@ scenario "upgrade" {
     variables {
       timeout           = 120 # seconds
       vault_hosts       = step.create_vault_cluster_targets.hosts
-      vault_install_dir = local.vault_install_dir
+      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
       vault_root_token  = step.create_vault_cluster.root_token
     }
   }
@@ -318,7 +334,7 @@ scenario "upgrade" {
 
     variables {
       vault_hosts       = step.create_vault_cluster_targets.hosts
-      vault_install_dir = local.vault_install_dir
+      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
       vault_root_token  = step.create_vault_cluster.root_token
     }
   }
@@ -333,7 +349,7 @@ scenario "upgrade" {
     }
 
     variables {
-      vault_install_dir = local.vault_install_dir
+      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
       leader_host       = step.get_leader_ip_for_step_down.leader_host
       vault_root_token  = step.create_vault_cluster.root_token
     }
@@ -351,7 +367,7 @@ scenario "upgrade" {
     variables {
       timeout           = 120 # seconds
       vault_hosts       = step.create_vault_cluster_targets.hosts
-      vault_install_dir = local.vault_install_dir
+      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
       vault_root_token  = step.create_vault_cluster.root_token
     }
   }
@@ -368,7 +384,7 @@ scenario "upgrade" {
 
     variables {
       vault_hosts       = step.create_vault_cluster_targets.hosts
-      vault_install_dir = local.vault_install_dir
+      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
       vault_root_token  = step.create_vault_cluster.root_token
     }
   }
@@ -386,7 +402,7 @@ scenario "upgrade" {
     variables {
       vault_instances       = step.create_vault_cluster_targets.hosts
       vault_edition         = matrix.edition
-      vault_install_dir     = local.vault_install_dir
+      vault_install_dir     = global.vault_install_dir[matrix.artifact_type]
       vault_product_version = matrix.artifact_source == "local" ? step.get_local_metadata.version : var.vault_product_version
       vault_revision        = matrix.artifact_source == "local" ? step.get_local_metadata.revision : var.vault_revision
       vault_build_date      = matrix.artifact_source == "local" ? step.get_local_metadata.build_date : var.vault_build_date
@@ -406,7 +422,7 @@ scenario "upgrade" {
 
     variables {
       vault_instances   = step.create_vault_cluster_targets.hosts
-      vault_install_dir = local.vault_install_dir
+      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
     }
   }
 
@@ -424,7 +440,7 @@ scenario "upgrade" {
 
     variables {
       node_public_ips   = step.get_updated_vault_cluster_ips.follower_public_ips
-      vault_install_dir = local.vault_install_dir
+      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
     }
   }
 
@@ -440,7 +456,7 @@ scenario "upgrade" {
     }
 
     variables {
-      vault_install_dir = local.vault_install_dir
+      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
       vault_instances   = step.create_vault_cluster_targets.hosts
       vault_root_token  = step.create_vault_cluster.root_token
     }
@@ -458,7 +474,7 @@ scenario "upgrade" {
 
     variables {
       vault_edition     = matrix.edition
-      vault_install_dir = local.vault_install_dir
+      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
       vault_instances   = step.create_vault_cluster_targets.hosts
     }
   }

--- a/enos/enos-variables.hcl
+++ b/enos/enos-variables.hcl
@@ -75,10 +75,34 @@ variable "project_name" {
   default     = "vault-enos-integration"
 }
 
-variable "rhel_distro_version" {
+variable "distro_version_amzn2" {
+  description = "The version of Amazon Linux 2 to use"
+  type        = string
+  default     = "2"
+}
+
+variable "distro_version_leap" {
+  description = "The version of openSUSE leap to use"
+  type        = string
+  default     = "15.5" // or "15.4"
+}
+
+variable "distro_version_rhel" {
   description = "The version of RHEL to use"
   type        = string
-  default     = "9.1" // or "8.8"
+  default     = "9.3" // or "8.9"
+}
+
+variable "distro_version_sles" {
+  description = "The version of SUSE SLES to use"
+  type        = string
+  default     = "v15_sp5_standard"
+}
+
+variable "distro_version_ubuntu" {
+  description = "The version of ubuntu to use"
+  type        = string
+  default     = "22.04" // or "20.04"
 }
 
 variable "tags" {
@@ -91,12 +115,6 @@ variable "terraform_plugin_cache_dir" {
   description = "The directory to cache Terraform modules and providers"
   type        = string
   default     = null
-}
-
-variable "ubuntu_distro_version" {
-  description = "The version of ubuntu to use"
-  type        = string
-  default     = "22.04" // or "20.04", "18.04"
 }
 
 variable "ui_test_filter" {

--- a/enos/enos.vars.hcl
+++ b/enos/enos.vars.hcl
@@ -23,9 +23,6 @@
 # aws_ssh_private_key_path is the path to the AWS keypair private key
 # aws_ssh_private_key_path = "./support/private_key.pem"
 
-# backend_edition is the backend (consul) release edition if applicable to the scenario.
-# backend_edition = "ce"
-
 # backend_license_path is the license for the backend if applicable (Consul Enterprise)".
 # backend_license_path = "./support/consul.hclic"
 
@@ -40,8 +37,20 @@
 # resources.
 # project_name = "vault-enos-integration"
 
-# rhel_distro_version is the version of RHEL to use for "distro:rhel" variants.
-# rhel_distro_version = "9.1" // or "8.8"
+# distro_version_amzn2 is the version of Amazon Linux 2 to use for "distro:amzn2" variants
+# distro_version_amzn2 = "2"
+
+# distro_version_leap is the version of openSUSE Leap to use for "distro:leap" variants
+# distro_version_leap = "15.5" // or "15.4"
+
+# distro_version_rhel is the version of RHEL to use for "distro:rhel" variants.
+# distro_version_rhel = "9.3" // or "8.9"
+
+# distro_version_sles is the version of SUSE SLES to use for "distro:sles" variants.
+# distro_version_sles = "v15_sp5_standard"
+
+# distro_version_ubuntu is the version of ubuntu to use for "distro:ubuntu" variants
+# distro_version_ubuntu = "22.04" // or "20.04", "18.04"
 
 # tags are a map of tags that will be applied to infrastructure resources that
 # support tagging.
@@ -58,9 +67,6 @@
 # ui_run_tests sets whether to run the UI tests or not for the ui scenario. If set to false a
 # cluster will be created but no tests will be run.
 # ui_run_tests = true
-
-# ubuntu_distro_version is the version of ubuntu to use for "distro:ubuntu" variants
-# ubuntu_distro_version = "22.04" // or "20.04", "18.04"
 
 # vault_artifact_path is the path to CRT generated or local vault.zip bundle. When
 # using the "builder:local" variant a bundle will be built from the current branch.

--- a/enos/modules/build_artifactory_artifact/locals.tf
+++ b/enos/modules/build_artifactory_artifact/locals.tf
@@ -6,12 +6,18 @@ locals {
   // file name extensions for the install packages of vault for the various architectures, distributions and editions
   package_extensions = {
     amd64 = {
-      ubuntu = "-1_amd64.deb"
+      amzn2  = "-1.x86_64.rpm"
+      leap   = "-1.x86_64.rpm"
       rhel   = "-1.x86_64.rpm"
+      sles   = "-1.x86_64.rpm"
+      ubuntu = "-1_amd64.deb"
     }
     arm64 = {
-      ubuntu = "-1_arm64.deb"
+      amzn2  = "-1.aarch64.rpm"
+      leap   = "-1.aarch64.rpm"
       rhel   = "-1.aarch64.rpm"
+      sles   = "-1.aarch64.rpm"
+      ubuntu = "-1_arm64.deb"
     }
   }
 
@@ -20,12 +26,19 @@ locals {
 
   // file name prefixes for the install packages of vault for the various distributions and artifact types (package or bundle)
   artifact_package_release_names = {
-    ubuntu = {
-      "ce"               = "vault_"
-      "ent"              = "vault-enterprise_",
-      "ent.fips1402"     = "vault-enterprise-fips1402_",
-      "ent.hsm"          = "vault-enterprise-hsm_",
-      "ent.hsm.fips1402" = "vault-enterprise-hsm-fips1402_",
+    amzn2 = {
+      "ce"               = "vault-"
+      "ent"              = "vault-enterprise-",
+      "ent.fips1402"     = "vault-enterprise-fips1402-",
+      "ent.hsm"          = "vault-enterprise-hsm-",
+      "ent.hsm.fips1402" = "vault-enterprise-hsm-fips1402-",
+    },
+    leap = {
+      "ce"               = "vault-"
+      "ent"              = "vault-enterprise-",
+      "ent.fips1402"     = "vault-enterprise-fips1402-",
+      "ent.hsm"          = "vault-enterprise-hsm-",
+      "ent.hsm.fips1402" = "vault-enterprise-hsm-fips1402-",
     },
     rhel = {
       "ce"               = "vault-"
@@ -33,19 +46,27 @@ locals {
       "ent.fips1402"     = "vault-enterprise-fips1402-",
       "ent.hsm"          = "vault-enterprise-hsm-",
       "ent.hsm.fips1402" = "vault-enterprise-hsm-fips1402-",
+    },
+    sles = {
+      "ce"               = "vault-"
+      "ent"              = "vault-enterprise-",
+      "ent.fips1402"     = "vault-enterprise-fips1402-",
+      "ent.hsm"          = "vault-enterprise-hsm-",
+      "ent.hsm.fips1402" = "vault-enterprise-hsm-fips1402-",
+    }
+    ubuntu = {
+      "ce"               = "vault_"
+      "ent"              = "vault-enterprise_",
+      "ent.fips1402"     = "vault-enterprise-fips1402_",
+      "ent.hsm"          = "vault-enterprise-hsm_",
+      "ent.hsm.fips1402" = "vault-enterprise-hsm-fips1402_",
     }
   }
 
-  // edition --> artifact name edition
-  artifact_name_edition = {
-    "ce"               = ""
-    "ent"              = ""
-    "ent.hsm"          = ".hsm"
-    "ent.fips1402"     = ".fips1402"
-    "ent.hsm.fips1402" = ".hsm.fips1402"
-  }
-
-  artifact_name_prefix    = var.artifact_type == "package" ? local.artifact_package_release_names[var.distro][var.edition] : "vault_"
+  # Prefix for the artifact name. Ex: vault_, vault-, vault-enterprise_, vault-enterprise-hsm-fips1402-, etc
+  artifact_name_prefix = var.artifact_type == "package" ? local.artifact_package_release_names[var.distro][var.edition] : "vault_"
+  # Suffix and extension for the artifact name. Ex: _linux_<arch>.zip, 
   artifact_name_extension = var.artifact_type == "package" ? local.package_extensions[var.arch][var.distro] : "_linux_${var.arch}.zip"
-  artifact_name           = var.artifact_type == "package" ? "${local.artifact_name_prefix}${replace(local.artifact_version, "-", "~")}${local.artifact_name_extension}" : "${local.artifact_name_prefix}${var.product_version}${local.artifact_name_extension}"
+  # Combine prefix/suffix/extension together to form the artifact name
+  artifact_name = var.artifact_type == "package" ? "${local.artifact_name_prefix}${replace(local.artifact_version, "-", "~")}${local.artifact_name_extension}" : "${local.artifact_name_prefix}${var.product_version}${local.artifact_name_extension}"
 }

--- a/enos/modules/disable_selinux/main.tf
+++ b/enos/modules/disable_selinux/main.tf
@@ -1,0 +1,30 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+terraform {
+  required_providers {
+    enos = {
+      source = "registry.terraform.io/hashicorp-forge/enos"
+    }
+  }
+}
+
+variable "hosts" {
+  type = map(object({
+    private_ip = string
+    public_ip  = string
+  }))
+  description = "The hosts to install packages on"
+}
+
+resource "enos_remote_exec" "make_selinux_permissive" {
+  for_each = var.hosts
+
+  scripts = [abspath("${path.module}/scripts/make-selinux-permissive.sh")]
+
+  transport = {
+    ssh = {
+      host = each.value.public_ip
+    }
+  }
+}

--- a/enos/modules/disable_selinux/scripts/make-selinux-permissive.sh
+++ b/enos/modules/disable_selinux/scripts/make-selinux-permissive.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+set -e
+
+fail() {
+  echo "$1" 1>&2
+  exit 1
+}
+
+if ! type getenforce &> /dev/null; then
+  exit 0
+fi
+
+if sudo getenforce | grep Enforcing; then
+  sudo setenforce 0
+fi

--- a/enos/modules/ec2_info/main.tf
+++ b/enos/modules/ec2_info/main.tf
@@ -1,27 +1,50 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
+# Note: in order to use the openSUSE Leap AMIs, the AWS account in use must "subscribe"
+# and accept SUSE's terms of use. You can do this at the links below. If the AWS account
+# you are using is already subscribed, this confirmation will be displayed on each page.
+# openSUSE Leap arm64 subscription: https://aws.amazon.com/marketplace/server/procurement?productId=a516e959-df54-4035-bb1a-63599b7a6df9
+# openSUSE leap amd64 subscription: https://aws.amazon.com/marketplace/server/procurement?productId=5535c495-72d4-4355-b169-54ffa874f849
+
 locals {
   architectures      = toset(["arm64", "x86_64"])
+  amzn2_owner_id     = "591542846629"
   canonical_owner_id = "099720109477"
+  sles_owner_id      = "013907871322"
+  suse_owner_id      = "679593333241"
   rhel_owner_id      = "309956199498"
   ids = {
     "arm64" = {
+      "amzn2" = {
+        "2" = data.aws_ami.amzn2["arm64"].id
+      }
       "rhel" = {
-        "8.8" = data.aws_ami.rhel_88["arm64"].id
-        "9.1" = data.aws_ami.rhel_91["arm64"].id
+        "8.9" = data.aws_ami.rhel_89["arm64"].id
+        "9.3" = data.aws_ami.rhel_93["arm64"].id
+      }
+      "sles" = {
+        "v15_sp5_standard" = data.aws_ami.sles_15_sp5_standard["arm64"].id
       }
       "ubuntu" = {
-        "18.04" = data.aws_ami.ubuntu_1804["arm64"].id
         "20.04" = data.aws_ami.ubuntu_2004["arm64"].id
         "22.04" = data.aws_ami.ubuntu_2204["arm64"].id
       }
     }
     "amd64" = {
+      "amzn2" = {
+        "2" = data.aws_ami.amzn2["x86_64"].id
+      }
+      "leap" = {
+        "15.4" = data.aws_ami.leap_154.id
+        "15.5" = data.aws_ami.leap_155.id
+      }
       "rhel" = {
-        "7.9" = data.aws_ami.rhel_79.id
-        "8.8" = data.aws_ami.rhel_88["x86_64"].id
-        "9.1" = data.aws_ami.rhel_91["x86_64"].id
+        "8.9" = data.aws_ami.rhel_89["x86_64"].id
+        "9.3" = data.aws_ami.rhel_93["x86_64"].id
+      }
+      "sles" = {
+        "v15_sp5_standard" = data.aws_ami.sles_15_sp5_standard["x86_64"].id
       }
       "ubuntu" = {
         "18.04" = data.aws_ami.ubuntu_1804["x86_64"].id
@@ -98,13 +121,14 @@ data "aws_ami" "ubuntu_2204" {
   owners = [local.canonical_owner_id]
 }
 
-data "aws_ami" "rhel_79" {
+data "aws_ami" "rhel_89" {
   most_recent = true
+  for_each    = local.architectures
 
   # Currently latest latest point release-1
   filter {
     name   = "name"
-    values = ["RHEL-7.9*HVM-20*"]
+    values = ["RHEL-8.9*HVM-20*"]
   }
 
   filter {
@@ -114,56 +138,105 @@ data "aws_ami" "rhel_79" {
 
   filter {
     name   = "architecture"
+    values = [each.value]
+  }
+
+  owners = [local.rhel_owner_id]
+}
+
+data "aws_ami" "rhel_93" {
+  most_recent = true
+  for_each    = local.architectures
+
+  # Currently latest latest point release-1
+  filter {
+    name   = "name"
+    values = ["RHEL-9.3*HVM-20*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = [each.value]
+  }
+
+  owners = [local.rhel_owner_id]
+}
+
+data "aws_ami" "amzn2" {
+  most_recent = true
+  for_each    = local.architectures
+
+  filter {
+    name   = "name"
+    values = ["amzn2-ami-ecs-hvm-2.0*"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = [each.value]
+  }
+
+  owners = [local.amzn2_owner_id]
+}
+
+data "aws_ami" "sles_15_sp5_standard" {
+  most_recent = true
+  for_each    = local.architectures
+
+  filter {
+    name   = "name"
+    values = ["suse-sles-15-sp5-v*-hvm-*"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = [each.value]
+  }
+
+  owners = [local.sles_owner_id]
+}
+
+data "aws_ami" "leap_154" {
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["openSUSE-Leap-15.4*"]
+  }
+
+  filter {
+    name = "architecture"
+    # Note: arm64 AMIs are offered for Leap 15.5, but not 15.4. For now we will
+    # only use x86_64 for both in order to not introduce complexity in our matrix
+    # exclusions.
     values = ["x86_64"]
   }
 
-  owners = [local.rhel_owner_id]
+  owners = [local.suse_owner_id]
 }
 
-data "aws_ami" "rhel_88" {
+data "aws_ami" "leap_155" {
   most_recent = true
-  for_each    = local.architectures
 
-  # Currently latest latest point release-1
   filter {
     name   = "name"
-    values = ["RHEL-8.8*HVM-20*"]
+    values = ["openSUSE-Leap-15.5*"]
   }
 
   filter {
-    name   = "virtualization-type"
-    values = ["hvm"]
+    name = "architecture"
+    # Note: arm64 AMIs are offered for Leap 15.5, but not 15.4. For now we will
+    # only use x86_64 for both in order to not introduce complexity in our matrix
+    # exclusions.
+    values = ["x86_64"]
   }
 
-  filter {
-    name   = "architecture"
-    values = [each.value]
-  }
-
-  owners = [local.rhel_owner_id]
-}
-
-data "aws_ami" "rhel_91" {
-  most_recent = true
-  for_each    = local.architectures
-
-  # Currently latest latest point release-1
-  filter {
-    name   = "name"
-    values = ["RHEL-9.1*HVM-20*"]
-  }
-
-  filter {
-    name   = "virtualization-type"
-    values = ["hvm"]
-  }
-
-  filter {
-    name   = "architecture"
-    values = [each.value]
-  }
-
-  owners = [local.rhel_owner_id]
+  owners = [local.suse_owner_id]
 }
 
 data "aws_region" "current" {}

--- a/enos/modules/install_packages/main.tf
+++ b/enos/modules/install_packages/main.tf
@@ -9,6 +9,32 @@ terraform {
   }
 }
 
+locals {
+  arch = {
+    "amd64" = "x86_64"
+    "arm64" = "aarch64"
+  }
+  package_manager = {
+    # Note: though we generally use "amzn2" as our distro name for Amazon Linux 2, 
+    # enos_host_info.hosts[each.key].distro returns "amzn", so that is what we reference here.
+    "amzn"          = "yum"
+    "opensuse-leap" = "zypper"
+    "rhel"          = "yum"
+    "sles"          = "zypper"
+    "ubuntu"        = "apt"
+  }
+  distro_repos = {
+    # Currently sles is the only distro that requires setting up repos before installing packages
+    "sles" = {
+      "15.5" = "https://download.opensuse.org/repositories/network:utilities/SLE_15_SP5/network:utilities.repo"
+    }
+    "rhel" = {
+      "8.9" = "https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm"
+      "9.3" = "https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm"
+    }
+  }
+}
+
 variable "packages" {
   type    = list(string)
   default = []
@@ -34,10 +60,43 @@ variable "retry_interval" {
   default     = 2
 }
 
-resource "enos_remote_exec" "install_packages" {
+resource "enos_host_info" "hosts" {
+  for_each = var.hosts
+
+  transport = {
+    ssh = {
+      host = each.value.public_ip
+    }
+  }
+}
+
+# Set up repos for each distro (in order to install some packages, some distros
+# require us to manually add the repo for that package first)
+resource "enos_remote_exec" "distro_repo_setup" {
   for_each = var.hosts
 
   environment = {
+    DISTRO          = enos_host_info.hosts[each.key].distro
+    DISTRO_REPOS    = try(local.distro_repos[enos_host_info.hosts[each.key].distro][enos_host_info.hosts[each.key].distro_version], "__none")
+    RETRY_INTERVAL  = var.retry_interval
+    TIMEOUT_SECONDS = var.timeout
+  }
+
+  scripts = [abspath("${path.module}/scripts/distro-repo-setup.sh")]
+
+  transport = {
+    ssh = {
+      host = each.value.public_ip
+    }
+  }
+}
+
+resource "enos_remote_exec" "install_packages" {
+  for_each   = var.hosts
+  depends_on = [enos_remote_exec.distro_repo_setup]
+
+  environment = {
+    PACKAGE_MANAGER = local.package_manager[enos_host_info.hosts[each.key].distro]
     PACKAGES        = length(var.packages) >= 1 ? join(" ", var.packages) : "__skip"
     RETRY_INTERVAL  = var.retry_interval
     TIMEOUT_SECONDS = var.timeout

--- a/enos/modules/install_packages/scripts/distro-repo-setup.sh
+++ b/enos/modules/install_packages/scripts/distro-repo-setup.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+set -e
+
+fail() {
+  echo "$1" 1>&2
+  exit 1
+}
+
+[[ -z "$DISTRO" ]] && fail "DISTRO env variable has not been set"
+[[ -z "$RETRY_INTERVAL" ]] && fail "RETRY_INTERVAL env variable has not been set"
+[[ -z "$TIMEOUT_SECONDS" ]] && fail "TIMEOUT_SECONDS env variable has not been set"
+
+setup_repos() {
+  # If we don't have any repos on the list for this distro, no action needed.
+  if [ ${#DISTRO_REPOS[@]} -lt 1 ]; then
+    echo "DISTRO_REPOS is empty; No repos required for the packages for this Linux distro."
+    return 0
+  fi
+
+  # Wait for cloud-init to finish so it doesn't race with any of our package installations.
+  # Note: Amazon Linux 2 throws Python 2.7 errors when running `cloud-init status` as
+  # non-root user (known bug).
+  sudo cloud-init status --wait
+
+  case $DISTRO in
+    "sles")
+      for repo in ${DISTRO_REPOS}; do
+        sudo zypper addrepo "${repo}"
+      done
+      ;;
+    "rhel")
+      for repo in ${DISTRO_REPOS}; do
+        sudo rm -r /var/cache/dnf
+        sudo dnf install -y "${repo}"
+        sudo dnf update -y --refresh
+      done
+      ;;
+    *)
+      return
+      ;;
+  esac
+}
+
+begin_time=$(date +%s)
+end_time=$((begin_time + TIMEOUT_SECONDS))
+while [ "$(date +%s)" -lt "$end_time" ]; do
+  if setup_repos; then
+    exit 0
+  fi
+
+  sleep "$RETRY_INTERVAL"
+done
+
+fail "Timed out waiting for distro repos to install"

--- a/enos/modules/install_packages/scripts/install-packages.sh
+++ b/enos/modules/install_packages/scripts/install-packages.sh
@@ -9,41 +9,75 @@ fail() {
   exit 1
 }
 
-[[ -z "$RETRY_INTERVAL" ]] && fail "RETRY_INTERVAL env variable has not been set"
-[[ -z "$TIMEOUT_SECONDS" ]] && fail "TIMEOUT_SECONDS env variable has not been set"
-[[ -z "$PACKAGES" ]] && fail "PACKAGES env variable has not been set"
+[[ -z "${RETRY_INTERVAL}" ]] && fail "RETRY_INTERVAL env variable has not been set"
+[[ -z "${TIMEOUT_SECONDS}" ]] && fail "TIMEOUT_SECONDS env variable has not been set"
+[[ -z "${PACKAGES}" ]] && fail "PACKAGES env variable has not been set"
+[[ -z "${PACKAGE_MANAGER}" ]] && fail "PACKAGE_MANAGER env variable has not been set"
 
 install_packages() {
-  if [ "$PACKAGES" = "__skip" ]; then
+  if [[ "${PACKAGES}" = "__skip" ]]; then
     return 0
-  fi
+  fi 
 
-  echo "Installing Dependencies: $PACKAGES"
-  if [ -f /etc/debian_version ]; then
-    # Do our best to make sure that we don't race with cloud-init. Wait a reasonable time until we
-    # see ec2 in the sources list. Very rarely cloud-init will take longer than we wait. In that case
-    # we'll just install our packages.
-    grep ec2 /etc/apt/sources.list || true
+  set -x
+  echo "Installing Dependencies: ${PACKAGES}"
 
-    cd /tmp
-    sudo apt update
-    # shellcheck disable=2068
-    sudo apt install -y ${PACKAGES[@]}
-  else
-    cd /tmp
-    # shellcheck disable=2068
-    sudo yum -y install ${PACKAGES[@]}
-  fi
+  # Use the default package manager of the current Linux distro to install packages
+  case $PACKAGE_MANAGER in
+
+    "apt")
+      sudo apt update
+      for package in ${PACKAGES}; do
+        if dpkg -s "${package}"; then
+          continue
+        else
+          echo "Installing ${package}"
+          sudo apt install -y "${package}"
+        fi
+      done
+      ;;
+
+    "yum")
+      for package in ${PACKAGES}; do
+        if rpm -q "${package}"; then
+          continue
+        else
+          echo "Installing ${package}"
+          sudo yum -y install "${package}"
+        fi
+      done
+      ;;
+
+    "zypper")
+      cd /tmp
+      sudo zypper --gpg-auto-import-keys ref
+      for package in ${PACKAGES}; do
+        if rpm -q "${package}"; then
+          continue
+        else
+          echo "Installing ${package}"
+          sudo zypper --non-interactive install "${package}"
+          date
+        fi
+        sudo zypper search -i
+      done
+      ;;
+
+    *)
+      fail "No matching package manager provided."
+      ;;
+
+  esac
 }
 
 begin_time=$(date +%s)
 end_time=$((begin_time + TIMEOUT_SECONDS))
-while [ "$(date +%s)" -lt "$end_time" ]; do
+while [[ "$(date +%s)" -lt "${end_time}" ]]; do
   if install_packages; then
     exit 0
   fi
 
-  sleep "$RETRY_INTERVAL"
+  sleep "${RETRY_INTERVAL}"
 done
 
 fail "Timed out waiting for packages to install"

--- a/enos/modules/softhsm_create_vault_keys/main.tf
+++ b/enos/modules/softhsm_create_vault_keys/main.tf
@@ -22,11 +22,12 @@ variable "hosts" {
 }
 
 locals {
-  pin        = resource.random_string.pin.result
-  aes_label  = "vault_hsm_aes_${local.pin}"
-  hmac_label = "vault_hsm_hmac_${local.pin}"
-  target     = tomap({ "1" = var.hosts[0] })
-  token      = "${var.cluster_id}_${local.pin}"
+  pin             = resource.random_string.pin.result
+  aes_label       = "vault_hsm_aes_${local.pin}"
+  hmac_label      = "vault_hsm_hmac_${local.pin}"
+  seal_attributes = jsondecode(resource.enos_remote_exec.create_keys.stdout)
+  target          = tomap({ "1" = var.hosts[0] })
+  token           = "${var.cluster_id}_${local.pin}"
 }
 
 resource "random_string" "pin" {
@@ -93,10 +94,6 @@ resource "enos_remote_exec" "get_keys" {
       host = var.hosts[0].public_ip
     }
   }
-}
-
-locals {
-  seal_attributes = jsondecode(resource.enos_remote_exec.create_keys.stdout)
 }
 
 output "seal_attributes" {

--- a/enos/modules/target_ec2_fleet/main.tf
+++ b/enos/modules/target_ec2_fleet/main.tf
@@ -335,4 +335,5 @@ data "aws_instance" "targets" {
   for_each = local.instances
 
   instance_id = aws_ec2_fleet.targets.fleet_instance_set[0].instance_ids[each.key]
+
 }

--- a/enos/modules/target_ec2_fleet/variables.tf
+++ b/enos/modules/target_ec2_fleet/variables.tf
@@ -26,6 +26,12 @@ variable "common_tags" {
   }
 }
 
+variable "disable_selinux" {
+  description = "Optionally disable SELinux for certain distros/versions"
+  type        = bool
+  default     = true
+}
+
 variable "instance_mem_min" {
   description = "The minimum amount of memory in mebibytes for each instance in the fleet. (1 MiB = 1024 bytes)"
   type        = number

--- a/enos/modules/target_ec2_instances/main.tf
+++ b/enos/modules/target_ec2_instances/main.tf
@@ -257,3 +257,13 @@ resource "aws_instance" "targets" {
     },
   )
 }
+
+module "disable_selinux" {
+  source = "../disable_selinux"
+  count  = var.disable_selinux == true ? 1 : 0
+
+  hosts = { for idx in range(var.instance_count) : idx => {
+    public_ip  = aws_instance.targets[idx].public_ip
+    private_ip = aws_instance.targets[idx].private_ip
+  } }
+}

--- a/enos/modules/target_ec2_instances/variables.tf
+++ b/enos/modules/target_ec2_instances/variables.tf
@@ -24,6 +24,12 @@ variable "common_tags" {
   default     = { "Project" : "vault-ci" }
 }
 
+variable "disable_selinux" {
+  description = "Optionally disable SELinux for certain distros/versions"
+  type        = bool
+  default     = true
+}
+
 variable "instance_count" {
   description = "The number of target instances to create"
   type        = number

--- a/enos/modules/target_ec2_shim/main.tf
+++ b/enos/modules/target_ec2_shim/main.tf
@@ -16,6 +16,7 @@ variable "ami_id" { default = null }
 variable "cluster_name" { default = null }
 variable "cluster_tag_key" { default = null }
 variable "common_tags" { default = null }
+variable "disable_selinux" { default = true }
 variable "instance_count" { default = 3 }
 variable "instance_cpu_max" { default = null }
 variable "instance_cpu_min" { default = null }

--- a/enos/modules/target_ec2_spot_fleet/main.tf
+++ b/enos/modules/target_ec2_spot_fleet/main.tf
@@ -454,3 +454,13 @@ data "aws_instance" "targets" {
 
   instance_id = data.aws_instances.targets.ids[each.key]
 }
+
+module "disable_selinux" {
+  source = "../disable_selinux"
+  count  = var.disable_selinux == true ? 1 : 0
+
+  hosts = { for idx in range(var.instance_count) : idx => {
+    public_ip  = aws_instance.targets[idx].public_ip
+    private_ip = aws_instance.targets[idx].private_ip
+  } }
+}

--- a/enos/modules/target_ec2_spot_fleet/variables.tf
+++ b/enos/modules/target_ec2_spot_fleet/variables.tf
@@ -26,6 +26,12 @@ variable "common_tags" {
   }
 }
 
+variable "disable_selinux" {
+  description = "Optionally disable SELinux for certain distros/versions"
+  type        = bool
+  default     = true
+}
+
 variable "instance_mem_min" {
   description = "The minimum amount of memory in mebibytes for each instance in the fleet. (1 MiB = 1024 bytes)"
   type        = number

--- a/enos/modules/vault_cluster/main.tf
+++ b/enos/modules/vault_cluster/main.tf
@@ -37,6 +37,13 @@ locals {
     "pkcs11" = null
   }
   leader = toset(slice(local.instances, 0, 1))
+  netcat_command = {
+    amzn          = "nc"
+    opensuse-leap = "netcat"
+    rhel          = "nc"
+    sles          = "nc"
+    ubuntu        = "netcat"
+  }
   recovery_shares = {
     "awskms" = 5
     "shamir" = null
@@ -48,6 +55,16 @@ locals {
     "pkcs11" = 3
   }
   vault_service_user = "vault"
+}
+
+resource "enos_host_info" "hosts" {
+  for_each = var.target_hosts
+
+  transport = {
+    ssh = {
+      host = each.value.public_ip
+    }
+  }
 }
 
 resource "enos_bundle_install" "consul" {
@@ -66,8 +83,21 @@ resource "enos_bundle_install" "consul" {
   }
 }
 
+# We run install_packages before we install Vault because for some combinations of
+# certain Linux distros and artifact types (e.g. SLES and RPM packages), there may
+# be packages that are required to perform Vault installation (e.g. openssl).
+module "install_packages" {
+  source = "../install_packages"
+
+  hosts    = var.target_hosts
+  packages = var.packages
+}
+
 resource "enos_bundle_install" "vault" {
   for_each = var.target_hosts
+  depends_on = [
+    module.install_packages, // Don't race for the package manager locks with install_packages
+  ]
 
   destination = var.install_dir
   release     = var.release == null ? var.release : merge({ product = "vault" }, var.release)
@@ -81,22 +111,17 @@ resource "enos_bundle_install" "vault" {
   }
 }
 
-module "install_packages" {
-  source = "../install_packages"
-  depends_on = [
-    enos_bundle_install.vault, // Don't race for the package manager locks with vault install
-  ]
-
-  hosts    = var.target_hosts
-  packages = var.packages
-}
-
 resource "enos_consul_start" "consul" {
   for_each = enos_bundle_install.consul
 
   bin_path = local.consul_bin_path
   data_dir = var.consul_data_dir
   config = {
+    # GetPrivateInterfaces is a go-sockaddr template that helps Consul get the correct
+    # addr in all of our default cases. This is required in the case of Amazon Linux,
+    # because amzn2 has a default docker listener that will make Consul try to use the
+    # incorrect addr.
+    bind_addr        = "{{ GetPrivateInterfaces | include \"type\" \"IP\" | sort \"default\" |  limit 1 | attr \"address\"}}"
     data_dir         = var.consul_data_dir
     datacenter       = "dc1"
     retry_join       = ["provider=aws tag_key=${var.backend_cluster_tag_key} tag_value=${var.backend_cluster_name}"]
@@ -122,6 +147,7 @@ module "start_vault" {
 
   depends_on = [
     enos_consul_start.consul,
+    module.install_packages,
     enos_bundle_install.vault,
   ]
 
@@ -307,7 +333,8 @@ resource "enos_remote_exec" "start_audit_socket_listener" {
   ])
 
   environment = {
-    SOCKET_PORT = local.audit_socket_port
+    NETCAT_COMMAND = local.netcat_command[enos_host_info.hosts[each.key].distro]
+    SOCKET_PORT    = local.audit_socket_port
   }
 
   scripts = [abspath("${path.module}/scripts/start-audit-socket-listener.sh")]

--- a/enos/modules/vault_cluster/scripts/enable-audit-devices.sh
+++ b/enos/modules/vault_cluster/scripts/enable-audit-devices.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 

--- a/enos/modules/vault_cluster/scripts/start-audit-socket-listener.sh
+++ b/enos/modules/vault_cluster/scripts/start-audit-socket-listener.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
@@ -9,18 +9,19 @@ fail() {
   exit 1
 }
 
+[[ -z "$NETCAT_COMMAND" ]] && fail "NETCAT_COMMAND env variable has not been set"
 [[ -z "$SOCKET_PORT" ]] && fail "SOCKET_PORT env variable has not been set"
 
 socket_listener_procs() {
-  pgrep -x nc
+  pgrep -x "${NETCAT_COMMAND}"
 }
 
 kill_socket_listener() {
-  pkill nc
+  pkill  "${NETCAT_COMMAND}"
 }
 
 test_socket_listener() {
-  nc -zvw 2 127.0.0.1 "$SOCKET_PORT" < /dev/null
+   "${NETCAT_COMMAND}" -zvw 2 127.0.0.1 "$SOCKET_PORT" < /dev/null
 }
 
 start_socket_listener() {
@@ -42,6 +43,7 @@ read_log() {
 }
 
 main() {
+
   if socket_listener_procs; then
     # Clean up old nc's that might not be working
     kill_socket_listener

--- a/enos/modules/vault_cluster/variables.tf
+++ b/enos/modules/vault_cluster/variables.tf
@@ -100,6 +100,12 @@ variable "consul_release" {
   }
 }
 
+variable "distro_version" {
+  type        = string
+  description = "The Linux distro version"
+  default     = null
+}
+
 variable "enable_audit_devices" {
   description = "If true every audit device will be enabled"
   type        = bool
@@ -120,7 +126,7 @@ variable "initialize_cluster" {
 
 variable "install_dir" {
   type        = string
-  description = "The directory where the vault binary will be installed"
+  description = "The directory where the Vault binary will be installed"
   default     = "/opt/vault/bin"
 }
 

--- a/enos/modules/vault_verify_raft_auto_join_voter/scripts/verify-raft-auto-join-voter.sh
+++ b/enos/modules/vault_verify_raft_auto_join_voter/scripts/verify-raft-auto-join-voter.sh
@@ -47,4 +47,4 @@ export VAULT_ADDR='http://127.0.0.1:8200'
 
 # Retry a few times because it can take some time for things to settle after
 # all the nodes are unsealed
-retry 7 check_voter_status
+retry 10 check_voter_status


### PR DESCRIPTION
This PR:

* Adds Enos module support for additional Linux distros in multiple versions: Amazon Linux (amzn2), OpenSUSE Leap (15.5, 15.4), SUSE SLES (v15 SP5), as well as support for installing and using various packages with each one
* Adds additional Linux distros into all scenarios that include distros in the matrix
* Adds support for Consul enterprise edition
* Adds consul_edition into all relevant scenarios
* Updates CI scenario sampling to include new matrix items
* Upgrades our RHEL versions from 8.8 and 9.1 to 8.9 and 9.3

This more than doubles the number of Linux distros/versions we test Vault on, and allows us to test integrations of Vault with Consul enterprise in addition to Consul community edition.