### PR TITLE
[docs] add note around CRL rotation not occuring on revoke if auto_rebuild is enabled

### DIFF
--- a/website/content/api-docs/secret/pki.mdx
+++ b/website/content/api-docs/secret/pki.mdx
@@ -1491,7 +1491,8 @@ $ curl \
 
 This endpoint revokes a certificate using its serial number. This is an
 alternative option to the standard method of revoking using Vault lease IDs. A
-successful revocation will rotate the CRL.
+successful revocation will rotate the CRL (unless `auto_rebuild` is set to true
+per [the CRL configuration](vault/api-docs/secret/pki#set-revocation-configuration)).
 
 ~> **Note**: This operation is privileged as it allows revocation of arbitrary
    certificates based purely on their serial number. It does not validate that
@@ -1550,7 +1551,8 @@ request is authorized by an appropriate individual (Proof of Possession).
 
 This is an alternative option to the standard method of revoking using Vault
 lease IDs or revocation via serial number. A successful revocation will
-rotate the CRL.
+rotate the CRL (unless `auto_rebuild` is set to true
+per [the CRL configuration](vault/api-docs/secret/pki#set-revocation-configuration)).
 
 It is not possible to revoke issuers using this path.
 


### PR DESCRIPTION
A note to clarify that revocation will not trigger a rotation of the CRL if auto_rebuild of the CRL is set to true/enabled.

https://developer.hashicorp.com/vault/api-docs/secret/pki#revoke-certificate

https://developer.hashicorp.com/vault/api-docs/secret/pki#revoke-certificate-with-private-key

> A successful revocation will rotate the CRL.

becomes

> A successful revocation will rotate the CRL (unless `auto_rebuild` is set to true per [the CRL configuration](vault/api-docs/secret/pki#set-revocation-configuration)).