### PR TITLE
`IsEnterprise` as `const` rather than `var`

### DIFF
--- a/helper/constants/constants_oss.go
+++ b/helper/constants/constants_oss.go
@@ -5,4 +5,4 @@
 
 package constants
 
-var IsEnterprise = false
+const IsEnterprise = false


### PR DESCRIPTION
I'm not sure if this was just an oversight or if there's a special reason we'd have the `constants.IsEnterprise` as a `var` which could be modified vs a `const` which cannot.

ENT PR: https://github.com/hashicorp/vault-enterprise/pull/5698