### PR TITLE
VAULT-25456 CE side of changes for snapshot restore namespace cache bug

### DIFF
--- a/changelog/27474.txt
+++ b/changelog/27474.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+storage/raft (enterprise): Fix issue with namespace cache not getting cleared on snapshot restore, resulting in namespaces not found in the snapshot being inaccurately represented by API responses.
+```

--- a/vault/namespaces_oss.go
+++ b/vault/namespaces_oss.go
@@ -19,4 +19,4 @@ func (c *Core) ListNamespaces(includePath bool) []*namespace.Namespace {
 	return []*namespace.Namespace{namespace.RootNamespace}
 }
 
-func (c *Core) ResetNamespaceCache() {}
+func (c *Core) resetNamespaceCache() {}

--- a/vault/namespaces_oss.go
+++ b/vault/namespaces_oss.go
@@ -18,3 +18,5 @@ func (c *Core) NamespaceByID(ctx context.Context, nsID string) (*namespace.Names
 func (c *Core) ListNamespaces(includePath bool) []*namespace.Namespace {
 	return []*namespace.Namespace{namespace.RootNamespace}
 }
+
+func (c *Core) ResetNamespaceCache() {}

--- a/vault/raft.go
+++ b/vault/raft.go
@@ -852,7 +852,7 @@ func (c *Core) raftSnapshotRestoreCallback(grabLock bool, sealNode bool) func(co
 
 		// Reset the namespace cache so that any namespaces cached
 		// before the snapshot restore will no longer be present.
-		c.ResetNamespaceCache()
+		c.resetNamespaceCache()
 
 		return nil
 	}

--- a/vault/raft.go
+++ b/vault/raft.go
@@ -850,6 +850,10 @@ func (c *Core) raftSnapshotRestoreCallback(grabLock bool, sealNode bool) func(co
 			return err
 		}
 
+		// Reset the namespace cache so that any namespaces cached
+		// before the snapshot restore will no longer be present.
+		c.ResetNamespaceCache()
+
 		return nil
 	}
 }


### PR DESCRIPTION
### Description

CE part of https://github.com/hashicorp/vault-enterprise/pull/6059

### TODO only if you're a HashiCorp employee
- [x] **Labels:** If this PR is the CE portion of an ENT change, and that ENT change is
  getting backported to N-2, use the new style `backport/ent/x.x.x+ent` labels
  instead of the old style `backport/x.x.x` labels.
- [x] **Labels:** If this PR is a CE only change, it can only be backported to N, so use
  the normal `backport/x.x.x` label (there should be only 1).
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
