### PR TITLE
Note that Vault Proxy is supported as a Windows Service

### DIFF
--- a/website/content/docs/agent-and-proxy/agent/winsvc.mdx
+++ b/website/content/docs/agent-and-proxy/agent/winsvc.mdx
@@ -2,7 +2,7 @@
 layout: docs
 page_title: Vault Agent Windows Service
 description: >-
-Vault Agent can be run as a Windows service.
+  Vault Agent can be run as a Windows service.
 ---
 
 # Vault Agent Windows service

--- a/website/content/docs/agent-and-proxy/agent/winsvc.mdx
+++ b/website/content/docs/agent-and-proxy/agent/winsvc.mdx
@@ -2,7 +2,7 @@
 layout: docs
 page_title: Vault Agent Windows Service
 description: >-
-  Vault Agent can be run as a Windows service.
+Vault Agent can be run as a Windows service.
 ---
 
 # Vault Agent Windows service
@@ -10,6 +10,10 @@ description: >-
 Vault Agent can be run as a Windows service. In order to do this, you need to register Vault Agent with the Windows
 Service Control Manager. After Vault Agent is registered, it can be started like any other Windows
 service.
+
+While this guide focuses on an example for Vault Agent, this example can be easily adapted to work for
+[Vault Proxy](/vault/docs/agent-and-proxy/proxy) by changing the config and subcommand
+given to `vault.exe` as appropriate.
 
 **Note:** These commands should be run in a PowerShell session with Administrator capabilities.
 
@@ -84,7 +88,7 @@ There are multiple ways to start the service.
 - Using the `sc.exe` command.
 - Using the `Start-Service` cmdlet.
 - Go to the Windows Service Manager, and look for **VaultAgent** in the service name column. Click the
-  `Start` button to start the service.
+`Start` button to start the service.
 
 ### Example starting Vault Agent using `sc.exe`
 

--- a/website/content/docs/agent-and-proxy/index.mdx
+++ b/website/content/docs/agent-and-proxy/index.mdx
@@ -2,8 +2,8 @@
 layout: docs
 page_title: Vault Agent and Vault Proxy
 description: |-
-  Vault Agent and Vault Proxy are daemons that can be used to perform some Vault
-  functionality automatically.
+Vault Agent and Vault Proxy are daemons that can be used to perform some Vault
+functionality automatically.
 ---
 
 # Vault Agent and Vault Proxy
@@ -89,7 +89,7 @@ and caching requests.
 |------------------------------------------------------------------------------------------|:------------------:|:-----------:|
 | [Auto-Auth][autoauth] to authenticate with Vault                                         |         x          |      x      |
 | [Caching][caching] the newly created tokens and leases                                   |         x          |      x      |
-| Run as a [Windows Service][winsvc]                                                       |         x          |             |
+| Run as a [Windows Service][winsvc]                                                       |         x          |      x      |
 | [Templating][template] to render user-supplied templates                                 |         x          |             |
 | [API Proxy][apiproxy] to act as a proxy for Vault API                                    | Will be deprecated |      x      |
 | [Process Supervisor][exec] for injecting secrets as environment variables into a process |         x          |             |

--- a/website/content/docs/agent-and-proxy/index.mdx
+++ b/website/content/docs/agent-and-proxy/index.mdx
@@ -2,8 +2,8 @@
 layout: docs
 page_title: Vault Agent and Vault Proxy
 description: |-
-Vault Agent and Vault Proxy are daemons that can be used to perform some Vault
-functionality automatically.
+  Vault Agent and Vault Proxy are daemons that can be used to perform some Vault
+  functionality automatically.
 ---
 
 # Vault Agent and Vault Proxy


### PR DESCRIPTION
While we don't have a page dedicated to it, Vault Proxy is supported as a Windows Service too, just like Agent. This caused some confusion (and a customer wondering if they had a migration path from Agent) so I thought it best to confirm that it does work.