### PR TITLE
UI: Ember deprecation prep for 5.0: ember-data:deprecate-array-like, part 2

### DIFF
--- a/ui/tests/acceptance/pki/pki-engine-route-cleanup-test.js
+++ b/ui/tests/acceptance/pki/pki-engine-route-cleanup-test.js
@@ -45,7 +45,7 @@ module('Acceptance | pki engine route cleanup test', function (hooks) {
       await click(SELECTORS.emptyStateLink);
       configs = this.store.peekAll('pki/action');
       urls = this.store.peekRecord('pki/config/urls', this.mountPath);
-      config = configs.objectAt(0);
+      config = configs.at(0);
       assert.strictEqual(configs.length, 1, 'One config model present');
       assert.false(urls.hasDirtyAttributes, 'URLs is loaded from endpoint');
       assert.true(config.hasDirtyAttributes, 'Config model is dirty');
@@ -60,7 +60,7 @@ module('Acceptance | pki engine route cleanup test', function (hooks) {
       await click(SELECTORS.emptyStateLink);
       configs = this.store.peekAll('pki/action');
       urls = this.store.peekRecord('pki/config/urls', this.mountPath);
-      config = configs.objectAt(0);
+      config = configs.at(0);
       assert.strictEqual(configs.length, 1, 'One config model present');
       assert.false(urls.hasDirtyAttributes, 'URLs is loaded from endpoint');
       assert.true(config.hasDirtyAttributes, 'Config model is dirty');
@@ -97,7 +97,7 @@ module('Acceptance | pki engine route cleanup test', function (hooks) {
       assert.strictEqual(roles.length, 0, 'No roles exist yet');
       await click(SELECTORS.createRoleLink);
       roles = this.store.peekAll('pki/role');
-      const role = roles.objectAt(0);
+      const role = roles.at(0);
       assert.strictEqual(roles.length, 1, 'New role exists');
       assert.true(role.isNew, 'Role is new model');
       await click(SELECTORS.roleForm.roleCancelButton);
@@ -114,7 +114,7 @@ module('Acceptance | pki engine route cleanup test', function (hooks) {
       assert.strictEqual(roles.length, 0, 'No roles exist yet');
       await click(SELECTORS.createRoleLink);
       roles = this.store.peekAll('pki/role');
-      const role = roles.objectAt(0);
+      const role = roles.at(0);
       assert.strictEqual(roles.length, 1, 'New role exists');
       assert.true(role.isNew, 'Role is new model');
       await click(SELECTORS.overviewBreadcrumb);
@@ -135,7 +135,7 @@ module('Acceptance | pki engine route cleanup test', function (hooks) {
       await click(SELECTORS.roleForm.roleCreateButton);
       assert.dom('[data-test-value-div="Role name"]').hasText(roleId, 'Shows correct role after create');
       roles = this.store.peekAll('pki/role');
-      role = roles.objectAt(0);
+      role = roles.at(0);
       assert.strictEqual(roles.length, 1, 'Role is created');
       assert.false(role.hasDirtyAttributes, 'Role no longer has dirty attributes');
 
@@ -175,7 +175,7 @@ module('Acceptance | pki engine route cleanup test', function (hooks) {
       await click(SELECTORS.importIssuerLink);
       issuers = this.store.peekAll('pki/action');
       assert.strictEqual(issuers.length, 1, 'Action model created');
-      const issuer = issuers.objectAt(0);
+      const issuer = issuers.at(0);
       assert.true(issuer.hasDirtyAttributes, 'Action has dirty attrs');
       assert.true(issuer.isNew, 'Action is new');
       // Exit
@@ -194,7 +194,7 @@ module('Acceptance | pki engine route cleanup test', function (hooks) {
       await click(SELECTORS.importIssuerLink);
       issuers = this.store.peekAll('pki/action');
       assert.strictEqual(issuers.length, 1, 'Action model created');
-      const issuer = issuers.objectAt(0);
+      const issuer = issuers.at(0);
       assert.true(issuer.hasDirtyAttributes, 'Action model has dirty attrs');
       assert.true(issuer.isNew, 'Action model is new');
       // Exit
@@ -214,7 +214,7 @@ module('Acceptance | pki engine route cleanup test', function (hooks) {
       await click(SELECTORS.generateIssuerRoot);
       actions = this.store.peekAll('pki/action');
       assert.strictEqual(actions.length, 1, 'Action model for generate-root created');
-      const action = actions.objectAt(0);
+      const action = actions.at(0);
       assert.true(action.hasDirtyAttributes, 'Action has dirty attrs');
       assert.true(action.isNew, 'Action is new');
       assert.strictEqual(action.actionType, 'generate-root', 'Action type is correct');
@@ -235,7 +235,7 @@ module('Acceptance | pki engine route cleanup test', function (hooks) {
       await click(SELECTORS.generateIssuerRoot);
       actions = this.store.peekAll('pki/action');
       assert.strictEqual(actions.length, 1, 'Action model for generate-root created');
-      const action = actions.objectAt(0);
+      const action = actions.at(0);
       assert.true(action.hasDirtyAttributes, 'Action has dirty attrs');
       assert.true(action.isNew, 'Action is new');
       assert.strictEqual(action.actionType, 'generate-root');
@@ -256,7 +256,7 @@ module('Acceptance | pki engine route cleanup test', function (hooks) {
       await click(SELECTORS.generateIssuerIntermediate);
       actions = this.store.peekAll('pki/action');
       assert.strictEqual(actions.length, 1, 'Action model for generate-csr created');
-      const action = actions.objectAt(0);
+      const action = actions.at(0);
       assert.true(action.hasDirtyAttributes, 'Action has dirty attrs');
       assert.true(action.isNew, 'Action is new');
       assert.strictEqual(action.actionType, 'generate-csr');
@@ -277,7 +277,7 @@ module('Acceptance | pki engine route cleanup test', function (hooks) {
       await click(SELECTORS.generateIssuerIntermediate);
       actions = this.store.peekAll('pki/action');
       assert.strictEqual(actions.length, 1, 'Action model for generate-csr created');
-      const action = actions.objectAt(0);
+      const action = actions.at(0);
       assert.true(action.hasDirtyAttributes, 'Action has dirty attrs');
       assert.true(action.isNew, 'Action is new');
       assert.strictEqual(action.actionType, 'generate-csr');
@@ -300,7 +300,7 @@ module('Acceptance | pki engine route cleanup test', function (hooks) {
       await visit(`/vault/secrets/${this.mountPath}/pki/issuers`);
 
       issuers = this.store.peekAll('pki/issuer');
-      const issuerId = issuers.objectAt(0).id;
+      const issuerId = issuers.at(0).id;
       assert.strictEqual(issuers.length, 1, 'Issuer exists on model in list');
       await visit(`/vault/secrets/${this.mountPath}/pki/issuers/${issuerId}/details`);
       await click(SELECTORS.issuerDetails.configure);
@@ -334,26 +334,26 @@ module('Acceptance | pki engine route cleanup test', function (hooks) {
       await visit(`/vault/secrets/${this.mountPath}/pki/overview`);
       await click(SELECTORS.keysTab);
       keys = this.store.peekAll('pki/key');
-      const configKeyId = keys.objectAt(0).id;
+      const configKeyId = keys.at(0).id;
       assert.strictEqual(keys.length, 1, 'One key exists from config');
       // Create key
       await click(SELECTORS.keyPages.generateKey);
       keys = this.store.peekAll('pki/key');
-      key = keys.objectAt(1);
+      key = keys.at(1);
       assert.strictEqual(keys.length, 2, 'New key exists');
       assert.true(key.isNew, 'Role is new model');
       // Exit
       await click(SELECTORS.keyForm.keyCancelButton);
       keys = this.store.peekAll('pki/key');
       assert.strictEqual(keys.length, 1, 'Second key is removed from store');
-      assert.strictEqual(keys.objectAt(0).id, configKeyId);
+      assert.strictEqual(keys.at(0).id, configKeyId);
       assert.strictEqual(currentURL(), `/vault/secrets/${this.mountPath}/pki/keys`, 'url is correct');
 
       // Create again
       await click(SELECTORS.keyPages.generateKey);
       assert.strictEqual(keys.length, 2, 'New key exists');
       keys = this.store.peekAll('pki/key');
-      key = keys.objectAt(1);
+      key = keys.at(1);
       assert.true(key.isNew, 'Key is new model');
       // Exit
       await click(SELECTORS.overviewBreadcrumb);
@@ -374,7 +374,7 @@ module('Acceptance | pki engine route cleanup test', function (hooks) {
       await click(SELECTORS.keyPages.keyEditLink);
       await fillIn(SELECTORS.keyForm.keyNameInput, 'foobar');
       keys = this.store.peekAll('pki/key');
-      key = keys.objectAt(0);
+      key = keys.at(0);
       assert.true(key.hasDirtyAttributes, 'Key model is dirty');
       // Exit
       await click(SELECTORS.keyForm.keyCancelButton);
@@ -391,7 +391,7 @@ module('Acceptance | pki engine route cleanup test', function (hooks) {
       await click(SELECTORS.keyPages.keyEditLink);
       await fillIn(SELECTORS.keyForm.keyNameInput, 'foobar');
       keys = this.store.peekAll('pki/key');
-      key = keys.objectAt(0);
+      key = keys.at(0);
       assert.true(key.hasDirtyAttributes, 'Key model is dirty');
 
       // Exit via breadcrumb


### PR DESCRIPTION
This PR is a follow on from https://github.com/hashicorp/vault/pull/26170 and handles removing `objectAt()` in tests which failed when running the full test suite and throwing errors for `matchId: 'ember-data:deprecate-array-like'`

✅ enterprise tests