### PR TITLE
Transit: Add cmac creation and verification APIs

### DIFF
--- a/builtin/logical/transit/backend.go
+++ b/builtin/logical/transit/backend.go
@@ -75,6 +75,7 @@ func Backend(ctx context.Context, conf *logical.BackendConfig) (*backend, error)
 			b.pathConfigKeys(),
 			b.pathCreateCsr(),
 			b.pathImportCertChain(),
+			b.pathCMAC(),
 		},
 
 		Secrets:      []*framework.Secret{},

--- a/builtin/logical/transit/key_utils.go
+++ b/builtin/logical/transit/key_utils.go
@@ -1,0 +1,61 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package transit
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/hashicorp/vault/sdk/helper/keysutil"
+	"github.com/hashicorp/vault/sdk/logical"
+)
+
+func (b *backend) getReadLockedPolicy(ctx context.Context, s logical.Storage, name string) (*keysutil.Policy, error) {
+	p, _, err := b.GetPolicy(ctx, keysutil.PolicyRequest{
+		Storage: s,
+		Name:    name,
+	}, b.GetRandomReader())
+	if err != nil {
+		return nil, err
+	}
+	if p == nil {
+		return nil, fmt.Errorf("%w: key %s not found", logical.ErrInvalidRequest, name)
+	}
+	if !b.System().CachingDisabled() {
+		p.Lock(false)
+	}
+	return p, nil
+}
+
+// runWithReadLockedPolicy hide away the details of running
+func (b *backend) runWithReadLockedPolicy(ctx context.Context, s logical.Storage, keyName string, f func(p *keysutil.Policy) (*logical.Response, error)) (*logical.Response, error) {
+	p, err := b.getReadLockedPolicy(ctx, s, keyName)
+	if err != nil {
+		if errors.Is(err, logical.ErrInvalidRequest) {
+			return logical.ErrorResponse(err.Error()), logical.ErrInvalidRequest
+		}
+		return nil, err
+	}
+	defer p.Unlock()
+	return f(p)
+}
+
+// validateKeyVersion verifies that the passed in key version is valid for our
+// current key policy, returning correct version to use within the policy.
+func validateKeyVersion(p *keysutil.Policy, ver int) (int, error) {
+	switch {
+	case ver < 0:
+		return 0, fmt.Errorf("cannot use negative key version %d", ver)
+	case ver == 0:
+		// Allowed, will use latest; set explicitly here to ensure the string
+		// is generated properly
+		ver = p.LatestVersion
+	case ver == p.LatestVersion:
+		// Allowed
+	case p.MinEncryptionVersion > 0 && ver < p.MinEncryptionVersion:
+		return 0, fmt.Errorf("cannot use key version %d: version is too old (disallowed by policy) for key %s", ver, p.Name)
+	}
+	return ver, nil
+}

