### PR TITLE
UI: add monthly new chart to sync clients tab

### DIFF
--- a/ui/app/components/clients/page/acme.hbs
+++ b/ui/app/components/clients/page/acme.hbs
@@ -27,6 +27,7 @@
         @label="Total ACME clients"
         @subText="The total number of ACME requests made to Vault during this time period."
         @value={{this.totalUsageCounts.acme_clients}}
+        @tooltipText="This number is the total for the queried date range. The chart displays a monthly breakdown of total clients per month."
         @size="l"
       />
     </:subTitle>

--- a/ui/app/components/clients/page/sync.hbs
+++ b/ui/app/components/clients/page/sync.hbs
@@ -67,7 +67,7 @@
           {{#let (this.average this.byMonthNewClients "secret_syncs") as |avg|}}
             {{#if avg}}
               <StatText
-                @label="Average new secret sync clients per month"
+                @label="Average new sync clients per month"
                 @value={{avg}}
                 @size="m"
                 class="chart-subTitle has-top-padding-l"

--- a/ui/app/components/clients/page/sync.hbs
+++ b/ui/app/components/clients/page/sync.hbs
@@ -3,12 +3,21 @@
   SPDX-License-Identifier: BUSL-1.1
 ~}}
 {{#if @isSecretsSyncActivated}}
-  {{#if this.isDateRange}}
+  {{#if (not this.byMonthActivityData)}}
+    {{! byMonthActivityData is an empty array if there is no monthly data (monthly breakdown was added in 1.11)
+    this means the user has queried dates before sync clients existed. we render an empty state instead of
+    "0 sync clients" (which is what the activity response returns) to be more explicit }}
+    <EmptyState
+      @title="No secrets sync clients"
+      @message="There is no sync data available for this {{if this.isDateRange 'date range' 'month'}}."
+      class="is-shadowless"
+    />
+  {{else if this.isDateRange}}
     <Clients::ChartContainer
       @title={{this.title}}
       @description={{this.description}}
       @timestamp={{@activity.responseTimestamp}}
-      @hasChartData={{this.byMonthActivityData}}
+      @hasChartData={{true}}
       class="no-legend"
     >
       <:subTitle>
@@ -16,8 +25,8 @@
           @label="Total sync clients"
           @subText="The total number of secrets synced from Vault to other destinations during this date range."
           @value={{this.totalUsageCounts.secret_syncs}}
+          @tooltipText="This number is the total for the queried date range. The chart displays a monthly breakdown of total sync clients per month."
           @size="l"
-          data-test-total-sync-clients
         />
       </:subTitle>
 
@@ -30,7 +39,6 @@
               @value={{avg}}
               @size="m"
               class="data-details-top has-top-padding-l"
-              data-test-average-sync-clients
             />
           {{/if}}
         {{/let}}
@@ -44,15 +52,40 @@
           @chartHeight={{200}}
         />
       </:chart>
-
-      <:emptyState>
-        <EmptyState
-          @title="No monthly secrets sync clients"
-          @subTitle="There is no secrets sync data available for this date range."
-          @bottomBorder={{true}}
-        />
-      </:emptyState>
     </Clients::ChartContainer>
+
+    {{! no need to render two empty charts! hide this one if there is no sync data }}
+    {{#if this.totalUsageCounts.secret_syncs}}
+      <Clients::ChartContainer
+        @title="Monthly new"
+        @description="Secrets sync clients which interacted with Vault for the first time each month. Each bar represents the total new sync clients for that month."
+        @timestamp={{@activity.responseTimestamp}}
+        @hasChartData={{true}}
+        class="no-legend"
+      >
+        <:stats>
+          {{#let (this.average this.byMonthNewClients "secret_syncs") as |avg|}}
+            {{#if avg}}
+              <StatText
+                @label="Average new secret sync clients per month"
+                @value={{avg}}
+                @size="m"
+                class="chart-subTitle has-top-padding-l"
+              />
+            {{/if}}
+          {{/let}}
+        </:stats>
+
+        <:chart>
+          <Clients::Charts::VerticalBarBasic
+            @chartTitle="Monthly new"
+            @data={{this.byMonthNewClients}}
+            @dataKey="secret_syncs"
+            @chartHeight={{200}}
+          />
+        </:chart>
+      </Clients::ChartContainer>
+    {{/if}}
   {{else}}
     <Clients::UsageStats @title={{this.title}} @description={{this.description}}>
       <StatText @label="Total sync clients" @value={{this.totalUsageCounts.secret_syncs}} @size="l" class="column" />

--- a/ui/app/components/clients/page/token.hbs
+++ b/ui/app/components/clients/page/token.hbs
@@ -13,10 +13,13 @@
     data-test-chart="monthly total"
   >
     <:subTitle>
-      <h2 class="chart-title">Total monthly clients</h2>
-      <p class="chart-subtext">
-        Each client is counted once per month. This can help with capacity planning.
-      </p>
+      <StatText
+        @label="Total clients"
+        @subText="The total number of entity and non-entity clients for this date range. Each client is counted once per month."
+        @value={{this.totalUsageCounts.clients}}
+        @tooltipText="This number is the total for the queried date range. The chart displays a monthly breakdown of total clients per month."
+        @size="l"
+      />
     </:subTitle>
 
     <:stats>
@@ -25,13 +28,6 @@
         @value={{this.averageTotalClients}}
         @size="m"
         class="data-details-top has-top-padding-l"
-      />
-
-      <StatText
-        @label="Average new clients per month"
-        @value={{this.averageNewClients}}
-        @size="m"
-        class="data-details-bottom has-top-padding-l"
       />
     </:stats>
 
@@ -42,7 +38,7 @@
 
   <Clients::ChartContainer
     @title="Monthly new"
-    @description="Entity or non-entity clients which interacted with Vault for the first time during this date range, displayed per month."
+    @description="Entity or non-entity clients which interacted with Vault for the first time during this date range. Each bar represents the total new clients for that month."
     @timestamp={{@activity.responseTimestamp}}
     @legend={{this.legend}}
     @hasChartData={{this.averageNewClients}}

--- a/ui/app/components/clients/page/token.hbs
+++ b/ui/app/components/clients/page/token.hbs
@@ -10,7 +10,6 @@
     @timestamp={{@activity.responseTimestamp}}
     @legend={{this.legend}}
     @hasChartData={{true}}
-    data-test-chart="monthly total"
   >
     <:subTitle>
       <StatText

--- a/ui/app/components/clients/page/token.hbs
+++ b/ui/app/components/clients/page/token.hbs
@@ -5,7 +5,7 @@
 
 {{#if (and this.byMonthActivityData this.isDateRange)}}
   <Clients::ChartContainer
-    @title="Entity/Non-entity clients"
+    @title="Entity/Non-entity clients usage"
     @description="This data can be used to understand how many entity and non-entity clients are using Vault each month for this date range."
     @timestamp={{@activity.responseTimestamp}}
     @legend={{this.legend}}

--- a/ui/app/components/clients/page/token.hbs
+++ b/ui/app/components/clients/page/token.hbs
@@ -6,7 +6,7 @@
 {{#if (and this.byMonthActivityData this.isDateRange)}}
   <Clients::ChartContainer
     @title="Entity/Non-entity clients usage"
-    @description="This data can be used to understand how many entity and non-entity clients are using Vault each month for this date range."
+    @description="This data can be used to understand how many entity and non-entity clients are using Vault each month for this date range. Each client is counted once per month."
     @timestamp={{@activity.responseTimestamp}}
     @legend={{this.legend}}
     @hasChartData={{true}}
@@ -14,7 +14,7 @@
     <:subTitle>
       <StatText
         @label="Total clients"
-        @subText="The total number of entity and non-entity clients for this date range. Each client is counted once per month."
+        @subText="The total number of entity and non-entity clients for this date range."
         @value={{this.totalUsageCounts.clients}}
         @tooltipText="This number is the total for the queried date range. The chart displays a monthly breakdown of total clients per month."
         @size="l"

--- a/ui/lib/core/addon/components/stat-text.hbs
+++ b/ui/lib/core/addon/components/stat-text.hbs
@@ -8,7 +8,8 @@
   data-test-stat-text={{or @label "true"}}
   ...attributes
 >
-  <div class="stat-label has-bottom-margin-xs">{{@label}}
+  <div class="stat-label has-bottom-margin-xs">
+    {{@label}}
     {{#if @tooltipText}}
       <Hds::TooltipButton @text={{@tooltipText}} aria-label="more information about {{@label}}">
         <FlightIcon @name="info" />

--- a/ui/tests/integration/components/clients/page/acme-test.js
+++ b/ui/tests/integration/components/clients/page/acme-test.js
@@ -37,7 +37,6 @@ module('Integration | Component | clients | Clients::Page::Acme', function (hook
     this.activity = await this.store.queryRecord('clients/activity', activityQuery);
     this.startTimestamp = START_TIME;
     this.endTimestamp = END_TIME;
-    this.isSecretsSyncActivated = true;
 
     this.renderComponent = () =>
       render(hbs`

--- a/ui/tests/integration/components/clients/page/sync-test.js
+++ b/ui/tests/integration/components/clients/page/sync-test.js
@@ -15,10 +15,11 @@ import { CLIENT_COUNT } from 'vault/tests/helpers/clients/client-count-selectors
 import { formatNumber } from 'core/helpers/format-number';
 import { calculateAverage } from 'vault/utils/chart-helpers';
 import { dateFormat } from 'core/helpers/date-format';
+import { assertBarChart } from 'vault/tests/helpers/clients/client-count-helpers';
 
 const START_TIME = getUnixTime(LICENSE_START);
 const END_TIME = getUnixTime(STATIC_NOW);
-const { statText, charts, usageStats } = CLIENT_COUNT;
+const { charts, chartContainer, statText, usageStats } = CLIENT_COUNT;
 
 module('Integration | Component | clients | Clients::Page::Sync', function (hooks) {
   setupRenderingTest(hooks);
@@ -52,9 +53,16 @@ module('Integration | Component | clients | Clients::Page::Sync', function (hook
   });
 
   test('it should render with full month activity data', async function (assert) {
-    assert.expect(4 + this.activity.byMonth.length);
+    const monthCount = this.activity.byMonth.length;
+    assert.expect(8 + monthCount * 2);
     const expectedTotal = formatNumber([this.activity.total.secret_syncs]);
     const expectedAvg = formatNumber([calculateAverage(this.activity.byMonth, 'secret_syncs')]);
+    const expectedNewAvg = formatNumber([
+      calculateAverage(
+        this.activity.byMonth.map((m) => m?.new_clients),
+        'secret_syncs'
+      ),
+    ]);
     await this.renderComponent();
     assert
       .dom(statText('Total sync clients'))
@@ -68,66 +76,65 @@ module('Integration | Component | clients | Clients::Page::Sync', function (hook
         `Average sync clients per month ${expectedAvg}`,
         `renders correct average sync stat ${expectedAvg}`
       );
+    assert.dom(statText('Average new sync clients per month')).hasTextContaining(`${expectedNewAvg}`);
 
     const formattedTimestamp = dateFormat([this.activity.responseTimestamp, 'MMM d yyyy, h:mm:ss aaa'], {
       withTimeZone: true,
     });
     assert.dom(charts.timestamp).hasText(`Updated ${formattedTimestamp}`, 'renders response timestamp');
 
-    // assert bar chart is correct
-    findAll(`${charts.chart('Secrets sync usage')} ${charts.xAxisLabel}`).forEach((e, i) => {
-      assert
-        .dom(e)
-        .hasText(
-          `${this.activity.byMonth[i].month}`,
-          `renders x-axis labels for bar chart: ${this.activity.byMonth[i].month}`
-        );
-    });
-
-    const dataBars = findAll(charts.dataBar).filter((b) => b.hasAttribute('height'));
-    assert.strictEqual(
-      dataBars.length,
-      this.activity.byMonth.filter((m) => m.clients).length,
-      'it renders a bar for each non-zero month'
-    );
-  });
-
-  test('it should render an empty state for no monthly data', async function (assert) {
-    assert.expect(5);
-    this.activity.set('byMonth', []);
-
-    await this.renderComponent();
-
-    assert.dom(charts.chart('Secrets sync usage')).doesNotExist('vertical bar chart does not render');
-    assert.dom(GENERAL.emptyStateTitle).hasText('No monthly secrets sync clients');
-    const formattedTimestamp = dateFormat([this.activity.responseTimestamp, 'MMM d yyyy, h:mm:ss aaa'], {
-      withTimeZone: true,
-    });
-    assert.dom(charts.timestamp).hasText(`Updated ${formattedTimestamp}`, 'renders timestamp');
-    assert.dom(statText('Total sync clients')).doesNotExist('total sync counts does not exist');
-    assert
-      .dom(statText('Average sync clients per month'))
-      .doesNotExist('average sync client counts does not exist');
+    assertBarChart(assert, 'Secrets sync usage', this.activity.byMonth);
+    assertBarChart(assert, 'Monthly new', this.activity.byMonth);
   });
 
   test('it should render stats without chart for a single month', async function (assert) {
-    assert.expect(4);
-    const activityQuery = { start_time: { timestamp: START_TIME }, end_time: { timestamp: START_TIME } };
+    assert.expect(5);
+    const activityQuery = { start_time: { timestamp: END_TIME }, end_time: { timestamp: END_TIME } };
     this.activity = await this.store.queryRecord('clients/activity', activityQuery);
-    const total = formatNumber([this.activity.total.secret_syncs]);
+    const expectedTotal = formatNumber([this.activity.total.secret_syncs]);
     await this.renderComponent();
 
-    assert.dom(charts.chart('Secrets sync usage')).doesNotExist('vertical bar chart does not render');
+    assert.dom(charts.chart('Secrets sync usage')).doesNotExist('total usage chart does not render');
+    assert.dom(chartContainer('Monthly new')).doesNotExist('monthly new chart does not render');
+    assert.dom(statText('Average sync clients per month')).doesNotExist();
+    assert.dom(statText('Average new sync clients per month')).doesNotExist();
     assert
       .dom(usageStats('Secrets sync usage'))
       .hasText(
-        `Secrets sync usage Usage metrics tutorial This data can be used to understand how many secrets sync clients have been used for this date range. Each Vault secret that is synced to at least one destination counts as one Vault client. Total sync clients ${total}`,
-        'renders sync stats instead of chart'
+        `Secrets sync usage Usage metrics tutorial This data can be used to understand how many secrets sync clients have been used for this date range. Each Vault secret that is synced to at least one destination counts as one Vault client. Total sync clients ${expectedTotal}`,
+        'it renders usage stats with single month copy'
       );
-    assert.dom(statText('Average total clients per month')).doesNotExist('total sync counts does not exist');
-    assert
-      .dom(statText('Average sync clients per month'))
-      .doesNotExist('average sync client counts does not exist');
+  });
+
+  // EMPTY STATES
+  test('it should render empty state when sync data does not exist for a date range', async function (assert) {
+    assert.expect(8);
+    // this happens when a user queries historical data that predates the monthly breakdown (added in 1.11)
+    // only entity + non-entity clients existed then, so we show an empty state for sync clients
+    // because the activity response just returns { secret_syncs: 0 } which isn't very clear
+    this.activity.byMonth = [];
+
+    await this.renderComponent();
+
+    assert.dom(GENERAL.emptyStateTitle).hasText('No secrets sync clients');
+    assert.dom(GENERAL.emptyStateMessage).hasText('There is no sync data available for this date range.');
+
+    assert.dom(charts.chart('Secrets sync usage')).doesNotExist('vertical bar chart does not render');
+    assert.dom(chartContainer('Monthly new')).doesNotExist('monthly new chart does not render');
+    assert.dom(statText('Total sync clients')).doesNotExist();
+    assert.dom(statText('Average sync clients per month')).doesNotExist();
+    assert.dom(statText('Average new sync clients per month')).doesNotExist();
+    assert.dom(usageStats('Secrets sync usage')).doesNotExist();
+  });
+
+  test('it should render empty state when sync data does not exist for a single month', async function (assert) {
+    assert.expect(1);
+    const activityQuery = { start_time: { timestamp: START_TIME }, end_time: { timestamp: START_TIME } };
+    this.activity = await this.store.queryRecord('clients/activity', activityQuery);
+    this.activity.byMonth = [];
+    await this.renderComponent();
+
+    assert.dom(GENERAL.emptyStateMessage).hasText('There is no sync data available for this month.');
   });
 
   test('it should render an empty state if secrets sync is not activated', async function (assert) {
@@ -146,8 +153,9 @@ module('Integration | Component | clients | Clients::Page::Sync', function (hook
     assert.dom(statText('Average sync clients per month')).doesNotExist();
   });
 
-  test('it should render an empty chart if secrets sync is activated but no secrets synced', async function (assert) {
+  test('it should render an empty total usage chart  if secrets sync is activated but monthly syncs are null or 0', async function (assert) {
     this.isSecretsSyncActivated = true;
+    // manually stub because mirage isn't setup to handle mixed data yet
     const counts = {
       clients: 10,
       entity_clients: 4,
@@ -181,8 +189,11 @@ module('Integration | Component | clients | Clients::Page::Sync', function (hook
       },
     ];
     this.activity.total = counts;
+    const monthCount = this.activity.byMonth.length;
+    assert.expect(6 + monthCount * 2);
     await this.renderComponent();
 
+    assert.dom(charts.chart('Secrets sync usage')).exists('renders empty sync usage chart');
     assert
       .dom(statText('Total sync clients'))
       .hasText(
@@ -191,5 +202,20 @@ module('Integration | Component | clients | Clients::Page::Sync', function (hook
     assert
       .dom(statText('Average sync clients per month'))
       .doesNotExist('Does not render average if the calculation is 0');
+    findAll(`${charts.chart('Secrets sync usage')} ${charts.xAxisLabel}`).forEach((e, i) => {
+      assert
+        .dom(e)
+        .hasText(
+          `${this.activity.byMonth[i].month}`,
+          `renders x-axis labels for empty bar chart: ${this.activity.byMonth[i].month}`
+        );
+    });
+    findAll(`${charts.chart('Secrets sync usage')} ${charts.dataBar}`).forEach((e, i) => {
+      assert.dom(e).isNotVisible(`does not render data bar for: ${this.activity.byMonth[i].month}`);
+    });
+
+    assert.dom(chartContainer('Monthly new')).doesNotExist('empty monthly new chart does not render at all');
+    assert.dom(statText('Average sync clients per month')).doesNotExist();
+    assert.dom(statText('Average new sync clients per month')).doesNotExist();
   });
 });

--- a/ui/tests/integration/components/clients/page/token-test.js
+++ b/ui/tests/integration/components/clients/page/token-test.js
@@ -20,7 +20,7 @@ import { CLIENT_COUNT } from 'vault/tests/helpers/clients/client-count-selectors
 const START_TIME = getUnixTime(LICENSE_START);
 const END_TIME = getUnixTime(STATIC_NOW);
 
-module('Integration | Component | clients | Page::Token', function (hooks) {
+module('Integration | Component | clients | Clients::Page::Token', function (hooks) {
   setupRenderingTest(hooks);
   setupMirage(hooks);
 
@@ -74,7 +74,6 @@ module('Integration | Component | clients | Page::Token', function (hooks) {
       return formatNumber([average]);
     };
     const expectedTotal = getAverage(this.activity.byMonth);
-    const expectedNew = getAverage(this.newActivity);
     const chart = CLIENT_COUNT.charts.chart('monthly total');
 
     await this.renderComponent();
@@ -82,9 +81,7 @@ module('Integration | Component | clients | Page::Token', function (hooks) {
     assert
       .dom(CLIENT_COUNT.charts.statTextValue('Average total clients per month'))
       .hasText(expectedTotal, 'renders correct total clients');
-    assert
-      .dom(CLIENT_COUNT.charts.statTextValue('Average new clients per month'))
-      .hasText(expectedNew, 'renders correct new clients');
+
     // assert bar chart is correct
     findAll(`${chart} ${CLIENT_COUNT.charts.bar.xAxisLabel}`).forEach((e, i) => {
       assert

--- a/ui/tests/integration/components/clients/page/token-test.js
+++ b/ui/tests/integration/components/clients/page/token-test.js
@@ -74,7 +74,7 @@ module('Integration | Component | clients | Clients::Page::Token', function (hoo
       return formatNumber([average]);
     };
     const expectedTotal = getAverage(this.activity.byMonth);
-    const chart = CLIENT_COUNT.charts.chart('monthly total');
+    const chart = CLIENT_COUNT.chartContainer('Entity/Non-entity clients usage');
 
     await this.renderComponent();
 


### PR DESCRIPTION
## with data

<img width="940" alt="Screenshot 2024-04-22 at 10 57 23 AM" src="https://github.com/hashicorp/vault/assets/68122737/1b245949-3a84-41a6-b799-5bb0678860f3">

## no data

<img width="1265" alt="Screenshot 2024-04-22 at 10 55 54 AM" src="https://github.com/hashicorp/vault/assets/68122737/42345c55-5b0f-4dbc-a8eb-243ac769359f">
