### PR TITLE
fix: don't show an undefined error in flash msg when unsyncing

### DIFF
--- a/ui/app/adapters/sync/association.js
+++ b/ui/app/adapters/sync/association.js
@@ -82,9 +82,14 @@ export default class SyncAssociationAdapter extends ApplicationAdapter {
       const association = Object.values(resp.data.associated_secrets).find((association) => {
         return association.mount === data.mount && association.secret_name === data.secret_name;
       });
+
+      // generate an id if an association is found
+      // (an association may not be found if the secret is being unsynced)
+      const id = association ? serializer.generateId(association) : undefined;
+
       return {
         ...association,
-        id: serializer.generateId(association),
+        id,
         destinationName: resp.data.store_name,
         destinationType: resp.data.store_type,
       };


### PR DESCRIPTION
### :hammer_and_wrench: Description
Fixes a broken flash message when unsyncing a secret.

### 🔗 Links


### :camera_flash: Screenshots
<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td>

<img width="856" alt="Screenshot 2024-04-15 at 12 01 17 PM" src="https://github.com/hashicorp/vault/assets/903288/0fdec706-eaea-4c6f-8093-8a6f48d9f7c6">


</td>

<td>

![image](https://github.com/hashicorp/vault/assets/903288/d726079d-8ccb-4faf-9c63-e10b10ea4409)

</td>
</tr>
</table>


### :building_construction: How to Build and Test the Change
1. create a KV v2 secret
2. Go to secret syncs and create a Github destination
3. Sync a secret to the destination
4. Unsync the destination
5. No more flash error! 🎉