### PR TITLE
Fix incorrectly deferred unlock in Consul service registration

### DIFF
--- a/serviceregistration/consul/consul_service_registration.go
+++ b/serviceregistration/consul/consul_service_registration.go
@@ -402,9 +402,9 @@ func (c *serviceRegistration) runEventDemuxer(waitGroup *sync.WaitGroup, shutdow
 						}
 
 						c.serviceLock.Lock()
-						defer c.serviceLock.Unlock()
-
 						registeredServiceID = serviceID
+						c.serviceLock.Unlock()
+
 						return
 					}
 				}()


### PR DESCRIPTION
I spotted this as part of investigating an escalation. It wasn't the issue in the escalation but it felt like an easy win to just fix this after seeing it as opposed to waiting for it to cause a deadlock somewhere.

This defer is called as part of a for loop, which can cause problems, and the intent seems to be just for that line, so it makes sense to make it explicit.