### PR TITLE
UI: pin async version in resolutions

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -209,6 +209,7 @@
     "xstate": "^3.3.3"
   },
   "resolutions": {
+    "async": "^2.6.4",
     "eslint-utils": "^1.4.1",
     "ember-basic-dropdown": "6.0.1",
     "highlight.js": "^10.4.1",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -7715,28 +7715,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"async@npm:^2.4.1":
-  version: 2.6.3
-  resolution: "async@npm:2.6.3"
-  dependencies:
-    lodash: ^4.17.14
-  checksum: 5e5561ff8fca807e88738533d620488ac03a5c43fce6c937451f7e35f943d33ad06c24af3f681a48cca3d2b0002b3118faff0a128dc89438a9bf0226f712c499
-  languageName: node
-  linkType: hard
-
 "async@npm:^2.6.4":
   version: 2.6.4
   resolution: "async@npm:2.6.4"
   dependencies:
     lodash: ^4.17.14
   checksum: a52083fb32e1ebe1d63e5c5624038bb30be68ff07a6c8d7dfe35e47c93fc144bd8652cbec869e0ac07d57dde387aa5f1386be3559cdee799cb1f789678d88e19
-  languageName: node
-  linkType: hard
-
-"async@npm:~0.2.9":
-  version: 0.2.10
-  resolution: "async@npm:0.2.10"
-  checksum: 9ea83419ba67dc4ecf42d4eb0d93ce0ac80a67cabb612f160ed096aef5d001e3184ec9e9be5d4dc39b2c51a34e2ae16f9b21d737068b0f615fccb4eea16d0138
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### :hammer_and_wrench: Description
Resolves the security vulnerability surfaced in: https://github.com/hashicorp/vault-enterprise/security/dependabot/108

`async` is used in many, many core places (see screenshot below), and so the most pragmatic way to ensure we're using the fixed version is to add it to the resolutions block.
<img width="647" alt="Screenshot 2024-04-09 at 4 10 33 PM" src="https://github.com/hashicorp/vault/assets/903288/7fd3baa4-354c-40d3-a1b7-a126d477703e">

### 🔗 Links
See JIRA # 25596