### PR TITLE
Update vault-plugin-auth-jwt to v0.16.1 in release/1.14.x

### DIFF
--- a/changelog/27122.txt
+++ b/changelog/27122.txt
@@ -1,0 +1,3 @@
+```release-note:change
+auth/jwt: Update plugin to v0.16.1
+```

--- a/go.mod
+++ b/go.mod
@@ -128,7 +128,7 @@ require (
 	github.com/hashicorp/vault-plugin-auth-centrify v0.15.1
 	github.com/hashicorp/vault-plugin-auth-cf v0.15.0
 	github.com/hashicorp/vault-plugin-auth-gcp v0.16.0
-	github.com/hashicorp/vault-plugin-auth-jwt v0.16.0
+	github.com/hashicorp/vault-plugin-auth-jwt v0.16.1
 	github.com/hashicorp/vault-plugin-auth-kerberos v0.10.0
 	github.com/hashicorp/vault-plugin-auth-kubernetes v0.16.0
 	github.com/hashicorp/vault-plugin-auth-oci v0.14.0

--- a/go.sum
+++ b/go.sum
@@ -2195,8 +2195,8 @@ github.com/hashicorp/vault-plugin-auth-cf v0.15.0 h1:zIVGlYXCRBY/ElucWdFC9xF27d2
 github.com/hashicorp/vault-plugin-auth-cf v0.15.0/go.mod h1:FEIjQkYmzno4MfU36MAjFUG9/JUWeMPxvBG5DRTMYVM=
 github.com/hashicorp/vault-plugin-auth-gcp v0.16.0 h1:DA/ZDLCrUsbHS/7Xqkkw7l2SgbQE9rWEHLLWYTGu8rw=
 github.com/hashicorp/vault-plugin-auth-gcp v0.16.0/go.mod h1:R0z/qdyxn0uq6hkKgux8KwenjV/n/CCaEz+qOF9GdPg=
-github.com/hashicorp/vault-plugin-auth-jwt v0.16.0 h1:BUk03WDSGZuB+kEq3HTOQ7ecEH2Z1Idit42jfB5EnpE=
-github.com/hashicorp/vault-plugin-auth-jwt v0.16.0/go.mod h1:Ve3r228afZOShwNvp+MGEKtm+ROskv10GG7bMXZb5OA=
+github.com/hashicorp/vault-plugin-auth-jwt v0.16.1 h1:QUGRRvO3x+4+/leav+K2I9BVeGJcSBjCjgNbsZXrSTA=
+github.com/hashicorp/vault-plugin-auth-jwt v0.16.1/go.mod h1:m5dbjs4Ept6CCHn+E6rRQzgwWBDX4nFcms6ycrBc/4c=
 github.com/hashicorp/vault-plugin-auth-kerberos v0.10.0 h1:YH2x9kIV0jKXk22tVkpydhmPeEgprC7IOfN8l0pjF6c=
 github.com/hashicorp/vault-plugin-auth-kerberos v0.10.0/go.mod h1:I6ulXug4oxx77DFYjqI1kVl+72TgXEo3Oju4tTOVfU4=
 github.com/hashicorp/vault-plugin-auth-kubernetes v0.16.0 h1:vuXNJvtMyoqQ01Sfwf2TNcJNkGcxP1vD3C7gpvuVkCU=


### PR DESCRIPTION
This PR upgrades vault-plugin-auth-jwt 0.16.0 -> 0.16.1 in release/1.14.x.