### PR TITLE
Fix heading level for Parameters in Identity/Group API doc page

### DIFF
--- a/website/content/api-docs/secret/identity/group-alias.mdx
+++ b/website/content/api-docs/secret/identity/group-alias.mdx
@@ -154,7 +154,7 @@ This endpoint deletes a group alias.
 | :------- | :----------------------------- |
 | `DELETE` | `/identity/group-alias/id/:id` |
 
-## Parameters
+### Parameters
 
 - `id` `(string: <required>)` – ID of the group alias.
 

--- a/website/content/api-docs/secret/identity/group.mdx
+++ b/website/content/api-docs/secret/identity/group.mdx
@@ -181,7 +181,7 @@ This endpoint deletes a group.
 | :------- | :----------------------- |
 | `DELETE` | `/identity/group/id/:id` |
 
-## Parameters
+### Parameters
 
 - `id` `(string: <required>)` – Identifier of the group.
 


### PR DESCRIPTION
This PR corrects the _heading level_ for the **Parameters** sub-section of the **Delete group by ID** section. The incorrect heading level was causing **On this page** TOC to contain a Parameters section.