### PR TITLE
UI: fix missing arrow for select dropdown

### DIFF
--- a/ui/app/styles/core/select.scss
+++ b/ui/app/styles/core/select.scss
@@ -5,7 +5,6 @@
 
 select {
   width: 100%;
-  appearance: none;
 }
 
 .select select {


### PR DESCRIPTION
## before

<img width="523" alt="Screenshot 2024-04-30 at 3 15 33 PM" src="https://github.com/hashicorp/vault/assets/68122737/78639ade-cc74-4d18-b4a0-ac60e0bb154d">

## after
<img width="545" alt="Screenshot 2024-04-30 at 3 15 17 PM" src="https://github.com/hashicorp/vault/assets/68122737/402290bf-8055-4223-a59b-89d1ad06c15a">
