### PR TITLE
improve autopilot logging when it starts up

### DIFF
--- a/changelog/27464.txt
+++ b/changelog/27464.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+storage/raft: Improve autopilot logging on startup to show config values clearly and avoid spurious logs
+```

--- a/physical/raft/raft_autopilot.go
+++ b/physical/raft/raft_autopilot.go
@@ -89,6 +89,27 @@ type AutopilotConfig struct {
 	UpgradeVersionTag string `mapstructure:"upgrade_version_tag"`
 }
 
+func (ac *AutopilotConfig) String() string {
+	s := "CleanupDeadServers:%t " +
+		"LastContactThreshold:%s " +
+		"DeadServerLastContactThreshold:%s " +
+		"MaxTrailingLogs:%d " +
+		"MinQuorum:%d " +
+		"ServerStabilizationTime:%s " +
+		"DisableUpgradeMigration:%t " +
+		"RedundancyZoneTag:%s " +
+		"UpgradeVersionTag:%s"
+	return fmt.Sprintf(s, ac.CleanupDeadServers,
+		ac.LastContactThreshold,
+		ac.DeadServerLastContactThreshold,
+		ac.MaxTrailingLogs,
+		ac.MinQuorum,
+		ac.ServerStabilizationTime,
+		ac.DisableUpgradeMigration,
+		ac.RedundancyZoneTag,
+		ac.UpgradeVersionTag)
+}
+
 // Merge combines the supplied config with the receiver. Supplied ones take
 // priority.
 func (to *AutopilotConfig) Merge(from *AutopilotConfig) {
@@ -832,6 +853,8 @@ func (b *RaftBackend) SetupAutopilot(ctx context.Context, storageConfig *Autopil
 	// Merge the setting provided over the API
 	b.autopilotConfig.Merge(storageConfig)
 
+	infoArgs := []interface{}{"config", b.autopilotConfig}
+
 	// Create the autopilot instance
 	options := []autopilot.Option{
 		autopilot.WithLogger(b.logger),
@@ -839,17 +862,18 @@ func (b *RaftBackend) SetupAutopilot(ctx context.Context, storageConfig *Autopil
 	}
 	if b.autopilotReconcileInterval != 0 {
 		options = append(options, autopilot.WithReconcileInterval(b.autopilotReconcileInterval))
+		infoArgs = append(infoArgs, []interface{}{"reconcile_interval", b.autopilotReconcileInterval}...)
 	}
 	if b.autopilotUpdateInterval != 0 {
 		options = append(options, autopilot.WithUpdateInterval(b.autopilotUpdateInterval))
+		infoArgs = append(infoArgs, []interface{}{"update_interval", b.autopilotUpdateInterval}...)
 	}
 	b.autopilot = autopilot.New(b.raft, NewDelegate(b), options...)
 	b.followerStates = followerStates
 	b.followerHeartbeatTicker = time.NewTicker(1 * time.Second)
-
 	b.l.Unlock()
 
-	b.logger.Info("starting autopilot", "config", b.autopilotConfig, "reconcile_interval", b.autopilotReconcileInterval)
+	b.logger.Info("starting autopilot", infoArgs...)
 	b.autopilot.Start(ctx)
 
 	go b.startFollowerHeartbeatTracker()


### PR DESCRIPTION
### Description
While dealing with an autopilot escalation, I noticed that the logging when autopilot starts up is suboptimal, for a few reasons.
* The struct that is written to the logs is fairly useless, as you only see values, not struct member names
* If the autopilot reconcile interval hasn't been modified via the config (which is the case the overwhelming majority of the time, I imagine) then `reconcile_interval 0s` is printed to the logs, which is incorrect, and actually alarming. What's happening is it's printing out the value of the reconcile interval as it exists on the raft backend, which is 0 by default, but _that's not actually the value autopilot is using_. This is misleading.

This makes the autopilot config struct print in a better way and also updates the logging to not actually print the values for reconcile interval or update interval unless they were actually changed from their defaults.

### TODO only if you're a HashiCorp employee
- [x] **Labels:** If this PR is the CE portion of an ENT change, and that ENT change is
  getting backported to N-2, use the new style `backport/ent/x.x.x+ent` labels
  instead of the old style `backport/x.x.x` labels.
- [x] **Labels:** If this PR is a CE only change, it can only be backported to N, so use
  the normal `backport/x.x.x` label (there should be only 1).
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
