### PR TITLE
UI:  Allow repeat data wrapping for wrap tool

### DIFF
--- a/changelog/27289.txt
+++ b/changelog/27289.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: Allow users to wrap inputted data again instead of resetting form
+```

--- a/ui/app/components/tool-actions-form.js
+++ b/ui/app/components/tool-actions-form.js
@@ -149,15 +149,8 @@ export default Component.extend(DEFAULTS, {
       });
     },
 
-    updateTtl(ttl) {
-      set(this, 'wrapTTL', ttl);
-    },
-
-    codemirrorUpdated(val, hasErrors) {
-      setProperties(this, {
-        buttonDisabled: hasErrors,
-        data: val,
-      });
+    onChange(param, value) {
+      set(this, param, value);
     },
   },
 });

--- a/ui/app/components/tool-actions-form.js
+++ b/ui/app/components/tool-actions-form.js
@@ -32,12 +32,12 @@ export default Component.extend(DEFAULTS, {
   flashMessages: service(),
   store: service(),
   // putting these attrs here so they don't get reset when you click back
-  //random
+  // random
   bytes: 32,
-  //hash
+  // hash
   format: 'base64',
   algorithm: 'sha2-256',
-
+  data: '{\n}',
   tagName: '',
 
   didReceiveAttrs() {
@@ -137,6 +137,16 @@ export default Component.extend(DEFAULTS, {
 
     onClear() {
       this.reset();
+    },
+
+    onBack(properties) {
+      // only reset specific properties so user can reuse input data and repeat the action
+      if (this.isDestroyed || this.isDestroying) {
+        return;
+      }
+      properties.forEach((prop) => {
+        set(this, prop, DEFAULTS[prop]);
+      });
     },
 
     updateTtl(ttl) {

--- a/ui/app/components/tool-wrap.js
+++ b/ui/app/components/tool-wrap.js
@@ -12,7 +12,6 @@ import { tracked } from '@glimmer/tracking';
  * ToolWrap components are components that sys/wrapping/wrap functionality.  Most of the functionality is passed through as actions from the tool-actions-form and then called back with properties.
  *
  * @example
- * ```js
  * <ToolWrap
  *  @onClear={{action "onClear"}}
  *  @token={{token}}
@@ -21,14 +20,14 @@ import { tracked } from '@glimmer/tracking';
  *  @updateTtl={{action "updateTtl"}}
  *  @buttonDisabled={{buttonDisabled}}
  *  @errors={{errors}}/>
