### PR TITLE
[Docs] Remove an extra space

### DIFF
--- a/website/content/docs/platform/servicenow/configuration.mdx
+++ b/website/content/docs/platform/servicenow/configuration.mdx
@@ -33,7 +33,7 @@ To consume Vault credentials from your MID server, you will need to:
 The credential resolver supports reading credentials from the following secret engines:
 
 * [Active Directory](/vault/docs/secrets/ad)
-* [AD/OpenLDAP] (/vault/docs/secrets/ldap)
+* [AD/OpenLDAP](/vault/docs/secrets/ldap)
 * [AWS](/vault/docs/secrets/aws)
 * [KV v1](/vault/docs/secrets/kv/kv-v1)
 * [KV v2](/vault/docs/secrets/kv/kv-v2)


### PR DESCRIPTION
### Description

🔍 [Deploy preview](https://vault-8ybwqkcp3-hashicorp.vercel.app/vault/docs/platform/servicenow/configuration#configuring-discovery-credentials)

This PR fixes the [broken hyperlink](https://developer.hashicorp.com/vault/docs/platform/servicenow/configuration#creating-a-secret-in-vault) due to an extra space

![image](https://github.com/hashicorp/vault/assets/7660718/48461542-2717-4b35-9c67-4539a6c0dfac)



### TODO only if you're a HashiCorp employee
- [ ] **Labels:** If this PR is the CE portion of an ENT change, and that ENT change is
  getting backported to N-2, use the new style `backport/ent/x.x.x+ent` labels
  instead of the old style `backport/x.x.x` labels.
- [x] **Labels:** If this PR is a CE only change, it can only be backported to N, so use
  the normal `backport/x.x.x` label (there should be only 1).
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
