### PR TITLE
UI: Fix generic v2 secret engine links

### DIFF
--- a/changelog/27019.txt
+++ b/changelog/27019.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fix link to v2 generic secrets engine from secrets list page.
+```

--- a/ui/app/models/secret-engine.js
+++ b/ui/app/models/secret-engine.js
@@ -148,6 +148,10 @@ export default class SecretEngineModel extends Model {
       const { engineRoute } = allEngines().find((engine) => engine.type === this.engineType);
       return `vault.cluster.secrets.backend.${engineRoute}`;
     }
+    if (this.isV2KV) {
+      // if it's KV v2 but not registered as an addon, it's type generic
+      return 'vault.cluster.secrets.backend.kv.list';
+    }
     return `vault.cluster.secrets.backend.list-root`;
   }
 

--- a/ui/app/routes/vault/cluster/secrets/backend/list.js
+++ b/ui/app/routes/vault/cluster/secrets/backend/list.js
@@ -96,6 +96,9 @@ export default Route.extend({
         return this.router.transitionTo('vault.cluster.secrets.backend.kv.list-directory', backend, secret);
       }
       return this.router.transitionTo(`vault.cluster.secrets.backend.${engineRoute}`, backend);
+    } else if (secretEngine.isV2KV) {
+      // if it's KV v2 but not registered as an addon, it's type generic
+      return this.router.transitionTo('vault.cluster.secrets.backend.kv.list', backend);
     }
     const modelType = this.getModelType(backend, tab);
     return this.pathHelp.getNewModel(modelType, backend).then(() => {

--- a/ui/tests/acceptance/secrets/backend/generic/secret-test.js
+++ b/ui/tests/acceptance/secrets/backend/generic/secret-test.js
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { currentRouteName, visit } from '@ember/test-helpers';
+import { click, currentRouteName, settled, visit } from '@ember/test-helpers';
+import { selectChoose } from 'ember-power-select/test-support';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { v4 as uuidv4 } from 'uuid';
@@ -63,7 +64,10 @@ module('Acceptance | secrets/generic/create', function (hooks) {
       // upgrade to version 2 generic mount
       `write sys/mounts/${path}/tune options=version=2`,
     ]);
-    await visit(`/vault/secrets/${path}/kv/list`);
+    await visit('/vault/secrets');
+    await selectChoose('[data-test-component="search-select"]#filter-by-engine-name', path);
+    await settled();
+    await click(`[data-test-secrets-backend-link="${path}"]`);
 
     assert
       .dom(PAGE.list.item('foo'))

--- a/ui/tests/acceptance/secrets/backend/generic/secret-test.js
+++ b/ui/tests/acceptance/secrets/backend/generic/secret-test.js
@@ -68,6 +68,11 @@ module('Acceptance | secrets/generic/create', function (hooks) {
     await selectChoose('[data-test-component="search-select"]#filter-by-engine-name', path);
     await settled();
     await click(`[data-test-secrets-backend-link="${path}"]`);
+    assert.strictEqual(
+      currentRouteName(),
+      'vault.cluster.secrets.backend.kv.list',
+      'navigates to the KV engine list page'
+    );
 
     assert
       .dom(PAGE.list.item('foo'))
@@ -80,6 +85,13 @@ module('Acceptance | secrets/generic/create', function (hooks) {
       assert.dom(PAGE.list.item(secret.path)).exists('lists both records');
     });
     assert.dom(PAGE.list.item()).exists({ count: 2 }, 'lists only the two secrets');
+
+    await visit(`/vault/secrets/${path}/list`);
+    assert.strictEqual(
+      currentRouteName(),
+      'vault.cluster.secrets.backend.kv.list',
+      'redirects to the KV engine list page from generic list'
+    );
 
     // Clean up
     await runCmd(deleteEngineCmd(path));


### PR DESCRIPTION
This PR fixes the links for generic engines that were upgraded to V2 so that they can see the correct data. 

**Before, after upgrading:**
![image](https://github.com/hashicorp/vault/assets/82459713/39abe6e7-61b4-4834-8477-8ea819b66083)

**After**
![image](https://github.com/hashicorp/vault/assets/82459713/e4df76b4-066f-4c3f-a909-fa4e3e790e1d)
