### PR TITLE
Update upgrade-to-1.6.0.mdx

### DIFF
--- a/website/content/docs/upgrading/upgrade-to-1.6.0.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.6.0.mdx
@@ -1,19 +1,19 @@
 ---
 layout: docs
-page_title: Upgrading to Vault 1.6.0 - Guides
+page_title: Upgrading to Vault 1.16.1 - Guides
 description: |-
   This page contains the list of deprecations and important or breaking changes
-  for Vault 1.6.0. Please read it carefully.
+  for Vault 1.16.1. Please read it carefully.
 ---
 
 # Overview
 
 This page contains the list of deprecations and important or breaking changes
-for Vault 1.6.0 compared to 1.5. Please read it carefully.
+for Vault 1.16.0 compared to 1.15. Please read it carefully.
 
 ## Go version
 
-Vault 1.6.0 is built with Go 1.15. Please review the [Go Release
+Vault 1.16.0 is built with Go 1.15. Please review the [Go Release
 Notes](https://golang.org/doc/go1.15) for full details. A few items of
 particular note:
 
@@ -46,8 +46,8 @@ more information on upgrading custom database plugins.
 
 ## Known issues
 
-Due to the known issue, Transform Secrets Engine users are recommended to upgrade to version 1.6.4.
-Due to the known issue, Lease Count Quota users with DR Secondaries are recommended to upgrade to version 1.6.6.
+Due to the known issue, Transform Secrets Engine users are recommended to upgrade to version 1.16.4.
+Due to the known issue, Lease Count Quota users with DR Secondaries are recommended to upgrade to version 1.16.6.
 
 @include 'transform-upgrade.mdx'
 


### PR DESCRIPTION
I guess it is not right the vault version reported (e.g. 1.6.0 should be 1.16.0 and also 1.16.0 doesnt formaly exist anymore)