### PR TITLE
[Secrets Sync] split activation modal into separate component

### DIFF
--- a/ui/lib/sync/addon/components/secrets/page/overview.hbs
+++ b/ui/lib/sync/addon/components/secrets/page/overview.hbs
@@ -34,10 +34,13 @@
   {{/if}}
 {{/unless}}
 
-{{! error message if post to activated endpoint fails }}
-{{#if this.error}}
+{{#if this.activationError}}
   {{#unless this.hideError}}
-    <MessageError @errorMessage={{this.error}} @onDismiss={{fn (mut this.hideError) true}} data-test-opt-in-error />
+    <MessageError
+      @errorMessage={{this.activationError}}
+      @onDismiss={{fn (mut this.hideError) true}}
+      data-test-opt-in-error
+    />
   {{/unless}}
 {{/if}}
 
@@ -198,37 +201,9 @@
 {{/if}}
 
 {{#if this.showActivateSecretsSyncModal}}
-  <Hds::Modal @onClose={{fn (mut this.showActivateSecretsSyncModal) false}} data-test-secrets-sync-opt-in-modal as |M|>
-    <M.Header @icon="alert-triangle">
-      Enable Secrets Sync feature
-    </M.Header>
-    <M.Body>
-      <p class="has-bottom-margin-m">
-        By enabling the Secrets Sync feature you may incur additional costs. Please review our
-        <Hds::Link::Inline
-          @isHrefExternal={{true}}
-          @href={{doc-link "/hcp/docs/vault/what-is-hcp-vault/client#secrets-sync"}}
-        >documentation</Hds::Link::Inline>
-        to learn more.
-      </p>
-      <Hds::Form::Checkbox::Field
-        {{on "change" (fn (mut this.hasConfirmedDocs) (not this.hasConfirmedDocs))}}
-        data-test-opt-in-check
-        as |F|
-      >
-        <F.Label>I've read the above linked document</F.Label>
-      </Hds::Form::Checkbox::Field>
-    </M.Body>
-    <M.Footer>
-      <Hds::ButtonSet>
-        <Hds::Button
-          data-test-opt-in-confirm
-          @text="Confirm"
-          disabled={{(not this.hasConfirmedDocs)}}
-          {{on "click" (perform this.onFeatureConfirm)}}
-        />
-        <Hds::Button data-test-opt-in-cancel @text="Cancel" @color="secondary" {{on "click" this.resetOptInModal}} />
-      </Hds::ButtonSet>
-    </M.Footer>
-  </Hds::Modal>
+  <Secrets::SyncActivationModal
+    @onClose={{fn (mut this.showActivateSecretsSyncModal) false}}
+    @onError={{this.onModalError}}
+    @isHvdManaged={{@isHvdManaged}}
+  />
 {{/if}}

--- a/ui/lib/sync/addon/components/secrets/page/overview.ts
+++ b/ui/lib/sync/addon/components/secrets/page/overview.ts
@@ -7,14 +7,11 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { service } from '@ember/service';
 import { task } from 'ember-concurrency';
-import { waitFor } from '@ember/test-waiters';
 import { action } from '@ember/object';
-import errorMessage from 'vault/utils/error-message';
 import Ember from 'ember';
 
 import type FlashMessageService from 'vault/services/flash-messages';
 import type StoreService from 'vault/services/store';
-import type RouterService from '@ember/routing/router-service';
 import type VersionService from 'vault/services/version';
 import type FlagsService from 'vault/services/flags';
 import type { SyncDestinationAssociationMetrics } from 'vault/vault/adapters/sync/association';
@@ -31,15 +28,13 @@ interface Args {
 export default class SyncSecretsDestinationsPageComponent extends Component<Args> {
   @service declare readonly flashMessages: FlashMessageService;
   @service declare readonly store: StoreService;
-  @service declare readonly router: RouterService;
   @service declare readonly version: VersionService;
   @service declare readonly flags: FlagsService;
 
   @tracked destinationMetrics: SyncDestinationAssociationMetrics[] = [];
   @tracked page = 1;
   @tracked showActivateSecretsSyncModal = false;
-  @tracked hasConfirmedDocs = false;
-  @tracked error = null;
+  @tracked activationError: null | string = null;
   // eventually remove when we deal with permissions on activation-features
   @tracked hideOptIn = false;
   @tracked hideError = false;
@@ -67,28 +62,7 @@ export default class SyncSecretsDestinationsPageComponent extends Component<Args
   });
 
   @action
-  resetOptInModal() {
-    this.showActivateSecretsSyncModal = false;
-    this.hasConfirmedDocs = false;
-  }
-
-  @task
-  @waitFor
-  *onFeatureConfirm() {
-    // must return null instead of root for non managed cluster.
-    // child namespaces are not sent.
-    const namespace = this.args.isHvdManaged ? 'admin' : null;
-    try {
-      yield this.store
-        .adapterFor('application')
-        .ajax('/v1/sys/activation-flags/secrets-sync/activate', 'POST', { namespace });
-      // must refresh and not transition because transition does not refresh the model from within a namespace
-      yield this.router.refresh();
-    } catch (error) {
-      this.error = errorMessage(error);
-      this.flashMessages.danger(`Error enabling feature \n ${errorMessage(error)}`);
-    } finally {
-      this.resetOptInModal();
-    }
+  onModalError(errorMsg: string) {
+    this.activationError = errorMsg;
   }
 }

--- a/ui/lib/sync/addon/components/secrets/sync-activation-modal.hbs
+++ b/ui/lib/sync/addon/components/secrets/sync-activation-modal.hbs
@@ -1,0 +1,38 @@
+{{!
+  Copyright (c) HashiCorp, Inc.
+  SPDX-License-Identifier: BUSL-1.1
+~}}
+
+<Hds::Modal @onClose={{@onClose}} data-test-secrets-sync-opt-in-modal as |M|>
+  <M.Header @icon="alert-triangle">
+    Enable Secrets Sync feature
+  </M.Header>
+  <M.Body>
+    <p class="has-bottom-margin-m">
+      By enabling the Secrets Sync feature you may incur additional costs. Please review our
+      <Hds::Link::Inline
+        @isHrefExternal={{true}}
+        @href={{doc-link "/hcp/docs/vault/what-is-hcp-vault/client#secrets-sync"}}
+      >documentation</Hds::Link::Inline>
+      to learn more.
+    </p>
+    <Hds::Form::Checkbox::Field
+      {{on "change" (fn (mut this.hasConfirmedDocs) (not this.hasConfirmedDocs))}}
+      data-test-opt-in-check
+      as |F|
+    >
+      <F.Label>I've read the above linked document</F.Label>
+    </Hds::Form::Checkbox::Field>
+  </M.Body>
+  <M.Footer>
+    <Hds::ButtonSet>
+      <Hds::Button
+        data-test-opt-in-confirm
+        @text="Confirm"
+        disabled={{not this.hasConfirmedDocs}}
+        {{on "click" (perform this.onFeatureConfirm)}}
+      />
+      <Hds::Button data-test-opt-in-cancel @text="Cancel" @color="secondary" {{on "click" @onClose}} />
+    </Hds::ButtonSet>
+  </M.Footer>
+</Hds::Modal>

--- a/ui/lib/sync/addon/components/secrets/sync-activation-modal.ts
+++ b/ui/lib/sync/addon/components/secrets/sync-activation-modal.ts
@@ -17,6 +17,7 @@ import type RouterService from '@ember/routing/router-service';
 interface Args {
   onClose: () => void;
   onError: (errorMessage: string) => void;
+  isHvdManaged: boolean;
 }
 
 export default class SyncActivationModal extends Component<Args> {
@@ -36,8 +37,9 @@ export default class SyncActivationModal extends Component<Args> {
     try {
       yield this.store
         .adapterFor('application')
-        .ajax('/v1/sys/activation-flags/secrets-sync/activate', 'POST');
-      this.router.transitionTo('vault.cluster.sync.secrets.overview');
+        .ajax('/v1/sys/activation-flags/secrets-sync/activate', 'POST', { namespace });
+      // must refresh and not transition because transition does not refresh the model from within a namespace
+      yield this.router.refresh();
     } catch (error) {
       this.args.onError(errorMessage(error));
       this.flashMessages.danger(`Error enabling feature \n ${errorMessage(error)}`);

--- a/ui/lib/sync/addon/components/secrets/sync-activation-modal.ts
+++ b/ui/lib/sync/addon/components/secrets/sync-activation-modal.ts
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { service } from '@ember/service';
+import { task } from 'ember-concurrency';
+import { waitFor } from '@ember/test-waiters';
+import errorMessage from 'vault/utils/error-message';
+
+import type FlashMessageService from 'vault/services/flash-messages';
+import type StoreService from 'vault/services/store';
+import type RouterService from '@ember/routing/router-service';
+
+interface Args {
+  onClose: () => void;
+  onError: (errorMessage: string) => void;
+}
+
+export default class SyncActivationModal extends Component<Args> {
+  @service declare readonly flashMessages: FlashMessageService;
+  @service declare readonly store: StoreService;
+  @service declare readonly router: RouterService;
+
+  @tracked hasConfirmedDocs = false;
+
+  @task
+  @waitFor
+  *onFeatureConfirm() {
+    // must return null instead of root for non managed cluster.
+    // child namespaces are not sent.
+    const namespace = this.args.isHvdManaged ? 'admin' : null;
+
+    try {
+      yield this.store
+        .adapterFor('application')
+        .ajax('/v1/sys/activation-flags/secrets-sync/activate', 'POST');
+      this.router.transitionTo('vault.cluster.sync.secrets.overview');
+    } catch (error) {
+      this.args.onError(errorMessage(error));
+      this.flashMessages.danger(`Error enabling feature \n ${errorMessage(error)}`);
+    } finally {
+      this.args.onClose();
+    }
+  }
+}

--- a/ui/tests/acceptance/sync/secrets/overview-test.js
+++ b/ui/tests/acceptance/sync/secrets/overview-test.js
@@ -117,16 +117,20 @@ module('Acceptance | sync | overview', function (hooks) {
         .dom(ts.cta.button)
         .doesNotExist('create first destination is not available until feature has been activated');
 
-      assert.dom(ts.overview.optInBanner).exists();
-      await click(ts.overview.optInBannerEnable);
+      assert.dom(ts.overview.optInBanner.container).exists();
+      await click(ts.overview.optInBanner.enable);
 
-      assert.dom(ts.overview.optInModal).exists('modal to opt-in and activate feature is shown');
-      await click(ts.overview.optInCheck);
-      await click(ts.overview.optInConfirm);
-
-      assert.dom(ts.overview.optInModal).doesNotExist('modal is gone once activation has been submitted');
       assert
-        .dom(ts.overview.optInBanner)
+        .dom(ts.overview.activationModal.container)
+        .exists('modal to opt-in and activate feature is shown');
+      await click(ts.overview.activationModal.checkbox);
+      await click(ts.overview.activationModal.confirm);
+
+      assert
+        .dom(ts.overview.activationModal.container)
+        .doesNotExist('modal is gone once activation has been submitted');
+      assert
+        .dom(ts.overview.optInBanner.container)
         .doesNotExist('opt-in banner is gone once activation has been submitted');
 
       await click(ts.cta.button);
@@ -172,9 +176,9 @@ module('Acceptance | sync | overview', function (hooks) {
       assert.dom('[data-test-badge-namespace]').hasText('foo');
 
       await click(ts.navLink('Secrets Sync'));
-      await click(ts.overview.optInBannerEnable);
-      await click(ts.overview.optInCheck);
-      await click(ts.overview.optInConfirm);
+      await click(ts.overview.optInBanner.enable);
+      await click(ts.overview.activationModal.checkbox);
+      await click(ts.overview.activationModal.confirm);
     });
 
     test('it should make activation-flag requests to correct namespace when managed', async function (assert) {
@@ -204,9 +208,9 @@ module('Acceptance | sync | overview', function (hooks) {
       assert.dom('[data-test-badge-namespace]').hasText('foo');
 
       await click(ts.navLink('Secrets Sync'));
-      await click(ts.overview.optInBannerEnable);
-      await click(ts.overview.optInCheck);
-      await click(ts.overview.optInConfirm);
+      await click(ts.overview.optInBanner.enable);
+      await click(ts.overview.activationModal.checkbox);
+      await click(ts.overview.activationModal.confirm);
     });
   });
 });

--- a/ui/tests/helpers/sync/sync-selectors.js
+++ b/ui/tests/helpers/sync/sync-selectors.js
@@ -55,6 +55,13 @@ export const PAGE = {
     optInBannerEnable: '[data-test-secrets-sync-opt-in-banner-enable]',
     optInBannerDescription: '[data-test-secrets-sync-opt-in-banner-description]',
     optInDismiss: '[data-test-secrets-sync-opt-in-banner] [data-test-icon="x"]',
+    activationModal: {
+      container: '[data-test-secrets-sync-opt-in-modal]',
+      checkbox: '[data-test-opt-in-check]',
+      confirm: '[data-test-opt-in-confirm]',
+      cancel: '[data-test-opt-in-cancel]',
+      error: '[data-test-opt-in-error]',
+    },
     optInModal: '[data-test-secrets-sync-opt-in-modal]',
     optInCheck: '[data-test-opt-in-check]',
     optInConfirm: '[data-test-opt-in-confirm]',

--- a/ui/tests/helpers/sync/sync-selectors.js
+++ b/ui/tests/helpers/sync/sync-selectors.js
@@ -51,21 +51,18 @@ export const PAGE = {
     },
   },
   overview: {
-    optInBanner: '[data-test-secrets-sync-opt-in-banner]',
-    optInBannerEnable: '[data-test-secrets-sync-opt-in-banner-enable]',
-    optInBannerDescription: '[data-test-secrets-sync-opt-in-banner-description]',
-    optInDismiss: '[data-test-secrets-sync-opt-in-banner] [data-test-icon="x"]',
+    optInBanner: {
+      container: '[data-test-secrets-sync-opt-in-banner]',
+      enable: '[data-test-secrets-sync-opt-in-banner-enable]',
+      description: '[data-test-secrets-sync-opt-in-banner-description]',
+      dismiss: '[data-test-secrets-sync-opt-in-banner] [data-test-icon="x"]',
+    },
     activationModal: {
       container: '[data-test-secrets-sync-opt-in-modal]',
       checkbox: '[data-test-opt-in-check]',
       confirm: '[data-test-opt-in-confirm]',
       cancel: '[data-test-opt-in-cancel]',
-      error: '[data-test-opt-in-error]',
     },
-    optInModal: '[data-test-secrets-sync-opt-in-modal]',
-    optInCheck: '[data-test-opt-in-check]',
-    optInConfirm: '[data-test-opt-in-confirm]',
-    optInCancel: '[data-test-opt-in-cancel]',
     optInError: '[data-test-opt-in-error]',
     createDestination: '[data-test-create-destination]',
     table: {

--- a/ui/tests/integration/components/sync/secrets/page/overview-test.js
+++ b/ui/tests/integration/components/sync/secrets/page/overview-test.js
@@ -181,27 +181,6 @@ module('Integration | Component | sync | Page::Overview', function (hooks) {
       await click(overview.optInBannerEnable);
 
       assert.dom(overview.optInModal).exists('Opt-in modal is shown');
-      assert.dom(overview.optInConfirm).isDisabled('Confirm button is disabled when checkbox is unchecked');
-
-      await click(overview.optInCheck);
-      assert.dom(overview.optInConfirm).isNotDisabled('confirm button is enabled once checkbox is checked');
-    });
-
-    test('it should make a POST to activate the feature', async function (assert) {
-      assert.expect(1);
-
-      await this.renderComponent();
-
-      this.server.post('/sys/activation-flags/secrets-sync/activate', () => {
-        assert.true(true, 'POST to secrets-sync/activate is called');
-        return {};
-      });
-
-      await this.renderComponent();
-
-      await click(overview.optInBannerEnable);
-      await click(overview.optInCheck);
-      await click(overview.optInConfirm);
     });
 
     test('it shows an error if activation fails', async function (assert) {

--- a/ui/tests/integration/components/sync/secrets/page/overview-test.js
+++ b/ui/tests/integration/components/sync/secrets/page/overview-test.js
@@ -117,14 +117,14 @@ module('Integration | Component | sync | Page::Overview', function (hooks) {
     test('it should show the opt-in banner if feature is not activated', async function (assert) {
       await this.renderComponent();
 
-      assert.dom(overview.optInBanner).exists('Opt-in banner is shown');
+      assert.dom(overview.optInBanner.container).exists('Opt-in banner is shown');
     });
 
     test('it should not show the opt-in banner if feature is activated', async function (assert) {
       this.isActivated = true;
       await this.renderComponent();
 
-      assert.dom(overview.optInBanner).doesNotExist('Opt-in banner is not shown');
+      assert.dom(overview.optInBanner.container).doesNotExist('Opt-in banner is not shown');
     });
   });
 
@@ -139,17 +139,17 @@ module('Integration | Component | sync | Page::Overview', function (hooks) {
       await this.renderComponent();
 
       assert
-        .dom(overview.optInBannerDescription)
+        .dom(overview.optInBanner.description)
         .hasText(
           'To use this feature, specific activation is required. Please contact your administrator to activate.'
         );
-      assert.dom(overview.optInBannerEnable).doesNotExist('Opt-in enable button does not show');
+      assert.dom(overview.optInBanner.enable).doesNotExist('Opt-in enable button does not show');
     });
 
     test('it should not show allow the user to dismiss the opt-in banner', async function (assert) {
       await this.renderComponent();
 
-      assert.dom(overview.optInDismiss).doesNotExist('dismiss opt-in banner does not show');
+      assert.dom(overview.optInBanner.dismiss).doesNotExist('dismiss opt-in banner does not show');
     });
   });
 
@@ -161,9 +161,9 @@ module('Integration | Component | sync | Page::Overview', function (hooks) {
     test('it should show the opt-in banner with activate description', async function (assert) {
       await this.renderComponent();
 
-      assert.dom(overview.optInBanner).exists('Opt-in banner is shown');
+      assert.dom(overview.optInBanner.container).exists('Opt-in banner is shown');
       assert
-        .dom(overview.optInBannerDescription)
+        .dom(overview.optInBanner.description)
         .hasText(
           "To use this feature, specific activation is required. Please review the feature documentation and enable it. If you're upgrading from beta, your previous data will be accessible after activation."
         );
@@ -172,15 +172,15 @@ module('Integration | Component | sync | Page::Overview', function (hooks) {
     test('it should show dismiss banner', async function (assert) {
       await this.renderComponent();
 
-      assert.dom(overview.optInDismiss).exists('dismiss opt-in banner shows');
+      assert.dom(overview.optInBanner.dismiss).exists('dismiss opt-in banner shows');
     });
 
     test('it should navigate to the opt-in modal', async function (assert) {
       await this.renderComponent();
 
-      await click(overview.optInBannerEnable);
+      await click(overview.optInBanner.enable);
 
-      assert.dom(overview.optInModal).exists('Opt-in modal is shown');
+      assert.dom(overview.activationModal.container).exists('Opt-in modal is shown');
     });
 
     test('it shows an error if activation fails', async function (assert) {
@@ -188,12 +188,12 @@ module('Integration | Component | sync | Page::Overview', function (hooks) {
 
       this.server.post('/sys/activation-flags/secrets-sync/activate', () => new Response(403));
 
-      await click(overview.optInBannerEnable);
-      await click(overview.optInCheck);
-      await click(overview.optInConfirm);
+      await click(overview.optInBanner.enable);
+      await click(overview.activationModal.checkbox);
+      await click(overview.activationModal.confirm);
 
       assert.dom(overview.optInError).exists('shows an error banner');
-      assert.dom(overview.optInBanner).exists('banner is visible so user can try to opt-in again');
+      assert.dom(overview.optInBanner.container).exists('banner is visible so user can try to opt-in again');
     });
   });
 
@@ -205,7 +205,7 @@ module('Integration | Component | sync | Page::Overview', function (hooks) {
     test('it should hide the opt-in banner', async function (assert) {
       await this.renderComponent();
 
-      assert.dom(overview.optInBanner).doesNotExist();
+      assert.dom(overview.optInBanner.container).doesNotExist();
     });
   });
 
@@ -213,7 +213,7 @@ module('Integration | Component | sync | Page::Overview', function (hooks) {
     test('it should hide the opt-in banner', async function (assert) {
       await this.renderComponent();
 
-      assert.dom(overview.optInBanner).doesNotExist();
+      assert.dom(overview.optInBanner.container).doesNotExist();
     });
   });
 

--- a/ui/tests/integration/components/sync/secrets/sync-activation-modal-test.js
+++ b/ui/tests/integration/components/sync/secrets/sync-activation-modal-test.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'vault/tests/helpers';
 import { setupEngine } from 'ember-engines/test-support';

--- a/ui/tests/integration/components/sync/secrets/sync-activation-modal-test.js
+++ b/ui/tests/integration/components/sync/secrets/sync-activation-modal-test.js
@@ -1,0 +1,43 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'vault/tests/helpers';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | Secrets::SyncActivationModal', function (hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function () {
+    this.onClose = () => {};
+    this.onError = () => {};
+
+    this.renderComponent = async () => {
+      await render(hbs`
+      <Secrets::SyncActivationModal @onClose={{this.onClose}} @onError={{this.onError}} />
+    `);
+    };
+  });
+
+  test('it renders with correct text', async function (assert) {
+    await this.renderComponent();
+
+    assert.dom(this.element).hasText('Hello');
+  });
+
+  test('it disables submit until user has confirmed docs', async function (assert) {
+    await this.renderComponent();
+
+    assert.dom(this.element).hasText('Hello');
+  });
+
+  module('on submit', function () {
+    module('success', function () {
+      test('it calls the activate endpoint', function () {});
+      test('it transitions back to sync overview', function () {});
+    });
+
+    module('on error', function () {
+      test('it calls onError', function () {});
+      test('it renders an error flash message', function () {});
+    });
+  });
+});

--- a/ui/tests/integration/components/sync/secrets/sync-activation-modal-test.js
+++ b/ui/tests/integration/components/sync/secrets/sync-activation-modal-test.js
@@ -1,43 +1,143 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'vault/tests/helpers';
-import { render } from '@ember/test-helpers';
+import { setupEngine } from 'ember-engines/test-support';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { render, click } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
+import sinon from 'sinon';
+import { overrideResponse } from 'vault/tests/helpers/stubs';
+import { PAGE } from 'vault/tests/helpers/sync/sync-selectors';
+
+const SELECTORS = PAGE.overview.activationModal;
 
 module('Integration | Component | Secrets::SyncActivationModal', function (hooks) {
   setupRenderingTest(hooks);
+  setupEngine(hooks, 'sync');
+  setupMirage(hooks);
 
   hooks.beforeEach(function () {
-    this.onClose = () => {};
-    this.onError = () => {};
+    this.onClose = sinon.stub();
+    this.onError = sinon.stub();
+    this.isHvdManaged = false;
 
     this.renderComponent = async () => {
-      await render(hbs`
-      <Secrets::SyncActivationModal @onClose={{this.onClose}} @onError={{this.onError}} />
-    `);
+      await render(
+        hbs`
+      <Secrets::SyncActivationModal @onClose={{this.onClose}} @onError={{this.onError}} @isHvdManaged={{this.isHvdManaged}}/>
+    `,
+        { owner: this.engine }
+      );
     };
   });
 
   test('it renders with correct text', async function (assert) {
     await this.renderComponent();
 
-    assert.dom(this.element).hasText('Hello');
+    assert
+      .dom(SELECTORS.container)
+      .hasTextContaining(
+        "By enabling the Secrets Sync feature you may incur additional costs. Please review our documentation to learn more. I've read the above linked document"
+      );
+  });
+
+  test('it calls onClose', async function (assert) {
+    await this.renderComponent();
+
+    await click(SELECTORS.cancel);
+
+    assert.true(this.onClose.called);
   });
 
   test('it disables submit until user has confirmed docs', async function (assert) {
     await this.renderComponent();
 
-    assert.dom(this.element).hasText('Hello');
+    assert.dom(SELECTORS.checkbox).isNotChecked('checkbox is initially unchecked');
+    assert.dom(SELECTORS.confirm).isDisabled('submit is disabled');
+    await click(SELECTORS.checkbox);
+
+    assert.dom(SELECTORS.checkbox).isChecked();
+    assert.dom(SELECTORS.confirm).isNotDisabled('submit is enabled once user has confirmed');
   });
 
-  module('on submit', function () {
-    module('success', function () {
-      test('it calls the activate endpoint', function () {});
-      test('it transitions back to sync overview', function () {});
+  module('on submit', function (hooks) {
+    hooks.beforeEach(function () {
+      const router = this.owner.lookup('service:router');
+      this.refreshStub = sinon.stub(router, 'refresh');
     });
 
-    module('on error', function () {
-      test('it calls onError', function () {});
-      test('it renders an error flash message', function () {});
+    module('success', function (hooks) {
+      hooks.beforeEach(function () {
+        this.server.post('/sys/activation-flags/secrets-sync/activate', () => {
+          return {};
+        });
+      });
+
+      test('HVD clusters: it calls the activate endpoint with correct namespace', async function (assert) {
+        this.isHvdManaged = true;
+        assert.expect(1);
+
+        this.server.post('/sys/activation-flags/secrets-sync/activate', (_, req) => {
+          assert.strictEqual(
+            req.requestHeaders['X-Vault-Namespace'],
+            'admin',
+            'POST to secrets-sync/activate is called with admin namespace'
+          );
+          return {};
+        });
+
+        await this.renderComponent();
+
+        await click(SELECTORS.checkbox);
+        await click(SELECTORS.confirm);
+      });
+
+      test('non-HVD clusters: it calls the activate endpoint with no namespace', async function (assert) {
+        assert.expect(1);
+
+        this.server.post('/sys/activation-flags/secrets-sync/activate', (_, req) => {
+          assert.strictEqual(
+            req.requestHeaders['X-Vault-Namespace'],
+            undefined,
+            'POST to secrets-sync/activate is called with no namespace'
+          );
+          return {};
+        });
+
+        await this.renderComponent();
+
+        await click(SELECTORS.checkbox);
+        await click(SELECTORS.confirm);
+      });
+
+      test('it refreshes the sync overview route', async function (assert) {
+        await this.renderComponent();
+
+        await click(SELECTORS.checkbox);
+        await click(SELECTORS.confirm);
+
+        assert.true(this.refreshStub.called);
+      });
+    });
+
+    module('on error', function (hooks) {
+      hooks.beforeEach(function () {
+        this.server.post('/sys/activation-flags/secrets-sync/activate', () => {
+          return overrideResponse(403);
+        });
+
+        const flashMessages = this.owner.lookup('service:flash-messages');
+        this.flashDangerSpy = sinon.spy(flashMessages, 'danger');
+      });
+
+      test('it handles errors', async function (assert) {
+        await this.renderComponent();
+
+        await click(SELECTORS.checkbox);
+        await click(SELECTORS.confirm);
+
+        assert.true(this.onError.called, 'calls the onError arg');
+        assert.true(this.flashDangerSpy.called, 'triggers an error flash message');
+      });
     });
   });
 });


### PR DESCRIPTION
### :hammer_and_wrench: Description
Split Activation modal into a separate component. There are no user facing changes here; just the new component and tests.