### PR TITLE
fix: Correctly handle redirects from pre 1.15.0 generic v2

### DIFF
--- a/changelog/27222.txt
+++ b/changelog/27222.txt
@@ -1,0 +1,3 @@
+```release-note:change
+bug: Correctly handle redirects from pre 1.15.0 generic v2
+```

--- a/ui/app/routes/vault/cluster/secrets/backend/secret-edit.js
+++ b/ui/app/routes/vault/cluster/secrets/backend/secret-edit.js
@@ -80,7 +80,7 @@ export default Route.extend({
       const parentKey = parentKeyForKey(secret);
       const mode = this.routeName.split('.').pop();
       // for kv v2, redirect users from the old url to the new engine url (1.15.0 +)
-      if (secretEngine.type === 'kv' && secretEngine.version === 2) {
+      if ((secretEngine.type === 'kv' || secretEngine.type === 'generic') && secretEngine.version === 2) {
         // if no secret param redirect to the create route
         // if secret param they are either viewing or editing secret so navigate to the details route
         if (!secret) {


### PR DESCRIPTION
Issue: https://github.com/hashicorp/vault/issues/27221

This PR adds check if the secret engine is of type `generic` and kv version v2 and redirects if so. 
