### PR TITLE
Extend removal timeline for Agent API Proxy

### DIFF
--- a/website/content/partials/deprecation/vault-agent-api-proxy.mdx
+++ b/website/content/partials/deprecation/vault-agent-api-proxy.mdx
@@ -2,7 +2,7 @@
 
 | Announced | Expected end of support | Expected removal |
 | :-------: | :---------------------: | :--------------: |
-| JUN 2023  | APR 2024                | CY24 Q2
+| JUN 2023  | APR 2024                | CY26 Q2
 
 Built-in API proxy support for Vault Agent is deprecated. We recommend migrating
 to [Vault Proxy](/vault/docs/agent-and-proxy/proxy/apiproxy) if you require


### PR DESCRIPTION
There's an internal dependency on Agent API proxy that requires more time to move to Vault Proxy.