### PR TITLE
UI: allow retries for MFA form errors

### DIFF
--- a/changelog/27574.txt
+++ b/changelog/27574.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Display an error and force a timeout when TOTP passcode is incorrect 
+```

--- a/ui/app/components/mfa/mfa-form.js
+++ b/ui/app/components/mfa/mfa-form.js
@@ -102,10 +102,20 @@ export default class MfaForm extends Component {
     }
   }
 
-  @task *newCodeDelay(message) {
-    // parse validity period from error string to initialize countdown
-    this.countdown = parseInt(message.match(/(\d\w seconds)/)[0].split(' ')[0]);
+  @task *newCodeDelay(errorMessage) {
+    let delay;
 
+    // parse validity period from error string to initialize countdown
+    const delayRegExMatches = errorMessage.match(/(\d+\w seconds)/);
+    if (delayRegExMatches && delayRegExMatches.length) {
+      delay = delayRegExMatches[0].split(' ')[0];
+    } else {
+      // default to 30 seconds if error message doesn't specify one
+      delay = 30;
+    }
+    this.countdown = parseInt(delay);
+
+    // skip countdown in testing environment
     if (Ember.testing) return;
 
     while (this.countdown > 0) {

--- a/ui/tests/integration/components/mfa-form-test.js
+++ b/ui/tests/integration/components/mfa-form-test.js
@@ -178,6 +178,8 @@ module('Integration | Component | mfa-form', function (hooks) {
   test('it should show countdown on passcode already used and rate limit errors', async function (assert) {
     const messages = {
       used: 'code already used; new code is available in 30 seconds',
+      // there an intentional typo in the error message (30s seconds)
+      // that is what the backend returns
       limit:
         'maximum TOTP validation attempts 4 exceeded the allowed attempts 3. Please try again in 30s seconds',
     };
@@ -198,7 +200,7 @@ module('Integration | Component | mfa-form', function (hooks) {
 
       assert
         .dom('[data-test-mfa-countdown]')
-        .includesText(expectedTime, 'countdown renders with correct initial value from error response');
+        .includesText('30', 'countdown renders with correct initial value from error response');
       assert.dom('[data-test-mfa-validate]').isDisabled('Button is disabled during countdown');
       assert.dom('[data-test-mfa-passcode]').isDisabled('Input is disabled during countdown');
       assert.dom('[data-test-inline-error-message]').exists('Alert message renders');

--- a/ui/tests/integration/components/mfa-form-test.js
+++ b/ui/tests/integration/components/mfa-form-test.js
@@ -178,8 +178,7 @@ module('Integration | Component | mfa-form', function (hooks) {
   test('it should show countdown on passcode already used and rate limit errors', async function (assert) {
     const messages = {
       used: 'code already used; new code is available in 30 seconds',
-      // there an intentional typo in the error message (30s seconds)
-      // that is what the backend returns
+      // note: the backend returns a duplicate "s" in "30s seconds" in the limit message below. we have intentionally left it as is to ensure our regex for parsing the delay time can handle it
       limit:
         'maximum TOTP validation attempts 4 exceeded the allowed attempts 3. Please try again in 30s seconds',
     };


### PR DESCRIPTION
### :hammer_and_wrench: Description
Fixes a bug where the MFA form wasn't displaying an error message nor countdown when a user tried to enter an incorrect one-time password too many times.
Fixes JIRA ticket # VAULT-28437


### :camera_flash: Screenshots
#### Before (notice missing error banner)
<img width="1840" alt="Screenshot 2024-06-21 at 3 57 30 PM" src="https://github.com/hashicorp/vault/assets/903288/dab5d27f-a084-4400-afc8-3e5ec27e300e">


#### After (error banner & countdown shown, button disabled)
<img width="1840" alt="Screenshot 2024-06-21 at 3 55 36 PM" src="https://github.com/hashicorp/vault/assets/903288/4fb60276-bb22-43c1-b922-688a30f1369d">



### :building_construction: How to Build and Test the Change
To replicate this you'll need to set up MFA and a userpass user. I recommend having two browser windows open: one for the `root` user and one for a userpass user. 

1. Create a policy `test` with all privileges (so the user can eventually enable MFA on their login):
```bash
path "*" {
  capabilities = ["create", "read", "update", "delete", "list", "sudo"]
}
```
2. Enable the `userpass` auth method
3. Create a user with the `test` policy
4. In the left sidebar, click "Multi-factor authentication"
5. Select TOTP and 'next'
6. Fill out `Vault` as the **issuer** (though it doesn't really matter). Enter 2 as the **max validation attempts**. Under **Enforcements** select "skip this step".
7. Click create.
8. Copy the MFA id from the URL. Ex `60c04ac9-943b-79f6-f466-e1f1d2c2fe19` in `mfa/methods/60c04ac9-943b-79f6-f466-e1f1d2c2fe19`
9. In an incognito window, go login as the user you created in step 3.
10. Once you're logged in, click "MFA" from the user dropdown. Paste in the MFA id from step 8.
11. Save the QR code in 1password as a one-time-password.
12. Back in your root user window, create a new enforcement.
13. Enter a name (is can be anything), and select TOTP. from the **MFA methods** search. Under **targets**, select "userpass". Click add to add it to the list of targets.
14. Now, back in your incognito, log out and try to log in again as your userpass user. You should be taken to the MFA form. 
15. Enter an incorrect OTP. You should see an error.
16. Enter an incorrect OTP 3 more times. You should see the countdown, an error indicating that you have tried too many times and must wait, and the button should be disabled.
17. The error should disappear after the countdown is finished.
18. Entering a correct OTP should allow you to log in.

### TODO only if you're a HashiCorp employee
- [x] **Labels:** If this PR is the CE portion of an ENT change, and that ENT change is
  getting backported to N-2, use the new style `backport/ent/x.x.x+ent` labels
  instead of the old style `backport/x.x.x` labels.
- [x] **Labels:** If this PR is a CE only change, it can only be backported to N, so use
  the normal `backport/x.x.x` label (there should be only 1).
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
