### PR TITLE
UI: Allow creation of AWS session_token type role

### DIFF
--- a/changelog/27424.txt
+++ b/changelog/27424.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Allow creation of session_token type roles for AWS secret backend
+```

--- a/ui/app/models/role-aws.js
+++ b/ui/app/models/role-aws.js
@@ -66,7 +66,7 @@ export default Model.extend({
       iam_user: ['name', 'credentialType', 'policyArns', 'policyDocument'],
       assumed_role: ['name', 'credentialType', 'roleArns', 'policyDocument'],
       federation_token: ['name', 'credentialType', 'policyDocument'],
-      session_token: [],
+      session_token: ['name', 'credentialType'],
     };
 
     return expandAttributeMeta(this, keysForType[credentialType]);


### PR DESCRIPTION
This PR fixes a bug where choosing `session_token` type when creating a role broke the creation flow:
![Kapture 2024-06-10 at 11 41 04](https://github.com/hashicorp/vault/assets/82459713/611105d5-ad1d-46b3-a163-b631335f3f29)

After fix:
<img width="1840" alt="Screenshot 2024-06-10 at 11 48 51" src="https://github.com/hashicorp/vault/assets/82459713/0694a603-986b-4aaa-b396-635b2e578449">
