### PR TITLE
docs: backport to 1.16.x jwt auth bound audiences

### DIFF
--- a/website/content/docs/upgrading/upgrade-to-1.16.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.16.x.mdx
@@ -83,6 +83,8 @@ more details on the configuration.
 
 ## Known issues and workarounds
 
+@include 'known-issues/1_16-jwt_auth_bound_audiences.mdx'
+
 @include 'known-issues/1_16-jwt_auth_config.mdx'
 
 @include 'known-issues/1_16-ldap_auth_login_anonymous_group_search.mdx'

--- a/website/content/partials/known-issues/1_16-jwt_auth_bound_audiences.mdx
+++ b/website/content/partials/known-issues/1_16-jwt_auth_bound_audiences.mdx
@@ -1,0 +1,31 @@
+### JWT auth login requires bound audiences on the role
+
+#### Affected versions
+
+- 1.15.9
+- 1.15.10
+- 1.16.3
+- 1.16.4
+
+#### Issue
+A behavior change was made in the jwt auth plugin to address CVE-2024-5798.
+Since the behavior change was a breaking change, we reverted the change in
+the versions after 1.15.10 and 1.16.4. However, the behavior change will go
+into effect in 1.17.
+
+The new behavior requires that the `bound_audiences` parameter of "jwt" roles
+**must** match at least one of the JWT's associated `aud` claims. The `aud`
+claim can be a single string or a list of strings as per
+[RFC 7519 Section 4.1.3](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3).
+
+Users may not be able to log into Vault if the JWT role is configured
+incorrectly. For additional details, refer to the
+[JWT auth method (API)](/vault/api-docs/auth/jwt) documentation.
+
+See this [issue](https://github.com/hashicorp/vault/issues/27343) for more details.
+
+#### Workaround
+
+Configure the `bound_audiences` parameter of "jwt" roles to match at least one
+of the JWT's associated `aud` claims. This configuratoin will be required for
+1.17 and later.


### PR DESCRIPTION
### Description
What does this PR do?

### TODO only if you're a HashiCorp employee
- [ ] **Labels:** If this PR is the CE portion of an ENT change, and that ENT change is
  getting backported to N-2, use the new style `backport/ent/x.x.x+ent` labels
  instead of the old style `backport/x.x.x` labels.
- [ ] **Labels:** If this PR is a CE only change, it can only be backported to N, so use
  the normal `backport/x.x.x` label (there should be only 1).
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
