### PR TITLE
Fix typo in KMIP backend documentation

### DIFF
--- a/website/content/docs/secrets/kmip.mdx
+++ b/website/content/docs/secrets/kmip.mdx
@@ -18,7 +18,7 @@ services and applications to perform cryptographic operations without having to
 manage cryptographic material, otherwise known as managed objects, by delegating
 its storage and lifecycle to a key management server.
 
-Vault's KMIP secrets engine listens on a separate port from the standard Vault listener. Each Vault server in a Vault cluster configured with a KMIP secrets engine uses the same listener configuration. The KMIP listener defaults to port 5696 and is configurable to alternative ports, for example, if there are multiple KMIP secrets engine mounts configured.  KMIP clients connect and authenticate to this KMIP secrets engine listener port using generated TLS certificates. KMIP clients may connect directly to any of the Vault servers on the configured KMIP port. A layer 4 tcp load balancer may be used in front of the Vault server's KMIP ports. The load balancer should support long-lived connections and it may use a round robin routing algorithm as Vault servers will forward to the primary Vault server, if necessary.
+Vault's KMIP secrets engine listens on a separate port from the standard Vault listener. Each Vault server in a Vault cluster configured with a KMIP secrets engine uses the same listener configuration. The KMIP listener defaults to port 5696 and is configurable to alternative ports, for example, if there are multiple KMIP secrets engine mounts configured.  KMIP clients connect and authenticate to this KMIP secrets engine listener port using generated TLS certificates. KMIP clients may connect directly to any of the Vault servers on the configured KMIP port. A layer 4 TCP load balancer may be used in front of the Vault server's KMIP ports. The load balancer should support long-lived connections and it may use a round robin routing algorithm as Vault servers will forward to the primary Vault server, if necessary.
 
 ## KMIP conformance
 
@@ -46,7 +46,7 @@ Vault implements version 1.4 of the following Key Management Interoperability Pr
   * [Advanced Cryptographic Server][advanced-cryptographic-server]
     * Supports *Encrypt*, *Decrypt*, *Sign*, *Signature Verify*, *MAC*, *MAC Verify*, *RNG Retrieve*, and *RNG Seed* client-to-server operations.
     * The supported hashing algorithms for Sign and Signature Verify operations are *SHA224*, *SHA256*, *SHA384*, *SHA512*, *RIPEMD160*, *SHA512_224*, *SHA512_256*, *SHA3_224*, *SHA3_256*, *SHA3_384*, and *SHA3_512* for *PSS* padding method, and algorithms *SHA224*, *SHA256*, *SHA384*, *SHA512*, and *RIPEMD160* for *PKCS1v15* padding method.
-    * The supported hashing algorithms for MAC and MAC Verify operations are *SHA224*, *SHA256*, *SHA384*, *SHA512*, *RIPEMD160*, *SHA512_224*, *SHA512_256*, *SHA3_224*, *SHA3_256*, *SHA3_384*, and *SHA3_512* (*MD4*, *MD5*, and *SHA1* are not supoorted).
+    * The supported hashing algorithms for MAC and MAC Verify operations are *SHA224*, *SHA256*, *SHA384*, *SHA512*, *RIPEMD160*, *SHA512_224*, *SHA512_256*, *SHA3_224*, *SHA3_256*, *SHA3_384*, and *SHA3_512* (*MD4*, *MD5*, and *SHA1* are not supported).
 
 Refer to [KMIP - Profiles Support](/vault/docs/secrets/kmip-profiles) page for more details.
 
@@ -76,7 +76,7 @@ requests.
     ```
 ### KMIP Certificate Authority for Client Certificates
 
-When the KMIP Secrets Engine is initially configured, Vault generates a KMIP 
+When the KMIP Secrets Engine is initially configured, Vault generates a KMIP
 Certificate Authority (CA) whose only purpose is to authenticate KMIP client
 certificates.
 


### PR DESCRIPTION
Fix a couple of typos in the KMIP backend documentation.