### PR TITLE
Add permissions check for secrets-sync/activate actions

### DIFF
--- a/ui/app/services/flags.ts
+++ b/ui/app/services/flags.ts
@@ -7,6 +7,7 @@ import Service, { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { keepLatestTask } from 'ember-concurrency';
 import { DEBUG } from '@glimmer/env';
+import lazyCapabilities, { apiPath } from 'vault/macros/lazy-capabilities';
 import type StoreService from 'vault/services/store';
 import type VersionService from 'vault/services/version';
 
@@ -75,5 +76,14 @@ export default class flagsService extends Service {
 
   fetchActivatedFlags() {
     return this.getActivatedFlags.perform();
+  }
+
+  @lazyCapabilities(apiPath`sys/activation-flags/secrets-sync/activate`) secretsSyncActivatePath;
+
+  get canActivateSecretsSync() {
+    return (
+      this.secretsSyncActivatePath.get('canCreate') !== false ||
+      this.secretsSyncActivatePath.get('canUpdate') !== false
+    );
   }
 }

--- a/ui/lib/sync/addon/components/secrets/page/overview.hbs
+++ b/ui/lib/sync/addon/components/secrets/page/overview.hbs
@@ -2,26 +2,33 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
 ~}}
-
 {{#unless @isActivated}}
   {{#if (or @licenseHasSecretsSync @isHvdManaged)}}
     {{#unless this.hideOptIn}}
+      {{! Allows users to dismiss activation banner if they have permissions to activate. }}
       <Hds::Alert
         @type="inline"
         @color="warning"
-        @onDismiss={{fn (mut this.hideOptIn) true}}
+        @onDismiss={{if this.flags.canActivateSecretsSync (fn (mut this.hideOptIn) true) undefined}}
         data-test-secrets-sync-opt-in-banner
         as |A|
       >
         <A.Title>Enable Secrets Sync feature</A.Title>
-        <A.Description>To use this feature, specific activation is required. Please review the feature documentation and
-          enable it. If you're upgrading from beta, your previous data will be accessible after activation.</A.Description>
-        <A.Button
-          @text="Enable"
-          @color="secondary"
-          {{on "click" (fn (mut this.showActivateSecretsSyncModal) true)}}
-          data-test-secrets-sync-opt-in-banner-enable
-        />
+        <A.Description>To use this feature, specific activation is required.
+          {{if
+            this.flags.canActivateSecretsSync
+            "Please review the feature documentation and
+          enable it. If you're upgrading from beta, your previous data will be accessible after activation."
+            "Please contact your administrator to activate."
+          }}</A.Description>
+        {{#if this.flags.canActivateSecretsSync}}
+          <A.Button
+            @text="Enable"
+            @color="secondary"
+            {{on "click" (fn (mut this.showActivateSecretsSyncModal) true)}}
+            data-test-secrets-sync-opt-in-banner-enable
+          />
+        {{/if}}
       </Hds::Alert>
     {{/unless}}
   {{/if}}

--- a/ui/lib/sync/addon/components/secrets/page/overview.ts
+++ b/ui/lib/sync/addon/components/secrets/page/overview.ts
@@ -16,6 +16,7 @@ import type FlashMessageService from 'vault/services/flash-messages';
 import type StoreService from 'vault/services/store';
 import type RouterService from '@ember/routing/router-service';
 import type VersionService from 'vault/services/version';
+import type FlagsService from 'vault/services/flags';
 import type { SyncDestinationAssociationMetrics } from 'vault/vault/adapters/sync/association';
 import type SyncDestinationModel from 'vault/vault/models/sync/destination';
 
@@ -30,6 +31,7 @@ export default class SyncSecretsDestinationsPageComponent extends Component<Args
   @service declare readonly store: StoreService;
   @service declare readonly router: RouterService;
   @service declare readonly version: VersionService;
+  @service declare readonly flags: FlagsService;
 
   @tracked destinationMetrics: SyncDestinationAssociationMetrics[] = [];
   @tracked page = 1;


### PR DESCRIPTION
This PR adds a permissions check inside the `flags.js` service, using the `lazy-capabilities` macro. While this is the first use case of a permissions check inside a service it made sense. The prevalent pattern is to check capabilities inside the model. But this one endpoint is a POST with no data returned or used on it, so adding a model/adapter/serializer is not necessary.

**No permissions to POST to `sys/activation-flags/secrets-sync/activate`**
![image (1)](https://github.com/hashicorp/vault/assets/6618863/b8d478c8-67a0-4f34-bd98-5ae94c7473fb)

**With permissions to POST**
_Same view as before_
![image (2)](https://github.com/hashicorp/vault/assets/6618863/6852b904-da12-48a7-a114-f79bf27c5b78)

