### PR TITLE
UI: Only include upgrades with previous versions

### DIFF
--- a/ui/lib/core/addon/utils/client-count-utils.ts
+++ b/ui/lib/core/addon/utils/client-count-utils.ts
@@ -149,10 +149,13 @@ export const formatByNamespace = (namespaceArray: NamespaceObject[]) => {
 // when querying historical data the response will always contain the latest client type keys because the activity log is
 // constructed based on the version of Vault the user is on (key values will be 0)
 export const destructureClientCounts = (verboseObject: Counts | ByNamespaceClients) => {
-  return CLIENT_TYPES.reduce((newObj: Record<ClientTypes, Counts[ClientTypes]>, clientType: ClientTypes) => {
-    newObj[clientType] = verboseObject[clientType];
-    return newObj;
-  }, {} as Record<ClientTypes, Counts[ClientTypes]>);
+  return CLIENT_TYPES.reduce(
+    (newObj: Record<ClientTypes, Counts[ClientTypes]>, clientType: ClientTypes) => {
+      newObj[clientType] = verboseObject[clientType];
+      return newObj;
+    },
+    {} as Record<ClientTypes, Counts[ClientTypes]>
+  );
 };
 
 export const sortMonthsByTimestamp = (monthsArray: ActivityMonthBlock[] | EmptyActivityMonthBlock[]) => {
@@ -178,19 +181,22 @@ export const namespaceArrayToObject = (
       // mounts_by_key is is used to filter further in a namespace and get monthly activity by mount
       // it's an object inside the namespace block where the keys are mount paths
       // and the values include new and total client counts for that mount in that month
-      const mounts_by_key = ns.mounts.reduce((mountObj: { [key: string]: MountByKey }, mount) => {
-        const newMountClients = newNsClients.mounts.find((m) => m.label === mount.label);
+      const mounts_by_key = ns.mounts.reduce(
+        (mountObj: { [key: string]: MountByKey }, mount) => {
+          const newMountClients = newNsClients.mounts.find((m) => m.label === mount.label);
 
-        if (newMountClients) {
-          mountObj[mount.label] = {
-            ...mount,
-            timestamp,
-            month,
-            new_clients: { month, timestamp, ...newMountClients },
-          };
-        }
-        return mountObj;
-      }, {} as { [key: string]: MountByKey });
+          if (newMountClients) {
+            mountObj[mount.label] = {
+              ...mount,
+              timestamp,
+              month,
+              new_clients: { month, timestamp, ...newMountClients },
+            };
+          }
+          return mountObj;
+        },
+        {} as { [key: string]: MountByKey }
+      );
 
       nsObject[ns.label] = {
         ...destructureClientCounts(ns),

--- a/ui/mirage/handlers/clients.js
+++ b/ui/mirage/handlers/clients.js
@@ -4,6 +4,7 @@
  */
 
 import {
+  add,
   addMonths,
   differenceInCalendarMonths,
   endOfMonth,
@@ -237,11 +238,11 @@ export default function (server) {
     return {
       request_id: 'version-history-request-id',
       data: {
-        keys: ['1.9.0', '1.9.1', '1.10.1', '1.14.4', '1.16.0', '1.17.0'],
+        keys: ['1.9.0', '1.9.1', '1.10.1', '1.10.3', '1.14.4', '1.16.0', '1.17.0'],
         key_info: {
           // entity/non-entity breakdown added
           '1.9.0': {
-            // we don't currently use build_date, including for accuracy. it's only tracked in versions >= 1.110
+            // we don't currently use build_date, including for accuracy. it's only tracked in versions >= 1.11.0
             build_date: null,
             previous_version: null,
             timestamp_installed: LICENSE_START.toISOString(),
@@ -255,12 +256,17 @@ export default function (server) {
           '1.10.1': {
             build_date: null,
             previous_version: '1.9.1',
-            timestamp_installed: UPGRADE_DATE.toISOString(),
+            timestamp_installed: addMonths(LICENSE_START, 2).toISOString(), // same as UPGRADE_DATE
+          },
+          '1.10.3': {
+            build_date: null,
+            previous_version: '1.10.1',
+            timestamp_installed: add(LICENSE_START, { months: 2, weeks: 3 }).toISOString(),
           },
           // no notable UI changes
           '1.14.4': {
             build_date: addMonths(LICENSE_START, 3).toISOString(),
-            previous_version: '1.10.1',
+            previous_version: '1.10.3',
             timestamp_installed: addMonths(LICENSE_START, 3).toISOString(),
           },
           // sync clients added

--- a/ui/tests/helpers/clients/client-count-helpers.js
+++ b/ui/tests/helpers/clients/client-count-helpers.js
@@ -4,9 +4,6 @@
  */
 
 import { click, findAll } from '@ember/test-helpers';
-
-import { LICENSE_START } from 'vault/mirage/handlers/clients';
-import { addMonths } from 'date-fns';
 import { CLIENT_COUNT, CHARTS } from './client-count-selectors';
 
 export async function dateDropdownSelect(month, year) {
@@ -567,34 +564,6 @@ export const MIXED_ACTIVITY_RESPONSE_STUB = {
     },
   ],
 };
-// format returned by model hook in routes/vault/cluster/clients.ts
-export const VERSION_HISTORY = [
-  {
-    version: '1.9.0',
-    previousVersion: null,
-    timestampInstalled: LICENSE_START.toISOString(),
-  },
-  {
-    version: '1.9.1',
-    previousVersion: '1.9.0',
-    timestampInstalled: addMonths(LICENSE_START, 1).toISOString(),
-  },
-  {
-    version: '1.10.1',
-    previousVersion: '1.9.1',
-    timestampInstalled: addMonths(LICENSE_START, 2).toISOString(),
-  },
-  {
-    version: '1.14.4',
-    previousVersion: '1.10.1',
-    timestampInstalled: addMonths(LICENSE_START, 3).toISOString(),
-  },
-  {
-    version: '1.16.0',
-    previousVersion: '1.14.4',
-    timestampInstalled: addMonths(LICENSE_START, 4).toISOString(),
-  },
-];
 
 // order of this array matters because index 0 is a month without data
 export const SERIALIZED_ACTIVITY_RESPONSE = {

--- a/ui/tests/integration/components/clients/page/counts-test.js
+++ b/ui/tests/integration/components/clients/page/counts-test.js
@@ -218,32 +218,31 @@ module('Integration | Component | clients | Page::Counts', function (hooks) {
         `Client count data contains 3 upgrades Vault was upgraded during this time period. Keep this in mind while looking at the data. Visit our Client count FAQ for more information.`,
         'it renders title and subtext'
       );
-    assert
-      .dom(`${CLIENT_COUNT.upgradeWarning} ul`)
-      .doesNotHaveTextContaining(
-        '1.9.1',
-        'Warning does not include subsequent patch releases (e.g. 1.9.1) of the same notable upgrade.'
-      );
+
     const [first, second, third] = findAll(`${CLIENT_COUNT.upgradeWarning} li`);
     assert
       .dom(first)
       .hasText(
-        `1.9.0 (upgraded on Jul 2, 2023) - We introduced changes to non-entity token and local auth mount logic for client counting in 1.9.`,
-        'alert includes 1.9.0 upgrade'
+        `1.9.1 (upgraded on Aug 2, 2023) - We introduced changes to non-entity token and local auth mount logic for client counting in 1.9.`,
+        'alert includes 1.9.1 upgrade'
       );
-
     assert
       .dom(second)
       .hasTextContaining(
         `1.10.1 (upgraded on Sep 2, 2023) - We added monthly breakdowns and mount level attribution starting in 1.10.`,
         'alert includes 1.10.1 upgrade'
       );
-
     assert
       .dom(third)
       .hasTextContaining(
         `1.17.0 (upgraded on Dec 2, 2023) - We separated ACME clients from non-entity clients starting in 1.17.`,
         'alert includes 1.17.0 upgrade'
+      );
+    assert
+      .dom(`${CLIENT_COUNT.upgradeWarning} ul`)
+      .doesNotHaveTextContaining(
+        '1.10.3',
+        'Warning does not include subsequent patch releases (e.g. 1.10.3) of the same notable upgrade.'
       );
   });
 

--- a/ui/tests/integration/components/open-api-explorer/swagger-ui-test.js
+++ b/ui/tests/integration/components/open-api-explorer/swagger-ui-test.js
@@ -5,10 +5,9 @@
 
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'vault/tests/helpers';
-import { waitFor } from '@ember/test-helpers';
+import { fillIn, render, typeIn, waitFor } from '@ember/test-helpers';
 import { setupEngine } from 'ember-engines/test-support';
 import { setupMirage } from 'ember-cli-mirage/test-support';
-import { render, fillIn } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
 const SELECTORS = {
@@ -52,8 +51,7 @@ module('Integration | Component | open-api-explorer | swagger-ui', function (hoo
 
     // in testing only the input is not filling correctly except after the second time
     await fillIn(SELECTORS.searchInput, 'moot');
-    await fillIn(SELECTORS.searchInput, 'token');
-
+    await typeIn(SELECTORS.searchInput, 'token');
     // for some reason search results are not rendered immediately in tests,
     // so asserting that the search input has the value we expect is the best we can do here
     // if the search fn breaks, this test will fail

--- a/ui/tests/integration/utils/client-count-utils-test.js
+++ b/ui/tests/integration/utils/client-count-utils-test.js
@@ -69,7 +69,7 @@ module('Integration | Util | client count utils', function (hooks) {
         },
         {
           previousVersion: '1.16.0',
-          timestampInstalled: '2023-12-02T01:00:00.000Z',
+          timestampInstalled: '2023-12-02T00:00:00.000Z',
           version: '1.17.0',
         },
       ];
@@ -109,7 +109,7 @@ module('Integration | Util | client count utils', function (hooks) {
         },
       ];
       const startTime = '2023-08-02T00:00:00.000Z'; // same date as 1.9.1 install date to catch same day edge cases
-      const endTime = '2023-11-02T01:00:00.000Z';
+      const endTime = '2023-11-02T00:00:00.000Z';
       const filteredHistory = filterVersionHistory(this.versionHistory, startTime, endTime);
       assert.deepEqual(
         JSON.stringify(filteredHistory),

--- a/ui/tests/integration/utils/client-count-utils-test.js
+++ b/ui/tests/integration/utils/client-count-utils-test.js
@@ -44,9 +44,10 @@ module('Integration | Util | client count utils', function (hooks) {
       this.versionHistory = await store.findAll('clients/version-history').then((resp) => {
         return resp.map(({ version, previousVersion, timestampInstalled }) => {
           return {
-            version,
+            // order of keys needs to match expected order
             previousVersion,
             timestampInstalled,
+            version,
           };
         });
       });
@@ -76,7 +77,7 @@ module('Integration | Util | client count utils', function (hooks) {
       const startTime = '2023-06-02T00:00:00Z'; // first upgrade installed '2023-07-02T00:00:00Z'
       const endTime = '2024-03-04T16:14:21.000Z'; // latest upgrade installed '2023-12-02T01:00:00.000Z'
       const filteredHistory = filterVersionHistory(this.versionHistory, startTime, endTime);
-      assert.strictEqual(
+      assert.deepEqual(
         JSON.stringify(filteredHistory),
         JSON.stringify(expected),
         'it returns all notable upgrades'
@@ -110,7 +111,11 @@ module('Integration | Util | client count utils', function (hooks) {
       const startTime = '2023-08-02T00:00:00.000Z'; // same date as 1.9.1 install date to catch same day edge cases
       const endTime = '2023-11-02T01:00:00.000Z';
       const filteredHistory = filterVersionHistory(this.versionHistory, startTime, endTime);
-      assert.propEqual(filteredHistory, expected, 'it only returns upgrades during date range');
+      assert.deepEqual(
+        JSON.stringify(filteredHistory),
+        JSON.stringify(expected),
+        'it only returns upgrades during date range'
+      );
       assert.notPropContains(
         filteredHistory,
         {

--- a/ui/tests/integration/utils/client-count-utils-test.js
+++ b/ui/tests/integration/utils/client-count-utils-test.js
@@ -76,7 +76,11 @@ module('Integration | Util | client count utils', function (hooks) {
       const startTime = '2023-06-02T00:00:00Z'; // first upgrade installed '2023-07-02T00:00:00Z'
       const endTime = '2024-03-04T16:14:21.000Z'; // latest upgrade installed '2023-12-02T01:00:00.000Z'
       const filteredHistory = filterVersionHistory(this.versionHistory, startTime, endTime);
-      assert.propEqual(filteredHistory, expected, 'it returns all notable upgrades');
+      assert.strictEqual(
+        JSON.stringify(filteredHistory),
+        JSON.stringify(expected),
+        'it returns all notable upgrades'
+      );
       assert.notPropContains(
         filteredHistory,
         {


### PR DESCRIPTION
This way the upgrade banner only displays for users upgrading to 1.17. For users with `previous_version: null` the alert banner is not relevant.

![image](https://github.com/hashicorp/vault/assets/68122737/0f05000f-ffb6-4b73-8856-f8a0090760b1)
