### PR TITLE
Rename isManaged and managedNamespaceRoot

### DIFF
--- a/ui/app/components/auth-jwt.js
+++ b/ui/app/components/auth-jwt.js
@@ -133,7 +133,7 @@ export default Component.extend({
     // The namespace can be either be passed as a query parameter, or be embedded
     // in the state param in the format `<state_id>,ns=<namespace>`. So if
     // `namespace` is empty, check for namespace in state as well.
-    if (namespace === '' || this.flagsService.managedNamespaceRoot) {
+    if (namespace === '' || this.flagsService.hvdManagedNamespaceRoot) {
       const i = state.indexOf(',ns=');
       if (i >= 0) {
         // ",ns=" is 4 characters

--- a/ui/app/components/sidebar/nav/cluster.js
+++ b/ui/app/components/sidebar/nav/cluster.js
@@ -23,11 +23,11 @@ export default class SidebarNavClusterComponent extends Component {
   }
 
   get badgeText() {
-    const isHVDManaged = this.flags.isHVDManaged;
+    const isHvdManaged = this.flags.isHvdManaged;
     const onLicense = this.version.hasSecretsSync;
     const isEnterprise = this.version.isEnterprise;
 
-    if (isHVDManaged) return 'Plus';
+    if (isHvdManaged) return 'Plus';
     if (isEnterprise && !onLicense) return 'Premium';
     if (!isEnterprise) return 'Enterprise';
     // no badge for Enterprise clusters with Secrets Sync on their license--the only remaining option.

--- a/ui/app/components/sidebar/nav/cluster.js
+++ b/ui/app/components/sidebar/nav/cluster.js
@@ -23,11 +23,11 @@ export default class SidebarNavClusterComponent extends Component {
   }
 
   get badgeText() {
-    const isManaged = this.flags.isManaged;
+    const isHVDManaged = this.flags.isHVDManaged;
     const onLicense = this.version.hasSecretsSync;
     const isEnterprise = this.version.isEnterprise;
 
-    if (isManaged) return 'Plus';
+    if (isHVDManaged) return 'Plus';
     if (isEnterprise && !onLicense) return 'Premium';
     if (!isEnterprise) return 'Enterprise';
     // no badge for Enterprise clusters with Secrets Sync on their license--the only remaining option.

--- a/ui/app/controllers/vault/cluster/auth.js
+++ b/ui/app/controllers/vault/cluster/auth.js
@@ -22,13 +22,13 @@ export default Controller.extend({
   namespaceQueryParam: alias('clusterController.namespaceQueryParam'),
   wrappedToken: alias('vaultController.wrappedToken'),
   redirectTo: alias('vaultController.redirectTo'),
-  managedNamespaceRoot: alias('flagsService.managedNamespaceRoot'),
+  hvdManagedNamespaceRoot: alias('flagsService.hvdManagedNamespaceRoot'),
   authMethod: '',
   oidcProvider: '',
 
   get namespaceInput() {
     const namespaceQP = this.clusterController.namespaceQueryParam;
-    if (this.managedNamespaceRoot) {
+    if (this.hvdManagedNamespaceRoot) {
       // When managed, the user isn't allowed to edit the prefix `admin/` for their nested namespace
       const split = namespaceQP.split('/');
       if (split.length > 1) {
@@ -42,8 +42,8 @@ export default Controller.extend({
 
   fullNamespaceFromInput(value) {
     const strippedNs = sanitizePath(value);
-    if (this.managedNamespaceRoot) {
-      return `${this.managedNamespaceRoot}/${strippedNs}`;
+    if (this.hvdManagedNamespaceRoot) {
+      return `${this.hvdManagedNamespaceRoot}/${strippedNs}`;
     }
     return strippedNs;
   },

--- a/ui/app/routes/vault/cluster.js
+++ b/ui/app/routes/vault/cluster.js
@@ -58,7 +58,7 @@ export default Route.extend(ModelBoundaryRoute, ClusterRoute, {
     const params = this.paramsFor(this.routeName);
     let namespace = params.namespaceQueryParam;
     const currentTokenName = this.auth.currentTokenName;
-    const managedRoot = this.flagsService.managedNamespaceRoot;
+    const managedRoot = this.flagsService.hvdManagedNamespaceRoot;
     assert(
       'Cannot use VAULT_CLOUD_ADMIN_NAMESPACE flag with non-enterprise Vault version',
       !(managedRoot && this.version.isCommunity)

--- a/ui/app/services/flags.ts
+++ b/ui/app/services/flags.ts
@@ -27,12 +27,12 @@ export default class flagsService extends Service {
   @tracked activatedFlags: string[] = [];
   @tracked featureFlags: string[] = [];
 
-  get isHVDManaged(): boolean {
+  get isHvdManaged(): boolean {
     return this.featureFlags.includes(FLAGS.vaultCloudNamespace);
   }
 
   get hvdManagedNamespaceRoot(): string | null {
-    return this.isHVDManaged ? 'admin' : null;
+    return this.isHvdManaged ? 'admin' : null;
   }
 
   getFeatureFlags = keepLatestTask(async () => {

--- a/ui/app/services/flags.ts
+++ b/ui/app/services/flags.ts
@@ -27,12 +27,12 @@ export default class flagsService extends Service {
   @tracked activatedFlags: string[] = [];
   @tracked featureFlags: string[] = [];
 
-  get isManaged(): boolean {
+  get isHVDManaged(): boolean {
     return this.featureFlags.includes(FLAGS.vaultCloudNamespace);
   }
 
-  get managedNamespaceRoot(): string | null {
-    return this.isManaged ? 'admin' : null;
+  get hvdManagedNamespaceRoot(): string | null {
+    return this.isHVDManaged ? 'admin' : null;
   }
 
   getFeatureFlags = keepLatestTask(async () => {

--- a/ui/app/templates/vault/cluster/auth.hbs
+++ b/ui/app/templates/vault/cluster/auth.hbs
@@ -62,9 +62,9 @@
               <div class="field-label is-normal">
                 <label class="is-label" for="namespace">Namespace</label>
               </div>
-              {{#if this.managedNamespaceRoot}}
+              {{#if this.hvdManagedNamespaceRoot}}
                 <div class="field-label">
-                  <span class="has-text-grey" data-test-managed-namespace-root>/{{this.managedNamespaceRoot}}</span>
+                  <span class="has-text-grey" data-test-managed-namespace-root>/{{this.hvdManagedNamespaceRoot}}</span>
                 </div>
               {{/if}}
               <div class="field-body">
@@ -73,7 +73,7 @@
                     <input
                       data-test-auth-form-ns-input
                       value={{this.namespaceInput}}
-                      placeholder={{if this.managedNamespaceRoot "/ (Default)" "/ (Root)"}}
+                      placeholder={{if this.hvdManagedNamespaceRoot "/ (Default)" "/ (Root)"}}
                       {{on "input" (perform this.updateNamespace value="target.value")}}
                       autocomplete="off"
                       spellcheck="false"

--- a/ui/lib/sync/addon/components/secrets/page/overview.hbs
+++ b/ui/lib/sync/addon/components/secrets/page/overview.hbs
@@ -4,7 +4,7 @@
 ~}}
 
 {{#unless @isActivated}}
-  {{#if (or @licenseHasSecretsSync @isHVDManaged)}}
+  {{#if (or @licenseHasSecretsSync @isHvdManaged)}}
     {{#unless this.hideOptIn}}
       <Hds::Alert
         @type="inline"

--- a/ui/lib/sync/addon/components/secrets/page/overview.hbs
+++ b/ui/lib/sync/addon/components/secrets/page/overview.hbs
@@ -4,7 +4,7 @@
 ~}}
 
 {{#unless @isActivated}}
-  {{#if (or @licenseHasSecretsSync @isManaged)}}
+  {{#if (or @licenseHasSecretsSync @isHVDManaged)}}
     {{#unless this.hideOptIn}}
       <Hds::Alert
         @type="inline"

--- a/ui/lib/sync/addon/components/sync-header.ts
+++ b/ui/lib/sync/addon/components/sync-header.ts
@@ -21,11 +21,11 @@ export default class SyncHeaderComponent extends Component<Args> {
   @service declare readonly flags: FlagsService;
 
   get badgeText() {
-    const isManaged = this.flags.isManaged;
+    const isHVDManaged = this.flags.isHVDManaged;
     const onLicense = this.version.hasSecretsSync;
     const isEnterprise = this.version.isEnterprise;
 
-    if (isManaged) return 'Plus feature';
+    if (isHVDManaged) return 'Plus feature';
     if (isEnterprise && !onLicense) return 'Premium feature';
     if (!isEnterprise) return 'Enterprise feature';
     // no badge for Enterprise clusters with Secrets Sync on their license--the only remaining option.

--- a/ui/lib/sync/addon/components/sync-header.ts
+++ b/ui/lib/sync/addon/components/sync-header.ts
@@ -21,11 +21,11 @@ export default class SyncHeaderComponent extends Component<Args> {
   @service declare readonly flags: FlagsService;
 
   get badgeText() {
-    const isHVDManaged = this.flags.isHVDManaged;
+    const isHvdManaged = this.flags.isHvdManaged;
     const onLicense = this.version.hasSecretsSync;
     const isEnterprise = this.version.isEnterprise;
 
-    if (isHVDManaged) return 'Plus feature';
+    if (isHvdManaged) return 'Plus feature';
     if (isEnterprise && !onLicense) return 'Premium feature';
     if (!isEnterprise) return 'Enterprise feature';
     // no badge for Enterprise clusters with Secrets Sync on their license--the only remaining option.

--- a/ui/lib/sync/addon/routes/secrets/overview.ts
+++ b/ui/lib/sync/addon/routes/secrets/overview.ts
@@ -19,12 +19,12 @@ export default class SyncSecretsOverviewRoute extends Route {
   async model() {
     const isActivated = this.flags.secretsSyncIsActivated;
     const licenseHasSecretsSync = this.version.hasSecretsSync;
-    const isHVDManaged = this.flags.isHVDManaged;
+    const isHvdManaged = this.flags.isHvdManaged;
 
     return hash({
       licenseHasSecretsSync,
       isActivated,
-      isHVDManaged,
+      isHvdManaged,
       destinations: isActivated ? this.store.query('sync/destination', {}).catch(() => []) : [],
       associations: isActivated
         ? this.store

--- a/ui/lib/sync/addon/routes/secrets/overview.ts
+++ b/ui/lib/sync/addon/routes/secrets/overview.ts
@@ -19,12 +19,12 @@ export default class SyncSecretsOverviewRoute extends Route {
   async model() {
     const isActivated = this.flags.secretsSyncIsActivated;
     const licenseHasSecretsSync = this.version.hasSecretsSync;
-    const isManaged = this.flags.isManaged;
+    const isHVDManaged = this.flags.isHVDManaged;
 
     return hash({
       licenseHasSecretsSync,
       isActivated,
-      isManaged,
+      isHVDManaged,
       destinations: isActivated ? this.store.query('sync/destination', {}).catch(() => []) : [],
       associations: isActivated
         ? this.store

--- a/ui/lib/sync/addon/templates/secrets/overview.hbs
+++ b/ui/lib/sync/addon/templates/secrets/overview.hbs
@@ -8,5 +8,5 @@
   @totalVaultSecrets={{this.model.associations.total_secrets}}
   @isActivated={{this.model.isActivated}}
   @licenseHasSecretsSync={{this.model.licenseHasSecretsSync}}
-  @isManaged={{this.model.isManaged}}
+  @isHVDManaged={{this.model.isHVDManaged}}
 />

--- a/ui/lib/sync/addon/templates/secrets/overview.hbs
+++ b/ui/lib/sync/addon/templates/secrets/overview.hbs
@@ -8,5 +8,5 @@
   @totalVaultSecrets={{this.model.associations.total_secrets}}
   @isActivated={{this.model.isActivated}}
   @licenseHasSecretsSync={{this.model.licenseHasSecretsSync}}
-  @isHVDManaged={{this.model.isHVDManaged}}
+  @isHvdManaged={{this.model.isHvdManaged}}
 />

--- a/ui/tests/acceptance/sync/secrets/overview-test.js
+++ b/ui/tests/acceptance/sync/secrets/overview-test.js
@@ -162,8 +162,8 @@ module('Acceptance | sync | overview', function (hooks) {
       this.server.post('/sys/activation-flags/secrets-sync/activate', (_, req) => {
         assert.strictEqual(
           req.requestHeaders['X-Vault-Namespace'],
-          'root',
-          'Request is made to root namespace'
+          'admin/foo',
+          'Request is made to admin/foo namespace'
         );
         return {};
       });

--- a/ui/tests/integration/components/sync/secrets/page/overview-test.js
+++ b/ui/tests/integration/components/sync/secrets/page/overview-test.js
@@ -35,11 +35,11 @@ module('Integration | Component | sync | Page::Overview', function (hooks) {
     this.destinations = await this.store.query('sync/destination', {});
     this.isActivated = true;
     this.licenseHasSecretsSync = true;
-    this.isHVDManaged = false;
+    this.isHvdManaged = false;
 
     this.renderComponent = () => {
       return render(
-        hbs`<Secrets::Page::Overview @destinations={{this.destinations}} @totalVaultSecrets={{7}} @isActivated={{this.isActivated}} @licenseHasSecretsSync={{this.licenseHasSecretsSync}} @isHVDManaged={{this.isHVDManaged}} />`,
+        hbs`<Secrets::Page::Overview @destinations={{this.destinations}} @totalVaultSecrets={{7}} @isActivated={{this.isActivated}} @licenseHasSecretsSync={{this.licenseHasSecretsSync}} @isHvdManaged={{this.isHvdManaged}} />`,
         {
           owner: this.engine,
         }
@@ -104,7 +104,7 @@ module('Integration | Component | sync | Page::Overview', function (hooks) {
   module('managed', function (hooks) {
     hooks.beforeEach(function () {
       this.isActivated = false;
-      this.isHVDManaged = true;
+      this.isHvdManaged = true;
       this.destinations = [];
     });
 

--- a/ui/tests/integration/components/sync/secrets/page/overview-test.js
+++ b/ui/tests/integration/components/sync/secrets/page/overview-test.js
@@ -35,11 +35,11 @@ module('Integration | Component | sync | Page::Overview', function (hooks) {
     this.destinations = await this.store.query('sync/destination', {});
     this.isActivated = true;
     this.licenseHasSecretsSync = true;
-    this.isManaged = false;
+    this.isHVDManaged = false;
 
     this.renderComponent = () => {
       return render(
-        hbs`<Secrets::Page::Overview @destinations={{this.destinations}} @totalVaultSecrets={{7}} @isActivated={{this.isActivated}} @licenseHasSecretsSync={{this.licenseHasSecretsSync}} @isManaged={{this.isManaged}} />`,
+        hbs`<Secrets::Page::Overview @destinations={{this.destinations}} @totalVaultSecrets={{7}} @isActivated={{this.isActivated}} @licenseHasSecretsSync={{this.licenseHasSecretsSync}} @isHVDManaged={{this.isHVDManaged}} />`,
         {
           owner: this.engine,
         }
@@ -104,7 +104,7 @@ module('Integration | Component | sync | Page::Overview', function (hooks) {
   module('managed', function (hooks) {
     hooks.beforeEach(function () {
       this.isActivated = false;
-      this.isManaged = true;
+      this.isHVDManaged = true;
       this.destinations = [];
     });
 

--- a/ui/tests/unit/services/flags-test.js
+++ b/ui/tests/unit/services/flags-test.js
@@ -98,22 +98,22 @@ module('Unit | Service | flags', function (hooks) {
     });
   });
 
-  module('#managedNamespaceRoot', function () {
+  module('#hvdManagedNamespaceRoot', function () {
     test('it returns null when flag is not present', function (assert) {
-      assert.strictEqual(this.service.managedNamespaceRoot, null);
+      assert.strictEqual(this.service.hvdManagedNamespaceRoot, null);
     });
 
     test('it returns the namespace root when flag is present', function (assert) {
       this.service.featureFlags = ['VAULT_CLOUD_ADMIN_NAMESPACE'];
       assert.strictEqual(
-        this.service.managedNamespaceRoot,
+        this.service.hvdManagedNamespaceRoot,
         'admin',
         'Managed namespace is admin when flag present'
       );
 
       this.service.featureFlags = ['SOMETHING_ELSE'];
       assert.strictEqual(
-        this.service.managedNamespaceRoot,
+        this.service.hvdManagedNamespaceRoot,
         null,
         'Flags were overwritten and root namespace is null again'
       );


### PR DESCRIPTION
`isManaged` -> `isHvdManaged`
`managedNamespaceRoot` -> `hvdManagedNamespaceRoot`

We decided to rename these to clarify what "managed" means—see original [PR discussion](https://github.com/hashicorp/vault/pull/26649/files#r1583563102).