### PR TITLE
bugfix: dashboard overview heading levels

### DIFF
--- a/ui/app/components/dashboard/client-count-card.hbs
+++ b/ui/app/components/dashboard/client-count-card.hbs
@@ -5,9 +5,9 @@
 
 <Hds::Card::Container @hasBorder={{true}} class="has-padding-l" data-test-card="client-count">
   <div class="is-flex-between">
-    <h3 class="title is-4 has-bottom-margin-xxs" data-test-client-count-title>
+    <h2 class="title is-4 has-bottom-margin-xxs" data-test-client-count-title>
       Client count
-    </h3>
+    </h2>
 
     <LinkTo @route="vault.cluster.clients">Details</LinkTo>
   </div>

--- a/ui/app/components/dashboard/learn-more-card.hbs
+++ b/ui/app/components/dashboard/learn-more-card.hbs
@@ -4,7 +4,7 @@
 ~}}
 
 <Hds::Card::Container @hasBorder={{true}} class="has-padding-l" data-test-card="learn-more">
-  <h3 class="title is-4 has-bottom-margin-xxs" data-test-learn-more-title>Learn more</h3>
+  <h2 class="title is-4 has-bottom-margin-xxs" data-test-learn-more-title>Learn more</h2>
   <div class="sub-text" data-test-learn-more-subtext>
     Explore the features of Vault and learn advance practices with the following tutorials and documentation.
   </div>

--- a/ui/app/components/dashboard/quick-actions-card.hbs
+++ b/ui/app/components/dashboard/quick-actions-card.hbs
@@ -4,10 +4,10 @@
 ~}}
 
 <Hds::Card::Container @hasBorder={{true}} class="has-padding-l" data-test-card="quick-actions">
-  <h3 class="title is-4">Quick actions</h3>
+  <h2 class="title is-4">Quick actions</h2>
   {{#if this.filteredSecretEngines}}
     <div class="has-top-margin-m has-bottom-margin-m">
-      <h4 class="title is-marginless is-6" data-test-card-subtitle="secrets-engines">Secrets engines</h4>
+      <h3 class="title is-marginless is-6" data-test-card-subtitle="secrets-engines">Secrets engines</h3>
       <p class="is-size-8 has-top-margin-xxs has-bottom-margin-s has-text-grey">Supported engines include databases, KV
         version 2, and PKI.</p>
       <SearchSelect
@@ -28,7 +28,7 @@
     </div>
 
     {{#if this.selectedEngine}}
-      <h4 id="action-select-title" class="title is-6" data-test-card-subtitle="secrets-engines">Action</h4>
+      <h3 id="action-select-title" class="title is-6" data-test-card-subtitle="secrets-engines">Action</h3>
       <Select
         @name="action-select"
         @options={{this.actionOptions}}
@@ -49,7 +49,7 @@
             @onChange={{fn (mut this.paramValue)}}
           />
         {{else}}
-          <h4 class="title is-6" data-test-card-subtitle="param">{{this.searchSelectParams.title}}</h4>
+          <h3 class="title is-6" data-test-card-subtitle="param">{{this.searchSelectParams.title}}</h3>
 
           <SearchSelect
             class="is-flex-grow-1"

--- a/ui/app/components/dashboard/secrets-engines-card.hbs
+++ b/ui/app/components/dashboard/secrets-engines-card.hbs
@@ -9,7 +9,7 @@
   data-test-card="secrets-engines"
 >
   <div class="is-flex-between">
-    <h3 class="title is-4 has-left-margin-xxs" data-test-dashboard-card-header="Secrets engines">Secrets engines</h3>
+    <h2 class="title is-4 has-left-margin-xxs" data-test-dashboard-card-header="Secrets engines">Secrets engines</h2>
 
     {{#if this.filteredSecretsEngines}}
       <LinkTo class="has-right-margin-xxs" @route="vault.cluster.secrets.backends">


### PR DESCRIPTION
If merged, this PR resolves the issue where dashboard heading levels did not only increase by one. **There should be no visual change with this PR, only underlying markup change.**

Bug: 
![CleanShot 2024-05-07 at 17 00 02@2x](https://github.com/hashicorp/vault/assets/4587451/1900d1b0-2b81-42ec-96e7-d1f62e4d63c8)


How it looked before:
![CleanShot 2024-05-07 at 17 01 45@2x](https://github.com/hashicorp/vault/assets/4587451/42632c76-1fec-49ef-ad1e-35ab3f1b4135)

How it looks after:
![CleanShot 2024-05-07 at 17 03 33@2x](https://github.com/hashicorp/vault/assets/4587451/109665e9-0810-4ca6-9054-61917e9270b7)
