### PR TITLE
Add policy creation to AppRole setup

### DIFF
--- a/website/content/docs/platform/servicenow/installation.mdx
+++ b/website/content/docs/platform/servicenow/installation.mdx
@@ -21,6 +21,11 @@ description: Installation steps for the Vault ServiceNow Credential Resolver.
 
     ```bash
     vault auth enable approle
+    vault policy write demo - <<EOF
+    path "secret/*" {
+      capabilities = ["read"]
+    }
+    EOF
     vault write auth/approle/role/role1 bind_secret_id=true token_policies=demo
     ```
 


### PR DESCRIPTION
It's not immediately obvious that the demo policy needs to be created beforehand and does not exist if only the tutorial steps are followed. Prompted by support ticket ZD-143426.