### PR TITLE
UI: Fix horizontal bar chart tooltip rendering

### DIFF
--- a/ui/app/components/clients/attribution.hbs
+++ b/ui/app/components/clients/attribution.hbs
@@ -55,7 +55,7 @@
 
       <div class="data-details-top" data-test-top-attribution>
         <h3 class="data-details">Top {{this.attributionBreakdown}}</h3>
-        <p class="data-details">{{this.topClientCounts.label}}</p>
+        <p class="data-details is-word-break">{{this.topClientCounts.label}}</p>
       </div>
 
       <div class="data-details-bottom" data-test-attribution-clients>

--- a/ui/app/components/clients/horizontal-bar-chart.js
+++ b/ui/app/components/clients/horizontal-bar-chart.js
@@ -162,15 +162,10 @@ export default class HorizontalBarChart extends Component {
       .style('opacity', '0')
       .style('mix-blend-mode', 'multiply');
 
-    const actionBarSelection = chartSvg.selectAll('rect.action-bar');
-
-    const compareAttributes = (elementA, elementB, attr) =>
-      select(elementA).attr(`${attr}`) === select(elementB).attr(`${attr}`);
-
     // MOUSE EVENTS FOR DATA BARS
     actionBars
-      .on('mouseover', (data) => {
-        const hoveredElement = actionBars.filter((bar) => bar[labelKey] === data[labelKey]).node();
+      .on('mouseover', (event, data) => {
+        const hoveredElement = event.currentTarget;
         this.tooltipTarget = hoveredElement;
         this.isLabel = false;
         this.tooltipText = []; // clear stats
@@ -188,28 +183,18 @@ export default class HorizontalBarChart extends Component {
 
     // MOUSE EVENTS FOR Y-AXIS LABELS
     labelActionBar
-      .on('mouseover', (data) => {
+      .on('mouseover', (event, data) => {
         if (data[labelKey].length >= CHAR_LIMIT) {
-          const hoveredElement = labelActionBar.filter((bar) => bar[labelKey] === data[labelKey]).node();
+          const hoveredElement = event.currentTarget;
           this.tooltipTarget = hoveredElement;
           this.isLabel = true;
           this.tooltipText = [data[labelKey]];
         } else {
           this.tooltipTarget = null;
         }
-        actionBarSelection
-          .filter(function () {
-            return compareAttributes(this, event.target, 'y');
-          })
-          .style('opacity', '1');
       })
       .on('mouseout', function () {
         this.tooltipTarget = null;
-        actionBarSelection
-          .filter(function () {
-            return compareAttributes(this, event.target, 'y');
-          })
-          .style('opacity', '0');
       });
 
     // client count total values to the right


### PR DESCRIPTION
I believe this bug was caused by upgrading the d3 pacakges

<img width="1061" alt="Screenshot 2024-04-24 at 2 56 38 PM" src="https://github.com/hashicorp/vault/assets/68122737/f98d88c1-983d-45a6-a93f-fd136e29cad7">

## and for long names
<img width="292" alt="Screenshot 2024-04-24 at 2 56 50 PM" src="https://github.com/hashicorp/vault/assets/68122737/ce4d3ca2-97bd-4537-9229-03be535902ce">
