### PR TITLE
UI: Follow on sync updates for 1.16 GA 

### DIFF
--- a/ui/app/components/clients/page/counts.hbs
+++ b/ui/app/components/clients/page/counts.hbs
@@ -146,7 +146,11 @@
     {{else}}
       <EmptyState
         @title="No data received {{if this.dateRangeMessage this.dateRangeMessage}}"
-        @message="Update the filter values or click the button to reset them."
+        @message={{if
+          this.version.isCommunity
+          "Select a start date above to query client count data."
+          "Update the filter values or click the button to reset them."
+        }}
       >
         <Hds::Button @text="Reset filters" @color="tertiary" @icon="reload" {{on "click" this.resetFilters}} />
       </EmptyState>

--- a/ui/app/components/clients/page/sync.hbs
+++ b/ui/app/components/clients/page/sync.hbs
@@ -22,15 +22,17 @@
       </:subTitle>
 
       <:stats>
-        {{#if (not-eq (this.average this.byMonthActivityData "secret_syncs") 0)}}
-          <StatText
-            @label="Average sync clients per month"
-            @value={{this.average this.byMonthActivityData "secret_syncs"}}
-            @size="m"
-            class="data-details-top has-top-padding-l"
-            data-test-average-sync-clients
-          />
-        {{/if}}
+        {{#let (this.average this.byMonthActivityData "secret_syncs") as |avg|}}
+          {{#if (not-eq (avg) 0)}}
+            <StatText
+              @label="Average sync clients per month"
+              @value={{avg}}
+              @size="m"
+              class="data-details-top has-top-padding-l"
+              data-test-average-sync-clients
+            />
+          {{/if}}
+        {{/let}}
       </:stats>
 
       <:chart>

--- a/ui/app/components/clients/page/sync.hbs
+++ b/ui/app/components/clients/page/sync.hbs
@@ -22,13 +22,15 @@
       </:subTitle>
 
       <:stats>
-        <StatText
-          @label="Average sync clients per month"
-          @value={{this.average this.byMonthActivityData "secret_syncs"}}
-          @size="m"
-          class="data-details-top has-top-padding-l"
-          data-test-average-sync-clients
-        />
+        {{#if (not-eq (this.average this.byMonthActivityData "secret_syncs") 0)}}
+          <StatText
+            @label="Average sync clients per month"
+            @value={{this.average this.byMonthActivityData "secret_syncs"}}
+            @size="m"
+            class="data-details-top has-top-padding-l"
+            data-test-average-sync-clients
+          />
+        {{/if}}
       </:stats>
 
       <:chart>

--- a/ui/app/components/clients/page/sync.hbs
+++ b/ui/app/components/clients/page/sync.hbs
@@ -23,7 +23,8 @@
 
       <:stats>
         {{#let (this.average this.byMonthActivityData "secret_syncs") as |avg|}}
-          {{#if (not-eq (avg) 0)}}
+          {{! intentionally hides a 0 average (0 is falsy) }}
+          {{#if avg}}
             <StatText
               @label="Average sync clients per month"
               @value={{avg}}

--- a/ui/app/routes/vault/cluster/clients/counts.ts
+++ b/ui/app/routes/vault/cluster/clients/counts.ts
@@ -11,6 +11,7 @@ import { getUnixTime } from 'date-fns';
 
 import type StoreService from 'vault/services/store';
 import type VersionService from 'vault/services/version';
+
 import type { ClientsRouteModel } from '../clients';
 import type ClientsConfigModel from 'vault/models/clients/config';
 import type ClientsVersionHistoryModel from 'vault/models/clients/version-history';
@@ -60,12 +61,9 @@ export default class ClientsCountsRoute extends Route {
     mountPath: { refreshModel: false, replace: true },
   };
 
-  async getActivity(
-    start_time: number,
-    end_time: number
-  ): Promise<[ClientsActivityModel | undefined, AdapterError | unknown] | [Record<string, never>, null]> {
+  async getActivity(start_time: number | null, end_time: number) {
     let activity, activityError;
-    // if there is no billingStartTimestamp or selected start date initially we allow the user to manually choose a date
+    // if there is no start_time we want the user to manually choose a date
     // in that case bypass the query so that the user isn't stuck viewing the activity error
     if (start_time) {
       try {
@@ -93,7 +91,7 @@ export default class ClientsCountsRoute extends Route {
     }
   }
 
-  async isSecretsSyncActivated(activity: ClientsActivityModel | Record<string, never> | undefined) {
+  async isSecretsSyncActivated(activity: ClientsActivityModel) {
     // if there are secrets, the feature is activated
     if (activity && activity.total?.secret_syncs > 0) return true;
 
@@ -107,12 +105,13 @@ export default class ClientsCountsRoute extends Route {
 
   async model(params: ClientsCountsRouteParams) {
     const { config, versionHistory } = this.modelFor('vault.cluster.clients') as ClientsRouteModel;
-    // we could potentially make an additional request to fetch the license and get the start date from there if the config request fails
-    const startTimestamp = Number(params.start_time) || getUnixTime(config.billingStartTimestamp);
+    // only enterprise versions will have a relevant billing start date, pass null so community users must select initial start time
+    const startTime = this.version.isEnterprise ? getUnixTime(config.billingStartTimestamp) : null;
+    const startTimestamp = Number(params.start_time) || startTime;
     const endTimestamp = Number(params.end_time) || getUnixTime(timestamp.now());
     const [activity, activityError] = await this.getActivity(startTimestamp, endTimestamp);
 
-    const isSecretsSyncActivated = await this.isSecretsSyncActivated(activity);
+    const isSecretsSyncActivated = await this.isSecretsSyncActivated(activity as ClientsActivityModel);
 
     return {
       activity,

--- a/ui/tests/acceptance/clients/counts-test.js
+++ b/ui/tests/acceptance/clients/counts-test.js
@@ -31,6 +31,15 @@ module('Acceptance | clients | counts', function (hooks) {
     timestamp.now.restore();
   });
 
+  test('it should prompt user to query start time for community version', async function (assert) {
+    assert.expect(2);
+    this.owner.lookup('service:version').type = 'community';
+    await visit('/vault/clients/counts/overview');
+
+    assert.dom(ts.emptyStateTitle).hasText('No data received');
+    assert.dom(ts.emptyStateMessage).hasText('Select a start date above to query client count data.');
+  });
+
   test('it should redirect to counts overview route for transitions to parent', async function (assert) {
     await visit('/vault/clients');
     assert.strictEqual(currentURL(), '/vault/clients/counts/overview', 'Redirects to counts overview route');

--- a/ui/tests/acceptance/clients/counts/overview-test.js
+++ b/ui/tests/acceptance/clients/counts/overview-test.js
@@ -318,7 +318,7 @@ module('Acceptance | clients | overview | sync not in license', function (hooks)
 
   hooks.beforeEach(async function () {
     this.store = this.owner.lookup('service:store');
-    // mocks endpoint for no additional license modules or CE edition
+    // mocks endpoint for no additional license modules
     this.server.get('/sys/license/features', () => ({ features: [] }));
 
     await authPage.login();

--- a/ui/tests/acceptance/clients/counts/overview-test.js
+++ b/ui/tests/acceptance/clients/counts/overview-test.js
@@ -318,6 +318,9 @@ module('Acceptance | clients | overview | sync not in license', function (hooks)
 
   hooks.beforeEach(async function () {
     this.store = this.owner.lookup('service:store');
+    // mocks endpoint for no additional license modules or CE edition
+    this.server.get('/sys/license/features', () => ({ features: [] }));
+
     await authPage.login();
     return visit('/vault/clients/counts/overview');
   });

--- a/ui/tests/integration/components/clients/page/sync-test.js
+++ b/ui/tests/integration/components/clients/page/sync-test.js
@@ -136,4 +136,49 @@ module('Integration | Component | clients | Clients::Page::Sync', function (hook
     assert.dom(syncTab.total).doesNotExist();
     assert.dom(syncTab.average).doesNotExist();
   });
+
+  test('it should render an empty chart if secrets sync is activated but no secrets synced', async function (assert) {
+    this.isSecretsSyncActivated = true;
+    const counts = {
+      clients: 10,
+      entity_clients: 4,
+      non_entity_clients: 6,
+      secret_syncs: 0,
+    };
+    const monthData = {
+      month: '1/24',
+      timestamp: '2024-01-01T00:00:00-08:00',
+      ...counts,
+      namespaces: [
+        {
+          label: 'root',
+          ...counts,
+          mounts: [],
+        },
+      ],
+    };
+    this.activity.byMonth = [
+      {
+        ...monthData,
+        namespaces_by_key: {
+          root: {
+            ...monthData,
+            mounts_by_key: {},
+          },
+        },
+        new_clients: {
+          ...monthData,
+        },
+      },
+    ];
+    this.activity.total = counts;
+    await this.renderComponent();
+
+    assert
+      .dom(syncTab.total)
+      .hasText(
+        'Total sync clients The total number of secrets synced from Vault to other destinations during this date range. 0'
+      );
+    assert.dom(syncTab.average).doesNotExist('Does not render average if the calculation is 0');
+  });
 });


### PR DESCRIPTION
Fixes issue on community where a default 0 date `0001-01-01T00:00:00Z` value for the billing start caused incorrect date querying. This regression was introduced when we refactored to use the `v1/sys/internal/counters/config` for the start time instead of making a query to the license for that info (which would fail on CE)

This PR also hides average sync count when the average is 0
# screenshot before fix
![image](https://github.com/hashicorp/vault/assets/68122737/745af695-5662-4046-846d-a00b93178c98)

<hr>
because there are so many months in the average calculation, the average is a decimal below 1 which rounds to `0` this isn't great UX so hiding in situations like this

<img width="947" alt="Screenshot 2024-03-22 at 12 55 18 PM" src="https://github.com/hashicorp/vault/assets/68122737/8921cebe-2cfe-4745-8644-c8b6e1af4b36">

<hr>

enterprise passed ✅ 


