### PR TITLE
Add chroot known-issue and sync activation-flag release note

### DIFF
--- a/website/content/docs/release-notes/1.16.1.mdx
+++ b/website/content/docs/release-notes/1.16.1.mdx
@@ -19,6 +19,7 @@ description: |-
 | 1.16.0+         | [Default LCQ enabled when upgrading pre-1.9](/vault/docs/upgrading/upgrade-to-1.16.x#default-lcq-pre-1.9-upgrade) |
 | 1.16.0+         | [External plugin environment variables take precedence over server variables](/vault/docs/upgrading/upgrade-to-1.16.x#external-plugin-variables)
 | 1.16.0+         | [LDAP auth entity alias names no longer include upndomain](/vault/docs/upgrading/upgrade-to-1.16.x#ldap-auth-entity-alias-names-no-longer-include-upndomain)
+| 1.16.0+         | [Secrets Sync now requires a one-time flag to operate](/vault/docs/upgrading/upgrade-to-1.16.x#secrets-sync-now-requires-setting-a-one-time-flag-before-use)
 | 1.16.0+         | [Azure secrets engine role creation failing](/vault/docs/upgrading/upgrade-to-1.16.x#azure-secrets-engine-role-creation-failing)
 | 1.16.1 - 1.16.3 | [New nodes added by autopilot upgrades provisioned with the wrong version](/vault/docs/upgrading/upgrade-to-1.15.x#new-nodes-added-by-autopilot-upgrades-provisioned-with-the-wrong-version)
 

--- a/website/content/docs/upgrading/upgrade-to-1.16.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.16.x.mdx
@@ -81,6 +81,13 @@ userattr="userprincipalname"
 Refer to the [LDAP auth method (API)](/vault/api-docs/auth/ldap) page for
 more details on the configuration.
 
+### Secrets Sync now requires setting a one-time flag before use
+
+To use the Secrets Sync feature, the feature must be activated with a new one-time
+operation called an activation-flag. The feature is gated until a Vault operator
+decides to trigger the flag. More information can be found in the
+[secrets sync documentation](vault/docs/sync#activating-the-feature).
+
 ## Known issues and workarounds
 
 @include 'known-issues/1_16-jwt_auth_bound_audiences.mdx'
@@ -104,3 +111,5 @@ more details on the configuration.
 @include 'known-issues/1_13-reload-census-panic-standby.mdx'
 
 @include 'known-issues/autopilot-upgrade-upgrade-version.mdx'
+
+@include 'known-issues/1_16_secrets-sync-chroot-activation.mdx'

--- a/website/content/docs/upgrading/upgrade-to-1.16.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.16.x.mdx
@@ -86,7 +86,7 @@ more details on the configuration.
 To use the Secrets Sync feature, the feature must be activated with a new one-time
 operation called an activation-flag. The feature is gated until a Vault operator
 decides to trigger the flag. More information can be found in the
-[secrets sync documentation](vault/docs/sync#activating-the-feature).
+[secrets sync documentation](/vault/docs/sync#activating-the-feature).
 
 ## Known issues and workarounds
 

--- a/website/content/partials/known-issues/1_16_secrets-sync-chroot-activation.mdx
+++ b/website/content/partials/known-issues/1_16_secrets-sync-chroot-activation.mdx
@@ -1,0 +1,15 @@
+### Secrets Sync cannot be activated from chroot namespace
+
+#### Affected versions
+
+- 1.16.0+
+
+#### Issue
+
+Secrets Sync cannot be activated from the chroot namespace. The Secrets Sync feature
+now requires a new activation-flag to be enabled before it can be used. Writing to
+any `sys/activation-flags/` path currently requires root namespace access.
+
+#### Workaround
+Users can request a Vault operator to activate the feature from the root namespace
+if they lack the necessary access.


### PR DESCRIPTION
### Description
Adds a known issue for chroot namespaces when trying to activate secrets sync. Adds a release note regarding the need to use the new activation-flags for secrets sync.

### TODO only if you're a HashiCorp employee
- [x] **Labels:** If this PR is the CE portion of an ENT change, and that ENT change is
  getting backported to N-2, use the new style `backport/ent/x.x.x+ent` labels
  instead of the old style `backport/x.x.x` labels.
- [x] **Labels:** If this PR is a CE only change, it can only be backported to N, so use
  the normal `backport/x.x.x` label (there should be only 1).
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
