### PR TITLE
changing vault.audit.log_response_failure metric doc

### DIFF
--- a/website/content/partials/telemetry-metrics/vault/audit/log_response_failure.mdx
+++ b/website/content/partials/telemetry-metrics/vault/audit/log_response_failure.mdx
@@ -2,11 +2,11 @@
 
 | Metric type | Value  | Description                                             |
 |-------------|--------|---------------------------------------------------------|
-| counter     | number | Number of audit log request failures across all devices |
+| counter     | number | Number of audit log response failures across all devices |
 
 The number of request failures is a **crucial metric**.
 
-A non-zero value for `vault.audit.log_response_failure` indicates that one of
+A non-zero value for `vault.audit.log_response_failure` indicates that all of
 the configured audit log devices failed to respond to Vault. If Vault cannot
 properly audit a request, or the response to a request, the original request
 will fail.

--- a/website/content/partials/telemetry-metrics/vault/audit/log_response_failure.mdx
+++ b/website/content/partials/telemetry-metrics/vault/audit/log_response_failure.mdx
@@ -7,7 +7,7 @@
 The number of request failures is a **crucial metric**.
 
 A non-zero value for `vault.audit.log_response_failure` indicates that all of
-the configured audit log devices failed to respond to Vault. If Vault cannot
+the configured audit log devices failed to log a response to a request to Vault. If Vault cannot
 properly audit a request, or the response to a request, the original request
 will fail.
 


### PR DESCRIPTION
<img width="1230" alt="Screenshot 2024-03-19 at 17 42 49" src="https://github.com/hashicorp/vault/assets/115136373/d9ad7946-da4b-4513-9a34-e93158f388b0">

I've changed the description for the vault.audit.log_response_failure metric from:
Number of audit log request failures across all devices 
into: 
Number of audit log response failures across all devices

I've changed the explanation from:

A non-zero value for vault.audit.log_response_failure indicates that one of the configured audit log devices failed to respond to Vault. If Vault cannot properly audit a request, or the response to a request, the original request will fail.
into:
A non-zero value for vault.audit.log_response_failure indicates that all of the configured audit log devices failed to respond to Vault. If Vault cannot properly audit a request, or the response to a request, the original request will fail.