### PR TITLE
Add SIGUSR2 pprof to agent and proxy

### DIFF
--- a/changelog/27510.txt
+++ b/changelog/27510.txt
@@ -1,3 +1,6 @@
 ```release-note:improvement
 agent: Add the ability to dump pprof to the filesystem using SIGUSR2
 ```
+```release-note:improvement
+proxy: Add the ability to dump pprof to the filesystem using SIGUSR2
+```

--- a/changelog/27510.txt
+++ b/changelog/27510.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+agent: Add the ability to dump pprof to the filesystem using SIGUSR2
+```

--- a/command/agent.go
+++ b/command/agent.go
@@ -76,7 +76,7 @@ type AgentCommand struct {
 
 	ShutdownCh chan struct{}
 	SighupCh   chan struct{}
-	SighUSR2Ch chan struct{}
+	SigUSR2Ch  chan struct{}
 
 	tlsReloadFuncsLock sync.RWMutex
 	tlsReloadFuncs     []reloadutil.ReloadFunc
@@ -761,7 +761,7 @@ func (c *AgentCommand) Run(args []string) int {
 				case c.reloadedCh <- struct{}{}:
 				default:
 				}
-			case <-c.SighUSR2Ch:
+			case <-c.SigUSR2Ch:
 				pprofPath := filepath.Join(os.TempDir(), "vault-agent-pprof")
 				err := os.MkdirAll(pprofPath, os.ModePerm)
 				if err != nil {

--- a/command/agent.go
+++ b/command/agent.go
@@ -765,7 +765,7 @@ func (c *AgentCommand) Run(args []string) int {
 				// We can only get pprof outputs via the API but sometimes Vault can get
 				// into a state where it cannot process requests so we can get pprof outputs
 				// via SIGUSR2.
-				pprofPath := filepath.Join(os.TempDir(), "vault-pprof")
+				pprofPath := filepath.Join(os.TempDir(), "vault-agent-pprof")
 				err := os.MkdirAll(pprofPath, os.ModePerm)
 				if err != nil {
 					c.logger.Error("Could not create temporary directory for pprof", "error", err)

--- a/command/agent.go
+++ b/command/agent.go
@@ -762,9 +762,6 @@ func (c *AgentCommand) Run(args []string) int {
 				default:
 				}
 			case <-c.SighUSR2Ch:
-				// We can only get pprof outputs via the API but sometimes Vault can get
-				// into a state where it cannot process requests so we can get pprof outputs
-				// via SIGUSR2.
 				pprofPath := filepath.Join(os.TempDir(), "vault-agent-pprof")
 				err := os.MkdirAll(pprofPath, os.ModePerm)
 				if err != nil {

--- a/command/agent.go
+++ b/command/agent.go
@@ -14,7 +14,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"runtime/pprof"
 	"sort"
 	"strings"
 	"sync"
@@ -763,39 +762,11 @@ func (c *AgentCommand) Run(args []string) int {
 				}
 			case <-c.SigUSR2Ch:
 				pprofPath := filepath.Join(os.TempDir(), "vault-agent-pprof")
-				err := os.MkdirAll(pprofPath, os.ModePerm)
+				cpuProfileDuration := time.Second * 1
+				err := WritePprofToFile(pprofPath, cpuProfileDuration)
 				if err != nil {
-					c.logger.Error("Could not create temporary directory for pprof", "error", err)
+					c.logger.Error(err.Error())
 					continue
-				}
-
-				dumps := []string{"goroutine", "heap", "allocs", "threadcreate", "profile"}
-				for _, dump := range dumps {
-					pFile, err := os.Create(filepath.Join(pprofPath, dump))
-					if err != nil {
-						c.logger.Error("error creating pprof file", "name", dump, "error", err)
-						break
-					}
-
-					if dump != "profile" {
-						err = pprof.Lookup(dump).WriteTo(pFile, 0)
-						if err != nil {
-							c.logger.Error("error generating pprof data", "name", dump, "error", err)
-							pFile.Close()
-							break
-						}
-					} else {
-						// CPU profiles need to run for a duration so we're going to run it
-						// just for one second to avoid blocking here.
-						if err := pprof.StartCPUProfile(pFile); err != nil {
-							c.logger.Error("could not start CPU profile: ", err)
-							pFile.Close()
-							break
-						}
-						time.Sleep(time.Second * 1)
-						pprof.StopCPUProfile()
-					}
-					pFile.Close()
 				}
 
 				c.logger.Info(fmt.Sprintf("Wrote pprof files to: %s", pprofPath))

--- a/command/agent.go
+++ b/command/agent.go
@@ -13,6 +13,8 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"path/filepath"
+	"runtime/pprof"
 	"sort"
 	"strings"
 	"sync"
@@ -74,6 +76,7 @@ type AgentCommand struct {
 
 	ShutdownCh chan struct{}
 	SighupCh   chan struct{}
+	SighUSR2Ch chan struct{}
 
 	tlsReloadFuncsLock sync.RWMutex
 	tlsReloadFuncs     []reloadutil.ReloadFunc
@@ -758,6 +761,47 @@ func (c *AgentCommand) Run(args []string) int {
 				case c.reloadedCh <- struct{}{}:
 				default:
 				}
+			case <-c.SighUSR2Ch:
+				// We can only get pprof outputs via the API but sometimes Vault can get
+				// into a state where it cannot process requests so we can get pprof outputs
+				// via SIGUSR2.
+				pprofPath := filepath.Join(os.TempDir(), "vault-pprof")
+				err := os.MkdirAll(pprofPath, os.ModePerm)
+				if err != nil {
+					c.logger.Error("Could not create temporary directory for pprof", "error", err)
+					continue
+				}
+
+				dumps := []string{"goroutine", "heap", "allocs", "threadcreate", "profile"}
+				for _, dump := range dumps {
+					pFile, err := os.Create(filepath.Join(pprofPath, dump))
+					if err != nil {
+						c.logger.Error("error creating pprof file", "name", dump, "error", err)
+						break
+					}
+
+					if dump != "profile" {
+						err = pprof.Lookup(dump).WriteTo(pFile, 0)
+						if err != nil {
+							c.logger.Error("error generating pprof data", "name", dump, "error", err)
+							pFile.Close()
+							break
+						}
+					} else {
+						// CPU profiles need to run for a duration so we're going to run it
+						// just for one second to avoid blocking here.
+						if err := pprof.StartCPUProfile(pFile); err != nil {
+							c.logger.Error("could not start CPU profile: ", err)
+							pFile.Close()
+							break
+						}
+						time.Sleep(time.Second * 1)
+						pprof.StopCPUProfile()
+					}
+					pFile.Close()
+				}
+
+				c.logger.Info(fmt.Sprintf("Wrote pprof files to: %s", pprofPath))
 			case <-ctx.Done():
 				return nil
 			}

--- a/command/agent_test.go
+++ b/command/agent_test.go
@@ -91,6 +91,7 @@ func testAgentCommand(tb testing.TB, logger hclog.Logger) (*cli.MockUi, *AgentCo
 		},
 		ShutdownCh: MakeShutdownCh(),
 		SighupCh:   MakeSighupCh(),
+		SigUSR2Ch:  MakeSigUSR2Ch(),
 		logger:     logger,
 		startedCh:  make(chan struct{}, 5),
 		reloadedCh: make(chan struct{}, 5),

--- a/command/commands.go
+++ b/command/commands.go
@@ -192,7 +192,7 @@ func initCommands(ui, serverCmdUi cli.Ui, runOpts *RunOptions) map[string]cli.Co
 				},
 				ShutdownCh: MakeShutdownCh(),
 				SighupCh:   MakeSighupCh(),
-				SighUSR2Ch: MakeSigUSR2Ch(),
+				SigUSR2Ch:  MakeSigUSR2Ch(),
 			}, nil
 		},
 		"agent generate-config": func() (cli.Command, error) {
@@ -577,6 +577,7 @@ func initCommands(ui, serverCmdUi cli.Ui, runOpts *RunOptions) map[string]cli.Co
 				},
 				ShutdownCh: MakeShutdownCh(),
 				SighupCh:   MakeSighupCh(),
+				SigUSR2Ch:  MakeSigUSR2Ch(),
 			}, nil
 		},
 		"policy": func() (cli.Command, error) {

--- a/command/commands.go
+++ b/command/commands.go
@@ -192,6 +192,7 @@ func initCommands(ui, serverCmdUi cli.Ui, runOpts *RunOptions) map[string]cli.Co
 				},
 				ShutdownCh: MakeShutdownCh(),
 				SighupCh:   MakeSighupCh(),
+				SighUSR2Ch: MakeSigUSR2Ch(),
 			}, nil
 		},
 		"agent generate-config": func() (cli.Command, error) {

--- a/command/proxy.go
+++ b/command/proxy.go
@@ -719,7 +719,7 @@ func (c *ProxyCommand) Run(args []string) int {
 				default:
 				}
 			case <-c.SigUSR2Ch:
-				pprofPath := filepath.Join(os.TempDir(), "vault-agent-pprof")
+				pprofPath := filepath.Join(os.TempDir(), "vault-proxy-pprof")
 				err := os.MkdirAll(pprofPath, os.ModePerm)
 				if err != nil {
 					c.logger.Error("Could not create temporary directory for pprof", "error", err)

--- a/command/proxy.go
+++ b/command/proxy.go
@@ -13,7 +13,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"runtime/pprof"
 	"sort"
 	"strings"
 	"sync"
@@ -720,39 +719,11 @@ func (c *ProxyCommand) Run(args []string) int {
 				}
 			case <-c.SigUSR2Ch:
 				pprofPath := filepath.Join(os.TempDir(), "vault-proxy-pprof")
-				err := os.MkdirAll(pprofPath, os.ModePerm)
+				cpuProfileDuration := time.Second * 1
+				err := WritePprofToFile(pprofPath, cpuProfileDuration)
 				if err != nil {
-					c.logger.Error("Could not create temporary directory for pprof", "error", err)
+					c.logger.Error(err.Error())
 					continue
-				}
-
-				dumps := []string{"goroutine", "heap", "allocs", "threadcreate", "profile"}
-				for _, dump := range dumps {
-					pFile, err := os.Create(filepath.Join(pprofPath, dump))
-					if err != nil {
-						c.logger.Error("error creating pprof file", "name", dump, "error", err)
-						break
-					}
-
-					if dump != "profile" {
-						err = pprof.Lookup(dump).WriteTo(pFile, 0)
-						if err != nil {
-							c.logger.Error("error generating pprof data", "name", dump, "error", err)
-							pFile.Close()
-							break
-						}
-					} else {
-						// CPU profiles need to run for a duration so we're going to run it
-						// just for one second to avoid blocking here.
-						if err := pprof.StartCPUProfile(pFile); err != nil {
-							c.logger.Error("could not start CPU profile: ", err)
-							pFile.Close()
-							break
-						}
-						time.Sleep(time.Second * 1)
-						pprof.StopCPUProfile()
-					}
-					pFile.Close()
 				}
 
 				c.logger.Info(fmt.Sprintf("Wrote pprof files to: %s", pprofPath))

--- a/command/proxy_test.go
+++ b/command/proxy_test.go
@@ -44,6 +44,7 @@ func testProxyCommand(tb testing.TB, logger hclog.Logger) (*cli.MockUi, *ProxyCo
 		},
 		ShutdownCh: MakeShutdownCh(),
 		SighupCh:   MakeSighupCh(),
+		SigUSR2Ch:  MakeSigUSR2Ch(),
 		logger:     logger,
 		startedCh:  make(chan struct{}, 5),
 		reloadedCh: make(chan struct{}, 5),

--- a/command/util.go
+++ b/command/util.go
@@ -210,28 +210,28 @@ func (r *recordingRoundTripper) RoundTrip(req *http.Request) (*http.Response, er
 func WritePprofToFile(path string, cpuProfileDuration time.Duration) error {
 	err := os.MkdirAll(path, os.ModePerm)
 	if err != nil {
-		return fmt.Errorf("could not create temporary directory for pprof", "error", err)
+		return fmt.Errorf("could not create temporary directory for pprof: %v", err)
 	}
 
 	dumps := []string{"goroutine", "heap", "allocs", "threadcreate", "profile"}
 	for _, dump := range dumps {
 		pFile, err := os.Create(filepath.Join(path, dump))
 		if err != nil {
-			return fmt.Errorf("error creating pprof file", "name", dump, "error", err)
+			return fmt.Errorf("error creating pprof file %s: %v", dump, err)
 		}
 
 		if dump != "profile" {
 			err = pprof.Lookup(dump).WriteTo(pFile, 0)
 			if err != nil {
 				pFile.Close()
-				return fmt.Errorf("error generating pprof data", "name", dump, "error", err)
+				return fmt.Errorf("error generating pprof data for %s: %v", dump, err)
 			}
 		} else {
 			// CPU profiles need to run for a duration so we're going to run it
 			// just for one second to avoid blocking here.
 			if err := pprof.StartCPUProfile(pFile); err != nil {
 				pFile.Close()
-				return fmt.Errorf("could not start CPU profile", "error", err)
+				return fmt.Errorf("could not start CPU profile: %v", err)
 			}
 			time.Sleep(cpuProfileDuration)
 			pprof.StopCPUProfile()

--- a/command/util.go
+++ b/command/util.go
@@ -8,6 +8,8 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"path/filepath"
+	"runtime/pprof"
 	"testing"
 	"time"
 
@@ -200,4 +202,41 @@ func (r *recordingRoundTripper) RoundTrip(req *http.Request) (*http.Response, er
 	return &http.Response{
 		StatusCode: 200,
 	}, nil
+}
+
+// WritePprofToFile will create a temporary directory at the specified path
+// and generate pprof files at that location. CPU requires polling over a
+// duration. For most situations 1 second is enough.
+func WritePprofToFile(path string, cpuProfileDuration time.Duration) error {
+	err := os.MkdirAll(path, os.ModePerm)
+	if err != nil {
+		return fmt.Errorf("could not create temporary directory for pprof", "error", err)
+	}
+
+	dumps := []string{"goroutine", "heap", "allocs", "threadcreate", "profile"}
+	for _, dump := range dumps {
+		pFile, err := os.Create(filepath.Join(path, dump))
+		if err != nil {
+			return fmt.Errorf("error creating pprof file", "name", dump, "error", err)
+		}
+
+		if dump != "profile" {
+			err = pprof.Lookup(dump).WriteTo(pFile, 0)
+			if err != nil {
+				pFile.Close()
+				return fmt.Errorf("error generating pprof data", "name", dump, "error", err)
+			}
+		} else {
+			// CPU profiles need to run for a duration so we're going to run it
+			// just for one second to avoid blocking here.
+			if err := pprof.StartCPUProfile(pFile); err != nil {
+				pFile.Close()
+				return fmt.Errorf("could not start CPU profile: ", err)
+			}
+			time.Sleep(cpuProfileDuration)
+			pprof.StopCPUProfile()
+		}
+		pFile.Close()
+	}
+	return nil
 }

--- a/command/util.go
+++ b/command/util.go
@@ -231,7 +231,7 @@ func WritePprofToFile(path string, cpuProfileDuration time.Duration) error {
 			// just for one second to avoid blocking here.
 			if err := pprof.StartCPUProfile(pFile); err != nil {
 				pFile.Close()
-				return fmt.Errorf("could not start CPU profile: ", err)
+				return fmt.Errorf("could not start CPU profile", "error", err)
 			}
 			time.Sleep(cpuProfileDuration)
 			pprof.StopCPUProfile()


### PR DESCRIPTION
This adds the ability to get pprof data from Agent and Proxy using SIGUSR2, similar to Vault server.