### PR TITLE
1.16 Manual backport of https://github.com/hashicorp/vault/pull/26072

### DIFF
--- a/helper/storagepacker/storagepacker_test.go
+++ b/helper/storagepacker/storagepacker_test.go
@@ -14,6 +14,7 @@ import (
 	uuid "github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/vault/helper/identity"
 	"github.com/hashicorp/vault/sdk/logical"
+	"google.golang.org/protobuf/types/known/anypb"
 )
 
 func BenchmarkStoragePacker(b *testing.B) {
@@ -154,7 +155,7 @@ func TestStoragePacker_SerializeDeserializeComplexItem(t *testing.T) {
 		Policies:        []string{"policy1", "policy2"},
 	}
 
-	marshaledEntity, err := ptypes.MarshalAny(entity)
+	marshaledEntity, err := anypb.New(entity)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/vault/identity_store.go
+++ b/vault/identity_store.go
@@ -24,6 +24,8 @@ import (
 	"github.com/hashicorp/vault/sdk/helper/locksutil"
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/patrickmn/go-cache"
+	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 const (
@@ -700,7 +702,7 @@ func (i *IdentityStore) Invalidate(ctx context.Context, key string) {
 				// cache. Clearing the cache. Writing to storage can't be
 				// performed by perf standbys. So only doing this in the active
 				// node of the secondary.
-				if i.localNode.ReplicationState().HasState(consts.ReplicationPerformanceSecondary) && i.localNode.HAState() != consts.PerfStandby {
+				if i.localNode.ReplicationState().HasState(consts.ReplicationPerformanceSecondary) && i.localNode.HAState() == consts.Active {
 					if err := i.localAliasPacker.DeleteItem(ctx, entity.ID+tmpSuffix); err != nil {
 						i.logger.Error("failed to clear local alias entity cache", "error", err, "entity_id", entity.ID)
 						return
@@ -715,7 +717,7 @@ func (i *IdentityStore) Invalidate(ctx context.Context, key string) {
 		// represent entities that are valid after invalidation. Clear the
 		// storage entries of local aliases for those entities that are
 		// indicated deleted by this invalidation.
-		if i.localNode.ReplicationState().HasState(consts.ReplicationPerformanceSecondary) && i.localNode.HAState() != consts.PerfStandby {
+		if i.localNode.ReplicationState().HasState(consts.ReplicationPerformanceSecondary) && i.localNode.HAState() == consts.Active {
 			for _, entity := range entitiesFetched {
 				if !strutil.StrListContains(entityIDs, entity.ID) {
 					if err := i.localAliasPacker.DeleteItem(ctx, entity.ID); err != nil {
@@ -1010,7 +1012,7 @@ func (i *IdentityStore) parseEntityFromBucketItem(ctx context.Context, item *sto
 	}
 
 	if persistNeeded && !i.localNode.ReplicationState().HasState(consts.ReplicationPerformanceSecondary) {
-		entityAsAny, err := ptypes.MarshalAny(&entity)
+		entityAsAny, err := anypb.New(&entity)
 		if err != nil {
 			return nil, err
 		}
@@ -1199,7 +1201,7 @@ func (i *IdentityStore) CreateOrFetchEntity(ctx context.Context, alias *logical.
 		}
 		a := entity.Aliases[idx]
 		a.Metadata = alias.Metadata
-		a.LastUpdateTime = ptypes.TimestampNow()
+		a.LastUpdateTime = timestamppb.Now()
 
 		update = true
 	}

--- a/vault/identity_store_aliases.go
+++ b/vault/identity_store_aliases.go
@@ -16,6 +16,8 @@ import (
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/helper/custommetadata"
 	"github.com/hashicorp/vault/sdk/logical"
+	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 // aliasPaths returns the API endpoints to operate on aliases.
@@ -356,7 +358,7 @@ func (i *IdentityStore) handleAliasUpdate(ctx context.Context, canonicalID, name
 		return nil, nil
 	}
 
-	alias.LastUpdateTime = ptypes.TimestampNow()
+	alias.LastUpdateTime = timestamppb.Now()
 
 	// Get our current entity, which may be the same as the new one if the
 	// canonical ID hasn't changed
@@ -635,7 +637,7 @@ func (i *IdentityStore) pathAliasIDDelete() framework.OperationFunc {
 				}
 			}
 
-			marshaledAliases, err := ptypes.MarshalAny(localAliases)
+			marshaledAliases, err := anypb.New(localAliases)
 			if err != nil {
 				return nil, err
 			}

--- a/vault/identity_store_entities.go
+++ b/vault/identity_store_entities.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/helper/consts"
 	"github.com/hashicorp/vault/sdk/logical"
+	"google.golang.org/protobuf/types/known/anypb"
 )
 
 func entityPathFields() map[string]*framework.FieldSchema {
@@ -1141,7 +1142,7 @@ func (i *IdentityStore) mergeEntity(ctx context.Context, txn *memdb.Txn, toEntit
 
 	if persist && !isPerfSecondaryOrStandby {
 		// Persist the entity which we are merging to
-		toEntityAsAny, err := ptypes.MarshalAny(toEntity)
+		toEntityAsAny, err := anypb.New(toEntity)
 		if err != nil {
 			return nil, err, nil
 		}

--- a/vault/identity_store_group_aliases.go
+++ b/vault/identity_store_group_aliases.go
@@ -8,11 +8,11 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/golang/protobuf/ptypes"
 	"github.com/hashicorp/vault/helper/identity"
 	"github.com/hashicorp/vault/helper/namespace"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/logical"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 func groupAliasPaths(i *IdentityStore) []*framework.Path {
@@ -170,7 +170,7 @@ func (i *IdentityStore) handleGroupAliasUpdateCommon(ctx context.Context, req *l
 
 	if groupAlias == nil {
 		groupAlias = &identity.Alias{
-			CreationTime: ptypes.TimestampNow(),
+			CreationTime: timestamppb.Now(),
 			NamespaceID:  ns.ID,
 		}
 		groupAlias.LastUpdateTime = groupAlias.CreationTime
@@ -178,7 +178,7 @@ func (i *IdentityStore) handleGroupAliasUpdateCommon(ctx context.Context, req *l
 		if ns.ID != groupAlias.NamespaceID {
 			return logical.ErrorResponse("existing alias not in the same namespace as request"), logical.ErrPermissionDenied
 		}
-		groupAlias.LastUpdateTime = ptypes.TimestampNow()
+		groupAlias.LastUpdateTime = timestamppb.Now()
 		if groupAlias.CreationTime == nil {
 			groupAlias.CreationTime = groupAlias.LastUpdateTime
 		}

--- a/vault/identity_store_test.go
+++ b/vault/identity_store_test.go
@@ -9,11 +9,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/armon/go-metrics"
 	"github.com/go-test/deep"
-	"github.com/golang/protobuf/ptypes"
 	uuid "github.com/hashicorp/go-uuid"
 	credGithub "github.com/hashicorp/vault/builtin/credential/github"
 	credUserpass "github.com/hashicorp/vault/builtin/credential/userpass"
@@ -21,6 +18,8 @@ import (
 	"github.com/hashicorp/vault/helper/namespace"
 	"github.com/hashicorp/vault/helper/storagepacker"
 	"github.com/hashicorp/vault/sdk/logical"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/anypb"
 )
 
 func TestIdentityStore_DeleteEntityAlias(t *testing.T) {
@@ -143,7 +142,7 @@ func TestIdentityStore_UnsealingWhenConflictingAliasNames(t *testing.T) {
 
 	// Persist the second entity directly without the regular flow. This will skip
 	// merging of these enties.
-	entity2Any, err := ptypes.MarshalAny(entity2)
+	entity2Any, err := anypb.New(entity2)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/vault/identity_store_util.go
+++ b/vault/identity_store_util.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	metrics "github.com/armon/go-metrics"
-	"github.com/golang/protobuf/ptypes"
 	"github.com/hashicorp/errwrap"
 	memdb "github.com/hashicorp/go-memdb"
 	"github.com/hashicorp/go-secure-stdlib/strutil"
@@ -23,6 +22,8 @@ import (
 	"github.com/hashicorp/vault/helper/storagepacker"
 	"github.com/hashicorp/vault/sdk/helper/consts"
 	"github.com/hashicorp/vault/sdk/logical"
+	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 var (
@@ -710,7 +711,7 @@ func (i *IdentityStore) processLocalAlias(ctx context.Context, lAlias *logical.A
 		localAliases.Aliases = append(localAliases.Aliases, alias)
 	}
 
-	marshaledAliases, err := ptypes.MarshalAny(localAliases)
+	marshaledAliases, err := anypb.New(localAliases)
 	if err != nil {
 		return nil, err
 	}
@@ -746,8 +747,8 @@ func (i *IdentityStore) processLocalAlias(ctx context.Context, lAlias *logical.A
 // still be aware of the entities. This temporary cache will be cleared when the
 // invalidation hits the secondary nodes.
 func (i *IdentityStore) cacheTemporaryEntity(ctx context.Context, entity *identity.Entity) error {
-	if i.localNode.ReplicationState().HasState(consts.ReplicationPerformanceSecondary) && i.localNode.HAState() != consts.PerfStandby {
-		marshaledEntity, err := ptypes.MarshalAny(entity)
+	if i.localNode.ReplicationState().HasState(consts.ReplicationPerformanceSecondary) && i.localNode.HAState() == consts.Active {
+		marshaledEntity, err := anypb.New(entity)
 		if err != nil {
 			return err
 		}
@@ -786,7 +787,7 @@ func (i *IdentityStore) persistEntity(ctx context.Context, entity *identity.Enti
 
 	// Store the entity with non-local aliases.
 	entity.Aliases = nonLocalAliases
-	marshaledEntity, err := ptypes.MarshalAny(entity)
+	marshaledEntity, err := anypb.New(entity)
 	if err != nil {
 		return err
 	}
@@ -806,7 +807,7 @@ func (i *IdentityStore) persistEntity(ctx context.Context, entity *identity.Enti
 		Aliases: localAliases,
 	}
 
-	marshaledAliases, err := ptypes.MarshalAny(aliases)
+	marshaledAliases, err := anypb.New(aliases)
 	if err != nil {
 		return err
 	}
@@ -1345,10 +1346,10 @@ func (i *IdentityStore) sanitizeAlias(ctx context.Context, alias *identity.Alias
 
 	// Set the creation and last update times
 	if alias.CreationTime == nil {
-		alias.CreationTime = ptypes.TimestampNow()
+		alias.CreationTime = timestamppb.Now()
 		alias.LastUpdateTime = alias.CreationTime
 	} else {
-		alias.LastUpdateTime = ptypes.TimestampNow()
+		alias.LastUpdateTime = timestamppb.Now()
 	}
 
 	return nil
@@ -1399,10 +1400,10 @@ func (i *IdentityStore) sanitizeEntity(ctx context.Context, entity *identity.Ent
 
 	// Set the creation and last update times
 	if entity.CreationTime == nil {
-		entity.CreationTime = ptypes.TimestampNow()
+		entity.CreationTime = timestamppb.Now()
 		entity.LastUpdateTime = entity.CreationTime
 	} else {
-		entity.LastUpdateTime = ptypes.TimestampNow()
+		entity.LastUpdateTime = timestamppb.Now()
 	}
 
 	// Ensure that MFASecrets is non-nil at any time. This is useful when MFA
@@ -1463,10 +1464,10 @@ func (i *IdentityStore) sanitizeAndUpsertGroup(ctx context.Context, group *ident
 
 	// Set the creation and last update times
 	if group.CreationTime == nil {
-		group.CreationTime = ptypes.TimestampNow()
+		group.CreationTime = timestamppb.Now()
 		group.LastUpdateTime = group.CreationTime
 	} else {
-		group.LastUpdateTime = ptypes.TimestampNow()
+		group.LastUpdateTime = timestamppb.Now()
 	}
 
 	// Remove duplicate entity IDs and check if all IDs are valid
@@ -1807,7 +1808,7 @@ func (i *IdentityStore) UpsertGroupInTxn(ctx context.Context, txn *memdb.Txn, gr
 	}
 
 	if persist {
-		groupAsAny, err := ptypes.MarshalAny(group)
+		groupAsAny, err := anypb.New(group)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Manual backport of https://github.com/hashicorp/vault/pull/26072

The issue was the orders of the imports in `vault/identity_store_test.go`.

I believe this shouldn't get merged until 1.16 is GA. I'll put a reminder so that I don't forget.