### PR TITLE
tests: remove flaky confirm-modal test

### DIFF
--- a/ui/tests/integration/components/confirm-modal-test.js
+++ b/ui/tests/integration/components/confirm-modal-test.js
@@ -30,10 +30,35 @@ module('Integration | Component | confirm-modal', function (hooks) {
     assert
       .dom('[data-test-confirm-action-message]')
       .hasText('You will not be able to recover it later.', 'renders default body text');
+  });
 
-    await click('[data-test-confirm-cancel-button]');
-    assert.true(this.onClose.called, 'calls the onClose action when Cancel is clicked');
+  test('it renders a custom title and message', async function (assert) {
+    await render(
+      hbs`<ConfirmModal @onConfirm={{this.onConfirm}} @onClose={{this.onClose}} @confirmTitle="Fancy Title" @confirmMessage="Riveting message" />`
+    );
+
+    assert.dom('[data-test-confirm-action-title]').hasText('Fancy Title', 'renders custom title');
+    assert.dom('[data-test-confirm-action-message]').hasText('Riveting message', 'renders custom body text');
+  });
+
+  test('it renders a disabled message', async function (assert) {
+    await render(
+      hbs`<ConfirmModal @onConfirm={{this.onConfirm}} @onClose={{this.onClose}} @disabledMessage="Nope" />`
+    );
+
+    assert.dom('[data-test-confirm-action-title]').hasText('Not allowed', 'renders disabled title');
+
+    assert.dom('[data-test-confirm-action-message]').hasText('Nope', 'renders disabled message');
+
+    assert
+      .dom('[data-test-confirm-button]')
+      .doesNotExist('confirm button is not rendered when action is disabled');
+  });
+
+  test('it calls onConfirm when the modal is confirmed', async function (assert) {
+    await render(hbs`<ConfirmModal @onConfirm={{this.onConfirm}} @onClose={{this.onClose}} />`);
+
     await click('[data-test-confirm-button]');
-    assert.true(this.onConfirm.called, 'calls the onConfirm action when Confirm is clicked');
+    assert.true(this.onConfirm.called);
   });
 });


### PR DESCRIPTION
✂️ Removes a flaky `confirm-modal` test
➕ added more thorough test coverage for disabled state / custom title & message etc

Unfortunately testing that the modal's `@onClose` arg is called is flaky because the component itself gets torn down almost immediately after clicking close (see screenshot). Instead of adding an arbitrary `waitFor` or `setTimeout`, i think it's safe to rely on the `HDS::Modal` integration tests to cover this situation.
![image](https://github.com/hashicorp/vault/assets/903288/167dcaa0-82f2-496d-8065-9e172acf8f4b)
