### PR TITLE
Handle namespace header for managed vs. non-managed

### DIFF
--- a/ui/lib/sync/addon/components/secrets/page/overview.ts
+++ b/ui/lib/sync/addon/components/secrets/page/overview.ts
@@ -71,14 +71,10 @@ export default class SyncSecretsDestinationsPageComponent extends Component<Args
   @task
   @waitFor
   *onFeatureConfirm() {
-    // If the cluster is managed let the application adapter handle adding the namespace header.
-    // For non-managed clusters never pass a namespace header.
-    const options = this.args.isHvdManaged ? undefined : { namespace: null };
-
     try {
       yield this.store
         .adapterFor('application')
-        .ajax('/v1/sys/activation-flags/secrets-sync/activate', 'POST', options);
+        .ajax('/v1/sys/activation-flags/secrets-sync/activate', 'POST');
       this.router.transitionTo('vault.cluster.sync.secrets.overview');
     } catch (error) {
       this.error = errorMessage(error);

--- a/ui/lib/sync/addon/components/secrets/page/overview.ts
+++ b/ui/lib/sync/addon/components/secrets/page/overview.ts
@@ -15,8 +15,6 @@ import Ember from 'ember';
 import type FlashMessageService from 'vault/services/flash-messages';
 import type StoreService from 'vault/services/store';
 import type RouterService from '@ember/routing/router-service';
-import type VersionService from 'vault/services/version';
-import type NamespaceService from 'vault/services/namespace';
 import type { SyncDestinationAssociationMetrics } from 'vault/vault/adapters/sync/association';
 import type SyncDestinationModel from 'vault/vault/models/sync/destination';
 
@@ -32,8 +30,6 @@ export default class SyncSecretsDestinationsPageComponent extends Component<Args
   @service declare readonly flashMessages: FlashMessageService;
   @service declare readonly store: StoreService;
   @service declare readonly router: RouterService;
-  @service declare readonly version: VersionService;
-  @service declare readonly namespace: NamespaceService;
 
   @tracked destinationMetrics: SyncDestinationAssociationMetrics[] = [];
   @tracked page = 1;

--- a/ui/lib/sync/addon/components/secrets/page/overview.ts
+++ b/ui/lib/sync/addon/components/secrets/page/overview.ts
@@ -68,12 +68,6 @@ export default class SyncSecretsDestinationsPageComponent extends Component<Args
     this.hasConfirmedDocs = false;
   }
 
-  // try {
-  //     yield this.store
-  //       .adapterFor('application')
-  //       .ajax('/v1/sys/activation-flags/secrets-sync/activate', 'POST', { namespace: null });
-  //     this.router.transitionTo('vault.cluster.sync.secrets.overview');
-  //   } catch (error) {
   @task
   @waitFor
   *onFeatureConfirm() {

--- a/ui/tests/acceptance/sync/secrets/overview-test.js
+++ b/ui/tests/acceptance/sync/secrets/overview-test.js
@@ -193,8 +193,8 @@ module('Acceptance | sync | overview', function (hooks) {
       this.server.post('/sys/activation-flags/secrets-sync/activate', (_, req) => {
         assert.strictEqual(
           req.requestHeaders['X-Vault-Namespace'],
-          'admin/foo',
-          'Request is made to the admin/foo namespace'
+          'admin',
+          'Request is made to the base admin namespace'
         );
         return {};
       });

--- a/ui/tests/acceptance/sync/secrets/overview-test.js
+++ b/ui/tests/acceptance/sync/secrets/overview-test.js
@@ -147,7 +147,7 @@ module('Acceptance | sync | overview', function (hooks) {
       await authPage.loginNs('admin/foo');
     });
 
-    test('it should make activation-flag requests to correct namespace', async function (assert) {
+    test('it should make activation-flag requests to correct namespace when not managed', async function (assert) {
       assert.expect(3);
 
       this.server.get('/sys/activation-flags', (_, req) => {
@@ -162,8 +162,8 @@ module('Acceptance | sync | overview', function (hooks) {
       this.server.post('/sys/activation-flags/secrets-sync/activate', (_, req) => {
         assert.strictEqual(
           req.requestHeaders['X-Vault-Namespace'],
-          'admin/foo',
-          'Request is made to admin/foo namespace'
+          undefined,
+          'Request is made without a namespace'
         );
         return {};
       });
@@ -193,8 +193,8 @@ module('Acceptance | sync | overview', function (hooks) {
       this.server.post('/sys/activation-flags/secrets-sync/activate', (_, req) => {
         assert.strictEqual(
           req.requestHeaders['X-Vault-Namespace'],
-          'admin',
-          'Request is made to the admin namespace'
+          'admin/foo',
+          'Request is made to the admin/foo namespace'
         );
         return {};
       });


### PR DESCRIPTION
For HVD clusters, we will be passing the base namespace header `admin` and `undefined` for non hvd clusters.

This PR adds this conditional and updates the tests. These are enterprise tests, so they need to be run locally.

- [x] Enterprise tests pass locally