### PR TITLE
Fix broken MFA links, add links to bottom of page

### DIFF
--- a/website/content/docs/enterprise/mfa/index.mdx
+++ b/website/content/docs/enterprise/mfa/index.mdx
@@ -18,22 +18,22 @@ Vault.
 
 MFA in Vault can be of the following types.
 
-- `Time-based One-time Password (TOTP)` - If configured and enabled on a path,
+- **Time-based One-time Password (TOTP)** - If configured and enabled on a path,
   this would require a TOTP passcode along with Vault token, to be presented
   while invoking the API request. The passcode will be validated against the
   TOTP key present in the identity of the caller in Vault.
 
-- `Okta` - If Okta push is configured and enabled on a path, then the enrolled
+- **Okta** - If Okta push is configured and enabled on a path, then the enrolled
   device of the user will get a push notification to approve or deny the access
   to the API. The Okta username will be derived from the caller identity's
   alias.
 
-- `Duo` - If Duo push is configured and enabled on a path, then the enrolled
+- **Duo** - If Duo push is configured and enabled on a path, then the enrolled
   device of the user will get a push notification to approve or deny the access
   to the API. The Duo username will be derived from the caller identity's
   alias.
 
-- `PingID` - If PingID push is configured and enabled on a path, then the
+- **PingID** - If PingID push is configured and enabled on a path, then the
   enrolled device of the user will get a push notification to approve or deny
   the access to the API. The PingID username will be derived from the caller
   identity's alias.
@@ -110,6 +110,13 @@ $ curl \
     http://127.0.0.1:8200/v1/secret/foo
 ```
 
-### API
+## API
 
 MFA can be managed entirely over the HTTP API. Please see [MFA API](/vault/api-docs/system/mfa) for more details.
+
+## Additional resources
+
+- [Duo MFA documentation](/vault/docs/enterprise/mfa/mfa-duo)
+- [Okta MFA documentation](/vault/docs/enterprise/mfa/mfa-okta)
+- [PingID MFA documentation](/vault/docs/enterprise/mfa/mfa-pingid)
+- [TOTP MFA documentation](/vault/docs/enterprise/mfa/mfa-totp)


### PR DESCRIPTION
🔍 [Preview deployment](https://vault-git-docs-fix-broken-mfa-links-hashicorp.vercel.app/vault/docs/enterprise/mfa)

- Remove broken links from top of page
- Add additional resources section to bottom with links to docs (so a practitioner does not leave the page by clicking links at the top)
- Make API section H2 so it appears in sidebar