### PR TITLE
NewTestCluster: follow up

### DIFF
--- a/vault/testing.go
+++ b/vault/testing.go
@@ -1414,17 +1414,13 @@ func NewTestCluster(t testing.T, base *CoreConfig, opts *TestClusterOptions) *Te
 	coreConfig := &CoreConfig{
 		LogicalBackends:    make(map[string]logical.Factory),
 		CredentialBackends: make(map[string]logical.Factory),
-		AuditBackends: map[string]audit.Factory{
-			"file":   audit.NewFileBackend,
-			"socket": audit.NewSocketBackend,
-			"syslog": audit.NewSyslogBackend,
-		},
-		RedirectAddr:    fmt.Sprintf("https://127.0.0.1:%d", listeners[0][0].Address.Port),
-		ClusterAddr:     "https://127.0.0.1:0",
-		DisableMlock:    true,
-		EnableUI:        true,
-		EnableRaw:       true,
-		BuiltinRegistry: corehelpers.NewMockBuiltinRegistry(),
+		AuditBackends:      make(map[string]audit.Factory),
+		RedirectAddr:       fmt.Sprintf("https://127.0.0.1:%d", listeners[0][0].Address.Port),
+		ClusterAddr:        "https://127.0.0.1:0",
+		DisableMlock:       true,
+		EnableUI:           true,
+		EnableRaw:          true,
+		BuiltinRegistry:    corehelpers.NewMockBuiltinRegistry(),
 	}
 
 	if base != nil {

--- a/vault/testing.go
+++ b/vault/testing.go
@@ -2094,8 +2094,10 @@ func (tc *TestCluster) initCores(t testing.T, opts *TestClusterOptions, addAudit
 			ClientToken: tc.RootToken,
 			Path:        "sys/audit/file",
 			Data: map[string]interface{}{
-				"type":      audit.TypeFile,
-				"file_path": "discard",
+				"type": audit.TypeFile,
+				"options": map[string]string{
+					"file_path": "discard",
+				},
 			},
 		}
 		resp, err := leader.Core.HandleRequest(namespace.RootContext(ctx), auditReq)


### PR DESCRIPTION
This PR fixes a mistake in test code introduced in https://github.com/hashicorp/vault/pull/26861.

From the previous PR:

> it will add the three supported ones (file, socket, syslog), and enable a file device with the discard file path (similar to a noop).

🙅🏼 

This PR reverts the change to front load adding all three supported audit device types, as the previous test cluster code used to check if we had `0` audit backends, and then add a single one and enable it. 

Finally the 'fix' is also to supply `file_path` within `options` as expected.