### PR TITLE
fix: add missing comma to docs nav data

### DIFF
--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -224,7 +224,7 @@
       {
         "title": "Cloud access management",
         "path": "concepts/cloud-access-management"
-      }
+      },
       {
         "title": "Integrated Storage",
         "routes": [


### PR DESCRIPTION
This PR adds a comma that was missing from an array element in `website/data/docs-nav-data.json`, which causes the JSON file to be unable to be parsed.