### PR TITLE
Backport update setup-copywrite to 1.14

### DIFF
--- a/.github/workflows/copywrite.yml
+++ b/.github/workflows/copywrite.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
-      - uses: hashicorp/setup-copywrite@v1.1.3
+      - uses: hashicorp/setup-copywrite@32638da2d4e81d56a0764aa1547882fc4d209636 # v1.1.3
         name: Setup Copywrite
         with:
           version: v0.16.4


### PR DESCRIPTION
Manual backport of https://github.com/hashicorp/vault/pull/26955 -- it seems this was updated elsewhere but not using the commit hash. Updating to commit hash for security mandate and to keep branches in sync.