### PR TITLE
Documentation for Self Healing Auto Auth Proxy and Agent

### DIFF
--- a/website/content/docs/agent-and-proxy/autoauth/index.mdx
+++ b/website/content/docs/agent-and-proxy/autoauth/index.mdx
@@ -22,8 +22,8 @@ When Vault Agent or Vault Proxy are started with Auto-Auth enabled, it will atte
 Vault token using the configured Method. On failure, it will exponentially back
 off and then retry. On success, unless the auth method is configured to wrap
 the tokens, it will keep the resulting token renewed until renewal is no longer
-allowed. If renewal fails, the token has been revoked, or the token has exceeded the maximum number of uses,
-it will attempt to reauthenticate.
+allowed. If renewal fails, the token has been revoked, the token has exceeded the maximum number of uses,
+or the token is an otherwise invalid value, it will attempt to reauthenticate.
 
 Every time an authentication is successful, the token is written to the
 configured Sinks, subject to their configuration.

--- a/website/content/docs/agent-and-proxy/autoauth/index.mdx
+++ b/website/content/docs/agent-and-proxy/autoauth/index.mdx
@@ -22,7 +22,7 @@ When Vault Agent or Vault Proxy are started with Auto-Auth enabled, it will atte
 Vault token using the configured Method. On failure, it will exponentially back
 off and then retry. On success, unless the auth method is configured to wrap
 the tokens, it will keep the resulting token renewed until renewal is no longer
-allowed. If renewal fails, the token has been revoked, the token has exceeded the maximum number of uses,
+allowed. If renewal fails, the token has been revoked, or the token has exceeded the maximum number of uses,
 it will attempt to reauthenticate.
 
 Every time an authentication is successful, the token is written to the

--- a/website/content/docs/agent-and-proxy/autoauth/index.mdx
+++ b/website/content/docs/agent-and-proxy/autoauth/index.mdx
@@ -22,7 +22,8 @@ When Vault Agent or Vault Proxy are started with Auto-Auth enabled, it will atte
 Vault token using the configured Method. On failure, it will exponentially back
 off and then retry. On success, unless the auth method is configured to wrap
 the tokens, it will keep the resulting token renewed until renewal is no longer
-allowed or fails, at which point it will attempt to reauthenticate.
+allowed. If renewal fails, the token has been revoked, the token has exceeded the maximum number of uses,
+it will attempt to reauthenticate.
 
 Every time an authentication is successful, the token is written to the
 configured Sinks, subject to their configuration.


### PR DESCRIPTION
Documentation for how Auto Auth will self-heal for Agent and Proxy.

RFC: https://hermes.hashicorp.services/document/1yTtWJEvyoYLPkYRQ3lxs6dHmqAVyC177BMEBEXuu8fE?draft=false