### PR TITLE
VAULT-28307 enos: allow arm64 fips1402 and hsm editions

### DIFF
--- a/enos/enos-scenario-agent.hcl
+++ b/enos/enos-scenario-agent.hcl
@@ -36,12 +36,6 @@ scenario "agent" {
       artifact_type   = ["package"]
     }
 
-    # HSM and FIPS 140-2 are only supported on amd64
-    exclude {
-      arch    = ["arm64"]
-      edition = ["ent.fips1402", "ent.hsm", "ent.hsm.fips1402"]
-    }
-
     # PKCS#11 can only be used on ent.hsm and ent.hsm.fips1402.
     exclude {
       seal    = ["pkcs11"]
@@ -54,8 +48,8 @@ scenario "agent" {
       arch   = ["arm64"]
     }
 
-    # softhsm packages not available for leap/sles; Enos support for softhsm
-    # on amzn2 to be added later.
+    # softhsm packages not available for leap/sles. Enos support for softhsm on amzn2 is
+    # not implemented yet.
     exclude {
       seal   = ["pkcs11"]
       distro = ["amzn2", "leap", "sles"]

--- a/enos/enos-scenario-autopilot.hcl
+++ b/enos/enos-scenario-autopilot.hcl
@@ -41,7 +41,8 @@ scenario "autopilot" {
       artifact_type   = ["package"]
     }
 
-    # HSM and FIPS 140-2 are only supported on amd64
+    # There are no published versions of these artifacts yet. We'll update this to exclude older
+    # versions after our initial publication of these editions for arm64.
     exclude {
       arch    = ["arm64"]
       edition = ["ent.fips1402", "ent.hsm", "ent.hsm.fips1402"]
@@ -59,8 +60,8 @@ scenario "autopilot" {
       arch   = ["arm64"]
     }
 
-    # softhsm packages not available for leap/sles; Enos support for softhsm
-    # on amzn2 to be added later.
+    # softhsm packages not available for leap/sles. Enos support for softhsm on amzn2 is
+    # not implemented yet.
     exclude {
       seal   = ["pkcs11"]
       distro = ["amzn2", "leap", "sles"]

--- a/enos/enos-scenario-proxy.hcl
+++ b/enos/enos-scenario-proxy.hcl
@@ -36,12 +36,6 @@ scenario "proxy" {
       artifact_type   = ["package"]
     }
 
-    # HSM and FIPS 140-2 are only supported on amd64
-    exclude {
-      arch    = ["arm64"]
-      edition = ["ent.fips1402", "ent.hsm", "ent.hsm.fips1402"]
-    }
-
     # PKCS#11 can only be used on ent.hsm and ent.hsm.fips1402.
     exclude {
       seal    = ["pkcs11"]
@@ -54,8 +48,8 @@ scenario "proxy" {
       arch   = ["arm64"]
     }
 
-    # softhsm packages not available for leap/sles; Enos support for softhsm
-    # on amzn2 to be added later.
+    # softhsm packages not available for leap/sles. Enos support for softhsm on amzn2 is
+    # not implemented yet.
     exclude {
       seal   = ["pkcs11"]
       distro = ["amzn2", "leap", "sles"]

--- a/enos/enos-scenario-replication.hcl
+++ b/enos/enos-scenario-replication.hcl
@@ -43,12 +43,6 @@ scenario "replication" {
       artifact_type   = ["package"]
     }
 
-    # HSM and FIPS 140-2 are only supported on amd64
-    exclude {
-      arch    = ["arm64"]
-      edition = ["ent.fips1402", "ent.hsm", "ent.hsm.fips1402"]
-    }
-
     # PKCS#11 can only be used on ent.hsm and ent.hsm.fips1402.
     exclude {
       primary_seal = ["pkcs11"]
@@ -66,8 +60,8 @@ scenario "replication" {
       arch   = ["arm64"]
     }
 
-    # softhsm packages not available for leap/sles; Enos support for softhsm
-    # on amzn2 to be added later.
+    # softhsm packages not available for leap/sles. Enos support for softhsm on amzn2 is
+    # not implemented yet.
     exclude {
       primary_seal = ["pkcs11"]
       distro       = ["amzn2", "leap", "sles"]

--- a/enos/enos-scenario-seal-ha.hcl
+++ b/enos/enos-scenario-seal-ha.hcl
@@ -41,12 +41,6 @@ scenario "seal_ha" {
       artifact_type   = ["package"]
     }
 
-    # HSM and FIPS 140-2 are only supported on amd64
-    exclude {
-      arch    = ["arm64"]
-      edition = ["ent.fips1402", "ent.hsm", "ent.hsm.fips1402"]
-    }
-
     # PKCS#11 can only be used on ent.hsm and ent.hsm.fips1402.
     exclude {
       primary_seal = ["pkcs11"]
@@ -64,15 +58,13 @@ scenario "seal_ha" {
       arch   = ["arm64"]
     }
 
-    # softhsm packages not available for leap/sles; Enos support for softhsm
-    # on amzn2 to be added later.
+    # softhsm packages not available for leap/sles. Enos support for softhsm on amzn2 is
+    # not implemented yet.
     exclude {
       primary_seal = ["pkcs11"]
       distro       = ["amzn2", "leap", "sles"]
     }
 
-    # softhsm packages not available for leap/sles; Enos support for softhsm
-    # on amzn2 to be added later.
     exclude {
       secondary_seal = ["pkcs11"]
       distro         = ["amzn2", "leap", "sles"]

--- a/enos/enos-scenario-smoke.hcl
+++ b/enos/enos-scenario-smoke.hcl
@@ -35,12 +35,6 @@ scenario "smoke" {
       artifact_type   = ["package"]
     }
 
-    # HSM and FIPS 140-2 are only supported on amd64
-    exclude {
-      arch    = ["arm64"]
-      edition = ["ent.fips1402", "ent.hsm", "ent.hsm.fips1402"]
-    }
-
     # PKCS#11 can only be used on ent.hsm and ent.hsm.fips1402.
     exclude {
       seal    = ["pkcs11"]
@@ -53,8 +47,8 @@ scenario "smoke" {
       arch   = ["arm64"]
     }
 
-    # softhsm packages not available for leap/sles; Enos support for softhsm
-    # on amzn2 to be added later.
+    # softhsm packages not available for leap/sles. Enos support for softhsm on amzn2 is
+    # not implemented yet.
     exclude {
       seal   = ["pkcs11"]
       distro = ["amzn2", "leap", "sles"]

--- a/enos/enos-scenario-upgrade.hcl
+++ b/enos/enos-scenario-upgrade.hcl
@@ -52,7 +52,8 @@ scenario "upgrade" {
       initial_version = [for e in matrix.initial_version : e if semverconstraint(e, "<1.11.0-0")]
     }
 
-    # HSM and FIPS 140-2 are only supported on amd64
+    # There are no published versions of these artifacts yet. We'll update this to exclude older
+    # versions after our initial publication of these editions for arm64.
     exclude {
       arch    = ["arm64"]
       edition = ["ent.fips1402", "ent.hsm", "ent.hsm.fips1402"]
@@ -70,8 +71,8 @@ scenario "upgrade" {
       arch   = ["arm64"]
     }
 
-    # softhsm packages not available for leap/sles; Enos support for softhsm
-    # on amzn2 to be added later.
+    # softhsm packages not available for leap/sles. Enos support for softhsm on amzn2 is
+    # not implemented yet.
     exclude {
       seal   = ["pkcs11"]
       distro = ["amzn2", "leap", "sles"]


### PR DESCRIPTION
### Description
In preparation for arm64 builds of `hsm`, `fips1402`, and `hsm.fips1402` editions of Vault Enterprise we'll allow them in our test scenarios.

Enterprise counterpart: https://github.com/hashicorp/vault-enterprise/pull/6106

### TODO only if you're a HashiCorp employee
- [x] **Labels:** If this PR is the CE portion of an ENT change, and that ENT change is
  getting backported to N-2, use the new style `backport/ent/x.x.x+ent` labels
  instead of the old style `backport/x.x.x` labels.
- [x] **Labels:** If this PR is a CE only change, it can only be backported to N, so use
  the normal `backport/x.x.x` label (there should be only 1).
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
