### PR TITLE
[UI] Clarify total secrets on Sync overview page

### DIFF
--- a/ui/lib/sync/addon/components/secrets/page/overview.hbs
+++ b/ui/lib/sync/addon/components/secrets/page/overview.hbs
@@ -173,7 +173,7 @@
     </OverviewCard>
     <OverviewCard
       @cardTitle="Total secrets"
-      @subText="The total number of secrets that have been synced from Vault. One secret will be counted as one sync client."
+      @subText="The total number of secrets that have been synced from Vault over time. One secret will be counted as one sync client."
       @actionText="View billing"
       @actionTo="clientCountOverview"
       @actionExternal={{true}}

--- a/ui/tests/integration/components/sync/secrets/page/overview-test.js
+++ b/ui/tests/integration/components/sync/secrets/page/overview-test.js
@@ -288,7 +288,7 @@ module('Integration | Component | sync | Page::Overview', function (hooks) {
         {
           cardTitle: 'Total secrets',
           subText:
-            'The total number of secrets that have been synced from Vault. One secret will be counted as one sync client.',
+            'The total number of secrets that have been synced from Vault over time. One secret will be counted as one sync client.',
           actionText: 'View billing',
           count: '7',
         },


### PR DESCRIPTION
### :hammer_and_wrench: Description
Clarify that total secrets refers to total secrets of all time.


### :camera_flash: Screenshots
<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td>

![Vault 26159 Sync Overview](https://github.com/hashicorp/vault/assets/903288/c5c3fbb8-5d2a-456f-a981-5195cc44e8fe)


</td>

<td>

![image](https://github.com/hashicorp/vault/assets/903288/c5b6942e-29a6-465c-a85e-3e7c41b39d73)


</td>
</tr>

<tr>
</table>


### :building_construction: How to Build and Test the Change
Running against mirage (or a cluster that contains secrets sync data), visit the secrets sync overview page. Note the total # of secrets card.