### PR TITLE
Prevent SelectableCards from click events when disabled

### DIFF
--- a/ui/lib/core/addon/components/selectable-card.hbs
+++ b/ui/lib/core/addon/components/selectable-card.hbs
@@ -8,8 +8,8 @@
   class="selectable-card {{if @disabled 'disabled'}}"
   @level={{if @disabled "base" "mid"}}
   @hasBorder={{true}}
-  {{on "click" @onClick}}
-  {{on "keypress" @onClick}}
+  {{on "click" (if @disabled (noop) @onClick)}}
+  {{on "keypress" (if @disabled (noop) @onClick)}}
   ...attributes
 >
   {{yield}}

--- a/ui/tests/integration/components/selectable-card-test.js
+++ b/ui/tests/integration/components/selectable-card-test.js
@@ -27,7 +27,7 @@ module('Integration | Component selectable-card', function (hooks) {
     assert.dom('.selectable-card').hasText('hello');
   });
 
-  test('it does not allow click or key actions on disabled card', async function (assert) {
+  test('it does process click event on disabled card', async function (assert) {
     await render(hbs`<SelectableCard @onClick={{this.onClick}} @disabled={{true}}>disabled</SelectableCard>`);
     await click('.selectable-card');
     assert.notOk(this.onClick.calledOnce, 'does not call the click event');

--- a/ui/tests/integration/components/selectable-card-test.js
+++ b/ui/tests/integration/components/selectable-card-test.js
@@ -26,4 +26,10 @@ module('Integration | Component selectable-card', function (hooks) {
     await render(hbs`<SelectableCard  @onClick={{this.onClick}}>hello</SelectableCard>`);
     assert.dom('.selectable-card').hasText('hello');
   });
+
+  test('it does not allow click or key actions on disabled card', async function (assert) {
+    await render(hbs`<SelectableCard @onClick={{this.onClick}} @disabled={{true}}>disabled</SelectableCard>`);
+    await click('.selectable-card');
+    assert.notOk(this.onClick.calledOnce, 'does not call the click event');
+  });
 });

--- a/ui/tests/integration/components/selectable-card-test.js
+++ b/ui/tests/integration/components/selectable-card-test.js
@@ -27,7 +27,7 @@ module('Integration | Component selectable-card', function (hooks) {
     assert.dom('.selectable-card').hasText('hello');
   });
 
-  test('it does process click event on disabled card', async function (assert) {
+  test('it does not process click event on disabled card', async function (assert) {
     await render(hbs`<SelectableCard @onClick={{this.onClick}} @disabled={{true}}>disabled</SelectableCard>`);
     await click('.selectable-card');
     assert.notOk(this.onClick.calledOnce, 'does not call the click event');


### PR DESCRIPTION
**Previously:**

https://github.com/hashicorp/vault/assets/6618863/a0513dff-3be7-4d2f-9584-fd4b62a9af58

**With Fix:**

https://github.com/hashicorp/vault/assets/6618863/d470d07d-3e69-4506-989c-28150c078c89



Guessing a backport to 1.16.x as I think [this](https://github.com/hashicorp/vault/issues/23739) might have been the regression pr.