- * ```
- * @param onClear {Function} - parent action that is passed through. Must be passed as {{action "onClear"}}
- * @param token=null {String} - property passed from parent to child and then passed back up to parent
- * @param selectedAction="wrap" - passed in from parent.  This is the wrap action, others include hash, etc.
- * @param codemirrorUpdated {Function} - parent action that is passed through. Must be passed as {{action "codemirrorUpdated"}}.
- * @param updateTtl {Function} - parent action that is passed through. Must be passed as {{action "updateTtl"}}
- * @param buttonDisabled=false {Boolean} - false default and if there is an error on codemirror it turns to true.
- * @param error=null {Object} - errors passed from parent as default then from child back to parent.
+ *
+ * @param {function} onClear - parent action that is passed through. Must be passed as {{action "onClear"}}
+ * @param {string} token=null - property passed from parent to child and then passed back up to parent
+ * @param {string} selectedAction="wrap" - passed in from parent.  This is the wrap action, others include hash, etc.
+ * @param {function} codemirrorUpdated - parent action that is passed through. Must be passed as {{action "codemirrorUpdated"}}.
+ * @param {function} updateTtl - parent action that is passed through. Must be passed as {{action "updateTtl"}}
+ * @param {boolean} buttonDisabled=false - false default and if there is an error on codemirror it turns to true.
+ * @param {object} error=null - errors passed from parent as default then from child back to parent.
  */
 
 export default class ToolWrap extends Component {

--- a/ui/app/components/tool-wrap.js
+++ b/ui/app/components/tool-wrap.js
@@ -31,13 +31,8 @@ import { tracked } from '@glimmer/tracking';
  */
 
 export default class ToolWrap extends Component {
-  @tracked data = '{\n}';
   @tracked buttonDisabled = false;
 
-  @action
-  onClear() {
-    this.args.onClear();
-  }
   @action
   updateTtl(evt) {
     if (!evt) return;
@@ -48,7 +43,6 @@ export default class ToolWrap extends Component {
   codemirrorUpdated(val, codemirror) {
     codemirror.performLint();
     const hasErrors = codemirror?.state.lint.marked?.length > 0;
-    this.data = val;
     this.buttonDisabled = hasErrors;
     this.args.codemirrorUpdated(val, hasErrors);
   }

--- a/ui/app/components/tool-wrap.js
+++ b/ui/app/components/tool-wrap.js
@@ -13,19 +13,18 @@ import { tracked } from '@glimmer/tracking';
  *
  * @example
  * <ToolWrap
+ *  @errors={{@errors}}
+ *  @onBack={{action "onBack" (array "token")}}
+ *  @onChange={{action "onChange"}}
  *  @onClear={{action "onClear"}}
- *  @token={{token}}
- *  @codemirrorUpdated={{action "codemirrorUpdated"}}
- *  @updateTtl={{action "updateTtl"}}
- *  @buttonDisabled={{buttonDisabled}}
- *  @errors={{errors}}/>
+ *  @token={{@token}}
+ * />
  *
- * @param {function} onClear - parent action that is passed through. Must be passed as {{action "onClear"}}
- * @param {string} token=null - property passed from parent to child and then passed back up to parent
- * @param {function} codemirrorUpdated - parent action that is passed through. Must be passed as {{action "codemirrorUpdated"}}.
- * @param {function} updateTtl - parent action that is passed through. Must be passed as {{action "updateTtl"}}
- * @param {boolean} buttonDisabled=false - false default and if there is an error on codemirror it turns to true.
- * @param {object} error=null - errors passed from parent as default then from child back to parent.
+ * @param {object} errors=null - errors returned if wrap fails
+ * @param {function} onBack - callback that only clears specific values so the action can be repeated. Must be passed as `{{action "onBack"}}`
+ * @param {function} onChange - callback that fires when inputs change and passes value and param name back to the parent
+ * @param {function} onClear - callback that resets all of values to defaults. Must be passed as `{{action "onClear"}}`
+ * @param {string} token=null - returned after user clicks "Wrap data", if there is a token value it displays instead of the JsonEditor
  */
 
 export default class ToolWrap extends Component {
@@ -35,13 +34,14 @@ export default class ToolWrap extends Component {
   updateTtl(evt) {
     if (!evt) return;
     const ttl = evt.enabled ? `${evt.seconds}s` : '30m';
-    this.args.updateTtl(ttl);
+    this.args.onChange('wrapTTL', ttl);
   }
+
   @action
   codemirrorUpdated(val, codemirror) {
     codemirror.performLint();
     const hasErrors = codemirror?.state.lint.marked?.length > 0;
     this.buttonDisabled = hasErrors;
-    this.args.codemirrorUpdated(val, hasErrors);
+    this.args.onChange('data', val);
   }
 }

--- a/ui/app/components/tool-wrap.js
+++ b/ui/app/components/tool-wrap.js
@@ -15,7 +15,6 @@ import { tracked } from '@glimmer/tracking';
  * <ToolWrap
  *  @onClear={{action "onClear"}}
  *  @token={{token}}
- *  @selectedAction="wrap"
  *  @codemirrorUpdated={{action "codemirrorUpdated"}}
  *  @updateTtl={{action "updateTtl"}}
  *  @buttonDisabled={{buttonDisabled}}
@@ -23,7 +22,6 @@ import { tracked } from '@glimmer/tracking';
  *
  * @param {function} onClear - parent action that is passed through. Must be passed as {{action "onClear"}}
  * @param {string} token=null - property passed from parent to child and then passed back up to parent
- * @param {string} selectedAction="wrap" - passed in from parent.  This is the wrap action, others include hash, etc.
  * @param {function} codemirrorUpdated - parent action that is passed through. Must be passed as {{action "codemirrorUpdated"}}.
  * @param {function} updateTtl - parent action that is passed through. Must be passed as {{action "updateTtl"}}
  * @param {boolean} buttonDisabled=false - false default and if there is an error on codemirror it turns to true.

--- a/ui/app/templates/components/tool-actions-form.hbs
+++ b/ui/app/templates/components/tool-actions-form.hbs
@@ -55,11 +55,13 @@
     <ToolWrap
       @token={{this.token}}
       @selectedAction={{this.selectedAction}}
+      @onBack={{action "onBack" (array "token")}}
       @onClear={{action "onClear"}}
       @codemirrorUpdated={{action "codemirrorUpdated"}}
       @updateTtl={{action "updateTtl"}}
       @buttonDisabled={{this.buttonDisabled}}
       @errors={{this.errors}}
+      @data={{this.data}}
     />
   {{else}}
     <EmptyState @title="Tool not available" />

--- a/ui/app/templates/components/tool-actions-form.hbs
+++ b/ui/app/templates/components/tool-actions-form.hbs
@@ -54,7 +54,6 @@
   {{else if (eq this.selectedAction "wrap")}}
     <ToolWrap
       @token={{this.token}}
-      @selectedAction={{this.selectedAction}}
       @onBack={{action "onBack" (array "token")}}
       @onClear={{action "onClear"}}
       @codemirrorUpdated={{action "codemirrorUpdated"}}

--- a/ui/app/templates/components/tool-actions-form.hbs
+++ b/ui/app/templates/components/tool-actions-form.hbs
@@ -56,9 +56,7 @@
       @token={{this.token}}
       @onBack={{action "onBack" (array "token")}}
       @onClear={{action "onClear"}}
-      @codemirrorUpdated={{action "codemirrorUpdated"}}
-      @updateTtl={{action "updateTtl"}}
-      @buttonDisabled={{this.buttonDisabled}}
+      @onChange={{action "onChange"}}
       @errors={{this.errors}}
       @data={{this.data}}
     />

--- a/ui/app/templates/components/tool-hash.hbs
+++ b/ui/app/templates/components/tool-hash.hbs
@@ -30,7 +30,7 @@
       />
     </div>
     <div class="control">
-      <Hds::Button @text="Back" @color="secondary" {{on "click" this.onClear}} data-test-tools-back={{true}} />
+      <Hds::Button @text="Back" @color="secondary" {{on "click" this.onClear}} data-test-button="Back" />
     </div>
   </div>
 {{else}}
@@ -80,7 +80,7 @@
   </div>
   <div class="field is-grouped box is-fullwidth is-bottomless">
     <div class="control">
-      <Hds::Button @text="Hash" type="submit" data-test-tools-submit="true" />
+      <Hds::Button @text="Hash" type="submit" data-test-tools-submit />
     </div>
   </div>
 {{/if}}

--- a/ui/app/templates/components/tool-lookup.hbs
+++ b/ui/app/templates/components/tool-lookup.hbs
@@ -13,12 +13,12 @@
 
 {{#if (or @creation_time @creation_ttl)}}
   <div class="box is-fullwidth is-sideless is-paddingless is-marginless">
-    <InfoTableRow @label="Creation path" @value={{@creation_path}} data-test-tools="token-lookup-row" />
-    <InfoTableRow @label="Creation time" @value={{@creation_time}} data-test-tools="token-lookup-row" />
-    <InfoTableRow @label="Creation TTL" @value={{@creation_ttl}} data-test-tools="token-lookup-row" />
+    <InfoTableRow @label="Creation path" @value={{@creation_path}} />
+    <InfoTableRow @label="Creation time" @value={{@creation_time}} />
+    <InfoTableRow @label="Creation TTL" @value={{@creation_ttl}} />
     {{#if @expirationDate}}
-      <InfoTableRow @label="Expiration date" @value={{@expirationDate}} data-test-tools="token-lookup-row" />
-      <InfoTableRow @label="Expires in" @value={{date-from-now @expirationDate}} data-test-tools="token-lookup-row" />
+      <InfoTableRow @label="Expiration date" @value={{@expirationDate}} />
+      <InfoTableRow @label="Expires in" @value={{date-from-now @expirationDate}} />
     {{/if}}
   </div>
   <div class="field is-grouped box is-fullwidth is-bottomless">
@@ -42,7 +42,7 @@
   </div>
   <div class="field is-grouped box is-fullwidth is-bottomless">
     <div class="control">
-      <Hds::Button @text="Lookup token" type="submit" data-test-tools-submit="true" />
+      <Hds::Button @text="Lookup token" type="submit" data-test-tools-submit />
     </div>
   </div>
 {{/if}}

--- a/ui/app/templates/components/tool-random.hbs
+++ b/ui/app/templates/components/tool-random.hbs
@@ -63,7 +63,7 @@
   </div>
   <div class="field is-grouped box is-fullwidth is-bottomless">
     <div class="control">
-      <Hds::Button @text="Generate" type="submit" data-test-tools-submit="true" />
+      <Hds::Button @text="Generate" type="submit" data-test-tools-submit />
     </div>
   </div>
 {{/if}}

--- a/ui/app/templates/components/tool-rewrap.hbs
+++ b/ui/app/templates/components/tool-rewrap.hbs
@@ -56,7 +56,7 @@
   </div>
   <div class="field is-grouped box is-fullwidth is-bottomless">
     <div class="control">
-      <Hds::Button @text="Rewrap token" type="submit" data-test-tools-submit="true" />
+      <Hds::Button @text="Rewrap token" type="submit" data-test-tools-submit />
     </div>
   </div>
 {{/if}}

--- a/ui/app/templates/components/tool-unwrap.hbs
+++ b/ui/app/templates/components/tool-unwrap.hbs
@@ -13,8 +13,8 @@
 
 {{#if @unwrap_data}}
   <Hds::Tabs as |T|>
-    <T.Tab data-test-button-data>Data</T.Tab>
-    <T.Tab data-test-button-details>Wrap Details</T.Tab>
+    <T.Tab data-test-tab="data">Data</T.Tab>
+    <T.Tab data-test-tab="details">Wrap Details</T.Tab>
     <T.Panel>
       <JsonEditor
         class="has-top-padding-m"
@@ -75,7 +75,7 @@
   </div>
   <div class="field is-grouped box is-fullwidth is-bottomless">
     <div class="control">
-      <Hds::Button @text="Unwrap data" type="submit" data-test-tools-submit="true" />
+      <Hds::Button @text="Unwrap data" type="submit" data-test-tools-submit />
     </div>
   </div>
 {{/if}}

--- a/ui/app/templates/components/tool-wrap.hbs
+++ b/ui/app/templates/components/tool-wrap.hbs
@@ -35,7 +35,7 @@
   </div>
 {{else}}
   <div class="box is-sideless is-fullwidth is-marginless">
-    <NamespaceReminder @mode="perform" @noun={{@selectedAction}} />
+    <NamespaceReminder @mode="perform" @noun="wrap" />
     <MessageError @errors={{@errors}} />
     <div class="field">
       <div class="control">

--- a/ui/app/templates/components/tool-wrap.hbs
+++ b/ui/app/templates/components/tool-wrap.hbs
@@ -34,10 +34,11 @@
         @textToCopy={{@token}}
         @onError={{(fn (set-flash-message "Clipboard copy failed. The Clipboard API requires a secure context." "danger"))}}
         class="primary"
+        data-test-button="Copy"
       />
     </div>
     <div class="control">
-      <Hds::Button @text="Back" @color="secondary" {{on "click" this.onClear}} />
+      <Hds::Button @text="Back" @color="secondary" {{on "click" this.onClear}} data-test-button="Back" />
     </div>
   </div>
 {{else}}
@@ -65,7 +66,7 @@
   </div>
   <div class="field is-grouped box is-fullwidth is-bottomless">
     <div class="control">
-      <Hds::Button @text="Wrap data" type="submit" data-test-tools-submit="true" disabled={{@buttonDisabled}} />
+      <Hds::Button @text="Wrap data" type="submit" data-test-tools-submit disabled={{@buttonDisabled}} />
     </div>
   </div>
 {{/if}}

--- a/ui/app/templates/components/tool-wrap.hbs
+++ b/ui/app/templates/components/tool-wrap.hbs
@@ -58,7 +58,7 @@
   </div>
   <div class="field is-grouped box is-fullwidth is-bottomless">
     <div class="control">
-      <Hds::Button @text="Wrap data" type="submit" data-test-tools-submit disabled={{@buttonDisabled}} />
+      <Hds::Button @text="Wrap data" type="submit" disabled={{this.buttonDisabled}} data-test-tools-submit />
     </div>
   </div>
 {{/if}}

--- a/ui/app/templates/components/tool-wrap.hbs
+++ b/ui/app/templates/components/tool-wrap.hbs
@@ -16,30 +16,22 @@
     <div class="field">
       <label for="wrap-info" class="is-label">Wrapped token</label>
       <div class="control">
-        <Textarea
-          @value={{@token}}
-          readonly={{true}}
-          class="textarea"
-          id="wrap-info"
-          name="wrap-info"
+        <Hds::Copy::Snippet
+          @textToCopy={{@token}}
+          @color="secondary"
           data-test-tools-input="wrapping-token"
+          @onError={{(fn
+            (set-flash-message "Clipboard copy failed. The Clipboard API requires a secure context." "danger")
+          )}}
         />
       </div>
     </div>
   </div>
   <div class="field is-grouped box is-fullwidth is-bottomless">
-    <div class="control">
-      <Hds::Copy::Button
-        @text="Copy"
-        @textToCopy={{@token}}
-        @onError={{(fn (set-flash-message "Clipboard copy failed. The Clipboard API requires a secure context." "danger"))}}
-        class="primary"
-        data-test-button="Copy"
-      />
-    </div>
-    <div class="control">
-      <Hds::Button @text="Back" @color="secondary" {{on "click" this.onClear}} data-test-button="Back" />
-    </div>
+    <Hds::ButtonSet>
+      <Hds::Button @icon="arrow-left" @text="Back" @color="tertiary" {{on "click" @onBack}} data-test-button="Back" />
+      <Hds::Button @text="Done" @color="secondary" {{on "click" @onClear}} data-test-button="Done" />
+    </Hds::ButtonSet>
   </div>
 {{else}}
   <div class="box is-sideless is-fullwidth is-marginless">
@@ -50,15 +42,15 @@
         <JsonEditor
           @title="Data to wrap"
           @subTitle="json-formatted"
-          @value={{this.data}}
-          @valueUpdated={{action this.codemirrorUpdated}}
+          @value={{@data}}
+          @valueUpdated={{this.codemirrorUpdated}}
         />
       </div>
     </div>
     <TtlPicker
       @label="Wrap TTL"
       @initialValue="30m"
-      @onChange={{action "updateTtl"}}
+      @onChange={{this.updateTtl}}
       @helperTextDisabled="Vault will use the default (30m)"
       @helperTextEnabled="Wrap will expire after"
       @changeOnInit={{true}}

--- a/ui/tests/acceptance/tools-test.js
+++ b/ui/tests/acceptance/tools-test.js
@@ -21,14 +21,9 @@ import authPage from 'vault/tests/pages/auth';
 import { capitalize } from '@ember/string';
 import codemirror from 'vault/tests/helpers/codemirror';
 import { setupMirage } from 'ember-cli-mirage/test-support';
-import { GENERAL } from '../helpers/general-selectors';
+import { GENERAL } from 'vault/tests/helpers/general-selectors';
+import { TOOLS_SELECTORS as TS } from 'vault/tests/helpers/tools-selectors';
 
-const SELECTORS = {
-  submit: '[data-test-tools-submit]',
-  toolsInput: (attr) => `[data-test-tools-input="${attr}"]`,
-  tab: (item) => `[data-test-tab="${item}"]`,
-  button: (action) => `[data-test-button="${action}"]`,
-};
 module('Acceptance | tools', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
@@ -64,16 +59,16 @@ module('Acceptance | tools', function (hooks) {
     codemirror().setValue(DATA_TO_WRAP);
 
     // wrap
-    await click(SELECTORS.submit);
-    const wrappedToken = await waitUntil(() => find(SELECTORS.toolsInput('wrapping-token')));
+    await click(TS.submit);
+    const wrappedToken = await waitUntil(() => find(TS.toolsInput('wrapping-token')));
     tokenStore.set(wrappedToken.value);
-    assert.dom(SELECTORS.toolsInput('wrapping-token')).hasValue(wrappedToken.value, 'has a wrapping token');
+    assert.dom(TS.toolsInput('wrapping-token')).hasValue(wrappedToken.value, 'has a wrapping token');
 
     //lookup
     await click(GENERAL.navLink('Lookup'));
 
-    await fillIn(SELECTORS.toolsInput('wrapping-token'), tokenStore.get());
-    await click(SELECTORS.submit);
+    await fillIn(TS.toolsInput('wrapping-token'), tokenStore.get());
+    await click(TS.submit);
     await waitUntil(() => findAll('[data-test-component="info-table-row"]').length >= 3);
     assert.dom(GENERAL.infoRowValue('Creation path')).hasText('sys/wrapping/wrap', 'show creation path row');
     assert.dom(GENERAL.infoRowValue('Creation time')).exists();
@@ -82,9 +77,9 @@ module('Acceptance | tools', function (hooks) {
     //rewrap
     await click(GENERAL.navLink('Rewrap'));
 
-    await fillIn(SELECTORS.toolsInput('wrapping-token'), tokenStore.get());
-    await click(SELECTORS.submit);
-    const rewrappedToken = await waitUntil(() => find(SELECTORS.toolsInput('rewrapped-token')));
+    await fillIn(TS.toolsInput('wrapping-token'), tokenStore.get());
+    await click(TS.submit);
+    const rewrappedToken = await waitUntil(() => find(TS.toolsInput('rewrapped-token')));
     assert.ok(rewrappedToken.value, 'has a new re-wrapped token');
     assert.notEqual(rewrappedToken.value, tokenStore.get(), 're-wrapped token is not the wrapped token');
     tokenStore.set(rewrappedToken.value);
@@ -93,17 +88,17 @@ module('Acceptance | tools', function (hooks) {
     //unwrap
     await click(GENERAL.navLink('Unwrap'));
 
-    await fillIn(SELECTORS.toolsInput('wrapping-token'), tokenStore.get());
-    await click(SELECTORS.submit);
+    await fillIn(TS.toolsInput('wrapping-token'), tokenStore.get());
+    await click(TS.submit);
     await waitFor('.CodeMirror');
     assert.deepEqual(
       JSON.parse(codemirror().getValue()),
       JSON.parse(DATA_TO_WRAP),
       'unwrapped data equals input data'
     );
-    await waitUntil(() => find(SELECTORS.tab('details')));
-    await click(SELECTORS.tab('details'));
-    await click(SELECTORS.tab('data'));
+    await waitUntil(() => find(TS.tab('details')));
+    await click(TS.tab('details'));
+    await click(TS.tab('data'));
     assert.deepEqual(
       JSON.parse(codemirror().getValue()),
       JSON.parse(DATA_TO_WRAP),
@@ -112,28 +107,28 @@ module('Acceptance | tools', function (hooks) {
     //random
     await click(GENERAL.navLink('Random'));
 
-    assert.dom(SELECTORS.toolsInput('bytes')).hasValue('32', 'defaults to 32 bytes');
-    await click(SELECTORS.submit);
-    const randomBytes = await waitUntil(() => find(SELECTORS.toolsInput('random-bytes')));
+    assert.dom(TS.toolsInput('bytes')).hasValue('32', 'defaults to 32 bytes');
+    await click(TS.submit);
+    const randomBytes = await waitUntil(() => find(TS.toolsInput('random-bytes')));
     assert.ok(randomBytes.value, 'shows the returned value of random bytes');
 
     //hash
     await click(GENERAL.navLink('Hash'));
 
-    await fillIn(SELECTORS.toolsInput('hash-input'), 'foo');
+    await fillIn(TS.toolsInput('hash-input'), 'foo');
     await click('[data-test-transit-b64-toggle="input"]');
 
-    await click(SELECTORS.submit);
-    let sumInput = await waitUntil(() => find(SELECTORS.toolsInput('sum')));
+    await click(TS.submit);
+    let sumInput = await waitUntil(() => find(TS.toolsInput('sum')));
     assert
       .dom(sumInput)
       .hasValue('LCa0a2j/xo/5m0U8HTBBNBNCLXBkg7+g+YpeiGJm564=', 'hashes the data, encodes input');
-    await click(SELECTORS.button('Back'));
+    await click(TS.button('Back'));
 
-    await fillIn(SELECTORS.toolsInput('hash-input'), 'e2RhdGE6ImZvbyJ9');
+    await fillIn(TS.toolsInput('hash-input'), 'e2RhdGE6ImZvbyJ9');
 
-    await click(SELECTORS.submit);
-    sumInput = await waitUntil(() => find(SELECTORS.toolsInput('sum')));
+    await click(TS.submit);
+    sumInput = await waitUntil(() => find(TS.toolsInput('sum')));
     assert
       .dom(sumInput)
       .hasValue('JmSi2Hhbgu2WYOrcOyTqqMdym7KT3sohCwAwaMonVrc=', 'hashes the data, passes b64 input through');
@@ -167,8 +162,8 @@ module('Acceptance | tools', function (hooks) {
     //unwrap
     await click(GENERAL.navLink('Unwrap'));
 
-    await fillIn(SELECTORS.toolsInput('wrapping-token'), 'sometoken');
-    await click(SELECTORS.submit);
+    await fillIn(TS.toolsInput('wrapping-token'), 'sometoken');
+    await click(TS.submit);
 
     await waitFor('.CodeMirror');
     assert.deepEqual(

--- a/ui/tests/acceptance/tools-test.js
+++ b/ui/tests/acceptance/tools-test.js
@@ -61,8 +61,7 @@ module('Acceptance | tools', function (hooks) {
     // wrap
     await click(TS.submit);
     const wrappedToken = await waitUntil(() => find(TS.toolsInput('wrapping-token')));
-    tokenStore.set(wrappedToken.value);
-    assert.dom(TS.toolsInput('wrapping-token')).hasValue(wrappedToken.value, 'has a wrapping token');
+    tokenStore.set(wrappedToken.innerText);
 
     //lookup
     await click(GENERAL.navLink('Lookup'));
@@ -112,7 +111,7 @@ module('Acceptance | tools', function (hooks) {
     const randomBytes = await waitUntil(() => find(TS.toolsInput('random-bytes')));
     assert.ok(randomBytes.value, 'shows the returned value of random bytes');
 
-    //hash
+    // hash
     await click(GENERAL.navLink('Hash'));
 
     await fillIn(TS.toolsInput('hash-input'), 'foo');

--- a/ui/tests/helpers/tools-selectors.ts
+++ b/ui/tests/helpers/tools-selectors.ts
@@ -1,0 +1,11 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+export const TOOLS_SELECTORS = {
+  submit: '[data-test-tools-submit]',
+  toolsInput: (attr: string) => `[data-test-tools-input="${attr}"]`,
+  tab: (item: string) => `[data-test-tab="${item}"]`,
+  button: (action: string) => `[data-test-button="${action}"]`,
+};

--- a/ui/tests/integration/components/tools/tool-wrap-test.js
+++ b/ui/tests/integration/components/tools/tool-wrap-test.js
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'vault/tests/helpers';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { click, fillIn, render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import sinon from 'sinon';
+import { GENERAL } from 'vault/tests/helpers/general-selectors';
+import codemirror from 'vault/tests/helpers/codemirror';
+import { TOOLS_SELECTORS as TS } from 'vault/tests/helpers/tools-selectors';
+
+module('Integration | Component | tools/tool-wrap', function (hooks) {
+  setupRenderingTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(function () {
+    this.onClear = sinon.spy();
+    this.updateTtl = sinon.spy();
+    this.codemirrorUpdated = sinon.spy();
+    this.buttonDisabled = true;
+    this.renderComponent = async () => {
+      await render(hbs`
+    <ToolWrap
+      @token={{this.token}}
+      @selectedAction="wrap"
+      @onClear={{this.onClear}}
+      @codemirrorUpdated={{this.codemirrorUpdated}}
+      @updateTtl={{this.updateTtl}}
+      @buttonDisabled={{this.buttonDisabled}}
+      @errors={{this.errors}}
+    />`);
+    };
+  });
+
+  test('it renders defaults', async function (assert) {
+    await this.renderComponent();
+
+    assert.dom('h1').hasText('Wrap Data', 'Title renders');
+    assert.strictEqual(codemirror().getValue(' '), '{ }', 'json editor initializes with empty object');
+    assert.dom(GENERAL.toggleInput('Wrap TTL')).isNotChecked('Wrap TTL defaults to disabled');
+    assert.dom(TS.submit).isDisabled();
+    assert.dom(TS.toolsInput('wrapping-token')).doesNotExist();
+  });
+
+  test('it renders token view', async function (assert) {
+    this.token =
+      'hvs.CAESINovdwZPz7-3gL60bE_MLzaPF6_xjhfel7SmsVeZwihaGiIKHGh2cy5XZWtEeEt5WmRwS1VYSTNDb1BBVUNsVFAQ3JIK';
+    await this.renderComponent();
+
+    assert.dom('h1').hasText('Wrap Data');
+    assert.dom('label').hasText('Wrapped token');
+    assert.dom('.CodeMirror').doesNotExist();
+    assert.dom(TS.toolsInput('wrapping-token')).hasValue(this.token);
+    await click(TS.button('Back'));
+    assert.true(this.onClear.calledOnce, 'onClear is called');
+  });
+
+  test('it fires callback actions', async function (assert) {
+    this.buttonDisabled = false;
+    const data = `{"foo": "bar"}`;
+    await this.renderComponent();
+    await codemirror().setValue(data);
+    await click(GENERAL.toggleInput('Wrap TTL'));
+    await fillIn(GENERAL.ttl.input('Wrap TTL'), '20');
+
+    assert.propEqual(this.codemirrorUpdated.lastCall.args, ['{"foo": "bar"}', false]);
+    assert.propEqual(this.updateTtl.lastCall.args, ['1200s']);
+  });
+});

--- a/ui/tests/integration/components/tools/tool-wrap-test.js
+++ b/ui/tests/integration/components/tools/tool-wrap-test.js
@@ -18,20 +18,24 @@ module('Integration | Component | tools/tool-wrap', function (hooks) {
   setupMirage(hooks);
 
   hooks.beforeEach(function () {
+    this.codemirrorUpdated = sinon.spy();
+    this.onBack = sinon.spy();
     this.onClear = sinon.spy();
     this.updateTtl = sinon.spy();
-    this.codemirrorUpdated = sinon.spy();
     this.buttonDisabled = true;
+    this.data = '{\n}';
     this.renderComponent = async () => {
       await render(hbs`
     <ToolWrap
       @token={{this.token}}
       @selectedAction="wrap"
