### PR TITLE
[secrets sync] add more thorough Secrets Sync landing page tests

### DIFF
--- a/ui/tests/acceptance/sync/secrets/overview-test.js
+++ b/ui/tests/acceptance/sync/secrets/overview-test.js
@@ -9,7 +9,7 @@ import { setupMirage } from 'ember-cli-mirage/test-support';
 import syncScenario from 'vault/mirage/scenarios/sync';
 import syncHandlers from 'vault/mirage/handlers/sync';
 import authPage from 'vault/tests/pages/auth';
-import { click, waitFor } from '@ember/test-helpers';
+import { click, waitFor, visit, currentURL } from '@ember/test-helpers';
 import { PAGE as ts } from 'vault/tests/helpers/sync/sync-selectors';
 import { runCmd } from 'vault/tests/helpers/commands';
 
@@ -19,50 +19,94 @@ module('Acceptance | sync | overview', function (hooks) {
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {
+    syncHandlers(this.server);
     this.version = this.owner.lookup('service:version');
     this.version.features = ['Secrets Sync'];
-    syncScenario(this.server);
-    syncHandlers(this.server);
-    return authPage.login();
+
+    await authPage.login();
   });
 
-  test('it should transition to correct routes when performing actions', async function (assert) {
-    await click(ts.navLink('Secrets Sync'));
-    await click(ts.destinations.list.create);
-    await click(ts.createCancel);
-    await click(ts.overviewCard.actionLink('Create new'));
-    await click(ts.createCancel);
-    await waitFor(ts.overview.table.actionToggle(0));
-    await click(ts.overview.table.actionToggle(0));
-    await click(ts.overview.table.action('sync'));
-    await click(ts.destinations.sync.cancel);
-    await click(ts.breadcrumbLink('Secrets Sync'));
-    await waitFor(ts.overview.table.actionToggle(0));
-    await click(ts.overview.table.actionToggle(0));
-    await click(ts.overview.table.action('details'));
-    assert.dom(ts.tab('Secrets')).hasClass('active', 'Navigates to secrets view for destination');
+  module('when feature is activated and has pre-existing destinations', function (hooks) {
+    hooks.beforeEach(async function () {
+      syncScenario(this.server);
+    });
+
+    test('it should transition to correct routes when performing actions', async function (assert) {
+      await click(ts.navLink('Secrets Sync'));
+      await click(ts.destinations.list.create);
+      await click(ts.createCancel);
+      await click(ts.overviewCard.actionLink('Create new'));
+      await click(ts.createCancel);
+      await waitFor(ts.overview.table.actionToggle(0));
+      await click(ts.overview.table.actionToggle(0));
+      await click(ts.overview.table.action('sync'));
+      await click(ts.destinations.sync.cancel);
+      await click(ts.breadcrumbLink('Secrets Sync'));
+      await waitFor(ts.overview.table.actionToggle(0));
+      await click(ts.overview.table.actionToggle(0));
+      await click(ts.overview.table.action('details'));
+      assert.dom(ts.tab('Secrets')).hasClass('active', 'Navigates to secrets view for destination');
+    });
   });
 
-  test('it should show opt-in banner and modal if secrets-sync is not activated', async function (assert) {
-    assert.expect(3);
-    this.server.get('/sys/activation-flags', () => {
-      return {
-        data: {
-          activated: [''],
-          unactivated: ['secrets-sync'],
-        },
-      };
+  module('when feature is not activated', function (hooks) {
+    hooks.beforeEach(async function () {
+      let wasActivatePOSTCalled = false;
+
+      // simulate the feature being activated once /secrets-sync/activate has been called
+      this.server.get('/sys/activation-flags', () => {
+        if (wasActivatePOSTCalled) {
+          return {
+            data: {
+              activated: ['secrets-sync'],
+              unactivated: [''],
+            },
+          };
+        } else {
+          return {
+            data: {
+              activated: [''],
+              unactivated: ['secrets-sync'],
+            },
+          };
+        }
+      });
+
+      this.server.post('/sys/activation-flags/secrets-sync/activate', () => {
+        wasActivatePOSTCalled = true;
+        return {};
+      });
+
+      // override mirage to simulate no pre-existing destinations
+      this.server.get('/sys/sync/destinations', () => {});
     });
-    this.server.post('/sys/activation-flags/secrets-sync/activate', () => {
-      return {};
+
+    test('the activation workflow works', async function (assert) {
+      await visit('/vault/sync/secrets/overview');
+
+      assert
+        .dom(ts.cta.button)
+        .doesNotExist('create first destination is not available until feature has been activated');
+
+      assert.dom(ts.overview.optInBanner).exists();
+      await click(ts.overview.optInBannerEnable);
+
+      assert.dom(ts.overview.optInModal).exists('modal to opt-in and activate feature is shown');
+      await click(ts.overview.optInCheck);
+      await click(ts.overview.optInConfirm);
+
+      assert.dom(ts.overview.optInModal).doesNotExist('modal is gone once activation has been submitted');
+      assert
+        .dom(ts.overview.optInBanner)
+        .doesNotExist('opt-in banner is gone once activation has been submitted');
+
+      await click(ts.cta.button);
+      assert.strictEqual(
+        currentURL(),
+        '/vault/sync/secrets/destinations/create',
+        'create new destination is available once feature is activated'
+      );
     });
-    await click(ts.navLink('Secrets Sync'));
-    assert.dom(ts.overview.optInBanner).exists('Opt-in banner is shown');
-    await click(ts.overview.optInBannerEnable);
-    assert.dom(ts.overview.optInModal).exists('Opt-in modal is shown');
-    assert.dom(ts.overview.optInConfirm).isDisabled('Confirm button is disabled when checkbox is unchecked');
-    await click(ts.overview.optInCheck);
-    await click(ts.overview.optInConfirm);
   });
 
   module('enterprise with namespaces', function (hooks) {
@@ -75,7 +119,8 @@ module('Acceptance | sync | overview', function (hooks) {
     });
 
     test('it should make activation-flag requests to correct namespace', async function (assert) {
-      assert.expect(6);
+      assert.expect(3);
+
       this.server.get('/sys/activation-flags', (_, req) => {
         assert.deepEqual(req.requestHeaders, {}, 'Request is unauthenticated and in root namespace');
         return {
@@ -94,22 +139,20 @@ module('Acceptance | sync | overview', function (hooks) {
         return {};
       });
 
-      assert.dom('[data-test-badge-namespace]').hasText('foo'); // confirm we're in admin/foo
+      // confirm we're in admin/foo
+      assert.dom('[data-test-badge-namespace]').hasText('foo');
+
       await click(ts.navLink('Secrets Sync'));
-      assert.dom(ts.overview.optInBanner).exists('Opt-in banner is shown');
       await click(ts.overview.optInBannerEnable);
-      assert.dom(ts.overview.optInModal).exists('Opt-in modal is shown');
-      assert
-        .dom(ts.overview.optInConfirm)
-        .isDisabled('Confirm button is disabled when checkbox is unchecked');
       await click(ts.overview.optInCheck);
       await click(ts.overview.optInConfirm);
     });
 
     test.skip('it should make activation-flag requests to correct namespace when managed', async function (assert) {
       // TODO: unskip for 1.16.1 when managed is supported
-      assert.expect(6);
+      assert.expect(3);
       this.owner.lookup('service:feature-flag').setFeatureFlags(['VAULT_CLOUD_ADMIN_NAMESPACE']);
+
       this.server.get('/sys/activation-flags', (_, req) => {
         assert.deepEqual(req.requestHeaders, {}, 'Request is unauthenticated and in root namespace');
         return {
@@ -128,14 +171,11 @@ module('Acceptance | sync | overview', function (hooks) {
         return {};
       });
 
-      assert.dom('[data-test-badge-namespace]').hasText('foo'); // confirm we're in admin/foo
+      // confirm we're in admin/foo
+      assert.dom('[data-test-badge-namespace]').hasText('foo');
+
       await click(ts.navLink('Secrets Sync'));
-      assert.dom(ts.overview.optInBanner).exists('Opt-in banner is shown');
       await click(ts.overview.optInBannerEnable);
-      assert.dom(ts.overview.optInModal).exists('Opt-in modal is shown');
-      assert
-        .dom(ts.overview.optInConfirm)
-        .isDisabled('Confirm button is disabled when checkbox is unchecked');
       await click(ts.overview.optInCheck);
       await click(ts.overview.optInConfirm);
     });

--- a/ui/tests/helpers/sync/sync-selectors.js
+++ b/ui/tests/helpers/sync/sync-selectors.js
@@ -53,7 +53,6 @@ export const PAGE = {
   overview: {
     optInBanner: '[data-test-secrets-sync-opt-in-banner]',
     optInBannerEnable: '[data-test-secrets-sync-opt-in-banner-enable]',
-    optInBannerEnableError: '[data-test-opt-in-banner-error]',
     optInModal: '[data-test-secrets-sync-opt-in-modal]',
     optInCheck: '[data-test-opt-in-check]',
     optInConfirm: '[data-test-opt-in-confirm]',

--- a/ui/tests/integration/components/sync/secrets/page/overview-test.js
+++ b/ui/tests/integration/components/sync/secrets/page/overview-test.js
@@ -43,36 +43,6 @@ module('Integration | Component | sync | Page::Overview', function (hooks) {
       );
   });
 
-  test('it should render landing cta component for enterprise with the secrets sync feature', async function (assert) {
-    this.destinations = [];
-    await this.renderComponent();
-
-    assert.dom(title).hasText('Secrets Sync', 'Page title renders');
-    assert.dom(cta.button).hasText('Create first destination', 'CTA action renders');
-    assert.dom(cta.summary).exists('CTA renders');
-  });
-
-  test('it should render landing cta component for community', async function (assert) {
-    this.version.type = 'community';
-    this.version.features = [];
-    this.destinations = [];
-
-    await this.renderComponent();
-
-    assert.dom(title).hasText('Secrets Sync Enterprise feature', 'Page title renders');
-    assert.dom(cta.button).doesNotExist('Create first destination button does not render');
-  });
-
-  test('it should render landing cta component for enterprise without the secrets sync feature', async function (assert) {
-    this.destinations = [];
-    this.version.features = [];
-    await this.renderComponent();
-
-    assert.dom(title).hasText('Secrets Sync Premium feature', 'Page title renders');
-    assert.dom(cta.button).doesNotExist('Create first destination button does not render');
-    assert.dom(cta.summary).exists('CTA renders');
-  });
-
   test('it should render header, tabs and toolbar for overview state', async function (assert) {
     await this.renderComponent();
 
@@ -83,93 +53,252 @@ module('Integration | Component | sync | Page::Overview', function (hooks) {
     assert.dom(overview.createDestination).hasText('Create new destination', 'Toolbar action renders');
   });
 
-  test('it should render secrets by destination table', async function (assert) {
-    const { icon, name, badge, total, updated, actionToggle, action } = overview.table;
-    const updatedDate = dateFormat(
-      [new Date('2023-09-20T10:51:53.961861096-04:00'), 'MMMM do yyyy, h:mm:ss a'],
-      {}
-    );
-
-    await this.renderComponent();
-
-    assert
-      .dom(overviewCard.title('Secrets by destination'))
-      .hasText('Secrets by destination', 'Overview card title renders for table');
-    assert.dom(icon(0)).hasAttribute('data-test-icon', 'aws-color', 'Destination icon renders');
-    assert.dom(name(0)).hasText('destination-aws', 'Destination name renders');
-
-    assert.dom(badge(0)).hasText('All synced', 'All synced badge renders');
-    assert.dom(badge(0)).hasClass('hds-badge--color-success', 'Correct color renders for All synced badge');
-
-    assert.dom(badge(1)).doesNotExist('Status badge does not render for destination with no associations');
-
-    assert.dom(badge(2)).hasText('1 Unsynced', 'Unsynced badge renders');
-    assert.dom(badge(2)).hasClass('hds-badge--color-neutral', 'Correct color renders for unsynced badge');
-
-    assert.dom(total(0)).hasText('1', '# of external secrets renders');
-    assert.dom(updated(0)).hasText(updatedDate, 'Last updated datetime renders');
-
-    assert.dom(total(1)).hasText('0', '# of external secrets renders for destination with no associations');
-    assert
-      .dom(updated(1))
-      .hasText('—', 'Last updated placeholder renders for destination with no associations');
-
-    await click(actionToggle(0));
-    assert.dom(action('sync')).hasText('Sync secrets', 'Sync action renders');
-    assert.dom(action('details')).hasText('View synced secrets', 'View synced secrets action renders');
-  });
-
-  test('it should paginate secrets by destination table', async function (assert) {
-    await this.renderComponent();
-
-    const { name, row } = overview.table;
-    assert.dom(row).exists({ count: 3 }, 'Correct number of table rows render based on page size');
-    assert.dom(name(0)).hasText('destination-aws', 'First destination renders on page 1');
-
-    await click(pagination.next);
-    await settled();
-    assert.dom(overview.table.row).exists({ count: 3 }, 'New items are fetched and rendered on page change');
-    assert.dom(name(0)).hasText('destination-gcp', 'First destination renders on page 2');
-  });
-
-  test('it should display empty state for secrets by destination table', async function (assert) {
-    this.server.get('/sys/sync/destinations/:type/:name/associations', () => {
-      return new Response(403, {}, { errors: ['Permission denied'] });
+  module('community', function (hooks) {
+    hooks.beforeEach(function () {
+      this.version.type = 'community';
+      this.version.features = [];
+      this.destinations = [];
+      this.activatedFeatures = [];
     });
 
-    await this.renderComponent();
+    test('it should show an upsell CTA', async function (assert) {
+      await this.renderComponent();
 
-    assert.dom(emptyStateTitle).hasText('Error fetching information', 'Empty state title renders');
-    assert
-      .dom(emptyStateMessage)
-      .hasText('Ensure that the policy has access to read sync associations.', 'Empty state message renders');
+      assert
+        .dom(title)
+        .hasText('Secrets Sync Enterprise feature', 'page title indicates feature is only for Enterprise');
+      assert.dom(cta.button).doesNotExist();
+    });
   });
 
-  test('it should render totals cards', async function (assert) {
-    await this.renderComponent();
+  module('ent', function (hooks) {
+    hooks.beforeEach(function () {
+      this.destinations = [];
+    });
 
-    const { title, description, action, content } = overviewCard;
-    const cardData = [
-      {
-        cardTitle: 'Total destinations',
-        subText: 'The total number of connected destinations',
-        actionText: 'Create new',
-        count: '6',
-      },
-      {
-        cardTitle: 'Total secrets',
-        subText:
-          'The total number of secrets that have been synced from Vault. One secret will be counted as one sync client.',
-        actionText: 'View billing',
-        count: '7',
-      },
-    ];
+    test('it should show an upsell CTA if license does NOT have the secrets sync feature', async function (assert) {
+      this.version.features = [];
+      await this.renderComponent();
 
-    cardData.forEach(({ cardTitle, subText, actionText, count }) => {
-      assert.dom(title(cardTitle)).hasText(cardTitle, 'Overview card title renders');
-      assert.dom(description(cardTitle)).hasText(subText, 'Destinations overview card description renders');
-      assert.dom(content(cardTitle)).hasText(count, 'Total count renders');
-      assert.dom(action(cardTitle)).hasText(actionText, 'Card action renders');
+      assert
+        .dom(title)
+        .hasText('Secrets Sync Premium feature', 'title indicates feature is only for Premium');
+      assert.dom(cta.button).doesNotExist();
+      assert.dom(cta.summary).exists();
+    });
+
+    test('it should show create CTA if license has the secrets sync feature', async function (assert) {
+      this.version.features = ['Secrets Sync'];
+      await this.renderComponent();
+
+      assert.dom(title).hasText('Secrets Sync');
+      assert.dom(cta.button).hasText('Create first destination', 'CTA action renders');
+      assert.dom(cta.summary).exists();
+    });
+  });
+
+  module('secrets sync not activated', function (hooks) {
+    hooks.beforeEach(async function () {
+      this.activatedFeatures = [];
+    });
+
+    test('it should show the opt-in banner', async function (assert) {
+      await this.renderComponent();
+
+      assert.dom(overview.optInBanner).exists('Opt-in banner is shown');
+    });
+
+    test('it should navigate to the opt-in modal', async function (assert) {
+      await this.renderComponent();
+
+      await click(overview.optInBannerEnable);
+
+      assert.dom(overview.optInModal).exists('Opt-in modal is shown');
+      assert.dom(overview.optInConfirm).isDisabled('Confirm button is disabled when checkbox is unchecked');
+
+      await click(overview.optInCheck);
+      assert.dom(overview.optInConfirm).isNotDisabled('confirm button is enabled once checkbox is checked');
+    });
+
+    test('it should make a POST to activate the feature', async function (assert) {
+      assert.expect(1);
+
+      await this.renderComponent();
+
+      this.server.post('/sys/activation-flags/secrets-sync/activate', () => {
+        assert.true(true, 'POST to secrets-sync/activate is called');
+        return {};
+      });
+
+      await this.renderComponent();
+
+      await click(overview.optInBannerEnable);
+      await click(overview.optInCheck);
+      await click(overview.optInConfirm);
+    });
+
+    test('it shows an error if activation fails', async function (assert) {
+      await this.renderComponent();
+
+      this.server.post('/sys/activation-flags/secrets-sync/activate', () => new Response(403));
+
+      await click(overview.optInBannerEnable);
+      await click(overview.optInCheck);
+      await click(overview.optInConfirm);
+
+      assert.dom(overview.optInError).exists('shows an error banner');
+      assert.dom(overview.optInBanner).exists('banner is visible so user can try to opt-in again');
+    });
+  });
+
+  module('secrets sync activated', function () {
+    test('it should hide the opt-in banner', async function (assert) {
+      await this.renderComponent();
+
+      assert.dom(overview.optInBanner).doesNotExist();
+    });
+  });
+
+  module('with no destinations', function (hooks) {
+    hooks.beforeEach(function () {
+      this.destinations = [];
+    });
+
+    test('it should show a CTA', async function (assert) {
+      await this.renderComponent();
+
+      assert.dom(cta.button).exists();
+
+      assert
+        .dom(overview.createDestination)
+        .doesNotExist('create new destination link is hidden if there are no pre-existing destinations');
+    });
+
+    test('it should hide the overview cards', async function (assert) {
+      await this.renderComponent();
+
+      assert
+        .dom(overviewCard.title('Secrets by destination'))
+        .doesNotExist('it does not show secrets by destination card if there are no destinations');
+      assert
+        .dom(overviewCard.title('Total destinations'))
+        .doesNotExist('it does not show total destinations card if there are no destinations');
+      assert
+        .dom(overviewCard.title('Total secrets'))
+        .doesNotExist('it does not show total secrets card if there are no destinations');
+    });
+  });
+
+  module('with destinations', function () {
+    test('it should show the overview cards', async function (assert) {
+      await this.renderComponent();
+
+      assert.dom(overviewCard.title('Secrets by destination')).exists();
+      assert.dom(overviewCard.title('Total destinations')).exists();
+      assert.dom(overviewCard.title('Total secrets')).exists();
+    });
+
+    module('Secrets by destination table', function () {
+      test('it should show the table with correct columns, data, badges, and actions', async function (assert) {
+        const { icon, name, badge, total, updated, actionToggle, action } = overview.table;
+        const updatedDate = dateFormat(
+          [new Date('2023-09-20T10:51:53.961861096-04:00'), 'MMMM do yyyy, h:mm:ss a'],
+          {}
+        );
+
+        await this.renderComponent();
+
+        assert
+          .dom(overviewCard.title('Secrets by destination'))
+          .hasText('Secrets by destination', 'Overview card title renders for table');
+        assert.dom(icon(0)).hasAttribute('data-test-icon', 'aws-color', 'Destination icon renders');
+        assert.dom(name(0)).hasText('destination-aws', 'Destination name renders');
+
+        assert.dom(badge(0)).hasText('All synced', 'All synced badge renders');
+        assert
+          .dom(badge(0))
+          .hasClass('hds-badge--color-success', 'Correct color renders for All synced badge');
+
+        assert
+          .dom(badge(1))
+          .doesNotExist('Status badge does not render for destination with no associations');
+
+        assert.dom(badge(2)).hasText('1 Unsynced', 'Unsynced badge renders');
+        assert.dom(badge(2)).hasClass('hds-badge--color-neutral', 'Correct color renders for unsynced badge');
+
+        assert.dom(total(0)).hasText('1', '# of external secrets renders');
+        assert.dom(updated(0)).hasText(updatedDate, 'Last updated datetime renders');
+
+        assert
+          .dom(total(1))
+          .hasText('0', '# of external secrets renders for destination with no associations');
+        assert
+          .dom(updated(1))
+          .hasText('—', 'Last updated placeholder renders for destination with no associations');
+
+        await click(actionToggle(0));
+        assert.dom(action('sync')).hasText('Sync secrets', 'Sync action renders');
+        assert.dom(action('details')).hasText('View synced secrets', 'View synced secrets action renders');
+      });
+
+      test('it should paginate the table', async function (assert) {
+        await this.renderComponent();
+
+        const { name, row } = overview.table;
+        assert.dom(row).exists({ count: 3 }, 'Correct number of table rows render based on page size');
+        assert.dom(name(0)).hasText('destination-aws', 'First destination renders on page 1');
+
+        await click(pagination.next);
+        await settled();
+        assert
+          .dom(overview.table.row)
+          .exists({ count: 3 }, 'New items are fetched and rendered on page change');
+        assert.dom(name(0)).hasText('destination-gcp', 'First destination renders on page 2');
+      });
+
+      test('it should show an empty state if there is an error fetching associations', async function (assert) {
+        this.server.get('/sys/sync/destinations/:type/:name/associations', () => {
+          return new Response(403, {}, { errors: ['Permission denied'] });
+        });
+
+        await this.renderComponent();
+
+        assert.dom(emptyStateTitle).hasText('Error fetching information', 'Empty state title renders');
+        assert
+          .dom(emptyStateMessage)
+          .hasText(
+            'Ensure that the policy has access to read sync associations.',
+            'Empty state message renders'
+          );
+      });
+    });
+
+    test('it should show the Totals cards', async function (assert) {
+      await this.renderComponent();
+
+      const { title, description, action, content } = overviewCard;
+      const cardData = [
+        {
+          cardTitle: 'Total destinations',
+          subText: 'The total number of connected destinations',
+          actionText: 'Create new',
+          count: '6',
+        },
+        {
+          cardTitle: 'Total secrets',
+          subText:
+            'The total number of secrets that have been synced from Vault. One secret will be counted as one sync client.',
+          actionText: 'View billing',
+          count: '7',
+        },
+      ];
+
+      cardData.forEach(({ cardTitle, subText, actionText, count }) => {
+        assert.dom(title(cardTitle)).hasText(cardTitle, `${cardTitle} card title renders`);
+        assert.dom(description(cardTitle)).hasText(subText, ` ${cardTitle} card description renders`);
+        assert.dom(content(cardTitle)).hasText(count, 'Total count renders');
+        assert.dom(action(cardTitle)).hasText(actionText, 'Card action renders');
+      });
     });
   });
 });

--- a/ui/tests/integration/components/sync/sync-header-test.js
+++ b/ui/tests/integration/components/sync/sync-header-test.js
@@ -32,24 +32,36 @@ module('Integration | Component | sync | SyncHeader', function (hooks) {
     assert.dom(breadcrumb).includesText('Destinations', 'renders breadcrumb');
   });
 
-  test('it should just render title for enterprise with secrets sync feature', async function (assert) {
-    this.version.type = 'enterprise';
-    this.version.features = ['Secrets Sync'];
-    await this.renderComponent();
-    assert.dom(title).hasText('Secrets Sync');
+  module('ent', function (hooks) {
+    hooks.beforeEach(async function () {
+      this.version.type = 'enterprise';
+    });
+
+    test('it should render title if license has secrets sync feature', async function (assert) {
+      this.version.features = ['Secrets Sync'];
+      await this.renderComponent();
+
+      assert.dom(title).hasText('Secrets Sync');
+    });
+
+    test('it should render title and premium badge if license does not have secrets sync feature', async function (assert) {
+      this.version.features = [];
+      await this.renderComponent();
+
+      assert.dom(title).hasText('Secrets Sync Premium feature');
+    });
   });
 
-  test('it should render title and premium badge for enterprise without secrets sync feature', async function (assert) {
-    this.version.type = 'enterprise';
-    this.version.features = [];
-    await this.renderComponent();
-    assert.dom(title).hasText('Secrets Sync Premium feature');
-  });
+  module('community', function (hooks) {
+    hooks.beforeEach(function () {
+      this.version.type = 'community';
+    });
 
-  test('it should render title and promotional enterprise badge for community version', async function (assert) {
-    this.version.type = 'community';
-    await this.renderComponent();
-    assert.dom(title).hasText('Secrets Sync Enterprise feature');
+    test('it should render title and enterprise badge', async function (assert) {
+      await this.renderComponent();
+
+      assert.dom(title).hasText('Secrets Sync Enterprise feature');
+    });
   });
 
   test('it should yield actions block', async function (assert) {


### PR DESCRIPTION
### :hammer_and_wrench: Description
Adds tests & reorganizes existing tests to ensure we are covering the Secrets Sync / Overview page when:
- [x] OSS
- [x]  Enterprise
    - [x] has feature in license
    - [x] does not have feature in license
    - [x] feature is activated
        - [x] there are destinations
        - [x] there are no destinations
        - [x] activation workflow works
        - [x] activation workflow handles errors
    - [x] feature is not activated

### 🔗 Links
Refer to the Whimsical diagram for another example of all possible states that the page could have. I used this as a reference when outlining all of the tests.

### :camera_flash: Screenshots
Note the tests now being organized in modules that make it clearer which scenario we're testing
![updatead tests](https://github.com/hashicorp/vault/assets/903288/41994780-1cbb-4f05-932b-1c72aafd9a47)



### :building_construction: How to Build and Test the Change
Take a look at the following test files and make sure they cover the scenarios outlined above:
- `tests/acceptance/sync/secrets/overview-test.js`
- `tests/integration/components/sync/secrets/page/overview-test.js`