### PR TITLE
UI: Update engine dropdowns

### DIFF
--- a/ui/app/styles/components/toolbar.scss
+++ b/ui/app/styles/components/toolbar.scss
@@ -41,7 +41,6 @@
   display: flex;
   height: 3rem;
   justify-content: space-between;
-  overflow-x: auto;
   width: 100%;
 
   @include from($mobile) {

--- a/ui/lib/core/addon/components/search-select.hbs
+++ b/ui/lib/core/addon/components/search-select.hbs
@@ -46,6 +46,7 @@
         @renderInPlace={{@renderInPlace}}
         @verticalPosition="below"
         @disabled={{@disabled}}
+        @ariaLabel={{or @ariaLabel @label (humanize @id)}}
         as |option|
       >
         {{#if this.shouldRenderName}}

--- a/ui/lib/core/addon/components/search-select.js
+++ b/ui/lib/core/addon/components/search-select.js
@@ -49,6 +49,7 @@ import { addToArray } from 'vault/helpers/add-to-array';
  * @param {string} id - The name of the form field
  * @param {string} [label] - Label for this form field
  * @param {string} [labelClass] - overwrite default label size (14px) from class="is-label"
+ * @param {string} [ariaLabel] - fallback accessible label if label is not provided
  * @param {string} [subText] - Text to be displayed below the label
  * @param {string} fallbackComponent - name of component to be rendered if the API call 403s
  * @param {string} [helpText] - Text to be displayed in the info tooltip for this form field
@@ -142,7 +143,7 @@ export default class SearchSelect extends Component {
     }
 
     if (!this.args.models) {
-      if (this.args.options) {
+      if (Array.isArray(this.args.options)) {
         const { options } = this.args;
         // if options are nested, let parent handle formatting - see path-filter-config-list.js
         this.dropdownOptions = options.some((e) => Object.keys(e).includes('groupName'))

--- a/ui/lib/pki/addon/components/page/pki-issuer-details.hbs
+++ b/ui/lib/pki/addon/components/page/pki-issuer-details.hbs
@@ -35,7 +35,13 @@
         Sign Intermediate
       </ToolbarLink>
     {{/if}}
-    <BasicDropdown @class="popup-menu" @horizontalPosition="auto-right" @verticalPosition="below" as |D|>
+    <BasicDropdown
+      @class="popup-menu"
+      @horizontalPosition="auto-right"
+      @verticalPosition="below"
+      @renderInPlace={{true}}
+      as |D|
+    >
       <D.Trigger
         data-test-popup-menu-trigger="true"
         class={{concat "toolbar-link" (if D.isOpen " is-active")}}

--- a/ui/lib/pki/addon/components/page/pki-issuer-list.hbs
+++ b/ui/lib/pki/addon/components/page/pki-issuer-list.hbs
@@ -8,7 +8,13 @@
     <ToolbarLink @route="issuers.import" @model={{@backend}} data-test-generate-issuer="import">
       Import
     </ToolbarLink>
-    <BasicDropdown @class="popup-menu" @horizontalPosition="auto-right" @verticalPosition="below" as |D|>
+    <BasicDropdown
+      @class="popup-menu"
+      @horizontalPosition="auto-right"
+      @verticalPosition="below"
+      @renderInPlace={{true}}
+      as |D|
+    >
       <D.Trigger
         class={{concat "toolbar-link" (if D.isOpen " is-active")}}
         @htmlTag="button"

--- a/ui/lib/pki/addon/components/page/pki-issuer-rotate-root.hbs
+++ b/ui/lib/pki/addon/components/page/pki-issuer-rotate-root.hbs
@@ -33,7 +33,13 @@
       >
         Sign Intermediate
       </ToolbarLink>
-      <BasicDropdown @class="popup-menu" @horizontalPosition="auto-right" @verticalPosition="below" as |D|>
+      <BasicDropdown
+        @class="popup-menu"
+        @horizontalPosition="auto-right"
+        @verticalPosition="below"
+        @renderInPlace={{true}}
+        as |D|
+      >
         <D.Trigger
           data-test-popup-menu-trigger
           class={{concat "toolbar-link" (if D.isOpen " is-active")}}

--- a/ui/lib/pki/addon/components/page/pki-overview.hbs
+++ b/ui/lib/pki/addon/components/page/pki-overview.hbs
@@ -39,6 +39,7 @@
         @disallowNewItems={{true}}
         @onChange={{this.handleRolesInput}}
         @fallbackComponent="input-search"
+        @renderInPlace={{true}}
         data-test-issue-certificate-input
       />
       <Hds::Button
@@ -64,6 +65,7 @@
         @disallowNewItems={{true}}
         @onChange={{this.handleCertificateInput}}
         @fallbackComponent="input-search"
+        @renderInPlace={{true}}
         data-test-view-certificate-input
       />
       <Hds::Button
@@ -89,7 +91,7 @@
         @onChange={{this.handleIssuerSearch}}
         @fallbackComponent="input-search"
         @shouldRenderName={{true}}
-        @nameKey={{"issuerName"}}
+        @renderInPlace={{true}}
         data-test-issue-issuer-input
       />
       <Hds::Button

--- a/ui/lib/pki/addon/components/page/pki-overview.ts
+++ b/ui/lib/pki/addon/components/page/pki-overview.ts
@@ -13,8 +13,8 @@ import type PkiIssuerModel from 'vault/models/pki/issuer';
 import type PkiRoleModel from 'vault/models/pki/role';
 
 interface Args {
-  issuers: PkiIssuerModel | number;
-  roles: PkiRoleModel | number;
+  issuers: PkiIssuerModel[] | number;
+  roles: PkiRoleModel[] | number;
   engine: string;
 }
 

--- a/ui/lib/pki/package.json
+++ b/ui/lib/pki/package.json
@@ -6,6 +6,7 @@
   ],
   "dependencies": {
     "date-fns": "*",
+    "ember-basic-dropdown": "*",
     "ember-cli-babel": "*",
     "ember-cli-htmlbars": "*",
     "ember-cli-typescript": "*",


### PR DESCRIPTION
This work is required as part of #26708 

As part of the upgrade to Ember 5, we also need to update `ember-power-select` and `ember-basic-dropdown`. As part of this upgrade, the dropdown content no longer renders in tests when the dropdown is located within an engine unless `@renderInPlace` is passed in. Since the changes required can be done separately from the upgrade, I decided to split the work out into its own PR. 

Another thing we needed to update for this to work for users is to update the styling of `toolbar-scroller`. With the previous CSS, the dropdown contents were hidden under a scrollbar:  
![image](https://github.com/hashicorp/vault/assets/82459713/a918f673-0322-4648-bd98-9a687e9d5570)

With these changes, it renders correctly: 
![image](https://github.com/hashicorp/vault/assets/82459713/f3fd4b71-d909-47e2-842b-c6030f1b10da)

After this toolbar update, we are unblocked from adopting HDS Dropdowns in the toolbar. 