### PR TITLE
NewTestCluster: default to enabling a 'discard' file audit device when none are configured

### DIFF
--- a/helper/builtinplugins/builtinplugins_test.go
+++ b/helper/builtinplugins/builtinplugins_test.go
@@ -8,7 +8,6 @@ import (
 
 	logicalKv "github.com/hashicorp/vault-plugin-secrets-kv"
 	"github.com/hashicorp/vault/api"
-	"github.com/hashicorp/vault/audit"
 	logicalDb "github.com/hashicorp/vault/builtin/logical/database"
 	vaulthttp "github.com/hashicorp/vault/http"
 	"github.com/hashicorp/vault/sdk/helper/consts"
@@ -44,11 +43,6 @@ func TestBuiltinPluginsWork(t *testing.T) {
 				"database": logicalDb.Factory,
 			},
 			PendingRemovalMountsAllowed: true,
-			// Specifying at least one audit backend factory will prevent NewTestCluster
-			// from attempting to enable a noop audit, and audit isn't required for this test.
-			AuditBackends: map[string]audit.Factory{
-				"noop": audit.NoopAuditFactory(nil),
-			},
 		},
 		&vault.TestClusterOptions{
 			HandlerFunc: vaulthttp.Handler,

--- a/vault/testing.go
+++ b/vault/testing.go
@@ -1540,9 +1540,11 @@ func NewTestCluster(t testing.T, base *CoreConfig, opts *TestClusterOptions) *Te
 		coreConfig.RawConfig = c
 	}
 
+	// If the caller didn't supply any configuration for types of audit device,
+	// default to adding `file` (and enabling it later).
 	addAuditBackend := len(coreConfig.AuditBackends) == 0
 	if addAuditBackend {
-		coreConfig.AuditBackends["noop"] = audit.NoopAuditFactory(nil)
+		coreConfig.AuditBackends[audit.TypeFile] = audit.NewFileBackend
 	}
 
 	if coreConfig.Physical == nil && (opts == nil || opts.PhysicalFactory == nil) {
@@ -1975,6 +1977,9 @@ func (tc *TestCluster) InitCores(t testing.T, opts *TestClusterOptions, addAudit
 	tc.initCores(t, opts, addAuditBackend)
 }
 
+// initCores attempts to initialize a core for a test cluster using the supplied
+// options. If the addAuditBackend flag is true, the core will have a file audit
+// device enabled with the 'discard' file path (See: /vault/docs/audit/file#discard).
 func (tc *TestCluster) initCores(t testing.T, opts *TestClusterOptions, addAuditBackend bool) {
 	leader := tc.Cores[0]
 
@@ -2087,8 +2092,11 @@ func (tc *TestCluster) initCores(t testing.T, opts *TestClusterOptions, addAudit
 		auditReq := &logical.Request{
 			Operation:   logical.UpdateOperation,
 			ClientToken: tc.RootToken,
-			Path:        "sys/audit/noop",
-			Data:        map[string]interface{}{"type": "noop"},
+			Path:        "sys/audit/file",
+			Data: map[string]interface{}{
+				"type":      audit.TypeFile,
+				"file_path": "discard",
+			},
 		}
 		resp, err := leader.Core.HandleRequest(namespace.RootContext(ctx), auditReq)
 		if err != nil {


### PR DESCRIPTION
There was a previous fail in a test (`TestBuiltinPluginsWork/Whole_OpenAPI_document`) which claimed to be related to audit, but 

This is no longer required, `NewTestCluster` will not create `noop` audit, if no device types are configured, it will add the three supported ones (file, socket, syslog), and enable a file device with the discard file path (similar to a noop).

Also removes [this code](https://github.com/hashicorp/vault/pull/24493/files#diff-b1c046263e9208998666de7c5b5ad210feddbd4e3fc894ac61d64455f195c4b2R48-R52) which was added not long ago to get a test working during the migration to eventlogger for audit,