### PR TITLE
UI: Dependabot alert for postcss

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -124,7 +124,6 @@
     "ember-a11y-testing": "^5.2.1",
     "ember-basic-dropdown": "6.0.1",
     "ember-cli": "~4.12.1",
-    "ember-cli-autoprefixer": "^0.8.1",
     "ember-cli-babel": "^7.26.11",
     "ember-cli-content-security-policy": "2.0.3",
     "ember-cli-dependency-checker": "^3.3.1",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -4320,22 +4320,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"autoprefixer@npm:^7.0.0":
-  version: 7.2.6
-  resolution: "autoprefixer@npm:7.2.6"
-  dependencies:
-    browserslist: ^2.11.3
-    caniuse-lite: ^1.0.30000805
-    normalize-range: ^0.1.2
-    num2fraction: ^1.2.2
-    postcss: ^6.0.17
-    postcss-value-parser: ^3.2.3
-  bin:
-    autoprefixer-info: ./bin/autoprefixer-info
-  checksum: 7ad12a58ca128d3e6b6dc5e4b3d83f2a12151216d30bcea1f1f2f8a91d2a019c58dd62fd039a6c1cf218f2ab557b03224703a4396c1b4f01b5c0818bc6ba4dd9
-  languageName: node
-  linkType: hard
-
 "autosize@npm:^4.0.0":
   version: 4.0.4
   resolution: "autosize@npm:4.0.4"
@@ -5479,17 +5463,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"broccoli-autoprefixer@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "broccoli-autoprefixer@npm:5.0.0"
-  dependencies:
-    autoprefixer: ^7.0.0
-    broccoli-persistent-filter: ^1.1.6
-    postcss: ^6.0.1
-  checksum: 468df300b679e2afa3d14091f42313300424218d74911dba8dd61a16ce4b0888c76c517ac524f043c01304b3bb78d6e87927e931c96446f9921e4504f5361654
-  languageName: node
-  linkType: hard
-
 "broccoli-babel-transpiler@npm:^6.5.0":
   version: 6.5.1
   resolution: "broccoli-babel-transpiler@npm:6.5.1"
@@ -6321,18 +6294,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"browserslist@npm:^2.11.3":
-  version: 2.11.3
-  resolution: "browserslist@npm:2.11.3"
-  dependencies:
-    caniuse-lite: ^1.0.30000792
-    electron-to-chromium: ^1.3.30
-  bin:
-    browserslist: ./cli.js
-  checksum: 2ff908162669461e881bad516885b703fd594a0b7a139bf150c1952a74fe4ed8668ac46367a0d136d39a717de65e51c867316951e9fe0f92664c65b205eb9d93
-  languageName: node
-  linkType: hard
-
 "browserslist@npm:^3.2.6":
   version: 3.2.8
   resolution: "browserslist@npm:3.2.8"
@@ -6544,7 +6505,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"caniuse-lite@npm:^1.0.0, caniuse-lite@npm:^1.0.30000792, caniuse-lite@npm:^1.0.30000805, caniuse-lite@npm:^1.0.30000844, caniuse-lite@npm:^1.0.30001304, caniuse-lite@npm:^1.0.30001587":
+"caniuse-lite@npm:^1.0.0, caniuse-lite@npm:^1.0.30000844, caniuse-lite@npm:^1.0.30001304, caniuse-lite@npm:^1.0.30001587":
   version: 1.0.30001611
   resolution: "caniuse-lite@npm:1.0.30001611"
   checksum: c5beb4a0aaabe24b01a577122c61e20ca0614d2e3adfd2e4de8dbdb8529eb9dba9922be8fd8be9eba48b6cadaada0b338aa3e0d0a17f42f6b3e9a614492c029a
@@ -8109,7 +8070,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron-to-chromium@npm:^1.3.30, electron-to-chromium@npm:^1.3.47, electron-to-chromium@npm:^1.4.668":
+"electron-to-chromium@npm:^1.3.47, electron-to-chromium@npm:^1.4.668":
   version: 1.4.744
   resolution: "electron-to-chromium@npm:1.4.744"
   checksum: 917a178500bd8a78ae73c2ad9e71981922ec47e443ca1dfdfbc7a343334e6dfbbaa28e612313710c35b6538b1332dc4d14dd533eb274a587ffad79b3f9908989
@@ -8266,16 +8227,6 @@ __metadata:
   peerDependencies:
     ember-source: ^3.13.0 || ^4.0.0 || >= 5.0.0
   checksum: bbfaeafdf89a7ab834d85502829d604e3eb439cb154652b21683492e3e59a918bbaf49d39703f1a896016521d7cf03dc05e89cf5cf06de88fd1489b8e00ef8bb
