### PR TITLE
Add vault-ui team to codeowners file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -35,6 +35,7 @@
 /website/content/docs/plugins/              @hashicorp/vault-ecosystem @hashicorp/vault-education-approvers
 /website/content/docs/upgrading/plugins.mdx @hashicorp/vault-ecosystem @hashicorp/vault-education-approvers
 
+/ui/  @hashicorp/vault-ui
 # UI code related to Vault's JWT/OIDC auth method and OIDC provider.
 # Changes to these files often require coordination with backend code,
 # so stewards of the backend code are added below for notification.


### PR DESCRIPTION
Adds team [vault-ui](https://github.com/orgs/hashicorp/teams/vault-ui) as codeowners of the `ui` directory