### PR TITLE
Adapt CI to use new filenames for misspell releases

### DIFF
--- a/.github/actions/set-up-misspell/action.yml
+++ b/.github/actions/set-up-misspell/action.yml
@@ -50,10 +50,10 @@ runs:
         ARCH="$(echo "$RUNNER_ARCH" | tr '[:upper:]' '[:lower:]')"
         OS="$(echo "$RUNNER_OS" | tr '[:upper:]' '[:lower:]')"
         if [ "$ARCH" = "x64" ]; then
-          export ARCH="64bit"
+          export ARCH="amd64"
         fi
         if [ "$OS" = "macos" ]; then
-          export OS="mac"
+          export OS="darwin"
         fi
 
         mkdir -p tmp


### PR DESCRIPTION
The upstream golangci/misspell has modified the asset's filenames within their v0.5.0 release.

v0.5.0 changed mac to darwin and the 64bit to amd64

