### PR TITLE
Retention months known issue workaround

### DIFF
--- a/website/content/partials/known-issues/perf-standbys-revert-to-standby.mdx
+++ b/website/content/partials/known-issues/perf-standbys-revert-to-standby.mdx
@@ -16,28 +16,30 @@ storage error:
 [ERROR] core: performance standby post-unseal setup failed: error="cannot write to readonly storage"
 ```
 
-This issue manifests due to the way upgrades are performed. New nodes added to a
-cluster with an older versioned leader will see the leader’s storage entry and
-attempt to update it with the new minimum value for `retention months`. This
-storage write will result in a readonly error on the newly added nodes.
+New nodes added to a cluster with an older versioned leader will see the
+leader’s storage entry and attempt to update it with the new minimum value for
+`retention months`. This storage write will result in a readonly error on the
+newly added nodes.
 
 Performance Standby nodes will revert to Standby after upgrading. You can verify
 the status of your cluster nodes by checking the
 [/sys/health](/vault/api-docs/system/health) endpoint.
 
-After a full upgrade is completed and the leader steps down, one of the standbys
-with this new value will become the active node and begin replicating the new
-value to all other nodes.
-
-This means that the Standby nodes on the affected version will receive the
-update and be able to unseal as Performance Standby nodes once the new leader is
-elected.
-
-Any new new node added to the cluster after the upgrade will also be able to
-unseal as Performance Standbys.
-
 Deployments that rely on scaling across Performance Standbys will now forward
 all requests to the active node, increasing the utilization of the active node.
+
+<Note title="Post-upgrade cluster membership">
+After a full upgrade is completed and the leader steps down, one of the standbys
+with this new value will become leader and begin replicating the new value to
+all other nodes.
+
+Once the the new leader is elected on an affected version of Vault. Standby
+nodes on the affected version will receive the update and be able to unseal
+again as Performance Standby.
+
+Any new node added to the cluster after the upgrade will also be able to unseal
+as Performance Standbys.
+</Note>
 
 A fix for the read-only storage error has been prioritized and escalated. The
 fix will be in releases 1.14.13, 1.15.9 and 1.16.3.

--- a/website/content/partials/known-issues/perf-standbys-revert-to-standby.mdx
+++ b/website/content/partials/known-issues/perf-standbys-revert-to-standby.mdx
@@ -9,22 +9,20 @@
 #### Issue
 
 If you previously set a value for `retention_months` via the
-[sys/internal/counters/config](/vault-api/sys/counters/config) endpoint,
-upgrading to Vault versions 1.14.12, 1.15.8, and 1.16.2 will cause Performance
-Standby nodes to attempt a storage write during unseal, resulting in a read-only
-storage error:
+[sys/internal/counters/config](/vault/api-docs/system/internal-counters#update-the-client-count-configuration)
+endpoint, upgrading to Vault versions 1.14.12, 1.15.8, and 1.16.2 will cause
+Performance Standby nodes to revert to Standby.
+
+Adding nodes with Vault versions 1.14.12, 1.15.8, or 1.16.2 to a cluster with an
+older versioned leader will see any previously set `retention_months` value and
+attempt to the new minimum value of `48`. The storage write will result in a
+read-only error:
 
 ```
 [ERROR] core: performance standby post-unseal setup failed: error="cannot write to readonly storage"
 ```
 
-Adding nodes with Vault versions 1.14.12, 1.15.8, or 1.16.2 to a cluster with an
-older versioned leader will see any previously set `retention_months` value and
-attempt to update it to the new minimum value of `48`. The storage write will
-result in a read-only error.
-
-Performance Standby nodes will revert to Standby after upgrading. You can verify
-the status of your nodes by checking the
+You can verify the status of your nodes by checking the
 [/sys/health](/vault/api-docs/system/health) endpoint.
 
 Deployments that rely on scaling across Performance Standbys will now forward
@@ -47,15 +45,16 @@ refer to the workaround section for options.
 
 Once the leader of the cluster has been updgraded to version 1.14.12, 1.15.8, or
 1.16.2, the workaround is to update the `retention_months` value on the active
-node via the [sys/counters/config](/vault/api-docs/sys/counters/config)
+node via the
+[sys/internal/counters/config](/vault/api-docs/system/internal-counters#update-the-client-count-configuration)
 endpoint:
 
 ```shell
 $ vault write sys/internal/counters/config retention_months=48
 ```
 
-This entry will be replicated to all nodes in the cluster, allowing them to
+This storage entry will be written to all nodes in the cluster, allowing them to
 immediately unseal as Performance Standbys.
 
-After this point, adding new nodes to the cluster will not cause the read-only
-error.
+After the new `retention_months` value is written to storage on the active node,
+adding new nodes to the cluster will not cause the read-only error.

--- a/website/content/partials/known-issues/perf-standbys-revert-to-standby.mdx
+++ b/website/content/partials/known-issues/perf-standbys-revert-to-standby.mdx
@@ -10,13 +10,15 @@
 
 If you previously set a value for `retention_months` via the
 [sys/internal/counters/config](/vault/api-docs/system/internal-counters#update-the-client-count-configuration)
-endpoint, upgrading to Vault versions 1.14.12, 1.15.8, and 1.16.2 will cause
-Performance Standby nodes to revert to Standby.
+endpoint, upgrading to Vault Enterprise versions 1.14.12, 1.15.8, and 1.16.2
+will cause Performance Standby nodes to revert to Standby.
 
-Adding nodes with Vault versions 1.14.12, 1.15.8, or 1.16.2 to a cluster with an
-older versioned leader will see any previously set `retention_months` value and
-attempt to write the new minimum value of `48`. The storage write will result in
-a read-only error:
+@alerts/enterprise-only
+
+Adding nodes with Vault Enterprise versions 1.14.12, 1.15.8, or 1.16.2 to a
+cluster with an older version leader will see any previously set
+`retention_months` value and attempt to write the new minimum value of `48`. The
+storage write will result in a read-only error:
 
 ```
 [ERROR] core: performance standby post-unseal setup failed: error="cannot write to readonly storage"

