### PR TITLE
enos: set the seal_ha_beta environment variable in 1.15.x

### DIFF
--- a/enos/enos-scenario-agent.hcl
+++ b/enos/enos-scenario-agent.hcl
@@ -12,6 +12,7 @@ scenario "agent" {
     distro          = global.distros
     edition         = global.editions
     seal            = global.seals
+    seal_ha_beta    = ["true", "false"]
 
     # Our local builder always creates bundles
     exclude {
@@ -208,6 +209,7 @@ scenario "agent" {
       manage_service       = local.manage_service
       packages             = concat(global.packages, global.distro_packages[matrix.distro])
       seal_attributes      = step.create_seal_key.attributes
+      seal_ha_beta         = matrix.seal_ha_beta
       seal_type            = matrix.seal
       storage_backend      = matrix.backend
       target_hosts         = step.create_vault_cluster_targets.hosts

--- a/enos/enos-scenario-autopilot.hcl
+++ b/enos/enos-scenario-autopilot.hcl
@@ -11,6 +11,7 @@ scenario "autopilot" {
     edition         = global.editions
     initial_version = global.upgrade_initial_versions
     seal            = global.seals
+    seal_ha_beta    = ["true", "false"]
 
     # Autopilot wasn't available before 1.11.x
     exclude {
@@ -167,6 +168,7 @@ scenario "autopilot" {
         version = matrix.initial_version
       }
       seal_attributes = step.create_seal_key.attributes
+      seal_ha_beta    = matrix.seal_ha_beta
       seal_type       = matrix.seal
       storage_backend = "raft"
       storage_backend_addl_config = {
@@ -252,6 +254,7 @@ scenario "autopilot" {
       packages                    = concat(global.packages, global.distro_packages[matrix.distro])
       root_token                  = step.create_vault_cluster.root_token
       seal_attributes             = step.create_seal_key.attributes
+      seal_ha_beta                = matrix.seal_ha_beta
       seal_type                   = matrix.seal
       shamir_unseal_keys          = matrix.seal == "shamir" ? step.create_vault_cluster.unseal_keys_hex : null
       storage_backend             = "raft"

--- a/enos/enos-scenario-proxy.hcl
+++ b/enos/enos-scenario-proxy.hcl
@@ -12,6 +12,7 @@ scenario "proxy" {
     distro          = global.distros
     edition         = global.editions
     seal            = global.seals
+    seal_ha_beta    = ["true", "false"]
 
     # Our local builder always creates bundles
     exclude {
@@ -208,6 +209,7 @@ scenario "proxy" {
       manage_service       = local.manage_service
       packages             = concat(global.packages, global.distro_packages[matrix.distro])
       seal_attributes      = step.create_seal_key.attributes
+      seal_ha_beta         = matrix.seal_ha_beta
       seal_type            = matrix.seal
       storage_backend      = matrix.backend
       target_hosts         = step.create_vault_cluster_targets.hosts

--- a/enos/enos-scenario-replication.hcl
+++ b/enos/enos-scenario-replication.hcl
@@ -15,6 +15,7 @@ scenario "replication" {
     edition           = global.editions
     primary_backend   = global.backends
     primary_seal      = global.seals
+    seal_ha_beta      = ["true", "false"]
     secondary_backend = global.backends
     secondary_seal    = global.seals
 
@@ -294,6 +295,7 @@ scenario "replication" {
       manage_service       = local.manage_service
       packages             = concat(global.packages, global.distro_packages[matrix.distro])
       seal_attributes      = step.create_primary_seal_key.attributes
+      seal_ha_beta         = matrix.seal_ha_beta
       seal_type            = matrix.primary_seal
       storage_backend      = matrix.primary_backend
       target_hosts         = step.create_primary_cluster_targets.hosts
@@ -352,6 +354,7 @@ scenario "replication" {
       manage_service       = local.manage_service
       packages             = concat(global.packages, global.distro_packages[matrix.distro])
       seal_attributes      = step.create_secondary_seal_key.attributes
+      seal_ha_beta         = matrix.seal_ha_beta
       seal_type            = matrix.secondary_seal
       storage_backend      = matrix.secondary_backend
       target_hosts         = step.create_secondary_cluster_targets.hosts
@@ -648,6 +651,7 @@ scenario "replication" {
       packages             = concat(global.packages, global.distro_packages[matrix.distro])
       root_token           = step.create_primary_cluster.root_token
       seal_attributes      = step.create_primary_seal_key.attributes
+      seal_ha_beta         = matrix.seal_ha_beta
       seal_type            = matrix.primary_seal
       shamir_unseal_keys   = matrix.primary_seal == "shamir" ? step.create_primary_cluster.unseal_keys_hex : null
       storage_backend      = matrix.primary_backend

--- a/enos/enos-scenario-smoke.hcl
+++ b/enos/enos-scenario-smoke.hcl
@@ -12,6 +12,7 @@ scenario "smoke" {
     distro          = global.distros
     edition         = global.editions
     seal            = global.seals
+    seal_ha_beta    = ["true", "false"]
 
     # Our local builder always creates bundles
     exclude {
@@ -208,6 +209,7 @@ scenario "smoke" {
       manage_service       = local.manage_service
       packages             = concat(global.packages, global.distro_packages[matrix.distro])
       seal_attributes      = step.create_seal_key.attributes
+      seal_ha_beta         = matrix.seal_ha_beta
       seal_type            = matrix.seal
       storage_backend      = matrix.backend
       target_hosts         = step.create_vault_cluster_targets.hosts

--- a/enos/enos-scenario-ui.hcl
+++ b/enos/enos-scenario-ui.hcl
@@ -3,8 +3,9 @@
 
 scenario "ui" {
   matrix {
-    backend = global.backends
-    edition = ["ce", "ent"]
+    backend      = global.backends
+    edition      = ["ce", "ent"]
+    seal_ha_beta = ["true", "false"]
   }
 
   terraform_cli = terraform_cli.default
@@ -110,6 +111,7 @@ scenario "ui" {
       cluster_tag_key = local.vault_tag_key
       common_tags     = local.tags
       seal_names      = step.create_seal_key.resource_names
+      seal_ha_beta    = matrix.seal_ha_beta
       vpc_id          = step.create_vpc.id
     }
   }

--- a/enos/modules/start_vault/main.tf
+++ b/enos/modules/start_vault/main.tf
@@ -14,6 +14,10 @@ terraform {
 
 locals {
   bin_path = "${var.install_dir}/vault"
+  environment = local.seal_secondary == null ? var.environment : merge(
+    var.environment,
+    { VAULT_ENABLE_SEAL_HA_BETA : tobool(var.seal_ha_beta) },
+  )
   // In order to get Terraform to plan we have to use collections with keys that are known at plan
   // time. Here we're creating locals that keep track of index values that point to our target hosts.
   followers = toset(slice(local.instances, 1, length(local.instances)))
@@ -157,7 +161,7 @@ resource "enos_vault_start" "leader" {
   bin_path    = local.bin_path
   config_dir  = var.config_dir
   config_mode = var.config_mode
-  environment = var.environment
+  environment = local.environment
   config = {
     api_addr     = "http://${var.target_hosts[each.value].private_ip}:8200"
     cluster_addr = "http://${var.target_hosts[each.value].private_ip}:8201"
@@ -198,7 +202,7 @@ resource "enos_vault_start" "followers" {
   bin_path    = local.bin_path
   config_dir  = var.config_dir
   config_mode = var.config_mode
-  environment = var.environment
+  environment = local.environment
   config = {
     api_addr     = "http://${var.target_hosts[each.value].private_ip}:8200"
     cluster_addr = "http://${var.target_hosts[each.value].private_ip}:8201"

--- a/enos/modules/start_vault/variables.tf
+++ b/enos/modules/start_vault/variables.tf
@@ -64,6 +64,11 @@ variable "seal_alias" {
   default     = "primary"
 }
 
+variable "seal_ha_beta" {
+  description = "Enable using Seal HA on clusters that meet minimum version requirements and are enterprise editions"
+  default     = true
+}
+
 variable "seal_alias_secondary" {
   type        = string
   description = "The secondary seal alias name"

--- a/enos/modules/vault_cluster/main.tf
+++ b/enos/modules/vault_cluster/main.tf
@@ -134,6 +134,7 @@ module "start_vault" {
   manage_service            = var.manage_service
   seal_attributes           = var.seal_attributes
   seal_attributes_secondary = var.seal_attributes_secondary
+  seal_ha_beta              = var.seal_ha_beta
   seal_type                 = var.seal_type
   seal_type_secondary       = var.seal_type_secondary
   service_username          = local.vault_service_user


### PR DESCRIPTION
The `VAULT_ENABLE_SEAL_HA_BETA` env var is still required to enable multiseal in 1.15.x.