### PR TITLE
Fix exponential backoff for api.LifetimeWatcher

### DIFF
--- a/api/lifetime_watcher.go
+++ b/api/lifetime_watcher.go
@@ -349,8 +349,11 @@ func (r *LifetimeWatcher) doRenewWithOptions(tokenMode bool, nonRenewable bool, 
 
 		if errorBackoff == nil {
 			sleepDuration = r.calculateSleepDuration(remainingLeaseDuration, priorDuration)
-		} else if errorBackoff.NextBackOff() == backoff.Stop {
-			return err
+		} else {
+			sleepDuration = errorBackoff.NextBackOff()
+			if sleepDuration == backoff.Stop {
+				return err
+			}
 		}
 
 		// remainingLeaseDuration becomes the priorDuration for the next loop

--- a/changelog/26383.txt
+++ b/changelog/26383.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+api: fixed a bug where LifetimeWatcher routines weren't respecting exponential backoff in the presence of unexpected errors
+```


### PR DESCRIPTION
I just opened up a bug for this PR, this fixes it. Here's the original context from the bug:

**Describe the bug**
We were using the Vault `LifetimeWatcher` from the `api` package in an internal project and noticed an issue with the backoff behavior of token renewal that was causing a bunch of our tests to fail when we upgraded to a new version of Vault.

The bug is here:

https://github.com/hashicorp/vault/blob/1274f2d79a1ae6f589ad64af2c1ab930545943c0/api/lifetime_watcher.go#L348-L354

`sleepDuration` appears to be the `time.Duration` used prior to re-running the renewal loop. In the case when `errBackoff` is `nil`, then a simple backoff duration is calculated based on the call to `calculateSleepDuration`. If `errBackoff` is **not nil** then `sleepDuration` is never set and the timeout in the following select block immediately fires again.

In our testing environment this was caught because our mock Vault server was returning an invalid response, so the renew operation was failing and we were getting an inordinate amount of immediate retries.

The fix is just refactoring the above block to capture the `errBackoff.NextBackoff()` value as `sleepDuration`.

fixes: https://github.com/hashicorp/vault/issues/26382