### PR TITLE
Ongoing refactoring of PKI revocation code

### DIFF
--- a/builtin/logical/pki/backend.go
+++ b/builtin/logical/pki/backend.go
@@ -6,7 +6,6 @@ package pki
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/vault/builtin/logical/pki/revocation"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -17,6 +16,7 @@ import (
 	"github.com/hashicorp/vault/builtin/logical/pki/issuing"
 	"github.com/hashicorp/vault/builtin/logical/pki/managed_key"
 	"github.com/hashicorp/vault/builtin/logical/pki/pki_backend"
+	"github.com/hashicorp/vault/builtin/logical/pki/revocation"
 	"github.com/hashicorp/vault/helper/metricsutil"
 	"github.com/hashicorp/vault/helper/namespace"
 	"github.com/hashicorp/vault/sdk/framework"

--- a/builtin/logical/pki/backend.go
+++ b/builtin/logical/pki/backend.go
@@ -6,6 +6,7 @@ package pki
 import (
 	"context"
 	"fmt"
+	"github.com/hashicorp/vault/builtin/logical/pki/revocation"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -143,7 +144,7 @@ func Backend(conf *logical.BackendConfig) *backend {
 
 			WriteForwardedStorage: []string{
 				crossRevocationPath,
-				unifiedRevocationWritePathPrefix,
+				revocation.UnifiedRevocationWritePathPrefix,
 				unifiedDeltaWALPath,
 			},
 

--- a/builtin/logical/pki/cert_util.go
+++ b/builtin/logical/pki/cert_util.go
@@ -11,7 +11,6 @@ import (
 	"encoding/base64"
 	"encoding/pem"
 	"fmt"
-	"github.com/hashicorp/vault/builtin/logical/pki/pki_backend"
 	"io"
 	"math/big"
 	"net"
@@ -23,6 +22,7 @@ import (
 
 	"github.com/hashicorp/vault/builtin/logical/pki/issuing"
 	"github.com/hashicorp/vault/builtin/logical/pki/parsing"
+	"github.com/hashicorp/vault/builtin/logical/pki/pki_backend"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/helper/certutil"
 	"github.com/hashicorp/vault/sdk/helper/errutil"

--- a/builtin/logical/pki/cert_util.go
+++ b/builtin/logical/pki/cert_util.go
@@ -203,7 +203,7 @@ func fetchCertBySerial(sc *storageContext, prefix, serial string) (*logical.Stor
 		}
 
 		unified := serial == unifiedCRLPath || serial == unifiedDeltaCRLPath
-		path, err = sc.resolveIssuerCRLPath(defaultRef, unified)
+		path, err = issuing.ResolveIssuerCRLPath(sc.GetContext(), sc.GetStorage(), sc.UseLegacyBundleCaStorage(), defaultRef, unified)
 		if err != nil {
 			return nil, err
 		}

--- a/builtin/logical/pki/crl_util.go
+++ b/builtin/logical/pki/crl_util.go
@@ -9,6 +9,7 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"fmt"
+	"github.com/hashicorp/vault/builtin/logical/pki/parsing"
 	"math/big"
 	"strings"
 	"sync"
@@ -954,8 +955,8 @@ func revokeCert(sc *storageContext, config *pki_backend.CrlConfig, cert *x509.Ce
 		return nil, nil
 	}
 
-	colonSerial := serialFromCert(cert)
-	hyphenSerial := normalizeSerial(colonSerial)
+	colonSerial := parsing.SerialFromCert(cert)
+	hyphenSerial := parsing.NormalizeSerialForStorage(colonSerial)
 
 	// Validate that no issuers match the serial number to be revoked. We need
 	// to gracefully degrade to the legacy cert bundle when it is required, as

--- a/builtin/logical/pki/crl_util.go
+++ b/builtin/logical/pki/crl_util.go
@@ -26,7 +26,7 @@ import (
 )
 
 const (
-	revokedPath                      = "revoked/"
+	revokedPath                      = revocation.RevokedPath
 	crossRevocationPrefix            = "cross-revocation-queue/"
 	crossRevocationPath              = crossRevocationPrefix + "{{clusterId}}/"
 	deltaWALLastBuildSerialName      = "last-build-serial"
@@ -974,7 +974,7 @@ func revokeCert(sc *storageContext, config *pki_backend.CrlConfig, cert *x509.Ce
 		}
 	}
 
-	curRevInfo, err := sc.fetchRevocationInfo(colonSerial)
+	curRevInfo, err := revocation.FetchRevocationInfo(sc, colonSerial)
 	if err != nil {
 		return nil, err
 	}

--- a/builtin/logical/pki/crl_util.go
+++ b/builtin/logical/pki/crl_util.go
@@ -1040,14 +1040,14 @@ func revokeCert(sc *storageContext, config *pki_backend.CrlConfig, cert *x509.Ce
 	// the unified storage space through a periodic function.
 	failedWritingUnifiedCRL := false
 	if config.UnifiedCRL {
-		entry := &unifiedRevocationEntry{
+		entry := &revocation.UnifiedRevocationEntry{
 			SerialNumber:      colonSerial,
 			CertExpiration:    cert.NotAfter,
 			RevocationTimeUTC: revInfo.RevocationTimeUTC,
 			CertificateIssuer: revInfo.CertificateIssuer,
 		}
 
-		ignoreErr := writeUnifiedRevocationEntry(sc, entry)
+		ignoreErr := revocation.WriteUnifiedRevocationEntry(sc.GetContext(), sc.GetStorage(), entry)
 		if ignoreErr != nil {
 			// Just log the error if we fail to write across clusters, a separate background
 			// thread will reattempt it later on as we have the local write done.
@@ -2031,7 +2031,7 @@ func getUnifiedRevokedCertEntries(sc *storageContext, issuerIDCertMap map[issuin
 				continue
 			}
 
-			var xRevEntry unifiedRevocationEntry
+			var xRevEntry revocation.UnifiedRevocationEntry
 			if err := entryRaw.DecodeJSON(&xRevEntry); err != nil {
 				return nil, nil, fmt.Errorf("failed json decoding of unified revocation entry at path %v: %w ", serialPath, err)
 			}

--- a/builtin/logical/pki/crl_util.go
+++ b/builtin/logical/pki/crl_util.go
@@ -9,7 +9,6 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"fmt"
-	"github.com/hashicorp/vault/builtin/logical/pki/parsing"
 	"math/big"
 	"strings"
 	"sync"
@@ -18,6 +17,7 @@ import (
 
 	"github.com/hashicorp/go-secure-stdlib/parseutil"
 	"github.com/hashicorp/vault/builtin/logical/pki/issuing"
+	"github.com/hashicorp/vault/builtin/logical/pki/parsing"
 	"github.com/hashicorp/vault/builtin/logical/pki/pki_backend"
 	"github.com/hashicorp/vault/builtin/logical/pki/revocation"
 	"github.com/hashicorp/vault/sdk/helper/certutil"

--- a/builtin/logical/pki/issuing/issuers.go
+++ b/builtin/logical/pki/issuing/issuers.go
@@ -569,7 +569,7 @@ func FetchCertBySerial(sc pki_backend.StorageContext, prefix, serial string) (*l
 		}
 
 		unified := serial == UnifiedCRLPath || serial == UnifiedDeltaCRLPath
-		path, err = ResolveIssuerCRLPath(sc, DefaultRef, unified)
+		path, err = ResolveIssuerCRLPath(sc.GetContext(), sc.GetStorage(), sc.UseLegacyBundleCaStorage(), DefaultRef, unified)
 		if err != nil {
 			return nil, err
 		}

--- a/builtin/logical/pki/issuing/issuers.go
+++ b/builtin/logical/pki/issuing/issuers.go
@@ -535,3 +535,102 @@ func ResolveIssuerCRLPath(ctx context.Context, storage logical.Storage, useLegac
 
 	return "crl", fmt.Errorf("unable to find CRL for issuer: id:%v/ref:%v", issuer, reference)
 }
+
+// FetchCertBySerial allows fetching certificates from the backend; it handles the slightly
+// separate pathing for CRL, and revoked certificates.
+//
+// Support for fetching CA certificates was removed, due to the new issuers
+// changes.
+func FetchCertBySerial(sc pki_backend.StorageContext, prefix, serial string) (*logical.StorageEntry, error) {
+	var path, legacyPath string
+	var err error
+	var certEntry *logical.StorageEntry
+
+	hyphenSerial := parsing.NormalizeSerialForStorage(serial)
+	colonSerial := strings.ReplaceAll(strings.ToLower(serial), "-", ":")
+
+	switch {
+	// Revoked goes first as otherwise crl get hardcoded paths which fail if
+	// we actually want revocation info
+	case strings.HasPrefix(prefix, "revoked/"):
+		legacyPath = "revoked/" + colonSerial
+		path = "revoked/" + hyphenSerial
+	case serial == LegacyCRLPath || serial == DeltaCRLPath || serial == UnifiedCRLPath || serial == UnifiedDeltaCRLPath:
+		warnings, err := sc.CrlBuilder().RebuildIfForced(sc)
+		if err != nil {
+			return nil, err
+		}
+		if len(warnings) > 0 {
+			msg := "During rebuild of CRL for cert fetch, got the following warnings:"
+			for index, warning := range warnings {
+				msg = fmt.Sprintf("%v\n %d. %v", msg, index+1, warning)
+			}
+			sc.Logger().Warn(msg)
+		}
+
+		unified := serial == UnifiedCRLPath || serial == UnifiedDeltaCRLPath
+		path, err = ResolveIssuerCRLPath(sc, DefaultRef, unified)
+		if err != nil {
+			return nil, err
+		}
+
+		if serial == DeltaCRLPath || serial == UnifiedDeltaCRLPath {
+			if sc.UseLegacyBundleCaStorage() {
+				return nil, fmt.Errorf("refusing to serve delta CRL with legacy CA bundle")
+			}
+
+			path += DeltaCRLPathSuffix
+		}
+	default:
+		legacyPath = PathCerts + colonSerial
+		path = PathCerts + hyphenSerial
+	}
+
+	certEntry, err = sc.GetStorage().Get(sc.GetContext(), path)
+	if err != nil {
+		return nil, errutil.InternalError{Err: fmt.Sprintf("error fetching certificate %s: %s", serial, err)}
+	}
+	if certEntry != nil {
+		if certEntry.Value == nil || len(certEntry.Value) == 0 {
+			return nil, errutil.InternalError{Err: fmt.Sprintf("returned certificate bytes for serial %s were empty", serial)}
+		}
+		return certEntry, nil
+	}
+
+	// If legacyPath is unset, it's going to be a CA or CRL; return immediately
+	if legacyPath == "" {
+		return nil, nil
+	}
+
+	// Retrieve the old-style path.  We disregard errors here because they
+	// always manifest on Windows, and thus the initial check for a revoked
+	// cert fails would return an error when the cert isn't revoked, preventing
+	// the happy path from working.
+	certEntry, _ = sc.GetStorage().Get(sc.GetContext(), legacyPath)
+	if certEntry == nil {
+		return nil, nil
+	}
+	if certEntry.Value == nil || len(certEntry.Value) == 0 {
+		return nil, errutil.InternalError{Err: fmt.Sprintf("returned certificate bytes for serial %s were empty", serial)}
+	}
+
+	// Update old-style paths to new-style paths
+	certEntry.Key = path
+	certCounter := sc.GetCertificateCounter()
+	certsCounted := certCounter.IsInitialized()
+	if err = sc.GetStorage().Put(sc.GetContext(), certEntry); err != nil {
+		return nil, errutil.InternalError{Err: fmt.Sprintf("error saving certificate with serial %s to new location: %s", serial, err)}
+	}
+	if err = sc.GetStorage().Delete(sc.GetContext(), legacyPath); err != nil {
+		// If we fail here, we have an extra (copy) of a cert in storage, add to metrics:
+		switch {
+		case strings.HasPrefix(prefix, "revoked/"):
+			certCounter.IncrementTotalRevokedCertificatesCount(certsCounted, path)
+		default:
+			certCounter.IncrementTotalCertificatesCount(certsCounted, path)
+		}
+		return nil, errutil.InternalError{Err: fmt.Sprintf("error deleting certificate with serial %s from old location", serial)}
+	}
+
+	return certEntry, nil
+}

--- a/builtin/logical/pki/parsing/certificate.go
+++ b/builtin/logical/pki/parsing/certificate.go
@@ -12,6 +12,14 @@ import (
 	"github.com/hashicorp/vault/sdk/helper/certutil"
 )
 
+func SerialFromCert(cert *x509.Certificate) string {
+	return SerialFromBigInt(cert.SerialNumber)
+}
+
+func SerialFromBigInt(serial *big.Int) string {
+	return strings.TrimSpace(certutil.GetHexFormatted(serial.Bytes(), ":"))
+}
+
 // NormalizeSerialForStorageFromBigInt given a serial number, format it as a string
 // that is safe to store within a filesystem
 func NormalizeSerialForStorageFromBigInt(serial *big.Int) string {

--- a/builtin/logical/pki/path_fetch_issuers.go
+++ b/builtin/logical/pki/path_fetch_issuers.go
@@ -1271,7 +1271,7 @@ func (b *backend) pathGetIssuerCRL(ctx context.Context, req *logical.Request, da
 		return response, nil
 	}
 
-	crlPath, err := sc.resolveIssuerCRLPath(issuerName, isUnified)
+	crlPath, err := issuing.ResolveIssuerCRLPath(sc.GetContext(), sc.GetStorage(), sc.UseLegacyBundleCaStorage(), issuerName, isUnified)
 	if err != nil {
 		return nil, err
 	}

--- a/builtin/logical/pki/path_tidy.go
+++ b/builtin/logical/pki/path_tidy.go
@@ -1566,7 +1566,7 @@ func (b *backend) doTidyCrossRevocationStore(ctx context.Context, req *logical.R
 				continue
 			}
 
-			var details unifiedRevocationEntry
+			var details revocation.UnifiedRevocationEntry
 			if err := entry.DecodeJSON(&details); err != nil {
 				return fmt.Errorf("error decoding cross-cluster revocation entry (%v) to tidy: %w", ePath, err)
 			}

--- a/builtin/logical/pki/path_tidy.go
+++ b/builtin/logical/pki/path_tidy.go
@@ -1149,7 +1149,7 @@ func (b *backend) doTidyRevocationStore(ctx context.Context, req *logical.Reques
 				b.tidyStatusIncMissingIssuerCertCount()
 				revInfo.CertificateIssuer = issuing.IssuerID("")
 				storeCert = true
-				if associateRevokedCertWithIsssuer(&revInfo, revokedCert, issuerIDCertMap) {
+				if revInfo.AssociateRevokedCertWithIsssuer(revokedCert, issuerIDCertMap) {
 					fixedIssuers += 1
 				}
 			}

--- a/builtin/logical/pki/periodic.go
+++ b/builtin/logical/pki/periodic.go
@@ -326,12 +326,12 @@ func readRevocationEntryAndTransfer(sc *storageContext, serial string) error {
 		return nil
 	}
 
-	entry := &unifiedRevocationEntry{
+	entry := &revocation.UnifiedRevocationEntry{
 		SerialNumber:      hyphenSerial,
 		CertExpiration:    cert.NotAfter,
 		RevocationTimeUTC: revocationTime,
 		CertificateIssuer: revInfo.CertificateIssuer,
 	}
 
-	return writeUnifiedRevocationEntry(sc, entry)
+	return revocation.WriteUnifiedRevocationEntry(sc.GetContext(), sc.GetStorage(), entry)
 }

--- a/builtin/logical/pki/periodic.go
+++ b/builtin/logical/pki/periodic.go
@@ -7,6 +7,7 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
+	"github.com/hashicorp/vault/builtin/logical/pki/revocation"
 	"sync/atomic"
 	"time"
 
@@ -294,7 +295,7 @@ func doUnifiedTransferMissingDeltaWALSerials(sc *storageContext, clusterId strin
 
 func readRevocationEntryAndTransfer(sc *storageContext, serial string) error {
 	hyphenSerial := normalizeSerial(serial)
-	revInfo, err := sc.fetchRevocationInfo(hyphenSerial)
+	revInfo, err := revocation.FetchRevocationInfo(sc, hyphenSerial)
 	if err != nil {
 		return fmt.Errorf("failed loading revocation entry for serial: %s: %w", serial, err)
 	}

--- a/builtin/logical/pki/periodic.go
+++ b/builtin/logical/pki/periodic.go
@@ -7,10 +7,10 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"github.com/hashicorp/vault/builtin/logical/pki/revocation"
 	"sync/atomic"
 	"time"
 
+	"github.com/hashicorp/vault/builtin/logical/pki/revocation"
 	"github.com/hashicorp/vault/sdk/helper/consts"
 	"github.com/hashicorp/vault/sdk/logical"
 )

--- a/builtin/logical/pki/pki_backend/common.go
+++ b/builtin/logical/pki/pki_backend/common.go
@@ -23,4 +23,5 @@ type Logger interface {
 type CertificateCounter interface {
 	IsInitialized() bool
 	IncrementTotalCertificatesCount(certsCounted bool, newSerial string)
+	IncrementTotalRevokedCertificatesCount(certsCounted bool, newSerial string)
 }

--- a/builtin/logical/pki/pki_backend/storage_context.go
+++ b/builtin/logical/pki/pki_backend/storage_context.go
@@ -5,6 +5,7 @@ package pki_backend
 
 import (
 	"context"
+	"github.com/hashicorp/go-hclog"
 
 	"github.com/hashicorp/vault/builtin/logical/pki/managed_key"
 	"github.com/hashicorp/vault/sdk/logical"
@@ -17,4 +18,7 @@ type StorageContext interface {
 	UseLegacyBundleCaStorage() bool
 	GetPkiManagedView() managed_key.PkiManagedKeyView
 	CrlBuilder() CrlBuilderType
+	GetCertificateCounter() CertificateCounter
+
+	Logger() hclog.Logger
 }

--- a/builtin/logical/pki/pki_backend/storage_context.go
+++ b/builtin/logical/pki/pki_backend/storage_context.go
@@ -5,8 +5,8 @@ package pki_backend
 
 import (
 	"context"
-	"github.com/hashicorp/go-hclog"
 
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/vault/builtin/logical/pki/managed_key"
 	"github.com/hashicorp/vault/sdk/logical"
 )

--- a/builtin/logical/pki/revocation/revocation_entry.go
+++ b/builtin/logical/pki/revocation/revocation_entry.go
@@ -5,10 +5,11 @@ package revocation
 
 import (
 	"context"
+	"time"
+
 	"github.com/hashicorp/vault/builtin/logical/pki/issuing"
 	"github.com/hashicorp/vault/builtin/logical/pki/parsing"
 	"github.com/hashicorp/vault/sdk/logical"
-	"time"
 )
 
 type UnifiedRevocationEntry struct {

--- a/builtin/logical/pki/revocation/revocation_entry.go
+++ b/builtin/logical/pki/revocation/revocation_entry.go
@@ -1,0 +1,33 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package revocation
+
+import (
+	"context"
+	"github.com/hashicorp/vault/builtin/logical/pki/issuing"
+	"github.com/hashicorp/vault/builtin/logical/pki/parsing"
+	"github.com/hashicorp/vault/sdk/logical"
+	"time"
+)
+
+type UnifiedRevocationEntry struct {
+	SerialNumber      string           `json:"-"`
+	CertExpiration    time.Time        `json:"certificate_expiration_utc"`
+	RevocationTimeUTC time.Time        `json:"revocation_time_utc"`
+	CertificateIssuer issuing.IssuerID `json:"issuer_id"`
+}
+
+const (
+	UnifiedRevocationReadPathPrefix  = "unified-revocation/"
+	UnifiedRevocationWritePathPrefix = UnifiedRevocationReadPathPrefix + "{{clusterId}}/"
+)
+
+func WriteUnifiedRevocationEntry(ctx context.Context, storage logical.Storage, ure *UnifiedRevocationEntry) error {
+	json, err := logical.StorageEntryJSON(UnifiedRevocationWritePathPrefix+parsing.NormalizeSerialForStorage(ure.SerialNumber), ure)
+	if err != nil {
+		return err
+	}
+
+	return storage.Put(ctx, json)
+}

--- a/builtin/logical/pki/revocation/revoke.go
+++ b/builtin/logical/pki/revocation/revoke.go
@@ -13,6 +13,10 @@ import (
 	"github.com/hashicorp/vault/sdk/helper/errutil"
 )
 
+const (
+	RevokedPath = "revoked/"
+)
+
 type RevocationInfo struct {
 	CertificateBytes  []byte           `json:"certificate_bytes"`
 	RevocationTime    int64            `json:"revocation_time"`
@@ -62,4 +66,20 @@ func FetchIssuerMapForRevocationChecking(sc pki_backend.StorageContext) (map[iss
 	}
 
 	return issuerIDCertMap, nil
+}
+
+func FetchRevocationInfo(sc pki_backend.StorageContext, serial string) (*RevocationInfo, error) {
+	var revInfo *RevocationInfo
+	revEntry, err := issuing.FetchCertBySerial(sc, RevokedPath, serial)
+	if err != nil {
+		return nil, err
+	}
+	if revEntry != nil {
+		err = revEntry.DecodeJSON(&revInfo)
+		if err != nil {
+			return nil, fmt.Errorf("error decoding existing revocation info: %w", err)
+		}
+	}
+
+	return revInfo, nil
 }

--- a/builtin/logical/pki/revocation/revoke.go
+++ b/builtin/logical/pki/revocation/revoke.go
@@ -4,6 +4,7 @@
 package revocation
 
 import (
+	"bytes"
 	"crypto/x509"
 	"fmt"
 	"time"
@@ -22,6 +23,20 @@ type RevocationInfo struct {
 	RevocationTime    int64            `json:"revocation_time"`
 	RevocationTimeUTC time.Time        `json:"revocation_time_utc"`
 	CertificateIssuer issuing.IssuerID `json:"issuer_id"`
+}
+
+func (ri *RevocationInfo) AssociateRevokedCertWithIsssuer(revokedCert *x509.Certificate, issuerIDCertMap map[issuing.IssuerID]*x509.Certificate) bool {
+	for issuerId, issuerCert := range issuerIDCertMap {
+		if bytes.Equal(revokedCert.RawIssuer, issuerCert.RawSubject) {
+			if err := revokedCert.CheckSignatureFrom(issuerCert); err == nil {
+				// Valid mapping. Add it to the specified entry.
+				ri.CertificateIssuer = issuerId
+				return true
+			}
+		}
+	}
+
+	return false
 }
 
 // FetchIssuerMapForRevocationChecking fetches a map of IssuerID->parsed cert for revocation

--- a/builtin/logical/pki/storage.go
+++ b/builtin/logical/pki/storage.go
@@ -19,7 +19,6 @@ import (
 	"github.com/hashicorp/vault/builtin/logical/pki/issuing"
 	"github.com/hashicorp/vault/builtin/logical/pki/managed_key"
 	"github.com/hashicorp/vault/builtin/logical/pki/pki_backend"
-	"github.com/hashicorp/vault/builtin/logical/pki/revocation"
 	"github.com/hashicorp/vault/helper/constants"
 	"github.com/hashicorp/vault/sdk/helper/certutil"
 	"github.com/hashicorp/vault/sdk/helper/errutil"
@@ -767,20 +766,4 @@ func (sc *storageContext) writeClusterConfig(config *issuing.ClusterConfigEntry)
 	}
 
 	return sc.Storage.Put(sc.Context, entry)
-}
-
-func (sc *storageContext) fetchRevocationInfo(serial string) (*revocation.RevocationInfo, error) {
-	var revInfo *revocation.RevocationInfo
-	revEntry, err := fetchCertBySerial(sc, revokedPath, serial)
-	if err != nil {
-		return nil, err
-	}
-	if revEntry != nil {
-		err = revEntry.DecodeJSON(&revInfo)
-		if err != nil {
-			return nil, fmt.Errorf("error decoding existing revocation info: %w", err)
-		}
-	}
-
-	return revInfo, nil
 }

--- a/builtin/logical/pki/storage.go
+++ b/builtin/logical/pki/storage.go
@@ -111,7 +111,7 @@ func (sc *storageContext) GetPkiManagedView() managed_key.PkiManagedKeyView {
 	return sc.Backend
 }
 
-func (sc *storageContext) GetCertificateCounter() *CertificateCounter {
+func (sc *storageContext) GetCertificateCounter() pki_backend.CertificateCounter {
 	return sc.Backend.GetCertificateCounter()
 }
 

--- a/builtin/logical/pki/storage_unified.go
+++ b/builtin/logical/pki/storage_unified.go
@@ -5,26 +5,15 @@ package pki
 
 import (
 	"fmt"
+	"github.com/hashicorp/vault/builtin/logical/pki/revocation"
 	"strings"
-	"time"
-
-	"github.com/hashicorp/vault/builtin/logical/pki/issuing"
-	"github.com/hashicorp/vault/sdk/logical"
 )
 
 const (
-	unifiedRevocationReadPathPrefix  = "unified-revocation/"
-	unifiedRevocationWritePathPrefix = unifiedRevocationReadPathPrefix + "{{clusterId}}/"
+	unifiedRevocationReadPathPrefix = revocation.UnifiedRevocationReadPathPrefix
 )
 
-type unifiedRevocationEntry struct {
-	SerialNumber      string           `json:"-"`
-	CertExpiration    time.Time        `json:"certificate_expiration_utc"`
-	RevocationTimeUTC time.Time        `json:"revocation_time_utc"`
-	CertificateIssuer issuing.IssuerID `json:"issuer_id"`
-}
-
-func getUnifiedRevocationBySerial(sc *storageContext, serial string) (*unifiedRevocationEntry, error) {
+func getUnifiedRevocationBySerial(sc *storageContext, serial string) (*revocation.UnifiedRevocationEntry, error) {
 	clusterPaths, err := lookupUnifiedClusterPaths(sc)
 	if err != nil {
 		return nil, err
@@ -38,7 +27,7 @@ func getUnifiedRevocationBySerial(sc *storageContext, serial string) (*unifiedRe
 		}
 
 		if entryRaw != nil {
-			var revEntry unifiedRevocationEntry
+			var revEntry revocation.UnifiedRevocationEntry
 			if err := entryRaw.DecodeJSON(&revEntry); err != nil {
 				return nil, fmt.Errorf("failed json decoding of unified entry at path %s: %w", serialPath, err)
 			}
@@ -48,15 +37,6 @@ func getUnifiedRevocationBySerial(sc *storageContext, serial string) (*unifiedRe
 	}
 
 	return nil, nil
-}
-
-func writeUnifiedRevocationEntry(sc *storageContext, ure *unifiedRevocationEntry) error {
-	json, err := logical.StorageEntryJSON(unifiedRevocationWritePathPrefix+normalizeSerial(ure.SerialNumber), ure)
-	if err != nil {
-		return err
-	}
-
-	return sc.Storage.Put(sc.Context, json)
 }
 
 // listClusterSpecificUnifiedRevokedCerts returns a list of revoked certificates from a given cluster

--- a/builtin/logical/pki/storage_unified.go
+++ b/builtin/logical/pki/storage_unified.go
@@ -5,8 +5,9 @@ package pki
 
 import (
 	"fmt"
-	"github.com/hashicorp/vault/builtin/logical/pki/revocation"
 	"strings"
+
+	"github.com/hashicorp/vault/builtin/logical/pki/revocation"
 )
 
 const (

--- a/builtin/logical/pki/util.go
+++ b/builtin/logical/pki/util.go
@@ -17,7 +17,6 @@ import (
 	"github.com/hashicorp/vault/builtin/logical/pki/managed_key"
 	"github.com/hashicorp/vault/builtin/logical/pki/parsing"
 	"github.com/hashicorp/vault/sdk/framework"
-	"github.com/hashicorp/vault/sdk/helper/certutil"
 	"github.com/hashicorp/vault/sdk/helper/errutil"
 	"github.com/hashicorp/vault/sdk/logical"
 )
@@ -40,11 +39,11 @@ var (
 )
 
 func serialFromCert(cert *x509.Certificate) string {
-	return serialFromBigInt(cert.SerialNumber)
+	return parsing.SerialFromCert(cert)
 }
 
 func serialFromBigInt(serial *big.Int) string {
-	return strings.TrimSpace(certutil.GetHexFormatted(serial.Bytes(), ":"))
+	return parsing.SerialFromBigInt(serial)
 }
 
 func normalizeSerialFromBigInt(serial *big.Int) string {


### PR DESCRIPTION
Continue refactoring PKI code to decouple it from the main PKI `Backend`.

These changes build on the work started on PR #27401.