### PR TITLE
VAULT-24798: Audit - error tweak

### DIFF
--- a/audit/entry_filter.go
+++ b/audit/entry_filter.go
@@ -42,7 +42,7 @@ func NewEntryFilter(filter string) (*EntryFilter, error) {
 	li := logical.LogInputBexpr{}
 	_, err = eval.Evaluate(li)
 	if err != nil {
-		return nil, fmt.Errorf("filter references an unsupported field: %s: %w: %w", filter, ErrExternalOptions, err)
+		return nil, fmt.Errorf("filter references an unsupported field: %s: %w", filter, ErrExternalOptions)
 	}
 
 	return &EntryFilter{evaluator: eval}, nil


### PR DESCRIPTION
Don't wrap the underlying error on filter field validation failure.

Once the Operator has seen:
```
filter references an unsupported field: foo == bar: invalid configuration
```

... then the following 'extra' info isn't really useful at all:
```
error finding value in datum: /foo at part 0: couldn't find key: struct field with name "foo"
```

We document the filter fields for Vault Operators: [filter properties for audit devices](https://developer.hashicorp.com/vault/docs/enterprise/audit/filtering#filter-properties-for-audit-devices).

Before:
![image](https://github.com/hashicorp/vault/assets/487783/f4027893-c4ec-4c78-b5c7-b908f0b7782b)

After:
![image](https://github.com/hashicorp/vault/assets/487783/782fdf9e-6a4b-4b9c-bf44-600d4dd10a9d)

* Please ignore the sneaky `bar` in screenshots, which goes against what we document (should be `\"bar\"`)