### PR TITLE
Extract logic to select appropriate RWMutex implementation for stateLock

### DIFF
--- a/vault/core.go
+++ b/vault/core.go
@@ -1001,21 +1001,8 @@ func CreateCore(conf *CoreConfig) (*Core, error) {
 		effectiveSDKVersion = version.GetVersion().Version
 	}
 
-	var detectDeadlocks []string
-	if conf.DetectDeadlocks != "" {
-		detectDeadlocks = strings.Split(conf.DetectDeadlocks, ",")
-		for k, v := range detectDeadlocks {
-			detectDeadlocks[k] = strings.ToLower(strings.TrimSpace(v))
-		}
-	}
-
-	// Use imported logging deadlock if requested
-	var stateLock locking.RWMutex
-	stateLock = &locking.SyncRWMutex{}
-
-	if slices.Contains(detectDeadlocks, "statelock") {
-		stateLock = &locking.DeadlockRWMutex{}
-	}
+	detectDeadlocks := parseDetectDeadlockConfigParameter(conf.DetectDeadlocks)
+	stateLock := createAppropriateRWMutex(detectDeadlocks, "statelock")
 
 	// Setup the core
 	c := &Core{

--- a/vault/core_locking.go
+++ b/vault/core_locking.go
@@ -1,0 +1,47 @@
+package vault
+
+import (
+	"slices"
+	"strings"
+
+	"github.com/hashicorp/vault/helper/locking"
+)
+
+//
+// This file contains locking helper functions that are related to core.go.
+//
+
+// parseDeadlockDetectionSetting takes the detectDeadlockConfigParameter string
+// and transforms it to a lowercase version of the string, then splits it into
+// a slice of strings by interpreting commas as the element delimiters.
+func parseDetectDeadlockConfigParameter(detectDeadlockConfigParameter string) []string {
+	if detectDeadlockConfigParameter == "" {
+		// This doesn't seem necessary, since the companion functions that use
+		// this slice can handle an empty slice just the same as a nil slice,
+		// but for the sake of compatibility, this will be introduced for now
+		// until all occurrences that rely on Core.detectDeadlocks have been
+		// switched to using functions from this file to create their locks.
+		return nil
+	}
+
+	result := strings.Split(strings.ToLower(detectDeadlockConfigParameter), ",")
+	for i := range result {
+		result[i] = strings.TrimSpace(result[i])
+	}
+
+	return result
+}
+
+// createAppropriateRWMutex determines if the specified lock (identifier) should
+// use a deadlock detecting implementation (locking.DeadlockRWMutex) or simply a
+// sync.RWMutex instance. This is done by splitting the deadlockDetectionLocks
+// string into a slice of strings. If the slice contains the specified lock
+// (identifier), then the deadlock detecting implementation is used, otherwise a
+// sync.Mutex is returned.
+func createAppropriateRWMutex(deadlockDetectionLocks []string, lock string) locking.RWMutex {
+	if slices.Contains(deadlockDetectionLocks, strings.ToLower(lock)) {
+		return &locking.DeadlockRWMutex{}
+	}
+
+	return &locking.SyncRWMutex{}
+}

--- a/vault/core_locking_test.go
+++ b/vault/core_locking_test.go
@@ -1,0 +1,101 @@
+package vault
+
+import (
+	"testing"
+
+	"github.com/hashicorp/vault/helper/locking"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestParseDetectDeadlockConfigParameter verifies that all types of strings
+// that could be obtained from the configuration file, are correctly parsed
+// into a slice of string elements.
+func TestParseDetectDeadlockConfigParameter(t *testing.T) {
+	for _, tc := range []struct {
+		name                          string
+		detectDeadlockConfigParameter string
+		expectedResult                []string
+	}{
+		{
+			name: "empty-string",
+		},
+		{
+			name:                          "single-value",
+			detectDeadlockConfigParameter: "bar",
+			expectedResult:                []string{"bar"},
+		},
+		{
+			name:                          "single-value-mixed-case",
+			detectDeadlockConfigParameter: "BaR",
+			expectedResult:                []string{"bar"},
+		},
+		{
+			name:                          "multiple-values",
+			detectDeadlockConfigParameter: "bar,BAZ,fIZ",
+			expectedResult:                []string{"bar", "baz", "fiz"},
+		},
+		{
+			name:                          "non-canonical-string-list",
+			detectDeadlockConfigParameter: "bar  ,  baz, ",
+			expectedResult:                []string{"bar", "baz", ""},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			result := parseDetectDeadlockConfigParameter(tc.detectDeadlockConfigParameter)
+			assert.ElementsMatch(t, tc.expectedResult, result)
+		})
+	}
+}
+
+// TestCreateAppropriateRWMutex verifies the correct behaviour in determining
+// whether a deadlock detecting RWMutex should be returned or not based on the
+// input arguments for the createAppropriateRWMutex function.
+func TestCreateAppropriateRWMutex(t *testing.T) {
+	mutexTypes := map[bool]string{
+		false: "locking.SyncRWMutex",
+		true:  "locking.DeadlockRWMutex",
+	}
+
+	for _, tc := range []struct {
+		name               string
+		detectDeadlocks    []string
+		lock               string
+		expectDeadlockLock bool
+	}{
+		{
+			name: "no-lock-types-specified",
+			lock: "foo",
+		},
+		{
+			name:            "single-lock-specified-no-match",
+			detectDeadlocks: []string{"bar"},
+			lock:            "foo",
+		},
+		{
+			name:               "single-lock-specified-match",
+			detectDeadlocks:    []string{"foo"},
+			lock:               "foo",
+			expectDeadlockLock: true,
+		},
+		{
+			name:            "multiple-locks-specified-no-match",
+			detectDeadlocks: []string{"bar", "baz", "fiz"},
+			lock:            "foo",
+		},
+		{
+			name:               "multiple-locks-specified-match",
+			detectDeadlocks:    []string{"bar", "foo", "baz"},
+			lock:               "foo",
+			expectDeadlockLock: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m := createAppropriateRWMutex(tc.detectDeadlocks, tc.lock)
+
+			_, ok := m.(*locking.DeadlockRWMutex)
+			if tc.expectDeadlockLock != ok {
+				t.Fatalf("unexpected RWMutex type returned, expected: %s got %s", mutexTypes[tc.expectDeadlockLock], mutexTypes[ok])
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Description
This change extracts the logic to assign the correct implementing type of **locking.RWMutex** for the **Core.stateLock** field out of the **CreateCore** function and into its own set of functions. The code aims to maintain the same semantics of the value of the **CoreConfig.DetectDeadlocks** field and the maintained **detectDeadlocks** field in the **Core** struct.

### TODO only if you're a HashiCorp employee
- [x] **Changelog:** Make sure there is one, or the `pr/no-changelog` label is
  applied. Brand new features have a differently
  formatted changelog than other changelogs, so pay attention to that. If this
  PR is the CE portion of an ENT PR, put the changelog here, _not_ in your ENT
  PR. Feel free to refer to the [instructions](https://github.com/hashicorp/vault/blob/main/CONTRIBUTING.md#changelog-entries) on changelog formatting if necessary.
- [ ] **Labels:** If this PR is the CE portion of an ENT change, and that ENT change is
  getting backported to N-2, use the new style `backport/ent/x.x.x+ent` labels
  instead of the old style `backport/x.x.x` labels.
- [ ] **Labels:** If this PR is a CE only change, it can only be backported to N, so use
  the normal `backport/x.x.x` label (there should be only 1).
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description.
