### PR TITLE
Update vault-plugin-auth-jwt to v0.17.3 in release/1.15.x

### DIFF
--- a/changelog/27063.txt
+++ b/changelog/27063.txt
@@ -1,0 +1,3 @@
+```release-note:change
+auth/jwt: Update plugin to v0.17.3
+```

--- a/go.mod
+++ b/go.mod
@@ -131,7 +131,7 @@ require (
 	github.com/hashicorp/vault-plugin-auth-centrify v0.15.1
 	github.com/hashicorp/vault-plugin-auth-cf v0.15.1
 	github.com/hashicorp/vault-plugin-auth-gcp v0.16.1
-	github.com/hashicorp/vault-plugin-auth-jwt v0.17.0
+	github.com/hashicorp/vault-plugin-auth-jwt v0.17.3
 	github.com/hashicorp/vault-plugin-auth-kerberos v0.10.1
 	github.com/hashicorp/vault-plugin-auth-kubernetes v0.17.1
 	github.com/hashicorp/vault-plugin-auth-oci v0.14.2

--- a/go.sum
+++ b/go.sum
@@ -2158,8 +2158,8 @@ github.com/hashicorp/vault-plugin-auth-cf v0.15.1 h1:gtHOfVU4KDs1URlSCbIoio4eNXb
 github.com/hashicorp/vault-plugin-auth-cf v0.15.1/go.mod h1:dPRh6mLCglXsiY9q/X6RSD39SUQyyFhbIbm4Y5JyG7s=
 github.com/hashicorp/vault-plugin-auth-gcp v0.16.1 h1:KasqciAWHP3Htruowdu8fhO5X1YFfY0Qi3nrsBlpDkU=
 github.com/hashicorp/vault-plugin-auth-gcp v0.16.1/go.mod h1:pLF4l4SjTMR24/FTsE1idVpKEeO8ah0x1Kpulw+I09I=
-github.com/hashicorp/vault-plugin-auth-jwt v0.17.0 h1:ZfgyFjZfquIn9qk1bytkaqUfG8mKx71RYaSb620dEh0=
-github.com/hashicorp/vault-plugin-auth-jwt v0.17.0/go.mod h1:R5ZtloCRWHnElOm+MXJadj2jkGMwF9Ybk3sn2kV3L48=
+github.com/hashicorp/vault-plugin-auth-jwt v0.17.3 h1:9g0bqXK+uwHCqUmxxT9dfDF9jv0Ggx34bsIUc3e1J1o=
+github.com/hashicorp/vault-plugin-auth-jwt v0.17.3/go.mod h1:OxYhVGUgrlI0Os9M1RgwNw4qxTJKCLE2N8GWDoXy1is=
 github.com/hashicorp/vault-plugin-auth-kerberos v0.10.1 h1:nXni7zfOyhOWJBC42iWqIEZA+aYCo3diyVrr1mHs5yo=
 github.com/hashicorp/vault-plugin-auth-kerberos v0.10.1/go.mod h1:S0XEzmbUO+iuC44a8wqnL869l6WH0DUMVqxTIEkITys=
 github.com/hashicorp/vault-plugin-auth-kubernetes v0.17.1 h1:MVGosnlKQcgr6z9xrehCi5taYJyRw67JIJMNHaMXSAc=


### PR DESCRIPTION
This PR upgrades vault-plugin-auth-jwt to 0.17.3.