### PR TITLE
VAULT-15682: Audit request header invalidation

### DIFF
--- a/ui/tests/integration/components/confirm-modal-test.js
+++ b/ui/tests/integration/components/confirm-modal-test.js
@@ -30,10 +30,35 @@ module('Integration | Component | confirm-modal', function (hooks) {
     assert
       .dom('[data-test-confirm-action-message]')
       .hasText('You will not be able to recover it later.', 'renders default body text');
+  });
 
-    await click('[data-test-confirm-cancel-button]');
-    assert.true(this.onClose.called, 'calls the onClose action when Cancel is clicked');
+  test('it renders a custom title and message', async function (assert) {
+    await render(
+      hbs`<ConfirmModal @onConfirm={{this.onConfirm}} @onClose={{this.onClose}} @confirmTitle="Fancy Title" @confirmMessage="Riveting message" />`
+    );
+
+    assert.dom('[data-test-confirm-action-title]').hasText('Fancy Title', 'renders custom title');
+    assert.dom('[data-test-confirm-action-message]').hasText('Riveting message', 'renders custom body text');
+  });
+
+  test('it renders a disabled message', async function (assert) {
+    await render(
+      hbs`<ConfirmModal @onConfirm={{this.onConfirm}} @onClose={{this.onClose}} @disabledMessage="Nope" />`
+    );
+
+    assert.dom('[data-test-confirm-action-title]').hasText('Not allowed', 'renders disabled title');
+
+    assert.dom('[data-test-confirm-action-message]').hasText('Nope', 'renders disabled message');
+
+    assert
+      .dom('[data-test-confirm-button]')
+      .doesNotExist('confirm button is not rendered when action is disabled');
+  });
+
+  test('it calls onConfirm when the modal is confirmed', async function (assert) {
+    await render(hbs`<ConfirmModal @onConfirm={{this.onConfirm}} @onClose={{this.onClose}} />`);
+
     await click('[data-test-confirm-button]');
-    assert.true(this.onConfirm.called, 'calls the onConfirm action when Confirm is clicked');
+    assert.true(this.onConfirm.called);
   });
 });

--- a/vault/audited_headers.go
+++ b/vault/audited_headers.go
@@ -53,7 +53,10 @@ func NewAuditedHeadersConfig(view *BarrierView) (*AuditedHeadersConfig, error) {
 
 	// This should be the only place where the AuditedHeadersConfig struct is initialized.
 	// Store the view so that we can reload headers when we 'invalidate'.
-	return &AuditedHeadersConfig{view: view}, nil
+	return &AuditedHeadersConfig{
+		view:    view,
+		Headers: make(map[string]*auditedHeaderSettings),
+	}, nil
 }
 
 // add adds or overwrites a header in the config and updates the barrier view
@@ -142,7 +145,7 @@ func (a *AuditedHeadersConfig) invalidate(ctx context.Context) error {
 		lowerHeaders[strings.ToLower(k)] = v
 	}
 
-	a.Headers = headers
+	a.Headers = lowerHeaders
 	return nil
 }
 

--- a/vault/audited_headers.go
+++ b/vault/audited_headers.go
@@ -23,20 +23,41 @@ const (
 	auditedHeadersSubPath = "audited-headers-config/"
 )
 
+// auditedHeadersKey returns the key at which audit header configuration is stored.
+func auditedHeadersKey() string {
+	return auditedHeadersSubPath + auditedHeadersEntry
+}
+
 type auditedHeaderSettings struct {
+	// HMAC is used to indicate whether the value of the header should be HMAC'd.
 	HMAC bool `json:"hmac"`
 }
 
 // AuditedHeadersConfig is used by the Audit Broker to write only approved
 // headers to the audit logs. It uses a BarrierView to persist the settings.
 type AuditedHeadersConfig struct {
+	// Headers stores the current headers that should be audited, and their settings.
 	Headers map[string]*auditedHeaderSettings
 
+	// view is the barrier view which should be used to access underlying audit header config data.
 	view *BarrierView
+
 	sync.RWMutex
 }
 
