### PR TITLE
cli: fixed HOME not set error

### DIFF
--- a/changelog/26243.txt
+++ b/changelog/26243.txt
@@ -1,4 +1,4 @@
 ```release-note:bug
-cli: fixed issue where Vault CLI would error out if HOME was not set for 
-the user.
+cli: fixed a bug where the Vault CLI would error out if 
+HOME was not set.
 ```

--- a/changelog/26243.txt
+++ b/changelog/26243.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+cli: fixed issue where Vault CLI would error out if HOME was not set for 
+the user.
+```

--- a/command/base.go
+++ b/command/base.go
@@ -85,8 +85,13 @@ type BaseCommand struct {
 func (c *BaseCommand) Client() (*api.Client, error) {
 	// Read the test client if present
 	if c.client != nil {
-		if err := c.applyHCPConfig(); err != nil {
-			return nil, err
+		// Ignoring homedir errors here and moving on to avoid
+		// spamming user with warnings/errors that homedir isn't set.
+		path, err := homedir.Dir()
+		if err == nil {
+			if err := c.applyHCPConfig(path); err != nil {
+				return nil, err
+			}
 		}
 
 		return c.client, nil
@@ -197,8 +202,13 @@ func (c *BaseCommand) Client() (*api.Client, error) {
 
 	c.client = client
 
-	if err := c.applyHCPConfig(); err != nil {
-		return nil, err
+	// Ignoring homedir errors here and moving on to avoid
+	// spamming user with warnings/errors that homedir isn't set.
+	path, err := homedir.Dir()
+	if err == nil {
+		if err := c.applyHCPConfig(path); err != nil {
+			return nil, err
+		}
 	}
 
 	if c.addrWarning != "" && c.UI != nil {
@@ -212,16 +222,9 @@ func (c *BaseCommand) Client() (*api.Client, error) {
 	return client, nil
 }
 
-func (c *BaseCommand) applyHCPConfig() error {
+func (c *BaseCommand) applyHCPConfig(path string) error {
 	if c.hcpTokenHelper == nil {
 		c.hcpTokenHelper = c.HCPTokenHelper()
-	}
-
-	// Silently bailing here because if HOME is not set it's going
-	// to spam the user with errors or warnings.
-	path, err := homedir.Dir()
-	if err != nil {
-		return nil
 	}
 
 	hcpToken, err := c.hcpTokenHelper.GetHCPToken(path)

--- a/command/base.go
+++ b/command/base.go
@@ -24,6 +24,7 @@ import (
 	"github.com/hashicorp/vault/command/config"
 	"github.com/hashicorp/vault/helper/namespace"
 	"github.com/mattn/go-isatty"
+	"github.com/mitchellh/go-homedir"
 	"github.com/pkg/errors"
 	"github.com/posener/complete"
 )
@@ -216,7 +217,14 @@ func (c *BaseCommand) applyHCPConfig() error {
 		c.hcpTokenHelper = c.HCPTokenHelper()
 	}
 
-	hcpToken, err := c.hcpTokenHelper.GetHCPToken()
+	// Silently bailing here because if HOME is not set it's going
+	// to spam the user with errors or warnings.
+	path, err := homedir.Dir()
+	if err != nil {
+		return nil
+	}
+
+	hcpToken, err := c.hcpTokenHelper.GetHCPToken(path)
 	if err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -135,7 +135,7 @@ require (
 	github.com/hashicorp/raft-boltdb/v2 v2.3.0
 	github.com/hashicorp/raft-snapshot v1.0.4
 	github.com/hashicorp/raft-wal v0.4.0
-	github.com/hashicorp/vault-hcp-lib v0.0.0-20240126195955-473e9a48e7b7
+	github.com/hashicorp/vault-hcp-lib v0.0.0-20240402205111-2312b38227ab
 	github.com/hashicorp/vault-plugin-auth-alicloud v0.17.0
 	github.com/hashicorp/vault-plugin-auth-azure v0.17.0
 	github.com/hashicorp/vault-plugin-auth-centrify v0.15.1

--- a/go.sum
+++ b/go.sum
@@ -2520,8 +2520,8 @@ github.com/hashicorp/raft-wal v0.4.0/go.mod h1:A6vP5o8hGOs1LHfC1Okh9xPwWDcmb6Vvu
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
 github.com/hashicorp/serf v0.10.1 h1:Z1H2J60yRKvfDYAOZLd2MU0ND4AH/WDz7xYHDWQsIPY=
 github.com/hashicorp/serf v0.10.1/go.mod h1:yL2t6BqATOLGc5HF7qbFkTfXoPIY0WZdWHfEvMqbG+4=
-github.com/hashicorp/vault-hcp-lib v0.0.0-20240126195955-473e9a48e7b7 h1:D9XTgYgpQgdZHToRpJQ6fZwWyOOSpLX3Y+D2aMlxQh4=
-github.com/hashicorp/vault-hcp-lib v0.0.0-20240126195955-473e9a48e7b7/go.mod h1:KpSNItDH9ojFPf4UkGCB0vv3cAAwvVxBU2On4EZ0f7c=
+github.com/hashicorp/vault-hcp-lib v0.0.0-20240402205111-2312b38227ab h1:n1GzFf7LwpVebVIjh5XKW2IQa/BqI/zPlFg2mmB26dQ=
+github.com/hashicorp/vault-hcp-lib v0.0.0-20240402205111-2312b38227ab/go.mod h1:Nb41BTPvmFbKB73D/+XpxIw6Nf2Rt+AOUvLzlDxwAGQ=
 github.com/hashicorp/vault-plugin-auth-alicloud v0.17.0 h1:0SOkYxjMjph3Tbtv37+pANJQnYDvlAdjKpdEbK6zzZs=
 github.com/hashicorp/vault-plugin-auth-alicloud v0.17.0/go.mod h1:79KUWOxY6Ftoad7b+vEmyCmY6eYKdHiADTP0w0TunsE=
 github.com/hashicorp/vault-plugin-auth-azure v0.17.0 h1:nFsWQV+sMEdJCvKpVODNeTPP36n5bi6yiQpBOdBsQWw=


### PR DESCRIPTION
When HCP subcommands were added it created a hard dependency on HOME being configured for users. The [upstream HCP lib](https://github.com/hashicorp/vault-hcp-lib/pull/37) has been slightly refactored to take a path argument and in the Vault CLI we are just ignoring home directory not set errors.

Fixes https://github.com/hashicorp/vault/issues/26199.