--- a/website/content/partials/known-issues/perf-standbys-revert-to-standby.mdx
+++ b/website/content/partials/known-issues/perf-standbys-revert-to-standby.mdx
@@ -14,7 +14,7 @@ endpoint, upgrading to Vault Enterprise versions 1.14.12, 1.15.8, and 1.16.2
 will cause [Performance Standby](/vault/docs/enterprise/performance-standby)
 nodes to revert to Standby mode.
 
-@alerts/enterprise-only
+@include 'alerts/enterprise-only.mdx'
 
 Adding nodes with Vault Enterprise versions 1.14.12, 1.15.8, or 1.16.2 to a
 cluster with an older versioned leader will see any previously set

--- a/website/content/partials/known-issues/perf-standbys-revert-to-standby.mdx
+++ b/website/content/partials/known-issues/perf-standbys-revert-to-standby.mdx
@@ -15,8 +15,8 @@ Performance Standby nodes to revert to Standby.
 
 Adding nodes with Vault versions 1.14.12, 1.15.8, or 1.16.2 to a cluster with an
 older versioned leader will see any previously set `retention_months` value and
-attempt to the new minimum value of `48`. The storage write will result in a
-read-only error:
+attempt to write the new minimum value of `48`. The storage write will result in
+a read-only error:
 
 ```
 [ERROR] core: performance standby post-unseal setup failed: error="cannot write to readonly storage"

--- a/website/content/partials/known-issues/perf-standbys-revert-to-standby.mdx
+++ b/website/content/partials/known-issues/perf-standbys-revert-to-standby.mdx
@@ -14,8 +14,6 @@ endpoint, upgrading to Vault Enterprise versions 1.14.12, 1.15.8, and 1.16.2
 will cause [Performance Standby](/vault/docs/enterprise/performance-standby)
 nodes to revert to Standby mode.
 
-@include 'alerts/enterprise-only.mdx'
-
 Adding nodes with Vault Enterprise versions 1.14.12, 1.15.8, or 1.16.2 to a
 cluster with an older versioned leader will see any previously set
 `retention_months` value and attempt to write the new minimum value of `48`. The

--- a/website/content/partials/known-issues/perf-standbys-revert-to-standby.mdx
+++ b/website/content/partials/known-issues/perf-standbys-revert-to-standby.mdx
@@ -11,12 +11,13 @@
 If you previously set a value for `retention_months` via the
 [sys/internal/counters/config](/vault/api-docs/system/internal-counters#update-the-client-count-configuration)
 endpoint, upgrading to Vault Enterprise versions 1.14.12, 1.15.8, and 1.16.2
-will cause Performance Standby nodes to revert to Standby.
+will cause [Performance Standby](/vault/docs/enterprise/performance-standby)
+nodes to revert to Standby mode.
 
 @alerts/enterprise-only
 
 Adding nodes with Vault Enterprise versions 1.14.12, 1.15.8, or 1.16.2 to a
-cluster with an older version leader will see any previously set
+cluster with an older versioned leader will see any previously set
 `retention_months` value and attempt to write the new minimum value of `48`. The
 storage write will result in a read-only error:
 

--- a/website/content/partials/known-issues/perf-standbys-revert-to-standby.mdx
+++ b/website/content/partials/known-issues/perf-standbys-revert-to-standby.mdx
@@ -22,23 +22,15 @@ for `retention months`. The storage write will result in a read-only error on
 newly added nodes.
 
 Performance Standby nodes will revert to Standby after upgrading. You can verify
-the status of your cluster nodes by checking the
+the status of your nodes by checking the
 [/sys/health](/vault/api-docs/system/health) endpoint.
 
 Deployments that rely on scaling across Performance Standbys will now forward
 all requests to the active node, increasing the utilization of the active node.
 
 <Note title="Post-upgrade cluster membership">
-After a full upgrade is completed and the old leader steps down, one of the
-Standby nodes with the new value will become leader and begin replicating the
-updated storage entry to all other nodes.
-
-Once the the new leader is elected on an affected version of Vault. Standby
-nodes on the affected version will receive the update and be able to unseal
-again as Performance Standby.
-
-Any new node added to the cluster after the leader upgrade will also be able to
-unseal as Performance Standbys.
+During the last step of a full upgrade, the old leader steps down. One of the
+Standby nodes will become leader.
 </Note>
 
 A fix for the read-only storage error has been prioritized and escalated. The
@@ -51,13 +43,16 @@ refer to the workaround section for options.
 
 #### Workaround
 
-There are several workaround for this known issue.
+The workaround for this issue is to update the `retention_months` value vaie the
+[sys/counters/config](/vault/api-docs/sys/counters/config) endpoint:
 
-If the active node has already been upgraded to the new version, do one of the following:
+```
+$ vault write sys/counters/config retention_months=48
+```
 
-1. Stop/start the Standby nodes.
-2. Add more nodes with the affected version to the cluster.
+This entry will be replicated to all nodes in the cluster, allowing them to
+immediately unseal as Performance Standbys.
 
-If the active node is still on an unaffected version of Vault, update
-`retention_months` value to `48` on the active node via the
-[/sys/counters/config](/vault/api-docs/sys/counters/config) endpoint.
+After this point, adding new nodes to the cluster will not cause the read-only
+error.
+

--- a/website/content/partials/known-issues/perf-standbys-revert-to-standby.mdx
+++ b/website/content/partials/known-issues/perf-standbys-revert-to-standby.mdx
@@ -8,7 +8,9 @@
 
 #### Issue
 
-Upgrading to Vault versions 1.14.12, 1.15.8, and 1.16.2 will cause Performance
+If you previously set a value for `retention_months` via the
+[sys/internal/counters/config](/vault-api/sys/counters/config) endpoint,
+upgrading to Vault versions 1.14.12, 1.15.8, and 1.16.2 will cause Performance
 Standby nodes to attempt a storage write during unseal, resulting in a read-only
 storage error:
 
@@ -16,10 +18,10 @@ storage error:
 [ERROR] core: performance standby post-unseal setup failed: error="cannot write to readonly storage"
 ```
 
