### PR TITLE
Fix failing enterprise-replication-modes-test

### DIFF
--- a/ui/tests/acceptance/enterprise-replication-modes-test.js
+++ b/ui/tests/acceptance/enterprise-replication-modes-test.js
@@ -34,11 +34,13 @@ module('Acceptance | Enterprise | replication modes', function (hooks) {
   });
 
   test('replication page when unsupported', async function (assert) {
-    await this.setupMocks({
+    this.server.get('sys/replication/status', () => ({
       data: {
         mode: 'unsupported',
       },
-    });
+    }));
+
+    await authPage.login();
     await visit('/vault/replication');
     assert.dom(s.title).hasText('Replication unsupported', 'it shows the unsupported view');
 
@@ -47,9 +49,10 @@ module('Acceptance | Enterprise | replication modes', function (hooks) {
     assert.dom(s.navLink('Disaster Recovery')).doesNotExist('hides dr link');
   });
 
-  test('replication page when disabled', async function (assert) {
+  test('replication page when disabled meep', async function (assert) {
     await this.setupMocks(STATUS_DISABLED_RESPONSE);
     await visit('/vault/replication');
+
     assert.dom(s.title).hasText('Enable Replication', 'it shows the enable view');
 
     // Nav links

--- a/ui/tests/acceptance/enterprise-replication-modes-test.js
+++ b/ui/tests/acceptance/enterprise-replication-modes-test.js
@@ -49,10 +49,9 @@ module('Acceptance | Enterprise | replication modes', function (hooks) {
     assert.dom(s.navLink('Disaster Recovery')).doesNotExist('hides dr link');
   });
 
-  test('replication page when disabled meep', async function (assert) {
+  test('replication page when disabled', async function (assert) {
     await this.setupMocks(STATUS_DISABLED_RESPONSE);
     await visit('/vault/replication');
-
     assert.dom(s.title).hasText('Enable Replication', 'it shows the enable view');
 
     // Nav links


### PR DESCRIPTION
Not sure why this wasn't working, but it wasn't just flaky, it was consistently failing. I broke apart the `setupMocks` function and called it directly inside the test itself and that fixed it. 

This is failing on 1.15.x and 1.16.x to so i'll attempt a backport.

- [x] ent test pass
- [ ] did a binary run through on replication to spot check: enable dr and add secondary then disable. enable performance and add secondary and then disable. 