### PR TITLE
UI: Fix kubernetes auth method role management

### DIFF
--- a/changelog/25999.txt
+++ b/changelog/25999.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fix kubernetes auth method roles tab  
+```

--- a/ui/app/components/mount-backend/type-form.hbs
+++ b/ui/app/components/mount-backend/type-form.hbs
@@ -29,5 +29,10 @@
 {{/each}}
 
 <div class="field is-grouped box is-fullwidth is-bottomless">
-  <Hds::Button @text="Cancel" @color="secondary" @route="vault.cluster.secrets.backends" />
+  <Hds::Button
+    @text="Cancel"
+    @color="secondary"
+    @route={{if (eq @mountType "secret") "vault.cluster.secrets.backends" "vault.cluster.access.methods"}}
+    data-test-cancel
+  />
 </div>

--- a/ui/app/helpers/mountable-auth-methods.js
+++ b/ui/app/helpers/mountable-auth-methods.js
@@ -5,6 +5,12 @@
 
 import { helper as buildHelper } from '@ember/component/helper';
 
+/**
+ * These are all the auth methods that can be mounted.
+ * Some methods may not be available for login via the UI,
+ * which are in the `supported-auth-backends` helper.
+ */
+
 const ENTERPRISE_AUTH_METHODS = [
   {
     displayName: 'SAML',

--- a/ui/app/helpers/supported-auth-backends.js
+++ b/ui/app/helpers/supported-auth-backends.js
@@ -5,6 +5,12 @@
 
 import { helper as buildHelper } from '@ember/component/helper';
 
+/**
+ * These are all the auth methods with which a user can log into the UI.
+ * This is a subset of the methods found in the `mountable-auth-methods` helper,
+ * which lists all the methods that can be mounted.
+ */
+
 const SUPPORTED_AUTH_BACKENDS = [
   {
     type: 'token',

--- a/ui/app/helpers/supported-managed-auth-backends.js
+++ b/ui/app/helpers/supported-managed-auth-backends.js
@@ -5,6 +5,8 @@
 
 import { helper as buildHelper } from '@ember/component/helper';
 
+// The UI supports management of these auth methods (i.e. configuring roles or users)
+// otherwise only configuration of the method is supported.
 const MANAGED_AUTH_BACKENDS = ['cert', 'kubernetes', 'ldap', 'okta', 'radius', 'userpass'];
 
 export function supportedManagedAuthBackends() {

--- a/ui/app/helpers/supported-managed-auth-backends.js
+++ b/ui/app/helpers/supported-managed-auth-backends.js
@@ -5,7 +5,7 @@
 
 import { helper as buildHelper } from '@ember/component/helper';
 
-const MANAGED_AUTH_BACKENDS = ['cert', 'userpass', 'ldap', 'okta', 'radius'];
+const MANAGED_AUTH_BACKENDS = ['cert', 'kubernetes', 'ldap', 'okta', 'radius', 'userpass'];
 
 export function supportedManagedAuthBackends() {
   return MANAGED_AUTH_BACKENDS;

--- a/ui/tests/acceptance/auth-list-test.js
+++ b/ui/tests/acceptance/auth-list-test.js
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-/* eslint qunit/no-conditional-assertions: "warn" */
 import { click, fillIn, settled, visit, currentURL } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
@@ -11,9 +10,9 @@ import { v4 as uuidv4 } from 'uuid';
 
 import authPage from 'vault/tests/pages/auth';
 import enablePage from 'vault/tests/pages/settings/auth/enable';
-import { allSupportedAuthBackends, supportedAuthBackends } from 'vault/helpers/supported-auth-backends';
 import { supportedManagedAuthBackends } from 'vault/helpers/supported-managed-auth-backends';
 import { deleteAuthCmd, mountAuthCmd, runCmd, createNS } from 'vault/tests/helpers/commands';
+import { methods } from 'vault/helpers/mountable-auth-methods';
 
 const SELECTORS = {
   backendLink: (path) => `[data-test-auth-backend-link="${path}"]`,
@@ -75,14 +74,34 @@ module('Acceptance | auth backend list', function (hooks) {
   });
 
   test('auth methods are linkable and link to correct view', async function (assert) {
-    assert.expect(24);
+    assert.expect(45);
     const uid = uuidv4();
     await visit('/vault/access');
 
     const supportManaged = supportedManagedAuthBackends();
-    const backends = supportedAuthBackends();
-    for (const backend of backends) {
-      const { type } = backend;
+    // Test all auth methods, not just those you can log in with
+    const backends = methods().map((backend) => backend.type);
+    assert.deepEqual(
+      backends,
+      [
+        'alicloud',
+        'approle',
+        'aws',
+        'azure',
+        'gcp',
+        'github',
+        'jwt',
+        'oidc',
+        'kubernetes',
+        'ldap',
+        'okta',
+        'radius',
+        'cert',
+        'userpass',
+      ],
+      'non-enterprise auth methods are available'
+    );
+    for (const type of backends) {
       const path = type === 'token' ? 'token' : `auth-list-${type}-${uid}`;
       if (type !== 'token') {
         await enablePage.enable(type, path);
@@ -122,41 +141,25 @@ module('Acceptance | auth backend list', function (hooks) {
   });
 
   test('enterprise: auth methods are linkable and link to correct view', async function (assert) {
-    assert.expect(19);
+    assert.expect(3);
     const uid = uuidv4();
     await visit('/vault/access');
 
-    const supportManaged = supportedManagedAuthBackends();
-    const backends = allSupportedAuthBackends();
-    for (const backend of backends) {
-      const { type } = backend;
-      const path = `auth-list-${type}-${uid}`;
-      if (type !== 'token') {
-        await enablePage.enable(type, path);
-      }
-      await settled();
-      await visit('/vault/access');
+    // Only SAML is enterprise-only for now
+    const type = 'saml';
+    const path = `auth-list-${type}-${uid}`;
+    await enablePage.enable(type, path);
+    await settled();
+    await visit('/vault/access');
 
-      // all auth methods should be linkable
-      await click(`[data-test-auth-backend-link="${type === 'token' ? type : path}"]`);
-      if (!supportManaged.includes(type)) {
-        assert.dom('[data-test-auth-section-tab]').exists({ count: 1 });
-        assert
-          .dom('[data-test-auth-section-tab]')
-          .hasText('Configuration', `only shows configuration tab for ${type} auth method`);
-        assert.dom('[data-test-doc-link] .doc-link').exists(`includes doc link for ${type} auth method`);
-      } else {
-        let expectedTabs = 2;
-        if (type == 'ldap' || type === 'okta') {
-          expectedTabs = 3;
-        }
-        assert
-          .dom('[data-test-auth-section-tab]')
-          .exists({ count: expectedTabs }, `has management tabs for ${type} auth method`);
-        // cleanup method
-        await runCmd(deleteAuthCmd(path));
-      }
-    }
+    // all auth methods should be linkable
+    await click(`[data-test-auth-backend-link="${path}"]`);
+    assert.dom('[data-test-auth-section-tab]').exists({ count: 1 });
+    assert
+      .dom('[data-test-auth-section-tab]')
+      .hasText('Configuration', `only shows configuration tab for ${type} auth method`);
+    assert.dom('[data-test-doc-link] .doc-link').exists(`includes doc link for ${type} auth method`);
+    await runCmd(deleteAuthCmd(path));
   });
 
   test('enterprise: token config within namespace', async function (assert) {


### PR DESCRIPTION
This PR reverts a regression introduced by https://github.com/hashicorp/vault/pull/25364 which accidentally hid the `roles` tab in the kubernetes UI. 
<img width="1126" alt="Screenshot 2024-03-18 at 11 26 40 AM" src="https://github.com/hashicorp/vault/assets/68122737/e73888cd-8897-433d-bea0-94cfe236964c">

