### PR TITLE
UI: Don't show Resultant-ACL banner when wildcard policy present

### DIFF
--- a/ui/app/services/permissions.js
+++ b/ui/app/services/permissions.js
@@ -86,8 +86,8 @@ const API_PATHS_TO_ROUTE_PARAMS = {
   chroot_namespace is set, all of the paths in the response will be prefixed
   with that namespace. Additionally, this endpoint is only added to the default
   policy in the user's root namespace, so we make the call to the user's root
-  namespace (the namespace where the user's auth method is mounted) no matter what
-  the current namespace is.
+  namespace (the namespace where the user's auth method is mounted) no matter
+  what the current namespace is.
 */
 
 export default class PermissionsService extends Service {
@@ -125,12 +125,12 @@ export default class PermissionsService extends Service {
   get wildcardPath() {
     const ns = [sanitizePath(this.chrootNamespace), sanitizePath(this.namespace.userRootNamespace)].join('/');
     // wildcard path comes back from root namespace as empty string,
-    // while within a namespace it's the namespace itself ending with a slash
+    // but within a namespace it's the namespace itself ending with a slash
     return ns === '/' ? '' : `${sanitizePath(ns)}/`;
   }
 
   /**
-   *
+   * hasWildcardAccess checks if the user has a wildcard policy
    * @param {object} globPaths key is path, value is object with capabilities
    * @returns {boolean} whether the user's policy includes wildcard access to NS
    */

--- a/ui/app/services/permissions.js
+++ b/ui/app/services/permissions.js
@@ -82,6 +82,12 @@ const API_PATHS_TO_ROUTE_PARAMS = {
     root: boolean;
     chroot_namespace?: string;
   };
+  There are a couple nuances to be aware of about this response. When a
+  chroot_namespace is set, all of the paths in the response will be prefixed
+  with that namespace. Additionally, this endpoint is only added to the default
+  policy in the user's root namespace, so we make the call to the user's root
+  namespace (the namespace where the user's auth method is mounted) no matter what
+  the current namespace is.
 */
 
 export default class PermissionsService extends Service {
@@ -91,7 +97,6 @@ export default class PermissionsService extends Service {
   @tracked permissionsBanner = null;
   @tracked chrootNamespace = null;
   @service store;
-  @service auth;
   @service namespace;
 
   get baseNs() {
@@ -145,7 +150,11 @@ export default class PermissionsService extends Service {
     }
     const namespace = this.baseNs;
     const allowed =
+      // check if the user has wildcard access to the relative root namespace
+      this.hasWildcardAccess(this.globPaths) ||
+      // or if any of their glob paths start with the namespace
       Object.keys(this.globPaths).any((k) => k.startsWith(namespace)) ||
+      // or if any of their exact paths start with the namespace
       Object.keys(this.exactPaths).any((k) => k.startsWith(namespace));
     this.permissionsBanner = allowed ? null : PERMISSIONS_BANNER_STATES.noAccess;
   }

--- a/ui/app/services/permissions.js
+++ b/ui/app/services/permissions.js
@@ -117,6 +117,27 @@ export default class PermissionsService extends Service {
     }
   }
 
+  get wildcardPath() {
+    const ns = [sanitizePath(this.chrootNamespace), sanitizePath(this.namespace.userRootNamespace)].join('/');
+    // wildcard path comes back from root namespace as empty string,
+    // while within a namespace it's the namespace itself ending with a slash
+    return ns === '/' ? '' : `${sanitizePath(ns)}/`;
+  }
+
+  /**
+   *
+   * @param {object} globPaths key is path, value is object with capabilities
+   * @returns {boolean} whether the user's policy includes wildcard access to NS
+   */
+  hasWildcardAccess(globPaths = {}) {
+    // First check if the wildcard path is in the globPaths object
+    if (!Object.keys(globPaths).includes(this.wildcardPath)) return false;
+
+    // if so, make sure the current namespace is a child of the wildcard path
+    return this.namespace.path.startsWith(this.wildcardPath);
+  }
+
+  // This method is called to recalculate whether to show the permissionsBanner when the namespace changes
   calcNsAccess() {
     if (this.canViewAll) {
       this.permissionsBanner = null;

--- a/ui/app/templates/vault/cluster.hbs
+++ b/ui/app/templates/vault/cluster.hbs
@@ -81,7 +81,7 @@
 
 {{#if this.auth.isActiveSession}}
   <TokenExpireWarning @expirationDate={{this.auth.tokenExpirationDate}} @allowingExpiration={{this.auth.allowExpiration}}>
-    {{#if (this.permissionBanner)}}
+    {{#if this.permissionBanner}}
       <ResultantAclBanner @isEnterprise={{this.activeCluster.version.isEnterprise}} @failType={{this.permissionBanner}} />
     {{/if}}
     {{outlet}}

--- a/ui/app/templates/vault/cluster.hbs
+++ b/ui/app/templates/vault/cluster.hbs
@@ -82,7 +82,9 @@
 {{#if this.auth.isActiveSession}}
   <TokenExpireWarning @expirationDate={{this.auth.tokenExpirationDate}} @allowingExpiration={{this.auth.allowExpiration}}>
     {{#if this.permissionBanner}}
-      <ResultantAclBanner @isEnterprise={{this.activeCluster.version.isEnterprise}} @failType={{this.permissionBanner}} />
+      <div class="has-top-margin-m">
+        <ResultantAclBanner @isEnterprise={{this.activeCluster.version.isEnterprise}} @failType={{this.permissionBanner}} />
+      </div>
     {{/if}}
     {{outlet}}
   </TokenExpireWarning>

--- a/ui/app/templates/vault/cluster.hbs
+++ b/ui/app/templates/vault/cluster.hbs
@@ -70,9 +70,6 @@
       @autoloaded={{eq this.activeCluster.licenseState "autoloaded"}}
     />
   {{/if}}
-  {{#if this.permissionBanner}}
-    <ResultantAclBanner @isEnterprise={{this.activeCluster.version.isEnterprise}} @failType={{this.permissionBanner}} />
-  {{/if}}
 </div>
 <div class="global-flash">
   {{#each this.flashMessages.queue as |flash|}}
@@ -84,6 +81,9 @@
 
 {{#if this.auth.isActiveSession}}
   <TokenExpireWarning @expirationDate={{this.auth.tokenExpirationDate}} @allowingExpiration={{this.auth.allowExpiration}}>
+    {{#if (this.permissionBanner)}}
+      <ResultantAclBanner @isEnterprise={{this.activeCluster.version.isEnterprise}} @failType={{this.permissionBanner}} />
+    {{/if}}
     {{outlet}}
   </TokenExpireWarning>
 {{else}}

--- a/ui/tests/unit/services/permissions-test.js
+++ b/ui/tests/unit/services/permissions-test.js
@@ -250,4 +250,138 @@ module('Unit | Service | permissions', function (hooks) {
       );
     });
   });
+
+  module('wildcardPath calculates correctly', function () {
+    [
+      {
+        scenario: 'no user root or chroot',
+        userRoot: '',
+        chroot: null,
+        expectedPath: '',
+      },
+      {
+        scenario: 'user root = child ns and no chroot',
+        userRoot: 'bar',
+        chroot: null,
+        expectedPath: 'bar/',
+      },
+      {
+        scenario: 'user root = child ns and chroot set',
+        userRoot: 'bar',
+        chroot: 'admin/',
+        expectedPath: 'admin/bar/',
+      },
+      {
+        scenario: 'no user root and chroot set',
+        userRoot: '',
+        chroot: 'admin/',
+        expectedPath: 'admin/',
+      },
+    ].forEach((testCase) => {
+      test(`when ${testCase.scenario}`, function (assert) {
+        const namespaceService = Service.extend({
+          userRootNamespace: testCase.userRoot,
+          path: 'current/path/does/not/matter',
+        });
+        this.owner.register('service:namespace', namespaceService);
+        this.service.set('chrootNamespace', testCase.chroot);
+        assert.strictEqual(this.service.wildcardPath, testCase.expectedPath);
+      });
+    });
+    test('when user root =child ns and chroot set', function (assert) {
+      const namespaceService = Service.extend({
+        path: 'bar/baz',
+        userRootNamespace: 'bar',
+      });
+      this.owner.register('service:namespace', namespaceService);
+      this.service.set('chrootNamespace', 'admin/');
+      assert.strictEqual(this.service.wildcardPath, 'admin/bar/');
+    });
+  });
+
+  module('hasWildcardAccess calculates correctly', function () {
+    // The resultant-acl endpoint returns paths with chroot and
+    // relative root prefixed on all paths.
+    [
+      {
+        scenario: 'when root wildcard in root namespace',
+        chroot: null,
+        userRoot: '',
+        currentNs: 'foo/bar',
+        globs: {
+          '': { capabilities: ['read'] },
+        },
+        expectedAccess: true,
+      },
+      {
+        scenario: 'when root wildcard in chroot ns',
+        chroot: 'admin/',
+        userRoot: '',
+        currentNs: 'admin/child',
+        globs: {
+          'admin/': { capabilities: ['read'] },
+        },
+        expectedAccess: true,
+      },
+      {
+        scenario: 'when namespace wildcard in child ns',
+        chroot: null,
+        userRoot: 'bar',
+        currentNs: 'bar/baz',
+        globs: {
+          'bar/': { capabilities: ['read'] },
+        },
+        expectedAccess: true,
+      },
+      {
+        scenario: 'when namespace wildcard in child ns & chroot',
+        chroot: 'foo/',
+        userRoot: 'bar',
+        currentNs: 'foo/bar/baz',
+        globs: {
+          'foo/bar/': { capabilities: ['read'] },
+        },
+        expectedAccess: true,
+      },
+      {
+        scenario: 'when namespace wildcard in different ns with chroot & user root',
+        chroot: 'foo/',
+        userRoot: 'bar',
+        currentNs: 'foo/bing',
+        globs: {
+          'foo/bar/': { capabilities: ['read'] },
+        },
+        expectedAccess: false,
+      },
+      {
+        scenario: 'when namespace wildcard in different ns without chroot',
+        chroot: null,
+        userRoot: 'bar',
+        currentNs: 'foo/bing',
+        globs: {
+          'bar/': { capabilities: ['read'] },
+        },
+        expectedAccess: false,
+      },
+      {
+        scenario: 'when globs is empty',
+        chroot: 'foo/',
+        userRoot: 'bar',
+        currentNs: 'foo/bing',
+        globs: {},
+        expectedAccess: false,
+      },
+    ].forEach((testCase) => {
+      test(`when ${testCase.scenario}`, function (assert) {
+        const namespaceService = Service.extend({
+          path: testCase.currentNs,
+          userRootNamespace: testCase.userRoot,
+        });
+        this.owner.register('service:namespace', namespaceService);
+        this.service.set('chrootNamespace', testCase.chroot);
+        const result = this.service.hasWildcardAccess(testCase.globs);
+        assert.strictEqual(result, testCase.expectedAccess);
+      });
+    });
+  });
 });


### PR DESCRIPTION
This PR is to update the behavior of the Resultant ACL banner so that it no longer shows in child namespaces if the user has a `"*"` path in their policy. 

- [x] Ent tests passed

### How to test
To set up namespaces with some users to log in and verify the behavior, run the following script: 
```
# create namespace
vault namespace create admin
vault namespace create -namespace=admin child

# create policies
vault policy write root-admin - <<EOF
path "*" {
capabilities = ["read", "list", "create", "update", "delete"]
}
EOF
vault policy write -namespace=admin admin - <<EOF
path "*" {
capabilities = ["read", "list", "create", "update", "delete"]
}
EOF

# create users
vault auth enable userpass
vault write auth/userpass/users/root password=password policies=root-admin
vault auth enable -namespace=admin userpass
vault auth tune -namespace=admin -listing-visibility="unauth" userpass
vault write -namespace=admin auth/userpass/users/admin password=password policies=admin
```

### Test 1
- Log into root namespace with `root` username
- resultant-acl banner is not rendered
- Navigate to `admin` namespace
**- Previously, resultant-acl banner would show but with these changes it does not**
- Change namespace in url to some namespace that does not exist (eg "foo")
**- Previously, resultant-acl banner would show but with these changes it does not**

### Test 2
- Log into admin namespace with `admin` username
- resultant-acl banner is not rendered
- Navigate to `child` namespace
**- Previously, resultant-acl banner would show but with these changes it does not**
- Change namespace in url to some namespace that does not exist (eg "foo")
- Resultant-acl banner should show

**Before**
![image](https://github.com/hashicorp/vault/assets/82459713/d6934421-73b0-42c9-8c9c-b887b2f22a30)

**After**
![image](https://github.com/hashicorp/vault/assets/82459713/23d020b2-ea40-4708-bbc8-70faa69997a8)


This PR also updates the Resultant-ACL banner so that it only shows when a user has a non-expired token. 
