### PR TITLE
Allow Managed clusters to see Secrets Sync Overview and Sidebar nav

### DIFF
--- a/ui/app/components/sidebar/nav/cluster.hbs
+++ b/ui/app/components/sidebar/nav/cluster.hbs
@@ -13,14 +13,12 @@
     @text="Secrets Engines"
     data-test-sidebar-nav-link="Secrets Engines"
   />
-  {{#if this.showSync}}
-    <Nav.Link
-      @route="vault.cluster.sync"
-      @text="Secrets Sync"
-      @badge={{this.syncBadge}}
-      data-test-sidebar-nav-link="Secrets Sync"
-    />
-  {{/if}}
+  <Nav.Link
+    @route="vault.cluster.sync"
+    @text="Secrets Sync"
+    @badge={{this.badgeText}}
+    data-test-sidebar-nav-link="Secrets Sync"
+  />
   {{#if (has-permission "access")}}
     <Nav.Link
       @route={{get (route-params-for "access") "route"}}

--- a/ui/app/components/sidebar/nav/cluster.js
+++ b/ui/app/components/sidebar/nav/cluster.js
@@ -29,7 +29,7 @@ export default class SidebarNavClusterComponent extends Component {
 
     if (isManaged) return 'Plus';
     if (isEnterprise && !onLicense) return 'Premium';
-    if (!isEnterprise) 'Enterprise';
+    if (!isEnterprise) return 'Enterprise';
     // no badge for Enterprise clusters with Secrets Sync on their license--the only remaining option.
     return undefined;
   }

--- a/ui/app/components/sidebar/nav/cluster.js
+++ b/ui/app/components/sidebar/nav/cluster.js
@@ -31,6 +31,6 @@ export default class SidebarNavClusterComponent extends Component {
     if (isEnterprise && !onLicense) return 'Premium';
     if (!isEnterprise) return 'Enterprise';
     // no badge for Enterprise clusters with Secrets Sync on their license--the only remaining option.
-    return undefined;
+    return '';
   }
 }

--- a/ui/app/components/sidebar/nav/cluster.js
+++ b/ui/app/components/sidebar/nav/cluster.js
@@ -21,15 +21,15 @@ export default class SidebarNavClusterComponent extends Component {
     // should only return true if we're in the true root namespace
     return this.namespace.inRootNamespace && !this.cluster?.hasChrootNamespace;
   }
+  get badgeText() {
+    const isManaged = this.flags.isManaged;
+    const onLicense = this.version.hasSecretsSync;
+    const isEnterprise = this.version.isEnterprise;
 
-  get showSync() {
-    // Only show sync if cluster is not managed
-    return this.flags.managedNamespaceRoot === null;
-  }
-
-  get syncBadge() {
-    if (this.version.isCommunity) return 'Enterprise';
-    if (!this.version.hasSecretsSync) return 'Premium';
+    if (isManaged) return 'Plus';
+    if (isEnterprise && !onLicense) return 'Premium';
+    if (!isEnterprise) 'Enterprise';
+    // no badge for Enterprise clusters with Secrets Sync on their license--the only remaining option.
     return undefined;
   }
 }

--- a/ui/app/components/sidebar/nav/cluster.js
+++ b/ui/app/components/sidebar/nav/cluster.js
@@ -21,6 +21,7 @@ export default class SidebarNavClusterComponent extends Component {
     // should only return true if we're in the true root namespace
     return this.namespace.inRootNamespace && !this.cluster?.hasChrootNamespace;
   }
+
   get badgeText() {
     const isManaged = this.flags.isManaged;
     const onLicense = this.version.hasSecretsSync;

--- a/ui/app/routes/application.js
+++ b/ui/app/routes/application.js
@@ -65,14 +65,7 @@ export default Route.extend({
     },
   },
 
-  async beforeModel() {
-    const result = await fetch('/v1/sys/internal/ui/feature-flags', {
-      method: 'GET',
-    });
-    if (result.status === 200) {
-      const body = await result.json();
-      const flags = body.feature_flags || [];
-      this.flagsService.setFeatureFlags(flags);
-    }
+  beforeModel() {
+    return this.flags.fetchFeatureFlags();
   },
 });

--- a/ui/app/routes/application.js
+++ b/ui/app/routes/application.js
@@ -66,6 +66,6 @@ export default Route.extend({
   },
 
   beforeModel() {
-    return this.flags.fetchFeatureFlags();
+    return this.flagsService.fetchFeatureFlags();
   },
 });

--- a/ui/app/services/flags.ts
+++ b/ui/app/services/flags.ts
@@ -38,6 +38,10 @@ export default class flagsService extends Service {
     return null;
   }
 
+  get isManaged() {
+    return this.managedNamespaceRoot !== null;
+  }
+
   // TODO getter will be used in the upcoming persona service
   get secretsSyncIsActivated() {
     return this.activatedFlags.includes('secrets-sync');

--- a/ui/app/services/flags.ts
+++ b/ui/app/services/flags.ts
@@ -42,7 +42,6 @@ export default class flagsService extends Service {
     return this.managedNamespaceRoot !== null;
   }
 
-  // TODO getter will be used in the upcoming persona service
   get secretsSyncIsActivated() {
     return this.activatedFlags.includes('secrets-sync');
   }

--- a/ui/app/services/flags.ts
+++ b/ui/app/services/flags.ts
@@ -31,18 +31,15 @@ export default class flagsService extends Service {
     this.flags = flags;
   }
 
-  get managedNamespaceRoot() {
-    if (this.flags && this.flags.includes(FLAGS.vaultCloudNamespace)) {
-      return 'admin';
-    }
-    return null;
+  get isManaged(): boolean {
+    return this.flags && this.flags.includes(FLAGS.vaultCloudNamespace);
   }
 
-  get isManaged() {
-    return this.managedNamespaceRoot !== null;
+  get managedNamespaceRoot(): string | null {
+    return this.isManaged ? 'admin' : null;
   }
 
-  get secretsSyncIsActivated() {
+  get secretsSyncIsActivated(): boolean {
     return this.activatedFlags.includes('secrets-sync');
   }
 

--- a/ui/app/services/version.js
+++ b/ui/app/services/version.js
@@ -48,8 +48,6 @@ export default class VersionService extends Service {
   }
 
   get hasSecretsSync() {
-    // TODO remove this conditional when we allow secrets sync in managed clusters
-    if (this.flags.managedNamespaceRoot !== null) return false;
     return this.features.includes('Secrets Sync');
   }
 

--- a/ui/lib/sync/addon/components/secrets/landing-cta.hbs
+++ b/ui/lib/sync/addon/components/secrets/landing-cta.hbs
@@ -15,8 +15,8 @@
 <div class="box is-fullwidth is-sideless is-flex-between is-shadowless" data-test-cta-container>
   {{! One cta message regardless of OSS vs Enterprise with/without secrets sync or managed cluster. }}
   <p>
-    This premium enterprise feature allows you to sync secrets to platforms and tools across your stack to get secrets when
-    and where you need them.
+    This feature allows you to sync secrets to platforms and tools across your stack to get secrets when and where you need
+    them.
     <Hds::Link::Standalone
       @text="Learn more about Secrets Sync"
       @icon="docs-link"

--- a/ui/lib/sync/addon/components/secrets/landing-cta.hbs
+++ b/ui/lib/sync/addon/components/secrets/landing-cta.hbs
@@ -5,38 +5,27 @@
 
 <SyncHeader @title="Secrets Sync">
   <:actions>
-    {{! Only allow users to create a destination if secrets-sync is activated and they have the secrets sync feature }}
-    {{#if (and @hasSecretsSync @isActivated)}}
+    {{! Only allow users who have activated the feature to create a destination. }}
+    {{#if @isActivated}}
       <Hds::Button @text="Create first destination" @route="secrets.destinations.create" data-test-cta-button />
     {{/if}}
   </:actions>
 </SyncHeader>
 
 <div class="box is-fullwidth is-sideless is-flex-between is-shadowless" data-test-cta-container>
-  {{#if @hasSecretsSync}}
-    <p>
-      Sync secrets to platforms and tools across your stack to get secrets when and where you need them.
-      <Hds::Link::Standalone
-        @icon="learn-link"
-        @text="Secrets Sync tutorial"
-        @href={{doc-link "/vault/tutorials/enterprise/secrets-sync"}}
-        data-test-cta-doc-link
-      />
-    </p>
-  {{else}}
-    <p>
-      This premium enterprise feature allows you to sync secrets to platforms and tools across your stack to get secrets when
-      and where you need them.
-      <Hds::Link::Standalone
-        @text="Learn more about Secrets Sync"
-        @icon="docs-link"
-        @iconPosition="trailing"
-        @isHrefExternal={{true}}
-        @href={{doc-link "/vault/tutorials/enterprise/secrets-sync"}}
-        data-test-cta-doc-link
-      />
-    </p>
-  {{/if}}
+  {{! One cta message regardless of OSS vs Enterprise with/without secrets sync or managed cluster. }}
+  <p>
+    This premium enterprise feature allows you to sync secrets to platforms and tools across your stack to get secrets when
+    and where you need them.
+    <Hds::Link::Standalone
+      @text="Learn more about Secrets Sync"
+      @icon="docs-link"
+      @iconPosition="trailing"
+      @isHrefExternal={{true}}
+      @href={{doc-link "/vault/tutorials/enterprise/secrets-sync"}}
+      data-test-cta-doc-link
+    />
+  </p>
 </div>
 
 <div class="is-flex-row gap-24 has-bottom-margin-m">

--- a/ui/lib/sync/addon/components/secrets/page/overview.hbs
+++ b/ui/lib/sync/addon/components/secrets/page/overview.hbs
@@ -3,27 +3,29 @@
   SPDX-License-Identifier: BUSL-1.1
 ~}}
 
-{{#if (and this.version.hasSecretsSync (not @isActivated))}}
-  {{#unless this.hideOptIn}}
-    <Hds::Alert
-      @type="inline"
-      @color="warning"
-      @onDismiss={{fn (mut this.hideOptIn) true}}
-      data-test-secrets-sync-opt-in-banner
-      as |A|
-    >
-      <A.Title>Enable Secrets Sync feature</A.Title>
-      <A.Description>To use this feature, specific activation is required. Please review the feature documentation and enable
-        it. If you're upgrading from beta, your previous data will be accessible after activation.</A.Description>
-      <A.Button
-        @text="Enable"
-        @color="secondary"
-        {{on "click" (fn (mut this.showActivateSecretsSyncModal) true)}}
-        data-test-secrets-sync-opt-in-banner-enable
-      />
-    </Hds::Alert>
-  {{/unless}}
-{{/if}}
+{{#unless @isActivated}}
+  {{#if (or @licenseHasSecretsSync @isManaged)}}
+    {{#unless this.hideOptIn}}
+      <Hds::Alert
+        @type="inline"
+        @color="warning"
+        @onDismiss={{fn (mut this.hideOptIn) true}}
+        data-test-secrets-sync-opt-in-banner
+        as |A|
+      >
+        <A.Title>Enable Secrets Sync feature</A.Title>
+        <A.Description>To use this feature, specific activation is required. Please review the feature documentation and
+          enable it. If you're upgrading from beta, your previous data will be accessible after activation.</A.Description>
+        <A.Button
+          @text="Enable"
+          @color="secondary"
+          {{on "click" (fn (mut this.showActivateSecretsSyncModal) true)}}
+          data-test-secrets-sync-opt-in-banner-enable
+        />
+      </Hds::Alert>
+    {{/unless}}
+  {{/if}}
+{{/unless}}
 
 {{! error message if post to activated endpoint fails }}
 {{#if this.error}}
@@ -185,7 +187,7 @@
     </OverviewCard>
   </div>
 {{else}}
-  <Secrets::LandingCta @isActivated={{@isActivated}} @hasSecretsSync={{this.version.hasSecretsSync}} />
+  <Secrets::LandingCta @isActivated={{@isActivated}} />
 {{/if}}
 
 {{#if this.showActivateSecretsSyncModal}}

--- a/ui/lib/sync/addon/components/secrets/page/overview.ts
+++ b/ui/lib/sync/addon/components/secrets/page/overview.ts
@@ -74,7 +74,7 @@ export default class SyncSecretsDestinationsPageComponent extends Component<Args
     try {
       yield this.store
         .adapterFor('application')
-        .ajax('/v1/sys/activation-flags/secrets-sync/activate', 'POST', { namespace: null });
+        .ajax('/v1/sys/activation-flags/secrets-sync/activate', 'POST');
       this.router.transitionTo('vault.cluster.sync.secrets.overview');
     } catch (error) {
       this.error = errorMessage(error);

--- a/ui/lib/sync/addon/components/sync-header.ts
+++ b/ui/lib/sync/addon/components/sync-header.ts
@@ -7,6 +7,7 @@ import Component from '@glimmer/component';
 import { service } from '@ember/service';
 
 import type VersionService from 'vault/services/version';
+import type FlagsService from 'vault/services/flags';
 import type { Breadcrumb } from 'vault/vault/app-types';
 
 interface Args {
@@ -17,12 +18,17 @@ interface Args {
 
 export default class SyncHeaderComponent extends Component<Args> {
   @service declare readonly version: VersionService;
+  @service declare readonly flags: FlagsService;
 
   get badgeText() {
-    return this.version.hasSecretsSync
-      ? ''
-      : this.version.isCommunity
-      ? 'Enterprise feature'
-      : 'Premium feature';
+    const isManaged = this.flags.isManaged;
+    const onLicense = this.version.hasSecretsSync;
+    const isEnterprise = this.version.isEnterprise;
+
+    if (isManaged) return 'Plus feature';
+    if (isEnterprise && !onLicense) return 'Premium feature';
+    if (!isEnterprise) 'Enterprise feature';
+    // no badge for Enterprise clusters with Secrets Sync on their license--the only remaining option.
+    return undefined;
   }
 }

--- a/ui/lib/sync/addon/components/sync-header.ts
+++ b/ui/lib/sync/addon/components/sync-header.ts
@@ -29,6 +29,6 @@ export default class SyncHeaderComponent extends Component<Args> {
     if (isEnterprise && !onLicense) return 'Premium feature';
     if (!isEnterprise) return 'Enterprise feature';
     // no badge for Enterprise clusters with Secrets Sync on their license--the only remaining option.
-    return undefined;
+    return '';
   }
 }

--- a/ui/lib/sync/addon/components/sync-header.ts
+++ b/ui/lib/sync/addon/components/sync-header.ts
@@ -27,7 +27,7 @@ export default class SyncHeaderComponent extends Component<Args> {
 
     if (isManaged) return 'Plus feature';
     if (isEnterprise && !onLicense) return 'Premium feature';
-    if (!isEnterprise) 'Enterprise feature';
+    if (!isEnterprise) return 'Enterprise feature';
     // no badge for Enterprise clusters with Secrets Sync on their license--the only remaining option.
     return undefined;
   }

--- a/ui/lib/sync/addon/routes/secrets/overview.ts
+++ b/ui/lib/sync/addon/routes/secrets/overview.ts
@@ -9,15 +9,22 @@ import { hash } from 'rsvp';
 
 import type FlagsService from 'vault/services/flags';
 import type StoreService from 'vault/services/store';
+import type VersionService from 'vault/services/version';
 
 export default class SyncSecretsOverviewRoute extends Route {
   @service declare readonly store: StoreService;
   @service declare readonly flags: FlagsService;
+  @service declare readonly version: VersionService;
 
   async model() {
     const isActivated = this.flags.secretsSyncIsActivated;
+    const licenseHasSecretsSync = this.version.hasSecretsSync;
+    const isManaged = this.flags.isManaged;
+
     return hash({
+      licenseHasSecretsSync,
       isActivated,
+      isManaged,
       destinations: isActivated ? this.store.query('sync/destination', {}).catch(() => []) : [],
       associations: isActivated
         ? this.store

--- a/ui/lib/sync/addon/routes/secrets/overview.ts
+++ b/ui/lib/sync/addon/routes/secrets/overview.ts
@@ -7,26 +7,15 @@ import Route from '@ember/routing/route';
 import { service } from '@ember/service';
 import { hash } from 'rsvp';
 
-import type RouterService from '@ember/routing/router-service';
 import type FlagsService from 'vault/services/flags';
 import type StoreService from 'vault/services/store';
 
 export default class SyncSecretsOverviewRoute extends Route {
-  @service declare readonly router: RouterService;
   @service declare readonly store: StoreService;
   @service declare readonly flags: FlagsService;
 
-  beforeModel(): void | Promise<unknown> {
-    if (this.flags.managedNamespaceRoot !== null) {
-      this.router.transitionTo('vault.cluster.dashboard');
-    }
-  }
-
   async model() {
-    const { activatedFeatures } = this.modelFor('secrets') as {
-      activatedFeatures: Array<string>;
-    };
-    const isActivated = activatedFeatures.includes('secrets-sync');
+    const isActivated = this.flags.secretsSyncIsActivated;
     return hash({
       isActivated,
       destinations: isActivated ? this.store.query('sync/destination', {}).catch(() => []) : [],

--- a/ui/lib/sync/addon/templates/secrets/overview.hbs
+++ b/ui/lib/sync/addon/templates/secrets/overview.hbs
@@ -7,4 +7,6 @@
   @destinations={{this.model.destinations}}
   @totalVaultSecrets={{this.model.associations.total_secrets}}
   @isActivated={{this.model.isActivated}}
+  @licenseHasSecretsSync={{this.model.licenseHasSecretsSync}}
+  @isManaged={{this.model.isManaged}}
 />

--- a/ui/tests/acceptance/sync/secrets/overview-test.js
+++ b/ui/tests/acceptance/sync/secrets/overview-test.js
@@ -162,7 +162,7 @@ module('Acceptance | sync | overview', function (hooks) {
       this.server.post('/sys/activation-flags/secrets-sync/activate', (_, req) => {
         assert.strictEqual(
           req.requestHeaders['X-Vault-Namespace'],
-          undefined,
+          'root',
           'Request is made to root namespace'
         );
         return {};
@@ -193,8 +193,8 @@ module('Acceptance | sync | overview', function (hooks) {
       this.server.post('/sys/activation-flags/secrets-sync/activate', (_, req) => {
         assert.strictEqual(
           req.requestHeaders['X-Vault-Namespace'],
-          undefined,
-          'Request is made to root namespace even from within an admin namespace'
+          'admin',
+          'Request is made to the admin namespace'
         );
         return {};
       });

--- a/ui/tests/acceptance/sync/secrets/overview-test.js
+++ b/ui/tests/acceptance/sync/secrets/overview-test.js
@@ -177,10 +177,9 @@ module('Acceptance | sync | overview', function (hooks) {
       await click(ts.overview.optInConfirm);
     });
 
-    test.skip('it should make activation-flag requests to correct namespace when managed', async function (assert) {
-      // TODO: unskip for 1.16.1 when managed is supported
+    test('it should make activation-flag requests to correct namespace when managed', async function (assert) {
       assert.expect(3);
-      this.owner.lookup('service:flags').setFeatureFlags(['VAULT_CLOUD_ADMIN_NAMESPACE']);
+      this.owner.lookup('service:flags').featureFlags = ['VAULT_CLOUD_ADMIN_NAMESPACE'];
 
       this.server.get('/sys/activation-flags', (_, req) => {
         assert.deepEqual(req.requestHeaders, {}, 'Request is unauthenticated and in root namespace');
@@ -194,8 +193,8 @@ module('Acceptance | sync | overview', function (hooks) {
       this.server.post('/sys/activation-flags/secrets-sync/activate', (_, req) => {
         assert.strictEqual(
           req.requestHeaders['X-Vault-Namespace'],
-          'admin',
-          'Request is made to admin namespace'
+          undefined,
+          'Request is made to root namespace even from within an admin namespace'
         );
         return {};
       });

--- a/ui/tests/helpers/sync/sync-selectors.js
+++ b/ui/tests/helpers/sync/sync-selectors.js
@@ -70,7 +70,7 @@ export const PAGE = {
       action: (name) => `[data-test-overview-table-action="${name}"]`,
     },
   },
-  syncBadge: {
+  badgeText: {
     icon: (name) => `[data-test-icon="${name}"]`,
     text: '.hds-badge__text',
   },

--- a/ui/tests/integration/components/sidebar/nav/cluster-test.js
+++ b/ui/tests/integration/components/sidebar/nav/cluster-test.js
@@ -138,7 +138,7 @@ module('Integration | Component | sidebar-nav-cluster', function (hooks) {
   });
 
   test('it should render badge for promotional links on managed clusters', async function (assert) {
-    this.owner.lookup('service:flags').setFeatureFlags(['VAULT_CLOUD_ADMIN_NAMESPACE']);
+    this.owner.lookup('service:flags').featureFlags = ['VAULT_CLOUD_ADMIN_NAMESPACE'];
     const promotionalLinks = ['Secrets Sync'];
     stubFeaturesAndPermissions(this.owner, true, true);
     await renderComponent();

--- a/ui/tests/integration/components/sidebar/nav/cluster-test.js
+++ b/ui/tests/integration/components/sidebar/nav/cluster-test.js
@@ -49,6 +49,7 @@ module('Integration | Component | sidebar-nav-cluster', function (hooks) {
 
   test('it should hide links and headings user does not have access too', async function (assert) {
     await renderComponent();
+
     assert
       .dom('[data-test-sidebar-nav-link]')
       .exists({ count: 3 }, 'Nav links are hidden other than secrets, secrets sync and dashboard');

--- a/ui/tests/integration/components/sidebar/nav/cluster-test.js
+++ b/ui/tests/integration/components/sidebar/nav/cluster-test.js
@@ -85,7 +85,8 @@ module('Integration | Component | sidebar-nav-cluster', function (hooks) {
 
   test('it should render badge for promotional links on community version', async function (assert) {
     const promotionalLinks = ['Secrets Sync'];
-    stubFeaturesAndPermissions(this.owner, false, true);
+    // if no features passed, it defaults to all features and we need to specifically remove Secrets Sync
+    stubFeaturesAndPermissions(this.owner, false, true, []);
     await renderComponent();
 
     promotionalLinks.forEach((link) => {
@@ -135,13 +136,16 @@ module('Integration | Component | sidebar-nav-cluster', function (hooks) {
     });
   });
 
-  test('it should not show sync links for managed cluster', async function (assert) {
+  test('it should render badge for promotional links on managed clusters', async function (assert) {
     this.owner.lookup('service:flags').setFeatureFlags(['VAULT_CLOUD_ADMIN_NAMESPACE']);
-    stubFeaturesAndPermissions(this.owner, true, true, ['Secrets Sync']);
+    const promotionalLinks = ['Secrets Sync'];
+    stubFeaturesAndPermissions(this.owner, true, true);
     await renderComponent();
 
-    assert
-      .dom(`[data-test-sidebar-nav-link="Secrets Sync"]`)
-      .doesNotExist(`Secret Sync is hidden in managed vault`);
+    promotionalLinks.forEach((link) => {
+      assert
+        .dom(`[data-test-sidebar-nav-link="${link}"]`)
+        .hasText(`${link} Plus`, `${link} link renders Plus badge`);
+    });
   });
 });

--- a/ui/tests/integration/components/sync-status-badge-test.js
+++ b/ui/tests/integration/components/sync-status-badge-test.js
@@ -35,8 +35,8 @@ module('Integration | Component | SyncStatusBadge', function (hooks) {
   test('it should render when status does not exist', async function (assert) {
     assert.expect(2);
     await this.renderComponent();
-    assert.dom(PAGE.syncBadge.icon('help')).exists('renders help icon');
-    assert.dom(PAGE.syncBadge.text).hasText(this.status);
+    assert.dom(PAGE.badgeText.icon('help')).exists('renders help icon');
+    assert.dom(PAGE.badgeText.text).hasText(this.status);
   });
 
   test('it renders badge and icon for each status type', async function (assert) {
@@ -46,8 +46,8 @@ module('Integration | Component | SyncStatusBadge', function (hooks) {
       const label = toLabel([status]);
       const { icon, color } = SYNC_STATUSES[status];
       await this.renderComponent();
-      assert.dom(PAGE.syncBadge.icon(icon)).exists(`status: ${status} renders icon: ${icon}`);
-      assert.dom(PAGE.syncBadge.text).hasText(label, `status: ${status} renders label: ${label}`);
+      assert.dom(PAGE.badgeText.icon(icon)).exists(`status: ${status} renders icon: ${icon}`);
+      assert.dom(PAGE.badgeText.text).hasText(label, `status: ${status} renders label: ${label}`);
       assert
         .dom('[data-test-badge]')
         .hasClass(`hds-badge--color-${color}`, `status: ${status} renders color: ${color}`);

--- a/ui/tests/integration/components/sync/secrets/landing-cta-test.js
+++ b/ui/tests/integration/components/sync/secrets/landing-cta-test.js
@@ -31,13 +31,13 @@ module('Integration | Component | sync | Secrets::LandingCta', function (hooks) 
     assert
       .dom(cta.summary)
       .hasText(
-        'This premium enterprise feature allows you to sync secrets to platforms and tools across your stack to get secrets when and where you need them. Learn more about Secrets Sync'
+        'This feature allows you to sync secrets to platforms and tools across your stack to get secrets when and where you need them. Learn more about Secrets Sync'
       );
     assert.dom(cta.link).hasText('Learn more about Secrets Sync');
     assert.dom(cta.button).doesNotExist('does not render create destination button');
   });
 
-  test('it should render CTA copy and action feature is activated', async function (assert) {
+  test('it should render CTA copy and action if feature is activated', async function (assert) {
     await render(hbs`<Secrets::LandingCta @isActivated={{true}} /> `, {
       owner: this.engine,
     });
@@ -45,7 +45,7 @@ module('Integration | Component | sync | Secrets::LandingCta', function (hooks) 
     assert
       .dom(cta.summary)
       .hasText(
-        'This premium enterprise feature allows you to sync secrets to platforms and tools across your stack to get secrets when and where you need them. Learn more about Secrets Sync'
+        'This feature allows you to sync secrets to platforms and tools across your stack to get secrets when and where you need them. Learn more about Secrets Sync'
       );
     assert.dom(cta.link).hasText('Learn more about Secrets Sync');
     assert.dom(cta.button).exists('it renders create destination button');

--- a/ui/tests/integration/components/sync/secrets/landing-cta-test.js
+++ b/ui/tests/integration/components/sync/secrets/landing-cta-test.js
@@ -44,9 +44,9 @@ module('Integration | Component | sync | Secrets::LandingCta', function (hooks) 
     assert
       .dom(cta.summary)
       .hasText(
-        'Sync secrets to platforms and tools across your stack to get secrets when and where you need them. Secrets Sync tutorial'
+        'This premium enterprise feature allows you to sync secrets to platforms and tools across your stack to get secrets when and where you need them. Learn more about Secrets Sync'
       );
-    assert.dom(cta.link).hasText('Secrets Sync tutorial');
+    assert.dom(cta.link).hasText('Learn more about Secrets Sync');
     assert.dom(cta.button).doesNotExist('does not render create destination button');
   });
 
@@ -58,9 +58,9 @@ module('Integration | Component | sync | Secrets::LandingCta', function (hooks) 
     assert
       .dom(cta.summary)
       .hasText(
-        'Sync secrets to platforms and tools across your stack to get secrets when and where you need them. Secrets Sync tutorial'
+        'This premium enterprise feature allows you to sync secrets to platforms and tools across your stack to get secrets when and where you need them. Learn more about Secrets Sync'
       );
-    assert.dom(cta.link).hasText('Secrets Sync tutorial');
+    assert.dom(cta.link).hasText('Learn more about Secrets Sync');
     assert.dom(cta.button).exists('it renders create destination button');
   });
 });

--- a/ui/tests/integration/components/sync/secrets/landing-cta-test.js
+++ b/ui/tests/integration/components/sync/secrets/landing-cta-test.js
@@ -23,8 +23,8 @@ module('Integration | Component | sync | Secrets::LandingCta', function (hooks) 
     this.transitionStub = sinon.stub(this.owner.lookup('service:router'), 'transitionTo');
   });
 
-  test('it should render promotional copy for community or enterprise version without feature', async function (assert) {
-    await render(hbs`<Secrets::LandingCta @isActivated={{false}} @hasSecretsSync={{false}} /> `, {
+  test('it should render promotional copy if feature is not activated', async function (assert) {
+    await render(hbs`<Secrets::LandingCta @isActivated={{false}} /> `, {
       owner: this.engine,
     });
 
@@ -37,21 +37,8 @@ module('Integration | Component | sync | Secrets::LandingCta', function (hooks) 
     assert.dom(cta.button).doesNotExist('does not render create destination button');
   });
 
-  test('it should render CTA copy but not action when feature exists on enterprise license and is not activated', async function (assert) {
-    await render(hbs`<Secrets::LandingCta @isActivated={{false}} @hasSecretsSync={{true}} /> `, {
-      owner: this.engine,
-    });
-    assert
-      .dom(cta.summary)
-      .hasText(
-        'This premium enterprise feature allows you to sync secrets to platforms and tools across your stack to get secrets when and where you need them. Learn more about Secrets Sync'
-      );
-    assert.dom(cta.link).hasText('Learn more about Secrets Sync');
-    assert.dom(cta.button).doesNotExist('does not render create destination button');
-  });
-
-  test('it should render CTA copy and action when feature exists on enterprise license and is activated', async function (assert) {
-    await render(hbs`<Secrets::LandingCta @isActivated={{true}} @hasSecretsSync={{true}} /> `, {
+  test('it should render CTA copy and action feature is activated', async function (assert) {
+    await render(hbs`<Secrets::LandingCta @isActivated={{true}} /> `, {
       owner: this.engine,
     });
 

--- a/ui/tests/integration/components/sync/secrets/page/overview-test.js
+++ b/ui/tests/integration/components/sync/secrets/page/overview-test.js
@@ -24,7 +24,6 @@ module('Integration | Component | sync | Page::Overview', function (hooks) {
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {
-    // the component calls on the two services below to determine the state of the page
     this.version = this.owner.lookup('service:version');
     this.store = this.owner.lookup('service:store');
     this.version.type = 'enterprise';
@@ -123,7 +122,7 @@ module('Integration | Component | sync | Page::Overview', function (hooks) {
     });
   });
 
-  module('secrets sync not activated and license has secrets sync', function (hooks) {
+  module('secrets sync is not activated and license has secrets sync', function (hooks) {
     hooks.beforeEach(async function () {
       this.isActivated = false;
     });
@@ -177,7 +176,7 @@ module('Integration | Component | sync | Page::Overview', function (hooks) {
     });
   });
 
-  module('secrets sync not activated and license does not have secrets sync', function (hooks) {
+  module('secrets sync is not activated and license does not have secrets sync', function (hooks) {
     hooks.beforeEach(async function () {
       this.licenseHasSecretsSync = false;
     });

--- a/ui/tests/integration/components/sync/secrets/page/overview-test.js
+++ b/ui/tests/integration/components/sync/secrets/page/overview-test.js
@@ -34,10 +34,9 @@ module('Integration | Component | sync | Page::Overview', function (hooks) {
     syncHandlers(this.server);
 
     this.destinations = await this.store.query('sync/destination', {});
-    // component test so set values that would normally be calculated on the route model from the services.
     this.isActivated = true;
     this.licenseHasSecretsSync = true;
-    this.isManged = false;
+    this.isManaged = false;
 
     this.renderComponent = () => {
       return render(
@@ -103,7 +102,28 @@ module('Integration | Component | sync | Page::Overview', function (hooks) {
     });
   });
 
-  module('secrets sync not activated', function (hooks) {
+  module('managed', function (hooks) {
+    hooks.beforeEach(function () {
+      this.isActivated = false;
+      this.isManaged = true;
+      this.destinations = [];
+    });
+
+    test('it should show the opt-in banner if feature is not activated', async function (assert) {
+      await this.renderComponent();
+
+      assert.dom(overview.optInBanner).exists('Opt-in banner is shown');
+    });
+
+    test('it should not show the opt-in banner if feature is activated', async function (assert) {
+      await this.renderComponent();
+      this.isActivated = true;
+
+      assert.dom(overview.optInBanner).doesNotExist('Opt-in banner is not shown');
+    });
+  });
+
+  module('secrets sync not activated and license has secrets sync', function (hooks) {
     hooks.beforeEach(async function () {
       this.isActivated = false;
     });
@@ -154,6 +174,18 @@ module('Integration | Component | sync | Page::Overview', function (hooks) {
 
       assert.dom(overview.optInError).exists('shows an error banner');
       assert.dom(overview.optInBanner).exists('banner is visible so user can try to opt-in again');
+    });
+  });
+
+  module('secrets sync not activated and license does not have secrets sync', function (hooks) {
+    hooks.beforeEach(async function () {
+      this.licenseHasSecretsSync = false;
+    });
+
+    test('it should hide the opt-in banner', async function (assert) {
+      await this.renderComponent();
+
+      assert.dom(overview.optInBanner).doesNotExist();
     });
   });
 

--- a/ui/tests/integration/components/sync/secrets/page/overview-test.js
+++ b/ui/tests/integration/components/sync/secrets/page/overview-test.js
@@ -116,8 +116,8 @@ module('Integration | Component | sync | Page::Overview', function (hooks) {
     });
 
     test('it should not show the opt-in banner if feature is activated', async function (assert) {
-      await this.renderComponent();
       this.isActivated = true;
+      await this.renderComponent();
 
       assert.dom(overview.optInBanner).doesNotExist('Opt-in banner is not shown');
     });

--- a/ui/tests/integration/components/sync/sync-header-test.js
+++ b/ui/tests/integration/components/sync/sync-header-test.js
@@ -68,7 +68,7 @@ module('Integration | Component | sync | SyncHeader', function (hooks) {
   module('managed', function (hooks) {
     hooks.beforeEach(function () {
       this.version.type = 'enterprise';
-      this.flags.setFeatureFlags(['VAULT_CLOUD_ADMIN_NAMESPACE']);
+      this.flags.featureFlags = ['VAULT_CLOUD_ADMIN_NAMESPACE'];
     });
 
     test('it should render title and plus badge', async function (assert) {

--- a/ui/tests/integration/components/sync/sync-header-test.js
+++ b/ui/tests/integration/components/sync/sync-header-test.js
@@ -18,6 +18,7 @@ module('Integration | Component | sync | SyncHeader', function (hooks) {
 
   hooks.beforeEach(function () {
     this.version = this.owner.lookup('service:version');
+    this.flags = this.owner.lookup('service:flags');
     this.title = 'Secrets Sync';
     this.renderComponent = () => {
       return render(hbs`<SyncHeader @title={{this.title}} @breadcrumbs={{this.breadcrumbs}} />`, {
@@ -61,6 +62,18 @@ module('Integration | Component | sync | SyncHeader', function (hooks) {
       await this.renderComponent();
 
       assert.dom(title).hasText('Secrets Sync Enterprise feature');
+    });
+  });
+
+  module('managed', function (hooks) {
+    hooks.beforeEach(function () {
+      this.version.type = 'enterprise';
+      this.flags.setFeatureFlags(['VAULT_CLOUD_ADMIN_NAMESPACE']);
+    });
+
+    test('it should render title and plus badge', async function (assert) {
+      await this.renderComponent();
+      assert.dom(title).hasText('Secrets Sync Plus feature');
     });
   });
 

--- a/ui/tests/unit/services/flags-test.js
+++ b/ui/tests/unit/services/flags-test.js
@@ -92,7 +92,7 @@ module('Unit | Service | flags', function (hooks) {
       await this.service.fetchFeatureFlags();
       assert.deepEqual(
         this.service.featureFlags,
-        FEATURE_FLAGS_RESPONSE,
+        FEATURE_FLAGS_RESPONSE.data.feature_flags,
         'Feature flags are fetched and set'
       );
     });

--- a/ui/tests/unit/services/flags-test.js
+++ b/ui/tests/unit/services/flags-test.js
@@ -14,6 +14,12 @@ const ACTIVATED_FLAGS_RESPONSE = {
   },
 };
 
+const FEATURE_FLAGS_RESPONSE = {
+  data: {
+    feature_flags: ['VAULT_CLOUD_ADMIN_NAMESPACE'],
+  },
+};
+
 module('Unit | Service | flags', function (hooks) {
   setupTest(hooks);
   setupMirage(hooks);
@@ -23,13 +29,8 @@ module('Unit | Service | flags', function (hooks) {
   });
 
   test('it loads with defaults', function (assert) {
-    assert.deepEqual(this.service.flags, [], 'Flags are empty until fetched');
+    assert.deepEqual(this.service.featureFlags, [], 'Flags are empty until fetched');
     assert.deepEqual(this.service.activatedFlags, [], 'Activated flags are empty until fetched');
-  });
-
-  test('#setFeatureFlags: it can set feature flags', function (assert) {
-    this.service.setFeatureFlags(['foo', 'bar']);
-    assert.deepEqual(this.service.flags, ['foo', 'bar'], 'Flags are set');
   });
 
   module('#fetchActivatedFlags', function (hooks) {
@@ -75,20 +76,42 @@ module('Unit | Service | flags', function (hooks) {
     });
   });
 
+  module('#fetchFeatureFlags', function (hooks) {
+    hooks.beforeEach(function () {
+      this.owner.lookup('service:version').type = 'enterprise';
+    });
+
+    test('it returns feature flags', async function (assert) {
+      assert.expect(2);
+
+      this.server.get('sys/internal/ui/feature-flags', () => {
+        assert.true(true, 'GET request made to feature-flags endpoint');
+        return FEATURE_FLAGS_RESPONSE;
+      });
+
+      await this.service.fetchFeatureFlags();
+      assert.deepEqual(
+        this.service.featureFlags,
+        FEATURE_FLAGS_RESPONSE,
+        'Feature flags are fetched and set'
+      );
+    });
+  });
+
   module('#managedNamespaceRoot', function () {
     test('it returns null when flag is not present', function (assert) {
       assert.strictEqual(this.service.managedNamespaceRoot, null);
     });
 
     test('it returns the namespace root when flag is present', function (assert) {
-      this.service.setFeatureFlags(['VAULT_CLOUD_ADMIN_NAMESPACE']);
+      this.service.featureFlags = ['VAULT_CLOUD_ADMIN_NAMESPACE'];
       assert.strictEqual(
         this.service.managedNamespaceRoot,
         'admin',
         'Managed namespace is admin when flag present'
       );
 
-      this.service.setFeatureFlags(['SOMETHING_ELSE']);
+      this.service.featureFlags = ['SOMETHING_ELSE'];
       assert.strictEqual(
         this.service.managedNamespaceRoot,
         null,


### PR DESCRIPTION
Note: merging to sidebranch until backend changes are merged. Final screenshots of all views will be added to sidebranch PR.

### Description
* Allows Managed clusters to view Secrets Sync from the sidebar nav and secrets sync overview.
* Updates badge text to include "Plus" when a user is coming from a managed cluster.
* Shows only one CTA message regardless of license / managed type.
* Updates tests.

- [x] Enterprise tests pass locally.