### PR TITLE
UI: clients typescript cleanup

### DIFF
--- a/ui/app/components/clients/page/counts.ts
+++ b/ui/app/components/clients/page/counts.ts
@@ -11,21 +11,22 @@ import { parseAPITimestamp } from 'core/utils/date-formatters';
 import { filterVersionHistory, formatDateObject } from 'core/utils/client-count-utils';
 import timestamp from 'core/utils/timestamp';
 
+import type AdapterError from '@ember-data/adapter';
+import type StoreService from 'vault/services/store';
 import type VersionService from 'vault/services/version';
 import type ClientsActivityModel from 'vault/models/clients/activity';
 import type ClientsConfigModel from 'vault/models/clients/config';
 import type ClientsVersionHistoryModel from 'vault/models/clients/version-history';
-import type StoreService from 'vault/services/store';
-
 interface Args {
   activity: ClientsActivityModel;
+  activityError?: AdapterError;
   config: ClientsConfigModel;
-  versionHistory: ClientsVersionHistoryModel[];
-  startTimestamp: number;
   endTimestamp: number;
-  namespace: string;
   mountPath: string;
+  namespace: string;
   onFilterChange: CallableFunction;
+  startTimestamp: number;
+  versionHistory: ClientsVersionHistoryModel[];
 }
 
 export default class ClientsCountsPageComponent extends Component<Args> {
@@ -158,7 +159,7 @@ export default class ClientsCountsPageComponent extends Component<Args> {
         ? this.activityForNamespace?.mounts.find((mount) => mount.label === mountPath)
         : this.activityForNamespace;
     }
-    return activity.total;
+    return activity?.total;
   }
 
   @action

--- a/ui/app/routes/vault/cluster/clients.ts
+++ b/ui/app/routes/vault/cluster/clients.ts
@@ -8,13 +8,6 @@ import { hash } from 'rsvp';
 import { service } from '@ember/service';
 
 import type StoreService from 'vault/services/store';
