### PR TITLE
Build the HSM binary for running ENT tests that require it.

### DIFF
--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -306,6 +306,15 @@ jobs:
         run: |
           git config --global url."https://${{ secrets.ELEVATED_GITHUB_TOKEN}}@github.com".insteadOf https://github.com
       - uses: ./.github/actions/install-external-tools
+      - name: Build Vault HSM binary for tests
+        if: inputs.binary-tests && matrix.id == inputs.total-runners && github.repository == 'hashicorp/vault-enterprise'
+        env:
+          GOPRIVATE: github.com/hashicorp/*
+        run: |
+          set -exo pipefail
+          time make prep enthsmdev
+          # The subsequent build of vault will blow away the bin folder
+          mv bin/vault vault-hsm-binary
       - if: inputs.binary-tests && matrix.id == inputs.total-runners
         name: Build dev binary for binary tests
         # The dev mode binary has to exist for binary tests that are dispatched on the last runner.
@@ -399,6 +408,11 @@ jobs:
           # The docker/binary tests are more expensive, and we've had problems with timeouts when running at full
           # parallelism.  The default if -p isn't specified is to use NumCPUs, which seems fine for regular tests.
           package_parallelism=""
+
+          if [ -f vault-hsm-binary ]; then
+            VAULT_HSM_BINARY="$(pwd)/vault-hsm-binary"
+            export VAULT_HSM_BINARY
+          fi
 
           if [ -f bin/vault ]; then
             VAULT_BINARY="$(pwd)/bin/vault"


### PR DESCRIPTION
There are enterprise tests that require the HSB binary, so build it when running the job in the vault-enterprise repository.