### PR TITLE
bugfix: landmark elements must have unique accnames

### DIFF
--- a/ui/lib/core/addon/components/toolbar-actions.hbs
+++ b/ui/lib/core/addon/components/toolbar-actions.hbs
@@ -3,6 +3,6 @@
   SPDX-License-Identifier: BUSL-1.1
 ~}}
 
-<nav class="toolbar-actions" ...attributes>
+<nav class="toolbar-actions" aria-label="toolbar actions" ...attributes>
   {{yield}}
 </nav>

--- a/ui/lib/core/addon/components/toolbar-filters.hbs
+++ b/ui/lib/core/addon/components/toolbar-filters.hbs
@@ -3,6 +3,6 @@
   SPDX-License-Identifier: BUSL-1.1
 ~}}
 
-<nav class="toolbar-filters" ...attributes>
+<nav class="toolbar-filters" aria-label="toolbar filters" ...attributes>
   {{yield}}
 </nav>

--- a/ui/lib/core/addon/components/toolbar.hbs
+++ b/ui/lib/core/addon/components/toolbar.hbs
@@ -3,7 +3,7 @@
   SPDX-License-Identifier: BUSL-1.1
 ~}}
 
-<nav class="toolbar" ...attributes>
+<nav class="toolbar" aria-label="toolbar" ...attributes>
   <div class="toolbar-scroller">
     {{yield}}
   </div>


### PR DESCRIPTION
If merged, this PR would resolve the issue where toolbar navigation components did not have unique accessible names. 

Details:
- Added aria-label attributes to the different toolbar `nav` elements