### PR TITLE
fix plugin update check pr num fetching

### DIFF
--- a/.github/workflows/plugin-update-check.yml
+++ b/.github/workflows/plugin-update-check.yml
@@ -67,12 +67,12 @@ jobs:
             --head "$VAULT_BRANCH" \
             --title "[DO NOT MERGE]: $PLUGIN_REPO Automated plugin update check" \
             --body "Updates $PLUGIN_REPO to verify vault CI. Full log: https://github.com/hashicorp/vault/actions/runs/$RUN_ID"
-
-            echo "vault_pr_num=$(gh pr list --head "$VAULT_BRANCH" --json number -q '.[0].number')" >> "$GITHUB_OUTPUT"
-            echo "vault_pr_url=$(gh pr list --head "$VAULT_BRANCH" --json url -q '.[0].url')" >> "$GITHUB_OUTPUT"
           else
             echo "Pull request already exists, won't create a new one."
           fi
+
+          echo "vault_pr_num=$(gh pr list --head "$VAULT_BRANCH" --json number -q '.[0].number')" >> "$GITHUB_OUTPUT"
+          echo "vault_pr_url=$(gh pr list --head "$VAULT_BRANCH" --json url -q '.[0].url')" >> "$GITHUB_OUTPUT"
 
       - name: Add labels to Vault CI check PR
         if: steps.changes.outputs.count > 0


### PR DESCRIPTION
When the Vault PR exists the workflow is unable to pass the PR num and url to the following steps. Example failure run: https://github.com/hashicorp/vault/actions/runs/8104485741/job/22151188307