### PR TITLE
VAULT-28192 Add known issue for Agent/Proxy CPU issue

### DIFF
--- a/website/content/docs/release-notes/1.17.0.mdx
+++ b/website/content/docs/release-notes/1.17.0.mdx
@@ -13,13 +13,13 @@ description: |-
 
 ## Important changes
 
-| Version | Change                  | Description                                                                                                                    |
-|---------|-------------------------|--------------------------------------------------------------------------------------------------------------------------------|
-| 1.17.0+ | New default             | [Allowed audit headers now have unremovable defaults](/vault/docs/upgrading/upgrade-to-1.17.x#audit-headers)                   |
-| 1.17.0+ | Opt out feature         | [PKI sign-intermediate now truncates `notAfter` field to signing issuer](/vault/docs/upgrading/upgrade-to-1.17.x#pki-truncate) |
-| 1.17.0+ | Beta feature deprecated | [Request limiter deprecated](/vault/docs/upgrading/upgrade-to-1.17.x#request-limiter)                                          |
-| 1.17.0+ | Known issue             | [PKI OCSP GET requests can return HTTP redirect responses](/vault/docs/upgrading/upgrade-to-1.17.x#pki-ocsp)                   |
-| 1.17.0  | Known issue             | [Vault Agent and Vault Proxy consume excessive amounts of CPU](/vault/docs/upgrading/upgrade-to-1.17.x#agent-proxy-cpu-1-17)   |
+| Change                  | Description                                                                                                                    |
+|-------------------------|--------------------------------------------------------------------------------------------------------------------------------|
+| New default             | [Allowed audit headers now have unremovable defaults](/vault/docs/upgrading/upgrade-to-1.17.x#audit-headers)                   |
+| Opt out feature         | [PKI sign-intermediate now truncates `notAfter` field to signing issuer](/vault/docs/upgrading/upgrade-to-1.17.x#pki-truncate) |
+| Beta feature deprecated | [Request limiter deprecated](/vault/docs/upgrading/upgrade-to-1.17.x#request-limiter)                                          |
+| Known issue             | [PKI OCSP GET requests can return HTTP redirect responses](/vault/docs/upgrading/upgrade-to-1.17.x#pki-ocsp)                   |
+| Known issue (1.17.0)    | [Vault Agent and Vault Proxy consume excessive amounts of CPU](/vault/docs/upgrading/upgrade-to-1.17.x#agent-proxy-cpu-1-17)   |
 
 ## Vault companion updates
 

--- a/website/content/docs/release-notes/1.17.0.mdx
+++ b/website/content/docs/release-notes/1.17.0.mdx
@@ -13,12 +13,13 @@ description: |-
 
 ## Important changes
 
-| Change                  | Description
-|-------------------------|------------
-| New default             | [Allowed audit headers now have unremovable defaults](/vault/docs/upgrading/upgrade-to-1.17.x#audit-headers)
-| Opt out feature         | [PKI sign-intermediate now truncates `notAfter` field to signing issuer](/vault/docs/upgrading/upgrade-to-1.17.x#pki-truncate)
-| Beta feature deprecated | [Request limiter deprecated](/vault/docs/upgrading/upgrade-to-1.17.x#request-limiter)
-| Known issue             | [PKI OCSP GET requests can return HTTP redirect responses](/vault/docs/upgrading/upgrade-to-1.17.x#pki-ocsp)
+| Version | Change                  | Description                                                                                                                    |
+|---------|-------------------------|--------------------------------------------------------------------------------------------------------------------------------|
+| 1.17.0+ | New default             | [Allowed audit headers now have unremovable defaults](/vault/docs/upgrading/upgrade-to-1.17.x#audit-headers)                   |
+| 1.17.0+ | Opt out feature         | [PKI sign-intermediate now truncates `notAfter` field to signing issuer](/vault/docs/upgrading/upgrade-to-1.17.x#pki-truncate) |
+| 1.17.0+ | Beta feature deprecated | [Request limiter deprecated](/vault/docs/upgrading/upgrade-to-1.17.x#request-limiter)                                          |
+| 1.17.0+ | Known issue             | [PKI OCSP GET requests can return HTTP redirect responses](/vault/docs/upgrading/upgrade-to-1.17.x#pki-ocsp)                   |
+| 1.17.0  | Known issue             | [Vault Agent and Vault Proxy consume excessive amounts of CPU](/vault/docs/upgrading/upgrade-to-1.17.x#agent-proxy-cpu-1-17)   |
 
 ## Vault companion updates
 
@@ -116,7 +117,7 @@ Follow the learn more links for more information, or browse the list of
       Learn more: <a href="/vault/docs/secrets/pki/est">Enrollment over Secure Transport (EST)</a> overview
     </td>
   </tr>
- 
+
    <tr>
     <td style={{verticalAlign: 'middle', textAlign: 'center'}}>GA</td>
     <td style={{verticalAlign: 'middle'}}>

--- a/website/content/docs/release-notes/1.17.0.mdx
+++ b/website/content/docs/release-notes/1.17.0.mdx
@@ -13,13 +13,13 @@ description: |-
 
 ## Important changes
 
-| Change                  | Description                                                                                                                    |
-|-------------------------|--------------------------------------------------------------------------------------------------------------------------------|
-| New default             | [Allowed audit headers now have unremovable defaults](/vault/docs/upgrading/upgrade-to-1.17.x#audit-headers)                   |
-| Opt out feature         | [PKI sign-intermediate now truncates `notAfter` field to signing issuer](/vault/docs/upgrading/upgrade-to-1.17.x#pki-truncate) |
-| Beta feature deprecated | [Request limiter deprecated](/vault/docs/upgrading/upgrade-to-1.17.x#request-limiter)                                          |
-| Known issue             | [PKI OCSP GET requests can return HTTP redirect responses](/vault/docs/upgrading/upgrade-to-1.17.x#pki-ocsp)                   |
-| Known issue (1.17.0)    | [Vault Agent and Vault Proxy consume excessive amounts of CPU](/vault/docs/upgrading/upgrade-to-1.17.x#agent-proxy-cpu-1-17)   |
+| Change                         | Description                                                                                                                    |
+|--------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
+| New default (1.17)             | [Allowed audit headers now have unremovable defaults](/vault/docs/upgrading/upgrade-to-1.17.x#audit-headers)                   |
+| Opt out feature (1.17)         | [PKI sign-intermediate now truncates `notAfter` field to signing issuer](/vault/docs/upgrading/upgrade-to-1.17.x#pki-truncate) |
+| Beta feature deprecated (1.17) | [Request limiter deprecated](/vault/docs/upgrading/upgrade-to-1.17.x#request-limiter)                                          |
+| Known issue (1.17.0+)          | [PKI OCSP GET requests can return HTTP redirect responses](/vault/docs/upgrading/upgrade-to-1.17.x#pki-ocsp)                   |
+| Known issue (1.17.0)           | [Vault Agent and Vault Proxy consume excessive amounts of CPU](/vault/docs/upgrading/upgrade-to-1.17.x#agent-proxy-cpu-1-17)   |
 
 ## Vault companion updates
 

--- a/website/content/docs/upgrading/upgrade-to-1.17.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.17.x.mdx
@@ -83,3 +83,5 @@ incorrectly. For additional details, refer to the
 ## Known issues and workarounds
 
 @include 'known-issues/ocsp-redirect.mdx'
+
+@include 'known-issues/agent-and-proxy-excessive-cpu-1-17.mdx'

--- a/website/content/partials/known-issues/agent-and-proxy-excessive-cpu-1-17.mdx
+++ b/website/content/partials/known-issues/agent-and-proxy-excessive-cpu-1-17.mdx
@@ -1,0 +1,12 @@
+<a id="agent-proxy-cpu-1-17" />
+
+### Vault Agent and Vault Proxy consume an excessive amount of CPU
+
+Vault Agent and Vault Proxy consume an exessive amount of CPU during normal
+operation in 1.17.0.
+
+We recommend waiting until 1.17.1 to upgrade Agent and Proxy.
+
+#### Impacted versions
+
+Affects 1.17.0.

--- a/website/content/partials/known-issues/ocsp-redirect.mdx
+++ b/website/content/partials/known-issues/ocsp-redirect.mdx
@@ -10,4 +10,4 @@ As a workaround, OCSP POST requests can be used which are unaffected.
 
 #### Impacted versions
 
-Affects all current versions of 1.12.x, 1.13.x, 1.14.x, 1.15.x, 1.16.x
+Affects all current versions of 1.12.x, 1.13.x, 1.14.x, 1.15.x, 1.16.x, 1.17.x.


### PR DESCRIPTION
### Description

This adds a known issue for the issue fixed by https://github.com/hashicorp/vault/pull/27518 and described by VAULT-28192.

As per guidance, I added versions to all of the Changes as opposed to adding a new Versions column.

### TODO only if you're a HashiCorp employee
- [x] **Labels:** If this PR is the CE portion of an ENT change, and that ENT change is
  getting backported to N-2, use the new style `backport/ent/x.x.x+ent` labels
  instead of the old style `backport/x.x.x` labels.
- [x] **Labels:** If this PR is a CE only change, it can only be backported to N, so use
  the normal `backport/x.x.x` label (there should be only 1).
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
