### PR TITLE
Show empty state on client count sync page if feature isn't activated

### DIFF
--- a/ui/app/components/clients/activity.ts
+++ b/ui/app/components/clients/activity.ts
@@ -21,6 +21,7 @@ import type {
 import type ClientsVersionHistoryModel from 'vault/models/clients/version-history';
 
 interface Args {
+  secretsSyncActivated?: boolean;
   activity: ClientsActivityModel;
   versionHistory: ClientsVersionHistoryModel[];
   startTimestamp: number;

--- a/ui/app/components/clients/activity.ts
+++ b/ui/app/components/clients/activity.ts
@@ -21,7 +21,7 @@ import type {
 import type ClientsVersionHistoryModel from 'vault/models/clients/version-history';
 
 interface Args {
-  secretsSyncActivated?: boolean;
+  isSecretsSyncActivated?: boolean;
   activity: ClientsActivityModel;
   versionHistory: ClientsVersionHistoryModel[];
   startTimestamp: number;

--- a/ui/app/components/clients/page/sync.hbs
+++ b/ui/app/components/clients/page/sync.hbs
@@ -2,7 +2,7 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
 ~}}
-{{#if @secretsSyncActivated}}
+{{#if @isSecretsSyncActivated}}
   {{#if this.isDateRange}}
     <Clients::ChartContainer
       @title={{this.title}}

--- a/ui/app/components/clients/page/sync.hbs
+++ b/ui/app/components/clients/page/sync.hbs
@@ -2,58 +2,68 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
 ~}}
+{{#if @secretsSyncActivated}}
+  {{#if this.isDateRange}}
+    <Clients::ChartContainer
+      @title={{this.title}}
+      @description={{this.description}}
+      @timestamp={{@activity.responseTimestamp}}
+      @hasChartData={{this.byMonthActivityData}}
+      class="no-legend"
+    >
+      <:subTitle>
+        <StatText
+          @label="Total sync clients"
+          @subText="The total number of secrets synced from Vault to other destinations during this date range."
+          @value={{this.totalUsageCounts.secret_syncs}}
+          @size="l"
+          data-test-total-sync-clients
+        />
+      </:subTitle>
 
-{{#if this.isDateRange}}
-  <Clients::ChartContainer
-    @title={{this.title}}
-    @description={{this.description}}
-    @timestamp={{@activity.responseTimestamp}}
-    @hasChartData={{this.byMonthActivityData}}
-    class="no-legend"
-  >
-    <:subTitle>
-      <StatText
-        @label="Total sync clients"
-        @subText="The total number of secrets synced from Vault to other destinations during this date range."
-        @value={{this.totalUsageCounts.secret_syncs}}
-        @size="l"
-        data-test-total-sync-clients
-      />
-    </:subTitle>
+      <:stats>
+        <StatText
+          @label="Average sync clients per month"
+          @value={{this.average this.byMonthActivityData "secret_syncs"}}
+          @size="m"
+          class="data-details-top has-top-padding-l"
+          data-test-average-sync-clients
+        />
+      </:stats>
 
-    <:stats>
-      <StatText
-        @label="Average sync clients per month"
-        @value={{this.average this.byMonthActivityData "secret_syncs"}}
-        @size="m"
-        class="data-details-top has-top-padding-l"
-        data-test-average-sync-clients
-      />
-    </:stats>
+      <:chart>
+        <Clients::Charts::VerticalBarBasic
+          @chartTitle={{this.title}}
+          @data={{this.byMonthActivityData}}
+          @dataKey="secret_syncs"
+          @chartHeight={{200}}
+        />
+      </:chart>
 
-    <:chart>
-      <Clients::Charts::VerticalBarBasic
-        @chartTitle={{this.title}}
-        @data={{this.byMonthActivityData}}
-        @dataKey="secret_syncs"
-        @chartHeight={{200}}
-      />
-    </:chart>
-
-    <:emptyState>
-      <EmptyState
-        @title="No monthly secrets sync clients"
-        @subTitle="There is no secrets sync data available for this date range."
-        @bottomBorder={{true}}
-      />
-    </:emptyState>
-  </Clients::ChartContainer>
-{{else}}
-  <div class="chart-wrapper" data-test-usage-stats>
-    <div class="chart-header has-bottom-margin-m">
-      <h2 class="chart-title">{{this.title}}</h2>
-      <p class="chart-description has-bottom-padding-m">{{this.description}}</p>
+      <:emptyState>
+        <EmptyState
+          @title="No monthly secrets sync clients"
+          @subTitle="There is no secrets sync data available for this date range."
+          @bottomBorder={{true}}
+        />
+      </:emptyState>
+    </Clients::ChartContainer>
+  {{else}}
+    <div class="chart-wrapper" data-test-usage-stats>
+      <div class="chart-header has-bottom-margin-m">
+        <h2 class="chart-title">{{this.title}}</h2>
+        <p class="chart-description has-bottom-padding-m">{{this.description}}</p>
+      </div>
+      <StatText @label="Total sync clients" @value={{this.totalUsageCounts.secret_syncs}} @size="l" />
     </div>
-    <StatText @label="Total sync clients" @value={{this.totalUsageCounts.secret_syncs}} @size="l" />
-  </div>
+  {{/if}}
+{{else}}
+  <EmptyState @title="No Secrets Sync clients" @message="No data is available because Secrets Sync has not been activated.">
+    <Hds::Link::Standalone
+      @icon="chevron-right"
+      @iconPosition="trailing"
+      @text="Activate Secrets Sync"
+      @route="vault.cluster.sync.secrets.overview"
+    />
+  </EmptyState>
 {{/if}}

--- a/ui/app/components/clients/page/sync.ts
+++ b/ui/app/components/clients/page/sync.ts
@@ -4,7 +4,6 @@
  */
 
 import ActivityComponent from '../activity';
-
 export default class SyncComponent extends ActivityComponent {
   title = 'Secrets sync usage';
   description =

--- a/ui/app/routes/vault/cluster/clients/counts.ts
+++ b/ui/app/routes/vault/cluster/clients/counts.ts
@@ -23,7 +23,7 @@ export interface ClientsCountsRouteParams {
   mountPath?: string | undefined;
 }
 
-interface ClientsCountsRouteModel {
+export interface ClientsCountsRouteModel {
   config: ClientsConfigModel;
   versionHistory: ClientsVersionHistoryModel;
   activity?: ClientsActivityModel;

--- a/ui/app/routes/vault/cluster/clients/counts/sync.ts
+++ b/ui/app/routes/vault/cluster/clients/counts/sync.ts
@@ -33,7 +33,7 @@ export default class ClientsCountsSyncRoute extends Route {
     }
   }
 
-  async secretsSyncActivated(activity: ClientsActivityModel | undefined) {
+  async isSecretsSyncActivated(activity: ClientsActivityModel | undefined) {
     // if there are secrets, the feature is activated
     if (activity && activity.total?.secret_syncs > 0) return true;
 
@@ -47,11 +47,11 @@ export default class ClientsCountsSyncRoute extends Route {
       'vault.cluster.clients.counts'
     ) as ClientsCountsRouteModel;
 
-    const secretsSyncActivated = await this.secretsSyncActivated(activity);
+    const isSecretsSyncActivated = await this.isSecretsSyncActivated(activity);
 
     return {
       activity,
-      secretsSyncActivated,
+      isSecretsSyncActivated,
       versionHistory,
       startTimestamp,
       endTimestamp,

--- a/ui/app/routes/vault/cluster/clients/counts/sync.ts
+++ b/ui/app/routes/vault/cluster/clients/counts/sync.ts
@@ -4,5 +4,57 @@
  */
 
 import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+import { DEBUG } from '@glimmer/env';
 
-export default class ClientsCountsSyncRoute extends Route {}
+import type { ClientsCountsRouteModel } from '../counts';
+import type StoreService from 'vault/services/store';
+import ClientsActivityModel from 'vault/vault/models/clients/activity';
+
+interface ActivationFlagsResponse {
+  data: {
+    activated: Array<string>;
+    unactivated: Array<string>;
+  };
+}
+
+export default class ClientsCountsSyncRoute extends Route {
+  @service declare readonly store: StoreService;
+
+  async getActivatedFeatures() {
+    try {
+      const resp: ActivationFlagsResponse = await this.store
+        .adapterFor('application')
+        .ajax('/v1/sys/activation-flags', 'GET', { unauthenticated: true, namespace: null });
+      return resp.data?.activated;
+    } catch (error) {
+      if (DEBUG) console.error(error); // eslint-disable-line no-console
+      return [];
+    }
+  }
+
+  async secretsSyncActivated(activity: ClientsActivityModel | undefined) {
+    // if there are secrets, the feature is activated
+    if (activity && activity.total?.secret_syncs > 0) return true;
+
+    // otherwise check explicitly if the feature has been activated
+    const activatedFeatures = await this.getActivatedFeatures();
+    return activatedFeatures.includes('secret-sync');
+  }
+
+  async model() {
+    const { activity, versionHistory, startTimestamp, endTimestamp } = this.modelFor(
+      'vault.cluster.clients.counts'
+    ) as ClientsCountsRouteModel;
+
+    const secretsSyncActivated = await this.secretsSyncActivated(activity);
+
+    return {
+      activity,
+      secretsSyncActivated,
+      versionHistory,
+      startTimestamp,
+      endTimestamp,
+    };
+  }
+}

--- a/ui/app/templates/vault/cluster/clients/counts/sync.hbs
+++ b/ui/app/templates/vault/cluster/clients/counts/sync.hbs
@@ -4,6 +4,7 @@
 ~}}
 
 <Clients::Page::Sync
+  @secretsSyncActivated={{this.model.secretsSyncActivated}}
   @activity={{this.model.activity}}
   @versionHistory={{this.model.versionHistory}}
   @startTimestamp={{this.model.startTimestamp}}

--- a/ui/app/templates/vault/cluster/clients/counts/sync.hbs
+++ b/ui/app/templates/vault/cluster/clients/counts/sync.hbs
@@ -4,7 +4,7 @@
 ~}}
 
 <Clients::Page::Sync
-  @secretsSyncActivated={{this.model.secretsSyncActivated}}
+  @isSecretsSyncActivated={{this.model.isSecretsSyncActivated}}
   @activity={{this.model.activity}}
   @versionHistory={{this.model.versionHistory}}
   @startTimestamp={{this.model.startTimestamp}}

--- a/ui/tests/acceptance/clients/counts/sync-test.js
+++ b/ui/tests/acceptance/clients/counts/sync-test.js
@@ -1,0 +1,96 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import { module, test } from 'qunit';
+import { setupApplicationTest } from 'ember-qunit';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import syncHandler from 'vault/mirage/handlers/sync';
+import { STATIC_NOW } from 'vault/mirage/handlers/clients';
+import { visit, click, currentURL } from '@ember/test-helpers';
+import sinon from 'sinon';
+import timestamp from 'core/utils/timestamp';
+import authPage from 'vault/tests/pages/auth';
+import { SELECTORS } from 'vault/tests/helpers/clients';
+
+module('Acceptance | clients | sync | activated', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  hooks.before(function () {
+    sinon.stub(timestamp, 'now').callsFake(() => STATIC_NOW);
+  });
+
+  hooks.beforeEach(async function () {
+    syncHandler(this.server);
+    await authPage.login();
+    return visit('/vault/clients/counts/sync');
+  });
+
+  hooks.after(function () {
+    timestamp.now.restore();
+  });
+
+  test('it should render charts when secrets sync is activated', async function (assert) {
+    syncHandler(this.server);
+
+    assert.dom(SELECTORS.charts.chart('Secrets sync usage')).exists('Secrets sync usage chart is rendered');
+    assert.dom(SELECTORS.syncTab.total).exists('Total sync clients chart is rendered');
+    assert.dom(SELECTORS.emptyStateTitle).doesNotExist();
+  });
+});
+
+module('Acceptance | clients | sync | not activated', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  hooks.before(function () {
+    sinon.stub(timestamp, 'now').callsFake(() => STATIC_NOW);
+  });
+
+  hooks.beforeEach(async function () {
+    await authPage.login();
+    return visit('/vault/clients/counts/sync');
+  });
+
+  hooks.after(function () {
+    timestamp.now.restore();
+  });
+
+  test('it should show an empty state when secrets sync is not activated', async function (assert) {
+    assert.expect(3);
+
+    // ensure secret_syncs clients activity is 0
+    this.server.get('/sys/internal/counters/activity', () => {
+      // return only the things that determine whether to show/hide secrets sync
+      return {
+        data: {
+          total: {
+            secret_syncs: 0,
+          },
+        },
+      };
+    });
+
+    this.server.get('/sys/activation-flags', () => {
+      assert.true(true, '/sys/activation-flags/ is called to check if secrets-sync is activated');
+
+      return {
+        data: {
+          activated: [],
+          unactivated: ['secrets-sync'],
+        },
+      };
+    });
+
+    assert.dom(SELECTORS.emptyStateTitle).exists('Shows empty state when secrets-sync is not activated');
+
+    await click(`${SELECTORS.emptyStateActions} .hds-link-standalone`);
+    assert.strictEqual(
+      currentURL(),
+      '/vault/sync/secrets/overview',
+      'action button navigates to secrets sync overview page'
+    );
+  });
+});

--- a/ui/tests/helpers/clients.js
+++ b/ui/tests/helpers/clients.js
@@ -66,7 +66,6 @@ export const SELECTORS = {
       plotPoint: '[data-test-line-chart="plot-point"]',
     },
   },
-  emptyStateTitle: '[data-test-empty-state-title]',
   usageStats: '[data-test-usage-stats]',
   dateDisplay: '[data-test-date-display]',
   attributionBlock: '[data-test-clients-attribution]',

--- a/ui/tests/integration/components/clients/page/sync-test.js
+++ b/ui/tests/integration/components/clients/page/sync-test.js
@@ -34,12 +34,12 @@ module('Integration | Component | clients | Clients::Page::Sync', function (hook
     this.activity = await this.store.queryRecord('clients/activity', activityQuery);
     this.startTimestamp = START_TIME;
     this.endTimestamp = END_TIME;
-    this.secretsSyncActivated = true;
+    this.isSecretsSyncActivated = true;
 
     this.renderComponent = () =>
       render(hbs`
       <Clients::Page::Sync
-        @secretsSyncActivated={{this.secretsSyncActivated}}
+        @isSecretsSyncActivated={{this.isSecretsSyncActivated}}
         @activity={{this.activity}}
         @versionHistory={{this.versionHistory}}
         @startTimestamp={{this.startTimestamp}}
@@ -122,7 +122,7 @@ module('Integration | Component | clients | Clients::Page::Sync', function (hook
   });
 
   test('it should render an empty state if secrets sync is not activated', async function (assert) {
-    this.secretsSyncActivated = false;
+    this.isSecretsSyncActivated = false;
 
     await this.renderComponent();
 

--- a/ui/tests/integration/components/clients/page/sync-test.js
+++ b/ui/tests/integration/components/clients/page/sync-test.js
@@ -30,6 +30,7 @@ module('Integration | Component | clients | Clients::Page::Sync', function (hook
       start_time: { timestamp: START_TIME },
       end_time: { timestamp: END_TIME },
     };
+    // set this to 0
     this.activity = await this.store.queryRecord('clients/activity', activityQuery);
     this.startTimestamp = START_TIME;
     this.endTimestamp = END_TIME;

--- a/ui/tests/integration/components/clients/page/sync-test.js
+++ b/ui/tests/integration/components/clients/page/sync-test.js
@@ -34,9 +34,12 @@ module('Integration | Component | clients | Clients::Page::Sync', function (hook
     this.activity = await this.store.queryRecord('clients/activity', activityQuery);
     this.startTimestamp = START_TIME;
     this.endTimestamp = END_TIME;
+    this.secretsSyncActivated = true;
+
     this.renderComponent = () =>
       render(hbs`
       <Clients::Page::Sync
+        @secretsSyncActivated={{this.secretsSyncActivated}}
         @activity={{this.activity}}
         @versionHistory={{this.versionHistory}}
         @startTimestamp={{this.startTimestamp}}
@@ -84,7 +87,7 @@ module('Integration | Component | clients | Clients::Page::Sync', function (hook
     assert.strictEqual(dataBars.length, this.activity.byMonth.filter((m) => m.counts !== null).length);
   });
 
-  test('it should render empty state for no monthly data', async function (assert) {
+  test('it should render an empty state for no monthly data', async function (assert) {
     assert.expect(5);
     this.activity.set('byMonth', []);
 
@@ -116,5 +119,21 @@ module('Integration | Component | clients | Clients::Page::Sync', function (hook
       );
     assert.dom(syncTab.total).doesNotExist('total sync counts does not exist');
     assert.dom(syncTab.average).doesNotExist('average sync client counts does not exist');
+  });
+
+  test('it should render an empty state if secrets sync is not activated', async function (assert) {
+    this.secretsSyncActivated = false;
+
+    await this.renderComponent();
+
+    assert.dom(SELECTORS.emptyStateTitle).hasText('No Secrets Sync clients');
+    assert
+      .dom(SELECTORS.emptyStateMessage)
+      .hasText('No data is available because Secrets Sync has not been activated.');
+    assert.dom(SELECTORS.emptyStateActions).hasText('Activate Secrets Sync');
+
+    assert.dom(charts.chart('Secrets sync usage')).doesNotExist();
+    assert.dom(syncTab.total).doesNotExist();
+    assert.dom(syncTab.average).doesNotExist();
   });
 });


### PR DESCRIPTION
### :hammer_and_wrench: Description
Adds an empty state to the Clients > Secrets Sync tab when the feature hasn't been activated yet.

Note: in the next PR we'll hide this page altogether for any user that doesn't have this feature included in their license.

### 🔗 Links
n/a

### :camera_flash: Screenshots
<img width="1840" alt="Screenshot 2024-03-19 at 3 52 05 PM" src="https://github.com/hashicorp/vault/assets/903288/1fa27b18-8c7d-43be-af5e-2f330cf1fb01">


### :building_construction: How to Build and Test the Change
With an OSS license:
1. Visit `/vault/clients/counts/sync`
2. You should see an empty state indicated that Secrets Sync has not been enabled yet

With an ENT license that doesn't have secrets sync enabled:
_same steps as OSS above_

With an ENT license that has secrets sync enabled:
1. Visit `/vault/clients/counts/sync`
2. You should NOT see the empty state. You should see client count charts instead.