### PR TITLE
[secrets sync] remove extra breadcrumb

### DIFF
--- a/ui/lib/sync/addon/components/sync-header.hbs
+++ b/ui/lib/sync/addon/components/sync-header.hbs
@@ -4,9 +4,11 @@
 ~}}
 
 <PageHeader as |p|>
-  <p.top>
-    <Page::Breadcrumbs @breadcrumbs={{or @breadcrumbs (array (hash label="Secrets Sync"))}} />
-  </p.top>
+  {{#if @breadcrumbs}}
+    <p.top>
+      <Page::Breadcrumbs @breadcrumbs={{@breadcrumbs}} />
+    </p.top>
+  {{/if}}
 
   <p.levelLeft>
     <h1 class="title is-3 has-bottom-margin-m" data-test-page-title>

--- a/ui/tests/integration/components/sync/secrets/page/destinations-test.js
+++ b/ui/tests/integration/components/sync/secrets/page/destinations-test.js
@@ -14,17 +14,7 @@ import sinon from 'sinon';
 
 import { PAGE } from 'vault/tests/helpers/sync/sync-selectors';
 
-const {
-  breadcrumb,
-  title,
-  tab,
-  filter,
-  searchSelect,
-  emptyStateTitle,
-  destinations,
-  menuTrigger,
-  confirmButton,
-} = PAGE;
+const { title, tab, filter, searchSelect, emptyStateTitle, destinations, menuTrigger, confirmButton } = PAGE;
 
 module('Integration | Component | sync | Page::Destinations', function (hooks) {
   setupRenderingTest(hooks);
@@ -71,7 +61,6 @@ module('Integration | Component | sync | Page::Destinations', function (hooks) {
 
   test('it should render header and tabs', async function (assert) {
     await this.renderComponent();
-    assert.dom(breadcrumb).includesText('Secrets Sync', 'Breadcrumb renders');
     assert.dom(title).hasText('Secrets Sync', 'Page title renders');
     assert.dom(tab('Overview')).exists('Overview tab renders');
     assert.dom(tab('Destinations')).exists('Destinations tab renders');

--- a/ui/tests/integration/components/sync/secrets/page/overview-test.js
+++ b/ui/tests/integration/components/sync/secrets/page/overview-test.js
@@ -16,17 +16,7 @@ import { PAGE } from 'vault/tests/helpers/sync/sync-selectors';
 import { Response } from 'miragejs';
 import { dateFormat } from 'core/helpers/date-format';
 
-const {
-  title,
-  breadcrumb,
-  tab,
-  overviewCard,
-  cta,
-  overview,
-  pagination,
-  emptyStateTitle,
-  emptyStateMessage,
-} = PAGE;
+const { title, tab, overviewCard, cta, overview, pagination, emptyStateTitle, emptyStateMessage } = PAGE;
 
 module('Integration | Component | sync | Page::Overview', function (hooks) {
   setupRenderingTest(hooks);
@@ -87,8 +77,6 @@ module('Integration | Component | sync | Page::Overview', function (hooks) {
     await this.renderComponent();
 
     assert.dom(title).hasText('Secrets Sync', 'Page title renders');
-    assert.dom(breadcrumb).exists({ count: 1 }, 'Correct number of breadcrumbs render');
-    assert.dom(breadcrumb).includesText('Secrets Sync', 'Top level breadcrumb renders');
     assert.dom(cta.button).doesNotExist('CTA does not render');
     assert.dom(tab('Overview')).hasText('Overview', 'Overview tab renders');
     assert.dom(tab('Destinations')).hasText('Destinations', 'Destinations tab renders');

--- a/ui/tests/integration/components/sync/sync-header-test.js
+++ b/ui/tests/integration/components/sync/sync-header-test.js
@@ -10,7 +10,7 @@ import hbs from 'htmlbars-inline-precompile';
 import { render } from '@ember/test-helpers';
 import { PAGE } from 'vault/tests/helpers/sync/sync-selectors';
 
-const { breadcrumb, title } = PAGE;
+const { title, breadcrumb } = PAGE;
 
 module('Integration | Component | sync | SyncHeader', function (hooks) {
   setupRenderingTest(hooks);
@@ -24,12 +24,6 @@ module('Integration | Component | sync | SyncHeader', function (hooks) {
         owner: this.engine,
       });
     };
-  });
-
-  test('it should render default breadcrumb', async function (assert) {
-    await this.renderComponent();
-    assert.dom(breadcrumb).exists({ count: 1 }, 'Correct number of breadcrumbs render');
-    assert.dom(breadcrumb).includesText('Secrets Sync', 'renders default breadcrumb');
   });
 
   test('it should render breadcrumbs', async function (assert) {


### PR DESCRIPTION
### :hammer_and_wrench: Description
Removes the extra breadcrumb on the Secrets Sync overview page per [HDS guidance](https://helios.hashicorp.design/components/breadcrumb#usage).

### :camera_flash: Screenshots
#### extra breadcrumb is gone from overview page
![breadcrumb](https://github.com/hashicorp/vault/assets/903288/2ce77fc3-054a-4edd-bee1-2ffbc123cd3b)

#### extra breadcrumb is gone from destinations page (since the overview page is already labeled by the tab)
![image](https://github.com/hashicorp/vault/assets/903288/3b03b281-f1b0-41cd-ba17-51229d243425)

#### breadcrumbs on child pages are still present
![image](https://github.com/hashicorp/vault/assets/903288/84415a63-3be1-48b1-a1ff-cbc6b1590b4d)



