### PR TITLE
clarify the JWT auth bound_audiences change in behaviour

### DIFF
--- a/website/content/docs/upgrading/upgrade-to-1.17.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.17.x.mdx
@@ -70,7 +70,8 @@ The beta request limiter will be removed from Vault entirely in a later release.
 
 ### JWT auth login requires bound audiences on the role
 
-The `bound_audiences` parameter of "jwt" roles **must** match at least one of
+The `bound_audiences` parameter of "jwt" roles is **mandatory** if the JWT contains an audience 
+(which is more often than not the case), and **must** match at least one of
 the JWT's associated `aud` claims. The `aud` claim claim can be a single string
 or a list of strings as per [RFC 7519 Section 4.1.3](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3).
 If the JWT's `aud` claim is not set, then the role's `bound_audiences`

--- a/website/content/partials/known-issues/1_16-jwt_auth_bound_audiences.mdx
+++ b/website/content/partials/known-issues/1_16-jwt_auth_bound_audiences.mdx
@@ -14,8 +14,8 @@ the versions after 1.15.10 and 1.16.4. However, the behavior change will go
 into effect in 1.17.
 
 The new behavior requires that the `bound_audiences` parameter of "jwt" roles
-**must** match at least one of the JWT's associated `aud` claims. The `aud`
-claim can be a single string or a list of strings as per
+**must** be set and **must** match at least one of the JWT's associated `aud` claims if there are any. 
+The `aud` claim can be a single string or a list of strings as per
 [RFC 7519 Section 4.1.3](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3).
 
 Users may not be able to log into Vault if the JWT role is configured


### PR DESCRIPTION
### Description

This PR clarifies the upgrade docs around the JWT bound_audiences change (the fact that it becomes a mandatory field if the JWT presents an `aud`, which is very often the case (e.g. with GitLab)).

