### PR TITLE
[UI] fix filter on api explorer

### DIFF
--- a/ui/lib/open-api-explorer/addon/components/swagger-ui.js
+++ b/ui/lib/open-api-explorer/addon/components/swagger-ui.js
@@ -26,24 +26,24 @@ export default class SwaggerUiComponent extends Component {
     return {
       fn: {
         opsFilter: (taggedOps, phrase) => {
-          // map over the options and filter out operations where the path doesn't match what's typed
-          return (
-            taggedOps
-              .map((tagObj) => {
-                const operations = tagObj.get('operations');
+          const filteredOperations = taggedOps.reduce((acc, tagObj) => {
+            const operations = tagObj.get('operations');
 
-                const matchingOperations = operations.filter((operationObj) => {
-                  const path = operationObj.get('path');
-                  return path.includes(phrase);
-                });
+            // filter out operations where the path doesn't match search phrase
+            const operationsWithMatchingPath = operations.filter((operationObj) => {
+              const path = operationObj.get('path');
+              return path.includes(phrase);
+            });
 
-                return tagObj.set('operations', matchingOperations);
-              })
-              // then traverse again and remove the top level item if there are no operations left after filtering
-              .filter((tagObj) => {
-                return !!tagObj.get('operations').size;
-              })
-          );
+            // if there are any operations left after filtering, add the tagObj to the accumulator
+            if (operationsWithMatchingPath.size > 0) {
+              acc.push(tagObj.set('operations', operationsWithMatchingPath));
+            }
+
+            return acc;
+          }, []);
+
+          return filteredOperations;
         },
       },
     };

--- a/ui/lib/open-api-explorer/addon/components/swagger-ui.js
+++ b/ui/lib/open-api-explorer/addon/components/swagger-ui.js
@@ -30,13 +30,19 @@ export default class SwaggerUiComponent extends Component {
           return (
             taggedOps
               .map((tagObj) => {
-                const operations = tagObj.operations.filter((operationObj) => {
-                  return operationObj.path.includes(phrase);
+                const operations = tagObj.get('operations');
+
+                const matchingOperations = operations.filter((operationObj) => {
+                  const path = operationObj.get('path');
+                  return path.includes(phrase);
                 });
-                return tagObj.set('operations', operations);
+
+                return tagObj.set('operations', matchingOperations);
               })
               // then traverse again and remove the top level item if there are no operations left after filtering
-              .filter((tagObj) => !!tagObj.operations.size)
+              .filter((tagObj) => {
+                return !!tagObj.get('operations').size;
+              })
           );
         },
       },

--- a/ui/tests/integration/components/open-api-explorer/swagger-ui-test.js
+++ b/ui/tests/integration/components/open-api-explorer/swagger-ui-test.js
@@ -8,8 +8,14 @@ import { setupRenderingTest } from 'vault/tests/helpers';
 import { waitUntil, find } from '@ember/test-helpers';
 import { setupEngine } from 'ember-engines/test-support';
 import { setupMirage } from 'ember-cli-mirage/test-support';
-import { render } from '@ember/test-helpers';
+import { render, fillIn } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
+
+const SELECTORS = {
+  container: '[data-test-swagger-ui]',
+  searchInput: '.operation-filter-input',
+  apiPathBlock: '.opblock-post',
+};
 
 module('Integration | Component | open-api-explorer | swagger-ui', function (hooks) {
   setupRenderingTest(hooks);
@@ -17,22 +23,39 @@ module('Integration | Component | open-api-explorer | swagger-ui', function (hoo
   setupMirage(hooks);
   hooks.beforeEach(function () {
     this.store = this.owner.lookup('service:store');
-  });
 
-  test('it renders', async function (assert) {
-    assert.expect(2);
     const openApiResponse = this.server.create('open-api-explorer');
     this.server.get('sys/internal/specs/openapi', () => {
       return openApiResponse;
     });
 
-    await render(hbs`<SwaggerUi/>`, {
-      owner: this.engine,
-    });
+    this.totalApiPaths = Object.keys(openApiResponse.paths).length;
 
-    await waitUntil(() => find('[data-test-swagger-ui]'));
-    assert.dom('[data-test-swagger-ui]').exists('renders component');
-    await waitUntil(() => find('.operation-filter-input'));
-    assert.dom('.opblock-post').exists({ count: 2 }, 'renders two blocks');
+    this.renderComponent = async () => {
+      await render(hbs`<SwaggerUi/>`, {
+        owner: this.engine,
+      });
+    };
+  });
+
+  test('it renders', async function (assert) {
+    await this.renderComponent();
+
+    await waitUntil(() => find(SELECTORS.container));
+
+    assert.dom(SELECTORS.container).exists('renders component');
+    assert.dom(SELECTORS.apiPathBlock).exists({ count: this.totalApiPaths }, 'renders all api paths');
+  });
+
+  test('it can search', async function (assert) {
+    await this.renderComponent();
+
+    await waitUntil(() => find(SELECTORS.searchInput));
+    await fillIn(SELECTORS.searchInput, 'token');
+
+    // for some reason search results are not rendered immediately in tests,
+    // so asserting that the search input has the value we expect is the best we can do here
+    // if the search fn breaks, this test will fail
+    assert.dom(SELECTORS.searchInput).hasValue('token', 'search input has value');
   });
 });


### PR DESCRIPTION
### :hammer_and_wrench: Description
Fixes the search filter on the OpenAPI explorer.

### 🔗 Links


### :camera_flash: Screenshots
https://github.com/hashicorp/vault/assets/903288/91e8ea50-a1a0-446c-86d4-9b9634738c09


### :building_construction: How to Build and Test the Change
Visit the OpenApi explorer page and the search box should work again 🎉