### PR TITLE
Fix enterprise tests failing after Web REPL a11y updates

### DIFF
--- a/ui/tests/acceptance/enterprise-kmip-test.js
+++ b/ui/tests/acceptance/enterprise-kmip-test.js
@@ -17,12 +17,6 @@ import { allEngines } from 'vault/helpers/mountable-secret-engines';
 import { runCmd } from 'vault/tests/helpers/commands';
 import { v4 as uuidv4 } from 'uuid';
 
-const getRandomPort = () => {
-  let a = Math.floor(100000 + Math.random() * 900000);
-  a = String(a);
-  return a.substring(0, 4);
-};
-
 const mount = async (backend) => {
   const res = await runCmd(`write sys/mounts/${backend} type=kmip`);
   await settled();
@@ -33,7 +27,7 @@ const mount = async (backend) => {
 };
 
 const mountWithConfig = async (backend) => {
-  const addr = `127.0.0.1:${getRandomPort()}`; // use random port
+  const addr = `127.0.0.1:5696`;
   await mount(backend);
   const res = await runCmd(`write ${backend}/config listen_addrs=${addr}`);
   if (res.includes('Error')) {
@@ -128,7 +122,7 @@ module('Acceptance | Enterprise | KMIP secrets', function (hooks) {
       `/vault/secrets/${backend}/kmip/configure`,
       'configuration navigates to the configure page'
     );
-    const addr = `127.0.0.1:${getRandomPort()}`;
+    const addr = `127.0.0.1:5696`;
     await fillIn('[data-test-string-list-input="0"]', addr);
     await scopesPage.submit();
     await settled();

--- a/ui/tests/acceptance/enterprise-namespaces-test.js
+++ b/ui/tests/acceptance/enterprise-namespaces-test.js
@@ -41,6 +41,7 @@ module('Acceptance | Enterprise | namespaces', function (hooks) {
       const targetNamespace = nses.slice(0, i + 1).join('/');
       const url = `/vault/secrets?namespace=${targetNamespace}`;
       // this is usually triggered when creating a ns in the form -- trigger a reload of the namespaces manually
+      await click('[data-test-namespace-toggle]');
       await click('[data-test-refresh-namespaces]');
       await waitFor(`[data-test-namespace-link="${targetNamespace}"]`);
       // check that the single namespace "beep" or "boop" not "beep/boop" shows in the toggle display


### PR DESCRIPTION
This PR updates a couple test failures after #26872 was merged. I also attempted to stabilize the KMIP flaky tests in this

- [x] Ent tests pass