### PR TITLE
UI Hide Secrets Sync from nav if not on license and/or no policy permissions

### DIFF
--- a/ui/app/components/sidebar/nav/cluster.hbs
+++ b/ui/app/components/sidebar/nav/cluster.hbs
@@ -13,12 +13,14 @@
     @text="Secrets Engines"
     data-test-sidebar-nav-link="Secrets Engines"
   />
-  <Nav.Link
-    @route="vault.cluster.sync"
-    @text="Secrets Sync"
-    @badge={{this.badgeText}}
-    data-test-sidebar-nav-link="Secrets Sync"
-  />
+  {{#if this.flags.showSecretsSync}}
+    <Nav.Link
+      @route="vault.cluster.sync"
+      @text="Secrets Sync"
+      @badge={{if this.flags.isHvdManaged "Plus" ""}}
+      data-test-sidebar-nav-link="Secrets Sync"
+    />
+  {{/if}}
   {{#if (has-permission "access")}}
     <Nav.Link
       @route={{get (route-params-for "access") "route"}}

--- a/ui/app/components/sidebar/nav/cluster.js
+++ b/ui/app/components/sidebar/nav/cluster.js
@@ -21,16 +21,4 @@ export default class SidebarNavClusterComponent extends Component {
     // should only return true if we're in the true root namespace
     return this.namespace.inRootNamespace && !this.cluster?.hasChrootNamespace;
   }
-
-  get badgeText() {
-    const isHvdManaged = this.flags.isHvdManaged;
-    const onLicense = this.version.hasSecretsSync;
-    const isEnterprise = this.version.isEnterprise;
-
-    if (isHvdManaged) return 'Plus';
-    if (isEnterprise && !onLicense) return 'Premium';
-    if (!isEnterprise) return 'Enterprise';
-    // no badge for Enterprise clusters with Secrets Sync on their license--the only remaining option.
-    return '';
-  }
 }

--- a/ui/app/routes/application.js
+++ b/ui/app/routes/application.js
@@ -65,7 +65,10 @@ export default Route.extend({
     },
   },
 
-  beforeModel() {
-    return this.flagsService.fetchFeatureFlags();
+  async beforeModel() {
+    // activatedFlags are called this high up in routing to show/hide Secrets sync on sidebar nav. More deeply nested in routing, this flag determines to hide/show an activation banner for Secrets sync.
+    // featureFlags are used for all sorts of things but need to be this high in routing because it determines if the cluster isHvdManaged or not.
+    await this.flagsService.fetchActivatedFlags();
+    await this.flagsService.fetchFeatureFlags();
   },
 });

--- a/ui/app/services/flags.ts
+++ b/ui/app/services/flags.ts
@@ -10,6 +10,7 @@ import { DEBUG } from '@glimmer/env';
 import lazyCapabilities, { apiPath } from 'vault/macros/lazy-capabilities';
 import type StoreService from 'vault/services/store';
 import type VersionService from 'vault/services/version';
+import type PermissionsService from 'vault/services/permissions';
 
 const FLAGS = {
   vaultCloudNamespace: 'VAULT_CLOUD_ADMIN_NAMESPACE',
@@ -24,6 +25,7 @@ const FLAGS = {
 export default class flagsService extends Service {
   @service declare readonly version: VersionService;
   @service declare readonly store: StoreService;
+  @service declare readonly permissions: PermissionsService;
 
   @tracked activatedFlags: string[] = [];
   @tracked featureFlags: string[] = [];
@@ -60,7 +62,6 @@ export default class flagsService extends Service {
   }
 
   getActivatedFlags = keepLatestTask(async () => {
-    if (this.version.isCommunity) return;
     // Response could change between user sessions.
     // Fire off endpoint without checking if activated features are already set.
     try {
@@ -85,5 +86,22 @@ export default class flagsService extends Service {
       this.secretsSyncActivatePath.get('canCreate') !== false ||
       this.secretsSyncActivatePath.get('canUpdate') !== false
     );
+  }
+
+  get showSecretsSync() {
+    const isHvdManaged = this.isHvdManaged;
+    const onLicense = this.version.hasSecretsSync;
+    const isEnterprise = this.version.isEnterprise;
+    const isActivated = this.secretsSyncIsActivated;
+
+    if (isHvdManaged) return true;
+    if (isEnterprise && !onLicense) return false;
+    if (!isEnterprise) return false;
+    if (isActivated) {
+      // if activated but the user does not have permissions to do anything on the `sys/sync` endpoint, hide navigation link.
+      return this.permissions.hasNavPermission('sync');
+    }
+    // The only remaining option is Enterprise with Secrets Sync on the license but the feature is not activated. In this case, we want to show the upsell page and message about either activating or having an admin activate.
+    return true;
   }
 }

--- a/ui/app/services/permissions.js
+++ b/ui/app/services/permissions.js
@@ -49,6 +49,9 @@ const API_PATHS = {
   settings: {
     customMessages: 'sys/config/ui/custom-messages',
   },
+  sync: {
+    sync: 'sys/sync',
+  },
 };
 
 const API_PATHS_TO_ROUTE_PARAMS = {

--- a/ui/lib/sync/addon/components/sync-header.hbs
+++ b/ui/lib/sync/addon/components/sync-header.hbs
@@ -16,8 +16,8 @@
         <Icon @name={{@icon}} @size="24" />
       {{/if}}
       {{@title}}
-      {{#if this.badgeText}}
-        <Hds::Badge @text={{this.badgeText}} @color="highlight" @size="large" />
+      {{#if this.flags.isHvdManaged}}
+        <Hds::Badge @text={{"Plus"}} @color="highlight" @size="large" />
       {{/if}}
     </h1>
   </p.levelLeft>

--- a/ui/lib/sync/addon/components/sync-header.ts
+++ b/ui/lib/sync/addon/components/sync-header.ts
@@ -6,7 +6,6 @@
 import Component from '@glimmer/component';
 import { service } from '@ember/service';
 
-import type VersionService from 'vault/services/version';
 import type FlagsService from 'vault/services/flags';
 import type { Breadcrumb } from 'vault/vault/app-types';
 
@@ -17,18 +16,5 @@ interface Args {
 }
 
 export default class SyncHeaderComponent extends Component<Args> {
-  @service declare readonly version: VersionService;
   @service declare readonly flags: FlagsService;
-
-  get badgeText() {
-    const isHvdManaged = this.flags.isHvdManaged;
-    const onLicense = this.version.hasSecretsSync;
-    const isEnterprise = this.version.isEnterprise;
-
-    if (isHvdManaged) return 'Plus feature';
-    if (isEnterprise && !onLicense) return 'Premium feature';
-    if (!isEnterprise) return 'Enterprise feature';
-    // no badge for Enterprise clusters with Secrets Sync on their license--the only remaining option.
-    return '';
-  }
 }

--- a/ui/lib/sync/addon/routes/secrets.ts
+++ b/ui/lib/sync/addon/routes/secrets.ts
@@ -13,13 +13,8 @@ export default class SyncSecretsRoute extends Route {
   @service declare readonly router: RouterService;
   @service declare readonly flags: FlagService;
 
-  beforeModel() {
-    return this.flags.fetchActivatedFlags();
-  }
-
   model() {
     return {
-      // TODO will modify when we use the persona service.
       activatedFeatures: this.flags.activatedFlags,
     };
   }

--- a/ui/types/vault/services/permissions.d.ts
+++ b/ui/types/vault/services/permissions.d.ts
@@ -16,4 +16,5 @@ export default class PermissionsService extends Service {
   canViewAll: boolean | null;
   permissionsBanner: string | null;
   chrootNamespace: string | null | undefined;
+  hasNavPermission: (string) => boolean;
 }


### PR DESCRIPTION
This PR hides Secrets Sync from the sidebar navigation under the following circumstances. The decisions was made to remove the upsell badges because showing Secrets Sync to users who do not have this feature or have the feature but do not have any access to the `sys/sync` endpoint is an anti-pattern to how the UI currently handles showing/hiding features.

These changes do the following:
1. Hides Secrets Sync nav from all **OSS** users.

2. Displays only one upsell badge for **HVD** managed clusters. We cannot tell which tier they are on, they if you're a managed cluster you will always see Secrets Sync. In the future this will likely change.

3.  If you're an **Enterprise** user **without** Secrets Sync on your license, you will not see it in the sidebar nav.

4. If you're an **Enterprise** user **with** Secrets Sync on your license and it's **NOT** activated, you will see the sidebar nav (regardless of your policy permissions).

5. If you're an **Enterprise** user **with** Secrets Sync on your license and it **IS** activated, you will only see Secrets Sync if you have access to sys/sync endpoints. 
 
Below is a user Bob with the ability to read on sys/sync/destinations only, and he can see it.

Below is a user Maria with the default policy (no access to sys/sync), she can not see it.
