### PR TITLE
UI: update secret engine mount ttl format

### DIFF
--- a/ui/tests/acceptance/settings/mount-secret-backend-test.js
+++ b/ui/tests/acceptance/settings/mount-secret-backend-test.js
@@ -77,11 +77,7 @@ module('Acceptance | settings/mount-secret-backend', function (hooks) {
       .maxTTLVal(maxTTLHours)
       .submit();
     await configPage.visit({ backend: path });
-    assert.strictEqual(
-      configPage.defaultTTL,
-      '0',
-      'shows 0 (with no seconds) which means using the system default TTL'
-    ); // https://developer.hashicorp.com/vault/api-docs/system/mounts#default_lease_ttl-1
+    assert.strictEqual(configPage.defaultTTL, '1 month 1 day', 'shows system default TTL');
     assert.strictEqual(configPage.maxTTL, `${this.calcDays(maxTTLHours)}`, 'shows the proper max TTL');
   });
 


### PR DESCRIPTION
Backend PR: https://github.com/hashicorp/vault/pull/23914 updated the value returned by `sys/mounts/internal` to give the actual system default value instead of `0` 
