### PR TITLE
PKI cert metadata should not cross cluster boundaries

### DIFF
--- a/builtin/logical/pki/backend.go
+++ b/builtin/logical/pki/backend.go
@@ -126,6 +126,7 @@ func Backend(conf *logical.BackendConfig) *backend {
 				clusterConfigPath,
 				issuing.PathCrls,
 				issuing.PathCerts,
+				issuing.PathCertMetadata,
 				acmePathPrefix,
 			},
 


### PR DESCRIPTION
Certificate meta-data should remain local to the cluster that is issuing the certificate, not be replicated to another cluster.