### PR TITLE
Address OCSP client caching issue

### DIFF
--- a/builtin/logical/pki/integration_test.go
+++ b/builtin/logical/pki/integration_test.go
@@ -630,9 +630,6 @@ func TestIntegrationOCSPClientWithPKI(t *testing.T) {
 			return testLogger
 		}, 10)
 
-		err = ocspClient.VerifyLeafCertificate(context.Background(), cert, issuer, conf)
-		require.NoError(t, err)
-
 		_, err = client.Logical().Write("pki/revoke", map[string]interface{}{
 			"serial_number": serialNumber,
 		})

--- a/changelog/25986.txt
+++ b/changelog/25986.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+auth/cert: Address an issue in which OCSP query responses were not cached
+```

--- a/sdk/helper/ocsp/client.go
+++ b/sdk/helper/ocsp/client.go
@@ -776,12 +776,27 @@ func (c *Client) extractOCSPCacheResponseValue(cacheValue *ocspCachedResponse, s
 		}, nil
 	}
 
+	sdkOcspStatus := internalStatusCodeToSDK(cacheValue.status)
+
 	return validateOCSP(&ocsp.Response{
 		ProducedAt: time.Unix(int64(cacheValue.producedAt), 0).UTC(),
 		ThisUpdate: time.Unix(int64(cacheValue.thisUpdate), 0).UTC(),
 		NextUpdate: time.Unix(int64(cacheValue.nextUpdate), 0).UTC(),
-		Status:     int(cacheValue.status),
+		Status:     sdkOcspStatus,
 	})
+}
+
+func internalStatusCodeToSDK(internalStatusCode ocspStatusCode) int {
+	switch internalStatusCode {
+	case ocspStatusGood:
+		return ocsp.Good
+	case ocspStatusRevoked:
+		return ocsp.Revoked
+	case ocspStatusUnknown:
+		return ocsp.Unknown
+	default:
+		return int(internalStatusCode)
+	}
 }
 
 /*

--- a/sdk/helper/ocsp/ocsp_test.go
+++ b/sdk/helper/ocsp/ocsp_test.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -246,6 +247,59 @@ func TestUnitExpiredOCSPResponse(t *testing.T) {
 	status, err := client.GetRevocationStatus(ctx, leafCert, rootCa, config)
 	require.ErrorContains(t, err, "invalid validity",
 		"Expected error got response: %v, %v", status, err)
+}
+
+// TestUnitResponsesAreCached verify that the OCSP responses are properly cached when
+// querying for the same leaf certificates
+func TestUnitResponsesAreCached(t *testing.T) {
+	rootCaKey, rootCa, leafCert := createCaLeafCerts(t)
+	numQueries := &atomic.Uint32{}
+	ocspHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		numQueries.Add(1)
+		now := time.Now()
+		ocspRes := ocsp.Response{
+			SerialNumber: leafCert.SerialNumber,
+			ThisUpdate:   now.Add(-1 * time.Hour),
+			NextUpdate:   now.Add(1 * time.Hour),
+			Status:       ocsp.Good,
+		}
+		response := buildOcspResponse(t, rootCa, rootCaKey, ocspRes)
+		_, _ = w.Write(response)
+	})
+	ts1 := httptest.NewServer(ocspHandler)
+	ts2 := httptest.NewServer(ocspHandler)
+	defer ts1.Close()
+	defer ts2.Close()
+
+	logFactory := func() hclog.Logger {
+		return hclog.NewNullLogger()
+	}
+	client := New(logFactory, 100)
+
+	config := &VerifyConfig{
+		OcspEnabled:         true,
+		OcspServersOverride: []string{ts1.URL, ts2.URL},
+		QueryAllServers:     true,
+	}
+
+	_, err := client.GetRevocationStatus(context.Background(), leafCert, rootCa, config)
+	require.NoError(t, err, "Failed fetching revocation status")
+	// Make sure that we queried both servers and not the cache
+	require.Equal(t, uint32(2), numQueries.Load())
+
+	// These query should be cached and not influence our counter
+	_, err = client.GetRevocationStatus(context.Background(), leafCert, rootCa, config)
+	require.NoError(t, err, "Failed fetching revocation status second time")
+
+	require.Equal(t, uint32(2), numQueries.Load())
+}
+
+func buildOcspResponse(t *testing.T, ca *x509.Certificate, caKey *ecdsa.PrivateKey, ocspRes ocsp.Response) []byte {
+	response, err := ocsp.CreateResponse(ca, ca, ocspRes, caKey)
+	if err != nil {
+		t.Fatalf("failed generating OCSP response: %v", err)
+	}
+	return response
 }
 
 func createCaLeafCerts(t *testing.T) (*ecdsa.PrivateKey, *x509.Certificate, *x509.Certificate) {


### PR DESCRIPTION
 - The OCSP cache built into the client that is used by cert-auth would cache the responses but when pulling out a cached value the response wasn't validating properly and was then thrown away. So effectively we were operating with no cache.

 - The issue was around a confusion of the client's internal status vs the Go SDK OCSP status integer values.