### PR TITLE
Audit: Timestamps on sink entries should match the creation time of the audit event

### DIFF
--- a/audit/event.go
+++ b/audit/event.go
@@ -26,6 +26,9 @@ const (
 	JSONxFormat format = "jsonx"
 )
 
+// Check AuditEvent implements the timeProvider at compile time.
+var _ timeProvider = (*AuditEvent)(nil)
+
 // AuditEvent is the audit event.
 type AuditEvent struct {
 	ID        string            `json:"id"`
@@ -153,4 +156,10 @@ func (t subtype) String() string {
 	}
 
 	return string(t)
+}
+
+// formattedTime returns the UTC time the AuditEvent was created in the RFC3339Nano
+// format (which removes trailing zeros from the seconds field).
+func (a *AuditEvent) formattedTime() string {
+	return a.Timestamp.UTC().Format(time.RFC3339Nano)
 }

--- a/audit/event_test.go
+++ b/audit/event_test.go
@@ -368,3 +368,13 @@ func TestAuditEvent_Subtype_String(t *testing.T) {
 		})
 	}
 }
+
+// TestAuditEvent_formattedTime is used to check the output from the formattedTime
+// method returns the correct format.
+func TestAuditEvent_formattedTime(t *testing.T) {
+	theTime := time.Date(2024, time.March, 22, 10, 0o0, 5, 10, time.UTC)
+	a, err := NewEvent(ResponseType, WithNow(theTime))
+	require.NoError(t, err)
+	require.NotNil(t, a)
+	require.Equal(t, "2024-03-22T10:00:05.00000001Z", a.formattedTime())
+}

--- a/audit/types.go
+++ b/audit/types.go
@@ -52,9 +52,9 @@ type Salter interface {
 // It is recommended that you pass data through Hash prior to formatting it.
 type Formatter interface {
 	// FormatRequest formats the logical.LogInput into an RequestEntry.
-	FormatRequest(context.Context, *logical.LogInput) (*RequestEntry, error)
+	FormatRequest(context.Context, *logical.LogInput, timeProvider) (*RequestEntry, error)
 	// FormatResponse formats the logical.LogInput into an ResponseEntry.
-	FormatResponse(context.Context, *logical.LogInput) (*ResponseEntry, error)
+	FormatResponse(context.Context, *logical.LogInput, timeProvider) (*ResponseEntry, error)
 }
 
 // HeaderFormatter is an interface defining the methods of the

--- a/changelog/26088.txt
+++ b/changelog/26088.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+audit: timestamps across multiple audit devices for an audit entry will now match.
+```


### PR DESCRIPTION
Previously when entries for audit were written to configured sinks (file, socket, syslog) the time associated with each entry was related to the exact time the sink tried to write it, and not the time the audit entry itself was created. 

This PR changes this so that the time the entry (audit event) is created is the time which appears in the sink logs, this will help Operators to coordinate entries across multiple audit device sinks.

Addresses https://github.com/hashicorp/vault/issues/8466