### PR TITLE
Remove SetConfig from setDefaultRetentionMonthsInConfig

### DIFF
--- a/vault/activity_log.go
+++ b/vault/activity_log.go
@@ -2044,9 +2044,6 @@ func (a *ActivityLog) setDefaultRetentionMonthsInConfig(ctx context.Context, inp
 	if err := a.view.Put(ctx, entry); err != nil {
 		return inputConfig, err
 	}
-
-	// Set the new config on the activity log
-	a.SetConfig(ctx, inputConfig)
 	return inputConfig, nil
 }
 


### PR DESCRIPTION
While creating CE PR for retention months bug PR https://github.com/hashicorp/vault-enterprise/pull/5869, removing SetConfig from setDefaultRetentionMonthsInConfig was missed. 
We do not need this, we call SetConfigInit immediately after setDefaultRetentionMonthsInConfig is called in NewActivityLog()
https://github.com/hashicorp/vault/blob/1884267e0f03f5e44c1100d3f5c790050068a9b3/vault/activity_log.go#L286