### PR TITLE
Agent: helper func tweak

### DIFF
--- a/command/agent_test.go
+++ b/command/agent_test.go
@@ -488,7 +488,6 @@ func TestAgent_NoAutoAuthTokenIfNotConfigured(t *testing.T) {
 
 	// Create token file
 	tokenFileName := makeTempFile(t, "token-file", serverClient.Token())
-	defer os.Remove(tokenFileName)
 
 	sinkFileName := makeTempFile(t, "sink-file", "")
 
@@ -531,7 +530,6 @@ vault {
 %s
 `, serverClient.Address(), apiProxyConfig, listenConfig, autoAuthConfig)
 	configPath := makeTempFile(t, "config.hcl", config)
-	defer os.Remove(configPath)
 
 	// Start proxy
 	ui, cmd := testAgentCommand(t, logger)

--- a/command/agent_test.go
+++ b/command/agent_test.go
@@ -1358,16 +1358,28 @@ func request(t *testing.T, client *api.Client, req *api.Request, expectedStatusC
 	return body
 }
 
-// makeTempFile creates a temp file and populates it.
+// makeTempFile creates a temp file with the specified name, populates it with the
+// supplied contents and closes it. The path to the file is returned, also the file
+// will be automatically removed when the test which created it, finishes.
 func makeTempFile(t *testing.T, name, contents string) string {
 	t.Helper()
-	f, err := os.CreateTemp("", name)
+
+	f, err := os.Create(filepath.Join(t.TempDir(), name))
 	if err != nil {
 		t.Fatal(err)
 	}
 	path := f.Name()
-	f.WriteString(contents)
-	f.Close()
+
+	_, err = f.WriteString(contents)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = f.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	return path
 }
 

--- a/command/proxy_test.go
+++ b/command/proxy_test.go
@@ -274,7 +274,6 @@ capabilities = ["deny"]
 
 	// Create token file
 	tokenFileName := makeTempFile(t, "token-file", firstToken)
-	defer os.Remove(tokenFileName)
 
 	sinkf, err := os.CreateTemp("", "sink.test.")
 	if err != nil {
@@ -319,7 +318,6 @@ auto_auth {
 	%s
 	`, serverClient.Address(), listenConfig, autoAuthConfig)
 	configPath := makeTempFile(t, "config.hcl", config)
-	defer os.Remove(configPath)
 
 	// Unset the environment variable so that proxy picks up the right test
 	// cluster address
@@ -430,7 +428,6 @@ func TestProxy_NoTriggerAutoAuth_ProxyTokenNotAutoAuth(t *testing.T) {
 
 	// Create token file
 	tokenFileName := makeTempFile(t, "token-file", firstToken)
-	defer os.Remove(tokenFileName)
 
 	sinkf, err := os.CreateTemp("", "sink.test.")
 	if err != nil {
@@ -476,7 +473,6 @@ auto_auth {
 	%s
 	`, serverClient.Address(), listenConfig, autoAuthConfig)
 	configPath := makeTempFile(t, "config.hcl", config)
-	defer os.Remove(configPath)
 
 	// Unset the environment variable so that proxy picks up the right test
 	// cluster address
@@ -595,7 +591,6 @@ func TestProxy_ReTriggerAutoAuth_ForceAutoAuthToken(t *testing.T) {
 
 	// Create token file
 	tokenFileName := makeTempFile(t, "token-file", firstToken)
-	defer os.Remove(tokenFileName)
 
 	sinkf, err := os.CreateTemp("", "sink.test.")
 	if err != nil {
@@ -641,7 +636,6 @@ auto_auth {
 	%s
 	`, serverClient.Address(), listenConfig, autoAuthConfig)
 	configPath := makeTempFile(t, "config.hcl", config)
-	defer os.Remove(configPath)
 
 	// Unset the environment variable so that proxy picks up the right test
 	// cluster address
@@ -789,8 +783,6 @@ func TestProxy_ReTriggerAutoAuth_ProxyIsAutoAuthToken(t *testing.T) {
 	// Write the RoleID and SecretID to temp files
 	roleIDPath := makeTempFile(t, "role_id.txt", roleID+"\n")
 	secretIDPath := makeTempFile(t, "secret_id.txt", secretID+"\n")
-	defer os.Remove(roleIDPath)
-	defer os.Remove(secretIDPath)
 
 	sinkf, err := os.CreateTemp("", "sink.test.")
 	if err != nil {
@@ -837,7 +829,6 @@ api_proxy {
 %s
 `, serverClient.Address(), listenConfig, autoAuthConfig)
 	configPath := makeTempFile(t, "config.hcl", config)
-	defer os.Remove(configPath)
 
 	// Unset the environment variable so that proxy picks up the right test
 	// cluster address
@@ -988,8 +979,6 @@ func TestProxy_ReTriggerAutoAuth_RevokedToken(t *testing.T) {
 	// Write the RoleID and SecretID to temp files
 	roleIDPath := makeTempFile(t, "role_id.txt", roleID+"\n")
 	secretIDPath := makeTempFile(t, "secret_id.txt", secretID+"\n")
-	defer os.Remove(roleIDPath)
-	defer os.Remove(secretIDPath)
 
 	sinkf, err := os.CreateTemp("", "sink.test.")
 	if err != nil {
@@ -1036,7 +1025,6 @@ api_proxy {
 %s
 `, serverClient.Address(), listenConfig, autoAuthConfig)
 	configPath := makeTempFile(t, "config.hcl", config)
-	defer os.Remove(configPath)
 
 	// Unset the environment variable so that proxy picks up the right test
 	// cluster address
@@ -1192,8 +1180,6 @@ func TestProxy_AutoAuth_UserAgent(t *testing.T) {
 	// Write the RoleID and SecretID to temp files
 	roleIDPath := makeTempFile(t, "role_id.txt", roleID+"\n")
 	secretIDPath := makeTempFile(t, "secret_id.txt", secretID+"\n")
-	defer os.Remove(roleIDPath)
-	defer os.Remove(secretIDPath)
 
 	sinkf, err := os.CreateTemp("", "sink.test.")
 	if err != nil {
@@ -1240,7 +1226,6 @@ api_proxy {
 %s
 `, serverClient.Address(), listenConfig, autoAuthConfig)
 	configPath := makeTempFile(t, "config.hcl", config)
-	defer os.Remove(configPath)
 
 	// Unset the environment variable so that proxy picks up the right test
 	// cluster address
@@ -1336,7 +1321,6 @@ vault {
 %s
 `, serverClient.Address(), listenConfig)
 	configPath := makeTempFile(t, "config.hcl", config)
-	defer os.Remove(configPath)
 
 	// Start the proxy
 	_, cmd := testProxyCommand(t, logger)
@@ -1428,7 +1412,6 @@ vault {
 %s
 `, serverClient.Address(), listenConfig, cacheConfig)
 	configPath := makeTempFile(t, "config.hcl", config)
-	defer os.Remove(configPath)
 
 	// Start the proxy
 	_, cmd := testProxyCommand(t, logger)
@@ -1506,7 +1489,6 @@ vault {
 %s
 `, serverClient.Address(), cacheConfig, listenConfig)
 	configPath := makeTempFile(t, "config.hcl", config)
-	defer os.Remove(configPath)
 
 	// Start proxy
 	_, cmd := testProxyCommand(t, logger)
@@ -1679,7 +1661,6 @@ vault {
 %s
 `, serverClient.Address(), retryConf, cacheConfig, listenConfig)
 			configPath := makeTempFile(t, "config.hcl", config)
-			defer os.Remove(configPath)
 
 			_, cmd := testProxyCommand(t, logger)
 			cmd.startedCh = make(chan struct{})
@@ -1752,7 +1733,6 @@ listener "tcp" {
 }
 `, listenAddr)
 	configPath := makeTempFile(t, "config.hcl", config)
-	defer os.Remove(configPath)
 
 	ui, cmd := testProxyCommand(t, logger)
 	cmd.client = serverClient
@@ -1842,7 +1822,6 @@ cache {}
 `, serverClient.Address(), listenAddr, listenAddr2)
 
 	configPath := makeTempFile(t, "config.hcl", config)
-	defer os.Remove(configPath)
 
 	_, cmd := testProxyCommand(t, nil)
 	cmd.startedCh = make(chan struct{})

--- a/command/proxy_test.go
+++ b/command/proxy_test.go
@@ -1511,7 +1511,6 @@ func TestProxy_NoAutoAuthTokenIfNotConfigured(t *testing.T) {
 
 	// Create token file
 	tokenFileName := makeTempFile(t, "token-file", serverClient.Token())
-	defer os.Remove(tokenFileName)
 
 	sinkFileName := makeTempFile(t, "sink-file", "")
 
@@ -1554,7 +1553,6 @@ vault {
 %s
 `, serverClient.Address(), apiProxyConfig, listenConfig, autoAuthConfig)
 	configPath := makeTempFile(t, "config.hcl", config)
-	defer os.Remove(configPath)
 
 	// Start proxy
 	ui, cmd := testProxyCommand(t, logger)


### PR DESCRIPTION
`makeTempFile` now uses `t.TempDir()` so it will remove files for you when your test finishes.