--- a/builtin/logical/transit/path_cmac.go
+++ b/builtin/logical/transit/path_cmac.go
@@ -1,0 +1,498 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package transit
+
+import (
+	"context"
+	"crypto/aes"
+	"crypto/subtle"
+	"encoding/base64"
+	"fmt"
+	"hash"
+	"strings"
+
+	aesCmac "github.com/aead/cmac/aes"
+	"github.com/hashicorp/go-secure-stdlib/parseutil"
+	"github.com/hashicorp/vault/sdk/framework"
+	"github.com/hashicorp/vault/sdk/helper/keysutil"
+	"github.com/hashicorp/vault/sdk/logical"
+	"github.com/mitchellh/mapstructure"
+)
+
+// cmacWriteInput captures all the arguments for a cmac write api call
+type cmacWriteInput struct {
+	IsBatch    bool
+	KeyName    string
+	KeyVersion int
+	Items      []cmacWriteItem
+}
+
+// cmacWriteItem represents a single request item to CMAC
+type cmacWriteItem struct {
+	Input     string `json:"input,omitempty" mapstructure:"input"`
+	MacLength int    `json:"mac_length" mapstructure:"mac_length"`
+	Reference string `json:"reference,omitempty" mapstructure:"reference,omitempty"`
+}
+
+// cmacWriteResponseItem represents an associated response to a request item
+type cmacWriteResponseItem struct {
+	// Reference is an arbitrary caller supplied string value that will be placed on the
+	// batch response to ease correlation between inputs and outputs
+	Reference string `json:"reference" mapstructure:"reference"`
+
+	// CMAC for the input present in the corresponding batch request item
+	CMAC string `json:"cmac,omitempty" mapstructure:"cmac"`
+
+	// Error, if set represents a failure encountered while encrypting a
+	// corresponding batch request item
+	Error string `json:"error,omitempty" mapstructure:"error"`
+}
+
+// cmacVerifyInput captures all arguments related to a CMAC verify API call
+type cmacVerifyInput struct {
+	IsBatch bool
+	KeyName string
+	Items   []cmacVerifyItem
+}
+
+// cmacVerifyItem captures inputs related to a single work item
+type cmacVerifyItem struct {
+	Input     string `json:"input,omitempty" mapstructure:"input"`
+	Cmac      string `json:"cmac,omitempty" mapstructure:"cmac,omitempty"`
+	MacLength int    `json:"mac_length" mapstructure:"mac_length"`
+	Reference string `json:"reference,omitempty" mapstructure:"reference,omitempty"`
+}
+
+// cmacVerifyResponseItem represents an associated response to a request item
+type cmacVerifyResponseItem struct {
+	// Valid indicates whether signature matches the signature derived from the input string
+	Valid bool `json:"valid,omitempty" mapstructure:"valid"`
+
+	// Error, if set represents a failure encountered while encrypting a
+	// corresponding batch request item
+	Error string `json:"error,omitempty" mapstructure:"error"`
+
+	// Reference is an arbitrary caller supplied string value that will be placed on the
+	// batch response to ease correlation between inputs and outputs
+	Reference string `json:"reference" mapstructure:"reference"`
+}
+
+func (b *backend) pathCMAC() *framework.Path {
+	return &framework.Path{
+		Pattern: "cmac/" + framework.GenericNameRegex("name") + framework.OptionalParamRegex("url_mac_length"),
+
+		DisplayAttrs: &framework.DisplayAttributes{
+			OperationPrefix: operationPrefixTransit,
+			OperationVerb:   "generate",
+			OperationSuffix: "cmac|cmac-with-mac-length",
+		},
+
+		Fields: map[string]*framework.FieldSchema{
+			"name": {
+				Type:        framework.TypeString,
+				Description: "The key to use for the CMAC function",
+			},
+
+			"input": {
+				Type:        framework.TypeString,
+				Description: "The base64-encoded input data",
+			},
+
+			"mac_length": {
+				Type:        framework.TypeInt,
+				Description: `MAC length to use (POST body parameter). Valid values are:`,
+			},
+
+			"url_mac_length": {
+				Type:        framework.TypeString,
+				Description: `MAC length to use (POST URL parameter), overrides mac_length`,
+			},
+
+			"key_version": {
+				Type: framework.TypeInt,
+				Description: `The version of the key to use for generating the CMAC.
+Must be 0 (for latest) or a value greater than or equal
+to the min_encryption_version configured on the key.`,
+			},
+
+			"batch_input": {
+				Type: framework.TypeSlice,
+				Description: `
+Specifies a list of items to be processed in a single batch. When this parameter
+is set, if the parameter 'input' is also set, it will be ignored.
+Any batch output will preserve the order of the batch input.`,
+			},
+		},
+
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.UpdateOperation: &framework.PathOperation{
+				Callback: b.pathCMACWrite,
+			},
+		},
+
+		HelpSynopsis:    pathCMACHelpSyn,
+		HelpDescription: pathCMACHelpDesc,
+	}
+}
+
+func (b *backend) pathCMACWrite(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	input, warnings, err := parseCmacWriteInput(d)
+	if err != nil {
+		return logical.ErrorResponse(err.Error()), logical.ErrInvalidRequest
+	}
+
+	return b.runWithReadLockedPolicy(ctx, req.Storage, input.KeyName, func(p *keysutil.Policy) (*logical.Response, error) {
+		if p.Type == keysutil.KeyType_MANAGED_KEY {
+			return logical.ErrorResponse("CMAC creation is not supported with managed keys"), logical.ErrInvalidRequest
+		}
+
+		if !p.Type.CMACSupported() {
+			return logical.ErrorResponse("key %s is not a supported CMAC key type: %s", p.Name, p.Type), logical.ErrInvalidRequest
+		}
+
+		input.KeyVersion, err = validateKeyVersion(p, input.KeyVersion)
+		if err != nil {
+			return logical.ErrorResponse(err.Error()), logical.ErrInvalidRequest
+		}
+		cmacKey, err := p.CMACKey(input.KeyVersion)
+		if err != nil {
+			return logical.ErrorResponse("failed fetching CMAC key for %s with version %d: %s", input.KeyName, input.KeyVersion, err.Error()), logical.ErrInvalidRequest
+		}
+
+		cmacResponseItems := make([]cmacWriteResponseItem, len(input.Items))
+		for i, item := range input.Items {
+			itemRes := cmacWriteResponseItem{
+				Reference: item.Reference,
+			}
+
+			cmacResp, err := performCmac(cmacKey, item.MacLength, item.Input)
+			if err != nil {
+				errMsg := fmt.Sprintf("failed processing item %d: %s", i, err.Error())
+				itemRes.Error = errMsg
+			} else {
+				itemRes.CMAC = encodeTransitSignature(cmacResp, input.KeyVersion)
+			}
+
+			cmacResponseItems[i] = itemRes
+		}
+
+		dataResponse, err := buildCmacWriteResponse(input.IsBatch, cmacResponseItems)
+		if err != nil {
+			return nil, err
+		}
+
+		resp := &logical.Response{
+			Data:     dataResponse,
+			Warnings: warnings,
+		}
+
+		return resp, nil
+	})
+}
+
+func parseCmacWriteInput(d *framework.FieldData) (cmacWriteInput, []string, error) {
+	keyName := d.Get("name").(string)
+	keyVersion := d.Get("key_version").(int)
+
+	if strings.TrimSpace(keyName) == "" {
+		return cmacWriteInput{}, nil, fmt.Errorf("name parameter must be provided")
+	}
+
+	urlMacLengthRaw := d.Get("url_mac_length").(string)
+	overrideMacLength := false
+	urlMacLength := 0
+	if strings.TrimSpace(urlMacLengthRaw) != "" {
+		var err error
+		overrideMacLength = true
+		urlMacLength, err = parseutil.SafeParseInt(urlMacLengthRaw)
+		if err != nil {
+			return cmacWriteInput{}, nil, fmt.Errorf("the url mac-length parameter failed parsing: %w", err)
+		}
+		err = validateMacLength(urlMacLength)
+		if err != nil {
+			return cmacWriteInput{}, nil, fmt.Errorf("the url mac-length parameter is invalid: %w", err)
+		}
+	}
+
+	batchInputRaw, isBatchInput := d.GetOk("batch_input")
+	var batchInputItems []cmacWriteItem
+	if isBatchInput {
+		err := mapstructure.Decode(batchInputRaw, &batchInputItems)
+		if err != nil {
+			return cmacWriteInput{}, nil, fmt.Errorf("failed to parse batch input: %w", err)
+		}
+	} else {
+		inputB64 := d.Get("input").(string)
+		macLength := d.Get("mac_length").(int)
+
+		batchInputItems = make([]cmacWriteItem, 1)
+		batchInputItems[0] = cmacWriteItem{
+			Input:     inputB64,
+			MacLength: macLength,
+		}
+	}
+
+	if len(batchInputItems) == 0 {
+		return cmacWriteInput{}, nil, fmt.Errorf("no inputs to process")
+	}
+
+	var warnings []string
+	for i := range batchInputItems {
+		if strings.TrimSpace(batchInputItems[i].Input) == "" {
+			return cmacWriteInput{}, nil, fmt.Errorf("input item %d was blank", i)
+		}
+
+		if overrideMacLength {
+			if batchInputItems[i].MacLength != 0 {
+				msg := fmt.Sprintf("input item %d mac_length of %d overridden by url_mac_length %d", i, batchInputItems[i].MacLength, urlMacLength)
+				warnings = append(warnings, msg)
+			}
+			batchInputItems[i].MacLength = urlMacLength
+		}
+	}
+
+	input := cmacWriteInput{
+		IsBatch:    isBatchInput,
+		KeyName:    keyName,
+		KeyVersion: keyVersion,
+		Items:      batchInputItems,
+	}
+
+	return input, warnings, nil
+}
+
+func performCmac(cmacKey []byte, tagSize int, base64Input string) ([]byte, error) {
+	rawInput, err := base64.StdEncoding.DecodeString(base64Input)
+	if err != nil {
+		return nil, fmt.Errorf("failed base 64 decoding: %w", err)
+	}
+
+	var hf hash.Hash
+	switch tagSize {
+	case 0:
+		hf, err = aesCmac.New(cmacKey)
+	default:
+		hf, err = aesCmac.NewWithTagSize(cmacKey, tagSize)
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("failed generating cmac hash function: %w", err)
+	}
+
+	return hf.Sum(rawInput), nil
+}
+
+func buildCmacWriteResponse(wasBatch bool, responses []cmacWriteResponseItem) (map[string]interface{}, error) {
+	numResponses := len(responses)
+	if numResponses < 1 {
+		return nil, fmt.Errorf("no CMAC responses were generated")
+	}
+
+	if wasBatch {
+		return map[string]interface{}{
+			"batch_results": responses,
+		}, nil
+	}
+
+	response := responses[0]
+	if response.Error != "" {
+		return nil, fmt.Errorf(response.Error)
+	}
+
+	return map[string]interface{}{
+		"cmac": response.CMAC,
+	}, nil
+}
+
+func (b *backend) pathCMACVerify(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	input, warnings, err := parseCmacVerifyInput(d)
+	if err != nil {
+		return logical.ErrorResponse(err.Error()), logical.ErrInvalidRequest
+	}
+
+	return b.runWithReadLockedPolicy(ctx, req.Storage, input.KeyName, func(p *keysutil.Policy) (*logical.Response, error) {
+		if p.Type == keysutil.KeyType_MANAGED_KEY {
+			return logical.ErrorResponse("CMAC verification is not supported with managed keys"), logical.ErrInvalidRequest
+		}
+
+		if !p.Type.CMACSupported() {
+			return logical.ErrorResponse("key %s is not a supported CMAC key type: %s", p.Name, p.Type), logical.ErrInvalidRequest
+		}
+
+		verifyCmacResponses := make([]cmacVerifyResponseItem, len(input.Items))
+		for i, item := range input.Items {
+			itemRes := cmacVerifyResponseItem{
+				Reference: item.Reference,
+			}
+
+			isValid, err := verifyCmacInput(p, item)
+			if err != nil {
+				itemRes.Error = err.Error()
+			} else {
+				itemRes.Valid = isValid
+			}
+
+			verifyCmacResponses[i] = itemRes
+		}
+
+		dataResponse, err := buildCmacVerifyResponse(input.IsBatch, verifyCmacResponses)
+		if err != nil {
+			return nil, err
+		}
+
+		resp := &logical.Response{
+			Data:     dataResponse,
+			Warnings: warnings,
+		}
+
+		return resp, nil
+	})
+}
+
+func parseCmacVerifyInput(d *framework.FieldData) (cmacVerifyInput, []string, error) {
+	keyName := d.Get("name").(string)
+
+	if strings.TrimSpace(keyName) == "" {
+		return cmacVerifyInput{}, nil, fmt.Errorf("name parameter must be provided")
+	}
+
+	urlAlgo := d.Get("urlalgorithm").(string) // Reuse the existing value for hmac in the url
+	urlMacLength := 0
+	overrideMacLength := false
+	if strings.TrimSpace(urlAlgo) != "" {
+		var err error
+		urlMacLength, err = parseutil.SafeParseInt(urlAlgo)
+		if err != nil {
+			return cmacVerifyInput{}, nil, fmt.Errorf("the url mac-length parameter failed parsing: %w", err)
+		}
+		overrideMacLength = true
+		err = validateMacLength(urlMacLength)
+		if err != nil {
+			return cmacVerifyInput{}, nil, fmt.Errorf("the url mac-length parameter is invalid: %w", err)
+		}
+	}
+
+	batchInputRaw, isBatchInput := d.GetOk("batch_input")
+	var batchInputItems []cmacVerifyItem
+	if isBatchInput {
+		err := mapstructure.Decode(batchInputRaw, &batchInputItems)
+		if err != nil {
+			return cmacVerifyInput{}, nil, fmt.Errorf("failed to parse batch input: %w", err)
+		}
+	} else {
+		inputB64 := d.Get("input").(string)
+		macLength := d.Get("mac_length").(int)
+		cmac := d.Get("cmac").(string)
+
+		batchInputItems = make([]cmacVerifyItem, 1)
+		batchInputItems[0] = cmacVerifyItem{
+			Input:     inputB64,
+			MacLength: macLength,
+			Cmac:      cmac,
+		}
+	}
+
+	if len(batchInputItems) == 0 {
+		return cmacVerifyInput{}, nil, fmt.Errorf("no inputs to process")
+	}
+
+	var warnings []string
+	for i := range batchInputItems {
+		if strings.TrimSpace(batchInputItems[i].Input) == "" {
+			return cmacVerifyInput{}, nil, fmt.Errorf("input field on item %d was blank", i)
+		}
+		if strings.TrimSpace(batchInputItems[i].Cmac) == "" {
+			return cmacVerifyInput{}, nil, fmt.Errorf("cmac field on item %d was blank", i)
+		}
+
+		if overrideMacLength {
+			if batchInputItems[i].MacLength != 0 {
+				msg := fmt.Sprintf("input item %d mac_length of %d overridden by url_mac_length %d", i, batchInputItems[i].MacLength, urlMacLength)
+				warnings = append(warnings, msg)
+			}
+			batchInputItems[i].MacLength = urlMacLength
+		} else {
+			err := validateMacLength(batchInputItems[i].MacLength)
+			if err != nil {
+				return cmacVerifyInput{}, nil, fmt.Errorf("mac_length field on item %d was not valid: %w", i, err)
+			}
+		}
+	}
+
+	input := cmacVerifyInput{
+		IsBatch: isBatchInput,
+		KeyName: keyName,
+		Items:   batchInputItems,
+	}
+
+	return input, warnings, nil
+}
+
+func validateMacLength(length int) error {
+	if length < 0 {
+		return fmt.Errorf("must not be less than 0")
+	}
+
+	if length > aes.BlockSize {
+		return fmt.Errorf("must not be greater than %d", aes.BlockSize)
+	}
+
+	return nil
+}
+
+func verifyCmacInput(p *keysutil.Policy, item cmacVerifyItem) (bool, error) {
+	origCmac, keyVersion, err := decodeTransitSignature(item.Cmac)
+	if err != nil {
+		return false, err
+	}
+
+	newKeyVersion, err := validateKeyVersion(p, keyVersion)
+	if err != nil {
+		return false, fmt.Errorf("invalid key version for key %s: %w", p.Name, err)
+	}
+
+	if newKeyVersion != keyVersion {
+		return false, fmt.Errorf("%s: %w", p.Name, err)
+	}
+
+	cmacKey, err := p.CMACKey(keyVersion)
+	if err != nil {
+		return false, fmt.Errorf("failed fetching CMAC key for %s with version %d: %w", p.Name, keyVersion, err)
+	}
+
+	cmac, err := performCmac(cmacKey, item.MacLength, item.Input)
+	if err != nil {
+		return false, err
+	}
+
+	return subtle.ConstantTimeCompare(origCmac, cmac) == 1, nil
+}
+
+func buildCmacVerifyResponse(isBatch bool, responses []cmacVerifyResponseItem) (map[string]interface{}, error) {
+	numResponses := len(responses)
+	if numResponses < 1 {
+		return nil, fmt.Errorf("no CMAC verification responses were generated")
+	}
+
+	if isBatch {
+		return map[string]interface{}{
+			"batch_results": responses,
+		}, nil
+	}
+
+	response := responses[0]
+	if response.Error != "" {
+		return nil, fmt.Errorf(response.Error)
+	}
+
+	return map[string]interface{}{
+		"valid": response.Valid,
+	}, nil
+}
+
+const pathCMACHelpSyn = `Generate a CMAC for input data using the named key`
+
+const pathCMACHelpDesc = `
+Generates a CMAC against the given input data and the named key.
+`

