### PR TITLE
Backport 1.16.2: only call associations and destinations if activated

### DIFF
--- a/ui/lib/sync/addon/components/secrets/page/overview.hbs
+++ b/ui/lib/sync/addon/components/secrets/page/overview.hbs
@@ -3,7 +3,7 @@
   SPDX-License-Identifier: BUSL-1.1
 ~}}
 
-{{#if (and this.version.hasSecretsSync (not this.isActivated))}}
+{{#if (and this.version.hasSecretsSync (not @isActivated))}}
   {{#unless this.hideOptIn}}
     <Hds::Alert
       @type="inline"
@@ -185,7 +185,7 @@
     </OverviewCard>
   </div>
 {{else}}
-  <Secrets::LandingCta @isActivated={{this.isActivated}} @hasSecretsSync={{this.version.hasSecretsSync}} />
+  <Secrets::LandingCta @isActivated={{@isActivated}} @hasSecretsSync={{this.version.hasSecretsSync}} />
 {{/if}}
 
 {{#if this.showActivateSecretsSyncModal}}

--- a/ui/lib/sync/addon/components/secrets/page/overview.ts
+++ b/ui/lib/sync/addon/components/secrets/page/overview.ts
@@ -49,10 +49,6 @@ export default class SyncSecretsDestinationsPageComponent extends Component<Args
     }
   }
 
-  get isActivated() {
-    return this.args.activatedFeatures.includes('secrets-sync');
-  }
-
   fetchAssociationsForDestinations = task(this, {}, async (page = 1) => {
     try {
       const total = page * this.pageSize;

--- a/ui/lib/sync/addon/routes/secrets/overview.ts
+++ b/ui/lib/sync/addon/routes/secrets/overview.ts
@@ -26,13 +26,16 @@ export default class SyncSecretsOverviewRoute extends Route {
     const { activatedFeatures } = this.modelFor('secrets') as {
       activatedFeatures: Array<string>;
     };
+    const isActivated = activatedFeatures.includes('secrets-sync');
     return hash({
-      destinations: this.store.query('sync/destination', {}).catch(() => []),
-      associations: this.store
-        .adapterFor('sync/association')
-        .queryAll()
-        .catch(() => []),
-      activatedFeatures,
+      isActivated,
+      destinations: isActivated ? this.store.query('sync/destination', {}).catch(() => []) : [],
+      associations: isActivated
+        ? this.store
+            .adapterFor('sync/association')
+            .queryAll()
+            .catch(() => [])
+        : [],
     });
   }
 }

--- a/ui/lib/sync/addon/templates/secrets/overview.hbs
+++ b/ui/lib/sync/addon/templates/secrets/overview.hbs
@@ -6,5 +6,5 @@
 <Secrets::Page::Overview
   @destinations={{this.model.destinations}}
   @totalVaultSecrets={{this.model.associations.total_secrets}}
-  @activatedFeatures={{this.model.activatedFeatures}}
+  @isActivated={{this.model.isActivated}}
 />

--- a/ui/tests/acceptance/sync/secrets/overview-test.js
+++ b/ui/tests/acceptance/sync/secrets/overview-test.js
@@ -9,7 +9,7 @@ import { setupMirage } from 'ember-cli-mirage/test-support';
 import syncScenario from 'vault/mirage/scenarios/sync';
 import syncHandlers from 'vault/mirage/handlers/sync';
 import authPage from 'vault/tests/pages/auth';
-import { click, visit, currentURL } from '@ember/test-helpers';
+import { click, visit, currentURL, waitFor } from '@ember/test-helpers';
 import { PAGE as ts } from 'vault/tests/helpers/sync/sync-selectors';
 import { runCmd } from 'vault/tests/helpers/commands';
 
@@ -26,24 +26,45 @@ module('Acceptance | enterprise | sync | overview', function (hooks) {
     await authPage.login();
   });
 
-  module('when feature is activated and has pre-existing destinations', function (hooks) {
+  module('when feature is activated', function (hooks) {
     hooks.beforeEach(async function () {
       syncScenario(this.server);
     });
 
-    test('it should transition to correct routes when performing actions', async function (assert) {
-      await click(ts.navLink('Secrets Sync'));
-      await click(ts.destinations.list.create);
-      await click(ts.createCancel);
-      await click(ts.overviewCard.actionLink('Create new'));
-      await click(ts.createCancel);
-      await click(ts.overview.table.actionToggle(0));
-      await click(ts.overview.table.action('sync'));
-      await click(ts.destinations.sync.cancel);
-      await click(ts.breadcrumbLink('Secrets Sync'));
-      await click(ts.overview.table.actionToggle(0));
-      await click(ts.overview.table.action('details'));
-      assert.dom(ts.tab('Secrets')).hasClass('active', 'Navigates to secrets view for destination');
+    test('it fetches destinations and associations', async function (assert) {
+      assert.expect(2);
+
+      this.server.get('/sys/sync/destinations', () => {
+        assert.true(true, 'destinations is called');
+      });
+      this.server.get('/sys/sync/associations', () => {
+        assert.true(true, 'associations is called');
+      });
+
+      await visit('/vault/sync/secrets/overview');
+    });
+
+    module('when there are pre-existing destinations', function (hooks) {
+      hooks.beforeEach(async function () {
+        syncScenario(this.server);
+      });
+
+      test('it should transition to correct routes when performing actions', async function (assert) {
+        await click(ts.navLink('Secrets Sync'));
+        await click(ts.destinations.list.create);
+        await click(ts.createCancel);
+        await click(ts.overviewCard.actionLink('Create new'));
+        await click(ts.createCancel);
+        await waitFor(ts.overview.table.actionToggle(0));
+        await click(ts.overview.table.actionToggle(0));
+        await click(ts.overview.table.action('sync'));
+        await click(ts.destinations.sync.cancel);
+        await click(ts.breadcrumbLink('Secrets Sync'));
+        await waitFor(ts.overview.table.actionToggle(0));
+        await click(ts.overview.table.actionToggle(0));
+        await click(ts.overview.table.action('details'));
+        assert.dom(ts.tab('Secrets')).hasClass('active', 'Navigates to secrets view for destination');
+      });
     });
   });
 
@@ -74,9 +95,19 @@ module('Acceptance | enterprise | sync | overview', function (hooks) {
         wasActivatePOSTCalled = true;
         return {};
       });
+    });
 
-      // override mirage to simulate no pre-existing destinations
-      this.server.get('/sys/sync/destinations', () => {});
+    test('it does not fetch destinations and associations', async function (assert) {
+      assert.expect(0);
+
+      this.server.get('/sys/sync/destinations', () => {
+        assert.true(false, 'destinations is not called');
+      });
+      this.server.get('/sys/sync/associations', () => {
+        assert.true(false, 'associations is not called');
+      });
+
+      await visit('/vault/sync/secrets/overview');
     });
 
     test('the activation workflow works', async function (assert) {

--- a/ui/tests/integration/components/sync/secrets/page/overview-test.js
+++ b/ui/tests/integration/components/sync/secrets/page/overview-test.js
@@ -41,15 +41,16 @@ module('Integration | Component | sync | Page::Overview', function (hooks) {
 
     const store = this.owner.lookup('service:store');
     this.destinations = await store.query('sync/destination', {});
-    this.activatedFeatures = ['secrets-sync'];
+    this.isActivated = true;
 
-    this.renderComponent = () =>
-      render(
-        hbs`<Secrets::Page::Overview @destinations={{this.destinations}} @totalVaultSecrets={{7}} @activatedFeatures={{this.activatedFeatures}} @adapterError={{null}} />`,
+    this.renderComponent = () => {
+      return render(
+        hbs`<Secrets::Page::Overview @destinations={{this.destinations}} @totalVaultSecrets={{7}} @isActivated={{this.isActivated}} />`,
         {
           owner: this.engine,
         }
       );
+    };
   });
 
   test('it should render header, tabs and toolbar for overview state', async function (assert) {
@@ -69,7 +70,7 @@ module('Integration | Component | sync | Page::Overview', function (hooks) {
       this.version.type = 'community';
       this.version.features = [];
       this.destinations = [];
-      this.activatedFeatures = [];
+      this.isActivated = false;
     });
 
     test('it should show an upsell CTA', async function (assert) {
@@ -110,7 +111,7 @@ module('Integration | Component | sync | Page::Overview', function (hooks) {
 
   module('secrets sync not activated', function (hooks) {
     hooks.beforeEach(async function () {
-      this.activatedFeatures = [];
+      this.isActivated = false;
     });
 
     test('it should show the opt-in banner', async function (assert) {
@@ -162,7 +163,7 @@ module('Integration | Component | sync | Page::Overview', function (hooks) {
     });
   });
 
-  module('secrets sync activated', function () {
+  module('secrets sync is activated', function () {
     test('it should hide the opt-in banner', async function (assert) {
       await this.renderComponent();
 


### PR DESCRIPTION
Manual backport of PR #26299 