### PR TITLE
UI: improve DR Operation Token flow with PGP 

### DIFF
--- a/changelog/26993.txt
+++ b/changelog/26993.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: Update PGP display and show error for Generate Operation Token flow with PGP
+```

--- a/ui/lib/core/addon/components/choose-pgp-key-form.hbs
+++ b/ui/lib/core/addon/components/choose-pgp-key-form.hbs
@@ -19,19 +19,22 @@
           )
         }}
       </p>
-      <h4 class="has-text-weight-bold is-size-7 has-bottom-padding-m is-fullwidth">
-        {{concat "PGP Key " this.pgpKeyFile.filename}}
-      </h4>
-      <Hds::Copy::Snippet
+      <Hds::CodeBlock
         class="has-bottom-margin-s"
-        @textToCopy={{this.pgpKey}}
-        @color="secondary"
-        @onError={{(fn
-          (set-flash-message "Clipboard copy failed. Please make sure the browser Clipboard API is allowed." "danger")
-        )}}
+        @isStandalone={{true}}
+        @hasLineNumbers={{false}}
+        @hasCopyButton={{true}}
+        @value={{this.pgpKey}}
         data-test-pgp-key-copy
-        @container="#shamir-flow-modal"
-      />
+        as |CB|
+      >
+        <CB.Title>
+          Base64 encoded PGP Key
+        </CB.Title>
+        <CB.Description>
+          Contents of PGP Key "{{this.pgpKeyFile.filename}}"
+        </CB.Description>
+      </Hds::CodeBlock>
     </div>
     <Hds::ButtonSet>
       <Hds::Button

--- a/ui/lib/core/addon/components/choose-pgp-key-form.hbs
+++ b/ui/lib/core/addon/components/choose-pgp-key-form.hbs
@@ -19,22 +19,20 @@
           )
         }}
       </p>
-      <Hds::CodeBlock
+      <h4 class="has-text-weight-bold is-size-7 has-bottom-padding-m is-fullwidth">
+        {{concat "PGP Key " this.pgpKeyFile.filename}}
+      </h4>
+      <Hds::Copy::Snippet
         class="has-bottom-margin-s"
-        @isStandalone={{true}}
-        @hasLineNumbers={{false}}
-        @hasCopyButton={{true}}
-        @value={{this.pgpKey}}
+        @textToCopy={{this.pgpKey}}
+        @color="secondary"
+        @onError={{(fn
+          (set-flash-message "Clipboard copy failed. Please make sure the browser Clipboard API is allowed." "danger")
+        )}}
+        @isTruncated={{true}}
         data-test-pgp-key-copy
-        as |CB|
-      >
-        <CB.Title>
-          Base64 encoded PGP Key
-        </CB.Title>
-        <CB.Description>
-          Contents of PGP Key "{{this.pgpKeyFile.filename}}"
-        </CB.Description>
-      </Hds::CodeBlock>
+        @container="#shamir-flow-modal"
+      />
     </div>
     <Hds::ButtonSet>
       <Hds::Button

--- a/ui/lib/core/addon/components/shamir/dr-token-flow.hbs
+++ b/ui/lib/core/addon/components/shamir/dr-token-flow.hbs
@@ -96,6 +96,7 @@
     </p>
   </Shamir::Form>
 {{else if this.generateWithPGP}}
+  <MessageError @errors={{this.errors}} />
   <ChoosePgpKeyForm
     @onCancel={{fn (mut this.generateWithPGP) false}}
     @onSubmit={{this.usePgpKey}}

--- a/ui/tests/integration/components/choose-pgp-key-form-test.js
+++ b/ui/tests/integration/components/choose-pgp-key-form-test.js
@@ -16,7 +16,7 @@ const CHOOSE_PGP = {
   useKeyButton: '[data-test-use-pgp-key-button]',
   pgpTextArea: '[data-test-pgp-file-textarea]',
   confirm: '[data-test-pgp-key-confirm]',
-  base64Output: '[data-test-pgp-key-copy] pre',
+  base64Output: '[data-test-pgp-key-copy]',
   submit: '[data-test-confirm-pgp-key-submit]',
   cancel: '[data-test-use-pgp-key-cancel]',
 };

--- a/ui/tests/integration/components/choose-pgp-key-form-test.js
+++ b/ui/tests/integration/components/choose-pgp-key-form-test.js
@@ -9,6 +9,17 @@ import { setupRenderingTest } from 'vault/tests/helpers';
 import { click, fillIn, render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
+const CHOOSE_PGP = {
+  begin: '[data-test-choose-pgp-key-form="begin"]',
+  description: '[data-test-choose-pgp-key-description]',
+  toggle: '[data-test-text-toggle]',
+  useKeyButton: '[data-test-use-pgp-key-button]',
+  pgpTextArea: '[data-test-pgp-file-textarea]',
+  confirm: '[data-test-pgp-key-confirm]',
+  base64Output: '[data-test-pgp-key-copy] pre',
+  submit: '[data-test-confirm-pgp-key-submit]',
+  cancel: '[data-test-use-pgp-key-cancel]',
+};
 module('Integration | Component | choose-pgp-key-form', function (hooks) {
   setupRenderingTest(hooks);
 
@@ -22,25 +33,24 @@ module('Integration | Component | choose-pgp-key-form', function (hooks) {
       hbs`<ChoosePgpKeyForm @onSubmit={{this.onSubmit}} @onCancel={{this.onCancel}} @formText="my custom form text" @buttonText="Do it" />`
     );
 
-    assert.dom('[data-test-choose-pgp-key-form="begin"]').exists('PGP key selection form exists');
+    assert.dom(CHOOSE_PGP.begin).exists('PGP key selection form exists');
+    assert.dom(CHOOSE_PGP.description).hasText('my custom form text', 'uses custom form text');
+    await click(CHOOSE_PGP.toggle);
+    assert.dom(CHOOSE_PGP.useKeyButton).isDisabled('use pgp button is disabled');
+    await fillIn(CHOOSE_PGP.pgpTextArea, 'base64-pgp-key');
+    assert.dom(CHOOSE_PGP.useKeyButton).isNotDisabled('use pgp button is no longer disabled');
+    await click(CHOOSE_PGP.useKeyButton);
     assert
-      .dom('[data-test-choose-pgp-key-description]')
-      .hasText('my custom form text', 'uses custom form text');
-    await click('[data-test-text-toggle]');
-    assert.dom('[data-test-use-pgp-key-button]').isDisabled('use pgp button is disabled');
-    await fillIn('[data-test-pgp-file-textarea]', 'base64-pgp-key');
-    assert.dom('[data-test-use-pgp-key-button]').isNotDisabled('use pgp button is no longer disabled');
-    await click('[data-test-use-pgp-key-button]');
-    assert
-      .dom('[data-test-pgp-key-confirm]')
+      .dom(CHOOSE_PGP.confirm)
       .hasText(
         'Below is the base-64 encoded PGP Key that will be used. Click the "Do it" button to proceed.',
         'Incorporates button text in confirmation'
       );
-    assert.dom('[data-test-pgp-key-copy]').hasText('base64-pgp-key', 'Shows PGP key contents');
-    assert.dom('[data-test-confirm-pgp-key-submit]').hasText('Do it', 'uses passed buttonText');
-    await click('[data-test-confirm-pgp-key-submit]');
+    assert.dom(CHOOSE_PGP.base64Output).hasText('base64-pgp-key', 'Shows PGP key contents');
+    assert.dom(CHOOSE_PGP.submit).hasText('Do it', 'uses passed buttonText');
+    await click(CHOOSE_PGP.submit);
   });
+
   test('it calls onSubmit correctly', async function (assert) {
     const submitSpy = sinon.spy();
     this.set('onSubmit', submitSpy);
@@ -48,24 +58,24 @@ module('Integration | Component | choose-pgp-key-form', function (hooks) {
       hbs`<ChoosePgpKeyForm @onSubmit={{this.onSubmit}} @onCancel={{this.onCancel}} @buttonText="Submit" />`
     );
 
-    assert.dom('[data-test-choose-pgp-key-form="begin"]').exists('PGP key selection form exists');
+    assert.dom(CHOOSE_PGP.begin).exists('PGP key selection form exists');
     assert
-      .dom('[data-test-choose-pgp-key-description]')
+      .dom(CHOOSE_PGP.description)
       .hasText('Choose a PGP Key from your computer or paste the contents of one in the form below.');
-    await click('[data-test-text-toggle]');
-    assert.dom('[data-test-use-pgp-key-button]').isDisabled('use pgp button is disabled');
-    await fillIn('[data-test-pgp-file-textarea]', 'base64-pgp-key');
-    assert.dom('[data-test-use-pgp-key-button]').isNotDisabled('use pgp button is no longer disabled');
-    await click('[data-test-use-pgp-key-button]');
+    await click(CHOOSE_PGP.toggle);
+    assert.dom(CHOOSE_PGP.useKeyButton).isDisabled('use pgp button is disabled');
+    await fillIn(CHOOSE_PGP.pgpTextArea, 'base64-pgp-key');
+    assert.dom(CHOOSE_PGP.useKeyButton).isNotDisabled('use pgp button is no longer disabled');
+    await click(CHOOSE_PGP.useKeyButton);
     assert
-      .dom('[data-test-pgp-key-confirm]')
+      .dom(CHOOSE_PGP.confirm)
       .hasText(
         'Below is the base-64 encoded PGP Key that will be used. Click the "Submit" button to proceed.',
         'Confirmation text has buttonText'
       );
-    assert.dom('[data-test-pgp-key-copy]').hasText('base64-pgp-key', 'Shows PGP key contents');
-    assert.dom('[data-test-confirm-pgp-key-submit]').hasText('Submit', 'uses passed buttonText');
-    await click('[data-test-confirm-pgp-key-submit]');
+    assert.dom(CHOOSE_PGP.base64Output).hasText('base64-pgp-key', 'Shows PGP key contents');
+    assert.dom(CHOOSE_PGP.submit).hasText('Submit', 'uses passed buttonText');
+    await click(CHOOSE_PGP.submit);
     assert.ok(submitSpy.calledOnceWith('base64-pgp-key'));
   });
 
@@ -76,9 +86,9 @@ module('Integration | Component | choose-pgp-key-form', function (hooks) {
       hbs`<ChoosePgpKeyForm @onSubmit={{this.onSubmit}} @onCancel={{this.onCancel}} @buttonText="Submit" />`
     );
 
-    await click('[data-test-text-toggle]');
-    await fillIn('[data-test-pgp-file-textarea]', 'base64-pgp-key');
-    await click('[data-test-use-pgp-key-cancel]');
+    await click(CHOOSE_PGP.toggle);
+    await fillIn(CHOOSE_PGP.pgpTextArea, 'base64-pgp-key');
+    await click(CHOOSE_PGP.cancel);
     assert.ok(cancelSpy.calledOnce);
   });
 });

--- a/ui/tests/integration/components/shamir/dr-token-flow-test.js
+++ b/ui/tests/integration/components/shamir/dr-token-flow-test.js
@@ -6,7 +6,7 @@
 import sinon from 'sinon';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'vault/tests/helpers';
-import { click, fillIn, find, render, waitUntil } from '@ember/test-helpers';
+import { click, fillIn, find, render, waitFor, waitUntil } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { overrideResponse } from 'vault/tests/helpers/stubs';
@@ -170,7 +170,7 @@ module('Integration | Component | shamir/dr-token-flow', function (hooks) {
   });
 
   test('it shows error with pgp key', async function (assert) {
-    assert.expect(3);
+    assert.expect(2);
     this.server.get('/sys/replication/dr/secondary/generate-operation-token/attempt', function () {
       return {};
     });
@@ -184,7 +184,8 @@ module('Integration | Component | shamir/dr-token-flow', function (hooks) {
     await fillIn('[data-test-pgp-file-textarea]', 'some-key-here');
     await click('[data-test-use-pgp-key-button]');
     await click('[data-test-confirm-pgp-key-submit]');
-    assert.dom(GENERAL.messageError).hasText('error parsing PGP key');
+    await waitFor(GENERAL.messageError);
+    assert.dom(GENERAL.messageError).hasText('Error error parsing PGP key');
   });
 
   test('it cancels correctly when generation not started', async function (assert) {

--- a/ui/tests/integration/components/shamir/dr-token-flow-test.js
+++ b/ui/tests/integration/components/shamir/dr-token-flow-test.js
@@ -175,7 +175,7 @@ module('Integration | Component | shamir/dr-token-flow', function (hooks) {
       return {};
     });
     this.server.post('/sys/replication/dr/secondary/generate-operation-token/attempt', () =>
-      overrideResponse(400, ['error parsing PGP key'])
+      overrideResponse(400, { errors: ['error parsing PGP key'] })
     );
     await render(hbs`<Shamir::DrTokenFlow @action="generate-dr-operation-token" />`);
     await click('[data-test-use-pgp-key-cta]');


### PR DESCRIPTION
This PR improves the DR Operation Token flow when using a PGP key. It replaces the CopySnippet component with CodeBlock which supports line wrapping, and it is updated so that errors returned from the API after clicking "Generate Operation Token" will show on the PGP screen. 

After: 
![image](https://github.com/hashicorp/vault/assets/82459713/6e7e9b22-2334-4224-9f6f-7c48fe4777e8)

Before: 
![19cad09a56b3ddd1e8a29bbbf49f1cfd](https://github.com/hashicorp/vault/assets/82459713/c78b3b17-f419-4a9e-b5d3-2e2365999ff6)

This is only being backport to 1.16 because CodeSnippet was released in [Helios 3.1.0](https://github.com/hashicorp/design-system/releases/tag/%40hashicorp%2Fdesign-system-components%403.1.0) and Vault upgraded to v3 in 1.16

- [x] Ent tests pass