### PR TITLE
Remove CE-only warning from shared tests

### DIFF
--- a/physical/raft/config.go
+++ b/physical/raft/config.go
@@ -238,7 +238,7 @@ func parseRaftBackendConfig(conf map[string]string, logger log.Logger) (*RaftBac
 	}
 
 	c.AutopilotRedundancyZone = conf["autopilot_redundancy_zone"]
-	if c.AutopilotRedundancyZone == "" {
+	if c.AutopilotRedundancyZone != "" {
 		emitEntWarning(logger, "autopilot_redundancy_zone")
 	}
 

--- a/physical/raft/config_test.go
+++ b/physical/raft/config_test.go
@@ -58,7 +58,7 @@ func TestRaft_ParseConfig(t *testing.T) {
 				cfg.RaftLogVerifierEnabled = true
 				cfg.RaftLogVerificationInterval = defaultRaftLogVerificationInterval
 			},
-			wantWarns: ceOnlyWarnings("raft_log_verification_interval is less than the minimum allowed"),
+			wantWarns: []string{"raft_log_verification_interval is less than the minimum allowed"},
 		},
 		{
 			name: "WAL verifier interval, one",
@@ -72,7 +72,7 @@ func TestRaft_ParseConfig(t *testing.T) {
 				// Below min so should get default
 				cfg.RaftLogVerificationInterval = defaultRaftLogVerificationInterval
 			},
-			wantWarns: ceOnlyWarnings("raft_log_verification_interval is less than the minimum allowed"),
+			wantWarns: []string{"raft_log_verification_interval is less than the minimum allowed"},
 		},
 		{
 			name: "WAL verifier interval, nothing",
@@ -84,7 +84,7 @@ func TestRaft_ParseConfig(t *testing.T) {
 				cfg.RaftLogVerifierEnabled = true
 				cfg.RaftLogVerificationInterval = defaultRaftLogVerificationInterval
 			},
-			wantWarns: ceOnlyWarnings("raft_log_verification_interval is less than the minimum allowed"),
+			wantWarns: []string{"raft_log_verification_interval is less than the minimum allowed"},
 		},
 		{
 			name: "WAL verifier interval, valid",

--- a/physical/raft/config_test.go
+++ b/physical/raft/config_test.go
@@ -113,7 +113,6 @@ func TestRaft_ParseConfig(t *testing.T) {
 			wantMutation: func(cfg *RaftBackendConfig) {
 				// Should be default
 			},
-			wantWarns: []string{"is configuration for a Vault Enterprise feature and has been ignored"},
 		},
 		{
 			name: "non-voter, retry-join, valid false",

--- a/physical/raft/raft_util_stubs_oss.go
+++ b/physical/raft/raft_util_stubs_oss.go
@@ -14,5 +14,5 @@ func (b *RaftBackend) entrySizeLimitForPath(path string) uint64 {
 }
 
 func emitEntWarning(logger hclog.Logger, field string) {
-	logger.Warn("%s is configuration for a Vault Enterprise feature and has been ignored.", field)
+	logger.Warn("configuration for a Vault Enterprise feature has been ignored", "field", field)
 }


### PR DESCRIPTION
I added this while developing #25992 as a quick check that the warnings were omitted (and that this test functionality worked) but didn't intend to commit it since it will conflict with Enterprise code.

Perhaps later it would be nice to have a clean way to be able to encode these warnings here but only for CE but that is a bigger change that is a bit gross so want to just get this mergeable in Ent for now while we discuss the cleanest pattern for that.