### PR TITLE
UI: Update transit links

### DIFF
--- a/ui/app/components/transit-edit.js
+++ b/ui/app/components/transit-edit.js
@@ -32,6 +32,42 @@ export default Component.extend(FocusOnInsertMixin, {
     this._super(...arguments);
   },
 
+  get breadcrumbs() {
+    const baseCrumbs = [
+      {
+        label: 'secrets',
+        route: 'vault.cluster.secrets',
+      },
+      {
+        label: this.key.backend,
+        route: 'vault.cluster.secrets.backend.list-root',
+        model: this.key.backend,
+      },
+    ];
+    if (this.mode === 'show') {
+      return [
+        ...baseCrumbs,
+        {
+          label: this.key.id,
+        },
+      ];
+    } else if (this.mode === 'edit') {
+      return [
+        ...baseCrumbs,
+        {
+          label: this.key.id,
+          route: 'vault.cluster.secrets.backend.show',
+          models: [this.key.backend, this.key.id],
+          query: { tab: 'details' },
+        },
+        { label: 'edit' },
+      ];
+    } else if (this.mode === 'create') {
+      return [...baseCrumbs, { label: 'create' }];
+    }
+    return baseCrumbs;
+  },
+
   waitForKeyUp: task(function* () {
     while (true) {
       const event = yield waitForEvent(document.body, 'keyup');

--- a/ui/app/routes/vault/cluster/secrets/backend/actions.js
+++ b/ui/app/routes/vault/cluster/secrets/backend/actions.js
@@ -31,5 +31,24 @@ export default EditBase.extend({
     this._super(...arguments);
     const { selectedAction } = this.paramsFor(this.routeName);
     controller.set('selectedAction', selectedAction || model.secret.supportedActions[0]);
+    controller.set('breadcrumbs', [
+      {
+        label: 'secrets',
+        route: 'vault.cluster.secrets',
+      },
+      {
+        label: model.secret.backend,
+        route: 'vault.cluster.secrets.backend.list-root',
+        model: model.secret.backend,
+      },
+      {
+        label: model.secret.id,
+        route: 'vault.cluster.secrets.backend.show',
+        models: [model.secret.backend, model.secret.id],
+      },
+      {
+        label: 'actions',
+      },
+    ]);
   },
 });

--- a/ui/app/templates/components/transit-edit.hbs
+++ b/ui/app/templates/components/transit-edit.hbs
@@ -5,13 +5,7 @@
 
 <PageHeader as |p|>
   <p.top>
-    <KeyValueHeader
-      @baseKey={{this.key}}
-      @path="vault.cluster.secrets.backend.list"
-      @mode={{this.mode}}
-      @root={{this.root}}
-      @showCurrent={{true}}
-    />
+    <Page::Breadcrumbs @breadcrumbs={{this.breadcrumbs}} />
   </p.top>
   <p.levelLeft>
     <h1 class="title is-3">

--- a/ui/app/templates/components/transit-form-create.hbs
+++ b/ui/app/templates/components/transit-form-create.hbs
@@ -132,7 +132,12 @@
         type="submit"
         disabled={{@requestInFlight}}
       />
-      <Hds::Button @text="Cancel" @color="secondary" @route="vault.cluster.secrets.backend.list-root" />
+      <Hds::Button
+        @text="Cancel"
+        @color="secondary"
+        @model={{@key.backend}}
+        @route="vault.cluster.secrets.backend.list-root"
+      />
     </Hds::ButtonSet>
   </div>
 </form>

--- a/ui/app/templates/components/transit-form-edit.hbs
+++ b/ui/app/templates/components/transit-form-edit.hbs
@@ -104,7 +104,7 @@
           @text="Cancel"
           @color="secondary"
           @route="vault.cluster.secrets.backend.show"
-          @model={{@key.id}}
+          @models={{array @key.backend @key.id}}
           @query={{hash tab="details"}}
         />
       </div>

--- a/ui/app/templates/components/transit-form-show.hbs
+++ b/ui/app/templates/components/transit-form-show.hbs
@@ -64,7 +64,7 @@
       {{/if}}
       {{#if (eq @mode "show")}}
         {{#if (or @capabilities.canUpdate @capabilities.canDelete)}}
-          <ToolbarSecretLink @secret={{@key.id}} @mode="edit" replace={{true}}>
+          <ToolbarSecretLink @secret={{@key.id}} @backend={{@key.backend}} @mode="edit" replace={{true}}>
             Edit encryption key
           </ToolbarSecretLink>
         {{/if}}
@@ -77,7 +77,7 @@
   <div class="transit-card-container">
     {{#each @model.supportedActions as |supportedAction|}}
       <LinkedBlock
-        @params={{array "vault.cluster.secrets.backend.actions" @model.id}}
+        @params={{array "vault.cluster.secrets.backend.actions" @model.backend @model.id}}
         @queryParams={{hash action=supportedAction.name}}
         class="transit-card"
         data-test-transit-card={{supportedAction.name}}

--- a/ui/app/templates/vault/cluster/secrets/backend/transit-actions-layout.hbs
+++ b/ui/app/templates/vault/cluster/secrets/backend/transit-actions-layout.hbs
@@ -34,6 +34,7 @@
             <li class={{if (eq supportedAction.name this.selectedAction) "is-active"}}>
               <SecretLink
                 @mode="actions"
+                @backend={{this.model.backend}}
                 @secret={{this.model.id}}
                 @queryParams={{hash action=supportedAction.name}}
                 data-test-transit-action-link={{supportedAction.name}}
@@ -51,7 +52,6 @@
         </ul>
       </nav>
     </div>
-
     <TransitKeyActions @selectedAction={{this.selectedAction}} @key={{this.model}} />
   </div>
 </div>

--- a/ui/app/templates/vault/cluster/secrets/backend/transit-actions-layout.hbs
+++ b/ui/app/templates/vault/cluster/secrets/backend/transit-actions-layout.hbs
@@ -7,13 +7,7 @@
   <div class="column">
     <PageHeader as |p|>
       <p.top>
-        <KeyValueHeader
-          @baseKey={{this.model}}
-          @path="vault.cluster.secrets.backend.list"
-          @mode={{this.mode}}
-          @root={{this.backendCrumb}}
-          @showCurrent={{true}}
-        />
+        <Page::Breadcrumbs @breadcrumbs={{this.breadcrumbs}} />
       </p.top>
       <p.levelLeft>
         <h1 class="title is-3">

--- a/ui/tests/acceptance/transit-test.js
+++ b/ui/tests/acceptance/transit-test.js
@@ -12,13 +12,13 @@ import { encodeString } from 'vault/utils/b64';
 import authPage from 'vault/tests/pages/auth';
 import { deleteEngineCmd, mountEngineCmd, runCmd } from 'vault/tests/helpers/commands';
 import codemirror from 'vault/tests/helpers/codemirror';
+import { GENERAL } from '../helpers/general-selectors';
 
 const SELECTORS = {
   secretLink: '[data-test-secret-link]',
   popupMenu: '[data-test-popup-menu-trigger]',
   versionsTab: '[data-test-transit-link="versions"]',
   actionsTab: '[data-test-transit-key-actions-link]',
-  rootCrumb: (path) => `[data-test-secret-breadcrumb="${path}"] a`,
   card: (action) => `[data-test-transit-card="${action}"]`,
   infoRow: (label) => `[data-test-value-div="${label}"]`,
   form: (item) => `[data-test-transit-key="${item}"]`,
@@ -248,7 +248,7 @@ module('Acceptance | transit (flaky)', function (hooks) {
     assert.dom(SELECTORS.infoRow('Deletion allowed')).hasText('false');
     assert.dom(SELECTORS.infoRow('Derived')).hasText('Yes');
     assert.dom(SELECTORS.infoRow('Convergent encryption')).hasText('Yes');
-    await click(SELECTORS.rootCrumb(this.path));
+    await click(GENERAL.breadcrumbLink(this.path));
     await click(SELECTORS.popupMenu);
     const actions = findAll('.hds-dropdown__list li');
     assert.strictEqual(actions.length, 2, 'shows 2 items in popup menu');

--- a/ui/tests/integration/components/transit-edit-test.js
+++ b/ui/tests/integration/components/transit-edit-test.js
@@ -19,7 +19,7 @@ module('Integration | Component | transit-edit', function (hooks) {
 
   hooks.beforeEach(function () {
     this.store = this.owner.lookup('service:store');
-    this.model = this.store.createRecord('transit-key');
+    this.model = this.store.createRecord('transit-key', { backend: 'transit-backend', id: 'some-key' });
     this.backendCrumb = {
       label: 'transit',
       text: 'transit',
@@ -30,7 +30,7 @@ module('Integration | Component | transit-edit', function (hooks) {
 
   test('it renders in create mode and updates model', async function (assert) {
     await render(hbs`
-    <TransitEdit 
+    <TransitEdit
       @key={{this.model}}
       @model={{this.model}}
       @mode="create"
@@ -58,14 +58,13 @@ module('Integration | Component | transit-edit', function (hooks) {
       1: 1684882652000,
     };
     await render(hbs`
-      <TransitEdit 
+      <TransitEdit
         @key={{this.model}}
         @model={{this.model}}
         @mode="edit"
         @root={{this.backendCrumb}}
         @preferAdvancedEdit={{false}}
       />`);
-
     assert.dom(SELECTORS.editForm).exists();
     assert.dom(SELECTORS.ttlToggle).isNotChecked();
 
@@ -86,7 +85,7 @@ module('Integration | Component | transit-edit', function (hooks) {
       1: 1684882652000,
     };
     await render(hbs`
-      <TransitEdit 
+      <TransitEdit
         @key={{this.model}}
         @model={{this.model}}
         @mode="edit"


### PR DESCRIPTION
This work is related to #26561 (see PR for motivation)

This PR adds the backend params to Transit secret engine links which were failing after replacing the router in the logout route. As part of this work, I replaced `KeyValueHeader` in transit with our `Page::Breadcrumbs` component, which has been our newer pattern. Both of the components use HDS breadcrumbs, but I didn't want to further complicate the logic in KeyValueHeader if we had a good replacement pattern.  

- [x] Ent tests passed

**Before**
![image](https://github.com/hashicorp/vault/assets/82459713/23078200-6fec-412c-9a05-f7351d2f28be)

**After**
![image](https://github.com/hashicorp/vault/assets/82459713/f7fb42e1-8875-4140-bad7-a26f20e61935)

