### PR TITLE
Added method to join PQ and current month, with tests

### DIFF
--- a/vault/activity/query.go
+++ b/vault/activity/query.go
@@ -319,3 +319,67 @@ func (s *PrecomputedQueryStore) DeleteQueriesBefore(ctx context.Context, retenti
 	}
 	return nil
 }
+
+func (m *MonthlyNamespaceRecord) ToNamespaceRecord() *NamespaceRecord {
+	return &NamespaceRecord{
+		NamespaceID:     m.NamespaceID,
+		Entities:        uint64(m.Counts.EntityClients),
+		NonEntityTokens: uint64(m.Counts.NonEntityClients),
+		SecretSyncs:     uint64(m.Counts.SecretSyncs),
+		Mounts:          m.Mounts,
+		ACMEClients:     uint64(m.Counts.ACMEClients),
+	}
+}
+
+func (n *NamespaceRecord) CombineWithMonthlyNamespaceRecord(nsRecord *MonthlyNamespaceRecord) {
+	existingMounts := make(map[string]*MountRecord)
+	for _, mountRecord := range n.Mounts {
+		existingMounts[mountRecord.MountPath] = mountRecord
+	}
+
+	for _, mountRecord := range nsRecord.Mounts {
+		if existingMountRecord, ok := existingMounts[mountRecord.MountPath]; ok {
+			existingMountRecord.Add(mountRecord)
+		} else {
+			n.Mounts = append(n.Mounts, mountRecord)
+		}
+	}
+
+	n.SecretSyncs += uint64(nsRecord.Counts.SecretSyncs)
+	n.Entities += uint64(nsRecord.Counts.EntityClients)
+	n.NonEntityTokens += uint64(nsRecord.Counts.NonEntityClients)
+	n.ACMEClients += uint64(nsRecord.Counts.ACMEClients)
+}
+
+func (m *MountRecord) Add(m2 *MountRecord) {
+	m.Counts.ACMEClients += m2.Counts.ACMEClients
+	m.Counts.NonEntityClients += m2.Counts.NonEntityClients
+	m.Counts.EntityClients += m2.Counts.EntityClients
+	m.Counts.SecretSyncs += m2.Counts.SecretSyncs
+}
+
+func (q *PrecomputedQuery) CombineWithCurrentMonth(currentMonth *MonthRecord) {
+	// Append the current months data to the precomputed query month's data
+	q.Months = append(q.Months, currentMonth)
+
+	existingNamespaceMounts := make(map[string]*NamespaceRecord)
+	// Store the existing namespaces and mounts in the precomputed query for easy access
+	for _, monthlyNamespaceRecord := range q.Namespaces {
+		existingNamespaceMounts[monthlyNamespaceRecord.NamespaceID] = monthlyNamespaceRecord
+	}
+
+	// Get the counts of each mount per namespace in the current month, and increment
+	// its total count in the precomputed query. These total values will be visible in the
+	// by_namespace grouping in the final response data
+	for _, nsRecord := range currentMonth.Namespaces {
+		namespaceId := nsRecord.NamespaceID
+
+		// If the namespace already exists in the previous months, iterate through the mounts and increment the counts
+		if existingNsRecord, ok := existingNamespaceMounts[namespaceId]; ok {
+			existingNsRecord.CombineWithMonthlyNamespaceRecord(nsRecord)
+		} else {
+			// Else just add the new namespace record to the slice in the precomputed query's namespace slice
+			q.Namespaces = append(q.Namespaces, nsRecord.ToNamespaceRecord())
+		}
+	}
+}

