### PR TITLE
Add a CI check for do-not-merge label

### DIFF
--- a/.github/workflows/do-not-merge-checker.yml
+++ b/.github/workflows/do-not-merge-checker.yml
@@ -1,0 +1,22 @@
+# This workflow fails if a 'do-not-merge' label is applied to the PR.
+name: Check do-not-merge
+
+on:
+  pull_request:
+    types: [reopened, labeled, unlabeled]
+    # Runs on PRs to main and release branches
+    branches:
+      - main
+      - release/**
+
+jobs:
+  # checks that a do-not-merge label is not present for a PR
+  do-not-merge-check:
+    # If there is a `do-not-merge` label, or this comes from a fork (community contributor) we ignore this check
+    if: ${{ (github.repository_owner == 'hashicorp' && contains(github.event.pull_request.labels.*.name, 'do-not-merge')) }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if do-not-merge label is applied
+        run: |
+          echo "Cannot merge with do-not-merge label applied."
+          exit 1

--- a/.github/workflows/do-not-merge-checker.yml
+++ b/.github/workflows/do-not-merge-checker.yml
@@ -13,7 +13,7 @@ jobs:
   # checks that a do-not-merge label is not present for a PR
   do-not-merge-check:
     # If there is a `do-not-merge` label, or this comes from a fork (community contributor) we ignore this check
-    if: ${{ (github.repository_owner == 'hashicorp' && contains(github.event.pull_request.labels.*.name, 'do-not-merge')) }}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'do-not-merge') }}
     runs-on: ubuntu-latest
     steps:
       - name: Fail if do-not-merge label is applied

--- a/.github/workflows/do-not-merge-checker.yml
+++ b/.github/workflows/do-not-merge-checker.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   # checks that a do-not-merge label is not present for a PR
   do-not-merge-check:
-    # If there is a `do-not-merge` label, or this comes from a fork (community contributor) we ignore this check
+    # If there is a `do-not-merge` label we ignore this check
     if: ${{ contains(github.event.pull_request.labels.*.name, 'do-not-merge') }}
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This PR adds a new CI check for the do-not-merge label. The check just fails if the label is present.