### PR TITLE
Store Cluster Name in Physical Storage

### DIFF
--- a/changelog/26878.txt
+++ b/changelog/26878.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core/metrics: store cluster name in unencrypted storage to prevent blank cluster name
+```


### PR DESCRIPTION
Vault currently displays duplicate and blank cluster labels when deployments are made with k8s.

This is the result of a race condition during the activation of the telemetry system. Telemetry is initialized before Vault is unsealed, therefore it is not able to pull the cluster name and information that is stored in encrypted storage.

To solve this, it was suggested that we store the cluster name in unencrypted storage, so that it can be accessed prior to Vault being unsealed. Vault will then attempt to pull from encrypted storage first, and if it is unable to pull out a valid name, it will then use the value stored in unencrypted storage.