### PR TITLE
Update userpass validations to handle password_hash

### DIFF
--- a/changelog/26577.txt
+++ b/changelog/26577.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: Update userpass user form to allow setting `password_hash` field.
+```

--- a/ui/app/components/generated-item.js
+++ b/ui/app/components/generated-item.js
@@ -35,8 +35,27 @@ export default Component.extend({
   props: computed('model', function () {
     return this.model.serialize();
   }),
+  validateForm() {
+    // Only validate on new models because blank passwords will not be updated
+    // in practice this only happens for userpass users
+    if (this.model.validate && this.model.isNew) {
+      const { isValid, state } = this.model.validate();
+      this.setProperties({
+        modelValidations: state,
+        isFormInvalid: !isValid,
+      });
+      return isValid;
+    } else {
+      this.set('isFormInvalid', false);
+      return true;
+    }
+  },
   saveModel: task(
     waitFor(function* () {
+      const isValid = this.validateForm();
+      if (!isValid) {
+        return;
+      }
       try {
         yield this.model.save();
       } catch (err) {
@@ -71,16 +90,6 @@ export default Component.extend({
   actions: {
     onKeyUp(name, value) {
       this.model.set(name, value);
-      if (this.model.validate) {
-        // Set validation error message for updated attribute
-        const { isValid, state } = this.model.validate();
-        this.setProperties({
-          modelValidations: state,
-          isFormInvalid: !isValid,
-        });
-      } else {
-        this.set('isFormInvalid', false);
-      }
     },
     deleteItem() {
       this.model.destroyRecord().then(() => {

--- a/ui/app/services/path-help.js
+++ b/ui/app/services/path-help.js
@@ -27,6 +27,7 @@ import {
   pathToHelpUrlSegment,
   reducePathsByPathName,
 } from 'vault/utils/openapi-helpers';
+import { isPresent } from '@ember/utils';
 
 export default class PathHelpService extends Service {
   @service store;
@@ -272,16 +273,19 @@ export default class PathHelpService extends Service {
           // Build and add validations on model
           // NOTE: For initial phase, initialize validations only for user pass auth
           if (backend === 'userpass') {
-            const validations = fieldGroups.reduce((obj, element) => {
-              if (element.default) {
-                element.default.forEach((v) => {
-                  const key = v.options.fieldValue || v.name;
-                  obj[key] = [{ type: 'presence', message: `${v.name} can't be blank` }];
-                });
-              }
-              return obj;
-            }, {});
-
+            const validations = {
+              password: [
+                {
+                  validator(model) {
+                    return (
+                      !(isPresent(model.password) && isPresent(model.passwordHash)) &&
+                      (isPresent(model.password) || isPresent(model.passwordHash))
+                    );
+                  },
+                  message: 'You must provide either password or password hash, but not both.',
+                },
+              ],
+            };
             newModel = withModelValidations(validations)(class GeneratedItemModel extends newModel {});
           }
         }

--- a/ui/app/templates/components/generated-item.hbs
+++ b/ui/app/templates/components/generated-item.hbs
@@ -59,12 +59,7 @@
     <div class="box is-sideless is-fullwidth is-marginless">
       <NamespaceReminder @mode="save" @noun={{this.itemType}} />
       <MessageError @model={{this.model}} />
-      <FormFieldGroups
-        @model={{this.model}}
-        @mode={{this.mode}}
-        @onKeyUp={{action "onKeyUp"}}
-        @modelValidations={{this.modelValidations}}
-      />
+      <FormFieldGroups @model={{this.model}} @mode={{this.mode}} @modelValidations={{this.modelValidations}} />
     </div>
     <div class="field is-grouped-split box is-fullwidth is-bottomless">
       <Hds::ButtonSet>


### PR DESCRIPTION
Userpass has a new way of adding or updating the user's password: `password_hash`. This PR updates the validation on userpass auth method in the following ways:
* move the validation check to on submit instead of key up, to match how our other forms work 
* If editing a user, skip validation and let the API return the error if there is one
* If password AND password_hash are blank on a new user, show the validation message and prevent API request
* If password AND password_hash are present on a new user, show the validation message and prevent API request

![9f37e251ab0cd46151ee0c5cb764090e](https://github.com/hashicorp/vault/assets/82459713/84bbaa5f-bb6a-4ff5-9c21-5a6cea08660c)

- [ ] Ent tests pass