### PR TITLE
UI: pin xmldom version in resolutions

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -224,7 +224,8 @@
     "xmlhttprequest-ssl": "^1.6.2",
     "@embroider/macros": "^1.15.0",
     "socket.io": "^4.6.2",
-    "json5": "^1.0.2"
+    "json5": "^1.0.2",
+    "@xmldom/xmldom": "^0.8.10"
   },
   "engines": {
     "node": "18"

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -7015,10 +7015,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmldom/xmldom@npm:^0.8.0":
-  version: 0.8.2
-  resolution: "@xmldom/xmldom@npm:0.8.2"
-  checksum: aeea8f670bfa52b3a1b2d355dab3bf4d58ef4969b1fd146a1ab91bf8acbb9d02953022e66e85279015a4e4027205620dfc001ed5d169b1711a09a0a079951e08
+"@xmldom/xmldom@npm:^0.8.10":
+  version: 0.8.10
+  resolution: "@xmldom/xmldom@npm:0.8.10"
+  checksum: 4c136aec31fb3b49aaa53b6fcbfe524d02a1dc0d8e17ee35bd3bf35e9ce1344560481cd1efd086ad1a4821541482528672306d5e37cdbd187f33d7fadd3e2cf0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### :hammer_and_wrench: Description
Resolves the security vulnerability surfaced in: https://github.com/hashicorp/vault-enterprise/security/dependabot/128

The vulnerability lies within `xmldom`, which is ultimately set by our version of `ember-cli` (see "before" screenshot).

Unfortunately even upgrading to `ember-cli` v 4.12.2 doesn't resolve the issue since it's still using the [version of testem](https://github.com/ember-cli/ember-cli/blob/v4.12.2/package.json#L125) that is using the vulnerable version of `xmldom`. The latest version of `testem` has the [same problem](73f0a816da ). Therefore it's best to set the `xmldom` version explicitly in the resolutions block.

I opted to pin to the latest release since it [didn't appear that any breaking changes occurred](https://github.com/xmldom/xmldom/releases).


### 📸 Screenshots
before
<img width="582" alt="Screenshot 2024-04-09 at 4 39 49 PM" src="https://github.com/hashicorp/vault/assets/903288/c6befc1b-dbcf-4515-a577-0299fed6017c">

after
<img width="563" alt="Screenshot 2024-04-09 at 4 59 57 PM" src="https://github.com/hashicorp/vault/assets/903288/86ef3e55-9eb2-4395-ac12-6ae327810908">

### 🔗 Links
See JIRA # 25217