### PR TITLE
Consistency using HMAC'd vs HMAC'ed in docs

### DIFF
--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -6331,11 +6331,11 @@ in the plugin catalog.`,
 	},
 
 	"tune_audit_non_hmac_request_keys": {
-		`The list of keys in the request data object that will not be HMAC'ed by audit devices.`,
+		`The list of keys in the request data object that will not be HMAC'd by audit devices.`,
 	},
 
 	"tune_audit_non_hmac_response_keys": {
-		`The list of keys in the response data object that will not be HMAC'ed by audit devices.`,
+		`The list of keys in the response data object that will not be HMAC'd by audit devices.`,
 	},
 
 	"tune_mount_options": {

--- a/website/content/api-docs/system/config-auditing.mdx
+++ b/website/content/api-docs/system/config-auditing.mdx
@@ -88,7 +88,7 @@ This endpoint enables auditing of a header.
 
 ### Parameters
 
-- `hmac` `(bool: false)` – Specifies if this header's value should be HMAC'ed in
+- `hmac` `(bool: false)` – Specifies if this header's value should be HMAC'd in
   the audit logs.
 
 ### Sample payload


### PR DESCRIPTION
Elsewhere in Vault the term used is `HMAC'd` as opposed to `HMAC'ed`.