### PR TITLE
[BACKPORT] Manual cherry-pick of #27454 to 1.16.x

### DIFF
--- a/website/content/docs/release-notes/1.15.0.mdx
+++ b/website/content/docs/release-notes/1.15.0.mdx
@@ -29,6 +29,8 @@ description: |-
 | 1.15.0 - 1.15.5 | [Deadlock can occur on performance secondary clusters with many mounts](/vault/docs/upgrading/upgrade-to-1.15.x#deadlock-can-occur-on-performance-secondary-clusters-with-many-mounts)                                            |
 | 1.15.0 - 1.15.5 | [Audit fails to recover from panics when formatting audit entries](/vault/docs/upgrading/upgrade-to-1.15.x#audit-fails-to-recover-from-panics-when-formatting-audit-entries)                                                      |
 | 1.15.0 - 1.15.7 | [Vault Enterprise performance standby nodes audit all request headers regardless of settings](/vault/docs/upgrading/upgrade-to-1.15.x#vault-enterprise-performance-standby-nodes-audit-all-request-headers)                       |
+| 1.15.3 - 1.15.9 | [New nodes added by autopilot upgrades provisioned with the wrong version](/vault/docs/upgrading/upgrade-to-1.15.x#new-nodes-added-by-autopilot-upgrades-provisioned-with-the-wrong-version)                                      |
+| 1.15.8+         | [Autopilot upgrade for Vault Enterprise fails](/vault/docs/upgrading/upgrade-to-1.15.x#autopilot)
 
 ## Vault companion updates
 

--- a/website/content/docs/release-notes/1.16.1.mdx
+++ b/website/content/docs/release-notes/1.16.1.mdx
@@ -20,6 +20,8 @@ description: |-
 | 1.16.0+         | [External plugin environment variables take precedence over server variables](/vault/docs/upgrading/upgrade-to-1.16.x#external-plugin-variables)
 | 1.16.0+         | [LDAP auth entity alias names no longer include upndomain](/vault/docs/upgrading/upgrade-to-1.16.x#ldap-auth-entity-alias-names-no-longer-include-upndomain)
 | 1.16.0+         | [Azure secrets engine role creation failing](/vault/docs/upgrading/upgrade-to-1.16.x#azure-secrets-engine-role-creation-failing)
+| 1.16.1 - 1.16.3 | [New nodes added by autopilot upgrades provisioned with the wrong version](/vault/docs/upgrading/upgrade-to-1.15.x#new-nodes-added-by-autopilot-upgrades-provisioned-with-the-wrong-version)
+| 1.15.8+         | [Autopilot upgrade for Vault Enterprise fails](/vault/docs/upgrading/upgrade-to-1.15.x#autopilot)
 
 ## Vault companion updates
 

--- a/website/content/docs/upgrading/upgrade-to-1.15.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.15.x.mdx
@@ -47,6 +47,8 @@ option.
 
 ## Known issues and workarounds
 
+@include 'known-issues/1_15-auto-upgrade.mdx'
+
 @include 'known-issues/transit-managed-keys-panics.mdx'
 
 @include 'known-issues/transit-managed-keys-sign-fails.mdx'

--- a/website/content/partials/known-issues/1_15-auto-upgrade.mdx
+++ b/website/content/partials/known-issues/1_15-auto-upgrade.mdx
@@ -1,0 +1,27 @@
+
+<a id="autopilot" />
+
+### Autopilot upgrade for Vault Enterprise fails
+
+#### Affected versions
+
+- 1.15.8+
+
+#### Issue
+
+The expected process for voter status management does not occur during the
+autopilot upgrade process. The autopilot upgrade process adds new nodes (new version) as
+`target_version_non_voters` then `target_version_voters` but existing nodes (old
+version) fail to upgrade and maintain their current voter status.
+
+#### Workaround
+
+1. Disable autopilot upgrades and manually upgrade all nodes in the cluster.
+1. Explicitly set the `autopilot_upgrade_version` parameter to the desired
+   version in the raft `storage` stanza on your new nodes:
+
+    ```hcl
+    storage "raft" {
+      autopilot_upgrade_version = "1.15.8"
+    }
+    ```


### PR DESCRIPTION
Manual backport of changes in #27454 to the 1.16.x release branch