### PR TITLE
UI: Update openapi to include `metadata` for pki certificates

### DIFF
--- a/ui/app/models/pki/certificate/base.js
+++ b/ui/app/models/pki/certificate/base.js
@@ -19,7 +19,7 @@ import lazyCapabilities, { apiPath } from 'vault/macros/lazy-capabilities';
  */
 
 // also displays parsedCertificate values in the template
-const certDisplayFields = ['certificate', 'commonName', 'revocationTime', 'serialNumber'];
+const certDisplayFields = ['certificate', 'commonName', 'revocationTime', 'serialNumber', 'metadata'];
 
 @withFormFields(certDisplayFields)
 export default class PkiCertificateBaseModel extends Model {

--- a/ui/app/models/pki/certificate/generate.js
+++ b/ui/app/models/pki/certificate/generate.js
@@ -11,6 +11,7 @@ const generateFromRole = [
   {
     default: ['commonName', 'userIds', 'customTtl', 'format', 'privateKeyFormat'],
   },
+  { enterpriseOnly: ['metadata'] },
   {
     'Subject Alternative Name (SAN) Options': [
       'excludeCnFromSans',
@@ -31,6 +32,7 @@ const certDisplayFields = [
   'issuingCa',
   'privateKey',
   'privateKeyType',
+  'metadata',
 ];
 @withFormFields(certDisplayFields, generateFromRole)
 export default class PkiCertificateGenerateModel extends PkiCertificateBaseModel {

--- a/ui/app/models/pki/certificate/sign.js
+++ b/ui/app/models/pki/certificate/sign.js
@@ -11,6 +11,7 @@ const generateFromRole = [
   {
     default: ['csr', 'commonName', 'customTtl', 'format', 'removeRootsFromChain'],
   },
+  { enterpriseOnly: ['metadata'] },
   {
     'Subject Alternative Name (SAN) Options': [
       'excludeCnFromSans',

--- a/ui/app/serializers/pki/certificate/base.js
+++ b/ui/app/serializers/pki/certificate/base.js
@@ -5,6 +5,7 @@
 
 import { parseCertificate } from 'vault/utils/parse-pki-cert';
 import ApplicationSerializer from '../../application';
+import { encodeString } from 'core/utils/b64';
 
 export default class PkiCertificateBaseSerializer extends ApplicationSerializer {
   primaryKey = 'serial_number';
@@ -26,5 +27,13 @@ export default class PkiCertificateBaseSerializer extends ApplicationSerializer 
       );
     }
     return super.normalizeResponse(...arguments);
+  }
+
+  serialize(snapshot) {
+    const data = super.serialize(snapshot);
+    if (Object.keys(data).includes('metadata')) {
+      data.metadata = encodeString(data.metadata);
+    }
+    return data;
   }
 }

--- a/ui/lib/pki/addon/components/pki-role-generate.hbs
+++ b/ui/lib/pki/addon/components/pki-role-generate.hbs
@@ -17,6 +17,15 @@
           </FormField>
         {{/each}}
       {{/let}}
+
+      {{#if this.version.isEnterprise}}
+        {{#let (get @model.formFieldGroups "1") as |group|}}
+          {{#each group.enterpriseOnly as |attr|}}
+            <FormField @model={{@model}} @attr={{attr}} @modelValidations={{this.modelValidations}} />
+          {{/each}}
+        {{/let}}
+      {{/if}}
+
       <FormFieldGroups
         @model={{@model}}
         @renderGroup="Subject Alternative Name (SAN) Options"

--- a/ui/lib/pki/addon/components/pki-role-generate.ts
+++ b/ui/lib/pki/addon/components/pki-role-generate.ts
@@ -15,6 +15,7 @@ import type FlashMessageService from 'vault/services/flash-messages';
 import type DownloadService from 'vault/services/download';
 import type PkiCertificateGenerateModel from 'vault/models/pki/certificate/generate';
 import type PkiCertificateSignModel from 'vault/models/pki/certificate/sign';
+import VersionService from 'vault/services/version';
 
 interface Args {
   onSuccess: CallableFunction;
@@ -25,6 +26,7 @@ interface Args {
 export default class PkiRoleGenerate extends Component<Args> {
   @service declare readonly router: Router;
   @service declare readonly store: Store;
+  @service declare readonly version: VersionService;
   @service declare readonly flashMessages: FlashMessageService;
   @service declare readonly download: DownloadService;
 

--- a/ui/tests/acceptance/open-api-path-help-test.js
+++ b/ui/tests/acceptance/open-api-path-help-test.js
@@ -15,6 +15,8 @@ import expectedAuthAttrs from 'vault/tests/helpers/openapi/expected-auth-attrs';
  * are known by UI developers and adequately addressed in the UI. When changes
  * are detected from this set of tests, they should be updated to pass and
  * smoke tested to ensure changes to not break the GUI workflow.
+ * In some cases, a ticket should be made to track updating the relevant model or form,
+ * if it is not updated automatically or is a more involved feature request.
  * Marked as enterprise so it only runs periodically
  */
 module('Acceptance | OpenAPI provides expected attributes enterprise', function (hooks) {

--- a/ui/tests/helpers/openapi/expected-secret-attrs.js
+++ b/ui/tests/helpers/openapi/expected-secret-attrs.js
@@ -625,6 +625,14 @@ const pki = {
       fieldGroup: 'default',
       type: 'string',
     },
+    metadata: {
+      editType: 'string',
+      fieldGroup: 'default',
+      helpText:
+        "User supplied metadata to store associated with this certificate's serial number, base64 encoded",
+      label: 'Metadata',
+      type: 'string',
+    },
     notAfter: {
       editType: 'string',
       helpText:
@@ -741,6 +749,14 @@ const pki = {
       helpText:
         'Reference to a existing issuer; either "default" for the configured default issuer, an identifier or the name assigned to the issuer.',
       fieldGroup: 'default',
+      type: 'string',
+    },
+    metadata: {
+      editType: 'string',
+      fieldGroup: 'default',
+      helpText:
+        "User supplied metadata to store associated with this certificate's serial number, base64 encoded",
+      label: 'Metadata',
       type: 'string',
     },
     notAfter: {


### PR DESCRIPTION
Originally I planned to also add the fields to the relevant certificate forms, but I had to revert the commit as I got this error, even though the binary was enterprise. Creating a jira ticket to add the field instead.
![Screenshot 2024-05-02 at 4 38 45 PM](https://github.com/hashicorp/vault/assets/68122737/3db814d7-4eb6-415f-8d43-f3deab433b36)
![Screenshot 2024-05-02 at 4 39 11 PM](https://github.com/hashicorp/vault/assets/68122737/30f504b7-d14b-4f54-90c4-8c6ea5737310)
