### PR TITLE
Fix docker image in developer quickstart

### DIFF
--- a/website/content/docs/get-started/developer-qs.mdx
+++ b/website/content/docs/get-started/developer-qs.mdx
@@ -36,7 +36,7 @@ Run the Vault server in a non-production "dev" mode in one of the following ways
 **For Docker users, run this command**:
 
 ```shell-session
-$ docker run -p 8200:8200 -e 'VAULT_DEV_ROOT_TOKEN_ID=dev-only-token' vault
+$ docker run -p 8200:8200 -e 'VAULT_DEV_ROOT_TOKEN_ID=dev-only-token' hashicorp/vault
 ```
 
 **For non-Docker users, run this command**:


### PR DESCRIPTION
We were pointing to the deprecated official images (https://hub.docker.com/_/vault) instead of the verified publisher images (https://hub.docker.com/r/hashicorp/vault) which is the one we publish `latest` to.

Should resolve https://github.com/hashicorp/vault/pull/23581 - credit to @cawoodm for finding.