### PR TITLE
UI: Fix sync test

### DIFF
--- a/ui/mirage/handlers/clients.js
+++ b/ui/mirage/handlers/clients.js
@@ -21,7 +21,7 @@ import { CLIENT_TYPES } from 'core/utils/client-count-utils';
 
 /*
 HOW TO ADD NEW TYPES:
-1. add key to CLIENT_TYPES 
+1. add key to CLIENT_TYPES
 2. Find "ADD NEW CLIENT TYPES HERE" comment below and add type to destructuring array
 3. Add generateMounts() for that client type to the mounts array
 */
@@ -30,6 +30,20 @@ export const STATIC_NOW = new Date('2024-01-25T23:59:59Z');
 const COUNTS_START = subMonths(STATIC_NOW, 12); // user started Vault cluster on 2023-01-25
 // upgrade happened 2 month after license start
 export const UPGRADE_DATE = addMonths(LICENSE_START, 2); // monthly attribution added
+
+// exported so that tests not using this scenario can use the same response
+export const CONFIG_RESPONSE = {
+  request_id: 'some-config-id',
+  data: {
+    billing_start_timestamp: formatRFC3339(LICENSE_START),
+    default_report_months: 12,
+    enabled: 'default-enabled',
+    minimum_retention_months: 48,
+    queries_available: false,
+    reporting_enabled: true,
+    retention_months: 48,
+  },
+};
 
 function getSum(array, key) {
   return array.reduce((sum, { counts }) => sum + counts[key], 0);
@@ -197,16 +211,7 @@ export default function (server) {
   });
 
   server.get('sys/internal/counters/config', function () {
-    return {
-      request_id: 'some-config-id',
-      data: {
-        default_report_months: 12,
-        enabled: 'default-enable',
-        queries_available: true,
-        retention_months: 24,
-        billing_start_timestamp: formatRFC3339(LICENSE_START),
-      },
-    };
+    return CONFIG_RESPONSE;
   });
 
   server.get('/sys/internal/counters/activity', (schema, req) => {

--- a/ui/tests/acceptance/clients/counts/sync-test.js
+++ b/ui/tests/acceptance/clients/counts/sync-test.js
@@ -7,13 +7,14 @@ import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import syncHandler from 'vault/mirage/handlers/sync';
-import { STATIC_NOW } from 'vault/mirage/handlers/clients';
+import { LICENSE_START, STATIC_NOW } from 'vault/mirage/handlers/clients';
 import { visit, click, currentURL } from '@ember/test-helpers';
 import sinon from 'sinon';
 import timestamp from 'core/utils/timestamp';
 import authPage from 'vault/tests/pages/auth';
 import { GENERAL } from 'vault/tests/helpers/general-selectors';
 import { CLIENT_COUNT, CHARTS } from 'vault/tests/helpers/clients/client-count-selectors';
+import { formatRFC3339 } from 'date-fns';
 
 module('Acceptance | clients | sync | activated', function (hooks) {
   setupApplicationTest(hooks);
@@ -50,6 +51,20 @@ module('Acceptance | clients | sync | not activated', function (hooks) {
   });
 
   hooks.beforeEach(async function () {
+    this.server.get('/sys/internal/counters/config', function () {
+      return {
+        request_id: 'abc-config',
+        data: {
+          billing_start_timestamp: formatRFC3339(LICENSE_START),
+          default_report_months: 12,
+          enabled: 'default-enabled',
+          minimum_retention_months: 48,
+          queries_available: false,
+          reporting_enabled: true,
+          retention_months: 48,
+        },
+      };
+    });
     await authPage.login();
     return visit('/vault/clients/counts/sync');
   });

--- a/ui/tests/acceptance/clients/counts/sync-test.js
+++ b/ui/tests/acceptance/clients/counts/sync-test.js
@@ -7,14 +7,13 @@ import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import syncHandler from 'vault/mirage/handlers/sync';
-import { LICENSE_START, STATIC_NOW } from 'vault/mirage/handlers/clients';
+import { CONFIG_RESPONSE, STATIC_NOW } from 'vault/mirage/handlers/clients';
 import { visit, click, currentURL } from '@ember/test-helpers';
 import sinon from 'sinon';
 import timestamp from 'core/utils/timestamp';
 import authPage from 'vault/tests/pages/auth';
 import { GENERAL } from 'vault/tests/helpers/general-selectors';
 import { CLIENT_COUNT, CHARTS } from 'vault/tests/helpers/clients/client-count-selectors';
-import { formatRFC3339 } from 'date-fns';
 
 module('Acceptance | clients | sync | activated', function (hooks) {
   setupApplicationTest(hooks);
@@ -52,18 +51,7 @@ module('Acceptance | clients | sync | not activated', function (hooks) {
 
   hooks.beforeEach(async function () {
     this.server.get('/sys/internal/counters/config', function () {
-      return {
-        request_id: 'abc-config',
-        data: {
-          billing_start_timestamp: formatRFC3339(LICENSE_START),
-          default_report_months: 12,
-          enabled: 'default-enabled',
-          minimum_retention_months: 48,
-          queries_available: false,
-          reporting_enabled: true,
-          retention_months: 48,
-        },
-      };
+      return CONFIG_RESPONSE;
     });
     await authPage.login();
     return visit('/vault/clients/counts/sync');


### PR DESCRIPTION
In order to fix the sync test failing on the empty state, I added a mirage response for `sys/internal/counters/config` to set a static `billingStartTimestamp`. Before, the test was relying on the real vault config, which has an unreliable billing start date. 

![image](https://github.com/hashicorp/vault/assets/82459713/fa101210-e827-491a-90b8-ea335198cfbb)

Unclear if we need to backport this or not -- if we find more client count tests failing on release branches we can backport this as necessary