### PR TITLE
Add WithCredentials to AWS auth API

### DIFF
--- a/api/auth/aws/aws.go
+++ b/api/auth/aws/aws.go
@@ -298,3 +298,12 @@ func WithRegion(region string) LoginOption {
 		return nil
 	}
 }
+
+// WithCredentials can be used to specify a custom set of credentials
+// from the source you choose.
+func WithCredentials(creds *credentials.Credentials) LoginOption {
+	return func(a *AWSAuth) error {
+		a.creds = creds
+		return nil
+	}
+}


### PR DESCRIPTION
The default behavior does not allow to fully customize the credentials used to access Vault thru AWS authentication.

The developer can choose to bypass process environment variables and override the default behavior.

Of course process' environment variables can be changed but it is an ugly hack hack.