### PR TITLE
enos: correctly set up profile

### DIFF
--- a/enos/enos-dev-scenario-pr-replication.hcl
+++ b/enos/enos-dev-scenario-pr-replication.hcl
@@ -3,11 +3,6 @@
 
 scenario "dev_pr_replication" {
   description = <<-EOF
-    This scenario spins up a single Vault cluster with either an external Consul cluster or
-    integrated Raft for storage. None of our test verification is included in this scenario in order
-    to improve end-to-end speed. If you wish to perform such verification you'll need to use a
-    non-dev scenario instead.
-
     This scenario spins up a two Vault clusters with either an external Consul cluster or
     integrated Raft for storage. The secondary cluster is configured with performance replication
     from the primary cluster. None of our test verification is included in this scenario in order

--- a/enos/modules/vault_cluster/main.tf
+++ b/enos/modules/vault_cluster/main.tf
@@ -250,7 +250,7 @@ resource "enos_remote_exec" "configure_login_shell_profile" {
 
   environment = {
     VAULT_ADDR        = "http://127.0.0.1:8200"
-    VAULT_TOKEN       = enos_vault_init.leader[0].root_token
+    VAULT_TOKEN       = var.root_token != null ? var.root_token : try(enos_vault_init.leader[0].root_token, "_")
     VAULT_INSTALL_DIR = var.install_dir
   }
 

--- a/enos/modules/vault_cluster/scripts/set-up-login-shell-profile.sh
+++ b/enos/modules/vault_cluster/scripts/set-up-login-shell-profile.sh
@@ -41,6 +41,12 @@ main() {
     fail "failed to determine login shell profile file location"
   fi
 
+  # If vault_cluster is used more than once, eg: autopilot or replication, this module can
+  # be called more than once. Short ciruit here if our profile is already set up.
+  if grep VAULT_ADDR < "$profile_file"; then
+    exit 0
+  fi
+
   if ! appendVaultProfileInformation "$profile_file"; then
     fail "failed to write vault configuration to login shell profile"
   fi


### PR DESCRIPTION
Handle cases where `vault_cluster` is used more than once on a host. This includes cases where we aren't initing.