### PR TITLE
Add missing audit_fields EST configuration parameter to docs

### DIFF
--- a/website/content/api-docs/secret/pki.mdx
+++ b/website/content/api-docs/secret/pki.mdx
@@ -4978,10 +4978,11 @@ $ curl \
 ```json
 {
   "data": {
+    "audit_fields": ["common_name", "alt_names", "ip_sans", "uri_sans"],
     "authenticators": {
       "cert": {
         "accessor": "auth_cert_7fe0c1cc",
-        "cert_role": ""
+        "cert_role": "est-ca"
       },
       "userpass": {
         "accessor": "auth_userpass_2b333949"
@@ -4989,9 +4990,10 @@ $ curl \
     },
     "default_mount": true,
     "default_path_policy": "sign-verbatim",
+    "enable_sentinel_parsing": true,
     "enabled": true,
     "label_to_path_policy": {
-      "test-label": "roles/est-clients"
+      "test-label": "role:est-clients"
     },
     "last_updated": "2024-01-31T10:45:22-05:00"
   }
@@ -5031,6 +5033,12 @@ updated values as a response along with an updated `last_updated` field.
 - `enable_sentinel_parsing` `(bool: false)` - Parse out fields from the provided CSR making them available for
  Sentinel policies.
 
+- `audit_fields` `(list: ["common_name", "alt_names", "ip_sans", "uri_sans"])` - Fields parsed from the CSR that
+ appear in the audit and can be used by sentinel policies. Allowed values are `csr`, `common_name`, `alt_names`,
+ `ip_sans`, `uri_sans`, `other_sans`, `signature_bits`, `exclude_cn_from_sans`, `ou`, `organization`, `country`,
+ `locality`, `province`, `street_address`, `postal_code`, `serial_number`, `use_pss`, `key_type`, `key_bits`,
+ `add_basic_constraints`
+
 #### Sample Payload
 
 ```json
@@ -5049,7 +5057,9 @@ updated values as a response along with an updated `last_updated` field.
     "userpass": {
       "accessor": "auth_userpass_b2b08fac"
     }
-  }
+  },
+  "enable_sentinel_parsing": true,
+  "audit_fields": ["common_name", "alt_names", "ip_sans", "uri_sans"]
 }
 ```
 


### PR DESCRIPTION
 - The API docs for the PKI EST configuration was missing the audit_fields parameter.
 - Also fix up the example EST responses