-      @onClear={{this.onClear}}
-      @codemirrorUpdated={{this.codemirrorUpdated}}
-      @updateTtl={{this.updateTtl}}
       @buttonDisabled={{this.buttonDisabled}}
       @errors={{this.errors}}
+      @onClear={{this.onClear}}
+      @onBack={{this.onBack}}
+      @codemirrorUpdated={{this.codemirrorUpdated}}
+      @updateTtl={{this.updateTtl}}
+      @data={{this.data}}
     />`);
     };
   });
@@ -44,8 +48,8 @@ module('Integration | Component | tools/tool-wrap', function (hooks) {
     assert.dom(GENERAL.toggleInput('Wrap TTL')).isNotChecked('Wrap TTL defaults to disabled');
     assert.dom(TS.submit).isDisabled();
     assert.dom(TS.toolsInput('wrapping-token')).doesNotExist();
-    assert.dom(TS.button('Copy')).doesNotExist();
     assert.dom(TS.button('Back')).doesNotExist();
+    assert.dom(TS.button('Done')).doesNotExist();
   });
 
   test('it renders token view', async function (assert) {
@@ -55,9 +59,10 @@ module('Integration | Component | tools/tool-wrap', function (hooks) {
     assert.dom('h1').hasText('Wrap Data');
     assert.dom('label').hasText('Wrapped token');
     assert.dom('.CodeMirror').doesNotExist();
-    assert.dom(TS.toolsInput('wrapping-token')).hasValue(this.token);
-    assert.dom(TS.button('Copy')).exists();
+    assert.dom(TS.toolsInput('wrapping-token')).hasText(this.token);
     await click(TS.button('Back'));
+    assert.true(this.onBack.calledOnce, 'onBack is called');
+    await click(TS.button('Done'));
     assert.true(this.onClear.calledOnce, 'onClear is called');
   });
 
@@ -69,7 +74,7 @@ module('Integration | Component | tools/tool-wrap', function (hooks) {
     await click(GENERAL.toggleInput('Wrap TTL'));
     await fillIn(GENERAL.ttl.input('Wrap TTL'), '20');
 
-    assert.propEqual(this.codemirrorUpdated.lastCall.args, [this.data, false], 'codemirrorUpdated is called');
+    assert.propEqual(this.codemirrorUpdated.lastCall.args, [data, false], 'codemirrorUpdated is called');
     assert.propEqual(this.updateTtl.lastCall.args, ['1200s'], 'updateTtl is called');
   });
 });

--- a/ui/tests/integration/components/tools/tool-wrap-test.js
+++ b/ui/tests/integration/components/tools/tool-wrap-test.js
@@ -28,7 +28,6 @@ module('Integration | Component | tools/tool-wrap', function (hooks) {
       await render(hbs`
     <ToolWrap
       @token={{this.token}}
