### PR TITLE
Added docs for the error message changes

### DIFF
--- a/website/content/docs/concepts/tokens.mdx
+++ b/website/content/docs/concepts/tokens.mdx
@@ -293,7 +293,7 @@ to ensure the validity of the parent token.
 When using a token that has been revoked, exceeded it's TTL, or is an otherwise invalid value, Vault will respond
 with a 403 error containing the following error messages: `invalid token` and `permission denied`.
 
-If using a token that with incorrect policy access, Vault will respond with a 403 error containing the error message
+When using a token with incorrect policy access, Vault will respond with a 403 error containing the error message
 `permission denied`.
 
 

--- a/website/content/docs/concepts/tokens.mdx
+++ b/website/content/docs/concepts/tokens.mdx
@@ -287,3 +287,13 @@ to Vault).
 As a corollary, batch tokens can be used across performance replication
 clusters, but only if they are orphan, since non-orphan tokens will not be able
 to ensure the validity of the parent token.
+
+## Error Responses
+
+When using a token that has been revoked, exceeded it's TTL, or is an otherwise invalid value, Vault will respond
+with a 403 error containing the following error messages: `invalid token` and `permission denied`.
+
+If using a token that with incorrect policy access, Vault will respond with a 403 error containing the error message
+`permission denied`.
+
+

--- a/website/content/docs/concepts/tokens.mdx
+++ b/website/content/docs/concepts/tokens.mdx
@@ -290,7 +290,7 @@ to ensure the validity of the parent token.
 
 ## Error Responses
 
-When using a token that has been revoked, exceeded it's TTL, or is an otherwise invalid value, Vault will respond
+When using a token that has been revoked, exceeded its TTL, or is an otherwise invalid value, Vault will respond
 with a 403 error containing the following error messages: `invalid token` and `permission denied`.
 
 When using a token with incorrect policy access, Vault will respond with a 403 error containing the error message

--- a/website/content/docs/concepts/tokens.mdx
+++ b/website/content/docs/concepts/tokens.mdx
@@ -293,7 +293,7 @@ to ensure the validity of the parent token.
 When using a token that has been revoked, exceeded its TTL, or is an otherwise invalid value, Vault will respond
 with a `403` response code error containing the following error messages: `invalid token` and `permission denied`.
 
-When using a token with incorrect policy access, Vault will respond with a 403 error containing the error message
+When using a token with incorrect policy access, Vault will respond with a `403` response code error containing the error message
 `permission denied`.
 
 

--- a/website/content/docs/concepts/tokens.mdx
+++ b/website/content/docs/concepts/tokens.mdx
@@ -291,7 +291,7 @@ to ensure the validity of the parent token.
 ## Error Responses
 
 When using a token that has been revoked, exceeded its TTL, or is an otherwise invalid value, Vault will respond
-with a 403 error containing the following error messages: `invalid token` and `permission denied`.
+with a `403` response code error containing the following error messages: `invalid token` and `permission denied`.
 
 When using a token with incorrect policy access, Vault will respond with a 403 error containing the error message
 `permission denied`.


### PR DESCRIPTION
Add documentation that specifies what error messages are returned by Vault when an invalid token is used.