### PR TITLE
[secrets sync] remove incorrect dom assertion

### DIFF
--- a/ui/tests/acceptance/clients/counts/overview-test.js
+++ b/ui/tests/acceptance/clients/counts/overview-test.js
@@ -278,6 +278,7 @@ module('Acceptance | clients | overview | sync in license, activated', function 
       .dom(SELECTORS.charts.statTextValue('Secrets sync clients'))
       .exists('shows secret sync data on overview');
     await click(SELECTORS.tab('sync'));
+
     assert.dom(SELECTORS.tab('sync')).hasClass('active');
     assert.dom(SELECTORS.emptyStateTitle).doesNotExist();
     assert
@@ -307,7 +308,6 @@ module('Acceptance | clients | overview | sync in license, not activated', funct
       .dom(SELECTORS.charts.chart('Secrets sync usage'))
       .doesNotExist('chart is hidden because feature is not activated');
 
-    assert.dom(SELECTORS.usageStats).exists();
     assert.dom('[data-test-stat-text="secret-syncs"]').doesNotExist();
   });
 });
@@ -332,7 +332,6 @@ module('Acceptance | clients | overview | sync not in license', function (hooks)
   test('it should hide secrets sync charts', async function (assert) {
     assert.dom(SELECTORS.charts.chart('Secrets sync usage')).doesNotExist();
 
-    assert.dom(SELECTORS.usageStats).exists();
     assert.dom('[data-test-stat-text="secret-syncs"]').doesNotExist();
   });
 });


### PR DESCRIPTION
Removes a test failure caused by an incorrect assertion.

@hellobontempo and I paired on this and we believe the error is occurring because client activity data is generated as the test suite runs other acceptance tests. This correctly caused the `<UsageStats />` component not to render (since there was activity data). 

Next up we should rewrite the test to stub the activity response to return 0 clients. That way we're ensuring that we can consistently predict the Vault cluster's client activity.