### PR TITLE
UI fix KVv2 in json editor when value is null

### DIFF
--- a/changelog/27094.txt
+++ b/changelog/27094.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fix KVv2 json editor to allow null values.
+```

--- a/changelog/278094.txt
+++ b/changelog/278094.txt
@@ -1,3 +1,0 @@
-```release-note:bug
-ui: Fix KVv2 json editor to allow null values.
-```

--- a/changelog/278094.txt
+++ b/changelog/278094.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fix KVv2 json editor to allow null values.
+```

--- a/ui/lib/core/addon/utils/advanced-secret.js
+++ b/ui/lib/core/addon/utils/advanced-secret.js
@@ -31,8 +31,7 @@ export function obfuscateData(obj) {
     if (Array.isArray(obj[key])) {
       newObj[key] = obj[key].map(() => '********');
     } else if (typeof obj[key] === 'object') {
-      // unfortunately in javascript if the value of a key is null
-      // calling typeof on this value will return object even if it is a string ex: { "test" : null }
+      // unfortunately in javascript typeof null returns object
       // this is due to a "historical js bug that will never be fixed"
       // we handle this situation here
       if (obj[key] === null) {

--- a/ui/lib/core/addon/utils/advanced-secret.js
+++ b/ui/lib/core/addon/utils/advanced-secret.js
@@ -31,6 +31,13 @@ export function obfuscateData(obj) {
     if (Array.isArray(obj[key])) {
       newObj[key] = obj[key].map(() => '********');
     } else if (typeof obj[key] === 'object') {
+      // unfortunately in javascript if the value of a key is null
+      // calling typeof on this value will return object even if it is a string ex: { "test" : null }
+      // this is due to a "historical js bug that will never be fixed"
+      // we handle this situation here
+      if (obj[key] === null) {
+        return (newObj[key] = '********');
+      }
       newObj[key] = obfuscateData(obj[key]);
     } else {
       newObj[key] = '********';

--- a/ui/lib/core/addon/utils/advanced-secret.js
+++ b/ui/lib/core/addon/utils/advanced-secret.js
@@ -30,7 +30,7 @@ export function obfuscateData(obj) {
   for (const key of Object.keys(obj)) {
     if (Array.isArray(obj[key])) {
       newObj[key] = obj[key].map(() => '********');
-    } else if (typeof obj[key] === 'object' && obj[key] === null) {
+    } else if (obj[key] === null) {
       // unfortunately in javascript typeof null returns object
       // this is due to a "historical js bug that will never be fixed"
       // we handle this situation here

--- a/ui/lib/core/addon/utils/advanced-secret.js
+++ b/ui/lib/core/addon/utils/advanced-secret.js
@@ -30,15 +30,13 @@ export function obfuscateData(obj) {
   for (const key of Object.keys(obj)) {
     if (Array.isArray(obj[key])) {
       newObj[key] = obj[key].map(() => '********');
-    } else if (typeof obj[key] === 'object') {
+    } else if (obj[key] === null) {
       // unfortunately in javascript typeof null returns object
       // this is due to a "historical js bug that will never be fixed"
-      // we handle this situation here
-      if (obj[key] === null) {
-        newObj[key] = '********';
-      } else {
-        newObj[key] = obfuscateData(obj[key]);
-      }
+      // we handle this situation here and make sure it doesn't get caught in the next else if block
+      newObj[key] = '********';
+    } else if (typeof obj[key] === 'object' && !obj[key] === null) {
+      newObj[key] = obfuscateData(obj[key]);
     } else {
       newObj[key] = '********';
     }

--- a/ui/lib/core/addon/utils/advanced-secret.js
+++ b/ui/lib/core/addon/utils/advanced-secret.js
@@ -35,7 +35,7 @@ export function obfuscateData(obj) {
       // this is due to a "historical js bug that will never be fixed"
       // we handle this situation here
       newObj[key] = '********';
-    } else if (typeof obj[key] === 'object' && obj[key] !== null) {
+    } else if (typeof obj[key] === 'object') {
       newObj[key] = obfuscateData(obj[key]);
     } else {
       newObj[key] = '********';

--- a/ui/lib/core/addon/utils/advanced-secret.js
+++ b/ui/lib/core/addon/utils/advanced-secret.js
@@ -36,9 +36,10 @@ export function obfuscateData(obj) {
       // this is due to a "historical js bug that will never be fixed"
       // we handle this situation here
       if (obj[key] === null) {
-        return (newObj[key] = '********');
+        newObj[key] = '********';
+      } else {
+        newObj[key] = obfuscateData(obj[key]);
       }
-      newObj[key] = obfuscateData(obj[key]);
     } else {
       newObj[key] = '********';
     }

--- a/ui/lib/core/addon/utils/advanced-secret.js
+++ b/ui/lib/core/addon/utils/advanced-secret.js
@@ -30,12 +30,12 @@ export function obfuscateData(obj) {
   for (const key of Object.keys(obj)) {
     if (Array.isArray(obj[key])) {
       newObj[key] = obj[key].map(() => '********');
-    } else if (obj[key] === null) {
+    } else if (typeof obj[key] === 'object' && obj[key] === null) {
       // unfortunately in javascript typeof null returns object
       // this is due to a "historical js bug that will never be fixed"
-      // we handle this situation here and make sure it doesn't get caught in the next else if block
+      // we handle this situation here
       newObj[key] = '********';
-    } else if (typeof obj[key] === 'object' && !obj[key] === null) {
+    } else if (typeof obj[key] === 'object' && obj[key] !== null) {
       newObj[key] = obfuscateData(obj[key]);
     } else {
       newObj[key] = '********';

--- a/ui/tests/unit/utils/advanced-secret-test.js
+++ b/ui/tests/unit/utils/advanced-secret-test.js
@@ -108,7 +108,40 @@ module('Unit | Utility | advanced-secret', function () {
         },
       ].forEach((test) => {
         const result = obfuscateData(test.data);
-        assert.deepEqual(result, test.obscured, `obfuscates values of ${test.name}`);
+        assert.deepEqual(result, test.obscured, `obfuscates object values of ${test.name}`);
+      });
+    });
+
+    test('it obfuscates null values', function (assert) {
+      assert.expect(2);
+      [
+        {
+          name: 'null value',
+          data: {
+            one: 'fish',
+            two: 'fish',
+            three: 'fish',
+            blue: null,
+          },
+          obscured: {
+            blue: '********',
+            one: '********',
+            three: '********',
+            two: '********',
+          },
+        },
+        {
+          name: 'null value nested-object',
+          data: {
+            one: { two: null },
+          },
+          obscured: {
+            one: { two: '********' },
+          },
+        },
+      ].forEach((test) => {
+        const result = obfuscateData(test.data);
+        assert.deepEqual(result, test.obscured, `obfuscates null values of ${test.name}`);
       });
     });
 


### PR DESCRIPTION
- [x] ent test pass
- [x] test coverage

Regression PR #24530  
Fixes Issue #26709

Note: confirmed that you can in fact pass null as a value using curl, so this was a situation we needed to allow in the UI.

**Before:**

https://github.com/hashicorp/vault/assets/6618863/4bf5b87e-cd88-4e5a-ae5e-139d98b86837


**After:**

https://github.com/hashicorp/vault/assets/6618863/b75ce618-4c6a-40d4-a7ef-da8d411052b8

