### PR TITLE
ui: fix broken helper link for web command

### DIFF
--- a/changelog/26858.txt
+++ b/changelog/26858.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fix broken help link in console for the web command.
+```

--- a/ui/app/templates/components/console/log-help.hbs
+++ b/ui/app/templates/components/console/log-help.hbs
@@ -25,6 +25,6 @@ Web REPL Commands:
 
 </pre>
   <p class="console-ui-panel-intro is-font-mono has-bottom-margin-s">
-    For more detailed documentation, see the <Hds::Link::Inline @href={{doc-link "/vault/docs/command/web"}}>HashiCorp Developer site</Hds::Link::Inline>.
+    For more detailed documentation, see the <Hds::Link::Inline @href={{doc-link "/vault/docs/commands/web"}}>HashiCorp Developer site</Hds::Link::Inline>.
   </p>
 </div>


### PR DESCRIPTION
The UI console has a broken link for the `web` command (missing an `s`).