### PR TITLE
UI: rearrange logic for adding timezone in date-format helper

### DIFF
--- a/ui/lib/core/addon/helpers/date-format.js
+++ b/ui/lib/core/addon/helpers/date-format.js
@@ -69,11 +69,12 @@ export function dateFormat([value, style], { withTimeZone = false }) {
   let zone; // local timezone ex: 'PST'
   try {
     // passing undefined means default to the browser's locale
-    zone = ' ' + date.toLocaleTimeString(undefined, { timeZoneName: 'short' }).split(' ')[2];
+    zone = date.toLocaleTimeString(undefined, { timeZoneName: 'short' }).split(' ')[2];
   } catch (e) {
-    zone = '';
+    zone = null;
   }
-  zone = withTimeZone ? zone : '';
+
+  zone = withTimeZone && zone ? ` ${zone}` : '';
   return format(date, style) + zone;
 }
 


### PR DESCRIPTION
I was unable to reproduce this issue. I downloaded Brave and am in an European timezone. I was not able to download the older version of Brave, but at least on newer versions this is no longer an issue. Updated the logic regardless so undefined timezones won't be displayed
![image](https://github.com/hashicorp/vault/assets/68122737/58592048-8147-48cb-a7ca-fde557532b07)
