### PR TITLE
Replace 'HCP Vault' with 'HCP Vault Dedicated' (#26457)

### DIFF
--- a/website/content/docs/auth/login-mfa/faq.mdx
+++ b/website/content/docs/auth/login-mfa/faq.mdx
@@ -11,7 +11,7 @@ This FAQ section contains frequently asked questions about the Login MFA feature
 - [Q: What MFA features can I access if I upgrade to Vault version 1.10?](#q-what-mfa-features-can-i-access-if-i-upgrade-to-vault-version-1-10)
 - [Q: What are the various MFA workflows that are available to me as a Vault user as of Vault version 1.10, and how are they different?](#q-what-are-the-various-mfa-workflows-that-are-available-to-me-as-a-vault-user-as-of-vault-version-1-10-and-how-are-they-different)
 - [Q: What is the Legacy MFA feature?](#q-what-is-the-legacy-mfa-feature)
-- [Q: Will HCP Vault support MFA?](#q-will-hcp-vault-support-mfa)
+- [Q: Will HCP Vault Dedicated support MFA?](#q-will-hcp-vault-support-mfa)
 - [Q: What is Single-Phase MFA vs. Two-Phase MFA?](#q-what-is-single-phase-mfa-vs-two-phase-mfa)
 - [Q: Are there new MFA API endpoints introduced as part of the new Vault version 1.10 MFA for login functionality?](#q-are-there-new-mfa-api-endpoints-introduced-as-part-of-the-new-vault-version-1-10-mfa-for-login-functionality)
 - [Q: How do MFA configurations differ between the Login MFA and Step-up Enterprise MFA?](#q-how-do-mfa-configurations-differ-between-the-login-mfa-and-step-up-enterprise-mfa)
@@ -44,9 +44,9 @@ The Step-up Enterprise MFA will co-exist with the newly introduced Login MFA sta
 
 [Legacy MFA](/vault/docs/v1.10.x/auth/mfa) is functionality that was available in Vault Community Edition, prior to introducing MFA in the Enterprise version. This is now a deprecated feature. Please see the [Vault Feature Deprecation Notice and Plans](/vault/docs/deprecation) for detailed product plans around deprecated features. We plan to remove Legacy MFA in 1.11.
 
-### Q: will HCP Vault support MFA?
+### Q: will HCP Vault Dedicated support MFA?
 
-Yes, HCP Vault will support MFA across all tiers and offering as part of the April 2022 release.
+Yes, HCP Vault Dedicated will support MFA across all tiers and offering as part of the April 2022 release.
 
 ### Q: what is Single-Phase MFA vs. Two-Phase MFA?
 

--- a/website/content/docs/concepts/namespace-api-lock.mdx
+++ b/website/content/docs/concepts/namespace-api-lock.mdx
@@ -27,7 +27,7 @@ unlocking the descendant.
 Blocking access to much of Vault can be an important break-glass tool in the
 event of unexpected behavior.
 
-For HCP Vault, this provides functionality analogous to sealing Vault, without
+For HCP Vault Dedicated, this provides functionality analogous to sealing Vault, without
 the Vault administrator requesting that the Managed Service Provider seal/unseal
 Vault.
 

--- a/website/content/docs/configuration/storage/index.mdx
+++ b/website/content/docs/configuration/storage/index.mdx
@@ -48,7 +48,7 @@ storage](/vault/docs/configuration/storage/raft) for most use cases rather than
 configuring another system to store Vault data externally. (Integrated Storage is
 an **embedded Vault data storage** available in Vault 1.4 or later.) Prior to Vault 1.4, Consul was the recommended Vault storage.
 
--> **NOTE:** [HCP Vault](https://cloud.hashicorp.com/products/vault) clusters
+-> **NOTE:** [HCP Vault Dedicated](https://cloud.hashicorp.com/products/vault) clusters
 use Integrated Storage as their storage backend.
 
 The table below compares the characteristics of Integrated Storage and External

--- a/website/content/docs/enterprise/license/faq.mdx
+++ b/website/content/docs/enterprise/license/faq.mdx
@@ -9,7 +9,7 @@ description: An overview of license.
 This FAQ section is for license changes and updates introduced for Vault Enterprise.
 - [Q: How do the license termination changes affect upgrades?](#q-how-do-the-license-termination-changes-affect-upgrades)
 - [Q: What impact on upgrades do the license termination behavior changes pose?](#q-what-impact-on-upgrades-do-the-license-termination-behavior-changes-pose)
-- [Q: Will these license changes impact HCP Vault?](#q-will-these-license-changes-impact-hcp-vault)
+- [Q: Will these license changes impact HCP Vault Dedicated?](#q-will-these-license-changes-impact-hcp-vault)
 - [Q: Do these license changes impact all Vault customers/licenses?](#q-do-these-license-changes-impact-all-vault-customers-licenses)
 - [Q: What is the product behavior change introduced by the licensing changes?](#q-what-is-the-product-behavior-change-introduced-by-the-licensing-changes)
 - [Q: How will Vault behave at startup when a license expires or terminates?](#q-how-will-vault-behave-at-startup-when-a-license-expires-or-terminates)
@@ -60,9 +60,9 @@ Vault will not start
 
 The Vault support team can issue you a temporary evaluation license to allow for security upgrades if your license has expired.
 
-### Q: will these license changes impact HCP Vault?
+### Q: will these license changes impact HCP Vault Dedicated?
 
-No, these changes will not impact HCP Vault.
+No, these changes will not impact HCP Vault Dedicated.
 
 ### Q: do these license changes impact all Vault customers/licenses?
 

--- a/website/content/docs/enterprise/namespaces/create-admin-namespace.mdx
+++ b/website/content/docs/enterprise/namespaces/create-admin-namespace.mdx
@@ -11,11 +11,11 @@ description: >-
 Grant access to a predefined subset of privileged system backend endpoints in
 the Vault API with an administrative namespace.
 
-<Tip title="HCP Vault has a built-in administrative namespace">
+<Tip title="HCP Vault Dedicated has a built-in administrative namespace">
 
-  HCP Vault clusters include an administrative namespace (`admin`) by default.
-  For more information on managing namespaces with HCP Vault, refer to the
-  [HCP Vault namespace considerations](/vault/tutorials/cloud-ops/hcp-vault-namespace-considerations)
+  HCP Vault Dedicated clusters include an administrative namespace (`admin`) by default.
+  For more information on managing namespaces with HCP Vault Dedicated, refer to the
+  [HCP Vault Dedicated namespace considerations](/vault/tutorials/cloud-ops/hcp-vault-namespace-considerations)
   guide.
 
 </Tip>

--- a/website/content/docs/enterprise/namespaces/index.mdx
+++ b/website/content/docs/enterprise/namespaces/index.mdx
@@ -160,6 +160,6 @@ Refer to the following tutorials to learn more about Vault namespaces:
   Relationship](/vault/tutorials/enterprise/namespaces-secrets-sharing)
 - [Vault Namespace and Mount Structuring
   Guide](/vault/tutorials/enterprise/namespace-structure)
-- [HCP Vault namespace
+- [HCP Vault Dedicated namespace
   considerations](/vault/tutorials/cloud-ops/hcp-vault-namespace-considerations)
 - [Using many Namespaces](/vault/docs/enterprise/namespaces/namespace-limits)

--- a/website/content/docs/interoperability-matrix.mdx
+++ b/website/content/docs/interoperability-matrix.mdx
@@ -45,7 +45,7 @@ The below table shows the partner product and if the partner’s technology work
 
 Partners who integrate with Vault to have Vault store and/or manage encryption keys with their products
 
-~> Note: HCP Vault Verified means that the integration has been verified to work with HCP Vault. All integrations have been verified with Vault self-managed.
+~> Note: HCP Vault Verified means that the integration has been verified to work with HCP Vault Dedicated. All integrations have been verified with Vault self-managed.
 
 <span style={{fontSize:'12px'}}>
 Vault Secrets Engine Key: EKM Provider = <a href="/docs/platform/mssql">Vault EKM provider for SQL server</a>; K/V = <a href="/docs/secrets/kv">K/V secrets engine</a>; KMSE = <a href="/docs/secrets/key-management">Key Management Secrets Engine</a>; KMIP = <a href="/docs/secrets/kmip">KMIP Secrets Engine</a>; PKCS#11 = <a href="/docs/enterprise/pkcs11-provider">PKCS#11 Provider</a>; Transit = <a href="/docs/secrets/transit">Transit Secrets Engine</a>

--- a/website/content/docs/partnerships.mdx
+++ b/website/content/docs/partnerships.mdx
@@ -38,7 +38,7 @@ Oftentimes these integrations involve modifying a partner’s product to become 
 
 There are many ways for an application to authenticate itself to Vault (see [Auth Methods](/vault/docs/auth/)), but we recommend partners use one of the following methods: [AppRole](/vault/docs/auth/approle), [JWT / OIDC](/vault/docs/auth/jwt), [TLS Certificates](/vault/docs/auth/cert) or [Username / Password](/vault/docs/auth/userpass). For an integration to be verified as production ready by HashiCorp, there needs to be at least one other Auth method supported besides [Token](/vault/docs/auth/token). Token is not recommended for use in production since it involves creating a manual long lived token (which is against best practice and poses a security risk). Using one of the above mentioned auth methods automatically creates short lived tokens and eliminates the need to manually generate a new token on a regular basis.
 
-As the number of customers using Vault Enterprise increases, partners are encouraged to support [Namespaces](/vault/tutorials/enterprise/namespaces). By supporting Namespaces, there is an additional benefit that an integration should be able to work with HCP Vault.
+As the number of customers using Vault Enterprise increases, partners are encouraged to support [Namespaces](/vault/tutorials/enterprise/namespaces). By supporting Namespaces, there is an additional benefit that an integration should be able to work with HCP Vault Dedicated.
 
 HSM (Hardware Security Module) are specific types of runtime integrations and can be configured to work with new or existing Vault deployments. They provide an added level of security and compliance. The HSM communicates with Vault using the PKCS#11 protocol thereby resulting in the integration to primarily involve verification of the operation of the functionality. You can find more information about Vault’s HSM support [here](/vault/docs/enterprise/hsm). A list of HSMs that have been verified to work with Vault is shown in our [interoperability matrix](/vault/docs/interoperability-matrix).
 
@@ -48,15 +48,15 @@ HSM (Hardware Security Module) are specific types of runtime integrations and ca
 
 -> **Note:** Integrations related Vault’s [storage](/vault/docs/concepts/storage) backend, [auto auth](/vault/docs/agent-and-proxy/autoauth), and [auto unseal](/vault/docs/concepts/seal#auto-unseal) functionality are not encouraged. Please reach out to [technologypartners@hashicorp.com](mailto:technologypartners@hashicorp.com) for any questions related to this.
 
-### HCP Vault
+### HCP Vault Dedicated
 
-HCP Vault is a managed version of Vault which is operated by HashiCorp to allow customers to quickly get up and running. HCP Vault uses the same binary as self-managed Vault Enterprise, and offers a consistent user experience. You can use the same Vault clients to communicate with HCP Vault as you use to communicate with Vault. Most runtime integrations can be verified with HCP Vault.
+HCP Vault Dedicated is a managed version of Vault which is operated by HashiCorp to allow customers to quickly get up and running. HCP Vault Dedicated uses the same binary as self-managed Vault Enterprise, and offers a consistent user experience. You can use the same Vault clients to communicate with HCP Vault Dedicated as you use to communicate with Vault. Most runtime integrations can be verified with HCP Vault Dedicated.
 
-Sign up for HCP Vault [here](https://portal.cloud.hashicorp.com/) and check out [this](/vault/tutorials/cloud) learn guide for quickly getting started.
+Sign up for HCP Vault Dedicated [here](https://portal.cloud.hashicorp.com/) and check out [this](/vault/tutorials/cloud) learn guide for quickly getting started.
 
 ### Vault integration badges
 
-There are two types of badges that partners could receive: Vault Enterprise Verified and HCP Vault Verified badges. Partners will be issued the Vault Enterprise badge for integrations that work with Vault Enterprise features such as namespaces, HSM support, or key management. Partners will be issued the HCP Vault badge once their integration has been verified to work with HCP Vault. The badge(s) would be displayed on their partner page (example: [MongoDB](https://www.hashicorp.com/partners/tech/mongodb#vault) and can also be used on their own website to help provide better visibility and differentiation to customers. The process for verification of these integrations is detailed below.
+There are two types of badges that partners could receive: Vault Enterprise Verified and HCP Vault Verified badges. Partners will be issued the Vault Enterprise badge for integrations that work with Vault Enterprise features such as namespaces, HSM support, or key management. Partners will be issued the HCP Vault Dedicated badge once their integration has been verified to work with HCP Vault Dedicated. The badge(s) would be displayed on their partner page (example: [MongoDB](https://www.hashicorp.com/partners/tech/mongodb#vault) and can also be used on their own website to help provide better visibility and differentiation to customers. The process for verification of these integrations is detailed below.
 
 <span style={{display:'block', textAlign:'center'}}>
 <ImageConfig inline height={200} width={200}>
@@ -66,7 +66,7 @@ There are two types of badges that partners could receive: Vault Enterprise Veri
 </ImageConfig>
 <ImageConfig inline height={200} width={200}>
 
-![HCP Vault](/img/HCPV_badge.png)
+![HCP Vault Dedicated](/img/HCPV_badge.png)
 
 </ImageConfig>
 </span>
@@ -133,14 +133,14 @@ Please remember that all integrations should have the appropriate documentation 
 - [Secret engine documentation](/vault/docs/secrets)
 - [Custom Secrets Engines | Vault - HashiCorp Learn](/vault/tutorials/custom-secrets-engine)
 
-**HCP Vault**
+**HCP Vault Dedicated**
 
-The process to spin up a testing instance of HCP Vault is very [straightforward](/vault/tutorials/cloud/get-started-vault). HCP has been designed as a turn-key managed service so configuration is minimal. Furthermore, HashiCorp provides all new users an initial credit which lasts for a couple of months when using the [development](https://cloud.hashicorp.com/products/vault/pricing) cluster. Used in conjunction with AWS free tier resources, there should be no cost beyond the time spent by the designated tester.
+The process to spin up a testing instance of HCP Vault Dedicated is very [straightforward](/vault/tutorials/cloud/get-started-vault). HCP has been designed as a turn-key managed service so configuration is minimal. Furthermore, HashiCorp provides all new users an initial credit which lasts for a couple of months when using the [development](https://cloud.hashicorp.com/products/vault/pricing) cluster. Used in conjunction with AWS free tier resources, there should be no cost beyond the time spent by the designated tester.
 
-There are a couple of items to consider when determining if the integration will work with HCP Vault.
+There are a couple of items to consider when determining if the integration will work with HCP Vault Dedicated.
 
-- Since HCP Vault is running Vault Enterprise, the integration will need to be aware of [Namespaces](/vault/tutorials/enterprise/namespaces). This is important as the main namespace in HCP Vault is called 'admin' which is different from the standard ‘root’ namespace in a self managed Vault instance. If the integration currently doesn't support namespaces, then an additional benefit of adding Namespace support iis that this will also enable it to work with all self managed Vault Enterprise installations.
-- HCP Vault is currently only deployed on AWS and so the partner’s application should be able to be deployed or run in AWS. This is vital so that HCP Vault is able to communicate with the application using a [private peered](/hcp/tutorials/networking/amazon-peering-hcp) connection via a [HashiCorp Virtual Network](/hcp/docs/hcp/network).
+- Since HCP Vault Dedicated is running Vault Enterprise, the integration will need to be aware of [Namespaces](/vault/tutorials/enterprise/namespaces). This is important as the main namespace in HCP Vault Dedicated is called 'admin' which is different from the standard ‘root’ namespace in a self managed Vault instance. If the integration currently doesn't support namespaces, then an additional benefit of adding Namespace support iis that this will also enable it to work with all self managed Vault Enterprise installations.
+- HCP Vault Dedicated is currently only deployed on AWS and so the partner’s application should be able to be deployed or run in AWS. This is vital so that HCP Vault Dedicated is able to communicate with the application using a [private peered](/hcp/tutorials/networking/amazon-peering-hcp) connection via a [HashiCorp Virtual Network](/hcp/docs/hcp/network).
 
 Additional resources:
 
@@ -150,7 +150,7 @@ Additional resources:
 
 ### 4. review
 
-During the review process, HashiCorp will provide feedback on the newly developed integration for both Vault and HCP Vault. This is an important step to allow HashiCorp to review and verify your Vault integration. Please reach out to [technologypartners@hashicorp.com](mailto:technologypartners@hashicorp.com) for verification.
+During the review process, HashiCorp will provide feedback on the newly developed integration for both Vault and HCP Vault Dedicated. This is an important step to allow HashiCorp to review and verify your Vault integration. Please reach out to [technologypartners@hashicorp.com](mailto:technologypartners@hashicorp.com) for verification.
 
 The review process can take some time to complete and may require some iterations through the code to address any problems identified by the HashiCorp team.
 
@@ -162,7 +162,7 @@ At this stage, it is expected that the integration is fully complete, the necess
 
 For Auth or Secret Engine plugins specifically, once the plugin has been verified by HashiCorp, it is recommended the plugin be hosted on Github so it can more easily be downloaded and installed within Vault. We also encourage partners to list their plugin on the [Vault Integrations](/vault/integrations) page. This is in addition to the listing of the plugin on the technology partners’ dedicated HashiCorp partner page. To have the plugin listed on the portal page, please do a pull request via the “edit in GitHub” link on the bottom of the page and add the plugin in the partner section.
 
-For HCP Vault verifications, the partner will be issued an HCP Vault Verified badge and will have this displayed on their partner page.
+For HCP Vault Dedicated verifications, the partner will be issued an HCP Vault Verified badge and will have this displayed on their partner page.
 
 ### 6. support
 

--- a/website/content/docs/secrets/databases/oracle.mdx
+++ b/website/content/docs/secrets/databases/oracle.mdx
@@ -9,9 +9,9 @@ description: |-
 
 # Oracle database secrets engine
 
--> The Oracle database plugin is now available for use with the database secrets engine for HCP Vault on AWS.
+-> The Oracle database plugin is now available for use with the database secrets engine for HCP Vault Dedicated on AWS.
    The plugin configuration (including installation of the Oracle Instant Client library) is managed
-   by HCP. Refer to the HCP Vault tab for more information.
+   by HCP. Refer to the HCP Vault Dedicated tab for more information.
 
 This secrets engine is a part of the database secrets engine. If you have not read the
 [database backend](/vault/docs/secrets/databases) page, please do so now as it explains how to set up the database backend and
@@ -36,9 +36,9 @@ found at its own git repository here:
 | Customizable (see: [Custom Plugins](/vault/docs/secrets/databases/custom)) | Yes                      | Yes           | Yes          | Yes (1.7+)             |
 
 </Tab>
-<Tab heading="HCP Vault" group="hcp">
+<Tab heading="HCP Vault Dedicated" group="hcp">
 
-~> The Oracle Database Plugin is managed by the HCP platform. No extra installation steps are required for HCP Vault.
+~> The Oracle Database Plugin is managed by the HCP platform. No extra installation steps are required for HCP Vault Dedicated.
 
 | Plugin Name                                                          | Root Credential Rotation | Dynamic Roles | Static Roles | Username Customization |
 | -------------------------------------------------------------------- | ------------------------ | ------------- | ------------ | ---------------------- |
@@ -250,7 +250,7 @@ vault write database/config/oracle-west \
 ```
 
 </Tab>
-<Tab heading="HCP Vault" group="hcp">
+<Tab heading="HCP Vault Dedicated" group="hcp">
 
 1. Enable the database secrets engine if it is not already enabled:
 
@@ -276,8 +276,8 @@ vault write database/config/oracle-west \
         password="myreallysecurepassword"
     ```
 
-   HCP Vault currently supports SSL connections for Oracle on Amazon Web Services (AWS) Relational Database Service (RDS).
-   If Oracle is deployed on AWS RDS, and uses SSL, see the [connecting with HCP Vault using SSL](#connect-with-hcp-vault-using-ssl) example.
+   HCP Vault Dedicated currently supports SSL connections for Oracle on Amazon Web Services (AWS) Relational Database Service (RDS).
+   If Oracle is deployed on AWS RDS, and uses SSL, see the [connecting with HCP Vault Dedicated using SSL](#connect-with-hcp-vault-using-ssl) example.
 
    If the version of Oracle you are using has a container database, you will need to connect to one of the
    pluggable databases rather than the container database in the `connection_url` field.
@@ -311,7 +311,7 @@ vault write database/config/oracle-west \
 
    See the [Commands](/vault/docs/commands#files) docs for more details.
 
-### Connect with HCP Vault using SSL
+### Connect with HCP Vault Dedicated using SSL
 
 Before using SSL with Oracle RDS, you must configure a option group with SSL and set the following:
 
@@ -349,7 +349,7 @@ $ vault write database/config/my-oracle-database \
   password="password"
 ```
 
-~> **Using TNS names:** `tnsnames.ora` configuration is not currently available with HCP Vault.
+~> **Using TNS names:** `tnsnames.ora` configuration is not currently available with HCP Vault Dedicated.
 
 </Tab>
 </Tabs>

--- a/website/content/docs/secrets/venafi.mdx
+++ b/website/content/docs/secrets/venafi.mdx
@@ -213,14 +213,14 @@ Venafi secrets engine:
    ```
 
 </Tab>
-<Tab heading="HCP Vault" group="hcp">
+<Tab heading="HCP Vault Dedicated" group="hcp">
 
-~> The Venafi Secrets Engine on HCP Vault currently supports Venafi Cloud or Trust Protection Platform instances secured using a certificate from a publicly trusted CA.
-Support for uploading a certificate signed by a private CA using trust_bundle_file parameter is not available on HCP Vault and requires running a self-managed Vault to use.
+~> The Venafi Secrets Engine on HCP Vault Dedicated currently supports Venafi Cloud or Trust Protection Platform instances secured using a certificate from a publicly trusted CA.
+Support for uploading a certificate signed by a private CA using trust_bundle_file parameter is not available on HCP Vault Dedicated and requires running a self-managed Vault to use.
 
 Before certificates can be issued, you must complete these steps to configure the Venafi secrets engine:
 
-1. Navigate to your HCP Vault cluster's [Integrations](/hcp/docs/vault/integrations#hashicorp-partner-plugins) page within the HCP portal
+1. Navigate to your HCP Vault Dedicated cluster's [Integrations](/hcp/docs/vault/integrations#hashicorp-partner-plugins) page within the HCP portal
 to add the Venafi secrets engine to your cluster.
 
 1. After the Venafi plugin has been successfully added to your cluster, you can use the Vault CLI to configure the Venafi secrets engine 

--- a/website/content/docs/what-is-vault.mdx
+++ b/website/content/docs/what-is-vault.mdx
@@ -87,9 +87,9 @@ The key features of Vault are:
 
 -> **Tip**: Learn more about Vault [use cases](/vault/docs/use-cases).
 
-### What is HCP Vault?
+### What is HCP Vault Dedicated?
 
-HashiCorp Cloud Platform (HCP) Vault is a hosted version of Vault, which is operated by HashiCorp to allow organizations to get up and running quickly. HCP Vault uses the same binary as self-hosted Vault, which means you will have a consistent user experience. You can use the same Vault clients to communicate with HCP Vault as you use to communicate with a self-hosted Vault. Refer to the [HCP Vault](/hcp/docs/vault) documentation to learn more.
+HashiCorp Cloud Platform (HCP) Vault Dedicated is a hosted version of Vault, which is operated by HashiCorp to allow organizations to get up and running quickly. HCP Vault Dedicated uses the same binary as self-hosted Vault, which means you will have a consistent user experience. You can use the same Vault clients to communicate with HCP Vault Dedicated as you use to communicate with a self-hosted Vault. Refer to the [HCP Vault Dedicated](/hcp/docs/vault) documentation to learn more.
 
 -> **Hands On:** Try the [Get started](/vault/tutorials/cloud) tutorials to set up a managed Vault cluster.
 

--- a/website/content/partials/alerts/enterprise-and-hcp-use.mdx
+++ b/website/content/partials/alerts/enterprise-and-hcp-use.mdx
@@ -7,6 +7,6 @@
   Requires a <a href="https://www.hashicorp.com/products/vault/pricing">
     Vault Enterprise
   </a> license or <a href="/hcp/docs/vault/tiers-and-features">
-    HCP Vault
+    HCP Vault Dedicated
   </a> cluster to <b>use</b>. 
 </EnterpriseAlert>

--- a/website/content/partials/alerts/enterprise-and-hcp.mdx
+++ b/website/content/partials/alerts/enterprise-and-hcp.mdx
@@ -2,6 +2,6 @@
   <a href="https://www.hashicorp.com/products/vault/pricing">
     Vault Enterprise
   </a> license or <a href="/hcp/docs/vault/tiers-and-features">
-    HCP Vault
+    HCP Vault Dedicated
   </a> cluster required. 
 </EnterpriseAlert>


### PR DESCRIPTION
This PR manually cherry-pick commits made by https://github.com/hashicorp/vault/pull/26457


* Replace 'HCP Vault' with 'HCP Vault Dedicated'

* Replace 'HCP Vault' with 'HCP Vault Dedicated' where applicable

* Replace 'Terraform Cloud' with 'HCP Terraform'

* Minor format fixes

* Update the side-nav title to 'HCP Terraform'

* Undo changes to Terraform Cloud secrets engine