-import type ClientsConfigModel from 'vault/models/clients/config';
-import type ClientsVersionHistoryModel from 'vault/models/clients/version-history';
-
-export interface ClientsRouteModel {
-  config: ClientsConfigModel;
-  versionHistory: ClientsVersionHistoryModel;
-}
 
 export default class ClientsRoute extends Route {
   @service declare readonly store: StoreService;

--- a/ui/app/routes/vault/cluster/clients/counts.ts
+++ b/ui/app/routes/vault/cluster/clients/counts.ts
@@ -73,7 +73,7 @@ export default class ClientsCountsRoute extends Route {
 
   async isSecretsSyncActivated(activity: ClientsActivityModel | undefined) {
     // if there are secrets, the feature is activated
-    if (activity && this._hasActivity(activity) && activity.total?.secret_syncs > 0) return true;
+    if (activity && activity.total?.secret_syncs > 0) return true;
 
     // if feature is not in license, it's definitely not activated
     if (!this.version.hasSecretsSync) return false;
@@ -121,8 +121,5 @@ export default class ClientsCountsRoute extends Route {
 
   _hasConfig(model: ClientsConfigModel | object): model is ClientsConfigModel {
     return 'billingStartTimestamp' in model;
-  }
-  _hasActivity(model: ClientsActivityModel | undefined): model is ClientsActivityModel {
-    return !!model && 'total' in model;
   }
 }

--- a/ui/app/routes/vault/cluster/clients/counts.ts
+++ b/ui/app/routes/vault/cluster/clients/counts.ts
@@ -12,35 +12,16 @@ import { getUnixTime } from 'date-fns';
 import type StoreService from 'vault/services/store';
 import type VersionService from 'vault/services/version';
 
-import type { ClientsRouteModel } from '../clients';
+import type { ModelFrom } from 'vault/vault/route';
+import type ClientsRoute from '../clients';
 import type ClientsConfigModel from 'vault/models/clients/config';
-import type ClientsVersionHistoryModel from 'vault/models/clients/version-history';
 import type ClientsActivityModel from 'vault/models/clients/activity';
-import type Controller from '@ember/controller';
-import type AdapterError from 'ember-data/adapter'; // eslint-disable-line ember/use-ember-data-rfc-395-imports
-
+import type ClientsCountsController from 'vault/controllers/vault/cluster/clients/counts';
 export interface ClientsCountsRouteParams {
   start_time?: string | number | undefined;
   end_time?: string | number | undefined;
   ns?: string | undefined;
   mountPath?: string | undefined;
-}
-
-export interface ClientsCountsRouteModel {
-  config: ClientsConfigModel;
-  versionHistory: ClientsVersionHistoryModel;
-  activity?: ClientsActivityModel;
-  activityError?: AdapterError;
-  isSecretsSyncActivated: boolean;
-  startTimestamp: number;
-  endTimestamp: number;
-}
-interface ClientsCountsController extends Controller {
-  model: ClientsCountsRouteModel;
-  start_time: number | undefined;
-  end_time: number | undefined;
-  ns: string | undefined;
-  mountPath: string | undefined;
 }
 
 interface ActivationFlagsResponse {
@@ -74,9 +55,8 @@ export default class ClientsCountsRoute extends Route {
       } catch (error) {
         activityError = error;
       }
-      return [activity, activityError];
     }
-    return [{}, null];
+    return { activity, activityError };
   }
 
   async getActivatedFeatures() {
@@ -91,9 +71,9 @@ export default class ClientsCountsRoute extends Route {
     }
   }
 
-  async isSecretsSyncActivated(activity: ClientsActivityModel) {
+  async isSecretsSyncActivated(activity: ClientsActivityModel | undefined) {
     // if there are secrets, the feature is activated
-    if (activity && activity.total?.secret_syncs > 0) return true;
+    if (activity && this._hasActivity(activity) && activity.total?.secret_syncs > 0) return true;
 
     // if feature is not in license, it's definitely not activated
     if (!this.version.hasSecretsSync) return false;
@@ -104,14 +84,18 @@ export default class ClientsCountsRoute extends Route {
   }
 
   async model(params: ClientsCountsRouteParams) {
-    const { config, versionHistory } = this.modelFor('vault.cluster.clients') as ClientsRouteModel;
-    // only enterprise versions will have a relevant billing start date, pass null so community users must select initial start time
-    const startTime = this.version.isEnterprise ? getUnixTime(config.billingStartTimestamp) : null;
+    const { config, versionHistory } = this.modelFor('vault.cluster.clients') as ModelFrom<ClientsRoute>;
+    // only enterprise versions will have a relevant billing start date, if null users must select initial start time
+    let startTime = null;
+    if (this.version.isEnterprise && this._hasConfig(config)) {
+      startTime = getUnixTime(config.billingStartTimestamp);
+    }
+
     const startTimestamp = Number(params.start_time) || startTime;
     const endTimestamp = Number(params.end_time) || getUnixTime(timestamp.now());
-    const [activity, activityError] = await this.getActivity(startTimestamp, endTimestamp);
+    const { activity, activityError } = await this.getActivity(startTimestamp, endTimestamp);
 
-    const isSecretsSyncActivated = await this.isSecretsSyncActivated(activity as ClientsActivityModel);
+    const isSecretsSyncActivated = await this.isSecretsSyncActivated(activity);
 
     return {
       activity,
@@ -133,5 +117,12 @@ export default class ClientsCountsRoute extends Route {
         mountPath: undefined,
       });
     }
+  }
+
+  _hasConfig(model: ClientsConfigModel | object): model is ClientsConfigModel {
+    return 'billingStartTimestamp' in model;
+  }
+  _hasActivity(model: ClientsActivityModel | undefined): model is ClientsActivityModel {
+    return !!model && 'total' in model;
   }
 }

--- a/ui/tests/acceptance/clients/counts-test.js
+++ b/ui/tests/acceptance/clients/counts-test.js
@@ -13,6 +13,7 @@ import authPage from 'vault/tests/pages/auth';
 import { GENERAL } from 'vault/tests/helpers/general-selectors';
 import { CLIENT_COUNT } from 'vault/tests/helpers/clients/client-count-selectors';
 import timestamp from 'core/utils/timestamp';
+import { overrideResponse } from 'vault/tests/helpers/stubs';
 
 module('Acceptance | clients | counts', function (hooks) {
   setupApplicationTest(hooks);
@@ -66,5 +67,19 @@ module('Acceptance | clients | counts', function (hooks) {
       '/vault/clients/counts/overview',
       'Query params are reset when exiting route'
     );
+  });
+
+  test('it should render empty state if no permission to query activity data', async function (assert) {
+    assert.expect(2);
+    server.get('/sys/internal/counters/activity', () => {
+      return overrideResponse(403);
+    });
+    await visit('/vault/clients/counts/overview');
+    assert.dom(GENERAL.emptyStateTitle).hasText('You are not authorized');
+    assert
+      .dom(GENERAL.emptyStateActions)
+      .hasText(
+        'You must be granted permissions to view this page. Ask your administrator if you think you should have access to the /v1/sys/internal/counters/activity endpoint.'
+      );
   });
 });

--- a/ui/tests/integration/components/clients/page/counts-test.js
+++ b/ui/tests/integration/components/clients/page/counts-test.js
@@ -16,6 +16,7 @@ import { dateDropdownSelect } from 'vault/tests/helpers/clients/client-count-hel
 import { selectChoose } from 'ember-power-select/test-support/helpers';
 import timestamp from 'core/utils/timestamp';
 import sinon from 'sinon';
+import { allowAllCapabilitiesStub } from 'vault/tests/helpers/stubs';
 
 const START_TIME = getUnixTime(LICENSE_START);
 const END_TIME = getUnixTime(STATIC_NOW);
@@ -30,6 +31,7 @@ module('Integration | Component | clients | Page::Counts', function (hooks) {
 
   hooks.beforeEach(async function () {
     clientsHandler(this.server);
+    this.server.post('/sys/capabilities-self', allowAllCapabilitiesStub());
     this.store = this.owner.lookup('service:store');
     const activityQuery = {
       start_time: { timestamp: START_TIME },


### PR DESCRIPTION
Some of the `as` typescript declarations were overriding the actual values. This cleans up some of those returns and uses the `<ModelFrom>` helper to derive the route model types (instead of explicitly defining them in the file)