### PR TITLE
VAULT-28281: Pass in accountName variable into validation function

### DIFF
--- a/changelog/27563.txt
+++ b/changelog/27563.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+storage/azure: Fix invalid account name initialization bug
+```

--- a/physical/azure/azure.go
+++ b/physical/azure/azure.go
@@ -69,7 +69,7 @@ func NewAzureBackend(conf map[string]string, logger log.Logger) (physical.Backen
 		}
 	}
 	if err := validateAccountName(accountName); err != nil {
-		return nil, fmt.Errorf("invalid account name %s: %w", name, err)
+		return nil, fmt.Errorf("invalid account name %s: %w", accountName, err)
 	}
 
 	accountKey := os.Getenv("AZURE_ACCOUNT_KEY")

--- a/physical/azure/azure.go
+++ b/physical/azure/azure.go
@@ -68,7 +68,7 @@ func NewAzureBackend(conf map[string]string, logger log.Logger) (physical.Backen
 			return nil, fmt.Errorf("'accountName' must be set")
 		}
 	}
-	if err := validateAccountName(name); err != nil {
+	if err := validateAccountName(accountName); err != nil {
 		return nil, fmt.Errorf("invalid account name %s: %w", name, err)
 	}
 

--- a/physical/azure/azure_test.go
+++ b/physical/azure/azure_test.go
@@ -35,7 +35,7 @@ func testFixture(t *testing.T) (*AzureBackend, func()) {
 	t.Helper()
 
 	ts := time.Now().UnixNano()
-	name := fmt.Sprintf("vlt%d", ts)
+	name := fmt.Sprintf("vlt-%d", ts)
 	_ = os.Setenv("AZURE_BLOB_CONTAINER", name)
 
 	cleanup := func() {}


### PR DESCRIPTION
### Description
Solves Azure Storage Backend initialization issue due to invalid account name. The container name was being passed into the account name verification function which has the potential of violating Azure's storage account name requirements.

### TODO only if you're a HashiCorp employee
- [N/A] **Labels:** If this PR is the CE portion of an ENT change, and that ENT change is
  getting backported to N-2, use the new style `backport/ent/x.x.x+ent` labels
  instead of the old style `backport/x.x.x` labels.
- [✅ ] **Labels:** If this PR is a CE only change, it can only be backported to N, so use
  the normal `backport/x.x.x` label (there should be only 1).
- [N/A] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [✅ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [N/A] **RFC:** If this change has an associated RFC, please link it in the description.
- [N/A] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
