### PR TITLE
Add stub enterprise logical system backend and init

### DIFF
--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -248,6 +248,7 @@ func NewSystemBackend(core *Core, logger log.Logger, config *logical.BackendConf
 	b.Backend.Invalidate = sysInvalidate(b)
 	b.Backend.InitializeFunc = sysInitialize(b)
 	b.Backend.Clean = sysClean(b)
+	b.entInit()
 	return b
 }
 
@@ -267,6 +268,7 @@ func (b *SystemBackend) rawPaths() []*framework.Path {
 // prefix. Conceptually it is similar to procfs on Linux.
 type SystemBackend struct {
 	*framework.Backend
+	entSystemBackend
 	Core        *Core
 	db          *memdb.MemDB
 	logger      log.Logger

--- a/vault/logical_system_stubs_oss.go
+++ b/vault/logical_system_stubs_oss.go
@@ -7,6 +7,10 @@ package vault
 
 //go:generate go run github.com/hashicorp/vault/tools/stubmaker
 
+type entSystemBackend struct{}
+
 func entUnauthenticatedPaths() []string {
 	return []string{}
 }
+
+func (s *SystemBackend) entInit() {}


### PR DESCRIPTION
This is used so that Enterprise code can do
additional initialization and store additional
state in the logical `SystemBackend`.