### PR TITLE
Automate feature changelog checking

### DIFF
--- a/.github/workflows/changelog-checker.yml
+++ b/.github/workflows/changelog-checker.yml
@@ -77,7 +77,7 @@ jobs:
             echo "Found invalid type (fix) in changelog - did you mean bug?"
             exit 1
           elif grep -q ':feature' "$changelog_files"; then
-            if ! grep -q 'feature\n**' "$changelog_files"; then
+            if ! grep -q '**' "$changelog_files"; then
               echo "Feature changelogs must be formatted like the following:"
               echo "**Feature Name**: Feature description"
               exit 1

--- a/.github/workflows/changelog-checker.yml
+++ b/.github/workflows/changelog-checker.yml
@@ -77,7 +77,7 @@ jobs:
             echo "Found invalid type (fix) in changelog - did you mean bug?"
             exit 1
           elif grep -q ':feature$' "$changelog_files"; then
-            if ! grep -q '**' "$changelog_files"; then
+            if ! grep -q '^\*\*' "$changelog_files"; then
               echo "Feature changelogs must be formatted like the following:"
               echo "**Feature Name**: Feature description"
               exit 1

--- a/.github/workflows/changelog-checker.yml
+++ b/.github/workflows/changelog-checker.yml
@@ -76,7 +76,7 @@ jobs:
           elif grep -q ':fix$' "$changelog_files"; then
             echo "Found invalid type (fix) in changelog - did you mean bug?"
             exit 1
-          elif grep -q ':feature' "$changelog_files"; then
+          elif grep -q ':feature$' "$changelog_files"; then
             if ! grep -q '**' "$changelog_files"; then
               echo "Feature changelogs must be formatted like the following:"
               echo "**Feature Name**: Feature description"

--- a/.github/workflows/changelog-checker.yml
+++ b/.github/workflows/changelog-checker.yml
@@ -48,8 +48,8 @@ jobs:
               echo "Not found."
               echo ""
               echo "Did not find a changelog entry named ${expected_changelog_file}"
-              echo "If your changelog file is correct, skip this check with the 'pr/no-changelog' label"
-              echo "Reference - https://github.com/hashicorp/vault/pull/10363 and https://github.com/hashicorp/vault/pull/11894"
+              echo "If your changelog file is correct, or this change does not need a changelog, skip this check with the 'pr/no-changelog' label"
+              echo "Reference - https://github.com/hashicorp/vault/blob/main/CONTRIBUTING.md#changelog-entries"
               exit 1
             fi
 
@@ -76,6 +76,12 @@ jobs:
           elif grep -q ':fix$' "$changelog_files"; then
             echo "Found invalid type (fix) in changelog - did you mean bug?"
             exit 1
+          elif grep -q ':feature' "$changelog_files"; then
+            if ! grep -q 'feature\n**' "$changelog_files"; then
+              echo "Feature changelogs must be formatted like the following:"
+              echo "**Feature Name**: Feature description"
+              exit 1
+            fi
           elif ! grep -q '```release-note:' "$changelog_files"; then
             # People often make changelog files like ```changelog:, which is incorrect.
             echo "Changelog file did not contain 'release-note' heading - check formatting."

--- a/changelog/27450.txt
+++ b/changelog/27450.txt
@@ -1,3 +1,3 @@
-```release-note:feature
+```release-note:improvement
 core/some-component: I'm incorrectly formatted :)
 ```

--- a/changelog/27450.txt
+++ b/changelog/27450.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+core/some-component: I'm incorrectly formatted :)
+```

--- a/changelog/27450.txt
+++ b/changelog/27450.txt
@@ -1,3 +1,0 @@
-```release-note:feature
-**Cool Feature**: I'm correctly formatted :)
-```

--- a/changelog/27450.txt
+++ b/changelog/27450.txt
@@ -1,3 +1,3 @@
-```release-note:improvement
-core/some-component: I'm incorrectly formatted :)
+```release-note:feature
+**Cool Feature**: I'm correctly formatted :)
 ```


### PR DESCRIPTION
This makes the changelog checker fail when a feature changelog is incorrectly formatted, and updates the information about where to find info on changelogs.

Fails like this:
<img width="523" alt="image" src="https://github.com/hashicorp/vault/assets/1594272/f71980d4-e8a8-4ef3-bdd8-7b7c689352d3">

For the following changelog:
<img width="424" alt="image" src="https://github.com/hashicorp/vault/assets/1594272/1984d4ab-cc81-4062-8cb3-85bcf3c15660">

I've validated that this works correctly with a correctly formatted changelog for features and non-features alike.

Passes fine for e.g.
<img width="373" alt="image" src="https://github.com/hashicorp/vault/assets/1594272/c17ee3c0-eea4-4918-9da4-8c527904b900">