-New nodes added to a cluster with an older versioned leader will see the
-leader’s storage entry and attempt to update it with a new minimum value of `48`
-for `retention months`. The storage write will result in a read-only error on
-newly added nodes.
+Adding nodes with Vault versions 1.14.12, 1.15.8, or 1.16.2 to a cluster with an
+older versioned leader will see any previously set `retention_months` value and
+attempt to update it to the new minimum value of `48`. The storage write will
+result in a read-only error.
 
 Performance Standby nodes will revert to Standby after upgrading. You can verify
 the status of your nodes by checking the
@@ -44,14 +46,16 @@ refer to the workaround section for options.
 #### Workaround
 
 Once the leader of the cluster has been updgraded to version 1.14.12, 1.15.8, or
-1.16.2, the workaround is to update the `retention_months` value via the
-[sys/counters/config](/vault/api-docs/sys/counters/config) endpoint:
+1.16.2, the workaround is to update the `retention_months` value on the active
+node via the [sys/counters/config](/vault/api-docs/sys/counters/config)
+endpoint:
+
 ```shell
-$ vault write sys/counters/config retention_months=48
+$ vault write sys/internal/counters/config retention_months=48
 ```
+
 This entry will be replicated to all nodes in the cluster, allowing them to
 immediately unseal as Performance Standbys.
 
 After this point, adding new nodes to the cluster will not cause the read-only
 error.
