### PR TITLE
Test fixes

### DIFF
--- a/builtin/credential/aws/path_login_test.go
+++ b/builtin/credential/aws/path_login_test.go
@@ -312,6 +312,8 @@ func TestBackend_validateVaultPostRequestValues(t *testing.T) {
 // panics when referencing the potentially-nil config in the login handler. For
 // details see https://github.com/hashicorp/vault/issues/23361.
 func TestBackend_pathLogin_NoClientConfig(t *testing.T) {
+	t.Setenv("AWS_SHARED_CREDENTIALS_FILE", "/dev/null")
+	t.Setenv("AWS_CONFIG_FILE", "/dev/null")
 	storage := new(logical.InmemStorage)
 	config := logical.TestBackendConfig()
 	config.StorageView = storage

--- a/vault/external_tests/consul_fencing_binary/consul_fencing_test.go
+++ b/vault/external_tests/consul_fencing_binary/consul_fencing_test.go
@@ -6,6 +6,7 @@ package consul_fencing
 import (
 	"context"
 	"fmt"
+	"os"
 	"sort"
 	"sync"
 	"sync/atomic"
@@ -39,7 +40,9 @@ func TestConsulFencing_PartitionedLeaderCantWrite(t *testing.T) {
 	logger.SetLevel(hclog.Trace)
 
 	clusterOpts := docker.DefaultOptions(t)
-	clusterOpts.ImageRepo = "hashicorp/vault-enterprise"
+	if clusterOpts.VaultLicense != "" || os.Getenv(testcluster.EnvVaultLicenseCI) != "" {
+		clusterOpts.ImageRepo = "hashicorp/vault-enterprise"
+	}
 	clusterOpts.ClusterOptions.Logger = logger
 
 	clusterOpts.Storage = consulStorage


### PR DESCRIPTION
I recently opened #27404 and had a possible fix, but `make test` had failures.  These changes are not at all related to each other, but they seemed trivial enough to combine and to skip issue creation.  I'd be happy to split this apart and/or create a dedicated issue if I'm wrong.

For the AWS change, my first instinct was to make those changes "higher up" (e.g. in the `Makefile` or in the build scripts), but I chose to be conservative.  I'm a long-time user of Vault, but I'm new to the build/test process.

For the consul test, the bug report that led to this test (#23013) was more likely to occur with Enterprise, which is likely why that image was used.  I do know the test passes using the OSS image, but I don't know if that reduces the usefulness of the test.  I can _get_ a license, but I saw (unofficial) comments in places that suggested that "regular devs" aren't expected to have a license when running the tests locally.  I could not find any obvious mechanism for ignoring enterprise-specific tests, so, for this change, I chose to assume:
1. tests should not require a license to run
2. there is still value in running the test using OSS, even if it doesn't fully reflect the original environment (vs. skipping the test when a license is not present)
3. those points outweigh the risk of "works on my machine" (where someone gets different results based on presence/absence of a license)

