### PR TITLE
terraform: pin to 1.7.5 until 1.8.0 crash is resolved

### DIFF
--- a/.github/workflows/enos-lint.yml
+++ b/.github/workflows/enos-lint.yml
@@ -41,6 +41,7 @@ jobs:
       - uses: hashicorp/setup-terraform@v3
         with:
           terraform_wrapper: false
+          terraform_version: "1.7.5" # Pin until 1.8.x crash has been resolved
       - uses: hashicorp/action-setup-enos@v1
         with:
           github-token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}

--- a/.github/workflows/enos-run-k8s.yml
+++ b/.github/workflows/enos-run-k8s.yml
@@ -38,6 +38,7 @@ jobs:
           # the Terraform wrapper will break Terraform execution in Enos because
           # it changes the output to text when we expect it to be JSON.
           terraform_wrapper: false
+          terraform_version: "1.7.5" # Pin until 1.8.x crash has been resolved
       - name: Set up Enos
         uses: hashicorp/action-setup-enos@v1
         with:

--- a/.github/workflows/test-ci-bootstrap.yml
+++ b/.github/workflows/test-ci-bootstrap.yml
@@ -32,6 +32,8 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.7.5" # Pin until 1.8.x crash has been resolved
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
         with:

--- a/.github/workflows/test-enos-scenario-ui.yml
+++ b/.github/workflows/test-enos-scenario-ui.yml
@@ -90,6 +90,7 @@ jobs:
         with:
           cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
           terraform_wrapper: false
+          terraform_version: "1.7.5" # Pin until 1.8.x crash has been resolved
       - name: Prepare scenario dependencies
         run: |
           mkdir -p ./enos/support/terraform-plugin-cache

--- a/.github/workflows/test-run-enos-scenario-matrix.yml
+++ b/.github/workflows/test-run-enos-scenario-matrix.yml
@@ -107,6 +107,7 @@ jobs:
           # the Terraform wrapper will break Terraform execution in Enos because
           # it changes the output to text when we expect it to be JSON.
           terraform_wrapper: false
+          terraform_version: "1.7.5" # Pin until 1.8.x crash has been resolved
       - uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_CI }}


### PR DESCRIPTION
It appears that our scenario modules have some sort of incompatibility with Terraform 1.8.0. Pin to 1.7.5 until it has been resolved.

Example: https://github.com/hashicorp/vault/actions/runs/8637615983/job/23680543071#step:10:86