### PR TITLE
Temporarily skip broken test

### DIFF
--- a/vault/external_plugin_container_test.go
+++ b/vault/external_plugin_container_test.go
@@ -84,6 +84,7 @@ func TestExternalPluginInContainer_MountAndUnmount(t *testing.T) {
 	})
 
 	t.Run("rootless runsc", func(t *testing.T) {
+		t.Skip("Temporarily skipping due to environment breakage")
 		if _, err := exec.LookPath("runsc"); err != nil {
 			t.Skip("Skipping test as runsc not found on path")
 		}


### PR DESCRIPTION
This test started failing on all branches this morning. Merging this to main won't help most of those branches, but at least it keeps main green and lets people get their branches green by merging in main while they wait for the proper fix.