### PR TITLE
Update POST activation-flags call

### DIFF
--- a/ui/lib/sync/addon/components/secrets/page/overview.ts
+++ b/ui/lib/sync/addon/components/secrets/page/overview.ts
@@ -18,7 +18,6 @@ import type RouterService from '@ember/routing/router-service';
 import type VersionService from 'vault/services/version';
 import type { SyncDestinationAssociationMetrics } from 'vault/vault/adapters/sync/association';
 import type SyncDestinationModel from 'vault/vault/models/sync/destination';
-import type FeatureFlagService from 'vault/services/feature-flag';
 
 interface Args {
   destinations: Array<SyncDestinationModel>;
@@ -28,7 +27,6 @@ interface Args {
 
 export default class SyncSecretsDestinationsPageComponent extends Component<Args> {
   @service declare readonly flashMessages: FlashMessageService;
-  @service declare readonly featureFlag: FeatureFlagService;
   @service declare readonly store: StoreService;
   @service declare readonly router: RouterService;
   @service declare readonly version: VersionService;
@@ -74,11 +72,10 @@ export default class SyncSecretsDestinationsPageComponent extends Component<Args
   @task
   @waitFor
   *onFeatureConfirm() {
-    const namespace = this.featureFlag.managedNamespaceRoot;
     try {
       yield this.store
         .adapterFor('application')
-        .ajax('/v1/sys/activation-flags/secrets-sync/activate', 'POST', { namespace });
+        .ajax('/v1/sys/activation-flags/secrets-sync/activate', 'POST', { namespace: null });
       this.router.transitionTo('vault.cluster.sync.secrets.overview');
     } catch (error) {
       this.error = errorMessage(error);

--- a/ui/tests/acceptance/sync/secrets/overview-test.js
+++ b/ui/tests/acceptance/sync/secrets/overview-test.js
@@ -104,7 +104,8 @@ module('Acceptance | sync | overview', function (hooks) {
       await click(ts.overview.optInConfirm);
     });
 
-    test('it should make activation-flag requests to correct namespace when managed', async function (assert) {
+    test.skip('it should make activation-flag requests to correct namespace when managed', async function (assert) {
+      // TODO: unskip for 1.16.1 when managed is supported
       assert.expect(6);
       this.owner.lookup('service:feature-flag').setFeatureFlags(['VAULT_CLOUD_ADMIN_NAMESPACE']);
       this.server.get('/sys/activation-flags', (_, req) => {


### PR DESCRIPTION
Recent changes to the backend mean that we now only make the POST request to activation-flags in the root namespace. 