### PR TITLE
UI: Don't show resultant-ACL banner in nested namespace if ancestor wildcard policy 

### DIFF
--- a/changelog/27263.txt
+++ b/changelog/27263.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-ui: Do not show resultant-ACL banner when parent namespace grants wildcard access.
+ui: Do not show resultant-ACL banner when ancestor namespace grants wildcard access.
 ```

--- a/changelog/27263.txt
+++ b/changelog/27263.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Do not show resultant-ACL banner when parent namespace grants wildcard access.
+```

--- a/ui/app/services/permissions.js
+++ b/ui/app/services/permissions.js
@@ -123,13 +123,13 @@ export default class PermissionsService extends Service {
   }
 
   /**
-   * hasWildcardAccess checks if the user has a wildcard access to target namespace
+   * hasWildcardNsAccess checks if the user has a wildcard access to target namespace
    * via full glob path or any ancestors of the target namespace
    * @param {string} targetNs is the current/target namespace that we are checking access for
    * @param {object} globPaths key is path, value is object with capabilities
    * @returns {boolean} whether the user's policy includes wildcard access to NS
    */
-  hasWildcardAccess(targetNs, globPaths = {}) {
+  hasWildcardNsAccess(targetNs, globPaths = {}) {
     const nsParts = sanitizePath(targetNs).split('/');
     let matchKey = null;
     // For each section of the namespace, check if there is a matching wildcard path
@@ -165,11 +165,11 @@ export default class PermissionsService extends Service {
     const namespace = this.fullCurrentNamespace;
     const allowed =
       // check if the user has wildcard access to the relative root namespace
-      this.hasWildcardAccess(namespace, this.globPaths) ||
+      this.hasWildcardNsAccess(namespace, this.globPaths) ||
       // or if any of their glob paths start with the namespace
-      Object.keys(this.globPaths).any((k) => k.startsWith(namespace)) ||
+      Object.keys(this.globPaths).any((k) => k.startsWith(namespace) && !this.isDenied(this.globPaths[k])) ||
       // or if any of their exact paths start with the namespace
-      Object.keys(this.exactPaths).any((k) => k.startsWith(namespace));
+      Object.keys(this.exactPaths).any((k) => k.startsWith(namespace) && !this.isDenied(this.exactPaths[k]));
     this.permissionsBanner = allowed ? null : PERMISSIONS_BANNER_STATES.noAccess;
   }
 

--- a/ui/app/services/permissions.js
+++ b/ui/app/services/permissions.js
@@ -99,7 +99,7 @@ export default class PermissionsService extends Service {
   @service store;
   @service namespace;
 
-  get baseNs() {
+  get fullCurrentNamespace() {
     const currentNs = this.namespace.path;
     return this.chrootNamespace
       ? `${sanitizePath(this.chrootNamespace)}/${sanitizePath(currentNs)}`
@@ -122,24 +122,38 @@ export default class PermissionsService extends Service {
     }
   }
 
-  get wildcardPath() {
-    const ns = [sanitizePath(this.chrootNamespace), sanitizePath(this.namespace.userRootNamespace)].join('/');
-    // wildcard path comes back from root namespace as empty string,
-    // but within a namespace it's the namespace itself ending with a slash
-    return ns === '/' ? '' : `${sanitizePath(ns)}/`;
-  }
-
   /**
-   * hasWildcardAccess checks if the user has a wildcard policy
+   * hasWildcardAccess checks if the user has a wildcard access to target namespace
+   * via full glob path or any ancestors of the target namespace
+   * @param {string} targetNs is the current/target namespace that we are checking access for
    * @param {object} globPaths key is path, value is object with capabilities
    * @returns {boolean} whether the user's policy includes wildcard access to NS
    */
-  hasWildcardAccess(globPaths = {}) {
-    // First check if the wildcard path is in the globPaths object
-    if (!Object.keys(globPaths).includes(this.wildcardPath)) return false;
+  hasWildcardAccess(targetNs, globPaths = {}) {
+    const nsParts = sanitizePath(targetNs).split('/');
+    let matchKey = null;
+    // For each section of the namespace, check if there is a matching wildcard path
+    while (nsParts.length > 0) {
+      // glob paths always end in a slash
+      const test = `${nsParts.join('/')}/`;
+      if (Object.keys(globPaths).includes(test)) {
+        matchKey = test;
+        break;
+      }
+      nsParts.pop();
+    }
+    // Finally, check if user has wildcard access to the root namespace
+    // which is represented by an empty string
+    if (!matchKey && Object.keys(globPaths).includes('')) {
+      matchKey = '';
+    }
+    if (null === matchKey) {
+      return false;
+    }
 
-    // if so, make sure the current namespace is a child of the wildcard path
-    return this.namespace.path.startsWith(this.wildcardPath);
+    // if there is a match, make sure it is an ancestor of the target namespace
+    // and the capabilities do not include deny
+    return targetNs.startsWith(matchKey) && !this.isDenied(globPaths[matchKey]);
   }
 
   // This method is called to recalculate whether to show the permissionsBanner when the namespace changes
@@ -148,10 +162,10 @@ export default class PermissionsService extends Service {
       this.permissionsBanner = null;
       return;
     }
-    const namespace = this.baseNs;
+    const namespace = this.fullCurrentNamespace;
     const allowed =
       // check if the user has wildcard access to the relative root namespace
-      this.hasWildcardAccess(this.globPaths) ||
+      this.hasWildcardAccess(namespace, this.globPaths) ||
       // or if any of their glob paths start with the namespace
       Object.keys(this.globPaths).any((k) => k.startsWith(namespace)) ||
       // or if any of their exact paths start with the namespace
@@ -200,7 +214,7 @@ export default class PermissionsService extends Service {
   }
 
   pathNameWithNamespace(pathName) {
-    const namespace = this.baseNs;
+    const namespace = this.fullCurrentNamespace;
     if (namespace) {
       return `${sanitizePath(namespace)}/${sanitizeStart(pathName)}`;
     } else {

--- a/ui/app/services/permissions.js
+++ b/ui/app/services/permissions.js
@@ -151,9 +151,8 @@ export default class PermissionsService extends Service {
       return false;
     }
 
-    // if there is a match, make sure it is an ancestor of the target namespace
-    // and the capabilities do not include deny
-    return targetNs.startsWith(matchKey) && !this.isDenied(globPaths[matchKey]);
+    // if there is a match make sure the capabilities do not include deny
+    return !this.isDenied(globPaths[matchKey]);
   }
 
   // This method is called to recalculate whether to show the permissionsBanner when the namespace changes

--- a/ui/tests/unit/services/permissions-test.js
+++ b/ui/tests/unit/services/permissions-test.js
@@ -352,8 +352,9 @@ module('Unit | Service | permissions', function (hooks) {
         scenario: 'when namespace access denied for child ns',
         chroot: null,
         userRoot: 'bar',
-        currentNs: 'bar/baz',
+        currentNs: 'bar/baz/bin',
         globs: {
+          'bar/': { capabilities: ['read'] },
           'bar/baz/': { capabilities: ['deny'] },
         },
         expectedAccess: false,

--- a/ui/tests/unit/services/permissions-test.js
+++ b/ui/tests/unit/services/permissions-test.js
@@ -366,15 +366,54 @@ module('Unit | Service | permissions', function (hooks) {
         globs: {},
         expectedAccess: false,
       },
+      {
+        scenario: 'when nested access granted in root namespace',
+        chroot: null,
+        userRoot: '',
+        currentNs: 'foo/bing',
+        globs: {
+          'foo/': { capabilities: ['read'] },
+        },
+        expectedAccess: true,
+      },
+      {
+        scenario: 'when nested access granted in root namespace and chroot',
+        chroot: 'foo/',
+        userRoot: '',
+        currentNs: 'foo/bing/baz',
+        globs: {
+          'foo/bing/': { capabilities: ['read'] },
+        },
+        expectedAccess: true,
+      },
+      {
+        scenario: 'when access granted via parent namespace and chroot',
+        chroot: null,
+        userRoot: 'foo',
+        currentNs: 'foo/bing/baz',
+        globs: {
+          'foo/bing/': { capabilities: ['read'] },
+        },
+        expectedAccess: true,
+      },
+      {
+        scenario: 'when namespace access denied for child ns',
+        chroot: null,
+        userRoot: 'bar',
+        currentNs: 'bar/baz',
+        globs: {
+          'bar/baz/': { capabilities: ['deny'] },
+        },
+        expectedAccess: false,
+      },
     ].forEach((testCase) => {
-      test(`when ${testCase.scenario}`, function (assert) {
+      test(testCase.scenario, function (assert) {
         const namespaceService = Service.extend({
-          path: testCase.currentNs,
           userRootNamespace: testCase.userRoot,
         });
         this.owner.register('service:namespace', namespaceService);
         this.service.set('chrootNamespace', testCase.chroot);
-        const result = this.service.hasWildcardAccess(testCase.globs);
+        const result = this.service.hasWildcardAccess(testCase.currentNs, testCase.globs);
         assert.strictEqual(result, testCase.expectedAccess);
       });
     });

--- a/ui/tests/unit/services/permissions-test.js
+++ b/ui/tests/unit/services/permissions-test.js
@@ -246,54 +246,6 @@ module('Unit | Service | permissions', function (hooks) {
     });
   });
 
-  module('wildcardPath calculates correctly', function () {
-    [
-      {
-        scenario: 'no user root or chroot',
-        userRoot: '',
-        chroot: null,
-        expectedPath: '',
-      },
-      {
-        scenario: 'user root = child ns and no chroot',
-        userRoot: 'bar',
-        chroot: null,
-        expectedPath: 'bar/',
-      },
-      {
-        scenario: 'user root = child ns and chroot set',
-        userRoot: 'bar',
-        chroot: 'admin/',
-        expectedPath: 'admin/bar/',
-      },
-      {
-        scenario: 'no user root and chroot set',
-        userRoot: '',
-        chroot: 'admin/',
-        expectedPath: 'admin/',
-      },
-    ].forEach((testCase) => {
-      test(`when ${testCase.scenario}`, function (assert) {
-        const namespaceService = Service.extend({
-          userRootNamespace: testCase.userRoot,
-          path: 'current/path/does/not/matter',
-        });
-        this.owner.register('service:namespace', namespaceService);
-        this.service.set('chrootNamespace', testCase.chroot);
-        assert.strictEqual(this.service.wildcardPath, testCase.expectedPath);
-      });
-    });
-    test('when user root =child ns and chroot set', function (assert) {
-      const namespaceService = Service.extend({
-        path: 'bar/baz',
-        userRootNamespace: 'bar',
-      });
-      this.owner.register('service:namespace', namespaceService);
-      this.service.set('chrootNamespace', 'admin/');
-      assert.strictEqual(this.service.wildcardPath, 'admin/bar/');
-    });
-  });
-
   module('hasWildcardAccess calculates correctly', function () {
     // The resultant-acl endpoint returns paths with chroot and
     // relative root prefixed on all paths.


### PR DESCRIPTION
This PR builds on the work from #26233. It hides the resultant-ACL banner if there are non-deny wildcard policies present for any ancestor of the current namespace. The changes in this PR are best illustrated through an example:

**Example scenario**
User Bob logs in at `foo` namespace and then navigates to namespace `/foo/bar/baz`. Bob has a policy with the following block: 
```
path "bar/*" {
  capabilities = ["read", "update", "list"]
}
```
before, the wildcard calculation would determine the user does not have access because it was only checking a wildcard path at the user's relative root namespace (in this case, `foo/`). With this change, the wildcard calculation takes the current namespace `foo/bar/baz` and checks at each level if the Bob has wildcard access. The results are as follows: 
- `foo/bar/baz/` ❌ no match
- `foo/bar/` ✅ match (exits loop)

- [ ] Ent tests pass