### PR TITLE
Add NewTestLoggerWithSuffix for tests that need multiple log files

### DIFF
--- a/helper/testhelpers/corehelpers/corehelpers.go
+++ b/helper/testhelpers/corehelpers/corehelpers.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/go-hclog"
@@ -210,13 +211,20 @@ type TestLogger struct {
 }
 
 func NewTestLogger(t testing.T) *TestLogger {
+	return NewTestLoggerWithSuffix(t, "")
+}
+
+func NewTestLoggerWithSuffix(t testing.T, logFileSuffix string) *TestLogger {
 	var logFile *os.File
 	var logPath string
 	output := os.Stderr
 
 	logDir := os.Getenv("VAULT_TEST_LOG_DIR")
 	if logDir != "" {
-		logPath = filepath.Join(logDir, t.Name()+".log")
+		if logFileSuffix != "" && !strings.HasPrefix(logFileSuffix, "_") {
+			logFileSuffix = "_" + logFileSuffix
+		}
+		logPath = filepath.Join(logDir, t.Name()+logFileSuffix+".log")
 		// t.Name may include slashes.
 		dir, _ := filepath.Split(logPath)
 		err := os.MkdirAll(dir, 0o755)


### PR DESCRIPTION
Make it possible to add a suffix to the file used by `TestLogger`.

This feature is to be used a unit test in vault-enterprise.