### PR TITLE
[docs] fix lack of space character

### DIFF
--- a/website/content/partials/ui/policy-requirements.mdx
+++ b/website/content/partials/ui/policy-requirements.mdx
@@ -1,6 +1,6 @@
 <Warning title="Set UI policies before enabling the UI"> 
 	
-  You cannot make policy adjustments or overwrites to the <code>ui/mounts</code> 
+  You cannot make policy adjustments or overwrites to the <code>ui/mounts</code>&nbsp;
   and <code>ui/resultant-acl</code> endpoints once you enable the Vault UI. Vault
   ignores policy updates that target these paths
   with <a href="/vault/docs/concepts/policies#deny">explicit <code>deny</code></a> capabilities.

--- a/website/content/partials/ui/policy-requirements.mdx
+++ b/website/content/partials/ui/policy-requirements.mdx
@@ -1,6 +1,6 @@
 <Warning title="Set UI policies before enabling the UI"> 
 	
-  You cannot make policy adjustments or overwrites to the <code>ui/mounts</code>
+  You cannot make policy adjustments or overwrites to the <code>ui/mounts</code> 
   and <code>ui/resultant-acl</code> endpoints once you enable the Vault UI. Vault
   ignores policy updates that target these paths
   with <a href="/vault/docs/concepts/policies#deny">explicit <code>deny</code></a> capabilities.


### PR DESCRIPTION
https://developer.hashicorp.com/vault/docs/concepts/policies#ui-policy-requirements

`to the ui/mountsand ui/resultant-acl`

needs a space after mounts