### PR TITLE
Add ToB Semgrep Rules

### DIFF
--- a/scan.hcl
+++ b/scan.hcl
@@ -15,7 +15,13 @@ repository {
   plugin "semgrep" {
     use_git_ignore = true
     exclude = ["vendor"]
-    config = ["tools/semgrep/ci", "p/r2c-security-audit", "r/trailofbits.go.hanging-goroutine.hanging-goroutine"]
+    config = [
+      "tools/semgrep/ci",
+      "p/r2c-security-audit",
+      "r/trailofbits.go.hanging-goroutine.hanging-goroutine",
+      "r/trailofbits.go.racy-append-to-slice.racy-append-to-slice",
+      "r/trailofbits.go.racy-write-to-map.racy-write-to-map",
+    ]
     exclude_rule = ["generic.html-templates.security.unquoted-attribute-var.unquoted-attribute-var"]
   }
   

--- a/scan.hcl
+++ b/scan.hcl
@@ -15,7 +15,7 @@ repository {
   plugin "semgrep" {
     use_git_ignore = true
     exclude = ["vendor"]
-    config = ["tools/semgrep/ci", "p/r2c-security-audit"]
+    config = ["tools/semgrep/ci", "p/r2c-security-audit", "r/trailofbits.go.hanging-goroutine.hanging-goroutine"]
     exclude_rule = ["generic.html-templates.security.unquoted-attribute-var.unquoted-attribute-var"]
   }
   


### PR DESCRIPTION
This PR introduces a few Semgrep rules:

- [trailofbits.go.hanging-goroutine.hanging-goroutine](https://semgrep.dev/playground/r/trailofbits.go.hanging-goroutine.hanging-goroutine?editorMode=advanced)
- [trailofbits.go.racy-append-to-slice.racy-append-to-slice](https://semgrep.dev/playground/r/trailofbits.go.racy-append-to-slice.racy-append-to-slice?editorMode=advanced)
- [trailofbits.go.racy-write-to-map.racy-write-to-map](https://semgrep.dev/playground/r/trailofbits.go.racy-write-to-map.racy-write-to-map?editorMode=advanced)