### PR TITLE
fix link to specifying ttl and audience section of kubernetes oidc provider

### DIFF
--- a/website/content/docs/auth/kubernetes.mdx
+++ b/website/content/docs/auth/kubernetes.mdx
@@ -166,7 +166,7 @@ injected service account tokens to a year to help smooth the transition to
 short-lived tokens. If you would like to disable this, set
 [--service-account-extend-token-expiration=false][k8s-extended-tokens] for
 `kube-apiserver` or specify your own `serviceAccountToken` volume mount. See
-[here](/vault/docs/auth/jwt/oidc-providers/kubernetes#specifying-ttl-and-audience) for an example.
+[here](/vault/docs/auth/jwt/oidc-providers/kubernetes#specify-ttl-and-audience) for an example.
 
 [k8s-extended-tokens]: https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/#options
 


### PR DESCRIPTION
Existing link is wrong - https://developer.hashicorp.com/vault/docs/auth/jwt/oidc-providers/kubernetes#specifying-ttl-and-audience and doesn't lead to the section in the browser. Correct link is - https://developer.hashicorp.com/vault/docs/auth/jwt/oidc-providers/kubernetes#specify-ttl-and-audience and leads to the correct section in the browser