### PR TITLE
Update configuration.mdx

### DIFF
--- a/website/content/docs/platform/servicenow/configuration.mdx
+++ b/website/content/docs/platform/servicenow/configuration.mdx
@@ -60,7 +60,7 @@ resolver validates that a username and password are present for:
 * vmware
 * windows
 
-And the credential resolver expects the following types to specify at least
+The credential resolver expects the following types to specify at least
 a username and a private key:
 
 * api_key
@@ -69,6 +69,22 @@ a username and a private key:
 * sn_cfg_ansible
 * sn_disco_certmgmt_certificate_ca
 * ssh_private_key
+
+For SNMPv3 credentials, the credential resolver can accept up to five values:
+
+* username
+* auth-protocol
+* auth-key
+* privacy-protocol
+* privacy-key
+
+Depending on the configuration of the SNMP endpoint, the username at least will always be required. See below for different SNMP endpoint configurations:
+
+Level         | Authentication | Encryption | What Happens
+--------------|----------------|------------|------------------------
+noAuthNoPriv  | Username       | None       | Username match for auth
+authNoPriv    | MD5 or SHA     | None       | Auth based on HMAC-MD5 or HMAC-SHA algorithms
+authPriv      | MD5 or SHA     | DES        | Auth based on HMAC-MD5 or HMAC-SHA algorithms; provides DES 56-bit encryption based on (CBC)-DES (DES-56) 
 
 ### Configuring the resolver to use a secret
 


### PR DESCRIPTION
Adding SNMPv3 fields to credential resolver documentation.

### Description
What does this PR do?

### TODO only if you're a HashiCorp employee
- [x] **Labels:** If this PR is the CE portion of an ENT change, and that ENT change is
  getting backported to N-2, use the new style `backport/ent/x.x.x+ent` labels
  instead of the old style `backport/x.x.x` labels.
- [x] **Labels:** If this PR is a CE only change, it can only be backported to N, so use
  the normal `backport/x.x.x` label (there should be only 1).
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
