### PR TITLE
VAULT-20396 Add limit of 100,000 to string templates

### DIFF
--- a/changelog/26110.txt
+++ b/changelog/26110.txt
@@ -1,0 +1,3 @@
+```release-note:change
+sdk: String templates now have a maximum size of 100,000 characters.
+```

--- a/sdk/helper/template/template.go
+++ b/sdk/helper/template/template.go
@@ -129,6 +129,10 @@ func NewTemplate(opts ...Opt) (up StringTemplate, err error) {
 		return StringTemplate{}, fmt.Errorf("missing template")
 	}
 
+	if len(up.rawTemplate) >= 100000 {
+		return StringTemplate{}, fmt.Errorf("template too large, length of template must be less than 100,000")
+	}
+
 	tmpl, err := template.New("template").
 		Funcs(up.funcMap).
 		Parse(up.rawTemplate)

--- a/sdk/helper/template/template_test.go
+++ b/sdk/helper/template/template_test.go
@@ -5,6 +5,7 @@ package template
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -149,6 +150,16 @@ Some string 6841cf80`,
 
 			require.Regexp(t, `^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$`, actual)
 		}
+	})
+
+	t.Run("overflow", func(t *testing.T) {
+		data := "{{" + strings.Repeat("(", 1000000)
+		_, err := NewTemplate(
+			Template(data),
+		)
+		// We expect an error due to unterminated {{, but also
+		// this test should not fail with an overflow
+		require.Error(t, err)
 	})
 }
 

--- a/sdk/helper/template/template_test.go
+++ b/sdk/helper/template/template_test.go
@@ -152,12 +152,12 @@ Some string 6841cf80`,
 		}
 	})
 
-	t.Run("overflow", func(t *testing.T) {
+	t.Run("too-large-overflow", func(t *testing.T) {
 		data := "{{" + strings.Repeat("(", 1000000)
 		_, err := NewTemplate(
 			Template(data),
 		)
-		// We expect an error due to unterminated {{, but also
+		// We expect an error due it being too large,
 		// this test should not fail with an overflow
 		require.Error(t, err)
 	})


### PR DESCRIPTION
We now enforce a limit of 100,000 characters on string templates in the `sdk/helpers` library. This should be large enough to support almost all use cases, even if it is a change.

See Jira for further details.