### PR TITLE
UI: Fix AWS secrets engine configure leases tab error

### DIFF
--- a/ui/app/adapters/secret-engine.js
+++ b/ui/app/adapters/secret-engine.js
@@ -91,7 +91,7 @@ export default ApplicationAdapter.extend({
     if (snapshot.attr('type') === 'ssh') {
       return this.ajax(`/v1/${encodePath(path)}/config/ca`, 'GET');
     }
-    return;
+    return { data: {} };
   },
 
   queryRecord(store, type, query) {

--- a/ui/tests/unit/adapters/secret-engine-test.js
+++ b/ui/tests/unit/adapters/secret-engine-test.js
@@ -50,4 +50,16 @@ module('Unit | Adapter | secret engine', function (hooks) {
     const adapter = this.owner.lookup('adapter:secret-engine');
     adapter['query'](storeStub, type, { path: 'foo/bar/baz' });
   });
+
+  test('Fails gracefully finding records for non ssh engines', function (assert) {
+    assert.expect(1);
+    const snapshot = {
+      attr() {
+        return { type: 'aws', path: 'aws/' };
+      },
+    };
+    const adapter = this.owner.lookup('adapter:secret-engine');
+    const response = adapter.findRecord(storeStub, 'aws', { path: 'aws' }, snapshot);
+    assert.propEqual(response, { data: {} }, 'returns empty data object');
+  });
 });


### PR DESCRIPTION
This failure was introduced by the ember upgrade, merged into 1.17 only, so there is no changelog. 
## before
![image](https://github.com/hashicorp/vault/assets/68122737/3371443d-cebd-44d9-911f-ac38a0e59a36)


## after fix 🔧 
<img width="1075" alt="Screenshot 2024-04-25 at 3 04 53 PM" src="https://github.com/hashicorp/vault/assets/68122737/f000f495-ab33-441b-8397-c2ff0ff2deb4">
