### PR TITLE
Add ENVs using NewTestDockerCluster

### DIFF
--- a/changelog/27457.txt
+++ b/changelog/27457.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-skd/helper: Add ENVs using NewTestDockerCluster
+sdk/helper: Add ENVs using NewTestDockerCluster
 ```

--- a/changelog/27457.txt
+++ b/changelog/27457.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+skd/helper: Add ENVs using NewTestDockerCluster
+```

--- a/changelog/27457.txt
+++ b/changelog/27457.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-sdk/helper: Add ENVs using NewTestDockerCluster
+sdk/helper: Allow setting environment variables when using NewTestDockerCluster
 ```

--- a/sdk/helper/testcluster/docker/environment.go
+++ b/sdk/helper/testcluster/docker/environment.go
@@ -805,20 +805,23 @@ func (n *DockerClusterNode) Start(ctx context.Context, opts *DockerClusterOption
 		}
 	}
 
+	envs := []string{
+		// For now we're using disable_mlock, because this is for testing
+		// anyway, and because it prevents us using external plugins.
+		"SKIP_SETCAP=true",
+		"VAULT_LOG_FORMAT=json",
+		"VAULT_LICENSE=" + opts.VaultLicense,
+	}
+	envs = append(envs, opts.Envs...)
+
 	r, err := dockhelper.NewServiceRunner(dockhelper.RunOptions{
 		ImageRepo: n.ImageRepo,
 		ImageTag:  n.ImageTag,
 		// We don't need to run update-ca-certificates in the container, because
 		// we're providing the CA in the raft join call, and otherwise Vault
 		// servers don't talk to one another on the API port.
-		Cmd: append([]string{"server"}, opts.Args...),
-		Env: []string{
-			// For now we're using disable_mlock, because this is for testing
-			// anyway, and because it prevents us using external plugins.
-			"SKIP_SETCAP=true",
-			"VAULT_LOG_FORMAT=json",
-			"VAULT_LICENSE=" + opts.VaultLicense,
-		},
+		Cmd:               append([]string{"server"}, opts.Args...),
+		Env:               envs,
 		Ports:             ports,
 		ContainerName:     n.Name(),
 		NetworkName:       opts.NetworkName,
@@ -1089,6 +1092,7 @@ type DockerClusterOptions struct {
 	CA          *testcluster.CA
 	VaultBinary string
 	Args        []string
+	Envs        []string
 	StartProbe  func(*api.Client) error
 	Storage     testcluster.ClusterStorage
 	DisableTLS  bool

--- a/sdk/helper/testcluster/docker/environment_test.go
+++ b/sdk/helper/testcluster/docker/environment_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package docker
 
 import (

--- a/sdk/helper/testcluster/docker/environment_test.go
+++ b/sdk/helper/testcluster/docker/environment_test.go
@@ -1,0 +1,35 @@
+package docker
+
+import (
+	"testing"
+)
+
+func TestSettingEnvsToContainer(t *testing.T) {
+	expectedEnv := "TEST_ENV=value1"
+	expectedEnv2 := "TEST_ENV=value2"
+	opts := &DockerClusterOptions{
+		ImageRepo: "hashicorp/vault",
+		ImageTag:  "latest",
+		Envs:      []string{expectedEnv, expectedEnv2},
+	}
+	cluster := NewTestDockerCluster(t, opts)
+	defer cluster.Cleanup()
+
+	envs := cluster.GetActiveClusterNode().Container.Config.Env
+
+	if !findEnv(envs, expectedEnv) {
+		t.Errorf("Missing ENV variable: %s", expectedEnv)
+	}
+	if !findEnv(envs, expectedEnv2) {
+		t.Errorf("Missing ENV variable: %s", expectedEnv2)
+	}
+}
+
+func findEnv(envs []string, env string) bool {
+	for _, e := range envs {
+		if e == env {
+			return true
+		}
+	}
+	return false
+}

--- a/sdk/helper/testcluster/docker/environment_test.go
+++ b/sdk/helper/testcluster/docker/environment_test.go
@@ -6,7 +6,7 @@ import (
 
 func TestSettingEnvsToContainer(t *testing.T) {
 	expectedEnv := "TEST_ENV=value1"
-	expectedEnv2 := "TEST_ENV=value2"
+	expectedEnv2 := "TEST_ENV2=value2"
 	opts := &DockerClusterOptions{
 		ImageRepo: "hashicorp/vault",
 		ImageTag:  "latest",


### PR DESCRIPTION
### Description
Currently NewTestDockerCluster had no means for setting any environment variables. This makes it tricky to create test for functionality that require thems, like having to set AWS environment variables.

DockerClusterOptions now exposes an option to pass extra enviroment variables to the containers, which are appended to the existing ones.

Related to: https://github.com/hashicorp/vault/issues/26852

### TODO only if you're a HashiCorp employee
- [ ] **Changelog:** Make sure there is one, or the `pr/no-changelog` label is
  applied. Brand new features have a differently
  formatted changelog than other changelogs, so pay attention to that. If this
  PR is the CE portion of an ENT PR, put the changelog here, _not_ in your ENT
  PR. Feel free to refer to the [instructions](https://github.com/hashicorp/vault/blob/main/CONTRIBUTING.md#changelog-entries) on changelog formatting if necessary.
- [ ] **Labels:** If this PR is the CE portion of an ENT change, and that ENT change is
  getting backported to N-2, use the new style `backport/ent/x.x.x+ent` labels
  instead of the old style `backport/x.x.x` labels.
- [ ] **Labels:** If this PR is a CE only change, it can only be backported to N, so use
  the normal `backport/x.x.x` label (there should be only 1).
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description.
