### PR TITLE
add new clients to namespace counts

### DIFF
--- a/vault/activity/query.go
+++ b/vault/activity/query.go
@@ -368,10 +368,10 @@ func (q *PrecomputedQuery) CombineWithCurrentMonth(currentMonth *MonthRecord) {
 		existingNamespaceMounts[monthlyNamespaceRecord.NamespaceID] = monthlyNamespaceRecord
 	}
 
-	// Get the counts of each mount per namespace in the current month, and increment
+	// Get the counts of new clients each mount per namespace in the current month, and increment
 	// its total count in the precomputed query. These total values will be visible in the
 	// by_namespace grouping in the final response data
-	for _, nsRecord := range currentMonth.Namespaces {
+	for _, nsRecord := range currentMonth.NewClients.Namespaces {
 		namespaceId := nsRecord.NamespaceID
 
 		// If the namespace already exists in the previous months, iterate through the mounts and increment the counts

--- a/vault/activity/query_test.go
+++ b/vault/activity/query_test.go
@@ -388,28 +388,28 @@ func TestCombineWithCurrentMonth(t *testing.T) {
 			{
 				NamespaceID: "ns1",
 				Counts: &CountsRecord{
-					EntityClients:    2,
-					NonEntityClients: 2,
-					SecretSyncs:      2,
-					ACMEClients:      2,
+					EntityClients:    4,
+					NonEntityClients: 4,
+					SecretSyncs:      4,
+					ACMEClients:      4,
 				},
 				Mounts: []*MountRecord{
 					{
 						MountPath: "m1",
 						Counts: &CountsRecord{
-							EntityClients:    1,
-							NonEntityClients: 1,
-							SecretSyncs:      1,
-							ACMEClients:      1,
+							EntityClients:    2,
+							NonEntityClients: 2,
+							SecretSyncs:      2,
+							ACMEClients:      2,
 						},
 					},
 					{
 						MountPath: "m2",
 						Counts: &CountsRecord{
-							EntityClients:    1,
-							NonEntityClients: 1,
-							SecretSyncs:      1,
-							ACMEClients:      1,
+							EntityClients:    2,
+							NonEntityClients: 2,
+							SecretSyncs:      2,
+							ACMEClients:      2,
 						},
 					},
 				},
@@ -417,28 +417,28 @@ func TestCombineWithCurrentMonth(t *testing.T) {
 			{
 				NamespaceID: "ns2",
 				Counts: &CountsRecord{
-					EntityClients:    2,
-					NonEntityClients: 2,
-					SecretSyncs:      2,
-					ACMEClients:      2,
+					EntityClients:    4,
+					NonEntityClients: 4,
+					SecretSyncs:      4,
+					ACMEClients:      4,
 				},
 				Mounts: []*MountRecord{
 					{
 						MountPath: "m1",
 						Counts: &CountsRecord{
-							EntityClients:    1,
-							NonEntityClients: 1,
-							SecretSyncs:      1,
-							ACMEClients:      1,
+							EntityClients:    2,
+							NonEntityClients: 2,
+							SecretSyncs:      2,
+							ACMEClients:      2,
 						},
 					},
 					{
 						MountPath: "m3",
 						Counts: &CountsRecord{
-							EntityClients:    1,
-							NonEntityClients: 1,
-							SecretSyncs:      1,
-							ACMEClients:      1,
+							EntityClients:    2,
+							NonEntityClients: 2,
+							SecretSyncs:      2,
+							ACMEClients:      2,
 						},
 					},
 				},
@@ -446,28 +446,119 @@ func TestCombineWithCurrentMonth(t *testing.T) {
 			{
 				NamespaceID: "ns3",
 				Counts: &CountsRecord{
-					EntityClients:    2,
-					NonEntityClients: 2,
-					SecretSyncs:      2,
-					ACMEClients:      2,
+					EntityClients:    4,
+					NonEntityClients: 4,
+					SecretSyncs:      4,
+					ACMEClients:      4,
 				},
 				Mounts: []*MountRecord{
 					{
 						MountPath: "m1",
 						Counts: &CountsRecord{
-							EntityClients:    1,
-							NonEntityClients: 1,
-							SecretSyncs:      1,
-							ACMEClients:      1,
+							EntityClients:    2,
+							NonEntityClients: 2,
+							SecretSyncs:      2,
+							ACMEClients:      2,
 						},
 					},
 					{
 						MountPath: "m2",
 						Counts: &CountsRecord{
-							EntityClients:    1,
-							NonEntityClients: 1,
-							SecretSyncs:      1,
-							ACMEClients:      1,
+							EntityClients:    2,
+							NonEntityClients: 2,
+							SecretSyncs:      2,
+							ACMEClients:      2,
+						},
+					},
+				},
+			},
+		},
+		NewClients: &NewClientRecord{
+			Namespaces: []*MonthlyNamespaceRecord{
+				{
+					NamespaceID: "ns1",
+					Counts: &CountsRecord{
+						EntityClients:    2,
+						NonEntityClients: 2,
+						SecretSyncs:      2,
+						ACMEClients:      2,
+					},
+					Mounts: []*MountRecord{
+						{
+							MountPath: "m1",
+							Counts: &CountsRecord{
+								EntityClients:    1,
+								NonEntityClients: 1,
+								SecretSyncs:      1,
+								ACMEClients:      1,
+							},
+						},
+						{
+							MountPath: "m2",
+							Counts: &CountsRecord{
+								EntityClients:    1,
+								NonEntityClients: 1,
+								SecretSyncs:      1,
+								ACMEClients:      1,
+							},
+						},
+					},
+				},
+				{
+					NamespaceID: "ns2",
+					Counts: &CountsRecord{
+						EntityClients:    2,
+						NonEntityClients: 2,
+						SecretSyncs:      2,
+						ACMEClients:      2,
+					},
+					Mounts: []*MountRecord{
+						{
+							MountPath: "m1",
+							Counts: &CountsRecord{
+								EntityClients:    1,
+								NonEntityClients: 1,
+								SecretSyncs:      1,
+								ACMEClients:      1,
+							},
+						},
+						{
+							MountPath: "m3",
+							Counts: &CountsRecord{
+								EntityClients:    1,
+								NonEntityClients: 1,
+								SecretSyncs:      1,
+								ACMEClients:      1,
+							},
+						},
+					},
+				},
+				{
+					NamespaceID: "ns3",
+					Counts: &CountsRecord{
+						EntityClients:    2,
+						NonEntityClients: 2,
+						SecretSyncs:      2,
+						ACMEClients:      2,
+					},
+					Mounts: []*MountRecord{
+						{
+							MountPath: "m1",
+							Counts: &CountsRecord{
+								EntityClients:    1,
+								NonEntityClients: 1,
+								SecretSyncs:      1,
+								ACMEClients:      1,
+							},
+						},
+						{
+							MountPath: "m2",
+							Counts: &CountsRecord{
+								EntityClients:    1,
+								NonEntityClients: 1,
+								SecretSyncs:      1,
+								ACMEClients:      1,
+							},
 						},
 					},
 				},


### PR DESCRIPTION
### Description
I realized I missed something when reviewing the original PR - this needs to be adding the *new* counts to the existing precomputed query, not the total counts. My bad!!

Updated the test to verify that we're combining the NewClients.Namespaces field, and not Namespaces.

### TODO only if you're a HashiCorp employee
- [x] **Labels:** If this PR is the CE portion of an ENT change, and that ENT change is
  getting backported to N-2, use the new style `backport/ent/x.x.x+ent` labels
  instead of the old style `backport/x.x.x` labels.
- [x] **Labels:** If this PR is a CE only change, it can only be backported to N, so use
  the normal `backport/x.x.x` label (there should be only 1).
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
