### PR TITLE
UI: Update custom message list filters

### DIFF
--- a/ui/app/styles/components/toolbar.scss
+++ b/ui/app/styles/components/toolbar.scss
@@ -136,3 +136,7 @@ a.disabled.toolbar-link {
   margin: 0 $spacing-8;
   width: 0;
 }
+
+.segment-filter {
+  width: min-content;
+}

--- a/ui/lib/config-ui/addon/components/messages/page/list.hbs
+++ b/ui/lib/config-ui/addon/components/messages/page/list.hbs
@@ -9,40 +9,61 @@
   @breadcrumbs={{this.breadcrumbs}}
 >
   <:toolbarFilters>
-    <FilterInput
-      aria-label="Search by message title"
-      placeholder="Search by message title"
-      id="message-filter"
-      value={{@params.pageFilter}}
-      @autofocus={{true}}
-      @onInput={{this.onFilterInputChange}}
-    />
-    <div>
-      <SearchSelect
-        @id="filter-by-message-status"
-        class="has-left-margin-s"
-        @options={{this.statusFilterOptions}}
-        @selectLimit="1"
-        @searchEnabled={{false}}
-        @fallbackComponent="select"
-        @onChange={{fn this.onFilterChange "status"}}
-        @placeholder="Filter by message status"
-        @inputValue={{if @params.status (array @params.status)}}
-        data-test-filter-by-message-status
-      />
-    </div>
-    <SearchSelect
-      @id="filter-by-message-type"
-      class="has-left-margin-s"
-      @options={{this.typeFilterOptions}}
-      @selectLimit="1"
-      @searchEnabled={{false}}
-      @fallbackComponent="select"
-      @onChange={{fn this.onFilterChange "type"}}
-      @placeholder="Filter by message type"
-      @inputValue={{if @params.type (array @params.type)}}
-      data-test-filter-by-message-type
-    />
+    <form {{on "submit" (perform this.handleSearch)}} aria-label="Filter custom message list">
+      <Hds::SegmentedGroup as |S|>
+        <S.Button
+          @color="secondary"
+          @text="Clear"
+          @icon={{"trash"}}
+          @isIconOnly={{true}}
+          type="reset"
+          {{on "click" this.resetFilters}}
+        />
+        <S.TextInput
+          @value={{@params.pageFilter}}
+          @type="search"
+          name="pageFilter"
+          class="segment-filter"
+          placeholder="Search secret path"
+          aria-label="Search by secret path"
+          size="32"
+          data-test-kv-list-filter
+        />
+        <S.Select
+          aria-label="Filter by message status"
+          name="status"
+          class="segment-filter {{unless @params.status 'has-text-grey'}}"
+          as |S|
+        >
+          <S.Options>
+            <option value="" class="default-option">Message status</option>
+            {{#each (array "active" "inactive") as |status|}}
+              <option value={{status}} selected={{eq @params.status status}}>{{status}}</option>
+            {{/each}}
+          </S.Options>
+        </S.Select>
+        <S.Select
+          aria-label="Filter by type"
+          name="type"
+          class="segment-filter {{unless @params.status 'has-text-grey'}}"
+          as |S|
+        >
+          <S.Options>
+            <option value="" class="has-text-grey">Message type</option>
+            {{#each (array "modal" "banner") as |type|}}
+              <option value={{type}} selected={{eq @params.type type}}>{{type}}</option>
+            {{/each}}
+          </S.Options>
+        </S.Select>
+        <S.Button
+          @color="secondary"
+          @text="Filter"
+          @icon={{if this.handleSearch.isRunning "loading" "search"}}
+          type="submit"
+          data-test-kv-list-filter-submit
+        />
+      </Hds::SegmentedGroup>
+    </form>
   </:toolbarFilters>
   <:toolbarActions>
     <Hds::Button
@@ -56,6 +77,54 @@
     />
   </:toolbarActions>
 </Messages::TabPageHeader>
+
+{{!--
+<div class="toolbar-basic">
+  <form {{on "submit" (perform this.handleSearch)}} aria-label="Filter custom message list">
+    <Hds::SegmentedGroup as |S|>
+      <S.TextInput
+        @value={{@params.pageFilter}}
+        name="search"
+        placeholder="Search secret path"
+        aria-label="Search by secret path"
+        size="32"
+        data-test-kv-list-filter
+      />
+      <S.Select aria-label="Filter by message status" name="status" as |S|>
+        <S.Options>
+          <option value="">Message status</option>
+          {{#each (array "active" "inactive") as |status|}}
+            <option value={{status}}>{{status}}</option>
+          {{/each}}
+        </S.Options>
+      </S.Select>
+      <S.Select aria-label="Filter by type" name="type" as |S|>
+        <S.Options>
+          <option value="">Message type</option>
+          {{#each (array "modal" "banner") as |status|}}
+            <option value={{status}}>{{status}}</option>
+          {{/each}}
+        </S.Options>
+      </S.Select>
+      <S.Button
+        @color="secondary"
+        @text="Search"
+        @icon={{if this.handleSearch.isRunning "loading" "search"}}
+        type="submit"
+        data-test-kv-list-filter-submit
+      />
+    </Hds::SegmentedGroup>
+  </form>
+  <Hds::Button
+    @text="Create message"
+    @icon="plus"
+    @color="secondary"
+    class="toolbar-button"
+    {{on "click" this.createMessage}}
+    data-test-button="create message"
+    aria-label="create message"
+  />
+</div> --}}
 
 {{#if @messages.length}}
   {{#each this.formattedMessages as |message|}}

--- a/ui/lib/config-ui/addon/components/messages/page/list.hbs
+++ b/ui/lib/config-ui/addon/components/messages/page/list.hbs
@@ -18,21 +18,23 @@
           @isIconOnly={{true}}
           type="reset"
           {{on "click" this.resetFilters}}
+          data-test-filter-reset
         />
         <S.TextInput
           @value={{@params.pageFilter}}
           @type="search"
           name="pageFilter"
           class="segment-filter"
-          placeholder="Search secret path"
-          aria-label="Search by secret path"
+          placeholder="Search by message title"
+          aria-label="Search by message title"
           size="32"
-          data-test-kv-list-filter
+          data-test-filter-by="pageFilter"
         />
         <S.Select
           aria-label="Filter by message status"
           name="status"
           class="segment-filter {{unless @params.status 'has-text-grey'}}"
+          data-test-filter-by="status"
           as |S|
         >
           <S.Options>
@@ -46,6 +48,7 @@
           aria-label="Filter by type"
           name="type"
           class="segment-filter {{unless @params.status 'has-text-grey'}}"
+          data-test-filter-by="type"
           as |S|
         >
           <S.Options>
@@ -57,10 +60,10 @@
         </S.Select>
         <S.Button
           @color="secondary"
-          @text="Filter"
-          @icon={{if this.handleSearch.isRunning "loading" "search"}}
+          @text="Apply filters"
+          @icon={{if this.handleSearch.isRunning "loading" "filter"}}
           type="submit"
-          data-test-kv-list-filter-submit
+          data-test-filter-submit
         />
       </Hds::SegmentedGroup>
     </form>

--- a/ui/lib/config-ui/addon/components/messages/page/list.js
+++ b/ui/lib/config-ui/addon/components/messages/page/list.js
@@ -3,14 +3,14 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
+import Ember from 'ember';
 import Component from '@glimmer/component';
 import { service } from '@ember/service';
-import { task } from 'ember-concurrency';
+import { task, timeout } from 'ember-concurrency';
 import { dateFormat } from 'core/helpers/date-format';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import errorMessage from 'vault/utils/error-message';
-import { next } from '@ember/runloop';
 
 /**
  * @module Page::MessagesList
@@ -31,26 +31,6 @@ export default class MessagesList extends Component {
 
   @tracked showMaxMessageModal = false;
   @tracked messageToDelete = null;
-
-  // This follows the pattern in sync/addon/components/secrets/page/destinations for FilterInput.
-  // Currently, FilterInput doesn't do a full page refresh causing it to lose focus.
-  // The work around is to verify that a transition from this route was completed and then focus the input.
-  constructor(owner, args) {
-    super(owner, args);
-    this.router.on('routeDidChange', this.focusNameFilter);
-  }
-
-  willDestroy() {
-    super.willDestroy();
-    this.router.off('routeDidChange', this.focusNameFilter);
-  }
-
-  focusNameFilter(transition) {
-    const route = 'vault.cluster.config-ui.messages.index';
-    if (transition?.from?.name === route && transition?.to?.name === route) {
-      next(() => document.getElementById('message-filter')?.focus());
-    }
-  }
 
   get formattedMessages() {
     return this.args.messages.map((message) => {
@@ -91,20 +71,6 @@ export default class MessagesList extends Component {
     return [{ label: 'Messages' }, { label }];
   }
 
-  get statusFilterOptions() {
-    return [
-      { id: 'active', name: 'active' },
-      { id: 'inactive', name: 'inactive' },
-    ];
-  }
-
-  get typeFilterOptions() {
-    return [
-      { id: 'modal', name: 'modal' },
-      { id: 'banner', name: 'banner' },
-    ];
-  }
-
   // callback from HDS pagination to set the queryParams page
   get paginationQueryParams() {
     return (page) => {
@@ -116,7 +82,8 @@ export default class MessagesList extends Component {
 
   transitionToMessagesWithParams(queryParams) {
     this.router.transitionTo('vault.cluster.config-ui.messages', {
-      queryParams,
+      // always reset back to page 1 when changing filters
+      queryParams: { ...queryParams, page: 1 },
     });
   }
 
@@ -136,17 +103,23 @@ export default class MessagesList extends Component {
     }
   }
 
-  @action
-  onFilterInputChange(pageFilter) {
-    this.transitionToMessagesWithParams({ pageFilter });
+  @task
+  *handleSearch(evt) {
+    evt.preventDefault();
+    const formData = new FormData(evt.target);
+    // shows loader to indicate that the search was executed
+    yield timeout(Ember.testing ? 0 : 250);
+    const params = {};
+    for (const key of formData.keys()) {
+      const val = formData.get(key) || undefined;
+      params[key] = val;
+    }
+    this.transitionToMessagesWithParams(params);
   }
 
   @action
-  onFilterChange(filterType, [filterOption]) {
-    const param = {};
-    param[filterType] = filterOption;
-    param.page = 1;
-    this.transitionToMessagesWithParams(param);
+  resetFilters() {
+    this.transitionToMessagesWithParams({ pageFilter: undefined, status: undefined, type: undefined });
   }
 
   @action


### PR DESCRIPTION
As part of managing the Ember 5 deprecations, the custom messages filters were causing errors in tests due to the DOM tearing down before the focus filter is able to finish running. Updating filters on type is a pattern we're moving away from, so to resolve the test failures we are replacing this filter bar with an explicit filter button. 

![new-custom-messages-filter](https://github.com/hashicorp/vault/assets/82459713/b2e0c392-1d6d-4ab6-8203-1ca33170fee2)
