### PR TITLE
TCP Listener: fix bug in parsing TCP listener settings for `proxy_protocol_behavior`

### DIFF
--- a/internalshared/configutil/listener.go
+++ b/internalshared/configutil/listener.go
@@ -562,9 +562,9 @@ func (l *Listener) parseProxySettings() error {
 
 	// Validation/sanity check on allowed settings for behavior.
 	switch l.ProxyProtocolBehavior {
-	case "allow_authorized", "deny_authorized", "use_always", "":
+	case "allow_authorized", "deny_unauthorized", "use_always", "":
 		// Ignore these cases, they're all valid values.
-		// In the case of 'allow_authorized' and 'deny_authorized', we don't need
+		// In the case of 'allow_authorized' and 'deny_unauthorized', we don't need
 		// to check how many addresses we have in ProxyProtocolAuthorizedAddrs
 		// as parseutil.ParseAddrs returns "one or more addresses" (or an error)
 		// so we'd have returned earlier.

--- a/internalshared/configutil/listener_test.go
+++ b/internalshared/configutil/listener_test.go
@@ -529,7 +529,7 @@ func TestListener_parseProxySettings(t *testing.T) {
 		"behavior-deny": {
 			rawProxyProtocolAuthorizedAddrs: "10.0.0.1,10.0.2.1",
 			expectedNumAddrs:                2,
-			proxyBehavior:                   "deny_authorized",
+			proxyBehavior:                   "deny_unauthorized",
 			isErrorExpected:                 false,
 		},
 	}


### PR DESCRIPTION
### Description

This PR fixes a bug which prevented Vault server from starting with TCP listener configuration that attempted to set `proxy_protocol_behavior` to [`deny_unauthorized`](https://developer.hashicorp.com/vault/docs/configuration/listener/tcp#proxy_protocol_behavior
), which is part of the public Vault documentation. 

Previously the expected setting during parsing was `deny_authorized` which was incorrect.

### TODO only if you're a HashiCorp employee
- [ ] **Changelog:** Make sure there is one, or the `pr/no-changelog` label is
  applied. Brand new features have a differently
  formatted changelog than other changelogs, so pay attention to that. If this
  PR is the CE portion of an ENT PR, put the changelog here, _not_ in your ENT
  PR. Feel free to refer to the [instructions](https://github.com/hashicorp/vault/blob/main/CONTRIBUTING.md#changelog-entries) on changelog formatting if necessary.
