### PR TITLE
Call tools before prep in "make bootstrap" rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -174,7 +174,7 @@ hooks:
 
 # bootstrap the build by generating any necessary code and downloading additional tools that may
 # be used by devs.
-bootstrap: prep tools
+bootstrap: tools prep
 
 # Note: if you have plugins in GOPATH you can update all of them via something like:
 # for i in $(ls | grep vault-plugin-); do cd $i; git remote update; git reset --hard origin/master; dep ensure -update; git add .; git commit; git push; cd ..; done


### PR DESCRIPTION
Moves the tools step in `make bootstrap` to occur before prep.

`enumer` is a new required tool, and building fails without it:
```
==> Running go generate...
builtin/logical/pki/path_config_acme.go:397: running "enumer": exec: "enumer": executable file not found in $PATH
```
`make bootstrap` which is supposed to acquire all necessary tools for building eventually fails on this same tool error.