### PR TITLE
Remove direct usage of logical/pki's storageContext.Backend field

### DIFF
--- a/builtin/logical/pki/acme_challenge_engine.go
+++ b/builtin/logical/pki/acme_challenge_engine.go
@@ -315,13 +315,13 @@ func (ace *ACMEChallengeEngine) AcceptChallenge(sc *storageContext, account stri
 func (ace *ACMEChallengeEngine) VerifyChallenge(runnerSc *storageContext, id string, validationQueueRetries int, finished chan bool, config *acmeConfigEntry) {
 	sc, cancel := runnerSc.WithFreshTimeout(MaxChallengeTimeout)
 	defer cancel()
-	runnerSc.Backend.Logger().Debug("Starting verification of challenge", "id", id)
+	runnerSc.Logger().Debug("Starting verification of challenge", "id", id)
 
 	if retry, retryAfter, err := ace._verifyChallenge(sc, id, config); err != nil {
 		// Because verification of this challenge failed, we need to retry
 		// it in the future. Log the error and re-add the item to the queue
 		// to try again later.
-		sc.Backend.Logger().Error(fmt.Sprintf("ACME validation failed for %v: %v", id, err))
+		sc.Logger().Error(fmt.Sprintf("ACME validation failed for %v: %v", id, err))
 
 		if retry {
 			validationQueueRetries++
@@ -331,10 +331,10 @@ func (ace *ACMEChallengeEngine) VerifyChallenge(runnerSc *storageContext, id str
 			// we have a secondary check here to see if we are consistently looping within the validation
 			// queue that is larger than the normal retry attempts we would allow.
 			if validationQueueRetries > MaxRetryAttempts*2 {
-				sc.Backend.Logger().Warn("reached max error attempts within challenge queue: %v, giving up", id)
+				sc.Logger().Warn("reached max error attempts within challenge queue: %v, giving up", id)
 				_, _, err = ace._verifyChallengeCleanup(sc, nil, id)
 				if err != nil {
-					sc.Backend.Logger().Warn("Failed cleaning up challenge entry: %v", err)
+					sc.Logger().Warn("Failed cleaning up challenge entry: %v", err)
 				}
 				finished <- true
 				return

--- a/builtin/logical/pki/acme_state.go
+++ b/builtin/logical/pki/acme_state.go
@@ -119,7 +119,7 @@ func (a *acmeState) reloadConfigIfRequired(sc *storageContext) error {
 		return nil
 	}
 
-	config, err := sc.getAcmeConfig()
+	config, err := getAcmeConfig(sc)
 	if err != nil {
 		return fmt.Errorf("failed reading ACME config: %w", err)
 	}

--- a/builtin/logical/pki/acme_wrappers.go
+++ b/builtin/logical/pki/acme_wrappers.go
@@ -496,7 +496,7 @@ func isAcmeDisabled(sc *storageContext, config *acmeConfigEntry, policy EabPolic
 
 	disableAcme, nonFatalErr := isPublicACMEDisabledByEnv()
 	if nonFatalErr != nil {
-		sc.Backend.Logger().Warn(fmt.Sprintf("could not parse env var '%s'", disableAcmeEnvVar), "error", nonFatalErr)
+		sc.Logger().Warn(fmt.Sprintf("could not parse env var '%s'", disableAcmeEnvVar), "error", nonFatalErr)
 	}
 
 	// The OS environment if true will override any configuration option.

--- a/builtin/logical/pki/acme_wrappers.go
+++ b/builtin/logical/pki/acme_wrappers.go
@@ -21,6 +21,7 @@ type acmeContext struct {
 	baseUrl    *url.URL
 	clusterUrl *url.URL
 	sc         *storageContext
+	acmeState  *acmeState
 	role       *issuing.RoleEntry
 	issuer     *issuing.IssuerEntry
 	// acmeDirectory is a string that can distinguish the various acme directories we have configured
@@ -32,7 +33,7 @@ type acmeContext struct {
 }
 
 func (c acmeContext) getAcmeState() *acmeState {
-	return c.sc.Backend.GetAcmeState()
+	return c.acmeState
 }
 
 type (
@@ -110,7 +111,7 @@ func (b *backend) acmeWrapper(opts acmeWrapperOpts, op acmeOperation) framework.
 	return acmeErrorWrapper(func(ctx context.Context, r *logical.Request, data *framework.FieldData) (*logical.Response, error) {
 		sc := b.makeStorageContext(ctx, r.Storage)
 
-		config, err := sc.Backend.GetAcmeState().getConfigWithUpdate(sc)
+		config, err := b.GetAcmeState().getConfigWithUpdate(sc)
 		if err != nil {
 			return nil, fmt.Errorf("failed to fetch ACME configuration: %w", err)
 		}
@@ -163,6 +164,7 @@ func (b *backend) acmeWrapper(opts acmeWrapperOpts, op acmeOperation) framework.
 			baseUrl:       acmeBaseUrl,
 			clusterUrl:    clusterBase,
 			sc:            sc,
+			acmeState:     b.acmeState,
 			role:          role,
 			issuer:        issuer,
 			acmeDirectory: acmeDirectory,

--- a/builtin/logical/pki/acme_wrappers.go
+++ b/builtin/logical/pki/acme_wrappers.go
@@ -135,7 +135,7 @@ func (b *backend) acmeWrapper(opts acmeWrapperOpts, op acmeOperation) framework.
 			return nil, err
 		}
 
-		role, issuer, err := getAcmeRoleAndIssuer(b, sc, data, config)
+		role, issuer, err := getAcmeRoleAndIssuer(sc, data, config)
 		if err != nil {
 			return nil, err
 		}
@@ -360,7 +360,7 @@ func getAcmeDirectory(r *logical.Request) (string, error) {
 	return strings.TrimLeft(acmePath[0:lastIndex]+"/acme/", "/"), nil
 }
 
-func getAcmeRoleAndIssuer(b *backend, sc *storageContext, data *framework.FieldData, config *acmeConfigEntry) (*issuing.RoleEntry, *issuing.IssuerEntry, error) {
+func getAcmeRoleAndIssuer(sc *storageContext, data *framework.FieldData, config *acmeConfigEntry) (*issuing.RoleEntry, *issuing.IssuerEntry, error) {
 	requestedIssuer := getRequestedAcmeIssuerFromPath(data)
 	requestedRole := getRequestedAcmeRoleFromPath(data)
 	issuerToLoad := requestedIssuer
@@ -381,13 +381,13 @@ func getAcmeRoleAndIssuer(b *backend, sc *storageContext, data *framework.FieldD
 				issuing.WithIssuer(requestedIssuer),
 				issuing.WithNoStore(false))
 		case Role:
-			role, err = getAndValidateAcmeRole(b, sc, extraInfo)
+			role, err = getAndValidateAcmeRole(sc, extraInfo)
 			if err != nil {
 				return nil, nil, err
 			}
 		}
 	} else { // Requested Role
-		role, err = getAndValidateAcmeRole(b, sc, requestedRole)
+		role, err = getAndValidateAcmeRole(sc, requestedRole)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -455,9 +455,9 @@ func getAcmeRoleAndIssuer(b *backend, sc *storageContext, data *framework.FieldD
 	return role, issuer, nil
 }
 
-func getAndValidateAcmeRole(b *backend, sc *storageContext, requestedRole string) (*issuing.RoleEntry, error) {
+func getAndValidateAcmeRole(sc *storageContext, requestedRole string) (*issuing.RoleEntry, error) {
 	var err error
-	role, err := b.GetRole(sc.Context, sc.Storage, requestedRole)
+	role, err := sc.GetRole(requestedRole)
 	if err != nil {
 		return nil, fmt.Errorf("%w: err loading role", ErrServerInternal)
 	}

--- a/builtin/logical/pki/acme_wrappers.go
+++ b/builtin/logical/pki/acme_wrappers.go
@@ -145,7 +145,7 @@ func (b *backend) acmeWrapper(opts acmeWrapperOpts, op acmeOperation) framework.
 			return nil, err
 		}
 
-		isCiepsEnabled, ciepsPolicy, err := getCiepsAcmeSettings(sc, opts, config, data)
+		isCiepsEnabled, ciepsPolicy, err := getCiepsAcmeSettings(sc, opts, config, data, b.ciepsState)
 		if err != nil {
 			return nil, err
 		}

--- a/builtin/logical/pki/acme_wrappers.go
+++ b/builtin/logical/pki/acme_wrappers.go
@@ -145,7 +145,7 @@ func (b *backend) acmeWrapper(opts acmeWrapperOpts, op acmeOperation) framework.
 			return nil, err
 		}
 
-		isCiepsEnabled, ciepsPolicy, err := getCiepsAcmeSettings(sc, opts, config, data, b.ciepsState)
+		isCiepsEnabled, ciepsPolicy, err := getCiepsAcmeSettings(b, sc, opts, config, data)
 		if err != nil {
 			return nil, err
 		}

--- a/builtin/logical/pki/acme_wrappers.go
+++ b/builtin/logical/pki/acme_wrappers.go
@@ -135,7 +135,7 @@ func (b *backend) acmeWrapper(opts acmeWrapperOpts, op acmeOperation) framework.
 			return nil, err
 		}
 
-		role, issuer, err := getAcmeRoleAndIssuer(sc, data, config)
+		role, issuer, err := getAcmeRoleAndIssuer(b, sc, data, config)
 		if err != nil {
 			return nil, err
 		}
@@ -360,7 +360,7 @@ func getAcmeDirectory(r *logical.Request) (string, error) {
 	return strings.TrimLeft(acmePath[0:lastIndex]+"/acme/", "/"), nil
 }
 
-func getAcmeRoleAndIssuer(sc *storageContext, data *framework.FieldData, config *acmeConfigEntry) (*issuing.RoleEntry, *issuing.IssuerEntry, error) {
+func getAcmeRoleAndIssuer(b *backend, sc *storageContext, data *framework.FieldData, config *acmeConfigEntry) (*issuing.RoleEntry, *issuing.IssuerEntry, error) {
 	requestedIssuer := getRequestedAcmeIssuerFromPath(data)
 	requestedRole := getRequestedAcmeRoleFromPath(data)
 	issuerToLoad := requestedIssuer
@@ -381,13 +381,13 @@ func getAcmeRoleAndIssuer(sc *storageContext, data *framework.FieldData, config 
 				issuing.WithIssuer(requestedIssuer),
 				issuing.WithNoStore(false))
 		case Role:
-			role, err = getAndValidateAcmeRole(sc, extraInfo)
+			role, err = getAndValidateAcmeRole(b, sc, extraInfo)
 			if err != nil {
 				return nil, nil, err
 			}
 		}
 	} else { // Requested Role
-		role, err = getAndValidateAcmeRole(sc, requestedRole)
+		role, err = getAndValidateAcmeRole(b, sc, requestedRole)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -455,9 +455,9 @@ func getAcmeRoleAndIssuer(sc *storageContext, data *framework.FieldData, config 
 	return role, issuer, nil
 }
 
-func getAndValidateAcmeRole(sc *storageContext, requestedRole string) (*issuing.RoleEntry, error) {
+func getAndValidateAcmeRole(b *backend, sc *storageContext, requestedRole string) (*issuing.RoleEntry, error) {
 	var err error
-	role, err := sc.Backend.GetRole(sc.Context, sc.Storage, requestedRole)
+	role, err := b.GetRole(sc.Context, sc.Storage, requestedRole)
 	if err != nil {
 		return nil, fmt.Errorf("%w: err loading role", ErrServerInternal)
 	}

--- a/builtin/logical/pki/cert_util.go
+++ b/builtin/logical/pki/cert_util.go
@@ -163,7 +163,7 @@ func (sc *storageContext) fetchCAInfoWithIssuer(issuerRef string, usage issuing.
 // fetchCAInfoByIssuerId will fetch the CA info, will return an error if no ca info exists for the given issuerId.
 // This does support the loading using the legacyBundleShimID
 func (sc *storageContext) fetchCAInfoByIssuerId(issuerId issuing.IssuerID, usage issuing.IssuerUsage) (*certutil.CAInfoBundle, error) {
-	return issuing.FetchCAInfoByIssuerId(sc.Context, sc.Storage, sc.Backend, issuerId, usage)
+	return issuing.FetchCAInfoByIssuerId(sc.Context, sc.Storage, sc.GetPkiManagedView(), issuerId, usage)
 }
 
 func fetchCertBySerialBigInt(sc *storageContext, prefix string, serial *big.Int) (*logical.StorageEntry, error) {

--- a/builtin/logical/pki/cert_util.go
+++ b/builtin/logical/pki/cert_util.go
@@ -250,7 +250,7 @@ func fetchCertBySerial(sc *storageContext, prefix, serial string) (*logical.Stor
 
 	// Update old-style paths to new-style paths
 	certEntry.Key = path
-	certCounter := sc.Backend.GetCertificateCounter()
+	certCounter := sc.GetCertificateCounter()
 	certsCounted := certCounter.IsInitialized()
 	if err = sc.Storage.Put(sc.Context, certEntry); err != nil {
 		return nil, errutil.InternalError{Err: fmt.Sprintf("error saving certificate with serial %s to new location: %s", serial, err)}

--- a/builtin/logical/pki/cert_util.go
+++ b/builtin/logical/pki/cert_util.go
@@ -139,7 +139,7 @@ func (sc *storageContext) fetchCAInfo(issuerRef string, usage issuing.IssuerUsag
 func (sc *storageContext) fetchCAInfoWithIssuer(issuerRef string, usage issuing.IssuerUsage) (*certutil.CAInfoBundle, issuing.IssuerID, error) {
 	var issuerId issuing.IssuerID
 
-	if sc.Backend.UseLegacyBundleCaStorage() {
+	if sc.UseLegacyBundleCaStorage() {
 		// We have not completed the migration so attempt to load the bundle from the legacy location
 		sc.Logger().Info("Using legacy CA bundle as PKI migration has not completed.")
 		issuerId = legacyBundleShimID
@@ -209,7 +209,7 @@ func fetchCertBySerial(sc *storageContext, prefix, serial string) (*logical.Stor
 		}
 
 		if serial == deltaCRLPath || serial == unifiedDeltaCRLPath {
-			if sc.Backend.UseLegacyBundleCaStorage() {
+			if sc.UseLegacyBundleCaStorage() {
 				return nil, fmt.Errorf("refusing to serve delta CRL with legacy CA bundle")
 			}
 

--- a/builtin/logical/pki/cert_util.go
+++ b/builtin/logical/pki/cert_util.go
@@ -190,7 +190,7 @@ func fetchCertBySerial(sc *storageContext, prefix, serial string) (*logical.Stor
 		legacyPath = "revoked/" + colonSerial
 		path = "revoked/" + hyphenSerial
 	case serial == legacyCRLPath || serial == deltaCRLPath || serial == unifiedCRLPath || serial == unifiedDeltaCRLPath:
-		warnings, err := sc.Backend.CrlBuilder().rebuildIfForced(sc)
+		warnings, err := sc.CrlBuilder().rebuildIfForced(sc)
 		if err != nil {
 			return nil, err
 		}

--- a/builtin/logical/pki/cert_util.go
+++ b/builtin/logical/pki/cert_util.go
@@ -141,7 +141,7 @@ func (sc *storageContext) fetchCAInfoWithIssuer(issuerRef string, usage issuing.
 
 	if sc.Backend.UseLegacyBundleCaStorage() {
 		// We have not completed the migration so attempt to load the bundle from the legacy location
-		sc.Backend.Logger().Info("Using legacy CA bundle as PKI migration has not completed.")
+		sc.Logger().Info("Using legacy CA bundle as PKI migration has not completed.")
 		issuerId = legacyBundleShimID
 	} else {
 		var err error
@@ -199,7 +199,7 @@ func fetchCertBySerial(sc *storageContext, prefix, serial string) (*logical.Stor
 			for index, warning := range warnings {
 				msg = fmt.Sprintf("%v\n %d. %v", msg, index+1, warning)
 			}
-			sc.Backend.Logger().Warn(msg)
+			sc.Logger().Warn(msg)
 		}
 
 		unified := serial == unifiedCRLPath || serial == unifiedDeltaCRLPath

--- a/builtin/logical/pki/cert_util_test.go
+++ b/builtin/logical/pki/cert_util_test.go
@@ -125,7 +125,7 @@ func TestPki_MultipleOUs(t *testing.T) {
 			OU:     []string{"Z", "E", "V"},
 		},
 	}
-	cb, _, err := generateCreationBundle(b, input, nil, nil)
+	cb, _, err := generateCreationBundle(b.System(), input, nil, nil)
 	if err != nil {
 		t.Fatalf("Error: %v", err)
 	}
@@ -245,7 +245,7 @@ func TestPki_PermitFQDNs(t *testing.T) {
 		name := name
 		testCase := testCase
 		t.Run(name, func(t *testing.T) {
-			cb, _, err := generateCreationBundle(b, testCase.input, nil, nil)
+			cb, _, err := generateCreationBundle(b.System(), testCase.input, nil, nil)
 			if err != nil {
 				t.Fatalf("Error: %v", err)
 			}

--- a/builtin/logical/pki/cieps_util_oss.go
+++ b/builtin/logical/pki/cieps_util_oss.go
@@ -20,6 +20,6 @@ func issueAcmeCertUsingCieps(_ *backend, _ *acmeContext, _ *logical.Request, _ *
 	return nil, "", fmt.Errorf("cieps is an enterprise only feature")
 }
 
-func getCiepsAcmeSettings(sc *storageContext, opts acmeWrapperOpts, config *acmeConfigEntry, data *framework.FieldData) (bool, string, error) {
+func getCiepsAcmeSettings(b *backend, sc *storageContext, opts acmeWrapperOpts, config *acmeConfigEntry, data *framework.FieldData) (bool, string, error) {
 	return false, "", nil
 }

--- a/builtin/logical/pki/crl_util.go
+++ b/builtin/logical/pki/crl_util.go
@@ -957,8 +957,8 @@ func fetchIssuerMapForRevocationChecking(sc *storageContext) (map[issuing.Issuer
 // storage.
 func tryRevokeCertBySerial(sc *storageContext, config *crlConfig, serial string) (*logical.Response, error) {
 	// revokeCert requires us to hold these locks before calling it.
-	sc.Backend.GetRevokeStorageLock().Lock()
-	defer sc.Backend.GetRevokeStorageLock().Unlock()
+	sc.GetRevokeStorageLock().Lock()
+	defer sc.GetRevokeStorageLock().Unlock()
 
 	certEntry, err := fetchCertBySerial(sc, issuing.PathCerts, serial)
 	if err != nil {

--- a/builtin/logical/pki/crl_util.go
+++ b/builtin/logical/pki/crl_util.go
@@ -188,7 +188,7 @@ func (cb *CrlBuilder) notifyOnConfigChange(sc *storageContext, priorConfig crlCo
 	// such as primary clusters as well as performance replicas, it is easier to do here than
 	// in two places (API layer and in invalidateFunc)
 	if priorConfig.UnifiedCRL != newConfig.UnifiedCRL && newConfig.UnifiedCRL {
-		sc.Backend.GetUnifiedTransferStatus().forceRun()
+		sc.GetUnifiedTransferStatus().forceRun()
 	}
 
 	if priorConfig.UseGlobalQueue != newConfig.UseGlobalQueue && newConfig.UseGlobalQueue {
@@ -1091,7 +1091,7 @@ func revokeCert(sc *storageContext, config *crlConfig, cert *x509.Certificate) (
 			// thread will reattempt it later on as we have the local write done.
 			sc.Logger().Error("Failed to write unified revocation entry, will re-attempt later",
 				"serial_number", colonSerial, "error", ignoreErr)
-			sc.Backend.GetUnifiedTransferStatus().forceRun()
+			sc.GetUnifiedTransferStatus().forceRun()
 
 			resp.AddWarning(fmt.Sprintf("Failed to write unified revocation entry, will re-attempt later: %v", err))
 			failedWritingUnifiedCRL = true
@@ -1148,7 +1148,7 @@ func writeRevocationDeltaWALs(sc *storageContext, config *crlConfig, resp *logic
 			// thread will reattempt it later on as we have the local write done.
 			sc.Logger().Error("Failed to write cross-cluster delta WAL entry, will re-attempt later",
 				"serial_number", colonSerial, "error", ignoredErr)
-			sc.Backend.GetUnifiedTransferStatus().forceRun()
+			sc.GetUnifiedTransferStatus().forceRun()
 
 			resp.AddWarning(fmt.Sprintf("Failed to write cross-cluster delta WAL entry, will re-attempt later: %v", ignoredErr))
 		}

--- a/builtin/logical/pki/crl_util.go
+++ b/builtin/logical/pki/crl_util.go
@@ -1103,7 +1103,7 @@ func revokeCert(sc *storageContext, config *crlConfig, cert *x509.Certificate) (
 		// already rebuilt the full CRL so the Delta WAL will be cleared
 		// afterwards. Writing an entry only to immediately remove it
 		// isn't necessary.
-		warnings, crlErr := sc.Backend.CrlBuilder().rebuild(sc, false)
+		warnings, crlErr := sc.CrlBuilder().rebuild(sc, false)
 		if crlErr != nil {
 			switch crlErr.(type) {
 			case errutil.UserError:
@@ -1243,7 +1243,7 @@ func buildAnyCRLs(sc *storageContext, forceNew bool, isDelta bool) ([]string, er
 	var wasLegacy bool
 
 	// First, fetch an updated copy of the CRL config. We'll pass this into buildCRL.
-	crlBuilder := sc.Backend.CrlBuilder()
+	crlBuilder := sc.CrlBuilder()
 	globalCRLConfig, err := crlBuilder.getConfigWithUpdate(sc)
 	if err != nil {
 		return nil, fmt.Errorf("error building CRL: while updating config: %w", err)
@@ -1439,7 +1439,7 @@ func buildAnyLocalCRLs(
 	// visible now, should also be visible on the complete CRL we're writing.
 	var currDeltaCerts []string
 	if !isDelta {
-		currDeltaCerts, err = sc.Backend.CrlBuilder().getPresentLocalDeltaWALForClearing(sc)
+		currDeltaCerts, err = sc.CrlBuilder().getPresentLocalDeltaWALForClearing(sc)
 		if err != nil {
 			return nil, nil, fmt.Errorf("error building CRLs: unable to get present delta WAL entries for removal: %w", err)
 		}
@@ -1503,7 +1503,7 @@ func buildAnyLocalCRLs(
 	if isDelta {
 		// Update our last build time here so we avoid checking for new certs
 		// for a while.
-		sc.Backend.CrlBuilder().lastDeltaRebuildCheck = time.Now()
+		sc.CrlBuilder().lastDeltaRebuildCheck = time.Now()
 
 		if len(lastDeltaSerial) > 0 {
 			// When we have a last delta serial, write out the relevant info
@@ -1582,7 +1582,7 @@ func buildAnyUnifiedCRLs(
 	// visible now, should also be visible on the complete CRL we're writing.
 	var currDeltaCerts []string
 	if !isDelta {
-		currDeltaCerts, err = sc.Backend.CrlBuilder().getPresentUnifiedDeltaWALForClearing(sc)
+		currDeltaCerts, err = sc.CrlBuilder().getPresentUnifiedDeltaWALForClearing(sc)
 		if err != nil {
 			return nil, nil, fmt.Errorf("error building CRLs: unable to get present delta WAL entries for removal: %w", err)
 		}
@@ -1646,7 +1646,7 @@ func buildAnyUnifiedCRLs(
 	if isDelta {
 		// Update our last build time here so we avoid checking for new certs
 		// for a while.
-		sc.Backend.CrlBuilder().lastDeltaRebuildCheck = time.Now()
+		sc.CrlBuilder().lastDeltaRebuildCheck = time.Now()
 
 		// Persist all of our known last revoked serial numbers here, as the
 		// last seen serial during build. This will allow us to detect if any

--- a/builtin/logical/pki/crl_util.go
+++ b/builtin/logical/pki/crl_util.go
@@ -916,7 +916,7 @@ func fetchIssuerMapForRevocationChecking(sc *storageContext) (map[issuing.Issuer
 	var err error
 	var issuers []issuing.IssuerID
 
-	if !sc.Backend.UseLegacyBundleCaStorage() {
+	if !sc.UseLegacyBundleCaStorage() {
 		issuers, err = sc.listIssuers()
 		if err != nil {
 			return nil, fmt.Errorf("could not fetch issuers list: %w", err)
@@ -1261,7 +1261,7 @@ func buildAnyCRLs(sc *storageContext, forceNew bool, isDelta bool) ([]string, er
 		return nil, nil
 	}
 
-	if !sc.Backend.UseLegacyBundleCaStorage() {
+	if !sc.UseLegacyBundleCaStorage() {
 		issuers, err = sc.listIssuers()
 		if err != nil {
 			return nil, fmt.Errorf("error building CRL: while listing issuers: %w", err)

--- a/builtin/logical/pki/crl_util.go
+++ b/builtin/logical/pki/crl_util.go
@@ -1055,7 +1055,7 @@ func revokeCert(sc *storageContext, config *crlConfig, cert *x509.Certificate) (
 		return nil, fmt.Errorf("error creating revocation entry: %w", err)
 	}
 
-	certCounter := sc.Backend.GetCertificateCounter()
+	certCounter := sc.GetCertificateCounter()
 	certsCounted := certCounter.IsInitialized()
 	err = sc.Storage.Put(sc.Context, revEntry)
 	if err != nil {

--- a/builtin/logical/pki/crl_util.go
+++ b/builtin/logical/pki/crl_util.go
@@ -938,7 +938,7 @@ func fetchIssuerMapForRevocationChecking(sc *storageContext) (map[issuing.Issuer
 			return nil, fmt.Errorf("faulty reference: %v - CA info not found", issuer)
 		}
 
-		parsedBundle, err := parseCABundle(sc.Context, sc.Backend, bundle)
+		parsedBundle, err := parseCABundle(sc.Context, sc.GetPkiManagedView(), bundle)
 		if err != nil {
 			return nil, errutil.InternalError{Err: err.Error()}
 		}

--- a/builtin/logical/pki/key_util.go
+++ b/builtin/logical/pki/key_util.go
@@ -17,7 +17,7 @@ import (
 )
 
 func comparePublicKey(sc *storageContext, key *issuing.KeyEntry, publicKey crypto.PublicKey) (bool, error) {
-	publicKeyForKeyEntry, err := getPublicKey(sc.Context, sc.Backend, key)
+	publicKeyForKeyEntry, err := getPublicKey(sc.Context, sc.GetPkiManagedView(), key)
 	if err != nil {
 		return false, err
 	}
@@ -25,9 +25,9 @@ func comparePublicKey(sc *storageContext, key *issuing.KeyEntry, publicKey crypt
 	return certutil.ComparePublicKeysAndType(publicKeyForKeyEntry, publicKey)
 }
 
-func getPublicKey(ctx context.Context, b *backend, key *issuing.KeyEntry) (crypto.PublicKey, error) {
+func getPublicKey(ctx context.Context, mkv managed_key.PkiManagedKeyView, key *issuing.KeyEntry) (crypto.PublicKey, error) {
 	if key.PrivateKeyType == certutil.ManagedPrivateKey {
-		return managed_key.GetPublicKeyFromKeyBytes(ctx, b, []byte(key.PrivateKey))
+		return managed_key.GetPublicKeyFromKeyBytes(ctx, mkv, []byte(key.PrivateKey))
 	}
 
 	signer, _, _, err := getSignerFromKeyEntryBytes(key)

--- a/builtin/logical/pki/path_acme_order.go
+++ b/builtin/logical/pki/path_acme_order.go
@@ -271,7 +271,7 @@ func (b *backend) acmeFinalizeOrderHandler(ac *acmeContext, r *logical.Request, 
 			return nil, err
 		}
 
-		err = issuing.StoreCertificate(ac.sc.Context, ac.sc.Storage, ac.sc.Backend.GetCertificateCounter(), signedCertBundle)
+		err = issuing.StoreCertificate(ac.sc.Context, ac.sc.Storage, ac.sc.GetCertificateCounter(), signedCertBundle)
 		if err != nil {
 			return nil, err
 		}

--- a/builtin/logical/pki/path_acme_order.go
+++ b/builtin/logical/pki/path_acme_order.go
@@ -546,7 +546,7 @@ func issueCertFromCsr(ac *acmeContext, csr *x509.CertificateRequest) (*certutil.
 
 	// We only allow ServerAuth key usage from ACME issued certs
 	// when configuration does not allow usage of ExtKeyusage field.
-	config, err := ac.sc.Backend.GetAcmeState().getConfigWithUpdate(ac.sc)
+	config, err := ac.acmeState.getConfigWithUpdate(ac.sc)
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to fetch ACME configuration: %w", err)
 	}

--- a/builtin/logical/pki/path_acme_order.go
+++ b/builtin/logical/pki/path_acme_order.go
@@ -539,7 +539,7 @@ func issueCertFromCsr(ac *acmeContext, csr *x509.CertificateRequest) (*certutil.
 		role:    ac.role,
 	}
 
-	normalNotAfter, _, err := getCertificateNotAfter(ac.sc.Backend, input, signingBundle)
+	normalNotAfter, _, err := getCertificateNotAfter(ac.sc.System(), input, signingBundle)
 	if err != nil {
 		return nil, "", fmt.Errorf("failed computing certificate TTL from role/mount: %v: %w", err, ErrMalformed)
 	}
@@ -573,7 +573,7 @@ func issueCertFromCsr(ac *acmeContext, csr *x509.CertificateRequest) (*certutil.
 	// unit, we have no way of validating this (via ACME here, without perhaps
 	// an external policy engine), and thus should not be setting it on our
 	// final issued certificate.
-	parsedBundle, _, err := signCert(ac.sc.Backend, input, signingBundle, false /* is_ca=false */, false /* use_csr_values */)
+	parsedBundle, _, err := signCert(ac.sc.System(), input, signingBundle, false /* is_ca=false */, false /* use_csr_values */)
 	if err != nil {
 		return nil, "", fmt.Errorf("%w: refusing to sign CSR: %s", ErrBadCSR, err.Error())
 	}

--- a/builtin/logical/pki/path_config_acme.go
+++ b/builtin/logical/pki/path_config_acme.go
@@ -57,7 +57,7 @@ var (
 	rolePrefixLength      = len(rolePrefix)
 )
 
-func (sc *storageContext) getAcmeConfig() (*acmeConfigEntry, error) {
+func getAcmeConfig(sc *storageContext) (*acmeConfigEntry, error) {
 	entry, err := sc.Storage.Get(sc.Context, storageAcmeConfig)
 	if err != nil {
 		return nil, err

--- a/builtin/logical/pki/path_config_acme.go
+++ b/builtin/logical/pki/path_config_acme.go
@@ -290,7 +290,7 @@ func (b *backend) pathAcmeWrite(ctx context.Context, req *logical.Request, d *fr
 	case Role:
 		defaultDirectoryRoleName = extraInfo
 
-		_, err := getAndValidateAcmeRole(b, sc, defaultDirectoryRoleName)
+		_, err := getAndValidateAcmeRole(sc, defaultDirectoryRoleName)
 		if err != nil {
 			return nil, fmt.Errorf("default directory policy role %v is not a valid ACME role: %w", defaultDirectoryRoleName, err)
 		}
@@ -307,7 +307,7 @@ func (b *backend) pathAcmeWrite(ctx context.Context, req *logical.Request, d *fr
 				return nil, fmt.Errorf("cannot use '*' as role name at index %d", index)
 			}
 
-			_, err := getAndValidateAcmeRole(b, sc, name)
+			_, err := getAndValidateAcmeRole(sc, name)
 			if err != nil {
 				return nil, fmt.Errorf("allowed_role %v is not a valid acme role: %w", name, err)
 			}

--- a/builtin/logical/pki/path_config_acme.go
+++ b/builtin/logical/pki/path_config_acme.go
@@ -290,7 +290,7 @@ func (b *backend) pathAcmeWrite(ctx context.Context, req *logical.Request, d *fr
 	case Role:
 		defaultDirectoryRoleName = extraInfo
 
-		_, err := getAndValidateAcmeRole(sc, defaultDirectoryRoleName)
+		_, err := getAndValidateAcmeRole(b, sc, defaultDirectoryRoleName)
 		if err != nil {
 			return nil, fmt.Errorf("default directory policy role %v is not a valid ACME role: %w", defaultDirectoryRoleName, err)
 		}
@@ -307,7 +307,7 @@ func (b *backend) pathAcmeWrite(ctx context.Context, req *logical.Request, d *fr
 				return nil, fmt.Errorf("cannot use '*' as role name at index %d", index)
 			}
 
-			_, err := getAndValidateAcmeRole(sc, name)
+			_, err := getAndValidateAcmeRole(b, sc, name)
 			if err != nil {
 				return nil, fmt.Errorf("allowed_role %v is not a valid acme role: %w", name, err)
 			}

--- a/builtin/logical/pki/path_fetch_keys.go
+++ b/builtin/logical/pki/path_fetch_keys.go
@@ -267,7 +267,7 @@ func (b *backend) pathGetKeyHandler(ctx context.Context, req *logical.Request, d
 			return nil, errutil.InternalError{Err: fmt.Sprintf("failed fetching managed key info from key id %s (%s): %v", key.ID, key.Name, err)}
 		}
 
-		pkForSkid, err = managed_key.GetManagedKeyPublicKey(sc.Context, sc.Backend, managedKeyUUID)
+		pkForSkid, err = managed_key.GetManagedKeyPublicKey(sc.Context, sc.GetPkiManagedView(), managedKeyUUID)
 		if err != nil {
 			return nil, err
 		}

--- a/builtin/logical/pki/path_issue_sign.go
+++ b/builtin/logical/pki/path_issue_sign.go
@@ -417,7 +417,7 @@ func (b *backend) pathIssueSignCert(ctx context.Context, req *logical.Request, d
 	var parsedBundle *certutil.ParsedCertBundle
 	var warnings []string
 	if useCSR {
-		parsedBundle, warnings, err = signCert(b, input, signingBundle, false, useCSRValues)
+		parsedBundle, warnings, err = signCert(b.System(), input, signingBundle, false, useCSRValues)
 	} else {
 		parsedBundle, warnings, err = generateCert(sc, input, signingBundle, false, rand.Reader)
 	}

--- a/builtin/logical/pki/path_ocsp.go
+++ b/builtin/logical/pki/path_ocsp.go
@@ -447,7 +447,7 @@ func lookupIssuerIds(sc *storageContext, optRevokedIssuer issuing.IssuerID) ([]i
 		return []issuing.IssuerID{optRevokedIssuer}, nil
 	}
 
-	if sc.Backend.UseLegacyBundleCaStorage() {
+	if sc.UseLegacyBundleCaStorage() {
 		return []issuing.IssuerID{legacyBundleShimID}, nil
 	}
 

--- a/builtin/logical/pki/path_ocsp.go
+++ b/builtin/logical/pki/path_ocsp.go
@@ -434,7 +434,7 @@ func getOcspIssuerParsedBundle(sc *storageContext, issuerId issuing.IssuerID) (*
 		return nil, nil, ErrIssuerHasNoKey
 	}
 
-	caBundle, err := parseCABundle(sc.Context, sc.Backend, bundle)
+	caBundle, err := parseCABundle(sc.Context, sc.GetPkiManagedView(), bundle)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/builtin/logical/pki/path_revoke.go
+++ b/builtin/logical/pki/path_revoke.go
@@ -563,7 +563,7 @@ func (b *backend) pathRevokeWrite(ctx context.Context, req *logical.Request, dat
 	var cert *x509.Certificate
 	var serial string
 
-	config, err := sc.Backend.CrlBuilder().getConfigWithUpdate(sc)
+	config, err := sc.CrlBuilder().getConfigWithUpdate(sc)
 	if err != nil {
 		return nil, fmt.Errorf("error revoking serial: %s: failed reading config: %w", serial, err)
 	}

--- a/builtin/logical/pki/path_root.go
+++ b/builtin/logical/pki/path_root.go
@@ -399,7 +399,7 @@ func (b *backend) pathIssuerSignIntermediate(ctx context.Context, req *logical.R
 		apiData: data,
 		role:    role,
 	}
-	parsedBundle, warnings, err := signCert(b, input, signingBundle, true, useCSRValues)
+	parsedBundle, warnings, err := signCert(b.System(), input, signingBundle, true, useCSRValues)
 	if err != nil {
 		switch err.(type) {
 		case errutil.UserError:

--- a/builtin/logical/pki/periodic.go
+++ b/builtin/logical/pki/periodic.go
@@ -36,8 +36,7 @@ func newUnifiedTransferStatus() *UnifiedTransferStatus {
 // send all missing local revocation entries to the unified space if the feature
 // is enabled.
 func runUnifiedTransfer(sc *storageContext) {
-	b := sc.Backend
-	status := b.GetUnifiedTransferStatus()
+	status := sc.GetUnifiedTransferStatus()
 
 	isPerfStandby := sc.System().ReplicationState().HasState(consts.ReplicationDRSecondary | consts.ReplicationPerformanceStandby)
 

--- a/builtin/logical/pki/periodic.go
+++ b/builtin/logical/pki/periodic.go
@@ -46,7 +46,7 @@ func runUnifiedTransfer(sc *storageContext) {
 		return
 	}
 
-	config, err := b.CrlBuilder().getConfigWithUpdate(sc)
+	config, err := sc.CrlBuilder().getConfigWithUpdate(sc)
 	if err != nil {
 		sc.Logger().Error("failed to retrieve crl config from storage for unified transfer background process",
 			"error", err)
@@ -125,7 +125,7 @@ func doUnifiedTransferMissingLocalSerials(sc *storageContext, clusterId string) 
 	errCount := 0
 	for i, serialNum := range localRevokedSerialNums {
 		if i%25 == 0 {
-			config, _ := sc.Backend.CrlBuilder().getConfigWithUpdate(sc)
+			config, _ := sc.CrlBuilder().getConfigWithUpdate(sc)
 			if config != nil && !config.UnifiedCRL {
 				return errors.New("unified crl has been disabled after we started, stopping")
 			}
@@ -224,7 +224,7 @@ func doUnifiedTransferMissingDeltaWALSerials(sc *storageContext, clusterId strin
 	errCount := 0
 	for index, serial := range localWALEntries {
 		if index%25 == 0 {
-			config, _ := sc.Backend.CrlBuilder().getConfigWithUpdate(sc)
+			config, _ := sc.CrlBuilder().getConfigWithUpdate(sc)
 			if config != nil && (!config.UnifiedCRL || !config.EnableDelta) {
 				return errors.New("unified or delta CRLs have been disabled after we started, stopping")
 			}

--- a/builtin/logical/pki/periodic.go
+++ b/builtin/logical/pki/periodic.go
@@ -48,7 +48,7 @@ func runUnifiedTransfer(sc *storageContext) {
 
 	config, err := b.CrlBuilder().getConfigWithUpdate(sc)
 	if err != nil {
-		b.Logger().Error("failed to retrieve crl config from storage for unified transfer background process",
+		sc.Logger().Error("failed to retrieve crl config from storage for unified transfer background process",
 			"error", err)
 		return
 	}
@@ -60,13 +60,13 @@ func runUnifiedTransfer(sc *storageContext) {
 
 	clusterId, err := b.System().ClusterID(sc.Context)
 	if err != nil {
-		b.Logger().Error("failed to fetch cluster id for unified transfer background process",
+		sc.Logger().Error("failed to fetch cluster id for unified transfer background process",
 			"error", err)
 		return
 	}
 
 	if !status.isRunning.CompareAndSwap(false, true) {
-		b.Logger().Debug("an existing unified transfer process is already running")
+		sc.Logger().Debug("an existing unified transfer process is already running")
 		return
 	}
 	defer status.isRunning.Store(false)
@@ -91,13 +91,13 @@ func runUnifiedTransfer(sc *storageContext) {
 
 	err = doUnifiedTransferMissingLocalSerials(sc, clusterId)
 	if err != nil {
-		b.Logger().Error("an error occurred running unified transfer", "error", err.Error())
+		sc.Logger().Error("an error occurred running unified transfer", "error", err.Error())
 		status.forceRerun.Store(true)
 	} else {
 		if config.EnableDelta {
 			err = doUnifiedTransferMissingDeltaWALSerials(sc, clusterId)
 			if err != nil {
-				b.Logger().Error("an error occurred running unified transfer", "error", err.Error())
+				sc.Logger().Error("an error occurred running unified transfer", "error", err.Error())
 				status.forceRerun.Store(true)
 			}
 		}
@@ -134,14 +134,14 @@ func doUnifiedTransferMissingLocalSerials(sc *storageContext, clusterId string) 
 			err := readRevocationEntryAndTransfer(sc, serialNum)
 			if err != nil {
 				errCount++
-				sc.Backend.Logger().Error("Failed transferring local revocation to unified space",
+				sc.Logger().Error("Failed transferring local revocation to unified space",
 					"serial", serialNum, "error", err)
 			}
 		}
 	}
 
 	if errCount > 0 {
-		sc.Backend.Logger().Warn(fmt.Sprintf("Failed transfering %d local serials to unified storage", errCount))
+		sc.Logger().Warn(fmt.Sprintf("Failed transfering %d local serials to unified storage", errCount))
 	}
 
 	return nil
@@ -247,7 +247,7 @@ func doUnifiedTransferMissingDeltaWALSerials(sc *storageContext, clusterId strin
 		if !isRevokedCopied {
 			// We need to wait here to copy over.
 			errCount += 1
-			sc.Backend.Logger().Debug("Delta WAL exists locally, but corresponding cross-cluster full revocation entry is missing; skipping", "serial", serial)
+			sc.Logger().Debug("Delta WAL exists locally, but corresponding cross-cluster full revocation entry is missing; skipping", "serial", serial)
 			continue
 		}
 
@@ -258,7 +258,7 @@ func doUnifiedTransferMissingDeltaWALSerials(sc *storageContext, clusterId strin
 		entry, err := sc.Storage.Get(sc.Context, localPath)
 		if err != nil || entry == nil {
 			errCount += 1
-			sc.Backend.Logger().Error("Failed reading local delta WAL entry to copy to cross-cluster", "serial", serial, "err", err)
+			sc.Logger().Error("Failed reading local delta WAL entry to copy to cross-cluster", "serial", serial, "err", err)
 			continue
 		}
 
@@ -266,14 +266,14 @@ func doUnifiedTransferMissingDeltaWALSerials(sc *storageContext, clusterId strin
 		err = sc.Storage.Put(sc.Context, entry)
 		if err != nil {
 			errCount += 1
-			sc.Backend.Logger().Error("Failed sync local delta WAL entry to cross-cluster unified delta WAL location", "serial", serial, "err", err)
+			sc.Logger().Error("Failed sync local delta WAL entry to cross-cluster unified delta WAL location", "serial", serial, "err", err)
 			continue
 		}
 	}
 
 	if errCount > 0 {
 		// See note above about why we don't fail here.
-		sc.Backend.Logger().Warn(fmt.Sprintf("Failed transfering %d local delta WAL serials to unified storage", errCount))
+		sc.Logger().Warn(fmt.Sprintf("Failed transfering %d local delta WAL serials to unified storage", errCount))
 		return nil
 	}
 
@@ -300,12 +300,12 @@ func readRevocationEntryAndTransfer(sc *storageContext, serial string) error {
 		return fmt.Errorf("failed loading revocation entry for serial: %s: %w", serial, err)
 	}
 	if revInfo == nil {
-		sc.Backend.Logger().Debug("no certificate revocation entry for serial", "serial", serial)
+		sc.Logger().Debug("no certificate revocation entry for serial", "serial", serial)
 		return nil
 	}
 	cert, err := x509.ParseCertificate(revInfo.CertificateBytes)
 	if err != nil {
-		sc.Backend.Logger().Debug("failed parsing certificate stored in revocation entry for serial",
+		sc.Logger().Debug("failed parsing certificate stored in revocation entry for serial",
 			"serial", serial, "error", err)
 		return nil
 	}

--- a/builtin/logical/pki/periodic.go
+++ b/builtin/logical/pki/periodic.go
@@ -39,9 +39,9 @@ func runUnifiedTransfer(sc *storageContext) {
 	b := sc.Backend
 	status := b.GetUnifiedTransferStatus()
 
-	isPerfStandby := b.System().ReplicationState().HasState(consts.ReplicationDRSecondary | consts.ReplicationPerformanceStandby)
+	isPerfStandby := sc.System().ReplicationState().HasState(consts.ReplicationDRSecondary | consts.ReplicationPerformanceStandby)
 
-	if isPerfStandby || b.System().LocalMount() {
+	if isPerfStandby || sc.System().LocalMount() {
 		// We only do this on active enterprise nodes, when we aren't a local mount
 		return
 	}
@@ -58,7 +58,7 @@ func runUnifiedTransfer(sc *storageContext) {
 		return
 	}
 
-	clusterId, err := b.System().ClusterID(sc.Context)
+	clusterId, err := sc.System().ClusterID(sc.Context)
 	if err != nil {
 		sc.Logger().Error("failed to fetch cluster id for unified transfer background process",
 			"error", err)

--- a/builtin/logical/pki/secret_certs.go
+++ b/builtin/logical/pki/secret_certs.go
@@ -78,7 +78,7 @@ func (b *backend) secretCredsRevoke(ctx context.Context, req *logical.Request, _
 		return nil, nil
 	}
 
-	config, err := sc.Backend.CrlBuilder().getConfigWithUpdate(sc)
+	config, err := sc.CrlBuilder().getConfigWithUpdate(sc)
 	if err != nil {
 		return nil, fmt.Errorf("error revoking serial: %s: failed reading config: %w", serial, err)
 	}

--- a/builtin/logical/pki/storage.go
+++ b/builtin/logical/pki/storage.go
@@ -97,6 +97,10 @@ func (sc *storageContext) GetPkiManagedView() managed_key.PkiManagedKeyView {
 	return sc.Backend
 }
 
+func (sc *storageContext) GetCertificateCounter() *CertificateCounter {
+	return sc.Backend.GetCertificateCounter()
+}
+
 func (sc *storageContext) listKeys() ([]issuing.KeyID, error) {
 	return issuing.ListKeys(sc.Context, sc.Storage)
 }

--- a/builtin/logical/pki/storage.go
+++ b/builtin/logical/pki/storage.go
@@ -89,6 +89,10 @@ func (sc *storageContext) CrlBuilder() *CrlBuilder {
 	return sc.Backend.CrlBuilder()
 }
 
+func (sc *storageContext) GetUnifiedTransferStatus() *UnifiedTransferStatus {
+	return sc.Backend.GetUnifiedTransferStatus()
+}
+
 func (sc *storageContext) listKeys() ([]issuing.KeyID, error) {
 	return issuing.ListKeys(sc.Context, sc.Storage)
 }

--- a/builtin/logical/pki/storage.go
+++ b/builtin/logical/pki/storage.go
@@ -93,6 +93,10 @@ func (sc *storageContext) GetUnifiedTransferStatus() *UnifiedTransferStatus {
 	return sc.Backend.GetUnifiedTransferStatus()
 }
 
+func (sc *storageContext) GetPkiManagedView() managed_key.PkiManagedKeyView {
+	return sc.Backend
+}
+
 func (sc *storageContext) listKeys() ([]issuing.KeyID, error) {
 	return issuing.ListKeys(sc.Context, sc.Storage)
 }

--- a/builtin/logical/pki/storage.go
+++ b/builtin/logical/pki/storage.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/hashicorp/go-hclog"
@@ -103,6 +104,10 @@ func (sc *storageContext) GetCertificateCounter() *CertificateCounter {
 
 func (sc *storageContext) UseLegacyBundleCaStorage() bool {
 	return sc.Backend.UseLegacyBundleCaStorage()
+}
+
+func (sc *storageContext) GetRevokeStorageLock() *sync.RWMutex {
+	return sc.Backend.GetRevokeStorageLock()
 }
 
 func (sc *storageContext) listKeys() ([]issuing.KeyID, error) {

--- a/builtin/logical/pki/storage.go
+++ b/builtin/logical/pki/storage.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/vault/builtin/logical/pki/issuing"
 	"github.com/hashicorp/vault/builtin/logical/pki/managed_key"
@@ -74,6 +75,10 @@ func (sc *storageContext) WithFreshTimeout(timeout time.Duration) (*storageConte
 		Storage: sc.Storage,
 		Backend: sc.Backend,
 	}, cancel
+}
+
+func (sc *storageContext) Logger() hclog.Logger {
+	return sc.Backend.Logger()
 }
 
 func (sc *storageContext) listKeys() ([]issuing.KeyID, error) {
@@ -653,7 +658,7 @@ func (sc *storageContext) getRevocationConfig() (*crlConfig, error) {
 	isLocalMount := sc.Backend.System().LocalMount()
 	if (!constants.IsEnterprise || isLocalMount) && (result.UnifiedCRLOnExistingPaths || result.UnifiedCRL || result.UseGlobalQueue) {
 		// An end user must have had Enterprise, enabled the unified config args and then downgraded to OSS.
-		sc.Backend.Logger().Warn("Not running Vault Enterprise or using a local mount, " +
+		sc.Logger().Warn("Not running Vault Enterprise or using a local mount, " +
 			"disabling unified_crl, unified_crl_on_existing_paths and cross_cluster_revocation config flags.")
 		result.UnifiedCRLOnExistingPaths = false
 		result.UnifiedCRL = false

--- a/builtin/logical/pki/storage.go
+++ b/builtin/logical/pki/storage.go
@@ -101,6 +101,10 @@ func (sc *storageContext) GetCertificateCounter() *CertificateCounter {
 	return sc.Backend.GetCertificateCounter()
 }
 
+func (sc *storageContext) UseLegacyBundleCaStorage() bool {
+	return sc.Backend.UseLegacyBundleCaStorage()
+}
+
 func (sc *storageContext) listKeys() ([]issuing.KeyID, error) {
 	return issuing.ListKeys(sc.Context, sc.Storage)
 }

--- a/builtin/logical/pki/storage.go
+++ b/builtin/logical/pki/storage.go
@@ -110,6 +110,10 @@ func (sc *storageContext) GetRevokeStorageLock() *sync.RWMutex {
 	return sc.Backend.GetRevokeStorageLock()
 }
 
+func (sc *storageContext) GetRole(name string) (*issuing.RoleEntry, error) {
+	return sc.Backend.GetRole(sc.Context, sc.Storage, name)
+}
+
 func (sc *storageContext) listKeys() ([]issuing.KeyID, error) {
 	return issuing.ListKeys(sc.Context, sc.Storage)
 }

--- a/builtin/logical/pki/storage.go
+++ b/builtin/logical/pki/storage.go
@@ -81,6 +81,10 @@ func (sc *storageContext) Logger() hclog.Logger {
 	return sc.Backend.Logger()
 }
 
+func (sc *storageContext) System() logical.SystemView {
+	return sc.Backend.System()
+}
+
 func (sc *storageContext) listKeys() ([]issuing.KeyID, error) {
 	return issuing.ListKeys(sc.Context, sc.Storage)
 }
@@ -655,7 +659,7 @@ func (sc *storageContext) getRevocationConfig() (*crlConfig, error) {
 		result.Expiry = defaultCrlConfig.Expiry
 	}
 
-	isLocalMount := sc.Backend.System().LocalMount()
+	isLocalMount := sc.System().LocalMount()
 	if (!constants.IsEnterprise || isLocalMount) && (result.UnifiedCRLOnExistingPaths || result.UnifiedCRL || result.UseGlobalQueue) {
 		// An end user must have had Enterprise, enabled the unified config args and then downgraded to OSS.
 		sc.Logger().Warn("Not running Vault Enterprise or using a local mount, " +

--- a/builtin/logical/pki/storage.go
+++ b/builtin/logical/pki/storage.go
@@ -85,6 +85,10 @@ func (sc *storageContext) System() logical.SystemView {
 	return sc.Backend.System()
 }
 
+func (sc *storageContext) CrlBuilder() *CrlBuilder {
+	return sc.Backend.CrlBuilder()
+}
+
 func (sc *storageContext) listKeys() ([]issuing.KeyID, error) {
 	return issuing.ListKeys(sc.Context, sc.Storage)
 }

--- a/builtin/logical/pki/util.go
+++ b/builtin/logical/pki/util.go
@@ -308,7 +308,7 @@ func (sc *storageContext) isIfModifiedSinceBeforeLastModified(helper *IfModified
 
 	switch helper.reqType {
 	case ifModifiedCRL, ifModifiedDeltaCRL:
-		if sc.Backend.CrlBuilder().invalidate.Load() {
+		if sc.CrlBuilder().invalidate.Load() {
 			// When we see the CRL is invalidated, respond with false
 			// regardless of what the local CRL state says. We've likely
 			// renamed some issuers or are about to rebuild a new CRL....
@@ -328,7 +328,7 @@ func (sc *storageContext) isIfModifiedSinceBeforeLastModified(helper *IfModified
 			lastModified = crlConfig.DeltaLastModified
 		}
 	case ifModifiedUnifiedCRL, ifModifiedUnifiedDeltaCRL:
-		if sc.Backend.CrlBuilder().invalidate.Load() {
+		if sc.CrlBuilder().invalidate.Load() {
 			// When we see the CRL is invalidated, respond with false
 			// regardless of what the local CRL state says. We've likely
 			// renamed some issuers or are about to rebuild a new CRL....


### PR DESCRIPTION
The Backend field in the struct storageContext in the pki package makes it impossible to re-use the code that uses it in other PKI backends.

Change the code to avoid making direct usage of the Backend field in preparation to make it more modular.