### PR TITLE
UI: patch lodash.template nested dependency

### DIFF
--- a/ui/.yarn/patches/lodash.template-npm-4.5.0-5272df3039.patch
+++ b/ui/.yarn/patches/lodash.template-npm-4.5.0-5272df3039.patch
@@ -1,0 +1,45 @@
+diff --git a/index.js b/index.js
+index f051141e362679e1cc12f3dca924d8f6e7f5459b..63815c4c53412263de74fd4d779cfd198be87c8e 100644
+--- a/index.js
++++ b/index.js
+@@ -17,6 +17,9 @@ var HOT_COUNT = 800,
+ var INFINITY = 1 / 0,
+     MAX_SAFE_INTEGER = 9007199254740991;
+ 
++/** Error message constants. */
++var INVALID_TEMPL_VAR_ERROR_TEXT = 'Invalid `variable` option passed into `_.template`';
++
+ /** `Object#toString` result references. */
+ var argsTag = '[object Arguments]',
+     arrayTag = '[object Array]',
+@@ -1343,6 +1346,18 @@ function keysIn(object) {
+   return isArrayLike(object) ? arrayLikeKeys(object, true) : baseKeysIn(object);
+ }
+ 
++/**
++   * Used to validate the `validate` option in `_.template` variable.
++   *
++   * Forbids characters which could potentially change the meaning of the function argument definition:
++   * - "()," (modification of function parameters)
++   * - "=" (default value)
++   * - "[]{}" (destructuring of function parameters)
++   * - "/" (beginning of a comment)
++   * - whitespace
++   */
++var reForbiddenIdentifierChars = /[()=,{}\[\]\/\s]/;
++
+ /**
+  * Creates a compiled template function that can interpolate data properties
+  * in "interpolate" delimiters, HTML-escape interpolated data properties in
+@@ -1522,6 +1537,11 @@ function template(string, options, guard) {
+   if (!variable) {
+     source = 'with (obj) {\n' + source + '\n}\n';
+   }
++  // Throw an error if a forbidden character was found in `variable`, to prevent
++  // potential command injection attacks.
++  else if (reForbiddenIdentifierChars.test(variable)) {
++    throw new Error(INVALID_TEMPL_VAR_ERROR_TEXT);
++  }
+   // Cleanup code by stripping empty strings.
+   source = (isEvaluating ? source.replace(reEmptyStringLeading, '') : source)
+     .replace(reEmptyStringMiddle, '$1')

--- a/ui/package.json
+++ b/ui/package.json
@@ -220,7 +220,9 @@
     "xmlhttprequest-ssl": "^1.6.2",
     "@embroider/macros": "^1.15.0",
     "socket.io": "^4.6.2",
-    "json5": "^1.0.2"
+    "json5": "^1.0.2",
+    "lodash.template@^4.4.0": "patch:lodash.template@npm%3A4.5.0#./.yarn/patches/lodash.template-npm-4.5.0-5272df3039.patch",
+    "lodash.template@^4.5.0": "patch:lodash.template@npm%3A4.5.0#./.yarn/patches/lodash.template-npm-4.5.0-5272df3039.patch"
   },
   "engines": {
     "node": "18"

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -13809,13 +13809,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash.template@npm:^4.4.0, lodash.template@npm:^4.5.0":
+"lodash.template@npm:4.5.0":
   version: 4.5.0
   resolution: "lodash.template@npm:4.5.0"
   dependencies:
     lodash._reinterpolate: ^3.0.0
     lodash.templatesettings: ^4.0.0
   checksum: ca64e5f07b6646c9d3dbc0fe3aaa995cb227c4918abd1cef7a9024cd9c924f2fa389a0ec4296aa6634667e029bc81d4bbdb8efbfde11df76d66085e6c529b450
+  languageName: node
+  linkType: hard
+
+"lodash.template@patch:lodash.template@npm%3A4.5.0#./.yarn/patches/lodash.template-npm-4.5.0-5272df3039.patch::locator=vault%40workspace%3A.":
+  version: 4.5.0
+  resolution: "lodash.template@patch:lodash.template@npm%3A4.5.0#./.yarn/patches/lodash.template-npm-4.5.0-5272df3039.patch::version=4.5.0&hash=fc7e65&locator=vault%40workspace%3A."
+  dependencies:
+    lodash._reinterpolate: ^3.0.0
+    lodash.templatesettings: ^4.0.0
+  checksum: 7d6d1f5d57bf1ef0dd2877e49f00a45423030372e9d7bd2982c98e5d25805038a51af19149eabe7643bf558dfec2d53bc0db2abd627d2e91755d14da638e6030
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
`ember-cli` and `ember-fetch` both use [lodash.template](https://www.npmjs.com/package/lodash.template) which is outdated. This PR patches the version we import with the changes from [this change to lodash](https://github.com/lodash/lodash/commit/3469357cff396a26c363f8c1b5a91dde28ba4b1c)