### PR TITLE
PKI: Change sign-intermediate to truncate notAfter by default (behavior change)

### DIFF
--- a/builtin/logical/pki/path_sign_issuers.go
+++ b/builtin/logical/pki/path_sign_issuers.go
@@ -36,6 +36,11 @@ func pathSignIntermediate(b *backend) *framework.Path {
 
 func buildPathIssuerSignIntermediateRaw(b *backend, pattern string, displayAttrs *framework.DisplayAttributes) *framework.Path {
 	fields := addIssuerRefField(map[string]*framework.FieldSchema{})
+	fields["enforce_leaf_not_after_behavior"] = &framework.FieldSchema{
+		Type:        framework.TypeBool,
+		Default:     false,
+		Description: "Do not truncate the NotAfter field, use the issuer's configured leaf_not_after_behavior",
+	}
 	path := &framework.Path{
 		Pattern:      pattern,
 		DisplayAttrs: displayAttrs,

--- a/changelog/26796.txt
+++ b/changelog/26796.txt
@@ -1,0 +1,3 @@
+```release-note:change
+secrets/pki: sign-intermediate API will truncate notAfter if calculated to go beyond the signing issuer's notAfter. Previously the notAfter was permitted to go beyond leading to invalid chains.
+```

--- a/website/content/api-docs/secret/pki.mdx
+++ b/website/content/api-docs/secret/pki.mdx
@@ -1023,6 +1023,11 @@ when signing an externally-owned intermediate.
    Access to this endpoint should be restricted by policy to only trusted
    operators.
 
+~> **Note**: As of 1.17.x the default behavior has changed to truncate the
+   signed intermediary's notAfter field to the signing issuer's notAfter
+   if it is computed to go beyond. Prior versions permitted the notAfter
+   to go beyond.
+
 | Method | Path                                        | Issuer    |
 | :----- | :------------------------------------------ | :-------  |
 | `POST` | `/pki/root/sign-intermediate`               | `default` |

--- a/website/content/api-docs/secret/pki.mdx
+++ b/website/content/api-docs/secret/pki.mdx
@@ -1411,6 +1411,9 @@ have access.**
 ~> Note: This value is only used as a default when the `ExtendedKeyUsage`
    extension is missing from the CSR.
 
+- `enforce_leaf_not_after_behavior` `(bool: false)` - If true, do not apply the default truncate
+  behavior to the issued CA certificate, instead defer to the issuer's configured `leaf_not_after_behavior`
+
 - `ttl` `(string: "")` - Specifies the requested Time To Live. Cannot be greater
   than the engine's `max_ttl` value. If not provided, the engine's `ttl` value
   will be used, which defaults to system values if not explicitly set. See

--- a/website/content/api-docs/secret/pki.mdx
+++ b/website/content/api-docs/secret/pki.mdx
@@ -1023,10 +1023,9 @@ when signing an externally-owned intermediate.
    Access to this endpoint should be restricted by policy to only trusted
    operators.
 
-~> **Note**: As of 1.17.x the default behavior has changed to truncate the
-   signed intermediary's notAfter field to the signing issuer's notAfter
-   if it is computed to go beyond. Prior versions permitted the notAfter
-   to go beyond.
+By default, Vault truncates the `notAfter` field of the signed intermediary
+to use the `notAfter` field of the signing issuer, it the computed field for the
+intermediary goes beyond the prescribed length.
 
 | Method | Path                                        | Issuer    |
 | :----- | :------------------------------------------ | :-------  |

--- a/website/content/docs/upgrading/upgrade-to-1.17.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.17.x.mdx
@@ -1,0 +1,33 @@
+---
+layout: docs
+page_title: Upgrade to Vault 1.17.x - Guides
+description: |-
+  Deprecations, important or breaking changes, and remediation recommendations
+  for anyone upgrading to 1.17.x from Vault 1.16.x.
+---
+
+# Overview
+
+The Vault 1.17.x upgrade guide contains information on deprecations, important
+or breaking changes, and remediation recommendations for anyone upgrading from
+Vault 1.16. **Please read carefully**.
+
+## Important changes
+
+### PKI sign-intermediate now truncates notAfter field to signing issuer
+
+Prior to 1.17.x the sign-intermediate API would permit a calculated notAfter field to go beyond
+the signing issuer's notAfter. This would lead to a CA chain that would not validate properly. As
+of 1.17.x the default behavior has changed to truncate the intermediary's notAfter value to
+the signing issuer's notAfter if calculated to be greater.
+
+#### How to opt out
+
+A new flag has been introduced on the sign-intermediate API `enforce_leaf_not_after_behavior`. Setting
+this flag to true, the sign-intermediate API will use the signing issuer's configured
+`leaf_not_after_behavior` value to control the behavior. Configuring the issuer to a value of `permit`
+will along with setting the `enforce_leaf_not_after_behavior` to true will restore the legacy behavior.
+
+## Known issues and workarounds
+
+@include 'known-issues/ocsp-redirect.mdx'

--- a/website/content/docs/upgrading/upgrade-to-1.17.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.17.x.mdx
@@ -16,17 +16,23 @@ Vault 1.16. **Please read carefully**.
 
 ### PKI sign-intermediate now truncates notAfter field to signing issuer
 
-Prior to 1.17.x the sign-intermediate API would permit a calculated notAfter field to go beyond
-the signing issuer's notAfter. This would lead to a CA chain that would not validate properly. As
-of 1.17.x the default behavior has changed to truncate the intermediary's notAfter value to
-the signing issuer's notAfter if calculated to be greater.
+Prior to 1.17.x, Vault allowed the calculated sign-intermediate `notAfter` field
+to go beyond the signing issuer `notAfter` field. The extended value lead to a
+CA chain that would not validate properly. As of 1.17.x, Vault truncates the
+intermediary `notAfter` value to the signing issuer `notAfter` if the calculated
+field is greater.
 
 #### How to opt out
 
-A new flag has been introduced on the sign-intermediate API `enforce_leaf_not_after_behavior`. Setting
-this flag to true, the sign-intermediate API will use the signing issuer's configured
-`leaf_not_after_behavior` value to control the behavior. Configuring the issuer to a value of `permit`
-will along with setting the `enforce_leaf_not_after_behavior` to true will restore the legacy behavior.
+You can use the new `enforce_leaf_not_after_behavior` flag on the
+sign-intermediate API along with the `leaf_not_after_behavior` flag for the
+signing issuer to opt out of the truncating behavior.
+
+When you set `enforce_leaf_not_after_behavior` to true, the sign-intermediate
+API uses the `leaf_not_after_behavior` value configured for the signing issuer
+to control truncation the behavior. Setting the issuer `leaf_not_after_behavior`
+field to `permit` and `enforce_leaf_not_after_behavior` to true restores the
+legacy behavior.
 
 ## Known issues and workarounds
 

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -2283,6 +2283,10 @@
         "path": "upgrading/raft-wal"
       },
       {
+        "title": "Upgrade to 1.17.x",
+        "path": "upgrading/upgrade-to-1.17.x"
+      },
+      {
         "title": "Upgrade to 1.16.x",
         "path": "upgrading/upgrade-to-1.16.x"
       },


### PR DESCRIPTION
 - The PKI sign-intermediate API allowed an end-user to request a TTL value that would extend beyond the signing issuer's notAfter. This would generate an invalid CA chain when properly validated.
 - We are now changing the default behavior to truncate the returned certificate to the signing issuer's notAfter.
 - End-users can get the old behavior by configuring the signing issuer's leaf_not_after_behavior field to permit, and call sign-intermediary with the new argument enforce_leaf_not_after_behavior to true. The new argument could also be used to enforce an error instead of truncating behavior if the signing issuer's leaf_not_after_behavior is set to err.