### PR TITLE
[docs] Clarify that Login MFA is not supported for token auth

### DIFF
--- a/website/content/docs/auth/login-mfa/index.mdx
+++ b/website/content/docs/auth/login-mfa/index.mdx
@@ -17,6 +17,8 @@ Login MFA is built on top of the Identity system of Vault.
 
 MFA in Vault includes the following login types:
 
+~> **NOTE:** The [Token](/vault/docs/auth/token) auth method cannot be configured with Vault's built-in Login MFA feature.
+
 - `Time-based One-time Password (TOTP)` - If configured and enabled on a login path,
   this would require a TOTP passcode along with a Vault token to be presented
   while invoking the API login request. The passcode will be validated against the

--- a/website/content/docs/auth/token.mdx
+++ b/website/content/docs/auth/token.mdx
@@ -6,6 +6,8 @@ description: The token store auth method is used to authenticate using tokens.
 
 # Token auth method
 
+~> **NOTE:** The Token auth method cannot be configured with Vault's built-in [Login MFA](/vault/docs/auth/login-mfa) feature.
+
 The `token` auth method is built-in and automatically available at `/auth/token`. It
 allows users to authenticate using a token, as well to create new tokens, revoke
 secrets by token, and more.


### PR DESCRIPTION
The [Token auth method](https://developer.hashicorp.com/vault/docs/auth/token) does not support [Login MFA](https://developer.hashicorp.com/vault/docs/auth/login-mfa). This PR adds two callouts on each of the linked pages.

Vercel preview:
- [Token auth method](https://vault-pxfk2h1vw-hashicorp.vercel.app/vault/docs/auth/token)
- [Login MFA](https://vault-pxfk2h1vw-hashicorp.vercel.app/vault/docs/auth/login-mfa)