--- a/builtin/logical/transit/path_cmac_test.go
+++ b/builtin/logical/transit/path_cmac_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
 package transit
 
 import (

--- a/builtin/logical/transit/path_cmac_test.go
+++ b/builtin/logical/transit/path_cmac_test.go
@@ -1,0 +1,537 @@
+package transit
+
+import (
+	"context"
+	"crypto/aes"
+	"encoding/base64"
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/vault/sdk/logical"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCmacValidOptions validates various successful CMAC generation and verification options
+// work together using the normal non-batch input parameters
+func TestCmacValidOptions(t *testing.T) {
+	b, s, keyNames := createBackendWithCmacKeys(t)
+	ctx := context.Background()
+
+	tests := []struct {
+		name          string
+		keyVersion    int
+		macLength     int
+		urlMacLength  int
+		expectWarning bool
+	}{
+		{"defaults", -1, -1, -1, false},
+		{"force-key-version-0", 0, -1, -1, false},
+		{"force-key-version-1", 1, -1, -1, false},
+		{"force-key-version-2", 2, -1, -1, false},
+		{"with-mac-length", -1, 2, -1, false},
+		{"with-url-mac-length", -1, -1, 8, false},
+		{"with-override-url-mac-length", -1, 3, aes.BlockSize, true},
+	}
+	for _, keyName := range keyNames {
+		for _, tc := range tests {
+			testName := fmt.Sprintf("%s-%s", keyName, tc.name)
+			t.Run(testName, func(t *testing.T) {
+				input := "dGhlIHF1aWNrIGJyb3duIGZveA==" // "the quick brown fox"
+				cmacPath := fmt.Sprintf("cmac/%s", keyName)
+				if tc.urlMacLength != -1 {
+					cmacPath = fmt.Sprintf("cmac/%s/%d", keyName, tc.urlMacLength)
+				}
+				cmacReq := &logical.Request{
+					Path:      cmacPath,
+					Operation: logical.UpdateOperation,
+					Storage:   s,
+					Data: map[string]interface{}{
+						"input": input,
+					},
+				}
+
+				if tc.keyVersion != -1 {
+					cmacReq.Data["key_version"] = tc.keyVersion
+				}
+
+				if tc.macLength != -1 {
+					cmacReq.Data["mac_length"] = tc.macLength
+				}
+
+				resp, err := b.HandleRequest(ctx, cmacReq)
+				if err != nil || (resp != nil && resp.IsError()) {
+					t.Fatalf("bad: err: %v\nresp: %#v", err, resp)
+				}
+
+				cmac := resp.Data["cmac"].(string)
+				assert.Equal(t, tc.expectWarning, len(resp.Warnings) > 0, "expect warnings was %v got %v", tc.expectWarning, resp.Warnings)
+
+				_, myKeyVersion, err := decodeTransitSignature(cmac)
+				require.NoError(t, err, "failed decoding cmac signature")
+
+				if tc.keyVersion == -1 || tc.keyVersion == 0 {
+					// If we didn't specify the key version or specified v0, we should have the
+					// latest key version within our signature output prefix
+					require.Equal(t, 2, myKeyVersion)
+				} else {
+					require.Equal(t, tc.keyVersion, myKeyVersion)
+				}
+
+				verifyPath := fmt.Sprintf("verify/%s", keyName)
+				if tc.urlMacLength != -1 {
+					verifyPath = fmt.Sprintf("verify/%s/%d", keyName, tc.urlMacLength)
+				}
+				cmacVerifyReq := &logical.Request{
+					Path:      verifyPath,
+					Operation: logical.UpdateOperation,
+					Storage:   s,
+					Data: map[string]interface{}{
+						"input": input,
+						"cmac":  cmac,
+					},
+				}
+				if tc.macLength != -1 {
+					cmacVerifyReq.Data["mac_length"] = tc.macLength
+				}
+
+				resp, err = b.HandleRequest(ctx, cmacVerifyReq)
+				if err != nil || (resp != nil && resp.IsError()) {
+					t.Fatalf("bad: err: %v\nresp: %#v", err, resp)
+				}
+
+				require.True(t, resp.Data["valid"].(bool), "verification of cmac failed")
+				assert.Equal(t, tc.expectWarning, len(resp.Warnings) > 0, "expect warnings was %v got %v", tc.expectWarning, resp.Warnings)
+			})
+		}
+	}
+}
+
+// TestCmacValidBatchInput validates various successful CMAC generation and verification options
+// work together using the batch input parameter
+func TestCmacValidBatchInput(t *testing.T) {
+	b, s, keyNames := createBackendWithCmacKeys(t)
+	ctx := context.Background()
+
+	tests := []struct {
+		name          string
+		keyVersion    int
+		urlMacLength  int
+		expectWarning bool
+	}{
+		{"defaults", -1, -1, false},
+		{"force-key-version-0", 0, -1, false},
+		{"force-key-version-1", 1, -1, false},
+		{"force-key-version-2", 2, -1, false},
+		{"with-override-url-mac-length", -1, aes.BlockSize, true},
+	}
+	for _, keyName := range keyNames {
+		for _, tc := range tests {
+			testName := fmt.Sprintf("%s-%s", keyName, tc.name)
+			t.Run(testName, func(t *testing.T) {
+				batchInput := make([]map[string]interface{}, 0, 10)
+				for i := range []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10} {
+					index := strconv.Itoa(i)
+					item := map[string]interface{}{
+						"input":      base64.StdEncoding.EncodeToString([]byte("the quick brown fox " + index)),
+						"reference":  index,
+						"mac_length": i,
+					}
+
+					batchInput = append(batchInput, item)
+				}
+				cmacPath := fmt.Sprintf("cmac/%s", keyName)
+				if tc.urlMacLength != -1 {
+					cmacPath = fmt.Sprintf("cmac/%s/%d", keyName, tc.urlMacLength)
+				}
+				cmacReq := &logical.Request{
+					Path:      cmacPath,
+					Operation: logical.UpdateOperation,
+					Storage:   s,
+					Data: map[string]interface{}{
+						"batch_input": batchInput,
+					},
+				}
+
+				if tc.keyVersion != -1 {
+					cmacReq.Data["key_version"] = tc.keyVersion
+				}
+
+				resp, err := b.HandleRequest(ctx, cmacReq)
+				if err != nil || (resp != nil && resp.IsError()) {
+					t.Fatalf("bad: err: %v\nresp: %#v", err, resp)
+				}
+				assert.Equal(t, tc.expectWarning, len(resp.Warnings) > 0, "expect warnings was %v got %v", tc.expectWarning, resp.Warnings)
+
+				verifyPath := fmt.Sprintf("verify/%s", keyName)
+				if tc.urlMacLength != -1 {
+					verifyPath = fmt.Sprintf("verify/%s/%d", keyName, tc.urlMacLength)
+				}
+
+				batchResp := resp.Data["batch_results"].([]cmacWriteResponseItem)
+				cmacByRef := make(map[string]string)
+				for _, result := range batchResp {
+					ref := result.Reference
+					cmac := result.CMAC
+
+					require.NotContains(t, cmacByRef, ref, "duplicated reference value %v in batch: %v", ref, batchResp)
+					cmacByRef[ref] = cmac
+				}
+
+				batchVerifyInput := make([]map[string]interface{}, 0, 10)
+				for i := range []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10} {
+					index := strconv.Itoa(i)
+					item := map[string]interface{}{
+						"input":      base64.StdEncoding.EncodeToString([]byte("the quick brown fox " + index)),
+						"cmac":       cmacByRef[index],
+						"reference":  index,
+						"mac_length": i,
+					}
+
+					batchVerifyInput = append(batchVerifyInput, item)
+				}
+
+				cmacVerifyReq := &logical.Request{
+					Path:      verifyPath,
+					Operation: logical.UpdateOperation,
+					Storage:   s,
+					Data: map[string]interface{}{
+						"batch_input": batchVerifyInput,
+					},
+				}
+
+				resp, err = b.HandleRequest(ctx, cmacVerifyReq)
+				if err != nil || (resp != nil && resp.IsError()) {
+					t.Fatalf("bad: err: %v\nresp: %#v", err, resp)
+				}
+
+				require.Contains(t, resp.Data, "batch_results", "verify response is missing batch_results: %v", resp.Data)
+				verifyRes := resp.Data["batch_results"].([]cmacVerifyResponseItem)
+				for i, res := range verifyRes {
+					require.True(t, res.Valid, "value was not considered valid: %v: %v", res, resp.Data)
+					require.Equal(t, strconv.Itoa(i), res.Reference, "reference values did not match")
+				}
+				assert.Equal(t, tc.expectWarning, len(resp.Warnings) > 0, "expect warnings was %v got %v", tc.expectWarning, resp.Warnings)
+			})
+		}
+	}
+}
+
+// TestCmacVerifyInvalidCmacEntries verifies that we return an output of not valid for different
+// scenarios that CMAC validation should fail, but not due to invalid input parameters.
+func TestCmacVerifyInvalidCmacEntries(t *testing.T) {
+	b, s, keyNames := createBackendWithCmacKeys(t)
+	ctx := context.Background()
+
+	// Get a valid CMAC first
+	keyName := keyNames[0]
+	input := "dGhlIHF1aWNrIGJyb3duIGZveA==" // "the quick brown fox"
+	cmacReq := &logical.Request{
+		Path:      fmt.Sprintf("cmac/%s", keyName),
+		Operation: logical.UpdateOperation,
+		Storage:   s,
+		Data: map[string]interface{}{
+			"input": input,
+		},
+	}
+	resp, err := b.HandleRequest(ctx, cmacReq)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("bad: err: %v\nresp: %#v", err, resp)
+	}
+	cmac := resp.Data["cmac"].(string)
+
+	garbageCmac := base64.StdEncoding.EncodeToString([]byte("garbage-cmac"))
+
+	tests := []struct {
+		name      string
+		keyName   string
+		macLength int
+		cmac      string
+	}{
+		{"different-key-version", keyName, -1, strings.ReplaceAll(cmac, ":v2:", ":v1:")},
+		{"different-key", keyNames[1], -1, cmac},
+		{"bad-base64-cmac", keyName, -1, "vault:v2:" + garbageCmac},
+		{"bad-mac-length", keyName, 8, cmac},
+	}
+	for _, tc := range tests {
+		testName := fmt.Sprintf("%s-%s", tc.keyName, tc.name)
+		t.Run(testName, func(t *testing.T) {
+			cmacVerifyReq := &logical.Request{
+				Path:      fmt.Sprintf("verify/%s", tc.keyName),
+				Operation: logical.UpdateOperation,
+				Storage:   s,
+				Data: map[string]interface{}{
+					"input": input,
+					"cmac":  tc.cmac,
+				},
+			}
+			if tc.macLength != -1 {
+				cmacVerifyReq.Data["mac_length"] = tc.macLength
+			}
+
+			resp, err = b.HandleRequest(ctx, cmacVerifyReq)
+			if err != nil || (resp != nil && resp.IsError()) {
+				t.Fatalf("bad: err: %v\nresp: %#v", err, resp)
+			}
+
+			require.False(t, resp.Data["valid"].(bool), "verification of cmac passed, should have failed")
+		})
+	}
+}
+
+// TestCmacWriteInvalidOptions verifies we properly error out when invalid inputs are provided to
+// the CMAC Write API call
+func TestCmacWriteInvalidOptions(t *testing.T) {
+	b, s, keyNames := createBackendWithCmacKeys(t)
+	ctx := context.Background()
+
+	// Create a non-cmac key
+	keyReq := &logical.Request{
+		Path:      "keys/encrypt-key",
+		Operation: logical.UpdateOperation,
+		Data:      map[string]interface{}{},
+		Storage:   s,
+	}
+
+	resp, err := b.HandleRequest(ctx, keyReq)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("failed to create encrypt-key: err: %v\nresp: %#v", err, resp)
+	}
+
+	keyName := keyNames[0]
+	input := "dGhlIHF1aWNrIGJyb3duIGZveA==" // "the quick brown fox"
+
+	tests := []struct {
+		name         string
+		keyName      string
+		input        string
+		keyVersion   int
+		macLength    int
+		urlMacLength int
+	}{
+		{"bad-keyname", "a-bad-key", input, -1, -1, -1},
+		{"non-cmac-key", "encrypt-key", input, -1, -1, -1},
+		{"missing-input", keyName, "", -1, -1, -1},
+		{"non-base64-input", keyName, "garbage-input", -1, -1, -1},
+		{"bad-neg-keyversion", keyName, input, -10, -1, -1},
+		{"bad-keyversion", keyName, input, 100, -1, -1},
+		{"bad-mac-length", keyName, input, -1, 100, -1},
+		{"bad-url-mac-length", keyName, input, -1, -1, 100},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cmacPath := fmt.Sprintf("cmac/%s", tc.keyName)
+			if tc.urlMacLength != -1 {
+				cmacPath = fmt.Sprintf("cmac/%s/%d", tc.keyName, tc.urlMacLength)
+			}
+			data := map[string]interface{}{}
+			if tc.input != "" {
+				data["input"] = tc.input
+			}
+			if tc.keyVersion != -1 {
+				data["key_version"] = tc.keyVersion
+			}
+			if tc.macLength != -1 {
+				data["mac_length"] = tc.macLength
+			}
+
+			cmacReq := &logical.Request{
+				Path:      cmacPath,
+				Operation: logical.UpdateOperation,
+				Storage:   s,
+				Data:      data,
+			}
+
+			resp, err := b.HandleRequest(ctx, cmacReq)
+			if err == nil && (resp != nil && !resp.IsError()) {
+				t.Fatalf("expected an error got none: resp: %v", resp)
+			}
+		})
+	}
+
+	batchTests := []struct {
+		name string
+		data interface{}
+	}{
+		{name: "empty-input-batch", data: []map[string]interface{}{}},
+		{name: "nil-input-batch", data: nil},
+	}
+	for _, tc := range batchTests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Test empty batch_input
+			cmacReq := &logical.Request{
+				Path:      fmt.Sprintf("cmac/%s", keyName),
+				Operation: logical.UpdateOperation,
+				Storage:   s,
+				Data: map[string]interface{}{
+					"batch_input": tc.data,
+				},
+			}
+
+			resp, err := b.HandleRequest(ctx, cmacReq)
+			if err == nil && (resp != nil && !resp.IsError()) {
+				t.Fatalf("expected an error got none: resp: %v", resp)
+			}
+		})
+	}
+}
+
+// TestCmacVerifyInvalidOptions verifies we properly error out when invalid inputs are provided to
+// the verify API in a cmac mode.
+func TestCmacVerifyInvalidOptions(t *testing.T) {
+	b, s, keyNames := createBackendWithCmacKeys(t)
+	ctx := context.Background()
+
+	// Create a non-cmac key
+	keyReq := &logical.Request{
+		Path:      "keys/encrypt-key",
+		Operation: logical.UpdateOperation,
+		Data:      map[string]interface{}{},
+		Storage:   s,
+	}
+
+	resp, err := b.HandleRequest(ctx, keyReq)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("failed to create encrypt-key: err: %v\nresp: %#v", err, resp)
+	}
+
+	// Get a valid CMAC first
+	keyName := keyNames[0]
+	input := "dGhlIHF1aWNrIGJyb3duIGZveA==" // "the quick brown fox"
+	cmacReq := &logical.Request{
+		Path:      fmt.Sprintf("cmac/%s", keyName),
+		Operation: logical.UpdateOperation,
+		Storage:   s,
+		Data: map[string]interface{}{
+			"input": input,
+		},
+	}
+	resp, err = b.HandleRequest(ctx, cmacReq)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("bad: err: %v\nresp: %#v", err, resp)
+	}
+	cmac := resp.Data["cmac"].(string)
+
+	tests := []struct {
+		name         string
+		keyName      string
+		input        string
+		cmac         string
+		macLength    int
+		urlMacLength int
+	}{
+		{"bad-keyname", "a-bad-key", input, cmac, -1, -1},
+		{"non-cmac-key", "encrypt-key", input, cmac, -1, -1},
+		{"missing-input", keyName, "", cmac, -1, -1},
+		{"non-base64-input", keyName, "garbage-input", cmac, -1, -1},
+		{"non-base64-cmac", keyName, input, "vault:v2:garbage-input", -1, -1},
+		{"no-base64-cmac", keyName, input, "vault:v2:", -1, -1},
+		{"non-digit-keyversion", keyName, input, strings.ReplaceAll(cmac, ":v2:", ":vblah:"), -1, -1},
+		{"bad-neg-keyversion", keyName, input, strings.ReplaceAll(cmac, ":v2:", ":v-10:"), -1, -1},
+		{"bad-keyversion", keyName, input, strings.ReplaceAll(cmac, ":v2:", ":v10:"), -1, -1},
+		{"bad-mac-length", keyName, input, cmac, 100, -1},
+		{"bad-url-mac-length", keyName, input, cmac, -1, 100},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cmacPath := fmt.Sprintf("verify/%s", tc.keyName)
+			if tc.urlMacLength != -1 {
+				cmacPath = fmt.Sprintf("verify/%s/%d", tc.keyName, tc.urlMacLength)
+			}
+			data := map[string]interface{}{}
+			if tc.input != "" {
+				data["input"] = tc.input
+			}
+			if tc.macLength != -1 {
+				data["mac_length"] = tc.macLength
+			}
+			if tc.cmac != "" {
+				data["cmac"] = tc.cmac
+			}
+
+			cmacReq := &logical.Request{
+				Path:      cmacPath,
+				Operation: logical.UpdateOperation,
+				Storage:   s,
+				Data:      data,
+			}
+
+			resp, err := b.HandleRequest(ctx, cmacReq)
+			if err == nil && (resp != nil && !resp.IsError()) {
+				t.Fatalf("expected an error got none: resp: %v", resp)
+			}
+			t.Logf("ERR: %v", err)
+			if resp != nil {
+				t.Logf("Response Error: %v", resp.Error())
+			}
+		})
+	}
+
+	batchTests := []struct {
+		name string
+		data interface{}
+	}{
+		{name: "empty-input-batch", data: []map[string]interface{}{}},
+		{name: "nil-input-batch", data: nil},
+	}
+	for _, tc := range batchTests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Test empty batch_input
+			cmacReq := &logical.Request{
+				Path:      fmt.Sprintf("verify/%s", keyName),
+				Operation: logical.UpdateOperation,
+				Storage:   s,
+				Data: map[string]interface{}{
+					"batch_input": tc.data,
+				},
+			}
+
+			resp, err := b.HandleRequest(ctx, cmacReq)
+			if err == nil && (resp != nil && !resp.IsError()) {
+				t.Fatalf("expected an error got none: resp: %v", resp)
+			}
+			t.Logf("ERR: %v", err)
+			if resp != nil {
+				t.Logf("Response Error: %v", resp.Error())
+			}
+		})
+	}
+}
+
+func createBackendWithCmacKeys(t *testing.T) (*backend, logical.Storage, []string) {
+	b, s := createBackendWithStorage(t)
+	ctx := context.Background()
+
+	keyNames := []string{"aes128-cmac", "aes256-cmac"}
+	for _, name := range keyNames {
+		keyReq := &logical.Request{
+			Path:      "keys/" + name,
+			Operation: logical.UpdateOperation,
+			Data: map[string]interface{}{
+				"type": name,
+			},
+			Storage: s,
+		}
+
+		resp, err := b.HandleRequest(ctx, keyReq)
+		if err != nil || (resp != nil && resp.IsError()) {
+			t.Fatalf("bad: err: %v\nresp: %#v", err, resp)
+		}
+
+		// Add another key version
+		rotateReq := &logical.Request{
+			Path:      fmt.Sprintf("keys/%s/rotate", name),
+			Operation: logical.UpdateOperation,
+			Data:      map[string]interface{}{},
+			Storage:   s,
+		}
+
+		resp, err = b.HandleRequest(ctx, rotateReq)
+		if err != nil || (resp != nil && resp.IsError()) {
+			t.Fatalf("bad: err: %v\nresp: %#v", err, resp)
+		}
+	}
+	return b, s, keyNames
+}

