### PR TITLE
Remove changelog checklist item from PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,4 +16,4 @@ What does this PR do?
   in the PR description, commit message, or branch name.
 - [ ] **RFC:** If this change has an associated RFC, please link it in the description.
 - [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
-  description.
+  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,11 +2,6 @@
 What does this PR do?
 
 ### TODO only if you're a HashiCorp employee
-- [ ] **Changelog:** Make sure there is one, or the `pr/no-changelog` label is
-  applied. Brand new features have a differently
-  formatted changelog than other changelogs, so pay attention to that. If this
-  PR is the CE portion of an ENT PR, put the changelog here, _not_ in your ENT
-  PR. Feel free to refer to the [instructions](https://github.com/hashicorp/vault/blob/main/CONTRIBUTING.md#changelog-entries) on changelog formatting if necessary.
 - [ ] **Labels:** If this PR is the CE portion of an ENT change, and that ENT change is
   getting backported to N-2, use the new style `backport/ent/x.x.x+ent` labels
   instead of the old style `backport/x.x.x` labels.


### PR DESCRIPTION
### Description
What does this PR do?

Removes the changelog checklist item from the PR template. 

I updated the GHA and enhanced it to check for the `feature` formatting here: https://github.com/hashicorp/vault/pull/27450

Based in discussion of the initial implementation of this, I believe this obviates the need for the changelog checklist item. I'm open to being challenged on that, and if there's additional changes we'd like to make to the changelog checker before we think it's okay to remove, I'm happy to implement those as part of this PR.

### TODO only if you're a HashiCorp employee
- [X] **Labels:** If this PR is the CE portion of an ENT change, and that ENT change is
  getting backported to N-2, use the new style `backport/ent/x.x.x+ent` labels
  instead of the old style `backport/x.x.x` labels.
- [X] **Labels:** If this PR is a CE only change, it can only be backported to N, so use
  the normal `backport/x.x.x` label (there should be only 1).
- [X] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [X] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [X] **RFC:** If this change has an associated RFC, please link it in the description.
- [X] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description.
