### PR TITLE
Transit operations on CMAC key types should fail on CE

### DIFF
--- a/builtin/logical/transit/path_cmac_ce.go
+++ b/builtin/logical/transit/path_cmac_ce.go
@@ -13,5 +13,5 @@ import (
 )
 
 func (b *backend) pathCMACVerify(_ context.Context, _ *logical.Request, _ *framework.FieldData) (*logical.Response, error) {
-	return logical.ErrorResponse("CMAC verification is only available in enterprise versions of Vault"), nil
+	return logical.ErrorResponse(ErrCmacEntOnly.Error()), nil
 }

--- a/builtin/logical/transit/path_keys.go
+++ b/builtin/logical/transit/path_keys.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/fatih/structs"
+	"github.com/hashicorp/vault/helper/constants"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/helper/keysutil"
 	"github.com/hashicorp/vault/sdk/logical"
@@ -246,6 +247,10 @@ func (b *backend) pathPolicyWrite(ctx context.Context, req *logical.Request, d *
 		}
 
 		polReq.ManagedKeyUUID = keyId
+	}
+
+	if polReq.KeyType.CMACSupported() && !constants.IsEnterprise {
+		return logical.ErrorResponse(ErrCmacEntOnly.Error()), logical.ErrInvalidRequest
 	}
 
 	p, upserted, err := b.GetPolicy(ctx, polReq, b.GetRandomReader())


### PR DESCRIPTION
 - Due to the amount of shared code for various key operations, have a general failure mechanism for CMAC key types within Transit when operating in CE