### PR TITLE
capture docker logs if container creation failed

### DIFF
--- a/helper/testhelpers/ldap/ldaphelper.go
+++ b/helper/testhelpers/ldap/ldaphelper.go
@@ -68,7 +68,10 @@ func PrepareTestContainer(t *testing.T, version string) (cleanup func(), cfg *ld
 		return docker.NewServiceURLParse(connURL)
 	})
 	if err != nil {
-		t.Fatalf("could not start local LDAP docker container: %s", err)
+		t.Logf("could not start local LDAP docker container: %s", err)
+		t.Log("Docker container logs: ")
+		t.Log(logsWriter.String())
+		t.FailNow()
 	}
 
 	return func() {


### PR DESCRIPTION
This PR also captures the logs of the docker container launched to run an LDAP server fas a fixture for testing when the **PrepareTestContainer** function itself fails the test currently running.

Since the t.Fatalf() method is equivalent to calling t.Logf() followed by t.FailNow(); this change replaces the call to t.Fatalf() with a t.Logf() call and then _also logs the failed docker container logs_ before finally calling t.FailNow().