### PR TITLE
enos: use the initial version's install dir in upgrade

### DIFF
--- a/enos/enos-globals.hcl
+++ b/enos/enos-globals.hcl
@@ -61,11 +61,18 @@ globals {
     "Project" : "Enos",
     "Environment" : "ci"
   }, var.tags)
+  // This reads the VERSION file, strips any pre-release metadata, and selects only initial
+  // versions that are less than our current version. E.g. A VERSION file containing 1.17.0-beta2
+  // would render: semverconstraint(v, "<1.17.0-0")
+  upgrade_version_stripped = join("-", [split("-", chomp(file("../version/VERSION")))[0], "0"])
   // NOTE: when backporting, make sure that our initial versions are less than that
   // release branch's version. Also beware if adding versions below 1.11.x. Some scenarios
   // that use this global might not work as expected with earlier versions. Below 1.8.x is
   // not supported in any way.
-  upgrade_initial_versions = ["1.8.12", "1.9.10", "1.10.11", "1.11.12", "1.12.11", "1.13.13", "1.14.13", "1.15.9", "1.16.3"]
+  upgrade_all_initial_versions_ce  = ["1.8.12", "1.9.10", "1.10.11", "1.11.12", "1.12.11", "1.13.13", "1.14.10", "1.15.6", "1.16.3", "1.17.0"]
+  upgrade_all_initial_versions_ent = ["1.8.12", "1.9.10", "1.10.11", "1.11.12", "1.12.11", "1.13.13", "1.14.13", "1.15.10", "1.16.4", "1.17.0"]
+  upgrade_initial_versions_ce      = [for v in global.upgrade_all_initial_versions_ce : v if semverconstraint(v, "<${global.upgrade_version_stripped}")]
+  upgrade_initial_versions_ent     = [for v in global.upgrade_all_initial_versions_ent : v if semverconstraint(v, "<${global.upgrade_version_stripped}")]
   vault_install_dir = {
     bundle  = "/opt/vault/bin"
     package = "/usr/bin"

--- a/enos/enos-scenario-autopilot.hcl
+++ b/enos/enos-scenario-autopilot.hcl
@@ -27,10 +27,7 @@ scenario "autopilot" {
     config_mode     = global.config_modes
     distro          = global.distros
     edition         = global.enterprise_editions
-    // This reads the VERSION file, strips any pre-release metadata, and selects only initial
-    // versions that are less than our current version. E.g. A VERSION file containing 1.17.0-beta2
-    // would render: semverconstraint(v, "<1.17.0-0")
-    initial_version = [for v in global.upgrade_initial_versions : v if semverconstraint(v, "<${join("-", [split("-", chomp(file("../version/VERSION")))[0], "0"])}")]
+    initial_version = global.upgrade_initial_versions_ent
     seal            = global.seals
 
     # Autopilot wasn't available before 1.11.x


### PR DESCRIPTION
### Description
Fix a race in the `upgrade` scenario by waiting for the cluster to elect a leader before attempting to get the ip addresses.

https://github.com/hashicorp/vault/actions/runs/9503957362/job/26200475179?pr=27493#step:11:55

### TODO only if you're a HashiCorp employee
- [x] **Labels:** If this PR is the CE portion of an ENT change, and that ENT change is
  getting backported to N-2, use the new style `backport/ent/x.x.x+ent` labels
  instead of the old style `backport/x.x.x` labels.
- [x] **Labels:** If this PR is a CE only change, it can only be backported to N, so use
  the normal `backport/x.x.x` label (there should be only 1).
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
