### PR TITLE
Clarify behavior of list operations when no results found

### DIFF
--- a/website/content/api-docs/index.mdx
+++ b/website/content/api-docs/index.mdx
@@ -132,6 +132,13 @@ $ curl \
 The API documentation uses `LIST` as the HTTP verb, but you can still use `GET`
 with the `?list=true` query string.
 
+When a list request is issued and the result is an empty set, the response will
+have the status code 404 and the following content:
+
+```json
+{"errors":[]}
+```
+
 To make an API with specific data in request body, issue a `POST`:
 
 ```text

--- a/website/content/api-docs/index.mdx
+++ b/website/content/api-docs/index.mdx
@@ -132,8 +132,7 @@ $ curl \
 The API documentation uses `LIST` as the HTTP verb, but you can still use `GET`
 with the `?list=true` query string.
 
-When a list request is issued and the result is an empty set, the response will
-have the status code 404 and the following content:
+If the list result is an empty set, Vault responds with status code 404 and the following JSON:
 
 ```json
 {"errors":[]}


### PR DESCRIPTION
This PR adds an explanation that when a **LIST** operation is issued and there are no results to return, the response is an HTTP 404 response.  For example, when no UI headers are configured:
```bash
$ curl -v -H "X-Vault-Token: $VAULT_TOKEN" -X LIST "$VAULT_ADDR/v1/sys/config/ui/headers"
*   Trying [::1]:8200...
* Connected to localhost (::1) port 8200
> LIST /v1/sys/config/ui/headers HTTP/1.1
> Host: localhost:8200
> User-Agent: curl/8.4.0
> Accept: */*
> X-Vault-Token: ********
>
< HTTP/1.1 404 Not Found
< Cache-Control: no-store
< Content-Type: application/json
< Strict-Transport-Security: max-age=31536000; includeSubDomains
< Date: Fri, 03 May 2024 17:51:46 GMT
< Content-Length: 14
<
{"errors":[]}
```

