### PR TITLE
Namespace banner bug Secrets Sync

### DIFF
--- a/changelog/26790.txt
+++ b/changelog/26790.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Refresh model within a namespace on the Secrets Sync overview page.
+```

--- a/ui/lib/sync/addon/components/secrets/page/overview.ts
+++ b/ui/lib/sync/addon/components/secrets/page/overview.ts
@@ -44,7 +44,6 @@ export default class SyncSecretsDestinationsPageComponent extends Component<Args
 
   constructor(owner: unknown, args: Args) {
     super(owner, args);
-    // console.log(this.args.id, 'MODELID');
     if (this.args.destinations.length) {
       this.fetchAssociationsForDestinations.perform();
     }

--- a/ui/lib/sync/addon/components/secrets/page/overview.ts
+++ b/ui/lib/sync/addon/components/secrets/page/overview.ts
@@ -44,6 +44,7 @@ export default class SyncSecretsDestinationsPageComponent extends Component<Args
 
   constructor(owner: unknown, args: Args) {
     super(owner, args);
+    // console.log(this.args.id, 'MODELID');
     if (this.args.destinations.length) {
       this.fetchAssociationsForDestinations.perform();
     }
@@ -75,7 +76,8 @@ export default class SyncSecretsDestinationsPageComponent extends Component<Args
       yield this.store
         .adapterFor('application')
         .ajax('/v1/sys/activation-flags/secrets-sync/activate', 'POST', { namespace: null });
-      this.router.transitionTo('vault.cluster.sync.secrets.overview');
+      // must refresh and not transition because transition does not refresh the model from within a namespace
+      yield this.router.refresh();
     } catch (error) {
       this.error = errorMessage(error);
       this.flashMessages.danger(`Error enabling feature \n ${errorMessage(error)}`);

--- a/ui/tests/acceptance/sync/secrets/overview-test.js
+++ b/ui/tests/acceptance/sync/secrets/overview-test.js
@@ -148,8 +148,8 @@ module('Acceptance | sync | overview', function (hooks) {
     });
 
     test('it should make activation-flag requests to correct namespace', async function (assert) {
-      assert.expect(3);
-
+      assert.expect(4);
+      // should call GET activation-flags twice because it the component needs an updated response after confirming to see if the feature has been activated
       this.server.get('/sys/activation-flags', (_, req) => {
         assert.deepEqual(req.requestHeaders, {}, 'Request is unauthenticated and in root namespace');
         return {

--- a/ui/tests/acceptance/sync/secrets/overview-test.js
+++ b/ui/tests/acceptance/sync/secrets/overview-test.js
@@ -149,7 +149,7 @@ module('Acceptance | sync | overview', function (hooks) {
 
     test('it should make activation-flag requests to correct namespace', async function (assert) {
       assert.expect(4);
-      // should call GET activation-flags twice because it the component needs an updated response after confirming to see if the feature has been activated
+      // should call GET activation-flags twice because we need an updated response after activating the feature
       this.server.get('/sys/activation-flags', (_, req) => {
         assert.deepEqual(req.requestHeaders, {}, 'Request is unauthenticated and in root namespace');
         return {


### PR DESCRIPTION
If you were in a namespace and you activated the feature the secrets.overview model would not refresh. Because this model is generated from the route and not a backing ember data model, it's not super easy to just pass in the model to the transitionTo method. Instead, we need to trigger the model refresh manually via the [router.refresh()](https://api.emberjs.com/ember/5.8/classes/Route/methods/modelFor?anchor=refresh) method.

**Before within namespace**

https://github.com/hashicorp/vault/assets/6618863/8611a853-ca22-4da3-bfc2-45d12bbf8308

**After within a namespace**

https://github.com/hashicorp/vault/assets/6618863/37afefc2-2519-442e-b4d8-2cc5637ab3b1

- [ ] Enterprise tests pass (sync specific, still issues running replication test locally)

- I checked if this was an issue on 1.16.x or maybe a result of a recent dependency upgrade but it appears to be a bug there as well. 
