### PR TITLE
plugin/wif: support external plugins

### DIFF
--- a/changelog/26384.txt
+++ b/changelog/26384.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+plugin/wif: fix a bug where the namespace was not set for external plugins using workload identity federation
+```

--- a/sdk/plugin/grpc_system.go
+++ b/sdk/plugin/grpc_system.go
@@ -421,7 +421,7 @@ func (s *gRPCSystemViewServer) GenerateIdentityToken(ctx context.Context, req *p
 	})
 	if err != nil {
 		return &pb.GenerateIdentityTokenResponse{}, status.Errorf(codes.Internal,
-			"failed to generate plugin identity token")
+			err.Error())
 	}
 
 	return &pb.GenerateIdentityTokenResponse{


### PR DESCRIPTION
We need to set the namespace on the context for external plugins. Otherwise, we won't be able to fetch the storage entry.