### PR TITLE
enos: renable undo logs verification

### DIFF
--- a/enos/enos-scenario-autopilot.hcl
+++ b/enos/enos-scenario-autopilot.hcl
@@ -245,7 +245,7 @@ scenario "autopilot" {
       config_mode          = matrix.config_mode
       enable_audit_devices = var.vault_enable_audit_devices
       hosts                = step.create_vault_cluster_targets.hosts
-      install_dir          = global.vault_install_dir[matrix.artifact_type]
+      install_dir          = local.vault_install_dir
       ip_version           = matrix.ip_version
       license              = matrix.edition != "ce" ? step.read_license.license : null
       packages             = concat(global.packages, global.distro_packages[matrix.distro][global.distro_version[matrix.distro]])
@@ -315,7 +315,7 @@ scenario "autopilot" {
       hosts             = step.create_vault_cluster.hosts
       ip_version        = matrix.ip_version
       vault_addr        = step.create_vault_cluster.api_addr_localhost
-      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
+      vault_install_dir = local.vault_install_dir
       vault_root_token  = step.create_vault_cluster.root_token
     }
   }
@@ -343,7 +343,7 @@ scenario "autopilot" {
       hosts             = step.create_vault_cluster.hosts
       leader_host       = step.get_vault_cluster_ips.leader_host
       vault_addr        = step.create_vault_cluster.api_addr_localhost
-      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
+      vault_install_dir = local.vault_install_dir
       vault_root_token  = step.create_vault_cluster.root_token
     }
   }
@@ -381,7 +381,7 @@ scenario "autopilot" {
       force_unseal                = matrix.seal == "shamir"
       hosts                       = step.create_vault_cluster_upgrade_targets.hosts
       initialize_cluster          = false
-      install_dir                 = global.vault_install_dir[matrix.artifact_type]
+      install_dir                 = local.vault_install_dir
       ip_version                  = matrix.ip_version
       license                     = matrix.edition != "ce" ? step.read_license.license : null
       local_artifact_path         = local.artifact_path
@@ -421,7 +421,7 @@ scenario "autopilot" {
     variables {
       hosts             = step.upgrade_vault_cluster_with_autopilot.hosts
       vault_addr        = step.upgrade_vault_cluster_with_autopilot.api_addr_localhost
-      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
+      vault_install_dir = local.vault_install_dir
     }
   }
 
@@ -443,7 +443,7 @@ scenario "autopilot" {
       hosts             = step.upgrade_vault_cluster_with_autopilot.hosts
       ip_version        = matrix.ip_version
       vault_addr        = step.upgrade_vault_cluster_with_autopilot.api_addr_localhost
-      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
+      vault_install_dir = local.vault_install_dir
       vault_root_token  = step.upgrade_vault_cluster_with_autopilot.root_token
     }
   }
@@ -471,7 +471,7 @@ scenario "autopilot" {
       vault_addr                      = step.create_vault_cluster.api_addr_localhost
       vault_autopilot_upgrade_version = matrix.artifact_source == "local" ? step.get_local_metadata.version : var.vault_product_version
       vault_autopilot_upgrade_status  = "await-server-removal"
-      vault_install_dir               = global.vault_install_dir[matrix.artifact_type]
+      vault_install_dir               = local.vault_install_dir
       vault_root_token                = step.upgrade_vault_cluster_with_autopilot.root_token
     }
   }
@@ -500,7 +500,7 @@ scenario "autopilot" {
       ip_version        = matrix.ip_version
       timeout           = 120 // seconds
       vault_addr        = step.create_vault_cluster.api_addr_localhost
-      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
+      vault_install_dir = local.vault_install_dir
       vault_root_token  = step.create_vault_cluster.root_token
     }
   }
@@ -530,7 +530,7 @@ scenario "autopilot" {
       hosts             = step.upgrade_vault_cluster_with_autopilot.hosts
       ip_version        = matrix.ip_version
       vault_addr        = step.create_vault_cluster.api_addr_localhost
-      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
+      vault_install_dir = local.vault_install_dir
       vault_root_token  = step.create_vault_cluster.root_token
     }
   }
@@ -554,7 +554,7 @@ scenario "autopilot" {
     variables {
       hosts             = step.get_updated_vault_cluster_ips.follower_hosts
       vault_addr        = step.upgrade_vault_cluster_with_autopilot.api_addr_localhost
-      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
+      vault_install_dir = local.vault_install_dir
     }
   }
 
@@ -585,7 +585,7 @@ scenario "autopilot" {
       operator_instance       = step.get_updated_vault_cluster_ips.leader_public_ip
       vault_addr              = step.upgrade_vault_cluster_with_autopilot.api_addr_localhost
       vault_cluster_addr_port = step.upgrade_vault_cluster_with_autopilot.cluster_port
-      vault_install_dir       = global.vault_install_dir[matrix.artifact_type]
+      vault_install_dir       = local.vault_install_dir
       vault_root_token        = step.create_vault_cluster.root_token
     }
   }
