### PR TITLE
Update OpenAPI glob to match backend response

### DIFF
--- a/ui/tests/helpers/openapi/expected-auth-attrs.js
+++ b/ui/tests/helpers/openapi/expected-auth-attrs.js
@@ -150,6 +150,17 @@ const azure = {
       label: 'Tenant ID',
       type: 'string',
     },
+    identityTokenAudience: {
+      editType: 'string',
+      fieldGroup: 'default',
+      helpText: 'Audience of plugin identity tokens',
+      type: 'string',
+    },
+    identityTokenTtl: {
+      editType: 'ttl',
+      fieldGroup: 'default',
+      helpText: 'Time-to-live of plugin identity tokens',
+    },
   },
 };
 
@@ -388,6 +399,23 @@ const gcp = {
       fieldGroup: 'default',
       defaultValue: 'field1,field2',
       label: 'iam_metadata',
+    },
+    identityTokenAudience: {
+      editType: 'string',
+      fieldGroup: 'default',
+      helpText: 'Audience of plugin identity tokens',
+      type: 'string',
+    },
+    identityTokenTtl: {
+      editType: 'ttl',
+      fieldGroup: 'default',
+      helpText: 'Time-to-live of plugin identity tokens',
+    },
+    serviceAccountEmail: {
+      editType: 'string',
+      fieldGroup: 'default',
+      helpText: 'Email ID for the Service Account to impersonate for Workload Identity Federation.',
+      type: 'string',
     },
   },
 };


### PR DESCRIPTION
- [x] ent tests pass.

Two changes: auth method config Azure and one for auth method config GCP.

I confirmed all of these changes are now on the UI config forms for these auth methods and they work as expected.

**Azure:**
![image](https://github.com/hashicorp/vault/assets/6618863/a60b55c8-ea0a-4846-825d-f593f9db4924)

**GCP:** _hard to get the full form in view_
![image](https://github.com/hashicorp/vault/assets/6618863/02af763c-e3cf-4775-8d4d-eeb82be68d55)

