### PR TITLE
Special case OCSP GET queries that might be corrupted by Go's mux

### DIFF
--- a/builtin/logical/pki/path_ocsp_test.go
+++ b/builtin/logical/pki/path_ocsp_test.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-secure-stdlib/parseutil"
+	"github.com/hashicorp/vault/api"
 	"github.com/hashicorp/vault/builtin/logical/pki/issuing"
 	"github.com/hashicorp/vault/builtin/logical/pki/pki_backend"
 	"github.com/hashicorp/vault/builtin/logical/pki/revocation"
@@ -370,6 +371,61 @@ func TestOcsp_MultipleMatchingIssuersOneWithoutSigningUsage(t *testing.T) {
 
 	requireOcspSignatureAlgoForKey(t, rotatedCert.SignatureAlgorithm, ocspResp.SignatureAlgorithm)
 	requireOcspResponseSignedBy(t, ocspResp, rotatedCert)
+}
+
+// Test that we do not get 301 redirected by Go's HTTP mux if we send in a request
+// that contains consecutive '/' characters within an OCSP GET request.
+func TestOcsp_GetBypassesGoMux(t *testing.T) {
+	t.Parallel()
+	coreConfig := &vault.CoreConfig{
+		LogicalBackends: map[string]logical.Factory{
+			"pki": Factory,
+		},
+	}
+	cluster := vault.NewTestCluster(t, coreConfig, &vault.TestClusterOptions{
+		HandlerFunc: vaulthttp.Handler,
+	})
+	cluster.Start()
+	defer cluster.Cleanup()
+	client := cluster.Cores[0].Client
+	mountPKIEndpoint(t, client, "pki")
+
+	ocspReq := "MHEwbzBtMGswaTANBglghkgBZQMEAgEFAAQgo1KrbbzfoAzTEALyEUTR13O9HI3KWq520V0g5q2rqcIEIIlLPPTMQq36V4dZ3MF/3uMweyq//rVTVa04em/IeKeLAhRTLBLyFWZQ3MtPVLeOQ4wCzr679g=="
+
+	ocspGetReq := client.NewRequest(http.MethodGet, "/v1/pki/ocsp/"+ocspReq)
+	// NewRequest will clean up our URL so reset it to the original value
+	ocspGetReq.URL.Path = "/v1/pki/ocsp/" + ocspReq
+	rawResp, err := client.RawRequest(ocspGetReq)
+	require.Error(t, err, "we expected an error from this request but didn't get any response: %v", rawResp)
+
+	// Expect a 401, unauthorized/unknown response as we don't have an issuer
+	require.Equal(t, 401, rawResp.StatusCode)
+	require.Equal(t, ocspResponseContentType, rawResp.Header.Get("Content-Type"))
+	bodyReader := rawResp.Body
+	respDer, err := io.ReadAll(bodyReader)
+	bodyReader.Close()
+	require.NoError(t, err, "failed reading response body")
+	require.Equal(t, respDer, ocsp.UnauthorizedErrorResponse, "expected the static ocsp unauthorized error response")
+
+	// Now lets also make sure that something that looks awfully like an OCSP query doesn't get
+	// influenced by the bypass
+	err = client.Sys().Mount("kv", &api.MountInput{
+		Type: "kv",
+	})
+	require.NoError(t, err, "failed mounting kv endpoint")
+	kvSecretPath := "ocsp/blah//blahblah"
+	err = client.KVv1("kv").Put(ctx, kvSecretPath, map[string]interface{}{
+		"my-key": "my-secret",
+	})
+	require.NoError(t, err, "Failed writing to KV store")
+
+	kvGetSecret := client.NewRequest(http.MethodGet, "/v1/kv/"+kvSecretPath)
+	kvGetSecret.URL.Path = "/v1/kv/" + kvSecretPath
+	rawResp, err = client.RawRequest(kvGetSecret)
+	// If we messed up checking if the mount was a PKI mount this wouldn't attempt to redirect.
+	require.ErrorContains(t, err, "redirects not allowed in these tests")
+	require.Equal(t, 301, rawResp.StatusCode)
+	require.Equal(t, "/v1/kv/ocsp/blah/blahblah", rawResp.Response.Header.Get("Location"))
 }
 
 // Make sure OCSP GET/POST requests work through the entire stack, and not just

--- a/http/handler.go
+++ b/http/handler.go
@@ -250,6 +250,7 @@ func handler(props *vault.HandlerProperties) http.Handler {
 	wrappedHandler := wrapHelpHandler(mux, core)
 	wrappedHandler = wrapCORSHandler(wrappedHandler, core)
 	wrappedHandler = rateLimitQuotaWrapping(wrappedHandler, core)
+	wrappedHandler = ocspGetWrappedHandler(wrappedHandler, core)
 	wrappedHandler = entWrapGenericHandler(core, wrappedHandler, props)
 	wrappedHandler = wrapMaxRequestSizeHandler(wrappedHandler, props)
 	wrappedHandler = priority.WrapRequestPriorityHandler(wrappedHandler)

--- a/vault/core.go
+++ b/vault/core.go
@@ -4571,3 +4571,13 @@ func (c *Core) setupAuditedHeadersConfig(ctx context.Context) error {
 
 	return nil
 }
+
+// GetMountTypeByAPIPath provide a quick way to get the plugin type from a mount table for an incoming request.
+func (c *Core) GetMountTypeByAPIPath(ctx context.Context, apiPath string) (string, string, bool) {
+	mountEntry, _, found := c.router.matchingMountEntryByPath(apiPath, true)
+	if !found || mountEntry == nil {
+		return "", "", false
+	}
+
+	return mountEntry.Type, mountEntry.Path, true
+}


### PR DESCRIPTION
### Description
  Workaround an incompatibility between Go's HTTP mux and a standard
  OCSP GET request that encodes in standard base64 and places that in the
  URL. Go's mux will try to canonicalize path components by changing
  repeated '/' into a single '/', which corrupts the base64 encoding of an
  OCSP request.

### TODO only if you're a HashiCorp employee
- [ ] **Labels:** If this PR is the CE portion of an ENT change, and that ENT change is
  getting backported to N-2, use the new style `backport/ent/x.x.x+ent` labels
  instead of the old style `backport/x.x.x` labels.
- [ ] **Labels:** If this PR is a CE only change, it can only be backported to N, so use
  the normal `backport/x.x.x` label (there should be only 1).
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