@@ -631,7 +631,7 @@ scenario "autopilot" {
       vault_addr                      = step.upgrade_vault_cluster_with_autopilot.api_addr_localhost
       vault_autopilot_upgrade_version = matrix.artifact_source == "local" ? step.get_local_metadata.version : var.vault_product_version
       vault_autopilot_upgrade_status  = "idle"
-      vault_install_dir               = global.vault_install_dir[matrix.artifact_type]
+      vault_install_dir               = local.vault_install_dir
       vault_root_token                = step.create_vault_cluster.root_token
     }
   }
@@ -689,7 +689,7 @@ scenario "autopilot" {
       hosts                 = step.upgrade_vault_cluster_with_autopilot.hosts
       vault_addr            = step.upgrade_vault_cluster_with_autopilot.api_addr_localhost
       vault_edition         = matrix.edition
-      vault_install_dir     = global.vault_install_dir[matrix.artifact_type]
+      vault_install_dir     = local.vault_install_dir
       vault_product_version = matrix.artifact_source == "local" ? step.get_local_metadata.version : var.vault_product_version
       vault_revision        = matrix.artifact_source == "local" ? step.get_local_metadata.revision : var.vault_revision
       vault_build_date      = matrix.artifact_source == "local" ? step.get_local_metadata.build_date : var.vault_build_date
@@ -719,10 +719,8 @@ scenario "autopilot" {
     }
   }
 
-  step "verify_undo_logs_status" {
-    skip_step = true
-    // NOTE: temporarily disable undo logs checking until it is fixed. See VAULT-20259
-    // skip_step = semverconstraint(var.vault_product_version, "<1.13.0-0")
+  step "verify_undo_logs_enabled_on_primary" {
+    skip_step   = semverconstraint(var.vault_product_version, "<1.13.0-0")
     module      = module.vault_verify_undo_logs
     description = <<-EOF
       Verifies that undo logs is correctly enabled on newly upgraded target hosts. For this it will
@@ -743,8 +741,30 @@ scenario "autopilot" {
     }
 
     variables {
-      hosts             = step.upgrade_vault_cluster_with_autopilot.hosts
-      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
+      expected_state    = 1 # Enabled
+      hosts             = step.get_updated_vault_cluster_ips.leader_hosts
+      timeout           = 180 # Seconds
+      vault_addr        = step.upgrade_vault_cluster_with_autopilot.api_addr_localhost
+      vault_install_dir = local.vault_install_dir
+      vault_root_token  = step.create_vault_cluster.root_token
+    }
+  }
+
+  step "verify_undo_logs_disabled_on_followers" {
+    skip_step  = semverconstraint(var.vault_product_version, "<1.13.0-0")
+    module     = module.vault_verify_undo_logs
+    depends_on = [step.verify_undo_logs_enabled_on_primary]
+
+    providers = {
+      enos = local.enos_provider[matrix.distro]
+    }
+
+    variables {
+      expected_state    = 0 # Disabled
+      hosts             = step.get_updated_vault_cluster_ips.follower_hosts
+      timeout           = 10 # Seconds
+      vault_addr        = step.upgrade_vault_cluster_with_autopilot.api_addr_localhost
+      vault_install_dir = local.vault_install_dir
       vault_root_token  = step.create_vault_cluster.root_token
     }
   }

--- a/enos/modules/vault_get_cluster_ips/main.tf
+++ b/enos/modules/vault_get_cluster_ips/main.tf
@@ -168,6 +168,10 @@ output "leader_host" {
   value = local.leader_host
 }
 
+output "leader_hosts" {
+  value = { 0 : local.leader_host }
+}
+
 output "leader_ipv6" {
   value = local.leader_ipv6
 }

--- a/enos/modules/vault_verify_undo_logs/main.tf
+++ b/enos/modules/vault_verify_undo_logs/main.tf
@@ -9,13 +9,35 @@ terraform {
   }
 }
 
