### PR TITLE
Update "Set Certificate Chain" docs for Transit secret engine

### DIFF
--- a/website/content/api-docs/secret/transit.mdx
+++ b/website/content/api-docs/secret/transit.mdx
@@ -573,9 +573,8 @@ the chain as it will overwrite any previously set certificate chain.
    chain against.  If the version is set to `latest` or is not set, the current
    key will be returned.
 
- - `certificate_chain` `(string: "")` - Optional PEM-encoded CSR template to use
-   as a basis for the new CSR signed by this key. If not set, an empty
-   CSR is used.
+ - `certificate_chain` `(string: <required>)` - A PEM encoded certificate chain. It should be composed 
+by one or more concatenated PEM blocks and ordered starting from the end-entity certificate.
 
 ### Sample request
 


### PR DESCRIPTION
I was browsing the docs trying to understand the use of "Sign CSR" and notice the doc for "Set Certificate Chain" `certificate_chain` parameter is incorrect from the description in the PR #21081.