### PR TITLE
UI: Update node to version 20

### DIFF
--- a/scripts/cross/Dockerfile
+++ b/scripts/cross/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update -y && apt-get install --no-install-recommends -y -q \
                          libltdl-dev \
                          libltdl7
 
-RUN curl -sL https://deb.nodesource.com/setup_18.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_20.x | bash -
 RUN curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
 

--- a/scripts/docker/Dockerfile.ui
+++ b/scripts/docker/Dockerfile.ui
@@ -19,7 +19,7 @@ RUN apt-get update -y && apt-get install --no-install-recommends -y -q \
                          libltdl-dev \
                          libltdl7
 
-RUN curl -sL https://deb.nodesource.com/setup_18.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_20.x | bash -
 RUN curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -199,7 +199,7 @@
     "lodash.template@^4.5.0": "patch:lodash.template@npm%3A4.5.0#./.yarn/patches/lodash.template-npm-4.5.0-5272df3039.patch"
   },
   "engines": {
-    "node": ">= 18"
+    "node": "20"
   },
   "ember": {
     "edition": "octane"


### PR DESCRIPTION
Now that we're on [Ember 5.4](https://github.com/hashicorp/vault/pull/26708), we can use [Node v20](https://github.com/ember-cli/ember-cli/blob/master/docs/node-support.md) 🎉 