### PR TITLE
audit: log request: use `timeout` (5s)

### DIFF
--- a/audit/broker.go
+++ b/audit/broker.go
@@ -299,7 +299,7 @@ func (b *Broker) LogRequest(ctx context.Context, in *logical.LogInput) (ret erro
 			return retErr.ErrorOrNil()
 		}
 
-		tempContext, auditCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		tempContext, auditCancel := context.WithTimeout(context.Background(), timeout)
 		defer auditCancel()
 		auditContext = namespace.ContextWithNamespace(tempContext, ns)
 	}


### PR DESCRIPTION
Use `timeout` rather than specifying separately.

~Fix~ tweak for https://github.com/hashicorp/vault/pull/26616 which used inline setting of `5 * time.Second` vs the `timeout` constant.