### PR TITLE
Cleanup package resolutions

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -211,10 +211,8 @@
     "xstate": "^3.3.3"
   },
   "resolutions": {
-    "cryptiles": "^4.1.2",
     "eslint-utils": "^1.4.1",
     "ember-basic-dropdown": "6.0.1",
-    "growl": "^1.10.0",
     "highlight.js": "^10.4.1",
     "https-proxy-agent": "^2.2.3",
     "ini": "^1.3.6",
@@ -225,7 +223,6 @@
     "qs": "^6.3.0",
     "serialize-javascript": "^3.1.0",
     "underscore": "^1.12.1",
-    "trim": "^0.0.3",
     "xmlhttprequest-ssl": "^1.6.2",
     "@embroider/macros": "^1.15.0",
     "socket.io": "^4.6.2",


### PR DESCRIPTION
I searched the codebase for each resolution and removed it if there was no reference to it. Afterward running `yarn install`, as expected, did **not** update the `yarn.lock` file  🎉  

<img width="1448" alt="Screenshot 2024-03-22 at 2 50 28 PM" src="https://github.com/hashicorp/vault/assets/68122737/385702b9-e408-411d-b08c-80745afdbc94">
