### PR TITLE
Secrets Sync: only call destinations and associations if isActivated

### DIFF
--- a/ui/lib/sync/addon/components/secrets/page/overview.hbs
+++ b/ui/lib/sync/addon/components/secrets/page/overview.hbs
@@ -3,7 +3,7 @@
   SPDX-License-Identifier: BUSL-1.1
 ~}}
 
-{{#if (and this.version.hasSecretsSync (not this.isActivated))}}
+{{#if (and this.version.hasSecretsSync (not @isActivated))}}
   {{#unless this.hideOptIn}}
     <Hds::Alert
       @type="inline"
@@ -185,7 +185,7 @@
     </OverviewCard>
   </div>
 {{else}}
-  <Secrets::LandingCta @isActivated={{this.isActivated}} @hasSecretsSync={{this.version.hasSecretsSync}} />
+  <Secrets::LandingCta @isActivated={{@isActivated}} @hasSecretsSync={{this.version.hasSecretsSync}} />
 {{/if}}
 
 {{#if this.showActivateSecretsSyncModal}}

--- a/ui/lib/sync/addon/components/secrets/page/overview.ts
+++ b/ui/lib/sync/addon/components/secrets/page/overview.ts
@@ -49,10 +49,6 @@ export default class SyncSecretsDestinationsPageComponent extends Component<Args
     }
   }
 
-  get isActivated() {
-    return this.args.activatedFeatures.includes('secrets-sync');
-  }
-
   fetchAssociationsForDestinations = task(this, {}, async (page = 1) => {
     try {
       const total = page * this.pageSize;

--- a/ui/lib/sync/addon/routes/secrets/overview.ts
+++ b/ui/lib/sync/addon/routes/secrets/overview.ts
@@ -26,13 +26,16 @@ export default class SyncSecretsOverviewRoute extends Route {
     const { activatedFeatures } = this.modelFor('secrets') as {
       activatedFeatures: Array<string>;
     };
+    const isActivated = activatedFeatures.includes('secrets-sync');
     return hash({
-      destinations: this.store.query('sync/destination', {}).catch(() => []),
-      associations: this.store
-        .adapterFor('sync/association')
-        .queryAll()
-        .catch(() => []),
-      activatedFeatures,
+      isActivated,
+      destinations: isActivated ? this.store.query('sync/destination', {}).catch(() => []) : [],
+      associations: isActivated
+        ? this.store
+            .adapterFor('sync/association')
+            .queryAll()
+            .catch(() => [])
+        : [],
     });
   }
 }

--- a/ui/lib/sync/addon/templates/secrets/overview.hbs
+++ b/ui/lib/sync/addon/templates/secrets/overview.hbs
@@ -6,5 +6,5 @@
 <Secrets::Page::Overview
   @destinations={{this.model.destinations}}
   @totalVaultSecrets={{this.model.associations.total_secrets}}
-  @activatedFeatures={{this.model.activatedFeatures}}
+  @isActivated={{this.model.isActivated}}
 />

--- a/ui/tests/acceptance/sync/secrets/overview-test.js
+++ b/ui/tests/acceptance/sync/secrets/overview-test.js
@@ -76,12 +76,18 @@ module('Acceptance | sync | overview', function (hooks) {
         wasActivatePOSTCalled = true;
         return {};
       });
-
-      // override mirage to simulate no pre-existing destinations
-      this.server.get('/sys/sync/destinations', () => {});
     });
 
     test('the activation workflow works', async function (assert) {
+      assert.expect(8);
+
+      this.server.get('/sys/sync/destinations', () => {
+        assert.true(false, 'destinations is not called');
+      });
+      this.server.get('/sys/sync/associations', () => {
+        assert.true(false, 'associations is not called');
+      });
+
       await visit('/vault/sync/secrets/overview');
 
       assert
@@ -90,6 +96,13 @@ module('Acceptance | sync | overview', function (hooks) {
 
       assert.dom(ts.overview.optInBanner).exists();
       await click(ts.overview.optInBannerEnable);
+
+      this.server.get('/sys/sync/destinations', () => {
+        assert.true(true, 'destinations is called');
+      });
+      this.server.get('/sys/sync/associations', () => {
+        assert.true(true, 'associations is called');
+      });
 
       assert.dom(ts.overview.optInModal).exists('modal to opt-in and activate feature is shown');
       await click(ts.overview.optInCheck);

--- a/ui/tests/integration/components/sync/secrets/page/overview-test.js
+++ b/ui/tests/integration/components/sync/secrets/page/overview-test.js
@@ -123,14 +123,14 @@ module('Integration | Component | sync | Page::Overview', function (hooks) {
     test('it should make a POST to activate the feature', async function (assert) {
       assert.expect(1);
 
-      await this.renderComponent(false);
+      await this.renderComponent();
 
       this.server.post('/sys/activation-flags/secrets-sync/activate', () => {
         assert.true(true, 'POST to secrets-sync/activate is called');
         return {};
       });
 
-      await this.renderComponent();
+      await this.renderComponent(false);
 
       await click(overview.optInBannerEnable);
       await click(overview.optInCheck);

--- a/ui/tests/integration/components/sync/secrets/page/overview-test.js
+++ b/ui/tests/integration/components/sync/secrets/page/overview-test.js
@@ -58,8 +58,8 @@ module('Integration | Component | sync | Page::Overview', function (hooks) {
     hooks.beforeEach(function () {
       this.version.type = 'community';
       this.version.features = [];
-      this.isActivated = false;
       this.destinations = [];
+      this.isActivated = false;
     });
 
     test('it should show an upsell CTA', async function (assert) {

--- a/ui/tests/integration/components/sync/secrets/page/overview-test.js
+++ b/ui/tests/integration/components/sync/secrets/page/overview-test.js
@@ -32,15 +32,16 @@ module('Integration | Component | sync | Page::Overview', function (hooks) {
 
     const store = this.owner.lookup('service:store');
     this.destinations = await store.query('sync/destination', {});
-    this.activatedFeatures = ['secrets-sync'];
 
-    this.renderComponent = () =>
-      render(
-        hbs`<Secrets::Page::Overview @destinations={{this.destinations}} @totalVaultSecrets={{7}} @activatedFeatures={{this.activatedFeatures}} @adapterError={{null}} />`,
+    this.renderComponent = (isActivated = true) => {
+      this.isActivated = isActivated;
+      return render(
+        hbs`<Secrets::Page::Overview @destinations={{this.destinations}} @totalVaultSecrets={{7}} @isActivated={{this.isActivated}} @adapterError={{null}} />`,
         {
           owner: this.engine,
         }
       );
+    };
   });
 
   test('it should render header, tabs and toolbar for overview state', async function (assert) {
@@ -58,11 +59,10 @@ module('Integration | Component | sync | Page::Overview', function (hooks) {
       this.version.type = 'community';
       this.version.features = [];
       this.destinations = [];
-      this.activatedFeatures = [];
     });
 
     test('it should show an upsell CTA', async function (assert) {
-      await this.renderComponent();
+      await this.renderComponent(false);
 
       assert
         .dom(title)
@@ -103,13 +103,13 @@ module('Integration | Component | sync | Page::Overview', function (hooks) {
     });
 
     test('it should show the opt-in banner', async function (assert) {
-      await this.renderComponent();
+      await this.renderComponent(false);
 
       assert.dom(overview.optInBanner).exists('Opt-in banner is shown');
     });
 
     test('it should navigate to the opt-in modal', async function (assert) {
-      await this.renderComponent();
+      await this.renderComponent(false);
 
       await click(overview.optInBannerEnable);
 
@@ -123,7 +123,7 @@ module('Integration | Component | sync | Page::Overview', function (hooks) {
     test('it should make a POST to activate the feature', async function (assert) {
       assert.expect(1);
 
-      await this.renderComponent();
+      await this.renderComponent(false);
 
       this.server.post('/sys/activation-flags/secrets-sync/activate', () => {
         assert.true(true, 'POST to secrets-sync/activate is called');
@@ -138,7 +138,7 @@ module('Integration | Component | sync | Page::Overview', function (hooks) {
     });
 
     test('it shows an error if activation fails', async function (assert) {
-      await this.renderComponent();
+      await this.renderComponent(false);
 
       this.server.post('/sys/activation-flags/secrets-sync/activate', () => new Response(403));
 
@@ -151,7 +151,7 @@ module('Integration | Component | sync | Page::Overview', function (hooks) {
     });
   });
 
-  module('secrets sync activated', function () {
+  module('secrets sync is activated', function () {
     test('it should hide the opt-in banner', async function (assert) {
       await this.renderComponent();
 

--- a/ui/tests/integration/components/sync/secrets/page/overview-test.js
+++ b/ui/tests/integration/components/sync/secrets/page/overview-test.js
@@ -32,11 +32,11 @@ module('Integration | Component | sync | Page::Overview', function (hooks) {
 
     const store = this.owner.lookup('service:store');
     this.destinations = await store.query('sync/destination', {});
+    this.isActivated = true;
 
-    this.renderComponent = (isActivated = true) => {
-      this.isActivated = isActivated;
+    this.renderComponent = () => {
       return render(
-        hbs`<Secrets::Page::Overview @destinations={{this.destinations}} @totalVaultSecrets={{7}} @isActivated={{this.isActivated}} @adapterError={{null}} />`,
+        hbs`<Secrets::Page::Overview @destinations={{this.destinations}} @totalVaultSecrets={{7}} @isActivated={{this.isActivated}} />`,
         {
           owner: this.engine,
         }
@@ -58,11 +58,12 @@ module('Integration | Component | sync | Page::Overview', function (hooks) {
     hooks.beforeEach(function () {
       this.version.type = 'community';
       this.version.features = [];
+      this.isActivated = false;
       this.destinations = [];
     });
 
     test('it should show an upsell CTA', async function (assert) {
-      await this.renderComponent(false);
+      await this.renderComponent();
 
       assert
         .dom(title)
@@ -99,17 +100,17 @@ module('Integration | Component | sync | Page::Overview', function (hooks) {
 
   module('secrets sync not activated', function (hooks) {
     hooks.beforeEach(async function () {
-      this.activatedFeatures = [];
+      this.isActivated = false;
     });
 
     test('it should show the opt-in banner', async function (assert) {
-      await this.renderComponent(false);
+      await this.renderComponent();
 
       assert.dom(overview.optInBanner).exists('Opt-in banner is shown');
     });
 
     test('it should navigate to the opt-in modal', async function (assert) {
-      await this.renderComponent(false);
+      await this.renderComponent();
 
       await click(overview.optInBannerEnable);
 
@@ -130,7 +131,7 @@ module('Integration | Component | sync | Page::Overview', function (hooks) {
         return {};
       });
 
-      await this.renderComponent(false);
+      await this.renderComponent();
 
       await click(overview.optInBannerEnable);
       await click(overview.optInCheck);
@@ -138,7 +139,7 @@ module('Integration | Component | sync | Page::Overview', function (hooks) {
     });
 
     test('it shows an error if activation fails', async function (assert) {
-      await this.renderComponent(false);
+      await this.renderComponent();
 
       this.server.post('/sys/activation-flags/secrets-sync/activate', () => new Response(403));
 


### PR DESCRIPTION
During the opt-in banner work we missed a conditional to not call the associations and destinations endpoints if the feature has not been activated. This PR moves the `isActivated` definition to the secrets model so that we can call on it to determine if destinations and associations should be called.

To test:
- On a fresh VRD, navigate to the Secrets sync page. You should not see any network requests made to the destinations or associations list endpoints. 
- Activate the feature via the opt-in modal.
- Look at the network request after the modal closes. The secrets model has been updated and thus the destinations and associations endpoints have been called.