--- a/go.mod
+++ b/go.mod
@@ -279,6 +279,7 @@ require (
 	github.com/Masterminds/sprig/v3 v3.2.3 // indirect
 	github.com/Microsoft/go-winio v0.6.1 // indirect
 	github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 // indirect
+	github.com/aead/cmac v0.0.0-20160719120800-7af84192f0b1 // indirect
 	github.com/agext/levenshtein v1.2.1 // indirect
 	github.com/andybalholm/brotli v1.0.5 // indirect
 	github.com/apache/arrow/go/v14 v14.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1341,6 +1341,8 @@ github.com/Sectorbob/mlab-ns2 v0.0.0-20171030222938-d3aa0c295a8a/go.mod h1:D73UA
 github.com/Shopify/logrus-bugsnag v0.0.0-20171204204709-577dee27f20d/go.mod h1:HI8ITrYtUY+O+ZhtlqUnD8+KwNPOyugEhfP9fdUIaEQ=
 github.com/abdullin/seq v0.0.0-20160510034733-d5467c17e7af h1:DBNMBMuMiWYu0b+8KMJuWmfCkcxl09JwdlqwDZZ6U14=
 github.com/abdullin/seq v0.0.0-20160510034733-d5467c17e7af/go.mod h1:5Jv4cbFiHJMsVxt52+i0Ha45fjshj6wxYr1r19tB9bw=
+github.com/aead/cmac v0.0.0-20160719120800-7af84192f0b1 h1:+JkXLHME8vLJafGhOH4aoV2Iu8bR55nU6iKMVfYVLjY=
+github.com/aead/cmac v0.0.0-20160719120800-7af84192f0b1/go.mod h1:nuudZmJhzWtx2212z+pkuy7B6nkBqa+xwNXZHL1j8cg=
 github.com/aerospike/aerospike-client-go/v5 v5.6.0 h1:tRxcUq0HY8fFPQEzF3EgrknF+w1xFO0YDfUb9Nm8yRI=
 github.com/aerospike/aerospike-client-go/v5 v5.6.0/go.mod h1:rJ/KpmClE7kiBPfvAPrGw9WuNOiz8v2uKbQaUyYPXtI=
 github.com/agext/levenshtein v1.2.1 h1:QmvMAjj2aEICytGiWzmxoE0x2KZvE0fvmqMOfy2tjT8=


### PR DESCRIPTION
This introduces a new API `/cmac/(mac-length)` within Transit to compute an AES based CMAC response based on the base64 passed input. It is similar in nature to the existing `/hmac` endpoint. Also this augments the existing `/verify` endpoint adding a new `cmac` argument to validate existing generated CMAC values.

A little refactoring to isolate away the key policy locking to hopefully make things a little clearer in the future, this refactoring has not been applied to the existing codebase before feedback on the idea is provided.