### PR TITLE
Leases: added note to go doc for loading an entry from the expiration manager

### DIFF
--- a/vault/expiration.go
+++ b/vault/expiration.go
@@ -2014,8 +2014,8 @@ func (m *ExpirationManager) renewAuthEntry(ctx context.Context, req *logical.Req
 }
 
 // loadEntry is used to read a lease entry.
-// NOTE: loadEntry may return nil for both the pointer to a leaseEntry and the
-// error, so callers should check the entry before attempting to access its fields.
+// NOTE: loadEntry will return nil for both the pointer to a leaseEntry and the error when
+// the entry is not found, so callers should check the entry before attempting to access its fields.
 func (m *ExpirationManager) loadEntry(ctx context.Context, leaseID string) (*leaseEntry, error) {
 	// Take out the lease locks after we ensure we are in restore mode
 	restoreMode := m.inRestoreMode()

--- a/vault/expiration.go
+++ b/vault/expiration.go
@@ -2013,7 +2013,9 @@ func (m *ExpirationManager) renewAuthEntry(ctx context.Context, req *logical.Req
 	return resp, nil
 }
 
-// loadEntry is used to read a lease entry
+// loadEntry is used to read a lease entry.
+// NOTE: loadEntry may return nil for both the pointer to a leaseEntry and the
+// error, so callers should check the entry before attempting to access its fields.
 func (m *ExpirationManager) loadEntry(ctx context.Context, leaseID string) (*leaseEntry, error) {
 	// Take out the lease locks after we ensure we are in restore mode
 	restoreMode := m.inRestoreMode()


### PR DESCRIPTION
Added a note to give callers a warning that under certain circumstances both return values may be `nil`.