### PR TITLE
Docs: Update deprecated transform command

### DIFF
--- a/website/content/docs/secrets/transform/index.mdx
+++ b/website/content/docs/secrets/transform/index.mdx
@@ -48,8 +48,7 @@ management tool.
 1. Create a transformation:
 
    ```text
-   $ vault write transform/transformation/ccn-fpe \
-     type=fpe \
+   $ vault write transform/transformations/fpe/ccn-fpe \
      template=ccn \
      tweak_source=internal \
      allowed_roles=payments

--- a/website/content/docs/secrets/transform/index.mdx
+++ b/website/content/docs/secrets/transform/index.mdx
@@ -52,7 +52,7 @@ management tool.
      template=ccn \
      tweak_source=internal \
      allowed_roles=payments
-   Success! Data written to: transform/transformation/ccn-fpe
+   Success! Data written to: transform/transformations/fpe/ccn-fpe
    ```
 
 1. Optionally, create a template:


### PR DESCRIPTION
The current docs for the transform secrets engine uses a deprecated command. Updating the command in favor of the type specific configuration endpoint.

- https://developer.hashicorp.com/vault/api-docs/secret/transform#create-update-transformation-deprecated-1-6
- https://developer.hashicorp.com/vault/api-docs/secret/transform#create-update-fpe-transformation