+variable "expected_state" {
+  type        = number
+  description = "The expected state to have in vault.core.replication.write_undo_logs telemetry. Must be either 1 for enabled or 0 for disabled."
+
+  validation {
+    condition     = contains([0, 1], var.expected_state)
+    error_message = "The expected_state must be either 0 or 1"
+  }
+}
+
 variable "hosts" {
   type = map(object({
     ipv6       = string
     private_ip = string
     public_ip  = string
   }))
-  description = "The vault cluster instances that were created"
+  description = "The vault cluster target hosts to check"
+}
+
+variable "retry_interval" {
+  type        = number
+  description = "How many seconds to wait between each retry"
+  default     = 2
+}
+
+variable "timeout" {
+  type        = number
+  description = "The max number of seconds to wait before timing out"
+  default     = 60
 }
 
 variable "vault_addr" {
@@ -37,6 +59,9 @@ resource "enos_remote_exec" "smoke-verify-undo-logs" {
   for_each = var.hosts
 
   environment = {
+    EXPECTED_STATE    = var.expected_state
+    RETRY_INTERVAL    = var.retry_interval
+    TIMEOUT_SECONDS   = var.timeout
     VAULT_ADDR        = var.vault_addr
     VAULT_INSTALL_DIR = var.vault_install_dir
     VAULT_TOKEN       = var.vault_root_token

--- a/enos/modules/vault_verify_undo_logs/scripts/smoke-verify-undo-logs.sh
+++ b/enos/modules/vault_verify_undo_logs/scripts/smoke-verify-undo-logs.sh
@@ -7,6 +7,9 @@ function fail() {
   exit 1
 }
 
+[[ -z "$EXPECTED_STATE" ]] && fail "EXPECTED_STAE env variable has not been set"
+[[ -z "$RETRY_INTERVAL" ]] && fail "RETRY_INTERVAL env variable has not been set"
+[[ -z "$TIMEOUT_SECONDS" ]] && fail "TIMEOUT_SECONDS env variable has not been set"
 [[ -z "$VAULT_ADDR" ]] && fail "VAULT_ADDR env variable has not been set"
 [[ -z "$VAULT_INSTALL_DIR" ]] && fail "VAULT_INSTALL_DIR env variable has not been set"
 [[ -z "$VAULT_TOKEN" ]] && fail "VAULT_TOKEN env variable has not been set"
@@ -14,23 +17,19 @@ function fail() {
 binpath=${VAULT_INSTALL_DIR}/vault
 test -x "$binpath" || fail "unable to locate vault binary at $binpath"
 
-count=0
-retries=5
-while :; do
+begin_time=$(date +%s)
+end_time=$((begin_time + TIMEOUT_SECONDS))
+while [ "$(date +%s)" -lt "$end_time" ]; do
   state=$($binpath read sys/metrics -format=json | jq -r '.data.Gauges[] | select(.Name == "vault.core.replication.write_undo_logs")')
   target_undo_logs_status="$(jq -r '.Value' <<< "$state")"
 
-  if [ "$target_undo_logs_status" == "1" ]; then
+  if [ "$target_undo_logs_status" == "$EXPECTED_STATE" ]; then
+    echo "vault.core.replication.write_undo_logs has expected Value: \"${EXPECTED_STATE}\""
     exit 0
   fi
 
-  wait=$((2 ** count))
-  count=$((count + 1))
-  if [ "$count" -lt "$retries" ]; then
-    echo "Waiting for vault.core.replication.write_undo_logs to have Value:1"
-    echo "$state"
-    sleep "$wait"
-  else
-    fail "Timed out waiting for vault.core.replication.write_undo_logs to have Value:1"
-  fi
+  echo "Waiting for vault.core.replication.write_undo_logs to have Value: \"${EXPECTED_STATE}\""
+  sleep "$RETRY_INTERVAL"
 done
+
+fail "Timed out waiting for vault.core.replication.write_undo_logs to have Value: \"${EXPECTED_STATE}\""

--- a/enos/modules/vault_verify_version/scripts/verify-cli-version.sh
+++ b/enos/modules/vault_verify_version/scripts/verify-cli-version.sh
@@ -43,5 +43,13 @@ version_output=$("$binpath" version)
 if [[ "$version_output" == "$version_expected_nosha" ]] || [[ "$version_output" == "$version_expected" ]]; then
   echo "Version verification succeeded!"
 else
-  fail "expected Version=$version_expected or $version_expected_nosha, got: $version_output"
+  msg="$(printf "\nThe Vault cluster did not match the expected version, expected:\n%s\nor\n%s\ngot:\n%s" "$version_expected" "$version_expected_nosha" "$version_output")"
+  if type diff &> /dev/null; then
+    # Diff exits non-zero if we have a diff, which we want, so we'll guard against failing early.
+    if ! version_diff=$(diff  <(echo "$version_expected" ) <(echo "$version_output") -u -L expected -L got); then
+      msg="$(printf "\nThe Vault cluster did not match the expected version:\n%s" "$version_diff")"
+    fi
+  fi
+
+  fail "$msg"
 fi


### PR DESCRIPTION
After VAULT-20259 we did not enable the undo logs verification. This
re-enables the check but modified to check the status of the primary and
follower nodes, as they should have different values.

While testing this I accidentally flubbed my version input and found the
diagnostic a bit confusing to read so I updated the error message on
version mismatch to be a bit easier to read.