### PR TITLE
backport: bump backport-assistant to v0.4.3

### DIFF
--- a/.github/workflows/backport-ce.yml
+++ b/.github/workflows/backport-ce.yml
@@ -13,7 +13,7 @@ jobs:
   backport-targeted-release-branch:
     if: github.event.pull_request.merged && github.repository == 'hashicorp/vault'
     runs-on: ubuntu-latest
-    container: hashicorpdev/backport-assistant:0.4.2
+    container: hashicorpdev/backport-assistant:0.4.3
     steps:
       - name: Backport changes to targeted release branch
         run: |


### PR DESCRIPTION
### Description
Updates the `backport-assistant` container image to `0.4.3` to get the latest bug fixes

### TODO only if you're a HashiCorp employee
- [x] **Labels:** If this PR is the CE portion of an ENT change, and that ENT change is
  getting backported to N-2, use the new style `backport/ent/x.x.x+ent` labels
  instead of the old style `backport/x.x.x` labels.
- [x] **Labels:** If this PR is a CE only change, it can only be backported to N, so use
  the normal `backport/x.x.x` label (there should be only 1).
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
