### PR TITLE
Add inmem_transactional storage option for tests

### DIFF
--- a/command/server_util.go
+++ b/command/server_util.go
@@ -36,8 +36,9 @@ func testServerCommand(tb testing.TB) (*cli.MockUi, *ServerCommand) {
 		SighupCh:   MakeSighupCh(),
 		SigUSR2Ch:  MakeSigUSR2Ch(),
 		PhysicalBackends: map[string]physical.Factory{
-			"inmem":    physInmem.NewInmem,
-			"inmem_ha": physInmem.NewInmemHA,
+			"inmem":               physInmem.NewInmem,
+			"inmem_ha":            physInmem.NewInmemHA,
+			"inmem_transactional": physInmem.NewTransactionalInmem,
 		},
 
 		// These prevent us from random sleep guessing...


### PR DESCRIPTION
This PR adds inmem_transactional to the map of available physical backends for TestServerCommand. This is harmless, as tests need to opt into the backend.

This is required to test AOP configuration on enterprise.