### PR TITLE
Fix remove association parameter in secrets-sync.mdx

### DIFF
--- a/website/content/api-docs/system/secrets-sync.mdx
+++ b/website/content/api-docs/system/secrets-sync.mdx
@@ -662,7 +662,7 @@ secret was already removed from the external system.
 - `mount` `(string: <required>)` - Specifies the mount where the secret is located. For example, if you can read a secret
 with `vault kv get -mount=my-kv my-secret-1`, the mount name is `my-kv`.
 
-- `name` `(string: <required>)` - Specifies the name of the secret to synchronize. For example, if you can read a secret
+- `secret_name` `(string: <required>)` - Specifies the name of the secret to synchronize. For example, if you can read a secret
 with `vault kv get -mount=my-kv my-secret-1`, the secret name is `my-secret-1`.
 
 ### Sample payload


### PR DESCRIPTION
Remove association mistakenly had two `name` parameters instead of `name` and `secret_name`.