### PR TITLE
Docs: Correct the link to namespace limits from within the new max_mount_and_namespace_table_entry_size docs

### DIFF
--- a/website/content/docs/configuration/storage/raft.mdx
+++ b/website/content/docs/configuration/storage/raft.mdx
@@ -143,8 +143,8 @@ delay) mode. The maximum allowed value is 10.
   can use this to increase the number of mounts and namespaces that can be
   stored without the risk of other storage entries becoming too large. All other
   notes on [`max_entry_size`](#max-entry-size) apply. Before changing this, read
-  the [/vault/docs/enterprise/namespaces/namespace-limits](Run Vault Enterprise
-  with many namespaces) guide regarding important performance considerations.
+  the [Run Vault Enterprise
+  with many namespaces](/vault/docs/enterprise/namespaces/namespace-limits) guide regarding important performance considerations.
 
 - `autopilot_reconcile_interval` `(string: "10s")` - This is the interval after
   which autopilot will pick up any state changes. State change could mean multiple


### PR DESCRIPTION
Link and link title were the wrong way round. Quick PR to fix that.


Will also need backporting to the 1.17 branch. I think I've added the right labels for that, but I don't do this regularly so I'm not sure :)