### PR TITLE
Update hashicorp/set-product-version to version 2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,7 +111,7 @@ jobs:
       - uses: ./.github/actions/checkout
         id: checkout # Make sure we check out correct ref after checking changed files
       # Get the vault version metadata
-      - uses: hashicorp/actions-set-product-version@v1
+      - uses: hashicorp/actions-set-product-version@d9b52fb778068099ca4c5e28e1ca0fee2544e114 # v2
         id: set-product-version
         with:
           checkout: false # don't override the reference we've checked out

--- a/.github/workflows/enos-lint.yml
+++ b/.github/workflows/enos-lint.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
       - id: set-product-version
-        uses: hashicorp/actions-set-product-version@v1
+        uses: hashicorp/actions-set-product-version@d9b52fb778068099ca4c5e28e1ca0fee2544e114 # v2
       - id: metadata
         run: |
           echo "version=${{ steps.set-product-version.outputs.product-version }}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
A reimplementation of https://github.com/hashicorp/vault/pull/26892 that uses commit hashes (required by security) instead of direct versions.