### PR TITLE
Update docs wording with example for static role rotation of access keys for AWS IAM Users

### DIFF
--- a/website/content/api-docs/secret/aws.mdx
+++ b/website/content/api-docs/secret/aws.mdx
@@ -658,9 +658,12 @@ to the configured `rotation_period`.
 <Note>
 
   Vault will create a new credential upon configuration, and if the maximum number of access keys already exist,
-  Vault will rotate the oldest one. Vault must do this to know the credential.
-
-  At each rotation, Vault will rotate the oldest existing credential.
+  Vault will rotate the oldest one. Vault must do this to know the credential. At each rotation, Vault will
+  rotate the oldest existing credential.
+  
+  For example, if an IAM User has no access keys when onboarded into Vault, then Vault will generate its first access
+  key for the user. On the first rotation, Vault will generate a second access key for the user. It is only upon the
+  next rotation cycle that the first access key will now be rotated.
 
 </Note>
 

--- a/website/content/api-docs/secret/aws.mdx
+++ b/website/content/api-docs/secret/aws.mdx
@@ -658,8 +658,8 @@ to the configured `rotation_period`.
 <Note>
 
   Vault will create a new credential upon configuration, and if the maximum number of access keys already exist,
-  Vault will rotate the oldest one. Vault must do this to know the credential. At each rotation, Vault will
-  rotate the oldest existing credential.
+  Vault will rotate the oldest one. Vault must do this to know the credential. At each rotation period, Vault will
+  continue to prioritize rotating the oldest-existing credential.
   
   For example, if an IAM User has no access keys when onboarded into Vault, then Vault will generate its first access
   key for the user. On the first rotation, Vault will generate a second access key for the user. It is only upon the


### PR DESCRIPTION
### Description
Clarifies the rotation of static role access keys using the IAM User example

### TODO only if you're a HashiCorp employee
- [ ] **Labels:** If this PR is the CE portion of an ENT change, and that ENT change is
  getting backported to N-2, use the new style `backport/ent/x.x.x+ent` labels
  instead of the old style `backport/x.x.x` labels.
- [x] **Labels:** If this PR is a CE only change, it can only be backported to N, so use
  the normal `backport/x.x.x` label (there should be only 1).
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.

Closes #27477