### PR TITLE
docs(token): document the token format

### DIFF
--- a/website/content/docs/concepts/tokens.mdx
+++ b/website/content/docs/concepts/tokens.mdx
@@ -36,6 +36,34 @@ Read on for a deeper dive into token concepts.  See the
 [tokens tutorial](/vault/tutorials/tokens/tokens)
 for details on how these concepts play out in practice.
 
+## Token formats
+
+Vault tokens are composed of a _prefix_ and a _body_.
+
+- The _prefix_ indicates the token's type:
+
+  Token Type | Vault 1.9.x or earlier | Vault 1.10 and later
+  -- | -- | --
+  Service tokens | s. | hvs.
+  Batch tokens | b. | hvb.
+  Recovery tokens | r. | hvr.
+
+- The _body_ is a randomly-generated 24 characters [Base62](https://en.wikipedia.org/wiki/Base62) string.
+
+Token are expected to match the following regexp: `(hv)?[sbr]\.[a-zA-Z0-9]{24}`
+
+Examples:
+
+```shell
+# Vault 1.9.x or earlier
+b.n6keuKu5Q6pXhaIcfnC9cFNd
+r.MEOkcS6xauDAZkS4bEvQTpbT
+
+# Vault 1.10 and later
+hvs.R0670sAqZnKX3yW40NddrPVk
+hvb.aYnhlZjetM09MRRc11FSLVk1
+```
+
 ## Token types
 
 As of Vault 1.0, there are two types of tokens: `service` tokens and `batch`


### PR DESCRIPTION
### Description

Add details on the format of Vault tokens, it should hopefully add clear documentation as to one can detect tokens.

The prefix tables comes from https://developer.hashicorp.com/vault/tutorials/tokens/tokens#token-prefix

The body's format was inferred from:
- https://github.com/hashicorp/vault/blob/fe1f36a1dc0afa46e7826709b2c442123fc4e557/vault/token_store.go#L72-L74
- https://github.com/hashicorp/vault/blob/fe1f36a1dc0afa46e7826709b2c442123fc4e557/vault/token_store.go#L999
- https://github.com/hashicorp/vault/blob/fe1f36a1dc0afa46e7826709b2c442123fc4e557/CHANGELOG-v0.md?plain=1#L113-L115

cc https://github.com/hashicorp/vault/issues/27151

### TODO only if you're a HashiCorp employee
- [ ] **Labels:** If this PR is the CE portion of an ENT change, and that ENT change is
  getting backported to N-2, use the new style `backport/ent/x.x.x+ent` labels
  instead of the old style `backport/x.x.x` labels.
- [ ] **Labels:** If this PR is a CE only change, it can only be backported to N, so use
  the normal `backport/x.x.x` label (there should be only 1).
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
