### PR TITLE
Add missing delegated_auth_accessors config field to /sys/mounts/<path> response

### DIFF
--- a/changelog/26876.txt
+++ b/changelog/26876.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core: Add missing field delegated_auth_accessors to GET /sys/mounts/:path API response
+```

--- a/command/secrets_enable.go
+++ b/command/secrets_enable.go
@@ -41,6 +41,7 @@ type SecretsEnableCommand struct {
 	flagExternalEntropyAccess     bool
 	flagVersion                   int
 	flagAllowedManagedKeys        []string
+	flagDelegatedAuthAccessors    []string
 	flagIdentityTokenKey          string
 }
 
@@ -229,6 +230,14 @@ func (c *SecretsEnableCommand) Flags() *FlagSets {
 			"each time with 1 key.",
 	})
 
+	f.StringSliceVar(&StringSliceVar{
+		Name:   flagNameDelegatedAuthAccessors,
+		Target: &c.flagDelegatedAuthAccessors,
+		Usage: "A list of permitted authentication accessors this backend can delegate authentication to. " +
+			"Note that multiple values may be specified by providing this option multiple times, " +
+			"each time with 1 accessor.",
+	})
+
 	f.StringVar(&StringVar{
 		Name:    flagNameIdentityTokenKey,
 		Target:  &c.flagIdentityTokenKey,
@@ -337,6 +346,10 @@ func (c *SecretsEnableCommand) Run(args []string) int {
 
 		if fl.Name == flagNameAllowedManagedKeys {
 			mountInput.Config.AllowedManagedKeys = c.flagAllowedManagedKeys
+		}
+
+		if fl.Name == flagNameDelegatedAuthAccessors {
+			mountInput.Config.DelegatedAuthAccessors = c.flagDelegatedAuthAccessors
 		}
 
 		if fl.Name == flagNamePluginVersion {

--- a/command/secrets_enable_test.go
+++ b/command/secrets_enable_test.go
@@ -119,6 +119,7 @@ func TestSecretsEnableCommand_Run(t *testing.T) {
 			"-allowed-response-headers", "authorization",
 			"-allowed-managed-keys", "key1,key2",
 			"-identity-token-key", "default",
+			"-delegated-auth-accessors", "authAcc1,authAcc2",
 			"-force-no-cache",
 			"pki",
 		})
@@ -170,6 +171,9 @@ func TestSecretsEnableCommand_Run(t *testing.T) {
 		}
 		if diff := deep.Equal([]string{"key1,key2"}, mountInfo.Config.AllowedManagedKeys); len(diff) > 0 {
 			t.Errorf("Failed to find expected values in AllowedManagedKeys. Difference is: %v", diff)
+		}
+		if diff := deep.Equal([]string{"authAcc1,authAcc2"}, mountInfo.Config.DelegatedAuthAccessors); len(diff) > 0 {
+			t.Errorf("Failed to find expected values in DelegatedAuthAccessors. Difference is: %v", diff)
 		}
 		if diff := deep.Equal("default", mountInfo.Config.IdentityTokenKey); len(diff) > 0 {
 			t.Errorf("Failed to find expected values in IdentityTokenKey. Difference is: %v", diff)

--- a/command/secrets_tune_test.go
+++ b/command/secrets_tune_test.go
@@ -195,6 +195,7 @@ func TestSecretsTuneCommand_Run(t *testing.T) {
 				"-identity-token-key", "default",
 				"-listing-visibility", "unauth",
 				"-plugin-version", version,
+				"-delegated-auth-accessors", "authAcc1,authAcc2",
 				"mount_tune_integration/",
 			})
 			if exp := 0; code != exp {
@@ -245,6 +246,9 @@ func TestSecretsTuneCommand_Run(t *testing.T) {
 			}
 			if diff := deep.Equal([]string{"key1,key2"}, mountInfo.Config.AllowedManagedKeys); len(diff) > 0 {
 				t.Errorf("Failed to find expected values in AllowedManagedKeys. Difference is: %v", diff)
+			}
+			if diff := deep.Equal([]string{"authAcc1,authAcc2"}, mountInfo.Config.DelegatedAuthAccessors); len(diff) > 0 {
+				t.Errorf("Failed to find expected values in DelegatedAuthAccessors. Difference is: %v", diff)
 			}
 			if diff := deep.Equal("default", mountInfo.Config.IdentityTokenKey); len(diff) > 0 {
 				t.Errorf("Failed to find expected values in IdentityTokenKey. Difference is: %v", diff)

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -1424,6 +1424,9 @@ func (b *SystemBackend) mountInfo(ctx context.Context, entry *MountEntry, legacy
 		}
 		entryConfig["user_lockout_config"] = userLockoutConfig
 	}
+	if rawVal, ok := entry.synthesizedConfigCache.Load("delegated_auth_accessors"); ok {
+		entryConfig["delegated_auth_accessors"] = rawVal.([]string)
+	}
 
 	// Add deprecation status only if it exists
 	builtinType := b.Core.builtinTypeFromMountEntry(ctx, entry)

--- a/website/content/docs/commands/secrets/enable.mdx
+++ b/website/content/docs/commands/secrets/enable.mdx
@@ -107,9 +107,9 @@ flags](/vault/docs/commands) included on all commands.
   in question is allowed to access. Note that multiple keys may be specified
   by providing this option multiple times, each time with 1 key.
 
-- `-delegated-auth-accessors` `(string: "")` - A list of permitted authentication
-  accessors this backend can delegate authentication to. Note that multiple accessors
-  may be specified by providing this option multiple times, each time with 1 accessor.
+- `-delegated-auth-accessors` `(string: "")` - An authorized accessors the auth
+  backend can delegate authentication to. To allow multiple accessors, provide
+  the `delegated-auth-accessors` multiple times, each time with 1 accessor.
 
 - `-plugin-version` `(string: "")` - Configures the semantic version of the plugin
   to use. If unspecified, implies the built-in or any matching unversioned plugin

--- a/website/content/docs/commands/secrets/enable.mdx
+++ b/website/content/docs/commands/secrets/enable.mdx
@@ -90,7 +90,7 @@ flags](/vault/docs/commands) included on all commands.
 - `-path` `(string: "")` Place where the secrets engine will be accessible. This
   must be unique cross all secrets engines. This defaults to the "type" of the
   secrets engine.
-  
+
   !> **Case-sensitive:** The path where you enable secrets engines is case-sensitive. For
   example, the KV secrets engine enabled at `kv/` and `KV/` are treated as two
   distinct instances of KV secrets engine.
@@ -107,6 +107,11 @@ flags](/vault/docs/commands) included on all commands.
   in question is allowed to access. Note that multiple keys may be specified
   either by providing the key names as a comma separated string or by providing
   this option multiple times, each time with 1 key.
+
+- `-delegated-auth-accessors` `(string: "")` - A list of permitted authentication
+  accessors this backend can delegate authentication to. Note that multiple keys
+  may be specified either by providing the key names as a comma separated string
+  or by providing this option multiple times, each time with 1 key.
 
 - `-plugin-version` `(string: "")` - Configures the semantic version of the plugin
   to use. If unspecified, implies the built-in or any matching unversioned plugin

--- a/website/content/docs/commands/secrets/enable.mdx
+++ b/website/content/docs/commands/secrets/enable.mdx
@@ -105,13 +105,11 @@ flags](/vault/docs/commands) included on all commands.
 
 - `-allowed-managed-keys` `(string: "")` - Managed key name(s) that the mount
   in question is allowed to access. Note that multiple keys may be specified
-  either by providing the key names as a comma separated string or by providing
-  this option multiple times, each time with 1 key.
+  by providing this option multiple times, each time with 1 key.
 
 - `-delegated-auth-accessors` `(string: "")` - A list of permitted authentication
-  accessors this backend can delegate authentication to. Note that multiple keys
-  may be specified either by providing the key names as a comma separated string
-  or by providing this option multiple times, each time with 1 key.
+  accessors this backend can delegate authentication to. Note that multiple accessors
+  may be specified by providing this option multiple times, each time with 1 accessor.
 
 - `-plugin-version` `(string: "")` - Configures the semantic version of the plugin
   to use. If unspecified, implies the built-in or any matching unversioned plugin

--- a/website/content/docs/commands/secrets/enable.mdx
+++ b/website/content/docs/commands/secrets/enable.mdx
@@ -107,7 +107,7 @@ flags](/vault/docs/commands) included on all commands.
   in question is allowed to access. Note that multiple keys may be specified
   by providing this option multiple times, each time with 1 key.
 
-- `-delegated-auth-accessors` `(string: "")` - An authorized accessors the auth
+- `-delegated-auth-accessors` `(string: "")` - An authorized accessor the auth
   backend can delegate authentication to. To allow multiple accessors, provide
   the `delegated-auth-accessors` multiple times, each time with 1 accessor.
 

--- a/website/content/docs/commands/secrets/tune.mdx
+++ b/website/content/docs/commands/secrets/tune.mdx
@@ -93,7 +93,7 @@ flags](/vault/docs/commands) included on all commands.
   in question is allowed to access. Note that multiple keys may be specified
   by providing this option multiple times, each time with 1 key.
 
-- `-delegated-auth-accessors` `(string: "")` - An authorized accessors the auth
+- `-delegated-auth-accessors` `(string: "")` - An authorized accessor the auth
   backend can delegate authentication to. To allow multiple accessors, provide
   the `delegated-auth-accessors` multiple times, each time with 1 accessor.
 

--- a/website/content/docs/commands/secrets/tune.mdx
+++ b/website/content/docs/commands/secrets/tune.mdx
@@ -93,9 +93,9 @@ flags](/vault/docs/commands) included on all commands.
   in question is allowed to access. Note that multiple keys may be specified
   by providing this option multiple times, each time with 1 key.
 
-- `-delegated-auth-accessors` `(string: "")` - A list of permitted authentication
-  accessors this backend can delegate authentication to. Note that multiple accessors
-  may be specified by providing this option multiple times, each time with 1 accessor.
+- `-delegated-auth-accessors` `(string: "")` - An authorized accessors the auth
+  backend can delegate authentication to. To allow multiple accessors, provide
+  the `delegated-auth-accessors` multiple times, each time with 1 accessor.
 
 - `-plugin-version` `(string: "")` - Configures the semantic version of the plugin
   to use. The new version will not start running until the mount is

--- a/website/content/docs/commands/secrets/tune.mdx
+++ b/website/content/docs/commands/secrets/tune.mdx
@@ -94,6 +94,11 @@ flags](/vault/docs/commands) included on all commands.
   either by providing the key names as a comma separated string or by providing
   this option multiple times, each time with 1 key.
 
+- `-delegated-auth-accessors` `(string: "")` - A list of permitted authentication
+  accessors this backend can delegate authentication to. Note that multiple keys
+  may be specified either by providing the key names as a comma separated string
+  or by providing this option multiple times, each time with 1 key.
+
 - `-plugin-version` `(string: "")` - Configures the semantic version of the plugin
   to use. The new version will not start running until the mount is
   [reloaded](/vault/docs/commands/plugin/reload).

--- a/website/content/docs/commands/secrets/tune.mdx
+++ b/website/content/docs/commands/secrets/tune.mdx
@@ -91,13 +91,11 @@ flags](/vault/docs/commands) included on all commands.
 
 - `-allowed-managed-keys` `(string: "")` - Managed key name(s) that the mount
   in question is allowed to access. Note that multiple keys may be specified
-  either by providing the key names as a comma separated string or by providing
-  this option multiple times, each time with 1 key.
+  by providing this option multiple times, each time with 1 key.
 
 - `-delegated-auth-accessors` `(string: "")` - A list of permitted authentication
-  accessors this backend can delegate authentication to. Note that multiple keys
-  may be specified either by providing the key names as a comma separated string
-  or by providing this option multiple times, each time with 1 key.
+  accessors this backend can delegate authentication to. Note that multiple accessors
+  may be specified by providing this option multiple times, each time with 1 accessor.
 
 - `-plugin-version` `(string: "")` - Configures the semantic version of the plugin
   to use. The new version will not start running until the mount is


### PR DESCRIPTION
 - The field hadn't been properly populated in the JSON struct being returned through the API response, but had been properly set in the stored structs in the backend.
 - Add missing update to the command tune docs for the -delegated-auth-accessors option that existed
 - Add -delegated-auth-accessors to the secret enable vault command along with a docs update