+// NewAuditedHeadersConfig should be used to create AuditedHeadersConfig.
+func NewAuditedHeadersConfig(view *BarrierView) (*AuditedHeadersConfig, error) {
+	if view == nil {
+		return nil, fmt.Errorf("barrier view cannot be nil")
+	}
+
+	// This should be the only place where the AuditedHeadersConfig struct is initialized.
+	// Store the view so that we can reload headers when we 'invalidate'.
+	return &AuditedHeadersConfig{view: view}, nil
+}
+
 // add adds or overwrites a header in the config and updates the barrier view
+// NOTE: add will acquire a write lock in order to update the underlying headers.
 func (a *AuditedHeadersConfig) add(ctx context.Context, header string, hmac bool) error {
 	if header == "" {
 		return fmt.Errorf("header value cannot be empty")
@@ -64,6 +85,7 @@ func (a *AuditedHeadersConfig) add(ctx context.Context, header string, hmac bool
 }
 
 // remove deletes a header out of the header config and updates the barrier view
+// NOTE: remove will acquire a write lock in order to update the underlying headers.
 func (a *AuditedHeadersConfig) remove(ctx context.Context, header string) error {
 	if header == "" {
 		return fmt.Errorf("header value cannot be empty")
@@ -91,8 +113,40 @@ func (a *AuditedHeadersConfig) remove(ctx context.Context, header string) error 
 	return nil
 }
 
-// ApplyConfig returns a map of approved headers and their values, either
-// hmac'ed or plaintext
+// invalidate attempts to refresh the allowed audit headers and their settings.
+// NOTE: invalidate will acquire a write lock in order to update the underlying headers.
+func (a *AuditedHeadersConfig) invalidate(ctx context.Context) error {
+	a.Lock()
+	defer a.Unlock()
+
+	// Get the actual headers entries, e.g. sys/audited-headers-config/audited-headers
+	out, err := a.view.Get(ctx, auditedHeadersEntry)
+	if err != nil {
+		return fmt.Errorf("failed to read config: %w", err)
+	}
+	if out == nil {
+		// We didn't get any data from this view.
+		return nil
+	}
+
+	headers := make(map[string]*auditedHeaderSettings)
+	err = out.DecodeJSON(&headers)
+	if err != nil {
+		return err
+	}
+
+	// Ensure that we are able to case-sensitively access the headers;
+	// necessary for the upgrade case
+	lowerHeaders := make(map[string]*auditedHeaderSettings, len(headers))
+	for k, v := range headers {
+		lowerHeaders[strings.ToLower(k)] = v
+	}
+
+	a.Headers = headers
+	return nil
+}
+
+// ApplyConfig returns a map of approved headers and their values, either hmac'ed or plaintext.
 func (a *AuditedHeadersConfig) ApplyConfig(ctx context.Context, headers map[string][]string, salter audit.Salter) (result map[string][]string, retErr error) {
 	// Grab a read lock
 	a.RLock()
@@ -130,36 +184,25 @@ func (a *AuditedHeadersConfig) ApplyConfig(ctx context.Context, headers map[stri
 	return result, nil
 }
 
-// Initialize the headers config by loading from the barrier view
+// setupAuditedHeadersConfig will initialize new audited headers configuration on
+// the Core by loading data from the barrier view.
 func (c *Core) setupAuditedHeadersConfig(ctx context.Context) error {
-	// Create a sub-view
+	// Create a sub-view, e.g. sys/audited-headers-config/
 	view := c.systemBarrierView.SubView(auditedHeadersSubPath)
 
-	// Create the config
-	out, err := view.Get(ctx, auditedHeadersEntry)
+	headers, err := NewAuditedHeadersConfig(view)
 	if err != nil {
-		return fmt.Errorf("failed to read config: %w", err)
+		return err
 	}
 
-	headers := make(map[string]*auditedHeaderSettings)
-	if out != nil {
-		err = out.DecodeJSON(&headers)
-		if err != nil {
-			return err
-		}
+	// Invalidate the headers now in order to load them for the first time.
+	err = headers.invalidate(ctx)
+	if err != nil {
+		return err
 	}
 
-	// Ensure that we are able to case-sensitively access the headers;
-	// necessary for the upgrade case
-	lowerHeaders := make(map[string]*auditedHeaderSettings, len(headers))
-	for k, v := range headers {
-		lowerHeaders[strings.ToLower(k)] = v
-	}
-
-	c.auditedHeaders = &AuditedHeadersConfig{
-		Headers: lowerHeaders,
-		view:    view,
-	}
+	// Update the Core.
+	c.auditedHeaders = headers
 
 	return nil
 }

--- a/vault/audited_headers.go
+++ b/vault/audited_headers.go
@@ -127,15 +127,15 @@ func (a *AuditedHeadersConfig) invalidate(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to read config: %w", err)
 	}
-	if out == nil {
-		// We didn't get any data from this view.
-		return nil
-	}
 
+	// If we cannot update the stored 'new' headers, we will clear the existing
+	// ones as part of invalidation.
 	headers := make(map[string]*auditedHeaderSettings)
-	err = out.DecodeJSON(&headers)
-	if err != nil {
-		return err
+	if out != nil {
+		err = out.DecodeJSON(&headers)
+		if err != nil {
+			return fmt.Errorf("failed to parse config: %w", err)
+		}
 	}
 
 	// Ensure that we are able to case-sensitively access the headers;

--- a/vault/audited_headers_test.go
+++ b/vault/audited_headers_test.go
@@ -17,22 +17,29 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// mockStorage is a struct that is used to mock barrier storage.
 type mockStorage struct {
 	mock.Mock
 }
 
+// List implements List from BarrierStorage interface.
+// ignore-nil-nil-function-check.
 func (m *mockStorage) List(_ context.Context, _ string) ([]string, error) {
 	return nil, nil
 }
 
+// Get implements Get from BarrierStorage interface.
+// ignore-nil-nil-function-check.
 func (m *mockStorage) Get(_ context.Context, _ string) (*logical.StorageEntry, error) {
 	return nil, nil
 }
 
+// Put implements Put from BarrierStorage interface.
 func (m *mockStorage) Put(_ context.Context, _ *logical.StorageEntry) error {
 	return nil
 }
 
+// Delete implements Delete from BarrierStorage interface.
 func (m *mockStorage) Delete(_ context.Context, _ string) error {
 	return nil
 }

--- a/vault/audited_headers_test.go
+++ b/vault/audited_headers_test.go
@@ -391,4 +391,23 @@ func TestAuditedHeaders_invalidate(t *testing.T) {
 	require.Len(t, ahc.Headers, 1)
 	_, ok := ahc.Headers["x-magic-header"]
 	require.True(t, ok)
+
+	// Do it again with more headers and random casing.
+	fakeHeaders2 := map[string]*auditedHeaderSettings{
+		"x-magic-header":           {},
+		"x-even-MORE-magic-header": {},
+	}
+	fakeBytes2, err := json.Marshal(fakeHeaders2)
+	require.NoError(t, err)
+	err = view.Put(context.Background(), &logical.StorageEntry{Key: auditedHeadersEntry, Value: fakeBytes2})
+	require.NoError(t, err)
+
+	// Invalidate and check we now see the header we stored
+	err = ahc.invalidate(context.Background())
+	require.NoError(t, err)
+	require.Len(t, ahc.Headers, 2)
+	_, ok = ahc.Headers["x-magic-header"]
+	require.True(t, ok)
+	_, ok = ahc.Headers["x-even-more-magic-header"]
+	require.True(t, ok)
 }


### PR DESCRIPTION
This PR adds a mechanism to allow for invalidation of audit request headers.

ENT PR: https://github.com/hashicorp/vault-enterprise/pull/5616
