### PR TITLE
VAULT-28192 fix Agent and Proxy consuming large amounts of CPU for auto-auth self-healing

### DIFF
--- a/changelog/27518.txt
+++ b/changelog/27518.txt
@@ -1,7 +1,7 @@
 ```release-note:bug
-agent: Fixed excessive CPU usage issue
+agent: Fixed an issue causing excessive CPU usage during normal operation
 ```
 
 ```release-note:bug
-proxy: Fixed excessive CPU usage issue
+proxy: Fixed an issue causing excessive CPU usage during normal operation
 ```

--- a/changelog/27518.txt
+++ b/changelog/27518.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+agent: Fixed excessive CPU usage issue
+```
+
+```release-note:bug
+proxy: Fixed excessive CPU usage issue
+```

--- a/command/agent/template/template.go
+++ b/command/agent/template/template.go
@@ -256,9 +256,10 @@ func (ts *Server) Run(ctx context.Context, incoming chan string, templates []*ct
 			if responseError.StatusCode == 403 && strings.Contains(responseError.Error(), logical.ErrInvalidToken.Error()) && !tokenRenewalInProgress.Load() {
 				ts.logger.Info("template server: received invalid token error")
 
-				// Drain the error channel before sending a new error
+				// Drain the error channel and incoming channel before sending a new error
 				select {
 				case <-invalidTokenCh:
+				case <-incoming:
 				default:
 				}
 				invalidTokenCh <- err

--- a/command/agent/template/template.go
+++ b/command/agent/template/template.go
@@ -246,31 +246,23 @@ func (ts *Server) Run(ctx context.Context, incoming chan string, templates []*ct
 				ts.runner.Stop()
 				return nil
 			}
-		default:
-			// We are using default instead of a new case block to prioritize the case where <-incoming has a new value over
-			// receiving an error message from the consul-template server
-			select {
-			case err := <-ts.runner.ServerErrCh:
-				var responseError *api.ResponseError
-				ok := errors.As(err, &responseError)
-				if !ok {
-					ts.logger.Error("template server: could not extract error response")
-					continue
-				}
-				if responseError.StatusCode == 403 && strings.Contains(responseError.Error(), logical.ErrInvalidToken.Error()) && !tokenRenewalInProgress.Load() {
-					ts.logger.Info("template server: received invalid token error")
-
-					// Drain the error channel before sending a new error
-					select {
-					case <-invalidTokenCh:
-					default:
-					}
-					invalidTokenCh <- err
-				}
-			default:
+		case err := <-ts.runner.ServerErrCh:
+			var responseError *api.ResponseError
+			ok := errors.As(err, &responseError)
+			if !ok {
+				ts.logger.Error("template server: could not extract error response")
 				continue
 			}
+			if responseError.StatusCode == 403 && strings.Contains(responseError.Error(), logical.ErrInvalidToken.Error()) && !tokenRenewalInProgress.Load() {
+				ts.logger.Info("template server: received invalid token error")
 
+				// Drain the error channel before sending a new error
+				select {
+				case <-invalidTokenCh:
+				default:
+				}
+				invalidTokenCh <- err
+			}
 		}
 	}
 }

--- a/command/agentproxyshared/auth/auth.go
+++ b/command/agentproxyshared/auth/auth.go
@@ -563,18 +563,12 @@ func (ah *AuthHandler) Run(ctx context.Context, am AuthMethod) error {
 				// Set authenticated when authentication succeeds
 				metrics.SetGauge([]string{ah.metricsSignifier, "authenticated"}, 1)
 				ah.logger.Info("renewed auth token")
-
 			case <-credCh:
 				ah.logger.Info("auth method found new credentials, re-authenticating")
 				break LifetimeWatcherLoop
-			default:
-				select {
-				case <-ah.InvalidToken:
-					ah.logger.Info("invalid token found, re-authenticating")
-					break LifetimeWatcherLoop
-				default:
-					continue
-				}
+			case <-ah.InvalidToken:
+				ah.logger.Info("invalid token found, re-authenticating")
+				break LifetimeWatcherLoop
 			}
 		}
 	}


### PR DESCRIPTION
### Description

Fixes an issue introduced in 1.17 where CPU usage in Agent and Proxy are extremely high due to the code taking the same path down a select statement repeatedly (in an infinite loop).

Will be backported to 1.17.

Fixes https://github.com/hashicorp/vault/issues/27505

### TODO only if you're a HashiCorp employee
- [x] **Labels:** If this PR is the CE portion of an ENT change, and that ENT change is
  getting backported to N-2, use the new style `backport/ent/x.x.x+ent` labels
  instead of the old style `backport/x.x.x` labels.
- [x] **Labels:** If this PR is a CE only change, it can only be backported to N, so use
  the normal `backport/x.x.x` label (there should be only 1).
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
