### PR TITLE
Backport 1.16.x: Fix json5 security vulnerability for version < 1.0.2

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -227,7 +227,8 @@
     "trim": "^0.0.3",
     "xmlhttprequest-ssl": "^1.6.2",
     "@embroider/macros": "^1.0.0",
-    "socket.io": "^4.6.2"
+    "socket.io": "^4.6.2",
+    "json5": "^1.0.2"
   },
   "engines": {
     "node": "18"

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -19655,52 +19655,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"json5@npm:^0.5.1":
-  version: 0.5.1
-  resolution: "json5@npm:0.5.1"
-  bin:
-    json5: lib/cli.js
-  checksum: 9b85bf06955b23eaa4b7328aa8892e3887e81ca731dd27af04a5f5f1458fbc5e1de57a24442e3272f8a888dd1abe1cb68eb693324035f6b3aeba4fcab7667d62
-  languageName: node
-  linkType: hard
-
-"json5@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "json5@npm:1.0.1"
+"json5@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "json5@npm:1.0.2"
   dependencies:
     minimist: ^1.2.0
   bin:
     json5: lib/cli.js
-  checksum: e76ea23dbb8fc1348c143da628134a98adf4c5a4e8ea2adaa74a80c455fc2cdf0e2e13e6398ef819bfe92306b610ebb2002668ed9fc1af386d593691ef346fc3
-  languageName: node
-  linkType: hard
-
-"json5@npm:^2.1.1, json5@npm:^2.2.2, json5@npm:^2.2.3":
-  version: 2.2.3
-  resolution: "json5@npm:2.2.3"
-  bin:
-    json5: lib/cli.js
-  checksum: 2a7436a93393830bce797d4626275152e37e877b265e94ca69c99e3d20c2b9dab021279146a39cdb700e71b2dd32a4cebd1514cd57cee102b1af906ce5040349
-  languageName: node
-  linkType: hard
-
-"json5@npm:^2.1.2":
-  version: 2.2.0
-  resolution: "json5@npm:2.2.0"
-  dependencies:
-    minimist: ^1.2.5
-  bin:
-    json5: lib/cli.js
-  checksum: e88fc5274bb58fc99547baa777886b069d2dd96d9cfc4490b305fd16d711dabd5979e35a4f90873cefbeb552e216b041a304fe56702bedba76e19bc7845f208d
-  languageName: node
-  linkType: hard
-
-"json5@npm:^2.2.1":
-  version: 2.2.1
-  resolution: "json5@npm:2.2.1"
-  bin:
-    json5: lib/cli.js
-  checksum: 74b8a23b102a6f2bf2d224797ae553a75488b5adbaee9c9b6e5ab8b510a2fc6e38f876d4c77dea672d4014a44b2399e15f2051ac2b37b87f74c0c7602003543b
+  checksum: 866458a8c58a95a49bef3adba929c625e82532bcff1fe93f01d29cb02cac7c3fe1f4b79951b7792c2da9de0b32871a8401a6e3c5b36778ad852bf5b8a61165d7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
"Backport" of https://github.com/hashicorp/vault/pull/26041

This dependency is used in a lot of ember packages and so adding it to the resolutions block seemed the best way to resolve this security vulnerability. 

one traced back to `ember-cli-page-object` 

```
# removed non-vulnerable versions from the output
ui|main⚡ ⇒ yarn why json5
├─ babel-core@npm:6.26.3
│  └─ json5@npm:0.5.1 (via npm:^0.5.1)
│
├─ find-babel-config@npm:1.2.0
│  └─ json5@npm:0.5.1 (via npm:^0.5.1)
│
├─ loader-utils@npm:1.4.0
│  └─ json5@npm:1.0.1 (via npm:^1.0.1)
```

```
└─ ember-cli-page-object@npm:1.17.10
   └─ ember-native-dom-helpers@npm:0.7.0 (via npm:^0.7.0)
      └─ ember-cli-babel@npm:6.18.0 (via npm:^6.6.0)
          └─ broccoli-babel-transpiler@npm:6.5.1 (via npm:^6.5.0)
              └─ babel-core@npm:6.26.3 (via npm:^6.26.0)
                  └─ json5@npm:0.5.1 (via npm:^0.5.1)
```
Another traced back to many, many ember packages
```
├─ ember-cli-babel@npm:7.26.11 # used in lots of ember packages (see screenshot)
├─ ember-cli@npm:4.12.1 # pinned to this version because of ember data
               └─ find-babel-config@npm:1.2.0
                  └─ json5@npm:0.5.1 (via npm:^0.5.1)
```
And this was just _some_ of them. So the best option here seemed to be adding it to the resolutions block
 <img width="496" alt="Screenshot 2024-03-19 at 12 11 43 PM" src="https://github.com/hashicorp/vault/assets/68122737/c0005f82-2bca-4d5a-b6c3-d8d3af488f04">

