### PR TITLE
Bump dev dependency: follow-redirects

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -224,7 +224,8 @@
     "xmlhttprequest-ssl": "^1.6.2",
     "@embroider/macros": "^1.15.0",
     "socket.io": "^4.6.2",
-    "json5": "^1.0.2"
+    "json5": "^1.0.2",
+    "follow-redirects": "^1.14.1"
   },
   "engines": {
     "node": "18"

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -15744,13 +15744,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"follow-redirects@npm:^1.0.0":
-  version: 1.14.0
-  resolution: "follow-redirects@npm:1.14.0"
+"follow-redirects@npm:^1.14.1":
+  version: 1.15.6
+  resolution: "follow-redirects@npm:1.15.6"
   peerDependenciesMeta:
     debug:
       optional: true
-  checksum: a6568930fb97f6f4c12eac52acc109e8677d4b26fcae463bab7de50c43e44886b94784be6608dd8f2ab4b015328377fb4be2e83abd2c8d6bc39ffe1cf11f7b5a
+  checksum: a62c378dfc8c00f60b9c80cab158ba54e99ba0239a5dd7c81245e5a5b39d10f0c35e249c3379eae719ff0285fff88c365dd446fab19dee771f1d76252df1bbf5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Required by FedRAMP to move from >1.14.7.
Notes:
* Cannot bump a specific dependency.
* [Follow-redirect](https://www.npmjs.com/package/follow-redirects)s ^1.0.0 (resolved to 1.14.0) is used by http-proxy.
* 1.18.1 [Http-proxy](https://github.com/http-party/node-http-proxy/blob/master/package.json#L17), highest current version still uses ^1.0.0 of follow-redirects.
* Http-proxy is used at 1.18.1 by [ember-cli](https://github.com/ember-cli/ember-cli/blob/master/package.json#L88) highest version 5.8. 
* Added to resolution block. No resolves in yarn lock to 1.15.6.