### PR TITLE
Add docs and changelog for PR 9733

### DIFF
--- a/changelog/9733.txt
+++ b/changelog/9733.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+db/cassandra: Add `disable_host_initial_lookup` option to backend, allowing the disabling of initial host lookup.
+```

--- a/website/content/docs/configuration/storage/cassandra.mdx
+++ b/website/content/docs/configuration/storage/cassandra.mdx
@@ -69,6 +69,12 @@ CREATE TABLE "vault"."entries" (
 - `password` `(string: "")` – Password to use when authenticating with the
   Cassandra hosts.
 
+- `disable_initial_host_lookup` `(bool: false)` - If set to true, Vault will not attempt
+  to get host info from the `system.peers` table. It will instead connect to
+  hosts supplied and will not attempt to look up the host information. This will
+  mean that `data_centre`, `rack` and `token` information will not be available and as
+  such host filtering and token aware query routing will not be available.
+
 - `initial_connection_timeout` `(int: 0)` - A timeout in seconds to wait until an initial connection is established
   with the Cassandra hosts. If not set, default value from Cassandra driver(gocql) will be used - 600ms
 


### PR DESCRIPTION
This is a strange PR, but it's a supporting PR for the code changes that come as part of this community PR: https://github.com/hashicorp/vault/pull/9733

This PR has been open for ~four years, and it seems unreasonable to ask the submitter to come back after all that time to add a changelog/docs. However, I don't want to let it languish since the PR seems like an easy win.

This is the compromise -- I can add the docs/changelog, since it's easy enough, and I'll merge both together so everyone wins.