### PR TITLE
Title case Leases edit and show breadcrumbs

### DIFF
--- a/ui/app/controllers/vault/cluster/access/leases/list.js
+++ b/ui/app/controllers/vault/cluster/access/leases/list.js
@@ -27,7 +27,7 @@ export default Controller.extend(ListController, {
   backendCrumb: computed('clusterController.model.name', function () {
     return {
       label: 'leases',
-      text: 'leases',
+      text: 'Leases',
       path: 'vault.cluster.access.leases.list-root',
       model: this.clusterController.model.name,
     };

--- a/ui/app/controllers/vault/cluster/access/leases/show.js
+++ b/ui/app/controllers/vault/cluster/access/leases/show.js
@@ -14,7 +14,7 @@ export default Controller.extend({
   backendCrumb: computed('clusterController.model.name', function () {
     return {
       label: 'leases',
-      text: 'leases',
+      text: 'Leases',
       path: 'vault.cluster.access.leases.list-root',
       model: this.clusterController.model.name,
     };


### PR DESCRIPTION
- [x] ent test pass.

Building off of this [PR](https://github.com/hashicorp/vault/pull/27144), I caught a few more cases of missing Title Case breadcrumbs. 

**Screenshots of the updated views:**

![image](https://github.com/hashicorp/vault/assets/6618863/fee9fa6a-c656-4ad6-84aa-64ffc95c6c24)

![image](https://github.com/hashicorp/vault/assets/6618863/cbce7494-0a4e-43e5-a4ce-ef90f6c0598a)

