### PR TITLE
Attempt to address TestAutoAuthSelfHealing_TokenFileAuth_SinkOutput flakiness

### DIFF
--- a/command/agent/agent_auto_auth_self_heal_test.go
+++ b/command/agent/agent_auto_auth_self_heal_test.go
@@ -194,17 +194,13 @@ func TestAutoAuthSelfHealing_TokenFileAuth_SinkOutput(t *testing.T) {
 	require.NoError(t, err)
 
 	// Wait for auto-auth to complete
-	updatedFileInfo, err := waitForFiles(t, pathTokenFile, fileInfo.ModTime())
+	_, err = waitForFiles(t, pathTokenFile, fileInfo.ModTime())
 	require.NoError(t, err)
 
 	// Verify the new token has been written to a file sink after re-authenticating using lookup-self
 	tokenInSink, err = os.ReadFile(pathTokenFile)
 	require.NoError(t, err)
 	require.Equal(t, newToken, string(tokenInSink))
-
-	// Wait for the lookup-self file to be updated (again)
-	_, err = waitForFiles(t, pathLookupSelf, updatedFileInfo.ModTime())
-	require.NoError(t, err)
 
 	// Verify the template has now been correctly rendered with the new token
 	templateContents, err := os.ReadFile(pathLookupSelf)

--- a/command/agent/agent_auto_auth_self_heal_test.go
+++ b/command/agent/agent_auto_auth_self_heal_test.go
@@ -172,6 +172,9 @@ func TestAutoAuthSelfHealing_TokenFileAuth_SinkOutput(t *testing.T) {
 	fileInfo, err := waitForFiles(t, pathTokenFile, preTriggerTime)
 	require.NoError(t, err)
 
+	templateFileInfo, err := waitForFiles(t, pathLookupSelf, preTriggerTime)
+	require.NoError(t, err)
+
 	tokenInSink, err := os.ReadFile(pathTokenFile)
 	require.NoError(t, err)
 	require.Equal(t, token, string(tokenInSink))
@@ -201,6 +204,10 @@ func TestAutoAuthSelfHealing_TokenFileAuth_SinkOutput(t *testing.T) {
 	tokenInSink, err = os.ReadFile(pathTokenFile)
 	require.NoError(t, err)
 	require.Equal(t, newToken, string(tokenInSink))
+
+	// Wait for the template file to have re-rendered
+	_, err = waitForFiles(t, pathLookupSelf, templateFileInfo.ModTime())
+	require.NoError(t, err)
 
 	// Verify the template has now been correctly rendered with the new token
 	templateContents, err := os.ReadFile(pathLookupSelf)


### PR DESCRIPTION
Was flaking like this:
```
    agent_auto_auth_self_heal_test.go:207: 
        	Error Trace:	/home/runner/actions-runner/_work/vault-enterprise/vault-enterprise/command/agent/agent_auto_auth_self_heal_test.go:207
        	Error:      	Received unexpected error:
        	            	timed out waiting for templates to render, last error: %!w(<nil>)
        	Test:       	TestAutoAuthSelfHealing_TokenFileAuth_SinkOutput
2024-04-09T12:37:47.155Z [TRACE] vault.read(auth/token/lookup-self): GET /v1/auth/token/lookup-self
```

I think what was happening is we didn't get the initial template render time, but the second render was happening before we started waiting in CI, so we would wait forever since the template has already rendered twice.

To solve this, I got the initial render time for the template, and waited based on that.