### PR TITLE
Docs/mount namespace entry size

### DIFF
--- a/website/content/docs/configuration/storage/raft.mdx
+++ b/website/content/docs/configuration/storage/raft.mdx
@@ -136,15 +136,16 @@ delay) mode. The maximum allowed value is 10.
     default to a value larger than the Integrated Storage default of 1MB, then you will 
     need to make the same change in Vault's Integrated Storage config.
 
-- `max_mount_and_namespace_table_entry_size` - This is a subset of
+- `max_mount_and_namespace_table_entry_size` `(integer)`- This is a subset of
   `max_entry_size` that allows a different limit to be set for the specific KV
   entries that contain mount tables, auth tables and namespace configuration
   data. Increasing this allows Vault to store more mounts and namespaces without
   increasing the risk of other user-controlled storage entries becoming too
   large. All other notes on [`max_entry_size`](#max-entry-size) apply. See
   [/vault/docs/enterprise/namespaces/namespace-limits](Run Vault Enterprise with
-  many namespaces) for more details. Use of this feature requires Vault
-  Enterprise.
+  many namespaces) for more details. If not explicitly configured, the
+  `max_entry_size` will continue to apply to mount and namespace tables. Use of
+  this feature requires Vault Enterprise.
 
 - `autopilot_reconcile_interval` `(string: "10s")` - This is the interval after
   which autopilot will pick up any state changes. State change could mean multiple

--- a/website/content/docs/configuration/storage/raft.mdx
+++ b/website/content/docs/configuration/storage/raft.mdx
@@ -115,10 +115,11 @@ delay) mode. The maximum allowed value is 10.
   in the Raft quorum but will still receive the data replication stream, adding
   read scalability to a cluster. This option has the same effect as the
   [`-non-voter`](/vault/docs/commands/operator/raft#non-voter) flag for the
-  `vault operator raft join` command, but only affects voting status when joining
-  via `retry_join` config. This setting can be overridden to true by setting the
-  `VAULT_RAFT_RETRY_JOIN_AS_NON_VOTER` environment variable to any non-empty value.
-  Only valid if there is at least one `retry_join` stanza.
+  `vault operator raft join` command, but only affects voting status when
+  joining via `retry_join` config. This setting can be overridden to true by
+  setting the `VAULT_RAFT_RETRY_JOIN_AS_NON_VOTER` environment variable to any
+  non-empty value. Only valid if there is at least one `retry_join` stanza. Use
+  of this feature requires Vault Enterprise.
 
 - `max_entry_size` `(integer: 1048576)` - This configures the maximum number of
   bytes for a Raft entry. It applies to both Put operations and transactions.
@@ -134,6 +135,16 @@ delay) mode. The maximum allowed value is 10.
     storage to Raft Integrated Storage,  and have changed this value in Consul from its
     default to a value larger than the Integrated Storage default of 1MB, then you will 
     need to make the same change in Vault's Integrated Storage config.
+
+- `max_mount_and_namespace_table_entry_size` - This is a subset of
+  `max_entry_size` that allows a different limit to be set for the specific KV
+  entries that contain mount tables, auth tables and namespace configuration
+  data. Increasing this allows Vault to store more mounts and namespaces without
+  increasing the risk of other user-controlled storage entries becoming too
+  large. All other notes on [`max_entry_size`](#max-entry-size) apply. See
+  [/vault/docs/enterprise/namespaces/namespace-limits](Run Vault Enterprise with
+  many namespaces) for more details. Use of this feature requires Vault
+  Enterprise.
 
 - `autopilot_reconcile_interval` `(string: "10s")` - This is the interval after
   which autopilot will pick up any state changes. State change could mean multiple

--- a/website/content/partials/storage-entry-size.mdx
+++ b/website/content/partials/storage-entry-size.mdx
@@ -3,9 +3,15 @@ by that backend.
 
 The default entry size limit for the integrated storage backend, is 1 MiB. You
 can configure the allowable entry size with the `max_entry_size` parameter in
-your the [storage stanza](/vault/docs/configuration/storage/raft#max_entry_size).
-Vault automatically chunks any storage entry that is larger than 512 KiB but
-smaller than `max_entry_size` into smaller pieces before writing the entry to Raft.
+your the [storage
+stanza](/vault/docs/configuration/storage/raft#max_entry_size). Vault
+automatically chunks any storage entry that is larger than 512 KiB but smaller
+than `max_entry_size` into smaller pieces before writing the entry to Raft.
+Vault Enterprise 1.17 and higher also exposes a
+`max_mount_and_namespace_table_entry_size` configuration that allows the limit
+to be increased but only for the KV entries necessary for the mount table and
+namespace metedata. Increasing this is recommended where available to avoid
+unintentionally allowing other storage entries to grow to be very large.
 
 For Vault deployments using the Consul storage backend, the default entry size
 limit is 512 KiB. The default size is enforced by Consul rather than Vault. You

--- a/website/content/partials/storage-entry-size.mdx
+++ b/website/content/partials/storage-entry-size.mdx
@@ -7,11 +7,13 @@ your the [storage
 stanza](/vault/docs/configuration/storage/raft#max_entry_size). Vault
 automatically chunks any storage entry that is larger than 512 KiB but smaller
 than `max_entry_size` into smaller pieces before writing the entry to Raft.
+
 Vault Enterprise 1.17 and higher also exposes a
 `max_mount_and_namespace_table_entry_size` configuration that allows the limit
 to be increased but only for the KV entries necessary for the mount table and
-namespace metedata. Increasing this is recommended where available to avoid
-unintentionally allowing other storage entries to grow to be very large.
+namespace metadata. To allow for more mounts or namespaces than the default
+entry size can support, it is recommended over `max_entry_size` where available
+as it avoids unintentionally allowing other storage entries to grow very large.
 
 For Vault deployments using the Consul storage backend, the default entry size
 limit is 512 KiB. The default size is enforced by Consul rather than Vault. You


### PR DESCRIPTION
Add documentation for the new configuration added in #25992.

I also fixed up the fact that we don't document `retry_join_as_non_voter` as an Enterprise feature today.