-

--- a/website/content/partials/known-issues/perf-standbys-revert-to-standby.mdx
+++ b/website/content/partials/known-issues/perf-standbys-revert-to-standby.mdx
@@ -16,9 +16,25 @@ storage error:
 [ERROR] core: performance standby post-unseal setup failed: error="cannot write to readonly storage"
 ```
 
+This issue manifests due to the way upgrades are performed. New nodes added to a
+cluster with an older versioned leader will see the leader’s storage entry and
+attempt to update it with the new minimum value for `retention months`. This
+storage write will result in a readonly error on the newly added nodes.
+
 Performance Standby nodes will revert to Standby after upgrading. You can verify
 the status of your cluster nodes by checking the
 [/sys/health](/vault/api-docs/system/health) endpoint.
+
+After a full upgrade is completed and the leader steps down, one of the standbys
+with this new value will become the active node and begin replicating the new
+value to all other nodes.
+
+This means that the Standby nodes on the affected version will receive the
+update and be able to unseal as Performance Standby nodes once the new leader is
+elected.
+
+Any new new node added to the cluster after the upgrade will also be able to
+unseal as Performance Standbys.
 
 Deployments that rely on scaling across Performance Standbys will now forward
 all requests to the active node, increasing the utilization of the active node.
@@ -33,22 +49,13 @@ refer to the workaround section for options.
 
 #### Workaround
 
-There is currently no known workaround for this issue.
+There are several workaround for this known issue.
 
-If you have already upgraded to the affected versions, you have two options:
+If the active node has already been upgraded to the new version, do one of the following:
 
-1. Carefully monitor the active nodes of your upgraded clusters to ensure that
-system resources are not oversaturated and request latencies are not untenably
-high.
+1. Stop/start the Standby nodes.
+2. Add more nodes with the affected version to the cluster.
 
-2. Consider downgrading to an earlier version of Vault and restoring from backup.
-
-<Note title="Important">
-Always back up your data before upgrading! Vault does not make
-backward-compatibility guarantees for its data store. Simply replacing the
-newly-installed Vault binary with the previous version will not cleanly
-downgrade Vault, as upgrades may perform changes to the underlying data
-structure that make the data incompatible with a downgrade. If you need to roll
-back to a previous version of Vault, you should roll back your data store as
-well by restoring from backup.
-</Note>
+If the active node has not been upgraded to the new version, update the
+`retention_months` value to `48` on the active node via the
+[/sys/counters/config](/vault/api-docs/sys/counters/config) endpoint.

--- a/website/content/partials/known-issues/perf-standbys-revert-to-standby.mdx
+++ b/website/content/partials/known-issues/perf-standbys-revert-to-standby.mdx
@@ -17,8 +17,8 @@ storage error:
 ```
 
 New nodes added to a cluster with an older versioned leader will see the