-  languageName: node
-  linkType: hard
-
-"ember-cli-autoprefixer@npm:^0.8.1":
-  version: 0.8.1
-  resolution: "ember-cli-autoprefixer@npm:0.8.1"
-  dependencies:
-    broccoli-autoprefixer: ^5.0.0
-    lodash: ^4.0.0
-  checksum: b756a311abe4d3e91cd170fa801d0cb5601f7e6d2b9d7406018719636479ee80e1ec3ca633ca1419971ec56bf5417bc6000fc2a128bd3e3f2ddbe4e22d8ea8da
   languageName: node
   linkType: hard
 
@@ -15130,13 +15081,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"normalize-range@npm:^0.1.2":
-  version: 0.1.2
-  resolution: "normalize-range@npm:0.1.2"
-  checksum: 9b2f14f093593f367a7a0834267c24f3cb3e887a2d9809c77d8a7e5fd08738bcd15af46f0ab01cc3a3d660386f015816b5c922cea8bf2ee79777f40874063184
-  languageName: node
-  linkType: hard
-
 "normalize.css@npm:4.1.1":
   version: 4.1.1
   resolution: "normalize.css@npm:4.1.1"
@@ -15229,13 +15173,6 @@ __metadata:
   dependencies:
     boolbase: ^1.0.0
   checksum: 5afc3dafcd1573b08877ca8e6148c52abd565f1d06b1eb08caf982e3fa289a82f2cae697ffb55b5021e146d60443f1590a5d6b944844e944714a5b549675bcd3
-  languageName: node
-  linkType: hard
-
-"num2fraction@npm:^1.2.2":
-  version: 1.2.2
-  resolution: "num2fraction@npm:1.2.2"
-  checksum: 1da9c6797b505d3f5b17c7f694c4fa31565bdd5c0e5d669553253aed848a580804cd285280e8a73148bd9628839267daee4967f24b53d4e893e44b563e412635
   languageName: node
   linkType: hard
 
@@ -16008,28 +15945,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss-value-parser@npm:^3.2.3":
-  version: 3.3.1
-  resolution: "postcss-value-parser@npm:3.3.1"
-  checksum: 62cd26e1cdbcf2dcc6bcedf3d9b409c9027bc57a367ae20d31dd99da4e206f730689471fd70a2abe866332af83f54dc1fa444c589e2381bf7f8054c46209ce16
-  languageName: node
-  linkType: hard
-
 "postcss-value-parser@npm:^4.1.0, postcss-value-parser@npm:^4.2.0":
   version: 4.2.0
   resolution: "postcss-value-parser@npm:4.2.0"
   checksum: 819ffab0c9d51cf0acbabf8996dffbfafbafa57afc0e4c98db88b67f2094cb44488758f06e5da95d7036f19556a4a732525e84289a425f4f6fd8e412a9d7442f
-  languageName: node
-  linkType: hard
-
-"postcss@npm:^6.0.1, postcss@npm:^6.0.17":
-  version: 6.0.23
-  resolution: "postcss@npm:6.0.23"
-  dependencies:
-    chalk: ^2.4.1
-    source-map: ^0.6.1
-    supports-color: ^5.4.0
-  checksum: cc6cb2c1dbcdefa6f57a71d67fe535c9e96543298bbe28f9a6a64c4f1e21b6127113890dd4cda8873d3f4e6613a0566b7b4bbb230204f3a9a309190bda065d81
   languageName: node
   linkType: hard
 
@@ -18267,7 +18186,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"supports-color@npm:^5.3.0, supports-color@npm:^5.4.0, supports-color@npm:^5.5.0":
+"supports-color@npm:^5.3.0, supports-color@npm:^5.5.0":
   version: 5.5.0
   resolution: "supports-color@npm:5.5.0"
   dependencies:
@@ -19447,7 +19366,6 @@ __metadata:
     ember-auto-import: ^2.7.2
     ember-basic-dropdown: 6.0.1
     ember-cli: ~4.12.1
-    ember-cli-autoprefixer: ^0.8.1
     ember-cli-babel: ^7.26.11
     ember-cli-content-security-policy: 2.0.3
     ember-cli-dependency-checker: ^3.3.1


### PR DESCRIPTION
the vulnerable version (`< 8.4.31`) of `postcss` traced back to `ember-cli-autoprefixer` which was originally installed to support IE 11 by this [PR](https://github.com/hashicorp/vault/pull/4379/files#diff-193b27d62e4fbda3d563009fed5ec6761a05f73558d94b39fab63ae948c679eaR47). We stopped supporting IE 11 as far back as 1.9.x, see [Vault UI Browser Support](https://developer.hashicorp.com/vault/docs/v1.9.x/browser-support). 

Uninstalling the dependency instead of updating. 