### PR TITLE
proto: pin protoc-gen-go-grpc to v1.3.0

### DIFF
--- a/.github/actions/install-external-tools/action.yml
+++ b/.github/actions/install-external-tools/action.yml
@@ -22,7 +22,7 @@ runs:
       # up here.
     - run: go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
       shell: bash
-    - run: go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
+    - run: go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.3.0
       shell: bash
     - run: go install github.com/favadi/protoc-go-inject-tag@latest
       shell: bash

--- a/tools/tools.sh
+++ b/tools/tools.sh
@@ -42,7 +42,7 @@ install_external() {
     github.com/golangci/revgrep/cmd/revgrep@latest
     golang.org/x/tools/cmd/goimports@latest
     google.golang.org/protobuf/cmd/protoc-gen-go@latest
-    google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
+    google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.3.0
     gotest.tools/gotestsum@latest
     honnef.co/go/tools/cmd/staticcheck@latest
     mvdan.cc/gofumpt@latest


### PR DESCRIPTION
Pin `protoc-gen-go-grpc` to `v1.3.0` as `v1.4.0` requires `google.golang.org/grpc >= v1.62`, which we are not currently updating on older branches. If we end up upgrading the grpc module we can upin this bring in the latest gRPC changes.