### PR TITLE
Backport 1.16.x - ui deps: specify ember scope explicitly

### DIFF
--- a/ui/lib/core/package.json
+++ b/ui/lib/core/package.json
@@ -19,7 +19,7 @@
     "ember-composable-helpers": "*",
     "ember-concurrency": "*",
     "ember-maybe-in-element": "*",
-    "ember/render-modifiers": "*",
+    "@ember/render-modifiers": "*",
     "ember-power-select": "*",
     "ember-router-helpers": "*",
     "ember-svg-jar": "*",


### PR DESCRIPTION
Manual backport of #26784 