--- a/vault/activity/query_test.go
+++ b/vault/activity/query_test.go
@@ -502,7 +502,6 @@ func TestCombineWithCurrentMonth(t *testing.T) {
 	assert.Equal(t, 4, int(pq.Namespaces[1].ACMEClients))
 	assert.Equal(t, 4, int(pq.Namespaces[1].Entities))
 	assert.Equal(t, 4, int(pq.Namespaces[1].NonEntityTokens))
-	assert.Equal(t, 3, len(pq.Namespaces[1].Mounts))
 	assert.Equal(t, 3, len(pq.Namespaces[1].Mounts)) // We added a new mount to this namespace (m3)
 	// Check that the duplicate mount got incremented properly (m1)
 	compareCountsRecords(t, &CountsRecord{

--- a/vault/activity/query_test.go
+++ b/vault/activity/query_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/vault/helper/timeutil"
 	"github.com/hashicorp/vault/sdk/helper/logging"
 	"github.com/hashicorp/vault/sdk/logical"
+	"github.com/stretchr/testify/assert"
 )
 
 func NewTestQueryStore(t *testing.T) *PrecomputedQueryStore {
@@ -291,4 +292,261 @@ func TestQueryStore_TimeRanges(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCombineWithCurrentMonth(t *testing.T) {
+	// Create two months worth of records
+	months := []*MonthRecord{
+		{
+			Counts: &CountsRecord{
+				EntityClients:    1,
+				NonEntityClients: 1,
+				SecretSyncs:      1,
+				ACMEClients:      1,
+			},
+		},
+		{
+			Counts: &CountsRecord{
+				EntityClients:    1,
+				NonEntityClients: 1,
+				SecretSyncs:      1,
+				ACMEClients:      1,
+			},
+		},
+	}
+	pq := &PrecomputedQuery{
+		Months: months,
+		Namespaces: []*NamespaceRecord{
+			{
+				NamespaceID:     "ns1",
+				Entities:        2,
+				ACMEClients:     2,
+				NonEntityTokens: 2,
+				SecretSyncs:     2,
+				Mounts: []*MountRecord{
+					{
+						MountPath: "m1",
+						Counts: &CountsRecord{
+							EntityClients:    1,
+							NonEntityClients: 1,
+							SecretSyncs:      1,
+							ACMEClients:      1,
+						},
+					},
+					{
+						MountPath: "m2",
+						Counts: &CountsRecord{
+							EntityClients:    1,
+							NonEntityClients: 1,
+							SecretSyncs:      1,
+							ACMEClients:      1,
+						},
+					},
+				},
+			},
+			{
+				NamespaceID:     "ns2",
+				Entities:        2,
+				ACMEClients:     2,
+				NonEntityTokens: 2,
+				SecretSyncs:     2,
+				Mounts: []*MountRecord{
+					{
+						MountPath: "m1",
+						Counts: &CountsRecord{
+							EntityClients:    1,
+							NonEntityClients: 1,
+							SecretSyncs:      1,
+							ACMEClients:      1,
+						},
+					},
+					{
+						MountPath: "m2",
+						Counts: &CountsRecord{
+							EntityClients:    1,
+							NonEntityClients: 1,
+							SecretSyncs:      1,
+							ACMEClients:      1,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// In the new month we will add clients to three namespaces
+	// Namespace 1: clients for m1 (already present in PQ), and clients for m2 (already present in PQ)
+	// Namespace 2: clients for m1 (already present in PQ), and clients for m3 (NOT in PQ)
+	// Namespace 2: all clients and mounts are new
+	newMonthlyRecord := &MonthRecord{
+		Namespaces: []*MonthlyNamespaceRecord{
+			{
+				NamespaceID: "ns1",
+				Counts: &CountsRecord{
+					EntityClients:    2,
+					NonEntityClients: 2,
+					SecretSyncs:      2,
+					ACMEClients:      2,
+				},
+				Mounts: []*MountRecord{
+					{
+						MountPath: "m1",
+						Counts: &CountsRecord{
+							EntityClients:    1,
+							NonEntityClients: 1,
+							SecretSyncs:      1,
+							ACMEClients:      1,
+						},
+					},
+					{
+						MountPath: "m2",
+						Counts: &CountsRecord{
+							EntityClients:    1,
+							NonEntityClients: 1,
+							SecretSyncs:      1,
+							ACMEClients:      1,
+						},
+					},
+				},
+			},
+			{
+				NamespaceID: "ns2",
+				Counts: &CountsRecord{
+					EntityClients:    2,
+					NonEntityClients: 2,
+					SecretSyncs:      2,
+					ACMEClients:      2,
+				},
+				Mounts: []*MountRecord{
+					{
+						MountPath: "m1",
+						Counts: &CountsRecord{
+							EntityClients:    1,
+							NonEntityClients: 1,
+							SecretSyncs:      1,
+							ACMEClients:      1,
+						},
+					},
+					{
+						MountPath: "m3",
+						Counts: &CountsRecord{
+							EntityClients:    1,
+							NonEntityClients: 1,
+							SecretSyncs:      1,
+							ACMEClients:      1,
+						},
+					},
+				},
+			},
+			{
+				NamespaceID: "ns3",
+				Counts: &CountsRecord{
+					EntityClients:    2,
+					NonEntityClients: 2,
+					SecretSyncs:      2,
+					ACMEClients:      2,
+				},
+				Mounts: []*MountRecord{
+					{
+						MountPath: "m1",
+						Counts: &CountsRecord{
+							EntityClients:    1,
+							NonEntityClients: 1,
+							SecretSyncs:      1,
+							ACMEClients:      1,
+						},
+					},
+					{
+						MountPath: "m2",
+						Counts: &CountsRecord{
+							EntityClients:    1,
+							NonEntityClients: 1,
+							SecretSyncs:      1,
+							ACMEClients:      1,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	pq.CombineWithCurrentMonth(newMonthlyRecord)
+
+	// There should be 3 namespaces (one new one from this month)
+	assert.Equal(t, 3, len(pq.Namespaces))
+	// There should be 3 months (one new month from this month)
+	assert.Equal(t, 3, len(pq.Months))
+
+	// Verify first namespace values
+	assert.Equal(t, 4, int(pq.Namespaces[0].SecretSyncs))
+	assert.Equal(t, 4, int(pq.Namespaces[0].ACMEClients))
+	assert.Equal(t, 4, int(pq.Namespaces[0].Entities))
+	assert.Equal(t, 4, int(pq.Namespaces[0].NonEntityTokens))
+	assert.Equal(t, 2, len(pq.Namespaces[0].Mounts))
+	for i := 0; i < 2; i++ {
+		compareCountsRecords(t, &CountsRecord{
+			EntityClients:    2,
+			ACMEClients:      2,
+			NonEntityClients: 2,
+			SecretSyncs:      2,
+		}, pq.Namespaces[0].Mounts[i].Counts)
+	}
+
+	// Verify second namespace values
+	assert.Equal(t, 4, int(pq.Namespaces[1].SecretSyncs))
+	assert.Equal(t, 4, int(pq.Namespaces[1].ACMEClients))
+	assert.Equal(t, 4, int(pq.Namespaces[1].Entities))
+	assert.Equal(t, 4, int(pq.Namespaces[1].NonEntityTokens))
+	assert.Equal(t, 3, len(pq.Namespaces[1].Mounts))
+	assert.Equal(t, 3, len(pq.Namespaces[1].Mounts)) // We added a new mount to this namespace (m3)
+	// Check that the duplicate mount got incremented properly (m1)
+	compareCountsRecords(t, &CountsRecord{
+		EntityClients:    2,
+		ACMEClients:      2,
+		NonEntityClients: 2,
+		SecretSyncs:      2,
+	}, pq.Namespaces[1].Mounts[0].Counts)
+	// Check the old mount counts have not changed (m2)
+	compareCountsRecords(t, &CountsRecord{
+		EntityClients:    1,
+		ACMEClients:      1,
+		NonEntityClients: 1,
+		SecretSyncs:      1,
+	}, pq.Namespaces[1].Mounts[1].Counts)
+	// Check the new mounts have been added (m3)
+	compareCountsRecords(t, &CountsRecord{
+		EntityClients:    1,
+		ACMEClients:      1,
+		NonEntityClients: 1,
+		SecretSyncs:      1,
+	}, pq.Namespaces[1].Mounts[2].Counts)
+
+	// Verify third namespace counts
+	// This is a completely new namespace
+	assert.Equal(t, 2, int(pq.Namespaces[2].SecretSyncs))
+	assert.Equal(t, 2, int(pq.Namespaces[2].ACMEClients))
+	assert.Equal(t, 2, int(pq.Namespaces[2].Entities))
+	assert.Equal(t, 2, int(pq.Namespaces[2].NonEntityTokens))
+	assert.Equal(t, 2, len(pq.Namespaces[2].Mounts))
+	assert.Equal(t, 2, len(pq.Namespaces[2].Mounts))
+	compareCountsRecords(t, &CountsRecord{
+		EntityClients:    1,
+		ACMEClients:      1,
+		NonEntityClients: 1,
+		SecretSyncs:      1,
+	}, pq.Namespaces[2].Mounts[0].Counts)
+	compareCountsRecords(t, &CountsRecord{
+		EntityClients:    1,
+		ACMEClients:      1,
+		NonEntityClients: 1,
+		SecretSyncs:      1,
+	}, pq.Namespaces[2].Mounts[1].Counts)
+}
+
+func compareCountsRecords(t *testing.T, record *CountsRecord, toCompare *CountsRecord) {
+	t.Helper()
+	assert.Equal(t, record.NonEntityClients, toCompare.NonEntityClients)
+	assert.Equal(t, record.ACMEClients, toCompare.ACMEClients)
+	assert.Equal(t, record.SecretSyncs, toCompare.SecretSyncs)
+	assert.Equal(t, record.EntityClients, toCompare.EntityClients)
 }

--- a/vault/activity/query_test.go
+++ b/vault/activity/query_test.go
@@ -294,6 +294,11 @@ func TestQueryStore_TimeRanges(t *testing.T) {
 	}
 }
 
+// TestCombineWithCurrentMonth is a unit test that verifies that an
+// internal join method to combine a precomputed query data structure
+// with the current month data.
+// This will create various repeating mounts, new mounts, and new namespaces and
+// verify that these two structures are properly combined.
 func TestCombineWithCurrentMonth(t *testing.T) {
 	// Create two months worth of records
 	months := []*MonthRecord{
@@ -527,7 +532,6 @@ func TestCombineWithCurrentMonth(t *testing.T) {
 	assert.Equal(t, 2, int(pq.Namespaces[2].ACMEClients))
 	assert.Equal(t, 2, int(pq.Namespaces[2].Entities))
 	assert.Equal(t, 2, int(pq.Namespaces[2].NonEntityTokens))
-	assert.Equal(t, 2, len(pq.Namespaces[2].Mounts))
 	assert.Equal(t, 2, len(pq.Namespaces[2].Mounts))
 	compareCountsRecords(t, &CountsRecord{
 		EntityClients:    1,


### PR DESCRIPTION
### Description
Adds functions to combine the precomputed Query and the current month records. This functions are unused at the moment. This is scaffolding to be able to combine the new totals we will calculate in future PR's using the HLL's.

ENT PR: https://github.com/hashicorp/vault-enterprise/pull/6079
closes https://github.com/hashicorp/vault-enterprise/pull/6079

### TODO only if you're a HashiCorp employee
- [ ] **Labels:** If this PR is the CE portion of an ENT change, and that ENT change is
  getting backported to N-2, use the new style `backport/ent/x.x.x+ent` labels
  instead of the old style `backport/x.x.x` labels.
- [ ] **Labels:** If this PR is a CE only change, it can only be backported to N, so use
  the normal `backport/x.x.x` label (there should be only 1).
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
