### PR TITLE
Document token format/prefix differences in the token concepts page

### DIFF
--- a/website/content/docs/concepts/tokens.mdx
+++ b/website/content/docs/concepts/tokens.mdx
@@ -44,6 +44,21 @@ about their differences, but it is useful to understand other token concepts
 first. The features in the following sections all apply to service tokens, and
 their applicability to batch tokens is discussed later.
 
+### Token prefixes
+
+Tokens have a specific prefix that indicate their type. As of Vault 1.10, this token
+format was updated. The following table lists the prefix differences. This format
+pattern and its change also apply for recovery tokens. After the prefix, a string of
+24 or more randomly-generated characters is appended.
+
+| Token Type      | Vault 1.9.x or earlier | Vault 1.10 and later |
+|-----------------|------------------------|----------------------|
+| Service tokens  | `s.<random>`           | `hvs.<random>`       |
+| Batch tokens    | `b.<random>`           | `hvb.<random>`       |
+| Recovery tokens | `r.<random>`           | `hvr.<random>`       |
+
+For example, a service token may look like `hvs.CvmS4c0DPTvHv5eJgXWMJg9r`.
+
 ## The token store
 
 Often in documentation or in help channels, the "token store" is referenced.

--- a/website/content/docs/concepts/tokens.mdx
+++ b/website/content/docs/concepts/tokens.mdx
@@ -38,11 +38,12 @@ for details on how these concepts play out in practice.
 
 ## Token types
 
-As of Vault 1.0, there are two types of tokens: `service` tokens and `batch`
-tokens. A section near the bottom of this page contains detailed information
-about their differences, but it is useful to understand other token concepts
-first. The features in the following sections all apply to service tokens, and
-their applicability to batch tokens is discussed later.
+There are three types of tokens. On this page `service` tokens and `batch` tokens are outlined,
+while `recovery` tokens are covered separately in their [own page](/docs/concepts/recovery-mode#recovery-tokens).
+A section near the bottom of this page contains detailed information about their differences,
+but it is useful to understand other token concepts first. The features in the following
+sections all apply to service tokens, and their applicability to batch tokens is discussed
+later.
 
 ### Token prefixes
 

--- a/website/content/docs/concepts/tokens.mdx
+++ b/website/content/docs/concepts/tokens.mdx
@@ -46,7 +46,7 @@ their applicability to batch tokens is discussed later.
 
 ### Token prefixes
 
-Tokens have a specific prefix that indicate their type. As of Vault 1.10, this token
+Tokens have a specific prefix that indicates their type. As of Vault 1.10, this token
 format was updated. The following table lists the prefix differences. This format
 pattern and its change also apply for recovery tokens. After the prefix, a string of
 24 or more randomly-generated characters is appended.


### PR DESCRIPTION
### Description
Briefly explain Vault token prefixes in the concepts page.

### TODO only if you're a HashiCorp employee
- [ ] **Labels:** If this PR is the CE portion of an ENT change, and that ENT change is
  getting backported to N-2, use the new style `backport/ent/x.x.x+ent` labels
  instead of the old style `backport/x.x.x` labels.
- [x] **Labels:** If this PR is a CE only change, it can only be backported to N, so use
  the normal `backport/x.x.x` label (there should be only 1).
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.

Closes #27151