### PR TITLE
Store metadata when it is an empty string (such as role, serial numbe…

### DIFF
--- a/builtin/logical/pki/path_issue_sign.go
+++ b/builtin/logical/pki/path_issue_sign.go
@@ -449,7 +449,7 @@ func (b *backend) pathIssueSignCert(ctx context.Context, req *logical.Request, d
 		}
 	}
 
-	if metadataInRequest && len(metadata.(string)) > 0 {
+	if metadataInRequest {
 		metadataBytes, err := base64.StdEncoding.DecodeString(metadata.(string))
 		if err != nil {
 			// TODO: Should we clean up the original cert here?


### PR DESCRIPTION
An example call:

```
kit@kit-Q44CF1473K vault-enterprise % vault write pki/issue/myrole common_name="jack.example.com" metadata="" ttl=30s
Key                 Value
---                 -----
ca_chain            [-----BEGIN CERTIFICATE-----...
```
```
kit@kit vault-enterprise % vault read pki/cert-metadata/06:54:57:81:b1:64:af:ea:48:40:b4:7c:98:c9:54:02:09:ca:34:7d
Key              Value
---              -----
expiration       2024-05-31T15:01:43Z
issuer_id        80eadb5e-a4c6-a986-f0d8-feb8b5312bea
role             myrole
serial_number    06:54:57:81:b1:64:af:ea:48:40:b4:7c:98:c9:54:02:09:ca:34:7d
kit@ vault-enterprise %
```