-      @selectedAction="wrap"
       @buttonDisabled={{this.buttonDisabled}}
       @errors={{this.errors}}
       @onClear={{this.onClear}}

--- a/ui/tests/integration/components/tools/tool-wrap-test.js
+++ b/ui/tests/integration/components/tools/tool-wrap-test.js
@@ -47,8 +47,7 @@ module('Integration | Component | tools/tool-wrap', function (hooks) {
   });
 
   test('it renders token view', async function (assert) {
-    this.token =
-      'hvs.CAESINovdwZPz7-3gL60bE_MLzaPF6_xjhfel7SmsVeZwihaGiIKHGh2cy5XZWtEeEt5WmRwS1VYSTNDb1BBVUNsVFAQ3JIK';
+    this.token = 'blah.jhfel7SmsVeZwihaGiIKHGh2cy5XZWtEeEt5WmRwS1VYSTNDb1BBVUNsVFAQ3JIK';
     await this.renderComponent();
 
     assert.dom('h1').hasText('Wrap Data');

--- a/ui/tests/integration/components/tools/tool-wrap-test.js
+++ b/ui/tests/integration/components/tools/tool-wrap-test.js
@@ -44,6 +44,8 @@ module('Integration | Component | tools/tool-wrap', function (hooks) {
     assert.dom(GENERAL.toggleInput('Wrap TTL')).isNotChecked('Wrap TTL defaults to disabled');
     assert.dom(TS.submit).isDisabled();
     assert.dom(TS.toolsInput('wrapping-token')).doesNotExist();
+    assert.dom(TS.button('Copy')).doesNotExist();
+    assert.dom(TS.button('Back')).doesNotExist();
   });
 
   test('it renders token view', async function (assert) {
@@ -54,6 +56,7 @@ module('Integration | Component | tools/tool-wrap', function (hooks) {
     assert.dom('label').hasText('Wrapped token');
     assert.dom('.CodeMirror').doesNotExist();
     assert.dom(TS.toolsInput('wrapping-token')).hasValue(this.token);
+    assert.dom(TS.button('Copy')).exists();
     await click(TS.button('Back'));
     assert.true(this.onClear.calledOnce, 'onClear is called');
   });
@@ -66,7 +69,7 @@ module('Integration | Component | tools/tool-wrap', function (hooks) {
     await click(GENERAL.toggleInput('Wrap TTL'));
     await fillIn(GENERAL.ttl.input('Wrap TTL'), '20');
 
-    assert.propEqual(this.codemirrorUpdated.lastCall.args, ['{"foo": "bar"}', false]);
-    assert.propEqual(this.updateTtl.lastCall.args, ['1200s']);
+    assert.propEqual(this.codemirrorUpdated.lastCall.args, [this.data, false], 'codemirrorUpdated is called');
+    assert.propEqual(this.updateTtl.lastCall.args, ['1200s'], 'updateTtl is called');
   });
 });

--- a/ui/tests/integration/components/tools/tool-wrap-test.js
+++ b/ui/tests/integration/components/tools/tool-wrap-test.js
@@ -45,7 +45,7 @@ module('Integration | Component | tools/tool-wrap', function (hooks) {
 
     assert.dom('h1').hasText('Wrap Data', 'Title renders');
     assert.strictEqual(codemirror().getValue(' '), '{ }', 'json editor initializes with empty object');
-    assert.dom(GENERAL.toggleInput('Wrap TTL')).isNotChecked('Wrap TTL defaults to disabled');
+    assert.dom(GENERAL.toggleInput('Wrap TTL')).isNotChecked('Wrap TTL defaults to unchecked');
     assert.dom(TS.submit).isDisabled();
     assert.dom(TS.toolsInput('wrapping-token')).doesNotExist();
     assert.dom(TS.button('Back')).doesNotExist();


### PR DESCRIPTION
## before
After initially wrapping data, clicking "Back" and then "Wrap data" again results in the incorrect data being sent to the backend, so upon "unwrapping" we do not get `{foo:"bar"}` but instead `{token:""}`
![wrap-before](https://github.com/hashicorp/vault/assets/68122737/a3983bec-28d6-4efa-bbc3-b0d56acc13b3)


## after
Notice that now both generated tokens unwrapped the expected data
![wrap-after](https://github.com/hashicorp/vault/assets/68122737/9f8dcc2a-6d0d-4d46-b13c-3bb717f53470)
