### PR TITLE
Wrap overloaded errors from the WAL backend (enterprise)

### DIFF
--- a/sdk/logical/response_util_test.go
+++ b/sdk/logical/response_util_test.go
@@ -7,6 +7,8 @@ import (
 	"errors"
 	"strings"
 	"testing"
+
+	"github.com/hashicorp/vault/sdk/helper/consts"
 )
 
 func TestResponseUtil_RespondErrorCommon_basic(t *testing.T) {
@@ -82,6 +84,17 @@ func TestResponseUtil_RespondErrorCommon_basic(t *testing.T) {
 			},
 			expectedErr:    errors.New("error due to wrong credentials"),
 			expectedStatus: 400,
+		},
+		{
+			title:   "Overloaded error",
+			respErr: consts.ErrOverloaded,
+			resp: &Response{
+				Data: map[string]interface{}{
+					"error": "overloaded, try again later",
+				},
+			},
+			expectedErr:    consts.ErrOverloaded,
+			expectedStatus: 503,
 		},
 	}
 

--- a/vault/core.go
+++ b/vault/core.go
@@ -203,6 +203,20 @@ func (e *ErrInvalidKey) Error() string {
 	return fmt.Sprintf("invalid key: %v", e.Reason)
 }
 
+// possiblyWrapOverloadedError wraps ErrInternalError with the provided err
+// argument and a description if the err argument is ErrOverloaded. This is a
+// conservative approach to wrapping in some call paths which previously
+// discarded lower-level errors and returned ErrInternalError. The intent is to
+// prevent potential behavior changes by reducing the scope of errors which are
+// bubbled up.
+func possiblyWrapOverloadedError(desc string, err error) error {
+	if errors.Is(err, consts.ErrOverloaded) {
+		return fmt.Errorf("%s: %w: %w", desc, err, ErrInternalError)
+	}
+
+	return ErrInternalError
+}
+
 type RegisterAuthFunc func(context.Context, time.Duration, string, *logical.Auth, string) error
 
 type activeAdvertisement struct {

--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -2404,7 +2404,7 @@ func (c *Core) RegisterAuth(ctx context.Context, tokenTTL time.Duration, path st
 
 	if err := c.tokenStore.create(ctx, &te); err != nil {
 		c.logger.Error("failed to create token", "error", err)
-		return ErrInternalError
+		return possiblyWrapOverloadedError("failed to create token", err)
 	}
 
 	// Populate the client token, accessor, and TTL
@@ -2424,7 +2424,7 @@ func (c *Core) RegisterAuth(ctx context.Context, tokenTTL time.Duration, path st
 				c.logger.Warn("failed to clean up token lease during login request", "request_path", path, "error", err)
 			}
 			c.logger.Error("failed to register token lease during login request", "request_path", path, "error", err)
-			return ErrInternalError
+			return possiblyWrapOverloadedError("failed to register token lease during login request", err)
 		}
 		if te.ExternalID != "" {
 			auth.ClientToken = te.ExternalID


### PR DESCRIPTION
This PR adds the CE plumbing to expose underyling ErrOverloaded errors. The wrapper allows the HTTP layer to correctly assign 503 status codes in responses.