### PR TITLE
install ember-sinon-qunit

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -155,7 +155,7 @@
     "ember-responsive": "5.0.0",
     "ember-router-helpers": "^0.4.0",
     "ember-service-worker": "meirish/ember-service-worker#configurable-scope",
-    "ember-sinon": "^4.0.0",
+    "ember-sinon-qunit": "^7.4.0",
     "ember-source": "~4.12.0",
     "ember-style-modifier": "^4.1.0",
     "ember-svg-jar": "2.4.4",

--- a/ui/tests/acceptance/clients/counts-test.js
+++ b/ui/tests/acceptance/clients/counts-test.js
@@ -20,7 +20,7 @@ module('Acceptance | clients | counts', function (hooks) {
   setupMirage(hooks);
 
   hooks.before(function () {
-    sinon.replace(timestamp, 'now', sinon.fake.returns(STATIC_NOW));
+    sinon.stub(timestamp, 'now').callsFake(() => STATIC_NOW);
   });
 
   hooks.beforeEach(async function () {

--- a/ui/tests/acceptance/clients/counts-test.js
+++ b/ui/tests/acceptance/clients/counts-test.js
@@ -20,17 +20,13 @@ module('Acceptance | clients | counts', function (hooks) {
   setupMirage(hooks);
 
   hooks.before(function () {
-    sinon.stub(timestamp, 'now').callsFake(() => STATIC_NOW);
+    sinon.replace(timestamp, 'now', sinon.fake.returns(STATIC_NOW));
   });
 
   hooks.beforeEach(async function () {
     clientsHandler(this.server);
     this.store = this.owner.lookup('service:store');
     return authPage.login();
-  });
-
-  hooks.after(function () {
-    timestamp.now.restore();
   });
 
   test('it should prompt user to query start time for community version', async function (assert) {

--- a/ui/tests/acceptance/clients/counts-test.js
+++ b/ui/tests/acceptance/clients/counts-test.js
@@ -19,11 +19,8 @@ module('Acceptance | clients | counts', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  hooks.before(function () {
-    sinon.stub(timestamp, 'now').callsFake(() => STATIC_NOW);
-  });
-
   hooks.beforeEach(async function () {
+    sinon.replace(timestamp, 'now', sinon.fake.returns(STATIC_NOW));
     clientsHandler(this.server);
     this.store = this.owner.lookup('service:store');
     return authPage.login();

--- a/ui/tests/acceptance/clients/counts/acme-test.js
+++ b/ui/tests/acceptance/clients/counts/acme-test.js
@@ -24,11 +24,8 @@ module('Acceptance | clients | counts | acme', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  hooks.before(function () {
-    sinon.stub(timestamp, 'now').callsFake(() => STATIC_NOW);
-  });
-
   hooks.beforeEach(async function () {
+    sinon.replace(timestamp, 'now', sinon.fake.returns(STATIC_NOW));
     this.server.get('sys/internal/counters/activity', () => {
       return {
         request_id: 'some-activity-id',

--- a/ui/tests/acceptance/clients/counts/acme-test.js
+++ b/ui/tests/acceptance/clients/counts/acme-test.js
@@ -25,7 +25,7 @@ module('Acceptance | clients | counts | acme', function (hooks) {
   setupMirage(hooks);
 
   hooks.before(function () {
-    sinon.stub(timestamp, 'now').callsFake(() => STATIC_NOW);
+    sinon.replace(timestamp, 'now', sinon.fake.returns(STATIC_NOW));
   });
 
   hooks.beforeEach(async function () {
@@ -52,10 +52,6 @@ module('Acceptance | clients | counts | acme', function (hooks) {
 
     await authPage.login();
     return visit('/vault');
-  });
-
-  hooks.after(function () {
-    timestamp.now.restore();
   });
 
   test('it navigates to acme tab', async function (assert) {

--- a/ui/tests/acceptance/clients/counts/acme-test.js
+++ b/ui/tests/acceptance/clients/counts/acme-test.js
@@ -25,7 +25,7 @@ module('Acceptance | clients | counts | acme', function (hooks) {
   setupMirage(hooks);
 
   hooks.before(function () {
-    sinon.replace(timestamp, 'now', sinon.fake.returns(STATIC_NOW));
+    sinon.stub(timestamp, 'now').callsFake(() => STATIC_NOW);
   });
 
   hooks.beforeEach(async function () {

--- a/ui/tests/acceptance/clients/counts/overview-test.js
+++ b/ui/tests/acceptance/clients/counts/overview-test.js
@@ -25,11 +25,8 @@ module('Acceptance | clients | overview', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  hooks.before(function () {
-    sinon.stub(timestamp, 'now').callsFake(() => STATIC_NOW);
-  });
-
   hooks.beforeEach(async function () {
+    sinon.stub(timestamp, 'now').callsFake(() => STATIC_NOW);
     clientsHandler(this.server);
     this.store = this.owner.lookup('service:store');
     await authPage.login();
@@ -229,11 +226,8 @@ module('Acceptance | clients | overview | sync in license, activated', function 
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  hooks.before(function () {
-    sinon.stub(timestamp, 'now').callsFake(() => STATIC_NOW);
-  });
-
   hooks.beforeEach(async function () {
+    sinon.stub(timestamp, 'now').callsFake(() => STATIC_NOW);
     clientsHandler(this.server);
     this.store = this.owner.lookup('service:store');
 

--- a/ui/tests/acceptance/clients/counts/overview-test.js
+++ b/ui/tests/acceptance/clients/counts/overview-test.js
@@ -26,7 +26,7 @@ module('Acceptance | clients | overview', function (hooks) {
   setupMirage(hooks);
 
   hooks.before(function () {
-    sinon.replace(timestamp, 'now', sinon.fake.returns(STATIC_NOW));
+    sinon.stub(timestamp, 'now').callsFake(() => STATIC_NOW);
   });
 
   hooks.beforeEach(async function () {
@@ -230,7 +230,7 @@ module('Acceptance | clients | overview | sync in license, activated', function 
   setupMirage(hooks);
 
   hooks.before(function () {
-    sinon.replace(timestamp, 'now', sinon.fake.returns(STATIC_NOW));
+    sinon.stub(timestamp, 'now').callsFake(() => STATIC_NOW);
   });
 
   hooks.beforeEach(async function () {

--- a/ui/tests/acceptance/clients/counts/overview-test.js
+++ b/ui/tests/acceptance/clients/counts/overview-test.js
@@ -26,7 +26,7 @@ module('Acceptance | clients | overview', function (hooks) {
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {
-    sinon.stub(timestamp, 'now').callsFake(() => STATIC_NOW);
+    sinon.replace(timestamp, 'now', sinon.fake.returns(STATIC_NOW));
     clientsHandler(this.server);
     this.store = this.owner.lookup('service:store');
     await authPage.login();
@@ -227,7 +227,7 @@ module('Acceptance | clients | overview | sync in license, activated', function 
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {
-    sinon.stub(timestamp, 'now').callsFake(() => STATIC_NOW);
+    sinon.replace(timestamp, 'now', sinon.fake.returns(STATIC_NOW));
     clientsHandler(this.server);
     this.store = this.owner.lookup('service:store');
 

--- a/ui/tests/acceptance/clients/counts/overview-test.js
+++ b/ui/tests/acceptance/clients/counts/overview-test.js
@@ -26,7 +26,7 @@ module('Acceptance | clients | overview', function (hooks) {
   setupMirage(hooks);
 
   hooks.before(function () {
-    sinon.stub(timestamp, 'now').callsFake(() => STATIC_NOW);
+    sinon.replace(timestamp, 'now', sinon.fake.returns(STATIC_NOW));
   });
 
   hooks.beforeEach(async function () {
@@ -34,10 +34,6 @@ module('Acceptance | clients | overview', function (hooks) {
     this.store = this.owner.lookup('service:store');
     await authPage.login();
     return visit('/vault/clients/counts/overview');
-  });
-
-  hooks.after(function () {
-    timestamp.now.restore();
   });
 
   test('it should render the correct tabs', async function (assert) {
@@ -234,7 +230,7 @@ module('Acceptance | clients | overview | sync in license, activated', function 
   setupMirage(hooks);
 
   hooks.before(function () {
-    sinon.stub(timestamp, 'now').callsFake(() => STATIC_NOW);
+    sinon.replace(timestamp, 'now', sinon.fake.returns(STATIC_NOW));
   });
 
   hooks.beforeEach(async function () {
@@ -250,10 +246,6 @@ module('Acceptance | clients | overview | sync in license, activated', function 
 
     await authPage.login();
     return visit('/vault/clients/counts/overview');
-  });
-
-  hooks.after(function () {
-    timestamp.now.restore();
   });
 
   test('it should render the correct tabs', async function (assert) {

--- a/ui/tests/acceptance/clients/counts/sync-test.js
+++ b/ui/tests/acceptance/clients/counts/sync-test.js
@@ -20,17 +20,13 @@ module('Acceptance | clients | sync | activated', function (hooks) {
   setupMirage(hooks);
 
   hooks.before(function () {
-    sinon.stub(timestamp, 'now').callsFake(() => STATIC_NOW);
+    sinon.replace(timestamp, 'now', sinon.fake.returns(STATIC_NOW));
   });
 
   hooks.beforeEach(async function () {
     syncHandler(this.server);
     await authPage.login();
     return visit('/vault/clients/counts/sync');
-  });
-
-  hooks.after(function () {
-    timestamp.now.restore();
   });
 
   test('it should render charts when secrets sync is activated', async function (assert) {
@@ -46,16 +42,12 @@ module('Acceptance | clients | sync | not activated', function (hooks) {
   setupMirage(hooks);
 
   hooks.before(function () {
-    sinon.stub(timestamp, 'now').callsFake(() => STATIC_NOW);
+    sinon.replace(timestamp, 'now', sinon.fake.returns(STATIC_NOW));
   });
 
   hooks.beforeEach(async function () {
     await authPage.login();
     return visit('/vault/clients/counts/sync');
-  });
-
-  hooks.after(function () {
-    timestamp.now.restore();
   });
 
   test('it should show an empty state when secrets sync is not activated', async function (assert) {

--- a/ui/tests/acceptance/clients/counts/sync-test.js
+++ b/ui/tests/acceptance/clients/counts/sync-test.js
@@ -20,7 +20,7 @@ module('Acceptance | clients | sync | activated', function (hooks) {
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {
-    sinon.stub(timestamp, 'now').callsFake(() => STATIC_NOW);
+    sinon.replace(timestamp, 'now', sinon.fake.returns(STATIC_NOW));
     syncHandler(this.server);
     await authPage.login();
     return visit('/vault/clients/counts/sync');

--- a/ui/tests/acceptance/clients/counts/sync-test.js
+++ b/ui/tests/acceptance/clients/counts/sync-test.js
@@ -19,11 +19,8 @@ module('Acceptance | clients | sync | activated', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  hooks.before(function () {
-    sinon.stub(timestamp, 'now').callsFake(() => STATIC_NOW);
-  });
-
   hooks.beforeEach(async function () {
+    sinon.stub(timestamp, 'now').callsFake(() => STATIC_NOW);
     syncHandler(this.server);
     await authPage.login();
     return visit('/vault/clients/counts/sync');

--- a/ui/tests/acceptance/clients/counts/sync-test.js
+++ b/ui/tests/acceptance/clients/counts/sync-test.js
@@ -38,11 +38,8 @@ module('Acceptance | clients | sync | not activated', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  hooks.before(function () {
-    sinon.stub(timestamp, 'now').callsFake(() => STATIC_NOW);
-  });
-
   hooks.beforeEach(async function () {
+    sinon.replace(timestamp, 'now', sinon.fake.returns(STATIC_NOW));
     await authPage.login();
     return visit('/vault/clients/counts/sync');
   });

--- a/ui/tests/acceptance/clients/counts/sync-test.js
+++ b/ui/tests/acceptance/clients/counts/sync-test.js
@@ -20,7 +20,7 @@ module('Acceptance | clients | sync | activated', function (hooks) {
   setupMirage(hooks);
 
   hooks.before(function () {
-    sinon.replace(timestamp, 'now', sinon.fake.returns(STATIC_NOW));
+    sinon.stub(timestamp, 'now').callsFake(() => STATIC_NOW);
   });
 
   hooks.beforeEach(async function () {
@@ -42,7 +42,7 @@ module('Acceptance | clients | sync | not activated', function (hooks) {
   setupMirage(hooks);
 
   hooks.before(function () {
-    sinon.replace(timestamp, 'now', sinon.fake.returns(STATIC_NOW));
+    sinon.stub(timestamp, 'now').callsFake(() => STATIC_NOW);
   });
 
   hooks.beforeEach(async function () {

--- a/ui/tests/acceptance/enterprise-license-banner-test.js
+++ b/ui/tests/acceptance/enterprise-license-banner-test.js
@@ -48,10 +48,8 @@ const generateHealthResponse = (now, state) => {
 module('Acceptance | Enterprise | License banner warnings', function (hooks) {
   setupApplicationTest(hooks);
 
-  hooks.before(function () {
-    sinon.stub(timestamp, 'now').callsFake(() => new Date('2018-04-03T14:15:30'));
-  });
   hooks.beforeEach(function () {
+    sinon.replace(timestamp, 'now', sinon.fake.returns(new Date('2018-04-03T14:15:30')));
     this.now = timestamp.now();
   });
   hooks.afterEach(function () {

--- a/ui/tests/acceptance/enterprise-license-banner-test.js
+++ b/ui/tests/acceptance/enterprise-license-banner-test.js
@@ -49,16 +49,13 @@ module('Acceptance | Enterprise | License banner warnings', function (hooks) {
   setupApplicationTest(hooks);
 
   hooks.before(function () {
-    sinon.stub(timestamp, 'now').callsFake(() => new Date('2018-04-03T14:15:30'));
+    sinon.replace(timestamp, 'now', sinon.fake.returns(new Date('2018-04-03T14:15:30')));
   });
   hooks.beforeEach(function () {
     this.now = timestamp.now();
   });
   hooks.afterEach(function () {
     this.server.shutdown();
-  });
-  hooks.after(function () {
-    timestamp.now.restore();
   });
 
   test('it shows no license banner if license expires in > 30 days', async function (assert) {

--- a/ui/tests/acceptance/enterprise-license-banner-test.js
+++ b/ui/tests/acceptance/enterprise-license-banner-test.js
@@ -49,7 +49,7 @@ module('Acceptance | Enterprise | License banner warnings', function (hooks) {
   setupApplicationTest(hooks);
 
   hooks.before(function () {
-    sinon.replace(timestamp, 'now', sinon.fake.returns(new Date('2018-04-03T14:15:30')));
+    sinon.stub(timestamp, 'now').callsFake(() => new Date('2018-04-03T14:15:30'));
   });
   hooks.beforeEach(function () {
     this.now = timestamp.now();

--- a/ui/tests/integration/components/calendar-widget-test.js
+++ b/ui/tests/integration/components/calendar-widget-test.js
@@ -17,7 +17,7 @@ module('Integration | Component | calendar-widget', function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.before(function () {
-    sinon.replace(timestamp, 'now', sinon.fake.returns(new Date('2018-04-03T14:15:30')));
+    sinon.stub(timestamp, 'now').callsFake(() => new Date('2018-04-03T14:15:30'));
   });
   hooks.beforeEach(function () {
     const CURRENT_DATE = timestamp.now();

--- a/ui/tests/integration/components/calendar-widget-test.js
+++ b/ui/tests/integration/components/calendar-widget-test.js
@@ -16,10 +16,8 @@ import timestamp from 'core/utils/timestamp';
 module('Integration | Component | calendar-widget', function (hooks) {
   setupRenderingTest(hooks);
 
-  hooks.before(function () {
-    sinon.stub(timestamp, 'now').callsFake(() => new Date('2018-04-03T14:15:30'));
-  });
   hooks.beforeEach(function () {
+    sinon.stub(timestamp, 'now').callsFake(() => new Date('2018-04-03T14:15:30'));
     const CURRENT_DATE = new Date('2018-04-03T14:15:30');
     this.set('currentDate', CURRENT_DATE);
     this.set('calendarStartDate', subMonths(CURRENT_DATE, 12));

--- a/ui/tests/integration/components/calendar-widget-test.js
+++ b/ui/tests/integration/components/calendar-widget-test.js
@@ -18,7 +18,7 @@ module('Integration | Component | calendar-widget', function (hooks) {
 
   hooks.beforeEach(function () {
     sinon.replace(timestamp, 'now', sinon.fake.returns(new Date('2018-04-03T14:15:30')));
-    const CURRENT_DATE = new Date('2018-04-03T14:15:30');
+    const CURRENT_DATE = timestamp.now();
     this.set('currentDate', CURRENT_DATE);
     this.set('calendarStartDate', subMonths(CURRENT_DATE, 12));
     this.set('calendarEndDate', CURRENT_DATE);

--- a/ui/tests/integration/components/calendar-widget-test.js
+++ b/ui/tests/integration/components/calendar-widget-test.js
@@ -20,7 +20,7 @@ module('Integration | Component | calendar-widget', function (hooks) {
     sinon.stub(timestamp, 'now').callsFake(() => new Date('2018-04-03T14:15:30'));
   });
   hooks.beforeEach(function () {
-    const CURRENT_DATE = timestamp.now();
+    const CURRENT_DATE = new Date('2018-04-03T14:15:30');
     this.set('currentDate', CURRENT_DATE);
     this.set('calendarStartDate', subMonths(CURRENT_DATE, 12));
     this.set('calendarEndDate', CURRENT_DATE);

--- a/ui/tests/integration/components/calendar-widget-test.js
+++ b/ui/tests/integration/components/calendar-widget-test.js
@@ -17,7 +17,7 @@ module('Integration | Component | calendar-widget', function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function () {
-    sinon.stub(timestamp, 'now').callsFake(() => new Date('2018-04-03T14:15:30'));
+    sinon.replace(timestamp, 'now', sinon.fake.returns(new Date('2018-04-03T14:15:30')));
     const CURRENT_DATE = new Date('2018-04-03T14:15:30');
     this.set('currentDate', CURRENT_DATE);
     this.set('calendarStartDate', subMonths(CURRENT_DATE, 12));

--- a/ui/tests/integration/components/calendar-widget-test.js
+++ b/ui/tests/integration/components/calendar-widget-test.js
@@ -17,7 +17,7 @@ module('Integration | Component | calendar-widget', function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.before(function () {
-    sinon.stub(timestamp, 'now').callsFake(() => new Date('2018-04-03T14:15:30'));
+    sinon.replace(timestamp, 'now', sinon.fake.returns(new Date('2018-04-03T14:15:30')));
   });
   hooks.beforeEach(function () {
     const CURRENT_DATE = timestamp.now();
@@ -27,9 +27,6 @@ module('Integration | Component | calendar-widget', function (hooks) {
     this.set('startTimestamp', subMonths(CURRENT_DATE, 12).toISOString());
     this.set('endTimestamp', CURRENT_DATE.toISOString());
     this.set('handleClientActivityQuery', sinon.spy());
-  });
-  hooks.after(function () {
-    timestamp.now.restore();
   });
 
   test('it renders and disables correct months when start date is 12 months ago', async function (assert) {

--- a/ui/tests/integration/components/clients/attribution-test.js
+++ b/ui/tests/integration/components/clients/attribution-test.js
@@ -19,7 +19,7 @@ module('Integration | Component | clients/attribution', function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.before(function () {
-    sinon.replace(timestamp, 'now', sinon.fake.returns(new Date('2018-04-03T14:15:30')));
+    sinon.stub(timestamp, 'now').callsFake(() => Date('2018-04-03T14:15:30'));
   });
 
   hooks.beforeEach(function () {

--- a/ui/tests/integration/components/clients/attribution-test.js
+++ b/ui/tests/integration/components/clients/attribution-test.js
@@ -19,7 +19,7 @@ module('Integration | Component | clients/attribution', function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.before(function () {
-    sinon.stub(timestamp, 'now').callsFake(() => Date('2018-04-03T14:15:30'));
+    sinon.stub(timestamp, 'now').callsFake(() => new Date('2018-04-03T14:15:30'));
   });
 
   hooks.beforeEach(function () {

--- a/ui/tests/integration/components/clients/attribution-test.js
+++ b/ui/tests/integration/components/clients/attribution-test.js
@@ -19,7 +19,7 @@ module('Integration | Component | clients/attribution', function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.before(function () {
-    sinon.stub(timestamp, 'now').callsFake(() => new Date('2018-04-03T14:15:30'));
+    sinon.replace(timestamp, 'now', sinon.fake.returns(new Date('2018-04-03T14:15:30')));
   });
 
   hooks.beforeEach(function () {
@@ -36,7 +36,6 @@ module('Integration | Component | clients/attribution', function (hooks) {
   });
 
   hooks.after(function () {
-    timestamp.now.restore();
     this.csvDownloadStub.restore();
   });
 

--- a/ui/tests/integration/components/clients/attribution-test.js
+++ b/ui/tests/integration/components/clients/attribution-test.js
@@ -19,13 +19,13 @@ module('Integration | Component | clients/attribution', function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.before(function () {
-    sinon.stub(timestamp, 'now').callsFake(() => new Date('2018-04-03T14:15:30'));
+    this.timestampStub = sinon.replace(timestamp, 'now', sinon.fake.returns(new Date('2018-04-03T14:15:30')));
   });
 
   hooks.beforeEach(function () {
     const { total, by_namespace } = SERIALIZED_ACTIVITY_RESPONSE;
     this.csvDownloadStub = sinon.stub(this.owner.lookup('service:download'), 'csv');
-    const mockNow = timestamp.now();
+    const mockNow = this.timestampStub();
     this.mockNow = mockNow;
     this.startTimestamp = formatRFC3339(subMonths(mockNow, 6));
     this.timestamp = formatRFC3339(mockNow);

--- a/ui/tests/integration/components/clients/line-chart-test.js
+++ b/ui/tests/integration/components/clients/line-chart-test.js
@@ -14,7 +14,7 @@ import timestamp from 'core/utils/timestamp';
 module('Integration | Component | clients/line-chart', function (hooks) {
   setupRenderingTest(hooks);
   hooks.before(function () {
-    sinon.stub(timestamp, 'now').callsFake(() => new Date('2018-04-03T14:15:30'));
+    this.timestampStub = sinon.replace(timestamp, 'now', sinon.fake.returns(new Date('2018-04-03T14:15:30')));
   });
   hooks.beforeEach(function () {
     this.set('xKey', 'foo');
@@ -67,7 +67,7 @@ module('Integration | Component | clients/line-chart', function (hooks) {
   });
 
   test('it renders upgrade data', async function (assert) {
-    const now = timestamp.now();
+    const now = this.timestampStub();
     this.set('dataset', [
       {
         foo: formatRFC3339(subMonths(now, 4)),
@@ -121,7 +121,7 @@ module('Integration | Component | clients/line-chart', function (hooks) {
 
   test('it renders tooltip', async function (assert) {
     assert.expect(1);
-    const now = timestamp.now();
+    const now = this.timestampStub();
     const tooltipData = [
       {
         month: format(subMonths(now, 4), 'M/yy'),

--- a/ui/tests/integration/components/clients/line-chart-test.js
+++ b/ui/tests/integration/components/clients/line-chart-test.js
@@ -14,7 +14,7 @@ import timestamp from 'core/utils/timestamp';
 module('Integration | Component | clients/line-chart', function (hooks) {
   setupRenderingTest(hooks);
   hooks.before(function () {
-    sinon.replace(timestamp, 'now', sinon.fake.returns(new Date('2018-04-03T14:15:30')));
+    sinon.stub(timestamp, 'now').callsFake(() => new Date('2018-04-03T14:15:30'));
   });
   hooks.beforeEach(function () {
     this.set('xKey', 'foo');

--- a/ui/tests/integration/components/clients/line-chart-test.js
+++ b/ui/tests/integration/components/clients/line-chart-test.js
@@ -14,7 +14,7 @@ import timestamp from 'core/utils/timestamp';
 module('Integration | Component | clients/line-chart', function (hooks) {
   setupRenderingTest(hooks);
   hooks.before(function () {
-    sinon.stub(timestamp, 'now').callsFake(() => new Date('2018-04-03T14:15:30'));
+    sinon.replace(timestamp, 'now', sinon.fake.returns(new Date('2018-04-03T14:15:30')));
   });
   hooks.beforeEach(function () {
     this.set('xKey', 'foo');
@@ -41,9 +41,6 @@ module('Integration | Component | clients/line-chart', function (hooks) {
         expectedLabel: '7/18',
       },
     ]);
-  });
-  hooks.after(function () {
-    timestamp.now.restore();
   });
 
   test('it renders', async function (assert) {

--- a/ui/tests/integration/components/clients/page/counts-test.js
+++ b/ui/tests/integration/components/clients/page/counts-test.js
@@ -26,7 +26,7 @@ module('Integration | Component | clients | Page::Counts', function (hooks) {
   setupMirage(hooks);
 
   hooks.before(function () {
-    sinon.stub(timestamp, 'now').callsFake(() => STATIC_NOW);
+    sinon.replace(timestamp, 'now', sinon.fake.returns(STATIC_NOW));
   });
 
   hooks.beforeEach(async function () {
@@ -58,9 +58,6 @@ module('Integration | Component | clients | Page::Counts', function (hooks) {
         <div data-test-yield>Yield block</div>
       </Clients::Page::Counts>
     `);
-  });
-  hooks.after(function () {
-    timestamp.now.restore();
   });
 
   test('it should render start date label and description based on version', async function (assert) {

--- a/ui/tests/integration/components/clients/page/counts-test.js
+++ b/ui/tests/integration/components/clients/page/counts-test.js
@@ -25,11 +25,8 @@ module('Integration | Component | clients | Page::Counts', function (hooks) {
   setupRenderingTest(hooks);
   setupMirage(hooks);
 
-  hooks.before(function () {
-    sinon.stub(timestamp, 'now').callsFake(() => STATIC_NOW);
-  });
-
   hooks.beforeEach(async function () {
+    sinon.stub(timestamp, 'now').callsFake(() => STATIC_NOW);
     clientsHandler(this.server);
     this.server.post('/sys/capabilities-self', allowAllCapabilitiesStub());
     this.store = this.owner.lookup('service:store');

--- a/ui/tests/integration/components/clients/page/counts-test.js
+++ b/ui/tests/integration/components/clients/page/counts-test.js
@@ -26,7 +26,7 @@ module('Integration | Component | clients | Page::Counts', function (hooks) {
   setupMirage(hooks);
 
   hooks.before(function () {
-    sinon.replace(timestamp, 'now', sinon.fake.returns(STATIC_NOW));
+    sinon.stub(timestamp, 'now').callsFake(() => STATIC_NOW);
   });
 
   hooks.beforeEach(async function () {

--- a/ui/tests/integration/components/clients/page/counts-test.js
+++ b/ui/tests/integration/components/clients/page/counts-test.js
@@ -26,7 +26,7 @@ module('Integration | Component | clients | Page::Counts', function (hooks) {
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {
-    sinon.stub(timestamp, 'now').callsFake(() => STATIC_NOW);
+    sinon.replace(timestamp, 'now', sinon.fake.returns(STATIC_NOW));
     clientsHandler(this.server);
     this.server.post('/sys/capabilities-self', allowAllCapabilitiesStub());
     this.store = this.owner.lookup('service:store');

--- a/ui/tests/integration/components/clients/running-total-test.js
+++ b/ui/tests/integration/components/clients/running-total-test.js
@@ -24,7 +24,7 @@ module('Integration | Component | clients/running-total', function (hooks) {
   setupMirage(hooks);
 
   hooks.before(function () {
-    sinon.stub(timestamp, 'now').callsFake(() => STATIC_NOW);
+    sinon.replace(timestamp, 'now', sinon.fake.returns(STATIC_NOW));
   });
 
   hooks.beforeEach(async function () {
@@ -64,10 +64,6 @@ module('Integration | Component | clients/running-total', function (hooks) {
         'scrollable-region-focusable': { enabled: false },
       },
     });
-  });
-
-  hooks.after(function () {
-    timestamp.now.restore();
   });
 
   test('it renders with full monthly activity data', async function (assert) {

--- a/ui/tests/integration/components/clients/running-total-test.js
+++ b/ui/tests/integration/components/clients/running-total-test.js
@@ -23,11 +23,8 @@ module('Integration | Component | clients/running-total', function (hooks) {
   setupRenderingTest(hooks);
   setupMirage(hooks);
 
-  hooks.before(function () {
-    sinon.stub(timestamp, 'now').callsFake(() => STATIC_NOW);
-  });
-
   hooks.beforeEach(async function () {
+    sinon.replace(timestamp, 'now', sinon.fake.returns(STATIC_NOW));
     clientsHandler(this.server);
     const store = this.owner.lookup('service:store');
     const activityQuery = {

--- a/ui/tests/integration/components/clients/running-total-test.js
+++ b/ui/tests/integration/components/clients/running-total-test.js
@@ -24,7 +24,7 @@ module('Integration | Component | clients/running-total', function (hooks) {
   setupMirage(hooks);
 
   hooks.before(function () {
-    sinon.replace(timestamp, 'now', sinon.fake.returns(STATIC_NOW));
+    sinon.stub(timestamp, 'now').callsFake(() => STATIC_NOW);
   });
 
   hooks.beforeEach(async function () {

--- a/ui/tests/integration/components/dashboard/client-count-card-test.js
+++ b/ui/tests/integration/components/dashboard/client-count-card-test.js
@@ -19,11 +19,8 @@ module('Integration | Component | dashboard/client-count-card', function (hooks)
   setupRenderingTest(hooks);
   setupMirage(hooks);
 
-  hooks.before(function () {
-    sinon.stub(timestamp, 'now').callsFake(() => STATIC_NOW);
-  });
-
   test('it should display client count information', async function (assert) {
+    sinon.replace(timestamp, 'now', sinon.fake.returns(STATIC_NOW));
     assert.expect(6);
     const { months, total } = ACTIVITY_RESPONSE_STUB;
     const [latestMonth] = months.slice(-1);

--- a/ui/tests/integration/components/dashboard/client-count-card-test.js
+++ b/ui/tests/integration/components/dashboard/client-count-card-test.js
@@ -20,11 +20,7 @@ module('Integration | Component | dashboard/client-count-card', function (hooks)
   setupMirage(hooks);
 
   hooks.before(function () {
-    sinon.stub(timestamp, 'now').callsFake(() => STATIC_NOW);
-  });
-
-  hooks.after(function () {
-    timestamp.now.restore();
+    sinon.replace(timestamp, 'now', sinon.fake.returns(STATIC_NOW));
   });
 
   test('it should display client count information', async function (assert) {

--- a/ui/tests/integration/components/dashboard/client-count-card-test.js
+++ b/ui/tests/integration/components/dashboard/client-count-card-test.js
@@ -20,7 +20,7 @@ module('Integration | Component | dashboard/client-count-card', function (hooks)
   setupMirage(hooks);
 
   hooks.before(function () {
-    sinon.replace(timestamp, 'now', sinon.fake.returns(STATIC_NOW));
+    sinon.stub(timestamp, 'now').callsFake(() => STATIC_NOW);
   });
 
   test('it should display client count information', async function (assert) {

--- a/ui/tests/integration/components/date-dropdown-test.js
+++ b/ui/tests/integration/components/date-dropdown-test.js
@@ -24,7 +24,7 @@ module('Integration | Component | date-dropdown', function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function () {
-    sinon.stub(timestamp, 'now').callsFake(() => new Date('2018-04-03T14:15:30'));
+    sinon.replace(timestamp, 'now', sinon.fake.returns(new Date('2018-04-03T14:15:30')));
   });
 
   test('it renders dropdown', async function (assert) {

--- a/ui/tests/integration/components/date-dropdown-test.js
+++ b/ui/tests/integration/components/date-dropdown-test.js
@@ -23,7 +23,7 @@ const SELECTORS = {
 module('Integration | Component | date-dropdown', function (hooks) {
   setupRenderingTest(hooks);
 
-  hooks.before(function () {
+  hooks.beforeEach(function () {
     sinon.stub(timestamp, 'now').callsFake(() => new Date('2018-04-03T14:15:30'));
   });
 

--- a/ui/tests/integration/components/date-dropdown-test.js
+++ b/ui/tests/integration/components/date-dropdown-test.js
@@ -24,10 +24,7 @@ module('Integration | Component | date-dropdown', function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.before(function () {
-    sinon.stub(timestamp, 'now').callsFake(() => new Date('2018-04-03T14:15:30'));
-  });
-  hooks.after(function () {
-    timestamp.now.restore();
+    sinon.replace(timestamp, 'now', sinon.fake.returns(new Date('2018-04-03T14:15:30')));
   });
 
   test('it renders dropdown', async function (assert) {

--- a/ui/tests/integration/components/date-dropdown-test.js
+++ b/ui/tests/integration/components/date-dropdown-test.js
@@ -24,7 +24,7 @@ module('Integration | Component | date-dropdown', function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.before(function () {
-    sinon.replace(timestamp, 'now', sinon.fake.returns(new Date('2018-04-03T14:15:30')));
+    sinon.stub(timestamp, 'now').callsFake(() => new Date('2018-04-03T14:15:30'));
   });
 
   test('it renders dropdown', async function (assert) {

--- a/ui/tests/integration/components/keymgmt/key-edit-test.js
+++ b/ui/tests/integration/components/keymgmt/key-edit-test.js
@@ -15,10 +15,10 @@ module('Integration | Component | keymgmt/key-edit', function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.before(function () {
-    sinon.stub(timestamp, 'now').callsFake(() => new Date('2018-04-03T14:15:30'));
+    this.timestampStub = sinon.replace(timestamp, 'now', sinon.fake.returns(new Date('2018-04-03T14:15:30')));
   });
   hooks.beforeEach(function () {
-    const now = timestamp.now();
+    const now = this.timestampStub();
     const model = EmberObject.create({
       name: 'Unicorns',
       id: 'Unicorns',

--- a/ui/tests/integration/components/keymgmt/key-edit-test.js
+++ b/ui/tests/integration/components/keymgmt/key-edit-test.js
@@ -38,9 +38,6 @@ module('Integration | Component | keymgmt/key-edit', function (hooks) {
     this.model = model;
     this.tab = '';
   });
-  hooks.after(function () {
-    timestamp.now.restore();
-  });
 
   // TODO: Add capabilities tests
   test('it renders show view as default', async function (assert) {

--- a/ui/tests/integration/components/kubernetes/page/credentials-test.js
+++ b/ui/tests/integration/components/kubernetes/page/credentials-test.js
@@ -19,7 +19,7 @@ module('Integration | Component | kubernetes | Page::Credentials', function (hoo
   setupMirage(hooks);
 
   hooks.before(function () {
-    sinon.stub(timestamp, 'now').callsFake(() => new Date('2018-04-03T14:15:30'));
+    sinon.replace(timestamp, 'now', sinon.fake.returns(new Date('2018-04-03T14:15:30')));
   });
   hooks.beforeEach(function () {
     this.backend = 'kubernetes-test';
@@ -52,9 +52,6 @@ module('Integration | Component | kubernetes | Page::Credentials', function (hoo
         }
       );
     };
-  });
-  hooks.after(function () {
-    timestamp.now.restore();
   });
 
   test('it should display generate credentials form', async function (assert) {

--- a/ui/tests/integration/components/kubernetes/page/credentials-test.js
+++ b/ui/tests/integration/components/kubernetes/page/credentials-test.js
@@ -18,10 +18,8 @@ module('Integration | Component | kubernetes | Page::Credentials', function (hoo
   setupEngine(hooks, 'kubernetes');
   setupMirage(hooks);
 
-  hooks.before(function () {
-    sinon.stub(timestamp, 'now').callsFake(() => new Date('2018-04-03T14:15:30'));
-  });
   hooks.beforeEach(function () {
+    sinon.stub(timestamp, 'now').callsFake(() => new Date('2018-04-03T14:15:30'));
     this.backend = 'kubernetes-test';
     this.roleName = 'role-0';
 

--- a/ui/tests/integration/components/kubernetes/page/credentials-test.js
+++ b/ui/tests/integration/components/kubernetes/page/credentials-test.js
@@ -19,7 +19,7 @@ module('Integration | Component | kubernetes | Page::Credentials', function (hoo
   setupMirage(hooks);
 
   hooks.before(function () {
-    sinon.replace(timestamp, 'now', sinon.fake.returns(new Date('2018-04-03T14:15:30')));
+    sinon.stub(timestamp, 'now').callsFake(() => new Date('2018-04-03T14:15:30'));
   });
   hooks.beforeEach(function () {
     this.backend = 'kubernetes-test';

--- a/ui/tests/integration/components/kubernetes/page/credentials-test.js
+++ b/ui/tests/integration/components/kubernetes/page/credentials-test.js
@@ -19,7 +19,7 @@ module('Integration | Component | kubernetes | Page::Credentials', function (hoo
   setupMirage(hooks);
 
   hooks.beforeEach(function () {
-    sinon.stub(timestamp, 'now').callsFake(() => new Date('2018-04-03T14:15:30'));
+    sinon.replace(timestamp, 'now', sinon.fake.returns(new Date('2018-04-03T14:15:30')));
     this.backend = 'kubernetes-test';
     this.roleName = 'role-0';
 

--- a/ui/tests/integration/components/license-banners-test.js
+++ b/ui/tests/integration/components/license-banners-test.js
@@ -19,7 +19,6 @@ module('Integration | Component | license-banners', function (hooks) {
   hooks.beforeEach(function () {
     sinon.replace(timestamp, 'now', sinon.fake.returns(new Date('2018-04-03T14:15:30')));
     const mockNow = timestamp.now();
-    this.now = mockNow;
     this.yesterday = subDays(mockNow, 1);
     this.nextMonth = addDays(mockNow, 30);
     this.outside30 = addDays(mockNow, 32);

--- a/ui/tests/integration/components/license-banners-test.js
+++ b/ui/tests/integration/components/license-banners-test.js
@@ -16,10 +16,8 @@ import timestamp from 'core/utils/timestamp';
 module('Integration | Component | license-banners', function (hooks) {
   setupRenderingTest(hooks);
 
-  hooks.before(function () {
-    sinon.stub(timestamp, 'now').callsFake(() => new Date('2018-04-03T14:15:30'));
-  });
   hooks.beforeEach(function () {
+    sinon.replace(timestamp, 'now', sinon.fake.returns(new Date('2018-04-03T14:15:30')));
     const mockNow = timestamp.now();
     this.now = mockNow;
     this.yesterday = subDays(mockNow, 1);

--- a/ui/tests/integration/components/license-banners-test.js
+++ b/ui/tests/integration/components/license-banners-test.js
@@ -17,7 +17,7 @@ module('Integration | Component | license-banners', function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.before(function () {
-    sinon.replace(timestamp, 'now', sinon.fake.returns(new Date('2018-04-03T14:15:30')));
+    sinon.stub(timestamp, 'now').callsFake(() => new Date('2018-04-03T14:15:30'));
   });
   hooks.beforeEach(function () {
     const mockNow = timestamp.now();

--- a/ui/tests/integration/components/license-banners-test.js
+++ b/ui/tests/integration/components/license-banners-test.js
@@ -17,7 +17,7 @@ module('Integration | Component | license-banners', function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.before(function () {
-    sinon.stub(timestamp, 'now').callsFake(() => new Date('2018-04-03T14:15:30'));
+    sinon.replace(timestamp, 'now', sinon.fake.returns(new Date('2018-04-03T14:15:30')));
   });
   hooks.beforeEach(function () {
     const mockNow = timestamp.now();
@@ -29,9 +29,6 @@ module('Integration | Component | license-banners', function (hooks) {
     this.version = this.owner.lookup('service:version');
     this.version.version = '1.13.1+ent';
     this.version.type = 'enterprise';
-  });
-  hooks.after(function () {
-    timestamp.now.restore();
   });
 
   test('it does not render if no expiry', async function (assert) {

--- a/ui/tests/test-helper.js
+++ b/ui/tests/test-helper.js
@@ -13,6 +13,7 @@ import './helpers/flash-message';
 import preloadAssets from 'ember-asset-loader/test-support/preload-assets';
 import { setupGlobalA11yHooks, setRunOptions } from 'ember-a11y-testing/test-support';
 import manifest from 'vault/config/asset-manifest';
+import setupSinon from 'ember-sinon-qunit';
 
 preloadAssets(manifest).then(() => {
   setup(QUnit.assert);
@@ -26,7 +27,7 @@ preloadAssets(manifest).then(() => {
       values: ['wcag2a'],
     },
   });
-
+  setupSinon();
   start({
     setupTestIsolationValidation: true,
   });

--- a/ui/tests/unit/adapters/clients-activity-test.js
+++ b/ui/tests/unit/adapters/clients-activity-test.js
@@ -16,13 +16,13 @@ module('Unit | Adapter | clients activity', function (hooks) {
   setupMirage(hooks);
 
   hooks.before(function () {
-    sinon.replace(timestamp, 'now', sinon.fake.returns(new Date('2023-01-13T09:30:15')));
+    this.timestampStub = sinon.replace(timestamp, 'now', sinon.fake.returns(new Date('2023-01-13T09:30:15')));
   });
   hooks.beforeEach(function () {
     this.store = this.owner.lookup('service:store');
     this.modelName = 'clients/activity';
-    this.startDate = subMonths(timestamp.now(), 6);
-    this.endDate = timestamp.now();
+    this.startDate = subMonths(this.timestampStub(), 6);
+    this.endDate = this.timestampStub();
     this.readableUnix = (unix) => parseAPITimestamp(fromUnixTime(unix).toISOString(), 'MMMM dd yyyy');
   });
 

--- a/ui/tests/unit/adapters/clients-activity-test.js
+++ b/ui/tests/unit/adapters/clients-activity-test.js
@@ -16,7 +16,7 @@ module('Unit | Adapter | clients activity', function (hooks) {
   setupMirage(hooks);
 
   hooks.before(function () {
-    sinon.stub(timestamp, 'now').callsFake(() => new Date('2023-01-13T09:30:15'));
+    this.timestampStub = sinon.replace(timestamp, 'now', sinon.fake.returns(new Date('2023-01-13T09:30:15')));
   });
   hooks.beforeEach(function () {
     this.store = this.owner.lookup('service:store');

--- a/ui/tests/unit/adapters/clients-activity-test.js
+++ b/ui/tests/unit/adapters/clients-activity-test.js
@@ -16,7 +16,7 @@ module('Unit | Adapter | clients activity', function (hooks) {
   setupMirage(hooks);
 
   hooks.before(function () {
-    sinon.stub(timestamp, 'now').callsFake(() => new Date('2023-01-13T09:30:15'));
+    sinon.replace(timestamp, 'now', sinon.fake.returns(new Date('2023-01-13T09:30:15')));
   });
   hooks.beforeEach(function () {
     this.store = this.owner.lookup('service:store');
@@ -24,9 +24,6 @@ module('Unit | Adapter | clients activity', function (hooks) {
     this.startDate = subMonths(timestamp.now(), 6);
     this.endDate = timestamp.now();
     this.readableUnix = (unix) => parseAPITimestamp(fromUnixTime(unix).toISOString(), 'MMMM dd yyyy');
-  });
-  hooks.after(function () {
-    timestamp.now.restore();
   });
 
   test('it does not format if both params are timestamp strings', async function (assert) {

--- a/ui/tests/unit/adapters/clients-activity-test.js
+++ b/ui/tests/unit/adapters/clients-activity-test.js
@@ -16,7 +16,7 @@ module('Unit | Adapter | clients activity', function (hooks) {
   setupMirage(hooks);
 
   hooks.before(function () {
-    this.timestampStub = sinon.replace(timestamp, 'now', sinon.fake.returns(new Date('2023-01-13T09:30:15')));
+    sinon.stub(timestamp, 'now').callsFake(() => new Date('2023-01-13T09:30:15'));
   });
   hooks.beforeEach(function () {
     this.store = this.owner.lookup('service:store');

--- a/ui/tests/unit/utils/timestamp-test.js
+++ b/ui/tests/unit/utils/timestamp-test.js
@@ -12,10 +12,8 @@ import { module, test } from 'qunit';
 */
 module('Unit | Utility | timestamp', function () {
   test('it can be overridden', function (assert) {
-    const stub = sinon.stub(timestamp, 'now').callsFake(() => new Date('2030-03-03T03:30:03'));
+    sinon.replace(timestamp, 'now', sinon.fake.returns(new Date('2030-03-03T03:30:03')));
     const result = timestamp.now();
     assert.strictEqual(result.toISOString(), new Date('2030-03-03T03:30:03').toISOString());
-    // Always make sure to restore the stub
-    stub.restore(); // timestamp.now.restore(); also works
   });
 });

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -2592,15 +2592,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sinonjs/commons@npm:^1, @sinonjs/commons@npm:^1.3.0, @sinonjs/commons@npm:^1.4.0, @sinonjs/commons@npm:^1.7.0":
-  version: 1.8.6
-  resolution: "@sinonjs/commons@npm:1.8.6"
-  dependencies:
-    type-detect: 4.0.8
-  checksum: 7d3f8c1e85f30cd4e83594fc19b7a657f14d49eb8d95a30095631ce15e906c869e0eff96c5b93dffea7490c00418b07f54582ba49c6560feb2a8c34c0b16832d
-  languageName: node
-  linkType: hard
-
 "@sinonjs/commons@npm:^2.0.0":
   version: 2.0.0
   resolution: "@sinonjs/commons@npm:2.0.0"
@@ -2628,27 +2619,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sinonjs/formatio@npm:^3.2.1":
-  version: 3.2.2
-  resolution: "@sinonjs/formatio@npm:3.2.2"
-  dependencies:
-    "@sinonjs/commons": ^1
-    "@sinonjs/samsam": ^3.1.0
-  checksum: ddc30698df9b0aa59204da93ca94fd04bc5672ac03c798c0a487c35d514d7d8e0ce0e4c72386fc80e29f59cb1cc54eeea3b7f804281b3c4e3dd2394de56c6e4a
-  languageName: node
-  linkType: hard
-
-"@sinonjs/samsam@npm:^3.1.0, @sinonjs/samsam@npm:^3.3.3":
-  version: 3.3.3
-  resolution: "@sinonjs/samsam@npm:3.3.3"
-  dependencies:
-    "@sinonjs/commons": ^1.3.0
-    array-from: ^2.1.1
-    lodash: ^4.17.15
-  checksum: 340f2f62dec3fa1e5e9300a75996bd12ab9d2da4f6b453fa5d1ee101cc5e58eb218af2e2584b496d41ba31c3c0854d47a691fd9a0d8b9092f3cb6a5c7a080856
-  languageName: node
-  linkType: hard
-
 "@sinonjs/samsam@npm:^8.0.0":
   version: 8.0.0
   resolution: "@sinonjs/samsam@npm:8.0.0"
@@ -2660,7 +2630,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sinonjs/text-encoding@npm:^0.7.1, @sinonjs/text-encoding@npm:^0.7.2":
+"@sinonjs/text-encoding@npm:^0.7.2":
   version: 0.7.2
   resolution: "@sinonjs/text-encoding@npm:0.7.2"
   checksum: fe690002a32ba06906cf87e2e8fe84d1590294586f2a7fd180a65355b53660c155c3273d8011a5f2b77209b819aa7306678ae6e4aea0df014bd7ffd4bbbcf1ab
@@ -3332,6 +3302,22 @@ __metadata:
   version: 1.7.5
   resolution: "@types/shell-quote@npm:1.7.5"
   checksum: 32b4d697c7d23dbadf40713692c47f1595f083a3b3deea76cb18e30a05d197aa9205d2b87f6d92edb60cda120b51e35d32bda96ed9b0a7e32921eed2deb4559e
+  languageName: node
+  linkType: hard
+
+"@types/sinon@npm:^10.0.19":
+  version: 10.0.20
+  resolution: "@types/sinon@npm:10.0.20"
+  dependencies:
+    "@types/sinonjs__fake-timers": "*"
+  checksum: 7322771345c202b90057f8112e0d34b7339e5ae1827fb1bfe385fc9e38ed6a2f18b4c66e88d27d98c775f7f74fb1167c0c14f61ca64155786534541e6c6eb05f
+  languageName: node
+  linkType: hard
+
+"@types/sinonjs__fake-timers@npm:*":
+  version: 8.1.5
+  resolution: "@types/sinonjs__fake-timers@npm:8.1.5"
+  checksum: 7e3c08f6c13df44f3ea7d9a5155ddf77e3f7314c156fa1c5a829a4f3763bafe2f75b1283b887f06e6b4296996a2f299b70f64ff82625f9af5885436e2524d10c
   languageName: node
   linkType: hard
 
@@ -4113,13 +4099,6 @@ __metadata:
   version: 1.1.1
   resolution: "array-flatten@npm:1.1.1"
   checksum: a9925bf3512d9dce202112965de90c222cd59a4fbfce68a0951d25d965cf44642931f40aac72309c41f12df19afa010ecadceb07cfff9ccc1621e99d89ab5f3b
-  languageName: node
-  linkType: hard
-
-"array-from@npm:^2.1.1":
-  version: 2.1.1
-  resolution: "array-from@npm:2.1.1"
-  checksum: 4cd5fa27aa6133b99a57c2881d2a8a66ec59b8e17a0c900f7e8ac9a0a2fae450ed682b67435467bfa71ac9328d025a760c5c46a95586a352180c5a79fc13015d
   languageName: node
   linkType: hard
 
@@ -5804,7 +5783,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"broccoli-merge-trees@npm:^3.0.0, broccoli-merge-trees@npm:^3.0.1, broccoli-merge-trees@npm:^3.0.2":
+"broccoli-merge-trees@npm:^3.0.1, broccoli-merge-trees@npm:^3.0.2":
   version: 3.0.2
   resolution: "broccoli-merge-trees@npm:3.0.2"
   dependencies:
@@ -7862,13 +7841,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"diff@npm:^3.5.0":
-  version: 3.5.0
-  resolution: "diff@npm:3.5.0"
-  checksum: 00842950a6551e26ce495bdbce11047e31667deea546527902661f25cc2e73358967ebc78cf86b1a9736ec3e14286433225f9970678155753a6291c3bca5227b
-  languageName: node
-  linkType: hard
-
 "diff@npm:^5.1.0":
   version: 5.2.0
   resolution: "diff@npm:5.2.0"
@@ -9434,15 +9406,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ember-sinon@npm:^4.0.0":
-  version: 4.1.1
-  resolution: "ember-sinon@npm:4.1.1"
+"ember-sinon-qunit@npm:^7.4.0":
+  version: 7.4.0
+  resolution: "ember-sinon-qunit@npm:7.4.0"
   dependencies:
-    broccoli-funnel: ^2.0.0
-    broccoli-merge-trees: ^3.0.0
-    ember-cli-babel: ^7.7.3
-    sinon: ^7.4.2
-  checksum: 8781e420e1495728264599a770d786290a46eceb841ea6a0b86cf196efd9155e78931ea3c88bfd546bd4b9c1627c0bd0edb6cdd957abbe6faa71247de8184443
+    "@embroider/addon-shim": ^1.8.6
+    "@types/sinon": ^10.0.19
+  peerDependencies:
+    ember-source: ">=3.28.0"
+    qunit: ^2.0.0
+    sinon: ^15.0.3 || ^16.0.0 || ^17.0.0
+  checksum: e83cd2113001f670d125e7ad186ca276fdcb74a0de44f296275c4e75ad4832d89103bc9ee23e3f5143d82bb01345313bb6a1f5b070f1b010cdd435d24e418105
   languageName: node
   linkType: hard
 
@@ -13302,13 +13276,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"just-extend@npm:^4.0.2":
-  version: 4.2.1
-  resolution: "just-extend@npm:4.2.1"
-  checksum: ff9fdede240fad313efeeeb68a660b942e5586d99c0058064c78884894a2690dc09bba44c994ad4e077e45d913fef01a9240c14a72c657b53687ac58de53b39c
-  languageName: node
-  linkType: hard
-
 "just-extend@npm:^6.2.0":
   version: 6.2.0
   resolution: "just-extend@npm:6.2.0"
@@ -13869,22 +13836,6 @@ __metadata:
   version: 1.9.1
   resolution: "loglevel@npm:1.9.1"
   checksum: e1c8586108c4d566122e91f8a79c8df728920e3a714875affa5120566761a24077ec8ec9e5fc388b022e39fc411ec6e090cde1b5775871241b045139771eeb06
-  languageName: node
-  linkType: hard
-
-"lolex@npm:^4.2.0":
-  version: 4.2.0
-  resolution: "lolex@npm:4.2.0"
-  checksum: 0a83bfe1748fc745515dff9b3f722422918f5f6975104d7e576fc32c06b5398ee0c58525684068d4de49cdd49874e00b5e2b2d72ce8c5d829dab86c8c08ca31f
-  languageName: node
-  linkType: hard
-
-"lolex@npm:^5.0.1":
-  version: 5.1.2
-  resolution: "lolex@npm:5.1.2"
-  dependencies:
-    "@sinonjs/commons": ^1.7.0
-  checksum: 7eb468d4ef4746c024d23cb2b75f679f79449a9d5cbe11abadf2f3b147c1d7ffe28816438bedfb8a75c58357a625c2f9ba197b050c226d2b3f0c4a956cf556fb
   languageName: node
   linkType: hard
 
@@ -14919,19 +14870,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nise@npm:^1.5.2":
-  version: 1.5.3
-  resolution: "nise@npm:1.5.3"
-  dependencies:
-    "@sinonjs/formatio": ^3.2.1
-    "@sinonjs/text-encoding": ^0.7.1
-    just-extend: ^4.0.2
-    lolex: ^5.0.1
-    path-to-regexp: ^1.7.0
-  checksum: ec3af21345dcaf34650a6f5420a11e0fd21a836ac5960f5e8523c301ee98465abf88b958f7b3084ecc6e0a7133e5cf7963f4df176b90b423c4da4984f1ebd75e
-  languageName: node
-  linkType: hard
-
 "nise@npm:^5.1.5":
   version: 5.1.9
   resolution: "nise@npm:5.1.9"
@@ -15750,15 +15688,6 @@ __metadata:
   version: 0.1.7
   resolution: "path-to-regexp@npm:0.1.7"
   checksum: 69a14ea24db543e8b0f4353305c5eac6907917031340e5a8b37df688e52accd09e3cebfe1660b70d76b6bd89152f52183f28c74813dbf454ba1a01c82a38abce
-  languageName: node
-  linkType: hard
-
-"path-to-regexp@npm:^1.7.0":
-  version: 1.8.0
-  resolution: "path-to-regexp@npm:1.8.0"
-  dependencies:
-    isarray: 0.0.1
-  checksum: 709f6f083c0552514ef4780cb2e7e4cf49b0cc89a97439f2b7cc69a608982b7690fb5d1720a7473a59806508fc2dae0be751ba49f495ecf89fd8fbc62abccbcd
   languageName: node
   linkType: hard
 
@@ -17422,21 +17351,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sinon@npm:^7.4.2":
-  version: 7.5.0
-  resolution: "sinon@npm:7.5.0"
-  dependencies:
-    "@sinonjs/commons": ^1.4.0
-    "@sinonjs/formatio": ^3.2.1
-    "@sinonjs/samsam": ^3.3.3
-    diff: ^3.5.0
-    lolex: ^4.2.0
-    nise: ^1.5.2
-    supports-color: ^5.5.0
-  checksum: e8cf6b3dd16e9c1ed1a2b9560c396a2d6205a4f32293b1762cb6ebb8f88cfa47db6aba45b0c1709ec396efb41d171d88c9b1ab8f32f35512eb9e5d0d0d15d307
-  languageName: node
-  linkType: hard
-
 "slash@npm:^1.0.0":
   version: 1.0.0
   resolution: "slash@npm:1.0.0"
@@ -18196,7 +18110,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"supports-color@npm:^5.3.0, supports-color@npm:^5.5.0":
+"supports-color@npm:^5.3.0":
   version: 5.5.0
   resolution: "supports-color@npm:5.5.0"
   dependencies:
@@ -19407,7 +19321,7 @@ __metadata:
     ember-responsive: 5.0.0
     ember-router-helpers: ^0.4.0
     ember-service-worker: "meirish/ember-service-worker#configurable-scope"
-    ember-sinon: ^4.0.0
+    ember-sinon-qunit: ^7.4.0
     ember-source: ~4.12.0
     ember-style-modifier: ^4.1.0
     ember-svg-jar: 2.4.4


### PR DESCRIPTION
We’ve recently has some flaky client count tests `Attempted to wrap now which is already wrapped` and [this](https://github.com/hashicorp/vault/actions/runs/8925563058#summary-24514533520) failure (snippet below) a lot lately on CI
```
Error: Browser timeout exceeded: 10s
Error while executing test: Acceptance | wrapped_token query param functionality: it should authenticate when hitting logout url with wrapped_token when logged out
Stderr: 
 Fontconfig error: No writable cache directories
[0502/143350.692707:INFO:config_dir_policy_loader.cc(118)] Skipping mandatory platform policies because no policy file was found at: /etc/opt/chrome/policies/managed
[0502/143350.712793:INFO:config_dir_policy_loader.cc(118)] Skipping recommended platform policies because no policy file was found at: /etc/opt/chrome/policies/recommended
[0502/143351.025464:WARNING:sandbox_linux.cc(420)] InitializeSandbox() called with multiple threads in process gpu-process.
[0502/143352.637846:WARNING:runtime_features.cc(730)] AttributionReportingCrossAppWeb cannot be enabled in this configuration. Use --enable-features=ConversionMeasurement,AttributionReportingCrossAppWeb in addition.

```
I think it's because `ember-sinon` is deprecated and we should be using [ember-sinon-qunit](https://github.com/elwayman02/ember-sinon-qunit?tab=readme-ov-file#ember-sinon-qunit):

> This addon integrates [sinon](http://jhawk.co/sinonjs) & [ember-qunit](http://jhawk.co/ember-qunit).
> Why not simply use sinon alone?
> `sinon` does not handle cleanup of `ember-quni`t tests. While `sinon` [sandboxes itself](https://sinonjs.org/guides/migrating-to-5.0), it's up to the user to consistently clean up sinon after each test. `ember-sinon-qunit` automatically restores `sinon`'s state to ensure nothing is leaked between tests. All spies/stubs created will be automatically restored to their original methods at the end of each test.

<hr>

##  💡  Things to note:
- calling `restore()` is not necessary because `ember-sinon-quint` cleans itself up (it's okay to leave, just redundant)
- **stubs should be in the `beforeEach` to consistently run for each test**. Locally I noticed the stub would only persist for the first test and then un-stub, or stub/re-stub when re-running the same test. While this could just be a race condition from locally re-running tests, the `beforeEach` is more reliable.
```js
hooks.beforeEach(function () {
   sinon.stub(timestamp, 'now').callsFake(() => STATIC_NOW);
});
```

- **using `fake` is a simpler ways to stub single functions instead of `callsFake`** ([docs](https://sinonjs.org/releases/v17/fakes/))

> When to use fakes?
> Fakes are alternatives to the Stubs and Spies, and they can fully replace all such use cases.
> They are intended to be simpler to use, and avoids many bugs by having immutable behaviour.
> The created fake Function, with or without behavior has the same API as a (sinon.spy)[spies](https://sinonjs.org/releases/v17/spies).
```js
// these both achieve the same thing, our current 
sinon.stub(timestamp, 'now').callsFake(() => new Date('2018-04-03T14:15:30'));

sinon.replace(timestamp, 'now', sinon.fake.returns(new Date('2018-04-03T14:15:30'))); 
```

- **the `before` hook can be used to stub (and call) the function once and then reuse the value in tests**
```js
hooks.before(function () {
   this.timestampStub = sinon.stub(timestamp, 'now').callsFake(() => new Date('2018-04-03T14:15:30'));
 });

hooks.beforeEach(function () {
   const mockNow = this.timestampStub();
   this.startTime =  mockNow
   this.endTime = addMonths(mockNow, 6));
});
```
_the above is an alternative stubbing and calling the function in each test run_
```js
hooks.beforeEach(async function () {
   sinon.replace(timestamp, 'now', sinon.fake.returns(STATIC_NOW));
   this.timestamp = timestamp.now()
});
```