### PR TITLE
Remove undefineded class=action

### DIFF
--- a/ui/app/components/sidebar/user-menu.hbs
+++ b/ui/app/components/sidebar/user-menu.hbs
@@ -32,20 +32,20 @@
               </li>
             {{/if}}
             {{#if this.hasEntityId}}
-              <li class="action">
+              <li>
                 <LinkTo @route="vault.cluster.mfa-setup" data-test-user-menu-item="mfa">
                   Multi-factor authentication
                 </LinkTo>
               </li>
             {{/if}}
             {{#if this.isUserpass}}
-              <li class="action">
+              <li>
                 <LinkTo @route="vault.cluster.access.reset-password" data-test-user-menu-item="reset-password">
                   Reset password
                 </LinkTo>
               </li>
             {{/if}}
-            <li class="action" id="container">
+            <li id="container">
               {{! container is required in navbar collapsed state }}
               <Hds::Copy::Button
                 @text="Copy token"
@@ -64,7 +64,7 @@
             </li>
             {{#if (is-before (now interval=1000) this.auth.tokenExpirationDate)}}
               {{#if this.auth.authData.renewable}}
-                <li class="action">
+                <li>
                   {{! TODO Hds::Button replacement skipped in favor of updating it when there is a Hds::Dropdown swapout }}
                   <button
                     type="button"
@@ -85,7 +85,7 @@
                 data-test-user-menu-item="revoke token"
               />
             {{/if}}
-            <li class="action">
+            <li>
               <LinkTo @route="vault.cluster.logout" @model={{this.currentCluster.cluster.name}} id="logout">
                 Log out
               </LinkTo>

--- a/ui/app/templates/components/calendar-widget.hbs
+++ b/ui/app/templates/components/calendar-widget.hbs
@@ -15,7 +15,7 @@
       <Hds::Text::Body class="calendar-title" @color="faint">DATE OPTIONS</Hds::Text::Body>
       {{! TODO Hds::Dropdown swapout }}
       <ul class="menu-list">
-        <li class="action">
+        <li>
           <button
             data-test-current-month
             class="link is-no-underline has-text-weight-semibold is-ghost"
@@ -26,7 +26,7 @@
             Current month
           </button>
         </li>
-        <li class="action">
+        <li>
           <button
             data-test-current-billing-period
             class="link is-no-underline has-text-weight-semibold is-ghost"
@@ -37,7 +37,7 @@
             Current billing period
           </button>
         </li>
-        <li class="action">
+        <li>
           <button
             data-test-show-calendar
             class={{concat "link is-no-underline has-text-weight-semibold is-ghost" (if this.showCalendar " is-active")}}

--- a/ui/lib/core/addon/components/copy-secret-dropdown.hbs
+++ b/ui/lib/core/addon/components/copy-secret-dropdown.hbs
@@ -12,7 +12,7 @@
   <D.Content @defaultClass="popup-menu-content is-wide">
     <nav class="box menu">
       <ul class="menu-list">
-        <li class="action">
+        <li>
           <Hds::Copy::Button
             @text="Copy JSON"
             @textToCopy={{@clipboardText}}
@@ -25,7 +25,7 @@
             data-test-copy-button={{@clipboardText}}
           />
         </li>
-        <li class="action">
+        <li>
           {{#if @wrappedData}}
             <MaskedInput @class="has-padding" @displayOnly={{true}} @allowCopy={{true}} @value={{@wrappedData}} />
           {{else}}

--- a/ui/lib/kv/addon/components/kv-version-dropdown.hbs
+++ b/ui/lib/kv/addon/components/kv-version-dropdown.hbs
@@ -13,7 +13,7 @@
     <nav class="box menu">
       <ul class="menu-list">
         {{#each @metadata.sortedVersions as |versionData|}}
-          <li data-test-version={{versionData.version}} class="action">
+          <li data-test-version={{versionData.version}}>
             {{#if @onSelect}}
               {{! TODO use Hds::Dropdown instead https://helios.hashicorp.design/components/dropdown }}
               <button

--- a/ui/lib/pki/addon/components/page/pki-issuer-details.hbs
+++ b/ui/lib/pki/addon/components/page/pki-issuer-details.hbs
@@ -40,7 +40,7 @@
           <ul class="menu-list">
             {{#if @pem}}
               {{! should never be null, but if it is we don't want to let users download an empty file }}
-              <li class="action">
+              <li>
                 <DownloadButton
                   class="link"
                   @filename={{@issuer.id}}
@@ -54,7 +54,7 @@
             {{/if}}
             {{#if @der}}
               {{! should never be null, but if it is we don't want to let users download an empty file }}
-              <li class="action">
+              <li>
                 <DownloadButton
                   class="link"
                   @filename={{@issuer.id}}

--- a/ui/lib/pki/addon/components/page/pki-issuer-list.hbs
+++ b/ui/lib/pki/addon/components/page/pki-issuer-list.hbs
@@ -20,12 +20,12 @@
       <D.Content @defaultClass="popup-menu-content">
         <nav class="box menu" aria-label="generate options">
           <ul class="menu-list">
-            <li class="action">
+            <li>
               <LinkTo @route="issuers.generate-root" {{on "click" (fn this.onLinkClick D)}} data-test-generate-issuer="root">
                 Root
               </LinkTo>
             </li>
-            <li class="action">
+            <li>
               <LinkTo
                 @route="issuers.generate-intermediate"
                 {{on "click" (fn this.onLinkClick D)}}

--- a/ui/lib/pki/addon/components/page/pki-issuer-rotate-root.hbs
+++ b/ui/lib/pki/addon/components/page/pki-issuer-rotate-root.hbs
@@ -46,7 +46,7 @@
         <D.Content @defaultClass="popup-menu-content">
           <nav class="box menu" aria-label="snapshots actions">
             <ul class="menu-list">
-              <li class="action">
+              <li>
                 <DownloadButton
                   class="link"
                   @filename={{@newRootModel.issuerId}}
@@ -57,7 +57,7 @@
                   @hideIcon={{true}}
                 />
               </li>
-              <li class="action">
+              <li>
                 <DownloadButton
                   class="link"
                   @filename={{@newRootModel.issuerId}}


### PR DESCRIPTION
Small clean up task to remove the use of the `class="action"`. This class was likely removed during a HDS component adoption. 

I checked these visually after removing the class and they functioned/appeared the same.

- [x] Enterprise test pass locally (pki changes so just double checking).