### PR TITLE
Prepare CE changes for [census.Agent] SetMetadata

### DIFF
--- a/command/server.go
+++ b/command/server.go
@@ -1711,7 +1711,7 @@ func (c *ServerCommand) Run(args []string) int {
 				sr.NotifyConfigurationReload(srConfig)
 			}
 
-			if err := core.ReloadCensus(); err != nil {
+			if err := core.ReloadCensusManager(); err != nil {
 				c.UI.Error(err.Error())
 			}
 

--- a/vault/activity_log.go
+++ b/vault/activity_log.go
@@ -1016,7 +1016,8 @@ func (a *ActivityLog) SetConfigInit(config activityConfig) {
 	a.defaultReportMonths = config.DefaultReportMonths
 	a.retentionMonths = config.RetentionMonths
 
-	if a.retentionMonths < a.configOverrides.MinimumRetentionMonths {
+	// Let tests override the minimum if they want to.
+	if a.configOverrides.MinimumRetentionMonths > 0 {
 		a.retentionMonths = a.configOverrides.MinimumRetentionMonths
 	}
 

--- a/vault/census.go
+++ b/vault/census.go
@@ -14,7 +14,6 @@ func (c *Core) setupCensusManager() error                        { return nil }
 func (c *Core) BillingStart() time.Time                          { return time.Time{} }
 func (c *Core) AutomatedLicenseReportingEnabled() bool           { return false }
 func (c *Core) CensusAgent() CensusReporter                      { return nil }
-func (c *Core) ReloadCensus() error                              { return nil }
 func (c *Core) teardownCensusManager() error                     { return nil }
 func (c *Core) StartManualCensusSnapshots()                      {}
 func (c *Core) ManualLicenseReportingEnabled() bool              { return false }

--- a/vault/census_stubs_oss.go
+++ b/vault/census_stubs_oss.go
@@ -10,4 +10,5 @@ import "context"
 //go:generate go run github.com/hashicorp/vault/tools/stubmaker
 
 func (c *Core) StartCensusReports(ctx context.Context) {}
-func (c *Core) ReloadCensusActivityLog() error         { return nil }
+func (c *Core) SetRetentionMonths(months int) error    { return nil }
+func (c *Core) ReloadCensusManager() error             { return nil }

--- a/vault/core.go
+++ b/vault/core.go
@@ -2445,15 +2445,12 @@ func (s standardUnsealStrategy) unseal(ctx context.Context, logger log.Logger, c
 			return err
 		}
 
-		if !c.perfStandby {
-			if err := c.setupCensusManager(); err != nil {
-				logger.Error("failed to instantiate the license reporting agent", "error", err)
-			}
-
-			c.StartCensusReports(ctx)
-
-			c.StartManualCensusSnapshots()
+		if err := c.setupCensusManager(); err != nil {
+			logger.Error("failed to instantiate the license reporting agent", "error", err)
 		}
+
+		c.StartCensusReports(ctx)
+		c.StartManualCensusSnapshots()
 
 	} else {
 		broker, err := audit.NewBroker(logger)
@@ -2847,7 +2844,6 @@ func (c *Core) preSeal() error {
 	if err := c.teardownCensusManager(); err != nil {
 		result = multierror.Append(result, fmt.Errorf("error tearing down reporting agent: %w", err))
 	}
-
 	if err := c.teardownCredentials(context.Background()); err != nil {
 		result = multierror.Append(result, fmt.Errorf("error tearing down credentials: %w", err))
 	}


### PR DESCRIPTION
### Description
What does this PR do?

This PR adds the CE plumbing to prepare enterprise for the SetMetadata
API.

Enterprise PR: hashicorp/vault-enterprise#5955
Resolves: VAULT-27310

- [x] **Labels:** If this PR is the CE portion of an ENT change, and that ENT change is
  getting backported to N-2, use the new style `backport/ent/x.x.x+ent` labels
  instead of the old style `backport/x.x.x` labels.
- [x] **Labels:** If this PR is a CE only change, it can only be backported to N, so use
  the normal `backport/x.x.x` label (there should be only 1).
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
