### PR TITLE
Audit: check if context is already cancelled when assessing viability for audit

### DIFF
--- a/audit/broker.go
+++ b/audit/broker.go
@@ -462,6 +462,8 @@ func (b *Broker) IsRegistered(name string) bool {
 
 // isContextViable examines the supplied context to see if its own deadline would
 // occur later than a newly created context with a specific timeout.
+// Additionally, whether the supplied context is already cancelled, thus making it
+// unviable.
 // If the existing context is viable it can be used 'as-is', if not, the caller
 // should consider creating a new context with the relevant deadline and associated
 // context values (e.g. namespace) in order to reduce the likelihood that the
@@ -470,6 +472,12 @@ func (b *Broker) IsRegistered(name string) bool {
 func isContextViable(ctx context.Context) bool {
 	if ctx == nil {
 		return false
+	}
+
+	select {
+	case <-ctx.Done():
+		return false
+	default:
 	}
 
 	deadline, hasDeadline := ctx.Deadline()

--- a/audit/broker_test.go
+++ b/audit/broker_test.go
@@ -160,11 +160,14 @@ func BenchmarkAuditBroker_File_Request_DevNull(b *testing.B) {
 }
 
 // TestBroker_isContextViable_basics checks the expected result of isContextViable
-// for basic inputs such as nil and a never-ending context.
+// for basic inputs such as nil, cancelled context and a never-ending context.
 func TestBroker_isContextViable_basics(t *testing.T) {
 	t.Parallel()
 
 	require.False(t, isContextViable(nil))
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	require.False(t, isContextViable(ctx))
 	require.True(t, isContextViable(context.Background()))
 }
 

--- a/changelog/27531.txt
+++ b/changelog/27531.txt
@@ -1,0 +1,5 @@
+```release-note:bug
+core/audit: Audit logging a Vault request/response checks if the existing context 
+is cancelled and will now use a new context with a 5 second timeout.
+If the existing context is cancelled a new context, will be used.
+```


### PR DESCRIPTION
### Description

When the audit system is asked to log a request or response, it now checks the viability of the existing supplied context. The context is considered unviable if it has `<5s` remaining on its deadline, and a new context is created for use.

However, we're seeing issues where some users are getting audit log failures as the incoming context is already cancelled entirely. This means that audit will fail and report telemetry etc. which isn't what users want. 

This PR includes the cancelled context in its evaluation of viability, and will create a new context with a `5s` timeout if it is cancelled. 

NOTE: We don't just return immediately from `LogRequest` and `LogResponse` if the context was cancelled, as we want to make every effort to capture that Vault was asked to service a request - in the audit log.

Should resolve: https://github.com/hashicorp/vault/issues/27521