-leader’s storage entry and attempt to update it with the new minimum value for
-`retention months`. This storage write will result in a readonly error on the
+leader’s storage entry and attempt to update it with a new minimum value of `48`
+for `retention months`. The storage write will result in a read-only error on
 newly added nodes.
 
 Performance Standby nodes will revert to Standby after upgrading. You can verify
@@ -29,16 +29,16 @@ Deployments that rely on scaling across Performance Standbys will now forward
 all requests to the active node, increasing the utilization of the active node.
 
 <Note title="Post-upgrade cluster membership">
-After a full upgrade is completed and the leader steps down, one of the standbys
-with this new value will become leader and begin replicating the new value to
-all other nodes.
+After a full upgrade is completed and the old leader steps down, one of the
+Standby nodes with the new value will become leader and begin replicating the
+updated storage entry to all other nodes.
 
 Once the the new leader is elected on an affected version of Vault. Standby
 nodes on the affected version will receive the update and be able to unseal
 again as Performance Standby.
 
-Any new node added to the cluster after the upgrade will also be able to unseal
-as Performance Standbys.
+Any new node added to the cluster after the leader upgrade will also be able to
+unseal as Performance Standbys.
 </Note>
 
 A fix for the read-only storage error has been prioritized and escalated. The
@@ -58,6 +58,6 @@ If the active node has already been upgraded to the new version, do one of the f
 1. Stop/start the Standby nodes.
 2. Add more nodes with the affected version to the cluster.
 
-If the active node has not been upgraded to the new version, update the
+If the active node is still on an unaffected version of Vault, update
 `retention_months` value to `48` on the active node via the
 [/sys/counters/config](/vault/api-docs/sys/counters/config) endpoint.

--- a/website/content/partials/known-issues/perf-standbys-revert-to-standby.mdx
+++ b/website/content/partials/known-issues/perf-standbys-revert-to-standby.mdx
@@ -29,8 +29,8 @@ Deployments that rely on scaling across Performance Standbys will now forward
 all requests to the active node, increasing the utilization of the active node.
 
 <Note title="Post-upgrade cluster membership">
-During the last step of a full upgrade, the old leader steps down. One of the
-Standby nodes will become leader.
+During the last step of a full upgrade, the old leader steps down, causing one
+of the Standby nodes to become leader.
 </Note>
 
 A fix for the read-only storage error has been prioritized and escalated. The
@@ -43,13 +43,12 @@ refer to the workaround section for options.
 
 #### Workaround
 
-The workaround for this issue is to update the `retention_months` value vaie the
+Once the leader of the cluster has been updgraded to version 1.14.12, 1.15.8, or
+1.16.2, the workaround is to update the `retention_months` value via the
 [sys/counters/config](/vault/api-docs/sys/counters/config) endpoint:
-
-```
+```shell
 $ vault write sys/counters/config retention_months=48
 ```
-
 This entry will be replicated to all nodes in the cluster, allowing them to
 immediately unseal as Performance Standbys.
 


### PR DESCRIPTION
This PR adds some workarounds to the perf standby unseal known issue affecting Vault version 1.14.12, 1.15.8, and 1.16.2.