### PR TITLE
UI: Add max ttl to acme certificates 

### DIFF
--- a/ui/app/models/pki/config/acme.js
+++ b/ui/app/models/pki/config/acme.js
@@ -66,6 +66,14 @@ export default class PkiConfigAcmeModel extends Model {
   })
   dnsResolver;
 
+  @attr({
+    label: 'Max TTL',
+    editType: 'ttl',
+    helperTextDisabled: 'Specify the maximum TTL for ACME certificates.',
+    helperTextEnabled: 'Role TTL values will be limited to this value.',
+  })
+  maxTtl;
+
   @lazyCapabilities(apiPath`${'id'}/config/acme`, 'id')
   acmePath;
 

--- a/ui/app/models/pki/config/acme.js
+++ b/ui/app/models/pki/config/acme.js
@@ -69,8 +69,9 @@ export default class PkiConfigAcmeModel extends Model {
   @attr({
     label: 'Max TTL',
     editType: 'ttl',
-    helperTextDisabled: 'Specify the maximum TTL for ACME certificates.',
-    helperTextEnabled: 'Role TTL values will be limited to this value.',
+    hideToggle: true,
+    helperTextEnabled:
+      'Specify the maximum TTL for ACME certificates. Role TTL values will be limited to this value.',
   })
   maxTtl;
 

--- a/ui/app/models/pki/sign-intermediate.js
+++ b/ui/app/models/pki/sign-intermediate.js
@@ -19,6 +19,7 @@ const validations = {
   'excludeCnFromSans',
   'customTtl',
   'notBeforeDuration',
+  'enforceLeafNotAfterBehavior',
   'format',
   'permittedDnsDomains',
   'maxPathLength',
@@ -55,6 +56,11 @@ export default class PkiSignIntermediateModel extends PkiCertificateBaseModel {
     defaultValue: '30s',
   })
   notBeforeDuration;
+
+  @attr('boolean', {
+    subText: "Do not truncate the NotAfter field, use the issuer's configured leaf_not_after_behavior",
+  })
+  enforceLeafNotAfterBehavior;
 
   @attr({
     label: 'Permitted DNS domains',

--- a/ui/lib/pki/addon/components/page/pki-configuration-details.hbs
+++ b/ui/lib/pki/addon/components/page/pki-configuration-details.hbs
@@ -42,6 +42,7 @@
       <InfoTableRow
         @label={{or attr.options.label (humanize (dasherize attr.name))}}
         @value={{or (get @acme attr.name) "None"}}
+        @formatTtl={{eq attr.options.editType "ttl"}}
       />
     {{/each}}
   {{/if}}

--- a/ui/tests/acceptance/open-api-path-help-test.js
+++ b/ui/tests/acceptance/open-api-path-help-test.js
@@ -19,46 +19,49 @@ import expectedAuthAttrs from 'vault/tests/helpers/openapi/expected-auth-attrs';
  * if it is not updated automatically or is a more involved feature request.
  * Marked as enterprise so it only runs periodically
  */
-module('Acceptance | OpenAPI provides expected attributes enterprise', function (hooks) {
-  setupApplicationTest(hooks);
-  hooks.beforeEach(function () {
-    this.pathHelp = this.owner.lookup('service:pathHelp');
-    this.store = this.owner.lookup('service:store');
-    return authPage.login();
-  });
-
-  // Secret engines that use OpenAPI
-  ['ssh', 'kmip', 'pki'].forEach(function (testCase) {
-    return module(`${testCase} engine`, function (hooks) {
-      hooks.beforeEach(async function () {
-        this.backend = `${testCase}-openapi`;
-        await runCmd(mountEngineCmd(testCase, this.backend), false);
-      });
-      hooks.afterEach(async function () {
-        await runCmd(deleteEngineCmd(this.backend), false);
-      });
-
-      secretEngineHelper(test, testCase);
+module(
+  'Acceptance | Heads up - backend param changes! Expected OpenAPI attributes enterprise',
+  function (hooks) {
+    setupApplicationTest(hooks);
+    hooks.beforeEach(function () {
+      this.pathHelp = this.owner.lookup('service:pathHelp');
+      this.store = this.owner.lookup('service:store');
+      return authPage.login();
     });
-  });
 
-  // All auth backends use OpenAPI except aws
-  ['azure', 'userpass', 'cert', 'gcp', 'github', 'jwt', 'kubernetes', 'ldap', 'okta', 'radius'].forEach(
-    function (testCase) {
-      return module(`${testCase} auth`, function (hooks) {
+    // Secret engines that use OpenAPI
+    ['ssh', 'kmip', 'pki'].forEach(function (testCase) {
+      return module(`${testCase} engine`, function (hooks) {
         hooks.beforeEach(async function () {
-          this.mount = `${testCase}-openapi`;
-          await runCmd(mountAuthCmd(testCase, this.mount), false);
+          this.backend = `${testCase}-openapi`;
+          await runCmd(mountEngineCmd(testCase, this.backend), false);
         });
         hooks.afterEach(async function () {
-          await runCmd(deleteAuthCmd(this.backend), false);
+          await runCmd(deleteEngineCmd(this.backend), false);
         });
 
-        authEngineHelper(test, testCase);
+        secretEngineHelper(test, testCase);
       });
-    }
-  );
-});
+    });
+
+    // All auth backends use OpenAPI except aws
+    ['azure', 'userpass', 'cert', 'gcp', 'github', 'jwt', 'kubernetes', 'ldap', 'okta', 'radius'].forEach(
+      function (testCase) {
+        return module(`${testCase} auth`, function (hooks) {
+          hooks.beforeEach(async function () {
+            this.mount = `${testCase}-openapi`;
+            await runCmd(mountAuthCmd(testCase, this.mount), false);
+          });
+          hooks.afterEach(async function () {
+            await runCmd(deleteAuthCmd(this.backend), false);
+          });
+
+          authEngineHelper(test, testCase);
+        });
+      }
+    );
+  }
+);
 
 function secretEngineHelper(test, secretEngine) {
   const engineData = expectedSecretAttrs[secretEngine];

--- a/ui/tests/helpers/openapi/expected-secret-attrs.js
+++ b/ui/tests/helpers/openapi/expected-secret-attrs.js
@@ -569,6 +569,12 @@ const pki = {
       fieldGroup: 'default',
       type: 'boolean',
     },
+    maxTtl: {
+      editType: 'ttl',
+      fieldGroup: 'default',
+      helpText:
+        'Specify the maximum TTL for ACME certificates. Role TTL values will be limited to this value',
+    },
   },
   'pki/certificate/generate': {
     role: {

--- a/ui/tests/helpers/openapi/expected-secret-attrs.js
+++ b/ui/tests/helpers/openapi/expected-secret-attrs.js
@@ -1206,6 +1206,12 @@ const pki = {
       fieldGroup: 'default',
       type: 'string',
     },
+    enforceLeafNotAfterBehavior: {
+      editType: 'boolean',
+      fieldGroup: 'default',
+      helpText: "Do not truncate the NotAfter field, use the issuer's configured leaf_not_after_behavior",
+      type: 'boolean',
+    },
     excludeCnFromSans: {
       editType: 'boolean',
       helpText:

--- a/ui/tests/integration/components/pki/pki-sign-intermediate-form-test.js
+++ b/ui/tests/integration/components/pki/pki-sign-intermediate-form-test.js
@@ -47,7 +47,7 @@ module('Integration | Component | pki-sign-intermediate-form', function (hooks) 
 
     assert.dom(selectors.form).exists('Form is rendered');
     assert.dom(selectors.resultsContainer).doesNotExist('Results display not rendered');
-    assert.dom('[data-test-field]').exists({ count: 9 }, '9 default fields shown');
+    assert.dom('[data-test-field]').exists({ count: 10 }, '10 default fields shown');
     assert.dom(selectors.toggleSigningOptions).exists();
     assert.dom(selectors.toggleSANOptions).exists();
     assert.dom(selectors.toggleAdditionalFields).exists();


### PR DESCRIPTION
Adds `max_ttl `to ACME config form and openApi expected attrs. In PKI sending `0` does not mean "use system defaults" and it is not an acceptable value. Hide the toggle for this TTL input and instead always show to avoid assumed default values.
![Screenshot 2024-05-09 at 8 02 00 PM](https://github.com/hashicorp/vault/assets/68122737/39499938-4fec-44cf-b07b-e8546e390a8d)

And adds `enforce_leaf_not_after_behavior` for Sign intermediate actions
![Screenshot 2024-05-09 at 8 11 37 PM](https://github.com/hashicorp/vault/assets/68122737/458b88fe-4ddf-4ff9-8fae-124b5db24389)
![Screenshot 2024-05-09 at 8 13 55 PM](https://github.com/hashicorp/vault/assets/68122737/b4fbfc58-b7f1-4602-a472-ff5f91d4da2a)

