### PR TITLE
Audit: remove any race to read headers

### DIFF
--- a/vault/audit_broker_test.go
+++ b/vault/audit_broker_test.go
@@ -27,8 +27,8 @@ func testAuditBackend(t *testing.T, path string, config map[string]string) audit
 	t.Helper()
 
 	headersCfg := &AuditedHeadersConfig{
-		Headers: make(map[string]*auditedHeaderSettings),
-		view:    nil,
+		headerSettings: make(map[string]*auditedHeaderSettings),
+		view:           nil,
 	}
 
 	view := &logical.InmemStorage{}

--- a/vault/audited_headers.go
+++ b/vault/audited_headers.go
@@ -60,7 +60,8 @@ func NewAuditedHeadersConfig(view *BarrierView) (*AuditedHeadersConfig, error) {
 }
 
 // header attempts to retrieve a copy of the settings associated with the specified header.
-// The second return parameter indicates whether the header existed in configuration.
+// The second boolean return parameter indicates whether the header existed in configuration,
+// it should be checked as when 'false' the returned settings will have the default values.
 func (a *AuditedHeadersConfig) header(name string) (auditedHeaderSettings, bool) {
 	a.RLock()
 	defer a.RUnlock()

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -1139,8 +1139,7 @@ func (b *SystemBackend) handleAuditedHeaderUpdate(ctx context.Context, req *logi
 		return logical.ErrorResponse("missing header name"), nil
 	}
 
-	headerConfig := b.Core.AuditedHeadersConfig()
-	err := headerConfig.add(ctx, header, hmac)
+	err := b.Core.AuditedHeadersConfig().add(ctx, header, hmac)
 	if err != nil {
 		return nil, err
 	}
@@ -1155,8 +1154,7 @@ func (b *SystemBackend) handleAuditedHeaderDelete(ctx context.Context, req *logi
 		return logical.ErrorResponse("missing header name"), nil
 	}
 
-	headerConfig := b.Core.AuditedHeadersConfig()
-	err := headerConfig.remove(ctx, header)
+	err := b.Core.AuditedHeadersConfig().remove(ctx, header)
 	if err != nil {
 		return nil, err
 	}
@@ -1165,14 +1163,13 @@ func (b *SystemBackend) handleAuditedHeaderDelete(ctx context.Context, req *logi
 }
 
 // handleAuditedHeaderRead returns the header configuration for the given header name
-func (b *SystemBackend) handleAuditedHeaderRead(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+func (b *SystemBackend) handleAuditedHeaderRead(_ context.Context, _ *logical.Request, d *framework.FieldData) (*logical.Response, error) {
 	header := d.Get("header").(string)
 	if header == "" {
 		return logical.ErrorResponse("missing header name"), nil
 	}
 
-	headerConfig := b.Core.AuditedHeadersConfig()
-	settings, ok := headerConfig.Headers[strings.ToLower(header)]
+	settings, ok := b.Core.AuditedHeadersConfig().header(header)
 	if !ok {
 		return logical.ErrorResponse("Could not find header in config"), nil
 	}
@@ -1185,12 +1182,12 @@ func (b *SystemBackend) handleAuditedHeaderRead(ctx context.Context, req *logica
 }
 
 // handleAuditedHeadersRead returns the whole audited headers config
-func (b *SystemBackend) handleAuditedHeadersRead(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
-	headerConfig := b.Core.AuditedHeadersConfig()
+func (b *SystemBackend) handleAuditedHeadersRead(_ context.Context, _ *logical.Request, _ *framework.FieldData) (*logical.Response, error) {
+	headerSettings := b.Core.AuditedHeadersConfig().headers()
 
 	return &logical.Response{
 		Data: map[string]interface{}{
-			"headers": headerConfig.Headers,
+			"headers": headerSettings,
 		},
 	}, nil
 }


### PR DESCRIPTION
This PR adjusts the way in which audited header settings are accessed for read operations (single header, all headers), in order to prevent any data race when the underlying headers are invalidated and updated. 