### PR TITLE
Title case "Secrets" in breadcrumbs to route secret

### DIFF
--- a/ui/app/components/transit-edit.js
+++ b/ui/app/components/transit-edit.js
@@ -35,7 +35,7 @@ export default Component.extend(FocusOnInsertMixin, {
   get breadcrumbs() {
     const baseCrumbs = [
       {
-        label: 'secrets',
+        label: 'Secrets',
         route: 'vault.cluster.secrets',
       },
       {

--- a/ui/app/routes/vault/cluster/secrets/backend/actions.js
+++ b/ui/app/routes/vault/cluster/secrets/backend/actions.js
@@ -33,7 +33,7 @@ export default EditBase.extend({
     controller.set('selectedAction', selectedAction || model.secret.supportedActions[0]);
     controller.set('breadcrumbs', [
       {
-        label: 'secrets',
+        label: 'Secrets',
         route: 'vault.cluster.secrets',
       },
       {

--- a/ui/lib/kubernetes/addon/routes/configuration.js
+++ b/ui/lib/kubernetes/addon/routes/configuration.js
@@ -27,7 +27,7 @@ export default class KubernetesConfigureRoute extends Route {
     super.setupController(controller, resolvedModel);
 
     controller.breadcrumbs = [
-      { label: 'secrets', route: 'secrets', linkExternal: true },
+      { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: resolvedModel.backend.id },
     ];
   }

--- a/ui/lib/kubernetes/addon/routes/configure.js
+++ b/ui/lib/kubernetes/addon/routes/configure.js
@@ -21,7 +21,7 @@ export default class KubernetesConfigureRoute extends Route {
     super.setupController(controller, resolvedModel);
 
     controller.breadcrumbs = [
-      { label: 'secrets', route: 'secrets', linkExternal: true },
+      { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: resolvedModel.backend, route: 'overview' },
       { label: 'configure' },
     ];

--- a/ui/lib/kubernetes/addon/routes/error.js
+++ b/ui/lib/kubernetes/addon/routes/error.js
@@ -12,7 +12,7 @@ export default class KubernetesErrorRoute extends Route {
   setupController(controller) {
     super.setupController(...arguments);
     controller.breadcrumbs = [
-      { label: 'secrets', route: 'secrets', linkExternal: true },
+      { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: this.secretMountPath.currentPath, route: 'overview' },
     ];
     controller.backend = this.modelFor('application');

--- a/ui/lib/kubernetes/addon/routes/overview.js
+++ b/ui/lib/kubernetes/addon/routes/overview.js
@@ -26,7 +26,7 @@ export default class KubernetesOverviewRoute extends Route {
     super.setupController(controller, resolvedModel);
 
     controller.breadcrumbs = [
-      { label: 'secrets', route: 'secrets', linkExternal: true },
+      { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: resolvedModel.backend.id },
     ];
   }

--- a/ui/lib/kubernetes/addon/routes/roles/index.js
+++ b/ui/lib/kubernetes/addon/routes/roles/index.js
@@ -40,7 +40,7 @@ export default class KubernetesRolesRoute extends Route {
     super.setupController(controller, resolvedModel);
 
     controller.breadcrumbs = [
-      { label: 'secrets', route: 'secrets', linkExternal: true },
+      { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: resolvedModel.backend.id },
     ];
   }

--- a/ui/lib/kv/addon/routes/configuration.js
+++ b/ui/lib/kv/addon/routes/configuration.js
@@ -24,7 +24,7 @@ export default class KvConfigurationRoute extends Route {
   setupController(controller, resolvedModel) {
     super.setupController(controller, resolvedModel);
     controller.breadcrumbs = [
-      { label: 'secrets', route: 'secrets', linkExternal: true },
+      { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: resolvedModel.mountConfig.id, route: 'list', model: resolvedModel.engineConfig.backend },
       { label: 'configuration' },
     ];

--- a/ui/lib/kv/addon/routes/create.js
+++ b/ui/lib/kv/addon/routes/create.js
@@ -31,7 +31,7 @@ export default class KvSecretsCreateRoute extends Route {
     super.setupController(controller, resolvedModel);
 
     const crumbs = [
-      { label: 'secrets', route: 'secrets', linkExternal: true },
+      { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: resolvedModel.backend, route: 'list', model: resolvedModel.backend },
       ...breadcrumbsForSecret(resolvedModel.backend, resolvedModel.path),
       { label: 'create' },

--- a/ui/lib/kv/addon/routes/error.js
+++ b/ui/lib/kv/addon/routes/error.js
@@ -12,7 +12,7 @@ export default class KvErrorRoute extends Route {
   setupController(controller) {
     super.setupController(...arguments);
     controller.breadcrumbs = [
-      { label: 'secrets', route: 'secrets', linkExternal: true },
+      { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: this.secretMountPath.currentPath, route: 'list', model: this.secretMountPath.currentPath },
     ];
     controller.mountName = this.secretMountPath.currentPath;

--- a/ui/lib/kv/addon/routes/list-directory.js
+++ b/ui/lib/kv/addon/routes/list-directory.js
@@ -71,7 +71,7 @@ export default class KvSecretsListRoute extends Route {
     resolvedModel.failedDirectoryQuery =
       resolvedModel.secrets === 403 && pathIsDirectory(resolvedModel.pathToSecret);
 
-    let breadcrumbsArray = [{ label: 'secrets', route: 'secrets', linkExternal: true }];
+    let breadcrumbsArray = [{ label: 'Secrets', route: 'secrets', linkExternal: true }];
     // if on top level don't link the engine breadcrumb label, but if within a directory, do link back to top level.
     if (this.routeName === 'list') {
       breadcrumbsArray.push({ label: resolvedModel.backend });

--- a/ui/lib/kv/addon/routes/secret/details/edit.js
+++ b/ui/lib/kv/addon/routes/secret/details/edit.js
@@ -35,7 +35,7 @@ export default class KvSecretDetailsEditRoute extends Route {
     super.setupController(controller, resolvedModel);
 
     controller.breadcrumbs = [
-      { label: 'secrets', route: 'secrets', linkExternal: true },
+      { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: resolvedModel.backend, route: 'list', model: resolvedModel.backend },
       ...breadcrumbsForSecret(resolvedModel.backend, resolvedModel.path),
       { label: 'edit' },

--- a/ui/lib/kv/addon/routes/secret/details/index.js
+++ b/ui/lib/kv/addon/routes/secret/details/index.js
@@ -11,7 +11,7 @@ export default class KvSecretDetailsIndexRoute extends Route {
     super.setupController(controller, resolvedModel);
 
     const breadcrumbsArray = [
-      { label: 'secrets', route: 'secrets', linkExternal: true },
+      { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: resolvedModel.backend, route: 'list', model: resolvedModel.backend },
       ...breadcrumbsForSecret(resolvedModel.backend, resolvedModel.path, true),
     ];

--- a/ui/lib/kv/addon/routes/secret/metadata/diff.js
+++ b/ui/lib/kv/addon/routes/secret/metadata/diff.js
@@ -12,7 +12,7 @@ export default class KvSecretMetadataDiffRoute extends Route {
   setupController(controller, resolvedModel) {
     super.setupController(controller, resolvedModel);
     const breadcrumbsArray = [
-      { label: 'secrets', route: 'secrets', linkExternal: true },
+      { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: resolvedModel.backend, route: 'list', model: resolvedModel.backend },
       ...breadcrumbsForSecret(resolvedModel.backend, resolvedModel.path),
       { label: 'version history', route: 'secret.metadata.versions' },

--- a/ui/lib/kv/addon/routes/secret/metadata/edit.js
+++ b/ui/lib/kv/addon/routes/secret/metadata/edit.js
@@ -13,7 +13,7 @@ export default class KvSecretMetadataEditRoute extends Route {
   setupController(controller, resolvedModel) {
     super.setupController(controller, resolvedModel);
     const breadcrumbsArray = [
-      { label: 'secrets', route: 'secrets', linkExternal: true },
+      { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: resolvedModel.backend, route: 'list', model: resolvedModel.backend },
       ...breadcrumbsForSecret(resolvedModel.backend, resolvedModel.path),
       { label: 'metadata', route: 'secret.metadata' },

--- a/ui/lib/kv/addon/routes/secret/metadata/index.js
+++ b/ui/lib/kv/addon/routes/secret/metadata/index.js
@@ -13,7 +13,7 @@ export default class KvSecretMetadataIndexRoute extends Route {
   setupController(controller, resolvedModel) {
     super.setupController(controller, resolvedModel);
     const breadcrumbsArray = [
-      { label: 'secrets', route: 'secrets', linkExternal: true },
+      { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: resolvedModel.backend, route: 'list', model: resolvedModel.backend },
       ...breadcrumbsForSecret(resolvedModel.backend, resolvedModel.path),
       { label: 'metadata' },

--- a/ui/lib/kv/addon/routes/secret/metadata/versions.js
+++ b/ui/lib/kv/addon/routes/secret/metadata/versions.js
@@ -10,7 +10,7 @@ export default class KvSecretMetadataVersionsRoute extends Route {
   setupController(controller, resolvedModel) {
     super.setupController(controller, resolvedModel);
     const breadcrumbsArray = [
-      { label: 'secrets', route: 'secrets', linkExternal: true },
+      { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: resolvedModel.backend, route: 'list', model: resolvedModel.backend },
       ...breadcrumbsForSecret(resolvedModel.backend, resolvedModel.path),
       { label: 'version history' },

--- a/ui/lib/kv/addon/routes/secret/paths.js
+++ b/ui/lib/kv/addon/routes/secret/paths.js
@@ -11,7 +11,7 @@ export default class KvSecretPathsRoute extends Route {
     super.setupController(controller, resolvedModel);
 
     controller.breadcrumbs = [
-      { label: 'secrets', route: 'secrets', linkExternal: true },
+      { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: resolvedModel.backend, route: 'list', model: resolvedModel.backend },
       ...breadcrumbsForSecret(resolvedModel.backend, resolvedModel.path),
       { label: 'paths' },

--- a/ui/lib/ldap/addon/routes/configuration.ts
+++ b/ui/lib/ldap/addon/routes/configuration.ts
@@ -50,7 +50,7 @@ export default class LdapConfigurationRoute extends Route {
     super.setupController(controller, resolvedModel, transition);
 
     controller.breadcrumbs = [
-      { label: 'secrets', route: 'secrets', linkExternal: true },
+      { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: resolvedModel.backendModel.id },
     ];
   }

--- a/ui/lib/ldap/addon/routes/error.ts
+++ b/ui/lib/ldap/addon/routes/error.ts
@@ -24,7 +24,7 @@ export default class LdapErrorRoute extends Route {
   setupController(controller: LdapErrorController, resolvedModel: AdapterError, transition: Transition) {
     super.setupController(controller, resolvedModel, transition);
     controller.breadcrumbs = [
-      { label: 'secrets', route: 'secrets', linkExternal: true },
+      { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: this.secretMountPath.currentPath, route: 'overview' },
     ];
     controller.backend = this.modelFor('application') as SecretEngineModel;

--- a/ui/lib/ldap/addon/routes/libraries/index.ts
+++ b/ui/lib/ldap/addon/routes/libraries/index.ts
@@ -50,7 +50,7 @@ export default class LdapLibrariesRoute extends Route {
     super.setupController(controller, resolvedModel, transition);
 
     controller.breadcrumbs = [
-      { label: 'secrets', route: 'secrets', linkExternal: true },
+      { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: resolvedModel.backendModel.id },
     ];
   }

--- a/ui/lib/ldap/addon/routes/overview.ts
+++ b/ui/lib/ldap/addon/routes/overview.ts
@@ -74,7 +74,7 @@ export default class LdapOverviewRoute extends Route {
     super.setupController(controller, resolvedModel, transition);
 
     controller.breadcrumbs = [
-      { label: 'secrets', route: 'secrets', linkExternal: true },
+      { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: resolvedModel.backendModel.id },
     ];
   }

--- a/ui/lib/ldap/addon/routes/roles/index.ts
+++ b/ui/lib/ldap/addon/routes/roles/index.ts
@@ -75,7 +75,7 @@ export default class LdapRolesRoute extends Route {
     super.setupController(controller, resolvedModel, transition);
 
     controller.breadcrumbs = [
-      { label: 'secrets', route: 'secrets', linkExternal: true },
+      { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: resolvedModel.backendModel.id },
     ];
   }

--- a/ui/lib/pki/addon/components/page/pki-role-details.ts
+++ b/ui/lib/pki/addon/components/page/pki-role-details.ts
@@ -23,7 +23,7 @@ export default class DetailsPage extends Component<Args> {
 
   get breadcrumbs() {
     return [
-      { label: 'secrets', route: 'secrets', linkExternal: true },
+      { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: this.secretMountPath.currentPath, route: 'overview' },
       { label: 'roles', route: 'roles.index' },
       { label: this.args.role.id },

--- a/ui/lib/pki/addon/routes/certificates/certificate/details.js
+++ b/ui/lib/pki/addon/routes/certificates/certificate/details.js
@@ -17,7 +17,7 @@ export default class PkiCertificateDetailsRoute extends Route {
   setupController(controller, model) {
     super.setupController(controller, model);
     controller.breadcrumbs = [
-      { label: 'secrets', route: 'secrets', linkExternal: true },
+      { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: this.secretMountPath.currentPath, route: 'overview', model: this.secretMountPath.currentPath },
       { label: 'certificates', route: 'certificates.index', model: this.secretMountPath.currentPath },
       { label: model.id },

--- a/ui/lib/pki/addon/routes/configuration/create.js
+++ b/ui/lib/pki/addon/routes/configuration/create.js
@@ -23,7 +23,7 @@ export default class PkiConfigurationCreateRoute extends Route {
   setupController(controller, resolvedModel) {
     super.setupController(controller, resolvedModel);
     controller.breadcrumbs = [
-      { label: 'secrets', route: 'secrets', linkExternal: true },
+      { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: this.secretMountPath.currentPath, route: 'overview', model: this.secretMountPath.currentPath },
       { label: 'configure' },
     ];

--- a/ui/lib/pki/addon/routes/configuration/edit.js
+++ b/ui/lib/pki/addon/routes/configuration/edit.js
@@ -25,7 +25,7 @@ export default class PkiConfigurationEditRoute extends Route {
   setupController(controller, resolvedModel) {
     super.setupController(controller, resolvedModel);
     controller.breadcrumbs = [
-      { label: 'secrets', route: 'secrets', linkExternal: true },
+      { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: this.secretMountPath.currentPath, route: 'overview', model: this.secretMountPath.currentPath },
       { label: 'configuration', route: 'configuration.index', model: this.secretMountPath.currentPath },
       { label: 'edit' },

--- a/ui/lib/pki/addon/routes/error.js
+++ b/ui/lib/pki/addon/routes/error.js
@@ -12,7 +12,7 @@ export default class PkiRolesErrorRoute extends Route {
   setupController(controller) {
     super.setupController(...arguments);
     controller.breadcrumbs = [
-      { label: 'secrets', route: 'secrets', linkExternal: true },
+      { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: this.secretMountPath.currentPath, route: 'overview' },
     ];
     controller.tabs = [

--- a/ui/lib/pki/addon/routes/issuers/generate-intermediate.js
+++ b/ui/lib/pki/addon/routes/issuers/generate-intermediate.js
@@ -19,7 +19,7 @@ export default class PkiIssuersGenerateIntermediateRoute extends Route {
   setupController(controller, resolvedModel) {
     super.setupController(controller, resolvedModel);
     controller.breadcrumbs = [
-      { label: 'secrets', route: 'secrets', linkExternal: true },
+      { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: this.secretMountPath.currentPath, route: 'overview', model: this.secretMountPath.currentPath },
       { label: 'issuers', route: 'issuers.index', model: this.secretMountPath.currentPath },
       { label: 'generate CSR' },

--- a/ui/lib/pki/addon/routes/issuers/generate-root.js
+++ b/ui/lib/pki/addon/routes/issuers/generate-root.js
@@ -19,7 +19,7 @@ export default class PkiIssuersGenerateRootRoute extends Route {
   setupController(controller, resolvedModel) {
     super.setupController(controller, resolvedModel);
     controller.breadcrumbs = [
-      { label: 'secrets', route: 'secrets', linkExternal: true },
+      { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: this.secretMountPath.currentPath, route: 'overview', model: this.secretMountPath.currentPath },
       { label: 'generate root' },
     ];

--- a/ui/lib/pki/addon/routes/issuers/import.js
+++ b/ui/lib/pki/addon/routes/issuers/import.js
@@ -19,7 +19,7 @@ export default class PkiIssuersImportRoute extends Route {
   setupController(controller, resolvedModel) {
     super.setupController(controller, resolvedModel);
     controller.breadcrumbs = [
-      { label: 'secrets', route: 'secrets', linkExternal: true },
+      { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: this.secretMountPath.currentPath, route: 'overview', model: this.secretMountPath.currentPath },
       { label: 'issuers', route: 'issuers.index', model: this.secretMountPath.currentPath },
       { label: 'import' },

--- a/ui/lib/pki/addon/routes/issuers/index.js
+++ b/ui/lib/pki/addon/routes/issuers/index.js
@@ -35,7 +35,7 @@ export default class PkiIssuersListRoute extends Route {
   setupController(controller, resolvedModel) {
     super.setupController(controller, resolvedModel);
     controller.breadcrumbs = [
-      { label: 'secrets', route: 'secrets', linkExternal: true },
+      { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: this.secretMountPath.currentPath, route: 'overview', model: this.secretMountPath.currentPath },
       { label: 'issuers', route: 'issuers.index', model: this.secretMountPath.currentPath },
     ];

--- a/ui/lib/pki/addon/routes/issuers/issuer.js
+++ b/ui/lib/pki/addon/routes/issuers/issuer.js
@@ -21,7 +21,7 @@ export default class PkiIssuerIndexRoute extends Route {
   setupController(controller, resolvedModel) {
     super.setupController(controller, resolvedModel);
     controller.breadcrumbs = [
-      { label: 'secrets', route: 'secrets', linkExternal: true },
+      { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: this.secretMountPath.currentPath, route: 'overview', model: this.secretMountPath.currentPath },
       { label: 'issuers', route: 'issuers.index', model: this.secretMountPath.currentPath },
     ];

--- a/ui/lib/pki/addon/routes/issuers/issuer/cross-sign.js
+++ b/ui/lib/pki/addon/routes/issuers/issuer/cross-sign.js
@@ -20,7 +20,7 @@ export default class PkiIssuerCrossSignRoute extends Route {
     super.setupController(controller, resolvedModel);
 
     controller.breadcrumbs = [
-      { label: 'secrets', route: 'secrets', linkExternal: true },
+      { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: this.secretMountPath.currentPath, route: 'overview', model: this.secretMountPath.currentPath },
       { label: 'issuers', route: 'issuers.index', model: this.secretMountPath.currentPath },
       {

--- a/ui/lib/pki/addon/routes/issuers/issuer/details.js
+++ b/ui/lib/pki/addon/routes/issuers/issuer/details.js
@@ -26,7 +26,7 @@ export default class PkiIssuerDetailsRoute extends Route {
   setupController(controller, resolvedModel) {
     super.setupController(controller, resolvedModel);
     controller.breadcrumbs = [
-      { label: 'secrets', route: 'secrets', linkExternal: true },
+      { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: this.secretMountPath.currentPath, route: 'overview', model: resolvedModel.backend },
       { label: 'issuers', route: 'issuers.index', model: resolvedModel.backend },
       { label: resolvedModel.issuer.id },

--- a/ui/lib/pki/addon/routes/issuers/issuer/edit.js
+++ b/ui/lib/pki/addon/routes/issuers/issuer/edit.js
@@ -23,7 +23,7 @@ export default class PkiIssuerEditRoute extends Route {
   setupController(controller, resolvedModel) {
     super.setupController(controller, resolvedModel);
     controller.breadcrumbs = [
-      { label: 'secrets', route: 'secrets', linkExternal: true },
+      { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: this.secretMountPath.currentPath, route: 'overview', model: this.secretMountPath.currentPath },
       { label: 'issuers', route: 'issuers.index', model: this.secretMountPath.currentPath },
       {

--- a/ui/lib/pki/addon/routes/issuers/issuer/rotate-root.js
+++ b/ui/lib/pki/addon/routes/issuers/issuer/rotate-root.js
@@ -39,7 +39,7 @@ export default class PkiIssuerRotateRootRoute extends Route {
   setupController(controller, resolvedModel) {
     super.setupController(controller, resolvedModel);
     controller.breadcrumbs = [
-      { label: 'secrets', route: 'secrets', linkExternal: true },
+      { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: this.secretMountPath.currentPath, route: 'overview', model: resolvedModel.oldRoot.backend },
       { label: 'issuers', route: 'issuers.index', model: resolvedModel.oldRoot.backend },
       {

--- a/ui/lib/pki/addon/routes/issuers/issuer/sign.js
+++ b/ui/lib/pki/addon/routes/issuers/issuer/sign.js
@@ -19,7 +19,7 @@ export default class PkiIssuerSignRoute extends Route {
   setupController(controller, resolvedModel) {
     super.setupController(controller, resolvedModel);
     controller.breadcrumbs = [
-      { label: 'secrets', route: 'secrets', linkExternal: true },
+      { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: this.secretMountPath.currentPath, route: 'overview', model: this.secretMountPath.currentPath },
       { label: 'issuers', route: 'issuers.index', model: this.secretMountPath.currentPath },
       {

--- a/ui/lib/pki/addon/routes/keys/create.js
+++ b/ui/lib/pki/addon/routes/keys/create.js
@@ -19,7 +19,7 @@ export default class PkiKeysCreateRoute extends Route {
   setupController(controller, resolvedModel) {
     super.setupController(controller, resolvedModel);
     controller.breadcrumbs = [
-      { label: 'secrets', route: 'secrets', linkExternal: true },
+      { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: this.secretMountPath.currentPath, route: 'overview', model: this.secretMountPath.currentPath },
       { label: 'keys', route: 'keys.index', model: this.secretMountPath.currentPath },
       { label: 'generate' },

--- a/ui/lib/pki/addon/routes/keys/import.js
+++ b/ui/lib/pki/addon/routes/keys/import.js
@@ -19,7 +19,7 @@ export default class PkiKeysImportRoute extends Route {
   setupController(controller, resolvedModel) {
     super.setupController(controller, resolvedModel);
     controller.breadcrumbs = [
-      { label: 'secrets', route: 'secrets', linkExternal: true },
+      { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: this.secretMountPath.currentPath, route: 'overview', model: this.secretMountPath.currentPath },
       { label: 'keys', route: 'keys.index', model: this.secretMountPath.currentPath },
       { label: 'import' },

--- a/ui/lib/pki/addon/routes/keys/index.js
+++ b/ui/lib/pki/addon/routes/keys/index.js
@@ -45,7 +45,7 @@ export default class PkiKeysIndexRoute extends Route {
   setupController(controller, resolvedModel) {
     super.setupController(controller, resolvedModel);
     controller.breadcrumbs = [
-      { label: 'secrets', route: 'secrets', linkExternal: true },
+      { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: this.secretMountPath.currentPath, route: 'overview', model: resolvedModel.parentModel.id },
       { label: 'keys', route: 'keys.index', model: resolvedModel.parentModel.id },
     ];

--- a/ui/lib/pki/addon/routes/keys/key/details.js
+++ b/ui/lib/pki/addon/routes/keys/key/details.js
@@ -15,7 +15,7 @@ export default class PkiKeyDetailsRoute extends Route {
   setupController(controller, resolvedModel) {
     super.setupController(controller, resolvedModel);
     controller.breadcrumbs = [
-      { label: 'secrets', route: 'secrets', linkExternal: true },
+      { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: this.secretMountPath.currentPath, route: 'overview', model: resolvedModel.backend },
       { label: 'keys', route: 'keys.index', model: resolvedModel.backend },
       { label: resolvedModel.id },

--- a/ui/lib/pki/addon/routes/keys/key/edit.js
+++ b/ui/lib/pki/addon/routes/keys/key/edit.js
@@ -18,7 +18,7 @@ export default class PkiKeyEditRoute extends Route {
   setupController(controller, resolvedModel) {
     super.setupController(controller, resolvedModel);
     controller.breadcrumbs = [
-      { label: 'secrets', route: 'secrets', linkExternal: true },
+      { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: this.secretMountPath.currentPath, route: 'overview', model: this.secretMountPath.currentPath },
       { label: 'keys', route: 'keys.index', model: this.secretMountPath.currentPath },
       { label: resolvedModel.id },

--- a/ui/lib/pki/addon/routes/roles/create.js
+++ b/ui/lib/pki/addon/routes/roles/create.js
@@ -30,7 +30,7 @@ export default class PkiRolesCreateRoute extends Route {
   setupController(controller, resolvedModel) {
     super.setupController(controller, resolvedModel);
     controller.breadcrumbs = [
-      { label: 'secrets', route: 'secrets', linkExternal: true },
+      { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: this.secretMountPath.currentPath, route: 'overview', model: this.secretMountPath.currentPath },
       { label: 'roles', route: 'roles.index', model: this.secretMountPath.currentPath },
       { label: 'create' },

--- a/ui/lib/pki/addon/routes/roles/role/details.js
+++ b/ui/lib/pki/addon/routes/roles/role/details.js
@@ -22,7 +22,7 @@ export default class RolesRoleDetailsRoute extends Route {
     super.setupController(controller, resolvedModel);
     const { id } = resolvedModel;
     controller.breadcrumbs = [
-      { label: 'secrets', route: 'secrets', linkExternal: true },
+      { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: this.secretMountPath.currentPath, route: 'overview', model: this.secretMountPath.currentPath },
       { label: 'roles', route: 'roles.index', model: this.secretMountPath.currentPath },
       { label: id },

--- a/ui/lib/pki/addon/routes/roles/role/edit.js
+++ b/ui/lib/pki/addon/routes/roles/role/edit.js
@@ -38,7 +38,7 @@ export default class PkiRoleEditRoute extends Route {
       role: { id },
     } = resolvedModel;
     controller.breadcrumbs = [
-      { label: 'secrets', route: 'secrets', linkExternal: true },
+      { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: this.secretMountPath.currentPath, route: 'overview', model: this.secretMountPath.currentPath },
       { label: 'roles', route: 'roles.index', model: this.secretMountPath.currentPath },
       { label: id, route: 'roles.role.details', models: [this.secretMountPath.currentPath, id] },

--- a/ui/lib/pki/addon/routes/roles/role/generate.js
+++ b/ui/lib/pki/addon/routes/roles/role/generate.js
@@ -23,7 +23,7 @@ export default class PkiRoleGenerateRoute extends Route {
     super.setupController(controller, resolvedModel);
     const { role } = this.paramsFor('roles/role');
     controller.breadcrumbs = [
-      { label: 'secrets', route: 'secrets', linkExternal: true },
+      { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: this.secretMountPath.currentPath, route: 'overview', model: this.secretMountPath.currentPath },
       { label: 'roles', route: 'roles.index', model: this.secretMountPath.currentPath },
       { label: role, route: 'roles.role.details', models: [this.secretMountPath.currentPath, role] },

--- a/ui/lib/pki/addon/routes/roles/role/sign.js
+++ b/ui/lib/pki/addon/routes/roles/role/sign.js
@@ -23,7 +23,7 @@ export default class PkiRoleSignRoute extends Route {
     super.setupController(controller, resolvedModel);
     const { role } = this.paramsFor('roles/role');
     controller.breadcrumbs = [
-      { label: 'secrets', route: 'secrets', linkExternal: true },
+      { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: this.secretMountPath.currentPath, route: 'overview', model: this.secretMountPath.currentPath },
       { label: 'roles', route: 'roles.index', model: this.secretMountPath.currentPath },
       { label: role, route: 'roles.role.details', models: [this.secretMountPath.currentPath, role] },

--- a/ui/lib/pki/addon/routes/tidy/auto/configure.js
+++ b/ui/lib/pki/addon/routes/tidy/auto/configure.js
@@ -19,7 +19,7 @@ export default class PkiTidyAutoConfigureRoute extends Route {
     const { id: backend } = resolvedModel;
     super.setupController(controller, resolvedModel);
     controller.breadcrumbs = [
-      { label: 'secrets', route: 'secrets', linkExternal: true },
+      { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: this.secretMountPath.currentPath, route: 'overview', model: backend },
       { label: 'configuration', route: 'configuration.index', model: backend },
       { label: 'tidy', route: 'tidy', model: backend },

--- a/ui/lib/pki/addon/routes/tidy/auto/index.js
+++ b/ui/lib/pki/addon/routes/tidy/auto/index.js
@@ -17,7 +17,7 @@ export default class TidyAutoIndexRoute extends Route {
     const { id: backend } = resolvedModel;
     super.setupController(...arguments);
     controller.breadcrumbs = [
-      { label: 'secrets', route: 'secrets', linkExternal: true },
+      { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: this.secretMountPath.currentPath, route: 'overview', model: backend },
       { label: 'tidy', route: 'tidy.index', model: backend },
       { label: 'auto' },

--- a/ui/lib/pki/addon/routes/tidy/manual.js
+++ b/ui/lib/pki/addon/routes/tidy/manual.js
@@ -19,7 +19,7 @@ export default class PkiTidyManualRoute extends Route {
   setupController(controller, resolvedModel) {
     super.setupController(controller, resolvedModel);
     controller.breadcrumbs = [
-      { label: 'secrets', route: 'secrets', linkExternal: true },
+      { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: this.secretMountPath.currentPath, route: 'overview', model: resolvedModel.backend },
       { label: 'configuration', route: 'configuration.index', model: resolvedModel.backend },
       { label: 'tidy', route: 'tidy', model: resolvedModel.backend },

--- a/ui/tests/acceptance/secrets/backend/kv/kv-v2-workflow-edge-cases-test.js
+++ b/ui/tests/acceptance/secrets/backend/kv/kv-v2-workflow-edge-cases-test.js
@@ -171,7 +171,7 @@ module('Acceptance | kv-v2 workflow | edge cases', function (hooks) {
         .dom(PAGE.error.message)
         .hasText(`Sorry, we were unable to find any content at /v1/${backend}/data/${root}/${subdirectory}.`);
 
-      assert.dom(PAGE.breadcrumbAtIdx(0)).hasText('secrets');
+      assert.dom(PAGE.breadcrumbAtIdx(0)).hasText('Secrets');
       assert.dom(PAGE.breadcrumbAtIdx(1)).hasText(backend);
       assert.dom(PAGE.secretTab('Secrets')).doesNotHaveClass('is-active');
       assert.dom(PAGE.secretTab('Configuration')).doesNotHaveClass('is-active');

--- a/ui/tests/acceptance/secrets/backend/kv/kv-v2-workflow-navigation-test.js
+++ b/ui/tests/acceptance/secrets/backend/kv/kv-v2-workflow-navigation-test.js
@@ -115,7 +115,7 @@ module('Acceptance | kv-v2 workflow | navigation', function (hooks) {
       // URL correct
       assert.strictEqual(currentURL(), `/vault/secrets/${backend}/kv/list`, 'lands on secrets list page');
       // Breadcrumbs correct
-      assertCorrectBreadcrumbs(assert, ['secrets', backend]);
+      assertCorrectBreadcrumbs(assert, ['Secrets', backend]);
       // Title correct
       assert.dom(PAGE.title).hasText(`${backend} version 2`);
       // Tabs correct
@@ -150,20 +150,20 @@ module('Acceptance | kv-v2 workflow | navigation', function (hooks) {
       await navToBackend(backend);
       assert.dom(PAGE.title).hasText(`${backend} version 2`, 'title text correct');
       assert.dom(PAGE.emptyStateTitle).doesNotExist('No empty state');
-      assertCorrectBreadcrumbs(assert, ['secret', backend]);
+      assertCorrectBreadcrumbs(assert, ['Secret', backend]);
       assert.dom(PAGE.list.filter).hasNoValue('List filter input is empty');
 
       // Navigate through list items
       await click(PAGE.list.item('app/'));
       assert.strictEqual(currentURL(), `/vault/secrets/${backend}/kv/list/app/`);
-      assertCorrectBreadcrumbs(assert, ['secret', backend, 'app']);
+      assertCorrectBreadcrumbs(assert, ['Secret', backend, 'app']);
       assert.dom(PAGE.title).hasText(`${backend} version 2`);
       assert.dom(PAGE.list.filter).hasValue('app/', 'List filter input is prefilled');
       assert.dom(PAGE.list.item('nested/')).exists('Shows nested secret');
 
       await click(PAGE.list.item('nested/'));
       assert.strictEqual(currentURL(), `/vault/secrets/${backend}/kv/list/app/nested/`);
-      assertCorrectBreadcrumbs(assert, ['secret', backend, 'app', 'nested']);
+      assertCorrectBreadcrumbs(assert, ['Secret', backend, 'app', 'nested']);
       assert.dom(PAGE.title).hasText(`${backend} version 2`);
       assert.dom(PAGE.list.filter).hasValue('app/nested/', 'List filter input is prefilled');
       assert.dom(PAGE.list.item('secret')).exists('Shows deeply nested secret');
@@ -173,7 +173,7 @@ module('Acceptance | kv-v2 workflow | navigation', function (hooks) {
         currentURL(),
         `/vault/secrets/${backend}/kv/app%2Fnested%2Fsecret/details?version=1`
       );
-      assertCorrectBreadcrumbs(assert, ['secret', backend, 'app', 'nested', 'secret']);
+      assertCorrectBreadcrumbs(assert, ['Secret', backend, 'app', 'nested', 'secret']);
       assert.dom(PAGE.title).hasText('app/nested/secret', 'title is full secret path');
       assertDetailsToolbar(assert);
 
@@ -277,7 +277,7 @@ module('Acceptance | kv-v2 workflow | navigation', function (hooks) {
         `/vault/secrets/${backend}/kv/${secretPathUrlEncoded}/metadata`,
         `goes to metadata page`
       );
-      assertCorrectBreadcrumbs(assert, ['secrets', backend, secretPath, 'metadata']);
+      assertCorrectBreadcrumbs(assert, ['Secrets', backend, secretPath, 'metadata']);
       assert.dom(PAGE.title).hasText(secretPath);
       assert
         .dom(`${PAGE.metadata.customMetadataSection} ${PAGE.emptyStateTitle}`)
@@ -293,7 +293,7 @@ module('Acceptance | kv-v2 workflow | navigation', function (hooks) {
         `/vault/secrets/${backend}/kv/${secretPathUrlEncoded}/metadata/edit`,
         `goes to metadata edit page`
       );
-      assertCorrectBreadcrumbs(assert, ['secrets', backend, secretPath, 'metadata', 'edit']);
+      assertCorrectBreadcrumbs(assert, ['Secrets', backend, secretPath, 'metadata', 'edit']);
       await click(FORM.cancelBtn);
       assert.strictEqual(
         currentURL(),
@@ -306,37 +306,37 @@ module('Acceptance | kv-v2 workflow | navigation', function (hooks) {
       const backend = this.backend;
       await navToBackend(backend);
       await click(PAGE.secretTab('Configuration'));
-      assertCorrectBreadcrumbs(assert, ['secrets', backend, 'configuration']);
+      assertCorrectBreadcrumbs(assert, ['Secrets', backend, 'configuration']);
       assert.dom(PAGE.title).hasText(`${backend} version 2`, 'correct page title for configuration');
 
       await click(PAGE.secretTab('Secrets'));
-      assertCorrectBreadcrumbs(assert, ['secrets', backend]);
+      assertCorrectBreadcrumbs(assert, ['Secrets', backend]);
       assert.dom(PAGE.title).hasText(`${backend} version 2`, 'correct page title for secret list');
 
       await click(PAGE.list.item(secretPath));
-      assertCorrectBreadcrumbs(assert, ['secrets', backend, secretPath]);
+      assertCorrectBreadcrumbs(assert, ['Secrets', backend, secretPath]);
       assert.dom(PAGE.title).hasText(secretPath, 'correct page title for secret detail');
 
       await click(PAGE.detail.createNewVersion);
-      assertCorrectBreadcrumbs(assert, ['secrets', backend, secretPath, 'edit']);
+      assertCorrectBreadcrumbs(assert, ['Secrets', backend, secretPath, 'edit']);
       assert.dom(PAGE.title).hasText('Create New Version', 'correct page title for secret edit');
 
       await click(PAGE.breadcrumbAtIdx(2));
       await click(PAGE.secretTab('Metadata'));
-      assertCorrectBreadcrumbs(assert, ['secrets', backend, secretPath, 'metadata']);
+      assertCorrectBreadcrumbs(assert, ['Secrets', backend, secretPath, 'metadata']);
       assert.dom(PAGE.title).hasText(secretPath, 'correct page title for metadata');
 
       await click(PAGE.metadata.editBtn);
-      assertCorrectBreadcrumbs(assert, ['secrets', backend, secretPath, 'metadata', 'edit']);
+      assertCorrectBreadcrumbs(assert, ['Secrets', backend, secretPath, 'metadata', 'edit']);
       assert.dom(PAGE.title).hasText('Edit Secret Metadata', 'correct page title for metadata edit');
 
       await click(PAGE.breadcrumbAtIdx(3));
       await click(PAGE.secretTab('Paths'));
-      assertCorrectBreadcrumbs(assert, ['secrets', backend, secretPath, 'paths']);
+      assertCorrectBreadcrumbs(assert, ['Secrets', backend, secretPath, 'paths']);
       assert.dom(PAGE.title).hasText(secretPath, 'correct page title for paths');
 
       await click(PAGE.secretTab('Version History'));
-      assertCorrectBreadcrumbs(assert, ['secrets', backend, secretPath, 'version history']);
+      assertCorrectBreadcrumbs(assert, ['Secrets', backend, secretPath, 'version history']);
       assert.dom(PAGE.title).hasText(secretPath, 'correct page title for version history');
     });
   });
@@ -362,7 +362,7 @@ module('Acceptance | kv-v2 workflow | navigation', function (hooks) {
       // URL correct
       assert.strictEqual(currentURL(), `/vault/secrets/${backend}/kv/list`, 'lands on secrets list page');
       // Breadcrumbs correct
-      assertCorrectBreadcrumbs(assert, ['secrets', backend]);
+      assertCorrectBreadcrumbs(assert, ['Secrets', backend]);
       // Title correct
       assert.dom(PAGE.title).hasText(`${backend} version 2`);
       // Tabs correct
@@ -410,7 +410,7 @@ module('Acceptance | kv-v2 workflow | navigation', function (hooks) {
       await navToBackend(backend);
       assert.dom(PAGE.title).hasText(`${backend} version 2`, 'title text correct');
       assert.dom(PAGE.emptyStateTitle).doesNotExist('No empty state');
-      assertCorrectBreadcrumbs(assert, ['secret', backend]);
+      assertCorrectBreadcrumbs(assert, ['Secret', backend]);
       assert
         .dom(PAGE.list.filter)
         .doesNotExist('List filter input does not render because no list capabilities');
@@ -423,7 +423,7 @@ module('Acceptance | kv-v2 workflow | navigation', function (hooks) {
         currentURL(),
         `/vault/secrets/${backend}/kv/app%2Fnested%2Fsecret/details?version=1`
       );
-      assertCorrectBreadcrumbs(assert, ['secret', backend, 'app', 'nested', 'secret']);
+      assertCorrectBreadcrumbs(assert, ['Secret', backend, 'app', 'nested', 'secret']);
       assert.dom(PAGE.title).hasText('app/nested/secret', 'title is full secret path');
       assertDetailsToolbar(assert, ['copy']);
 
@@ -477,7 +477,7 @@ module('Acceptance | kv-v2 workflow | navigation', function (hooks) {
         `/vault/secrets/${backend}/kv/${secretPathUrlEncoded}/metadata`,
         `goes to metadata page`
       );
-      assertCorrectBreadcrumbs(assert, ['secrets', backend, secretPath, 'metadata']);
+      assertCorrectBreadcrumbs(assert, ['Secrets', backend, secretPath, 'metadata']);
       assert.dom(PAGE.title).hasText(secretPath);
       assert.dom(PAGE.toolbarAction).doesNotExist('no toolbar actions available on metadata');
       assert
@@ -493,28 +493,28 @@ module('Acceptance | kv-v2 workflow | navigation', function (hooks) {
       const backend = this.backend;
       await navToBackend(backend);
       await click(PAGE.secretTab('Configuration'));
-      assertCorrectBreadcrumbs(assert, ['secrets', backend, 'configuration']);
+      assertCorrectBreadcrumbs(assert, ['Secrets', backend, 'configuration']);
       assert.dom(PAGE.title).hasText(`${backend} version 2`, 'title correct on config page');
 
       await click(PAGE.secretTab('Secrets'));
-      assertCorrectBreadcrumbs(assert, ['secrets', backend]);
+      assertCorrectBreadcrumbs(assert, ['Secrets', backend]);
       assert.dom(PAGE.title).hasText(`${backend} version 2`, 'title correct on secrets list');
 
       await typeIn(PAGE.list.overviewInput, 'app/nested/secret');
       await click(PAGE.list.overviewButton);
-      assertCorrectBreadcrumbs(assert, ['secrets', backend, 'app', 'nested', 'secret']);
+      assertCorrectBreadcrumbs(assert, ['Secrets', backend, 'app', 'nested', 'secret']);
       assert.dom(PAGE.title).hasText('app/nested/secret', 'title correct on secret detail');
 
       assert.dom(PAGE.detail.createNewVersion).doesNotExist('cannot create new version');
 
       await click(PAGE.secretTab('Metadata'));
-      assertCorrectBreadcrumbs(assert, ['secrets', backend, 'app', 'nested', 'secret', 'metadata']);
+      assertCorrectBreadcrumbs(assert, ['Secrets', backend, 'app', 'nested', 'secret', 'metadata']);
       assert.dom(PAGE.title).hasText('app/nested/secret', 'title correct on metadata');
 
       assert.dom(PAGE.metadata.editBtn).doesNotExist('cannot edit metadata');
 
       await click(PAGE.secretTab('Paths'));
-      assertCorrectBreadcrumbs(assert, ['secrets', backend, 'app', 'nested', 'secret', 'paths']);
+      assertCorrectBreadcrumbs(assert, ['Secrets', backend, 'app', 'nested', 'secret', 'paths']);
       assert.dom(PAGE.title).hasText('app/nested/secret', 'correct page title for paths');
 
       assert.dom(PAGE.secretTab('Version History')).doesNotExist('Version History tab not shown');
@@ -543,7 +543,7 @@ module('Acceptance | kv-v2 workflow | navigation', function (hooks) {
       // URL correct
       assert.strictEqual(currentURL(), `/vault/secrets/${backend}/kv/list`, 'lands on secrets list page');
       // Breadcrumbs correct
-      assertCorrectBreadcrumbs(assert, ['secrets', backend]);
+      assertCorrectBreadcrumbs(assert, ['Secrets', backend]);
       // Title correct
       assert.dom(PAGE.title).hasText(`${backend} version 2`);
       // Tabs correct
@@ -578,13 +578,13 @@ module('Acceptance | kv-v2 workflow | navigation', function (hooks) {
       await navToBackend(backend);
       assert.dom(PAGE.title).hasText(`${backend} version 2`, 'title text correct');
       assert.dom(PAGE.emptyStateTitle).doesNotExist('No empty state');
-      assertCorrectBreadcrumbs(assert, ['secret', backend]);
+      assertCorrectBreadcrumbs(assert, ['Secret', backend]);
       assert.dom(PAGE.list.filter).hasNoValue('List filter input is empty');
 
       // Navigate through list items
       await click(PAGE.list.item('app/'));
       assert.strictEqual(currentURL(), `/vault/secrets/${backend}/kv/list/app/`);
-      assertCorrectBreadcrumbs(assert, ['secret', backend, 'app']);
+      assertCorrectBreadcrumbs(assert, ['Secret', backend, 'app']);
       assert.dom(PAGE.title).hasText(`${backend} version 2`);
       assert.dom(PAGE.list.filter).doesNotExist('List filter hidden since no nested list access');
 
@@ -598,7 +598,7 @@ module('Acceptance | kv-v2 workflow | navigation', function (hooks) {
         currentURL(),
         `/vault/secrets/${backend}/kv/app%2Fnested%2Fsecret/details?version=1`
       );
-      assertCorrectBreadcrumbs(assert, ['secret', backend, 'app', 'nested', 'secret']);
+      assertCorrectBreadcrumbs(assert, ['Secret', backend, 'app', 'nested', 'secret']);
       assert.dom(PAGE.title).hasText('app/nested/secret', 'title is full secret path');
       assertDetailsToolbar(assert, ['delete', 'copy']);
 
@@ -650,7 +650,7 @@ module('Acceptance | kv-v2 workflow | navigation', function (hooks) {
         `/vault/secrets/${backend}/kv/${secretPathUrlEncoded}/metadata`,
         `goes to metadata page`
       );
-      assertCorrectBreadcrumbs(assert, ['secrets', backend, secretPath, 'metadata']);
+      assertCorrectBreadcrumbs(assert, ['Secrets', backend, secretPath, 'metadata']);
       assert.dom(PAGE.title).hasText(secretPath);
       assert
         .dom(`${PAGE.metadata.customMetadataSection} ${PAGE.emptyStateTitle}`)
@@ -666,27 +666,27 @@ module('Acceptance | kv-v2 workflow | navigation', function (hooks) {
       await navToBackend(backend);
 
       await click(PAGE.secretTab('Configuration'));
-      assertCorrectBreadcrumbs(assert, ['secrets', backend, 'configuration']);
+      assertCorrectBreadcrumbs(assert, ['Secrets', backend, 'configuration']);
       assert.dom(PAGE.title).hasText(`${backend} version 2`, 'correct page title for configuration');
 
       await click(PAGE.secretTab('Secrets'));
-      assertCorrectBreadcrumbs(assert, ['secrets', backend]);
+      assertCorrectBreadcrumbs(assert, ['Secrets', backend]);
       assert.dom(PAGE.title).hasText(`${backend} version 2`, 'correct page title for secret list');
 
       await click(PAGE.list.item(secretPath));
-      assertCorrectBreadcrumbs(assert, ['secrets', backend, secretPath]);
+      assertCorrectBreadcrumbs(assert, ['Secrets', backend, secretPath]);
       assert.dom(PAGE.title).hasText(secretPath, 'correct page title for secret detail');
 
       assert.dom(PAGE.detail.createNewVersion).doesNotExist('cannot create new version');
 
       await click(PAGE.secretTab('Metadata'));
-      assertCorrectBreadcrumbs(assert, ['secrets', backend, secretPath, 'metadata']);
+      assertCorrectBreadcrumbs(assert, ['Secrets', backend, secretPath, 'metadata']);
       assert.dom(PAGE.title).hasText(secretPath, 'correct page title for metadata');
 
       assert.dom(PAGE.metadata.editBtn).doesNotExist('cannot edit metadata');
 
       await click(PAGE.secretTab('Paths'));
-      assertCorrectBreadcrumbs(assert, ['secrets', backend, secretPath, 'paths']);
+      assertCorrectBreadcrumbs(assert, ['Secrets', backend, secretPath, 'paths']);
       assert.dom(PAGE.title).hasText(secretPath, 'correct page title for paths');
 
       assert.dom(PAGE.secretTab('Version History')).doesNotExist('Version History tab not shown');
@@ -714,7 +714,7 @@ module('Acceptance | kv-v2 workflow | navigation', function (hooks) {
       // URL correct
       assert.strictEqual(currentURL(), `/vault/secrets/${backend}/kv/list`, 'lands on secrets list page');
       // Breadcrumbs correct
-      assertCorrectBreadcrumbs(assert, ['secrets', backend]);
+      assertCorrectBreadcrumbs(assert, ['Secrets', backend]);
       // Title correct
       assert.dom(PAGE.title).hasText(`${backend} version 2`);
       // Tabs correct
@@ -749,20 +749,20 @@ module('Acceptance | kv-v2 workflow | navigation', function (hooks) {
       await navToBackend(backend);
       assert.dom(PAGE.title).hasText(`${backend} version 2`, 'title text correct');
       assert.dom(PAGE.emptyStateTitle).doesNotExist('No empty state');
-      assertCorrectBreadcrumbs(assert, ['secret', backend]);
+      assertCorrectBreadcrumbs(assert, ['Secret', backend]);
       assert.dom(PAGE.list.filter).hasNoValue('List filter input is empty');
 
       // Navigate through list items
       await click(PAGE.list.item('app/'));
       assert.strictEqual(currentURL(), `/vault/secrets/${backend}/kv/list/app/`);
-      assertCorrectBreadcrumbs(assert, ['secret', backend, 'app']);
+      assertCorrectBreadcrumbs(assert, ['Secret', backend, 'app']);
       assert.dom(PAGE.title).hasText(`${backend} version 2`);
       assert.dom(PAGE.list.filter).hasValue('app/', 'List filter input is prefilled');
       assert.dom(PAGE.list.item('nested/')).exists('Shows nested secret');
 
       await click(PAGE.list.item('nested/'));
       assert.strictEqual(currentURL(), `/vault/secrets/${backend}/kv/list/app/nested/`);
-      assertCorrectBreadcrumbs(assert, ['secret', backend, 'app', 'nested']);
+      assertCorrectBreadcrumbs(assert, ['Secret', backend, 'app', 'nested']);
       assert.dom(PAGE.title).hasText(`${backend} version 2`);
       assert.dom(PAGE.list.filter).hasValue('app/nested/', 'List filter input is prefilled');
       assert.dom(PAGE.list.item('secret')).exists('Shows deeply nested secret');
@@ -773,7 +773,7 @@ module('Acceptance | kv-v2 workflow | navigation', function (hooks) {
         `/vault/secrets/${backend}/kv/app%2Fnested%2Fsecret/details`,
         `Goes to URL with version`
       );
-      assertCorrectBreadcrumbs(assert, ['secret', backend, 'app', 'nested', 'secret']);
+      assertCorrectBreadcrumbs(assert, ['Secret', backend, 'app', 'nested', 'secret']);
       assert.dom(PAGE.title).hasText('app/nested/secret', 'title is full secret path');
       assertDetailsToolbar(assert, ['delete', 'destroy', 'versionDropdown']);
       assert.dom(PAGE.detail.versionDropdown).hasText('Version 1', 'Shows version timestamp');
@@ -837,7 +837,7 @@ module('Acceptance | kv-v2 workflow | navigation', function (hooks) {
         `/vault/secrets/${backend}/kv/${secretPathUrlEncoded}/metadata`,
         `goes to metadata page`
       );
-      assertCorrectBreadcrumbs(assert, ['secrets', backend, secretPath, 'metadata']);
+      assertCorrectBreadcrumbs(assert, ['Secrets', backend, secretPath, 'metadata']);
       assert.dom(PAGE.title).hasText(secretPath);
       assert
         .dom(`${PAGE.metadata.customMetadataSection} ${PAGE.emptyStateTitle}`)
@@ -853,7 +853,7 @@ module('Acceptance | kv-v2 workflow | navigation', function (hooks) {
         `/vault/secrets/${backend}/kv/${secretPathUrlEncoded}/metadata/edit`,
         `goes to metadata edit page`
       );
-      assertCorrectBreadcrumbs(assert, ['secrets', backend, secretPath, 'metadata', 'edit']);
+      assertCorrectBreadcrumbs(assert, ['Secrets', backend, secretPath, 'metadata', 'edit']);
       await click(FORM.cancelBtn);
       assert.strictEqual(
         currentURL(),
@@ -866,32 +866,32 @@ module('Acceptance | kv-v2 workflow | navigation', function (hooks) {
       const backend = this.backend;
       await navToBackend(backend);
       await click(PAGE.secretTab('Configuration'));
-      assertCorrectBreadcrumbs(assert, ['secrets', backend, 'configuration']);
+      assertCorrectBreadcrumbs(assert, ['Secrets', backend, 'configuration']);
       assert.dom(PAGE.title).hasText(`${backend} version 2`, 'correct page title for configuration');
 
       await click(PAGE.secretTab('Secrets'));
-      assertCorrectBreadcrumbs(assert, ['secrets', backend]);
+      assertCorrectBreadcrumbs(assert, ['Secrets', backend]);
       assert.dom(PAGE.title).hasText(`${backend} version 2`, 'correct page title for secret list');
 
       await click(PAGE.list.item(secretPath));
-      assertCorrectBreadcrumbs(assert, ['secrets', backend, secretPath]);
+      assertCorrectBreadcrumbs(assert, ['Secrets', backend, secretPath]);
       assert.dom(PAGE.title).hasText(secretPath, 'correct page title for secret detail');
 
       await click(PAGE.secretTab('Metadata'));
-      assertCorrectBreadcrumbs(assert, ['secrets', backend, secretPath, 'metadata']);
+      assertCorrectBreadcrumbs(assert, ['Secrets', backend, secretPath, 'metadata']);
       assert.dom(PAGE.title).hasText(secretPath, 'correct page title for metadata');
 
       await click(PAGE.metadata.editBtn);
-      assertCorrectBreadcrumbs(assert, ['secrets', backend, secretPath, 'metadata', 'edit']);
+      assertCorrectBreadcrumbs(assert, ['Secrets', backend, secretPath, 'metadata', 'edit']);
       assert.dom(PAGE.title).hasText('Edit Secret Metadata', 'correct page title for metadata edit');
 
       await click(PAGE.breadcrumbAtIdx(3));
       await click(PAGE.secretTab('Paths'));
-      assertCorrectBreadcrumbs(assert, ['secrets', backend, secretPath, 'paths']);
+      assertCorrectBreadcrumbs(assert, ['Secrets', backend, secretPath, 'paths']);
       assert.dom(PAGE.title).hasText(secretPath, 'correct page title for paths');
 
       await click(PAGE.secretTab('Version History'));
-      assertCorrectBreadcrumbs(assert, ['secrets', backend, secretPath, 'version history']);
+      assertCorrectBreadcrumbs(assert, ['Secrets', backend, secretPath, 'version history']);
       assert.dom(PAGE.title).hasText(secretPath, 'correct page title for version history');
     });
   });
@@ -917,7 +917,7 @@ module('Acceptance | kv-v2 workflow | navigation', function (hooks) {
       // URL correct
       assert.strictEqual(currentURL(), `/vault/secrets/${backend}/kv/list`, 'lands on secrets list page');
       // Breadcrumbs correct
-      assertCorrectBreadcrumbs(assert, ['secrets', backend]);
+      assertCorrectBreadcrumbs(assert, ['Secrets', backend]);
       // Title correct
       assert.dom(PAGE.title).hasText(`${backend} version 2`);
       // Tabs correct
@@ -954,7 +954,7 @@ module('Acceptance | kv-v2 workflow | navigation', function (hooks) {
       await navToBackend(backend);
       assert.dom(PAGE.title).hasText(`${backend} version 2`, 'title text correct');
       assert.dom(PAGE.emptyStateTitle).doesNotExist('No empty state');
-      assertCorrectBreadcrumbs(assert, ['secret', backend]);
+      assertCorrectBreadcrumbs(assert, ['Secret', backend]);
       assert.dom(PAGE.list.filter).doesNotExist('List filter input is not rendered');
 
       // Navigate to secret
@@ -966,7 +966,7 @@ module('Acceptance | kv-v2 workflow | navigation', function (hooks) {
         `/vault/secrets/${backend}/kv/app%2Fnested%2Fsecret/details`,
         'goes to secret detail page'
       );
-      assertCorrectBreadcrumbs(assert, ['secret', backend, 'app', 'nested', 'secret']);
+      assertCorrectBreadcrumbs(assert, ['Secret', backend, 'app', 'nested', 'secret']);
       assert.dom(PAGE.title).hasText('app/nested/secret', 'title is full secret path');
       assertDetailsToolbar(assert, ['createNewVersion']);
 
@@ -1052,7 +1052,7 @@ module('Acceptance | kv-v2 workflow | navigation', function (hooks) {
         `/vault/secrets/${backend}/kv/${secretPathUrlEncoded}/metadata`,
         `goes to metadata page`
       );
-      assertCorrectBreadcrumbs(assert, ['secrets', backend, secretPath, 'metadata']);
+      assertCorrectBreadcrumbs(assert, ['Secrets', backend, secretPath, 'metadata']);
       assert.dom(PAGE.title).hasText(secretPath);
       assert
         .dom(`${PAGE.metadata.customMetadataSection} ${PAGE.emptyStateTitle}`)
@@ -1064,32 +1064,32 @@ module('Acceptance | kv-v2 workflow | navigation', function (hooks) {
       const backend = this.backend;
       await navToBackend(backend);
       await click(PAGE.secretTab('Configuration'));
-      assertCorrectBreadcrumbs(assert, ['secrets', backend, 'configuration']);
+      assertCorrectBreadcrumbs(assert, ['Secrets', backend, 'configuration']);
       assert.dom(PAGE.title).hasText(`${backend} version 2`, 'correct page title for configuration');
 
       await click(PAGE.secretTab('Secrets'));
-      assertCorrectBreadcrumbs(assert, ['secrets', backend]);
+      assertCorrectBreadcrumbs(assert, ['Secrets', backend]);
       assert.dom(PAGE.title).hasText(`${backend} version 2`, 'correct page title for secret list');
 
       await typeIn(PAGE.list.overviewInput, secretPath);
       await click(PAGE.list.overviewButton);
-      assertCorrectBreadcrumbs(assert, ['secrets', backend, secretPath]);
+      assertCorrectBreadcrumbs(assert, ['Secrets', backend, secretPath]);
       assert.dom(PAGE.title).hasText(secretPath, 'correct page title for secret detail');
 
       await click(PAGE.detail.createNewVersion);
-      assertCorrectBreadcrumbs(assert, ['secrets', backend, secretPath, 'edit']);
+      assertCorrectBreadcrumbs(assert, ['Secrets', backend, secretPath, 'edit']);
       assert.dom(PAGE.title).hasText('Create New Version', 'correct page title for secret edit');
 
       await click(PAGE.breadcrumbAtIdx(2));
       await click(PAGE.secretTab('Metadata'));
-      assertCorrectBreadcrumbs(assert, ['secrets', backend, secretPath, 'metadata']);
+      assertCorrectBreadcrumbs(assert, ['Secrets', backend, secretPath, 'metadata']);
       assert.dom(PAGE.title).hasText(secretPath, 'correct page title for metadata');
 
       assert.dom(PAGE.metadata.editBtn).doesNotExist('cannot edit metadata');
 
       await click(PAGE.breadcrumbAtIdx(2));
       await click(PAGE.secretTab('Paths'));
-      assertCorrectBreadcrumbs(assert, ['secrets', backend, secretPath, 'paths']);
+      assertCorrectBreadcrumbs(assert, ['Secrets', backend, secretPath, 'paths']);
       assert.dom(PAGE.title).hasText(secretPath, 'correct page title for paths');
 
       assert.dom(PAGE.secretTab('Version History')).doesNotExist('Version History tab not shown');
@@ -1130,20 +1130,20 @@ path "${this.backend}/*" {
       await navToBackend(backend);
       assert.dom(PAGE.title).hasText(`${backend} version 2`, 'title text correct');
       assert.dom(PAGE.emptyStateTitle).doesNotExist('No empty state');
-      assertCorrectBreadcrumbs(assert, ['secret', backend]);
+      assertCorrectBreadcrumbs(assert, ['Secret', backend]);
       assert.dom(PAGE.list.filter).hasNoValue('List filter input is empty');
 
       // Navigate through list items
       await click(PAGE.list.item('app/'));
       assert.strictEqual(currentURL(), `/vault/secrets/${backend}/kv/list/app/`);
-      assertCorrectBreadcrumbs(assert, ['secret', backend, 'app']);
+      assertCorrectBreadcrumbs(assert, ['Secret', backend, 'app']);
       assert.dom(PAGE.title).hasText(`${backend} version 2`);
       assert.dom(PAGE.list.filter).hasValue('app/', 'List filter input is prefilled');
       assert.dom(PAGE.list.item('nested/')).exists('Shows nested secret');
 
       await click(PAGE.list.item('nested/'));
       assert.strictEqual(currentURL(), `/vault/secrets/${backend}/kv/list/app/nested/`);
-      assertCorrectBreadcrumbs(assert, ['secret', backend, 'app', 'nested']);
+      assertCorrectBreadcrumbs(assert, ['Secret', backend, 'app', 'nested']);
       assert.dom(PAGE.title).hasText(`${backend} version 2`);
       assert.dom(PAGE.list.filter).hasValue('app/nested/', 'List filter input is prefilled');
       assert.dom(PAGE.list.item('secret')).exists('Shows deeply nested secret');
@@ -1173,7 +1173,7 @@ path "${this.backend}/*" {
         `/vault/secrets/${backend}/kv/app%2Fnested%2Fsecret/details?version=1`,
         'goes to secret details'
       );
-      assertCorrectBreadcrumbs(assert, ['secret', backend, 'app', 'nested', 'secret']);
+      assertCorrectBreadcrumbs(assert, ['Secret', backend, 'app', 'nested', 'secret']);
       assert.dom(PAGE.title).hasText('app/nested/secret', 'title is full secret path');
       assertDetailsToolbar(assert, ['delete', 'copy', 'createNewVersion']);
 
@@ -1197,11 +1197,11 @@ path "${this.backend}/*" {
       const backend = this.backend;
       await navToBackend(backend);
       await click(PAGE.secretTab('Configuration'));
-      assertCorrectBreadcrumbs(assert, ['secrets', backend, 'configuration']);
+      assertCorrectBreadcrumbs(assert, ['Secrets', backend, 'configuration']);
       assert.dom(PAGE.title).hasText(`${backend} version 2`, 'correct page title for configuration');
 
       await click(PAGE.secretTab('Secrets'));
-      assertCorrectBreadcrumbs(assert, ['secrets', backend]);
+      assertCorrectBreadcrumbs(assert, ['Secrets', backend]);
       assert.dom(PAGE.title).hasText(`${backend} version 2`, 'correct page title for secret list');
 
       await visit(`/vault/secrets/${backend}/kv/${secretPathUrlEncoded}/details`);
@@ -1224,25 +1224,25 @@ path "${this.backend}/*" {
       );
       await click(PAGE.list.item(secretPath));
 
-      assertCorrectBreadcrumbs(assert, ['secrets', backend, secretPath]);
+      assertCorrectBreadcrumbs(assert, ['Secrets', backend, secretPath]);
       assert.dom(PAGE.title).hasText(secretPath, 'correct page title for secret detail');
 
       await click(PAGE.secretTab('Metadata'));
-      assertCorrectBreadcrumbs(assert, ['secrets', backend, secretPath, 'metadata']);
+      assertCorrectBreadcrumbs(assert, ['Secrets', backend, secretPath, 'metadata']);
       assert.dom(PAGE.title).hasText(secretPath, 'correct page title for metadata');
 
       assert.dom(PAGE.metadata.editBtn).doesNotExist('cannot edit metadata');
 
       await click(PAGE.breadcrumbAtIdx(2));
       await click(PAGE.secretTab('Paths'));
-      assertCorrectBreadcrumbs(assert, ['secrets', backend, secretPath, 'paths']);
+      assertCorrectBreadcrumbs(assert, ['Secrets', backend, secretPath, 'paths']);
       assert.dom(PAGE.title).hasText(secretPath, 'correct page title for paths');
 
       assert.dom(PAGE.secretTab('Version History')).doesNotExist('Version History tab not shown');
 
       await click(PAGE.secretTab('Secret'));
       await click(PAGE.detail.createNewVersion);
-      assertCorrectBreadcrumbs(assert, ['secrets', backend, secretPath, 'edit']);
+      assertCorrectBreadcrumbs(assert, ['Secrets', backend, secretPath, 'edit']);
       assert.dom(PAGE.title).hasText('Create New Version', 'correct page title for secret edit');
     });
   });

--- a/ui/tests/helpers/ldap/ldap-helpers.js
+++ b/ui/tests/helpers/ldap/ldap-helpers.js
@@ -18,7 +18,7 @@ export const createSecretsEngine = (store) => {
 };
 
 export const generateBreadcrumbs = (backend, childRoute) => {
-  const breadcrumbs = [{ label: 'secrets', route: 'secrets', linkExternal: true }];
+  const breadcrumbs = [{ label: 'Secrets', route: 'secrets', linkExternal: true }];
   const root = { label: backend };
   if (childRoute) {
     root.route = 'overview';

--- a/ui/tests/integration/components/kubernetes/page/configuration-test.js
+++ b/ui/tests/integration/components/kubernetes/page/configuration-test.js
@@ -42,7 +42,7 @@ module('Integration | Component | kubernetes | Page::Configuration', function (h
     };
 
     this.breadcrumbs = [
-      { label: 'secrets', route: 'secrets', linkExternal: true },
+      { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: this.backend.id },
     ];
 

--- a/ui/tests/integration/components/kubernetes/page/configure-test.js
+++ b/ui/tests/integration/components/kubernetes/page/configure-test.js
@@ -34,7 +34,7 @@ module('Integration | Component | kubernetes | Page::Configure', function (hooks
     });
     this.editModel = this.store.peekRecord('kubernetes/config', 'kubernetes-edit');
     this.breadcrumbs = [
-      { label: 'secrets', route: 'secrets', linkExternal: true },
+      { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: 'kubernetes', route: 'overview' },
       { label: 'configure' },
     ];

--- a/ui/tests/integration/components/kubernetes/page/overview-test.js
+++ b/ui/tests/integration/components/kubernetes/page/overview-test.js
@@ -43,7 +43,7 @@ module('Integration | Component | kubernetes | Page::Overview', function (hooks)
     this.backend = this.store.peekRecord('secret-engine', 'kubernetes-test');
     this.roles = this.store.peekAll('kubernetes/role');
     this.breadcrumbs = [
-      { label: 'secrets', route: 'secrets', linkExternal: true },
+      { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: this.backend.id },
     ];
     this.promptConfig = false;

--- a/ui/tests/integration/components/kubernetes/page/roles-test.js
+++ b/ui/tests/integration/components/kubernetes/page/roles-test.js
@@ -36,7 +36,7 @@ module('Integration | Component | kubernetes | Page::Roles', function (hooks) {
     this.roles = this.store.peekAll('kubernetes/role');
     this.filterValue = '';
     this.breadcrumbs = [
-      { label: 'secrets', route: 'secrets', linkExternal: true },
+      { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: this.backend.id },
     ];
     this.promptConfig = false;

--- a/ui/tests/integration/components/kubernetes/tab-page-header-test.js
+++ b/ui/tests/integration/components/kubernetes/tab-page-header-test.js
@@ -27,7 +27,7 @@ module('Integration | Component | kubernetes | TabPageHeader', function (hooks) 
     });
     this.model = this.store.peekRecord('secret-engine', 'kubernetes-test');
     this.mount = this.model.path.slice(0, -1);
-    this.breadcrumbs = [{ label: 'secrets', route: 'secrets', linkExternal: true }, { label: this.mount }];
+    this.breadcrumbs = [{ label: 'Secrets', route: 'secrets', linkExternal: true }, { label: this.mount }];
   });
 
   test('it should render breadcrumbs', async function (assert) {

--- a/ui/tests/integration/components/kubernetes/tab-page-header-test.js
+++ b/ui/tests/integration/components/kubernetes/tab-page-header-test.js
@@ -34,7 +34,7 @@ module('Integration | Component | kubernetes | TabPageHeader', function (hooks) 
     await render(hbs`<TabPageHeader @model={{this.model}} @breadcrumbs={{this.breadcrumbs}} />`, {
       owner: this.engine,
     });
-    assert.dom('[data-test-breadcrumbs] li:nth-child(1) a').hasText('secrets', 'Secrets breadcrumb renders');
+    assert.dom('[data-test-breadcrumbs] li:nth-child(1) a').hasText('Secrets', 'Secrets breadcrumb renders');
 
     assert
       .dom('[data-test-breadcrumbs] li:nth-child(2)')

--- a/ui/tests/integration/components/kv/kv-page-header-test.js
+++ b/ui/tests/integration/components/kv/kv-page-header-test.js
@@ -46,7 +46,7 @@ module('Integration | Component | kv | kv-page-header', function (hooks) {
     await render(hbs`<KvPageHeader @breadcrumbs={{this.breadcrumbs}} @pageTitle="Create new version"/>`, {
       owner: this.engine,
     });
-    assert.dom('[data-test-breadcrumbs] li:nth-child(1) a').hasText('secrets', 'Secrets breadcrumb renders');
+    assert.dom('[data-test-breadcrumbs] li:nth-child(1) a').hasText('Secrets', 'Secrets breadcrumb renders');
     assert.dom('[data-test-breadcrumbs] li:nth-child(2) a').hasText(this.backend, 'engine name renders');
     assert.dom('[data-test-breadcrumbs] li:nth-child(3) a').hasText(this.path, 'secret path renders');
     assert

--- a/ui/tests/integration/components/kv/kv-page-header-test.js
+++ b/ui/tests/integration/components/kv/kv-page-header-test.js
@@ -34,7 +34,7 @@ module('Integration | Component | kv | kv-page-header', function (hooks) {
 
     this.model = this.store.peekRecord('kv/data', this.id);
     this.breadcrumbs = [
-      { label: 'secrets', route: 'secrets', linkExternal: true },
+      { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: this.model.backend, route: 'secrets' },
       { label: this.model.path, route: 'secrets.secret.details', model: this.model.path },
       { label: 'edit' },

--- a/ui/tests/integration/components/kv/page/kv-page-configuration-test.js
+++ b/ui/tests/integration/components/kv/page/kv-page-configuration-test.js
@@ -52,7 +52,7 @@ module('Integration | Component | kv-v2 | Page::Configuration', function (hooks)
     };
 
     this.breadcrumbs = [
-      { label: 'secrets', route: 'secrets', linkExternal: true },
+      { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: this.model.mountConfig.path, route: 'list' },
       { label: 'configuration' },
     ];

--- a/ui/tests/integration/components/kv/page/kv-page-list-test.js
+++ b/ui/tests/integration/components/kv/page/kv-page-list-test.js
@@ -59,7 +59,7 @@ module('Integration | Component | kv | Page::List', function (hooks) {
     this.model.meta = META;
     this.backend = 'kv-engine';
     this.breadcrumbs = [
-      { label: 'secrets', route: 'secrets', linkExternal: true },
+      { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: this.backend, route: 'list' },
     ];
     this.failedDirectoryQuery = false;

--- a/ui/tests/integration/components/kv/page/kv-page-metadata-details-test.js
+++ b/ui/tests/integration/components/kv/page/kv-page-metadata-details-test.js
@@ -56,7 +56,7 @@ module('Integration | Component | kv-v2 | Page::Secret::Metadata::Details', func
       metadata: this.metadata,
     };
     this.breadcrumbs = [
-      { label: 'secrets', route: 'secrets', linkExternal: true },
+      { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: this.model.backend, route: 'list' },
       { label: this.model.path },
     ];

--- a/ui/tests/integration/components/kv/page/kv-page-metadata-edit-test.js
+++ b/ui/tests/integration/components/kv/page/kv-page-metadata-edit-test.js
@@ -41,7 +41,7 @@ module('Integration | Component | kv | Page::Secret::Metadata::Edit', function (
   test('it renders all inputs for a model that has all default values', async function (assert) {
     assert.expect(5);
     this.breadcrumbs = [
-      { label: 'secrets', route: 'secrets', linkExternal: true },
+      { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: this.metadataModelCreate.backend, route: 'list' },
       { label: this.metadataModelCreate.path, route: 'secret.details', model: this.metadataModelCreate.path },
       { label: 'metadata' },
@@ -71,7 +71,7 @@ module('Integration | Component | kv | Page::Secret::Metadata::Edit', function (
   test('it displays previous inputs from metadata record and saves new values', async function (assert) {
     assert.expect(5);
     this.breadcrumbs = [
-      { label: 'secrets', route: 'secrets', linkExternal: true },
+      { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: this.metadataModelEdit.backend, route: 'list' },
       { label: this.metadataModelEdit.path, route: 'secret.details', model: this.metadataModelEdit.path },
       { label: 'metadata' },
@@ -128,7 +128,7 @@ module('Integration | Component | kv | Page::Secret::Metadata::Edit', function (
   test('it displays validation errors and does not save inputs on cancel', async function (assert) {
     assert.expect(2);
     this.breadcrumbs = [
-      { label: 'secrets', route: 'secrets', linkExternal: true },
+      { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: this.metadataModelEdit.backend, route: 'list' },
       { label: this.metadataModelEdit.path, route: 'secret.details', model: this.metadataModelEdit.path },
       { label: 'metadata' },
@@ -159,7 +159,7 @@ module('Integration | Component | kv | Page::Secret::Metadata::Edit', function (
     assert.expect(1);
     this.server.post('/sys/capabilities-self', allowAllCapabilitiesStub('list'));
     this.breadcrumbs = [
-      { label: 'secrets', route: 'secrets', linkExternal: true },
+      { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: this.metadataModelEdit.backend, route: 'list' },
       { label: this.metadataModelEdit.path, route: 'secret.details', model: this.metadataModelEdit.path },
       { label: 'metadata' },

--- a/ui/tests/integration/components/kv/page/kv-page-secret-details-test.js
+++ b/ui/tests/integration/components/kv/page/kv-page-secret-details-test.js
@@ -79,7 +79,7 @@ module('Integration | Component | kv-v2 | Page::Secret::Details', function (hook
       metadata: this.metadata,
     };
     this.breadcrumbs = [
-      { label: 'secrets', route: 'secrets', linkExternal: true },
+      { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: this.model.backend, route: 'list' },
       { label: this.model.path },
     ];

--- a/ui/tests/integration/components/kv/page/kv-page-secret-edit-test.js
+++ b/ui/tests/integration/components/kv/page/kv-page-secret-edit-test.js
@@ -33,7 +33,7 @@ module('Integration | Component | kv-v2 | Page::Secret::Edit', function (hooks) 
       casVersion: 1,
     });
     this.breadcrumbs = [
-      { label: 'secrets', route: 'secrets', linkExternal: true },
+      { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: this.backend, route: 'list' },
       { label: 'edit' },
     ];

--- a/ui/tests/integration/components/kv/page/kv-page-secret-paths-test.js
+++ b/ui/tests/integration/components/kv/page/kv-page-secret-paths-test.js
@@ -19,7 +19,7 @@ module('Integration | Component | kv-v2 | Page::Secret::Paths', function (hooks)
     this.backend = 'kv-engine';
     this.path = 'my-secret';
     this.breadcrumbs = [
-      { label: 'secrets', route: 'secrets', linkExternal: true },
+      { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: this.backend, route: 'list' },
       { label: this.path },
     ];

--- a/ui/tests/integration/components/kv/page/kv-page-secrets-create-test.js
+++ b/ui/tests/integration/components/kv/page/kv-page-secrets-create-test.js
@@ -30,7 +30,7 @@ module('Integration | Component | kv-v2 | Page::Secrets::Create', function (hook
     this.secret = this.store.createRecord('kv/data', { backend: this.backend, casVersion: 0 });
     this.metadata = this.store.createRecord('kv/metadata', { backend: this.backend });
     this.breadcrumbs = [
-      { label: 'secrets', route: 'secrets', linkExternal: true },
+      { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: this.backend, route: 'list' },
       { label: 'create' },
     ];

--- a/ui/tests/integration/components/kv/page/kv-page-version-history-test.js
+++ b/ui/tests/integration/components/kv/page/kv-page-version-history-test.js
@@ -36,7 +36,7 @@ module('Integration | Component | kv | Page::Secret::Metadata::Version-History',
     });
     this.metadata = store.peekRecord('kv/metadata', metadata.id);
     this.breadcrumbs = [
-      { label: 'secrets', route: 'secrets', linkExternal: true },
+      { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: this.metadata.backend, route: 'list' },
       { label: this.metadata.path, route: 'secret.details', model: this.metadata.path },
       { label: 'version history' },

--- a/ui/tests/integration/components/ldap/tab-page-header-test.js
+++ b/ui/tests/integration/components/ldap/tab-page-header-test.js
@@ -34,7 +34,7 @@ module('Integration | Component | ldap | TabPageHeader', function (hooks) {
     await render(hbs`<TabPageHeader @model={{this.model}} @breadcrumbs={{this.breadcrumbs}} />`, {
       owner: this.engine,
     });
-    assert.dom('[data-test-breadcrumbs] li:nth-child(1) a').hasText('secrets', 'Secrets breadcrumb renders');
+    assert.dom('[data-test-breadcrumbs] li:nth-child(1) a').hasText('Secrets', 'Secrets breadcrumb renders');
 
     assert
       .dom('[data-test-breadcrumbs] li:nth-child(2)')

--- a/ui/tests/integration/components/ldap/tab-page-header-test.js
+++ b/ui/tests/integration/components/ldap/tab-page-header-test.js
@@ -27,7 +27,7 @@ module('Integration | Component | ldap | TabPageHeader', function (hooks) {
     });
     this.model = this.store.peekRecord('secret-engine', 'ldap-test');
     this.mount = this.model.path.slice(0, -1);
-    this.breadcrumbs = [{ label: 'secrets', route: 'secrets', linkExternal: true }, { label: this.mount }];
+    this.breadcrumbs = [{ label: 'Secrets', route: 'secrets', linkExternal: true }, { label: this.mount }];
   });
 
   test('it should render breadcrumbs', async function (assert) {

--- a/ui/tests/integration/components/pki/page/pki-configure-create-test.js
+++ b/ui/tests/integration/components/pki/page/pki-configure-create-test.js
@@ -21,7 +21,7 @@ module('Integration | Component | page/pki-configure-create', function (hooks) {
     this.store = this.owner.lookup('service:store');
     this.cancelSpy = sinon.spy();
     this.breadcrumbs = [
-      { label: 'secrets', route: 'secrets', linkExternal: true },
+      { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: 'pki', route: 'overview', model: 'pki' },
       { label: 'configure' },
     ];

--- a/ui/tests/integration/components/pki/page/pki-tidy-auto-settings-test.js
+++ b/ui/tests/integration/components/pki/page/pki-tidy-auto-settings-test.js
@@ -21,7 +21,7 @@ module('Integration | Component | page/pki-tidy-auto-settings', function (hooks)
     this.store = this.owner.lookup('service:store');
 
     this.breadcrumbs = [
-      { label: 'secrets', route: 'secrets', linkExternal: true },
+      { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: backend, route: 'overview', model: backend },
       { label: 'tidy', route: 'tidy.index', model: backend },
       { label: 'auto' },


### PR DESCRIPTION
All static breadcrumbs should be title case per designs capitalization policy. I will link the JIRA ticket internally.

This pr only targets the keyword Secrets. 

- [x] ent tests pass.

**Before:**
![image](https://github.com/hashicorp/vault/assets/6618863/9067fa9c-6020-4299-8058-334b2a3a611d)

**After:**
![image](https://github.com/hashicorp/vault/assets/6618863/0107dd92-5fc4-46ab-bf40-4634bfd7fb69)

