### PR TITLE
Plumbing to support mount table path registration

### DIFF
--- a/physical/raft/raft.go
+++ b/physical/raft/raft.go
@@ -601,6 +601,13 @@ func (b *RaftBackend) RegisterMountTablePath(path string) {
 	}
 }
 
+// GetSpecialPathLimits returns any paths registered with special entry size
+// limits. It's really only used to make integration testing of the plumbing for
+// these paths simpler.
+func (b *RaftBackend) GetSpecialPathLimits() map[string]uint64 {
+	return b.specialPathLimits
+}
+
 type snapshotStoreDelay struct {
 	logger  log.Logger
 	wrapped raft.SnapshotStore

--- a/vault/auth.go
+++ b/vault/auth.go
@@ -44,6 +44,11 @@ const (
 	credentialTableType = "auth"
 )
 
+func init() {
+	// Register the keys we use for auth "mount" tables
+	registerMountOrNamespaceTablePaths(coreAuthConfigPath, coreLocalAuthConfigPath)
+}
+
 var (
 	// errLoadAuthFailed if loadCredentials encounters an error
 	errLoadAuthFailed = errors.New("failed to setup auth table")

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -52,6 +52,11 @@ const (
 	mountTableType = "mounts"
 )
 
+func init() {
+	// Register the keys we use for mount tables
+	registerMountOrNamespaceTablePaths(coreMountConfigPath, coreLocalMountConfigPath)
+}
+
 // ListingVisibilityType represents the types for listing visibility
 type ListingVisibilityType string
 

--- a/vault/path_registry.go
+++ b/vault/path_registry.go
@@ -1,0 +1,34 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package vault
+
+import "github.com/hashicorp/vault/sdk/physical"
+
+// This is a separate file in vault package for now to keep it simple. In the
+// future if we choose to break up vault package such that namespaces or mount
+// table are moved, this could become a separate helper package but since it's
+// so trivial and not clear if it should be used for other types of paths it
+// seems like overkill to design a whole package API when we don't know the
+// future requirements yet.
+
+var registeredMountOrNamespaceTableKeys []string
+
+// registerMountOrNamespaceTablePaths is meant to be called in init() to allow
+// code within vault core to register "special" backend storage keys that
+// should be considered part of the mount table and/or namespace metadata in a
+// natural place alongside the rest of the code that matters for that subsystem.
+// We need to know them centrally within NewCore so that we can register them
+// with Backends that want to apply different limits to mount table entries and
+// namespace config.
+func registerMountOrNamespaceTablePaths(paths ...string) {
+	registeredMountOrNamespaceTableKeys = append(registeredMountOrNamespaceTableKeys, paths...)
+}
+
+func applyMountAndNamespaceTableKeys(b physical.Backend) {
+	if b, ok := b.(physical.MountTableLimitingBackend); ok {
+		for _, path := range registeredMountOrNamespaceTableKeys {
+			b.RegisterMountTablePath(path)
+		}
+	}
+}

--- a/vault/path_registry_test.go
+++ b/vault/path_registry_test.go
@@ -1,0 +1,43 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package vault
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/vault/sdk/physical/inmem"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMountTableAndNamespacePathRegistry tests that the mount and namespace
+// path registry works.
+func TestMountTableAndNamespacePathRegistry(t *testing.T) {
+	// Make a copy of the registered paths so we can cleanup later otherwise we
+	// leave the global state poluted in the process and may break other tests.
+	originalPaths := registeredMountOrNamespaceTableKeys
+	defer func() {
+		registeredMountOrNamespaceTableKeys = originalPaths
+	}()
+
+	// Register some dummy paths to test here
+	registerMountOrNamespaceTablePaths("mounty1", "mounty2")
+
+	backend, err := inmem.NewInmem(nil, hclog.NewNullLogger())
+	require.NoError(t, err)
+
+	imb := backend.(*inmem.InmemBackend)
+
+	applyMountAndNamespaceTableKeys(backend)
+
+	// I wanted to avoid hard coding the actual paths that are registered in init
+	// here in an assertion against all paths registered since the whole point of
+	// the registry is to avoid hard coding those elsewhere in code! So instead we
+	// test that our own dummy registrations exist and ignore anything else.
+
+	registeredPaths := imb.GetMountTablePaths()
+
+	require.Contains(t, registeredPaths, "mounty1")
+	require.Contains(t, registeredPaths, "mounty2")
+}


### PR DESCRIPTION
This is a no-op change in Community edition but supports a new Enterprise feature added in #25992. The changelog entry was already added in that PR too.