### PR TITLE
Remove Leap 15.4 from Enos testing matrices and AMI data sources

### DIFF
--- a/enos/enos-globals.hcl
+++ b/enos/enos-globals.hcl
@@ -49,7 +49,7 @@ globals {
   sample_attributes = {
     aws_region            = ["us-east-1", "us-west-2"]
     distro_version_amzn2  = ["2"]
-    distro_version_leap   = ["15.4", "15.5"]
+    distro_version_leap   = ["15.5"]
     distro_version_rhel   = ["8.9", "9.3"]
     distro_version_sles   = ["v15_sp5_standard"]
     distro_version_ubuntu = ["20.04", "22.04"]

--- a/enos/enos-scenario-agent.hcl
+++ b/enos/enos-scenario-agent.hcl
@@ -32,7 +32,7 @@ scenario "agent" {
       edition = ["ce", "ent", "ent.fips1402"]
     }
 
-    # arm64 AMIs are not offered for Leap 15.4
+    # arm64 AMIs are not offered for Leap
     exclude {
       distro = ["leap"]
       arch   = ["arm64"]

--- a/enos/enos-scenario-autopilot.hcl
+++ b/enos/enos-scenario-autopilot.hcl
@@ -35,7 +35,7 @@ scenario "autopilot" {
       edition = ["ce", "ent", "ent.fips1402"]
     }
 
-    # arm64 AMIs are not offered for Leap 15.4
+    # arm64 AMIs are not offered for Leap
     exclude {
       distro = ["leap"]
       arch   = ["arm64"]

--- a/enos/enos-scenario-proxy.hcl
+++ b/enos/enos-scenario-proxy.hcl
@@ -32,7 +32,7 @@ scenario "proxy" {
       edition = ["ce", "ent", "ent.fips1402"]
     }
 
-    # arm64 AMIs are not offered for Leap 15.4
+    # arm64 AMIs are not offered for Leap
     exclude {
       distro = ["leap"]
       arch   = ["arm64"]

--- a/enos/enos-scenario-replication.hcl
+++ b/enos/enos-scenario-replication.hcl
@@ -42,7 +42,7 @@ scenario "replication" {
       edition        = ["ce", "ent", "ent.fips1402"]
     }
 
-    # arm64 AMIs are not offered for Leap 15.4
+    # arm64 AMIs are not offered for Leap
     exclude {
       distro = ["leap"]
       arch   = ["arm64"]

--- a/enos/enos-scenario-seal-ha.hcl
+++ b/enos/enos-scenario-seal-ha.hcl
@@ -39,7 +39,7 @@ scenario "seal_ha" {
       edition        = ["ce", "ent", "ent.fips1402"]
     }
 
-    # arm64 AMIs are not offered for Leap 15.4
+    # arm64 AMIs are not offered for Leap
     exclude {
       distro = ["leap"]
       arch   = ["arm64"]

--- a/enos/enos-scenario-smoke.hcl
+++ b/enos/enos-scenario-smoke.hcl
@@ -32,7 +32,7 @@ scenario "smoke" {
       edition = ["ce", "ent", "ent.fips1402"]
     }
 
-    # arm64 AMIs are not offered for Leap 15.4
+    # arm64 AMIs are not offered for Leap
     exclude {
       distro = ["leap"]
       arch   = ["arm64"]

--- a/enos/enos-scenario-upgrade.hcl
+++ b/enos/enos-scenario-upgrade.hcl
@@ -45,7 +45,7 @@ scenario "upgrade" {
       edition = ["ce", "ent", "ent.fips1402"]
     }
 
-    # arm64 AMIs are not offered for Leap 15.4
+    # arm64 AMIs are not offered for Leap
     exclude {
       distro = ["leap"]
       arch   = ["arm64"]

--- a/enos/enos-variables.hcl
+++ b/enos/enos-variables.hcl
@@ -84,7 +84,7 @@ variable "distro_version_amzn2" {
 variable "distro_version_leap" {
   description = "The version of openSUSE leap to use"
   type        = string
-  default     = "15.5" // or "15.4"
+  default     = "15.5"
 }
 
 variable "distro_version_rhel" {

--- a/enos/enos.vars.hcl
+++ b/enos/enos.vars.hcl
@@ -41,7 +41,7 @@
 # distro_version_amzn2 = "2"
 
 # distro_version_leap is the version of openSUSE Leap to use for "distro:leap" variants
-# distro_version_leap = "15.5" // or "15.4"
+# distro_version_leap = "15.5"
 
 # distro_version_rhel is the version of RHEL to use for "distro:rhel" variants.
 # distro_version_rhel = "9.3" // or "8.9"
@@ -50,7 +50,7 @@
 # distro_version_sles = "v15_sp5_standard"
 
 # distro_version_ubuntu is the version of ubuntu to use for "distro:ubuntu" variants
-# distro_version_ubuntu = "22.04" // or "20.04", "18.04"
+# distro_version_ubuntu = "22.04" // or "20.04"
 
 # tags are a map of tags that will be applied to infrastructure resources that
 # support tagging.

--- a/enos/modules/ec2_info/main.tf
+++ b/enos/modules/ec2_info/main.tf
@@ -36,7 +36,6 @@ locals {
         "2" = data.aws_ami.amzn2["x86_64"].id
       }
       "leap" = {
-        "15.4" = data.aws_ami.leap_154.id
         "15.5" = data.aws_ami.leap_155.id
       }
       "rhel" = {
@@ -47,34 +46,11 @@ locals {
         "v15_sp5_standard" = data.aws_ami.sles_15_sp5_standard["x86_64"].id
       }
       "ubuntu" = {
-        "18.04" = data.aws_ami.ubuntu_1804["x86_64"].id
         "20.04" = data.aws_ami.ubuntu_2004["x86_64"].id
         "22.04" = data.aws_ami.ubuntu_2204["x86_64"].id
       }
     }
   }
-}
-
-data "aws_ami" "ubuntu_1804" {
-  most_recent = true
-  for_each    = local.architectures
-
-  filter {
-    name   = "name"
-    values = ["ubuntu/images/hvm-ssd/ubuntu-*-18.04-*-server-*"]
-  }
-
-  filter {
-    name   = "virtualization-type"
-    values = ["hvm"]
-  }
-
-  filter {
-    name   = "architecture"
-    values = [each.value]
-  }
-
-  owners = [local.canonical_owner_id]
 }
 
 data "aws_ami" "ubuntu_2004" {
@@ -201,25 +177,6 @@ data "aws_ami" "sles_15_sp5_standard" {
   owners = [local.sles_owner_id]
 }
 
-data "aws_ami" "leap_154" {
-  most_recent = true
-
-  filter {
-    name   = "name"
-    values = ["openSUSE-Leap-15.4*"]
-  }
-
-  filter {
-    name = "architecture"
-    # Note: arm64 AMIs are offered for Leap 15.5, but not 15.4. For now we will
-    # only use x86_64 for both in order to not introduce complexity in our matrix
-    # exclusions.
-    values = ["x86_64"]
-  }
-
-  owners = [local.suse_owner_id]
-}
-
 data "aws_ami" "leap_155" {
   most_recent = true
 
@@ -230,9 +187,7 @@ data "aws_ami" "leap_155" {
 
   filter {
     name = "architecture"
-    # Note: arm64 AMIs are offered for Leap 15.5, but not 15.4. For now we will
-    # only use x86_64 for both in order to not introduce complexity in our matrix
-    # exclusions.
+    # Note: arm64 AMIs are not offered for Leap.
     values = ["x86_64"]
   }
 


### PR DESCRIPTION
This weekend, assumingly in accordance with Leap 15.4 EOL processes, all Leap 15.4 AMIs were pulled (except for a single micro AMI), therefore breaking our query for these AMIs. In this PR we remove the broken Leap 15.4 data source as well as references to Leap 15.4 in Enos testing. We also remove a few vestiges from previous testing of Ubuntu 18.04 which is EOL as well. 