### PR TITLE
Add missing cmac argument to Transit verify API docs

### DIFF
--- a/website/content/api-docs/secret/transit.mdx
+++ b/website/content/api-docs/secret/transit.mdx
@@ -1575,7 +1575,8 @@ the response will include the derived public key for each item.
 ## Verify signed data
 
 This endpoint returns whether the provided signature is valid for the given
-data.
+data from either the [sign data](#sign-data), [generate HMAC](#generate-hmac)
+or [generate CMAC](#generate-cmac) API calls.
 
 | Method | Path                                      |
 | :----- | :---------------------------------------- |
@@ -1624,12 +1625,16 @@ data.
   `input` or `batch_input` must be supplied.
 
 - `signature` `(string: "")` – Specifies the signature output from the
-  `/transit/sign` function. Either this must be supplied or `hmac` must be
-  supplied.
+  `/transit/sign` function. One of the following arguments must be supplied
+  `signature`, `hmac` or `cmac`.
 
 - `hmac` `(string: "")` – Specifies the signature output from the
-  `/transit/hmac` function. Either this must be supplied or `signature` must be
-  supplied.
+  `/transit/hmac` function. One of the following arguments must be supplied
+  `signature`, `hmac` or `cmac`.
+
+- `cmac` `(string: "")` <EnterpriseAlert inline="true" /> – Specifies the signature output from the
+  `/transit/cmac` function. One of the following arguments must be supplied
+  `signature`, `hmac` or `cmac`.
 
 - `reference` `(string: "")` -
   A user-supplied string that will be present in the `reference` field on the
@@ -1767,6 +1772,8 @@ $ curl \
 ## Generate CMAC <EnterpriseAlert inline="true" />
 
 This endpoint returns the CMAC of given data using the specified key.
+The [verify](#verify-signed-data) API can be called with the cmac
+argument to verify returned CMACs.
 
 | Method | Path                                    |
 | :----- | :-------------------------------------- |


### PR DESCRIPTION
Add a little bit of cross linking within the Transit API docs along with documenting the new missing `cmac` argument within the existing verify API.