### PR TITLE
Address cert auth error message logic error

### DIFF
--- a/builtin/credential/cert/path_login_test.go
+++ b/builtin/credential/cert/path_login_test.go
@@ -202,7 +202,7 @@ func testAccStepResolveRoleExpectRoleResolutionToFail(t *testing.T, connState tl
 				t.Fatal("Error not part of response.")
 			}
 
-			if !strings.Contains(errString, "invalid certificate") {
+			if !strings.Contains(errString, certAuthFailMsg) {
 				t.Fatalf("Error was not due to invalid role name. Error: %s", errString)
 			}
 			return nil
@@ -230,7 +230,7 @@ func testAccStepResolveRoleOCSPFail(t *testing.T, connState tls.ConnectionState,
 				t.Fatal("Error not part of response.")
 			}
 
-			if !strings.Contains(errString, "no chain matching") {
+			if !strings.Contains(errString, certAuthFailMsg) {
 				t.Fatalf("Error was not due to OCSP failure. Error: %s", errString)
 			}
 			return nil

--- a/changelog/27202.txt
+++ b/changelog/27202.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+auth/cert: Merge error messages returned in login failures and include error when present  
+```


### PR DESCRIPTION
 - Cert auth had a logic error when crafting the error response when configured with a leaf certificate to validate against. It would generate an error response that used a nil error.
 - Make the cert auth error messages the same when we fail to match constraints