### PR TITLE
Update cert metadata docs

### DIFF
--- a/website/content/api-docs/secret/pki.mdx
+++ b/website/content/api-docs/secret/pki.mdx
@@ -50,7 +50,7 @@ update your API calls accordingly.
   - [OCSP Request](#ocsp-request)
   - [List Certificates](#list-certificates)
   - [Read Certificate](#read-certificate)
-  - [Read Metadata](#read-metadata)
+  - [Read Certificate Metadata <EnterpriseAlert inline="true" />](#read-certificate-metadata)
 - [Managing Keys and Issuers](#managing-keys-and-issuers)
   - [List Issuers](#list-issuers)
   - [List Keys](#list-keys)
@@ -672,7 +672,10 @@ It is suggested to limit access to the path-overridden issue endpoint (on
   signed certificate. This field is validated against `allowed_user_ids` on
   the role.
 
-- `metadata` `(string: "")` - Metadata to be associated with the certificate.
+- `metadata` `(string: "")` - <EnterpriseAlert inline="true" /> A blank
+  or base 64 encoded value to be associated with the certificate's serial
+  number. The role's `no_store_metadata` must be set to false, otherwise an
+  error is returned when specified.
 
 #### Sample payload
 
@@ -900,7 +903,10 @@ It is suggested to limit access to the path-overridden sign endpoint (on
   signed certificate. This field is validated against `allowed_user_ids` on
   the role.
 
-- `metadata` `(string: "")` - Metadata to be associated with the certificate.
+- `metadata` `(string: "")` - <EnterpriseAlert inline="true" /> A blank
+  or base 64 encoded value to be associated with the certificate's serial
+  number. The role's `no_store_metadata` must be set to false, otherwise an
+  error is returned when specified.
 
 #### Sample payload
 
@@ -1467,7 +1473,10 @@ have access.**
   User ID (OID 0.9.2342.19200300.100.1.1) Subject values to be placed on the
   signed certificate. No validation on names is performed using this endpoint.
 
-- `metadata` `(string: "")` - Metadata to be associated with the certificate.
+- `metadata` `(string: "")` - <EnterpriseAlert inline="true" /> A blank
+  or base 64 encoded value to be associated with the certificate's serial
+  number. The role's `no_store_metadata` must be set to false, otherwise an
+  error is returned when specified.
 
 #### Sample payload
 
@@ -2137,9 +2146,7 @@ $ curl \
 }
 ```
 
-<a name="read-cert-metadata"></a>
-
-### Read metadata
+### Read Certificate Metadata <EnterpriseAlert inline="true" />
 
 This endpoint retrieves the metadata associated with the certificate
 specified by the serial number.
@@ -3645,9 +3652,11 @@ request is denied.
   Use the bare wildcard `*` value to allow any value. See also the `user_ids`
   request parameter.
 
-- `no_store_metadata` `(bool: false)` - If set, metadata can be stored associated
-  with certificates issued/signed against this role. This is independent of `no_store`,
-  so metadata can be stored regardless of whether certificates are stored.
+- `no_store_metadata` `(bool: false)` - <EnterpriseAlert inline="true" /> allows
+  metadata to be stored keyed on the certificate's serial number. The field is
+  independent of `no_store`, allowing metadata storage regardless of whether
+  certificates are stored. If true, metadata is not stored and an error is returned
+  if the `metadata` field is specified on issuance APIs
 
 #### Sample payload
 

--- a/website/content/api-docs/secret/pki.mdx
+++ b/website/content/api-docs/secret/pki.mdx
@@ -2176,7 +2176,8 @@ $ curl \
     "issuer_id": "e27bf456-51e1-d937-0001-4a609184fd9b",
     "expiration": "2022-11-02T14:41:47.327515Z",
     "metadata": "user-provided-metadata",
-    "role": "role-name"
+    "role": "role-name",
+    "serial_number": "67:b4:f7:2c:aa:ef:b9:30:f6:ae:f5:12:21:79:ac:08:8a:86:89:72"
   }
 }
 ```

--- a/website/content/api-docs/secret/pki.mdx
+++ b/website/content/api-docs/secret/pki.mdx
@@ -1402,7 +1402,8 @@ have access.**
    path and takes the value `default`.
 
 - `name` `(string: "")` - Specifies a role. If set, the following parameters
-  from the role will have effect: `ttl`, `max_ttl`, `generate_lease`, `no_store` and `not_before_duration`.
+  from the role will have effect: `ttl`, `max_ttl`, `issuer`, `generate_lease`,
+  `no_store`, `no_store_metadata` and `not_before_duration`.
 
 - `csr` `(string: <required>)` - Specifies the PEM-encoded CSR.
 

--- a/website/content/docs/secrets/pki/considerations.mdx
+++ b/website/content/docs/secrets/pki/considerations.mdx
@@ -166,7 +166,8 @@ some considerations to be aware of:
  - Storage is an important factor: with [BYOC Revocation](/vault/api-docs/secret/pki#revoke-certificate),
    using `no_store=true` still gives you the ability to revoke certificates
    and audit logs can be used to track issuance. Clusters using a remote
-   storage (like Consul) over a slow network and using `no_store=false` will
+   storage (like Consul) over a slow network and using `no_store=false`
+   or `no_store_cert_metadata=false` along with specifying metadata on issuance, will
    result in additional latency on issuance. Adding leases for every issued
    certificate compounds the problem.
 
@@ -466,7 +467,8 @@ CRLs adequately small.
 
 ### Cluster performance and quantity of leaf certificates
 
-As mentioned above, keeping TTLs short (or using `no_store=true`) and avoiding
+As mentioned above, keeping TTLs short (or using `no_store=true` and
+`no_store_cert_metadata=true`) and avoiding
 leases is important for a healthy cluster. However it is important to note
 this is a scale problem: 10-1000 long-lived, stored certificates are probably
 fine, but 50k-100k become a problem and 500k+ stored, unexpired certificates
@@ -702,9 +704,9 @@ be used sparingly, if at all).
    unless IP address certificates are explicitly required.
  - When using short TTLs (< 30 days) or with high issuance volume, it is
    generally recommend to set `no_store` to `true` (defaults to `false`).
-   This prevents revocation but allows higher throughput as Vault no longer
-   needs to store every issued certificate. This is discussed more in the
-   [Replicated Datasets](#replicated-datasets) section below.
+   This prevents serial number based revocation, but allows higher throughput
+   as Vault no longer needs to store every issued certificate. This is discussed
+   more in the [Replicated Datasets](#replicated-datasets) section below.
  - Do not use roles with root certificates (`issuer_ref`). Root certificates
    should generally only issue intermediates (see the section on [CA hierarchy
    above](#use-a-ca-hierarchy)), which doesn't rely on roles.
@@ -905,12 +907,13 @@ sent to the appropriate cluster that the data was generated on.
 | CRL                      | No                         |
 | Revoked Certificates     | No                         |
 | Leaf/Issued Certificates | No                         |
+| Certificate Metadata     | No                         |
 
 The main effect is that within the PKI secrets engine leaf certificates
 issued with `no_store` set to `false` are stored local to the cluster that issued them.
 This allows for both primary and [Performance Secondary](/vault/docs/enterprise/replication#architecture)
 clusters' active node to issue certificates for greater scalability. As a
-result, these certificates and any revocations are visible only on the issuing
+result, these certificates, metadata and any revocations are visible only on the issuing
 cluster. This additionally means each cluster has its own set of CRLs, distinct
 from other clusters. These CRLs should either be unified into a single CRL for
 distribution from a single URI, or server operators should know to fetch all
@@ -937,10 +940,12 @@ and thus scale horizontally across all nodes within a cluster.
 | sign                          | Update <sup>\*</sup> |
 | sign-verbatim                 | Update <sup>\*</sup> |
 
-\* Only if the corresponding role has `no_store` set to true and `generate_lease`
-set to false. If `generate_lease` is true the lease creation will be forwarded to
-the active node; if `no_store` is false the entire request will be forwarded to
-the active node.
+\* Only if the corresponding role has `no_store` set to true, `generate_lease`
+set to false and no metadata is being written. If `generate_lease` is true the
+lease creation will be forwarded to the active node; if `no_store` is false
+the entire request will be forwarded to the active node.
+If `no_store_cert_metadata=false` and `metadata` argument is provided the entire
+request will be forwarded to the active node.
 
 ## PSS support
 


### PR DESCRIPTION
 - Add missing enterprise notices on parameters and titles
 - Mention that the metadata parameter is a base64 encoded string
 - Tweak the no_store_metadata description
 - Update some entries within the PKI considerations page