### PR TITLE
docs: remove non-existing file reference

### DIFF
--- a/website/content/docs/upgrading/upgrade-to-1.16.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.16.x.mdx
@@ -89,8 +89,6 @@ more details on the configuration.
 
 @include 'known-issues/1_16-ldap_auth_login_missing_entity_alias.mdx'
 
-@include 'known-issues/1_16-ldap_auth_entity_alias_missing_upndomain.mdx'
-
 @include 'known-issues/1_16-default-policy-needs-to-be-updated.mdx'
 
 @include 'known-issues/1_16-default-lcq-pre-1_9-upgrade.mdx'


### PR DESCRIPTION
I initially had the content in the partial file. Then I opted to put the content in the website/content/docs/upgrading/upgrade-to-1.16.x.mdx file instead. This was not a known issue but a behavior change.