### PR TITLE
AOP: Make config reloadable (enterprise)

### DIFF
--- a/command/server.go
+++ b/command/server.go
@@ -1669,6 +1669,8 @@ func (c *ServerCommand) Run(args []string) int {
 
 			core.ReloadRequestLimiter()
 
+			core.ReloadOverloadController()
+
 			// reloading HCP link
 			hcpLink, err = c.reloadHCPLink(hcpLink, config, core, hcpLogger)
 			if err != nil {

--- a/vault/core_stubs_oss.go
+++ b/vault/core_stubs_oss.go
@@ -108,3 +108,5 @@ func (c *Core) SetMultisealEnabled(_ bool) {}
 func (c *Core) ReloadReplicationCanaryWriteInterval() {}
 
 func (c *Core) GetReplicationLagMillisIgnoreErrs() int64 { return 0 }
+
+func (c *Core) ReloadOverloadController() {}

--- a/vault/core_util.go
+++ b/vault/core_util.go
@@ -222,6 +222,3 @@ func (c *Core) GetRequestLimiter(key string) *limits.RequestLimiter {
 
 // ReloadRequestLimiter is a no-op on CE.
 func (c *Core) ReloadRequestLimiter() {}
-
-// ReloadOverloadController is a no-op on CE.
-func (c *Core) ReloadOverloadController() {}

--- a/vault/core_util.go
+++ b/vault/core_util.go
@@ -222,3 +222,6 @@ func (c *Core) GetRequestLimiter(key string) *limits.RequestLimiter {
 
 // ReloadRequestLimiter is a no-op on CE.
 func (c *Core) ReloadRequestLimiter() {}
+
+// ReloadOverloadController is a no-op on CE.
+func (c *Core) ReloadOverloadController() {}


### PR DESCRIPTION
CE stubs to support reloadable AOP config.
Enterprise PR: https://github.com/hashicorp/vault-enterprise/pull/5805/files