### PR TITLE
CE changes for https://github.com/hashicorp/vault-enterprise/pull/569…

### DIFF
--- a/physical/raft/raft.go
+++ b/physical/raft/raft.go
@@ -37,7 +37,6 @@ import (
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/hashicorp/vault/sdk/physical"
 	"github.com/hashicorp/vault/vault/cluster"
-	"github.com/hashicorp/vault/version"
 	etcdbolt "go.etcd.io/bbolt"
 )
 
@@ -600,7 +599,10 @@ func (b *RaftBackend) NonVoter() bool {
 	return b.nonVoter
 }
 
-func (b *RaftBackend) EffectiveVersion() string {
+// UpgradeVersion returns the string that should be used by autopilot during automated upgrades. We return the
+// specified upgradeVersion if it's present. If it's not, we fall back to effectiveSDKVersion, which is
+// Vault's binary version (though that can be overridden for tests).
+func (b *RaftBackend) UpgradeVersion() string {
 	b.l.RLock()
 	defer b.l.RUnlock()
 
@@ -608,7 +610,7 @@ func (b *RaftBackend) EffectiveVersion() string {
 		return b.upgradeVersion
 	}
 
-	return version.GetVersion().Version
+	return b.effectiveSDKVersion
 }
 
 // DisableUpgradeMigration returns the state of the DisableUpgradeMigration config flag and whether it was set or not

--- a/physical/raft/raft_autopilot.go
+++ b/physical/raft/raft_autopilot.go
@@ -408,7 +408,8 @@ func (d *Delegate) KnownServers() map[raft.ServerID]*autopilot.Server {
 		}
 
 		// If version isn't found in the state, fake it using the version from the leader so that autopilot
-		// doesn't demote the node to a non-voter, just because of a missed heartbeat.
+		// doesn't demote the node to a non-voter, just because of a missed heartbeat. Note that this should
+		// be the SDK version, not the upgrade version.
 		currentServerID := raft.ServerID(id)
 		followerVersion := state.Version
 		leaderVersion := d.effectiveSDKVersion
@@ -465,7 +466,7 @@ func (d *Delegate) KnownServers() map[raft.ServerID]*autopilot.Server {
 		NodeStatus:  autopilot.NodeAlive,
 		NodeType:    autopilot.NodeVoter, // The leader must be a voter
 		Meta: d.meta(&FollowerState{
-			UpgradeVersion: d.EffectiveVersion(),
+			UpgradeVersion: d.UpgradeVersion(),
 			RedundancyZone: d.RedundancyZone(),
 		}),
 		Version:  d.effectiveSDKVersion,

--- a/vault/ha.go
+++ b/vault/ha.go
@@ -109,7 +109,7 @@ func (c *Core) getHAMembers() ([]HAStatusNode, error) {
 	}
 
 	if rb := c.getRaftBackend(); rb != nil {
-		leader.UpgradeVersion = rb.EffectiveVersion()
+		leader.UpgradeVersion = rb.UpgradeVersion()
 		leader.RedundancyZone = rb.RedundancyZone()
 	}
 

--- a/vault/request_forwarding_rpc.go
+++ b/vault/request_forwarding_rpc.go
@@ -151,7 +151,7 @@ func (c *forwardingClient) startHeartbeat() {
 				req.RaftTerm = raftBackend.Term()
 				req.RaftDesiredSuffrage = raftBackend.DesiredSuffrage()
 				req.RaftRedundancyZone = raftBackend.RedundancyZone()
-				req.RaftUpgradeVersion = raftBackend.EffectiveVersion()
+				req.RaftUpgradeVersion = raftBackend.UpgradeVersion()
 				labels = append(labels, metrics.Label{Name: "peer_id", Value: raftBackend.NodeID()})
 			}
 


### PR DESCRIPTION
Original PR here https://github.com/hashicorp/vault/pull/26449

This had to be done manually because of a conflict in `vault/raft.go`. Note that the changes that were made to that file in this backport is just a reordering of statements to match the order in the original PR. No actual code changes.