### PR TITLE
Skip TestConsulFencing_PartitionedLeaderCantWrite until we make it less flaky

### DIFF
--- a/vault/external_tests/consul_fencing_binary/consul_fencing_test.go
+++ b/vault/external_tests/consul_fencing_binary/consul_fencing_test.go
@@ -29,6 +29,8 @@ import (
 // (and Consul lock improvements) and should _never_ fail now we correctly fence
 // writes.
 func TestConsulFencing_PartitionedLeaderCantWrite(t *testing.T) {
+	t.Skip("Skipping the test due to flakiness, it will be resolved in VAULT-27978.")
+
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
 	defer cancel()
 


### PR DESCRIPTION
`TestConsulFencing_PartitionedLeaderCantWrite` has been intermittently failing in CI. This PR disables (skips) the test for now. Once this is merged in we will focus on making the test more reliable and re-enabling it.