### PR TITLE
add dev-ui to Windows make.bat

### DIFF
--- a/make.bat
+++ b/make.bat
@@ -6,7 +6,7 @@ set _EXITCODE=0
 REM If no target is provided, default to test.
 if [%1]==[] goto test
 
-set _TARGETS=bin,bootstrap,dev,generate,test,testacc,testrace,vet
+set _TARGETS=bin,bootstrap,dev,dev-ui,ember-dist,generate,install-ui-dependencies,testacc,testrace,vet
 set _EXTERNAL_TOOLS=github.com/kardianos/govendor
 
 REM Run target.
@@ -111,3 +111,21 @@ REM any common errors.
 	echo target defaults to test if none is provided.
 	exit /b 2
 	goto :eof
+
+:install-ui-dependencies
+       echo Installing JavaScript assets
+       cd ui\ & call yarn
+       goto :eof
+
+:ember-dist
+	cd ui\ & call npm rebuild node-sass
+	echo Building Ember application
+	call yarn run build_windows
+	goto :eof
+
+:dev-ui
+	call .\scripts\windows\assetcheck.bat
+	call :generate
+	call .\scripts\windows\build.bat "%CD%" VAULT_DEV VAULT_UI
+	goto :eof
+

--- a/scripts/windows/assetcheck.bat
+++ b/scripts/windows/assetcheck.bat
@@ -1,0 +1,6 @@
+if not exist http/web_ui/index.html (
+   echo "Compiled UI assets not found. They can be built with: '.\make.bat ember-dist'"
+   echo.
+   echo.
+   exit 1
+)

--- a/scripts/windows/build.bat
+++ b/scripts/windows/build.bat
@@ -3,9 +3,12 @@ setlocal
 
 set _EXITCODE=0
 set _DEV_BUILD=0
+set _BUILD_TAGS=""
+set _UI_TAG="ui"
 
 if not exist %1 exit /b 1
 if x%2 == xVAULT_DEV set _DEV_BUILD=1
+if x%3 == xVAULT_UI set _BUILD_TAGS=%_BUILD_TAGS% %_UI_TAG%
 
 cd %1
 md bin 2>nul
@@ -65,6 +68,7 @@ echo ==^> Building...
 go build^
  -ldflags "-X github.com/hashicorp/vault/version.GitCommit=%_GIT_COMMIT%%_GIT_DIRTY% -X github.com/hashicorp/vault/version.BuildDate=%_BUILD_DATE%"^
  -o "bin/vault.exe"^
+ -tags "%_BUILD_TAGS%"^
  .
 
 if %ERRORLEVEL% equ 1 set %_EXITCODE%=1


### PR DESCRIPTION
The Windows `make.bat` script does not currently support UI development. This PR introduces the ability to build Vault with a UI on Windows.

Fixes https://github.com/hashicorp/vault/issues/12979