### PR TITLE
Clarify the wording of AWS auth docs around alias source

### DIFF
--- a/website/content/api-docs/auth/aws.mdx
+++ b/website/content/api-docs/auth/aws.mdx
@@ -204,7 +204,7 @@ This configures the way that Vault interacts with the
 
 - `iam_alias` `(string: "role_id")` - How to generate the identity alias when
   using the `iam` auth method. Valid choices are `role_id`, `unique_id`, and
-  `full_arn` When `role_id` is selected, the randomly generated ID of the role
+  `full_arn` When `role_id` is selected, the randomly generated ID of the Vault role
   is used. When `unique_id` is selected, the [IAM Unique
   ID](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers#identifiers-unique-ids)
   of the IAM principal (either the user or role) is used as the identity alias
@@ -229,7 +229,7 @@ This configures the way that Vault interacts with the
 - `ec2_alias` `(string: "role_id")` - Configures how to generate the identity
   alias when using the `ec2` auth method. Valid choices are `role_id`,
   `instance_id`, and `image_id`. When `role_id` is selected, the randomly
-  generated ID of the role is used. When `instance_id` is selected, the
+  generated ID of the Vault role is used. When `instance_id` is selected, the
   instance identifier is used as the identity alias name. When `image_id` is
   selected, AMI ID of the instance is used as the identity alias name.
 

--- a/website/content/partials/authn-names.mdx
+++ b/website/content/partials/authn-names.mdx
@@ -1,24 +1,24 @@
 In addition to custom authentication methods configured with secure plugins,
 Vault supports many standardized authentication methods by default.
 
-| AuthN method                                                            | Unique ID                                    | Configured with  |
-|-------------------------------------------------------------------------|----------------------------------------------|------------------|
-| [AliCloud](/vault/docs/auth/alicloud)                                   | Principal ID                                 | Not configurable |
-| [AppRole](/vault/api-docs/auth/approle#create-update-approle)           | Role ID                                      | Not configurable |
-| [AWS IAM](/vault/docs/auth/aws#iam-auth-method)                         | Role ID (default), IAM unique ID, Full ARN   | `iam_alias`      |
-| [AWS EC2](/vault/docs/auth/aws#ec2-auth-method)                         | Role ID (default), EC2 instance ID, AMI ID   | `ec2_alias`      |
-| [Azure](/vault/api-docs/auth/azure#create-role)                         | Subject (from JWT claim)                     | Not configurable |
-| [Cloud Foundry](/vault/docs/auth/cf)                                    | App ID                                       | Not configurable |
-| [GitHub](/vault/docs/auth/github)                                       | User login name associated with token        | Not configurable |
-| [Google Cloud](/vault/api-docs/auth/gcp#create-role)                    | Role ID (default), Service account unique ID | `iam_alias`      |
-| [JWT/OIDC](/vault/api-docs/auth/jwt#create-role)                        | The presented claims (no default value)      | `user_claim`     |
-| [Kerberos](/vault/docs/auth/kerberos)                                   | Username                                     | Not configurable |
-| [Kubernetes](/vault/api-docs/auth/kubernetes#create-role)               | Service account UID                          | Not configurable |
-| [LDAP](/vault/docs/auth/ldap)                                           | Username                                     | Not configurable |
-| [OCI](/vault/api-docs/auth/oci#create-role)                             | Rolename                                     | Not configurable |
-| [Okta](/vault/api-docs/auth/okta#register-user)                         | Username                                     | Not configurable |
-| [RADIUS](/vault/docs/auth/radius)                                       | Username                                     | Not configurable |
-| [SAML](/vault/docs/auth/saml)                                           | Assertion Subject                            | Not configurable |
-| [TLS Certificate](/vault/api-docs/auth/cert#create-ca-certificate-role) | Subject CommonName                           | Not configurable |
-| [Token](/vault/docs/auth/token)                                         | `entity_alias`                               | Not configurable |
-| [Username/Password](/vault/api-docs/auth/userpass#create-update-user)   | Username                                     | Not configurable |
+| AuthN method                                                            | Unique ID                                        | Configured with  |
+|-------------------------------------------------------------------------|--------------------------------------------------|------------------|
+| [AliCloud](/vault/docs/auth/alicloud)                                   | Principal ID                                     | Not configurable |
+| [AppRole](/vault/api-docs/auth/approle#create-update-approle)           | Role ID                                          | Not configurable |
+| [AWS IAM](/vault/docs/auth/aws#iam-auth-method)                         | Vault Role ID (default), IAM unique ID, Full ARN | `iam_alias`      |
+| [AWS EC2](/vault/docs/auth/aws#ec2-auth-method)                         | Vault Role ID (default), EC2 instance ID, AMI ID | `ec2_alias`      |
+| [Azure](/vault/api-docs/auth/azure#create-role)                         | Subject (from JWT claim)                         | Not configurable |
+| [Cloud Foundry](/vault/docs/auth/cf)                                    | App ID                                           | Not configurable |
+| [GitHub](/vault/docs/auth/github)                                       | User login name associated with token            | Not configurable |
+| [Google Cloud](/vault/api-docs/auth/gcp#create-role)                    | Role ID (default), Service account unique ID     | `iam_alias`      |
+| [JWT/OIDC](/vault/api-docs/auth/jwt#create-role)                        | The presented claims (no default value)          | `user_claim`     |
+| [Kerberos](/vault/docs/auth/kerberos)                                   | Username                                         | Not configurable |
+| [Kubernetes](/vault/api-docs/auth/kubernetes#create-role)               | Service account UID                              | Not configurable |
+| [LDAP](/vault/docs/auth/ldap)                                           | Username                                         | Not configurable |
+| [OCI](/vault/api-docs/auth/oci#create-role)                             | Rolename                                         | Not configurable |
+| [Okta](/vault/api-docs/auth/okta#register-user)                         | Username                                         | Not configurable |
+| [RADIUS](/vault/docs/auth/radius)                                       | Username                                         | Not configurable |
+| [SAML](/vault/docs/auth/saml)                                           | Assertion Subject                                | Not configurable |
+| [TLS Certificate](/vault/api-docs/auth/cert#create-ca-certificate-role) | Subject CommonName                               | Not configurable |
+| [Token](/vault/docs/auth/token)                                         | `entity_alias`                                   | Not configurable |
+| [Username/Password](/vault/api-docs/auth/userpass#create-update-user)   | Username                                         | Not configurable |


### PR DESCRIPTION
The current docs about the entity alias for AWS Auth are a bit vague, saying the "role" ID is used. This PR adds an explicit mention that it's the _Vault_ role ID which is used, and not the AWS Role ID.