### PR TITLE
[UI tests] remove parallel commands in test

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -31,10 +31,10 @@
     "start:chroot": "ember server --proxy=http://127.0.0.1:8300 --port=4300",
     "test": "concurrently --kill-others-on-fail -P -c \"auto\" -n lint:js,lint:hbs,vault \"yarn:lint:js:quiet\" \"yarn:lint:hbs:quiet\" \"node scripts/start-vault.js {@}\" --",
     "test:enos": "concurrently --kill-others-on-fail -P -c \"auto\" -n lint:js,lint:hbs,enos \"yarn:lint:js:quiet\" \"yarn:lint:hbs:quiet\" \"node scripts/enos-test-ember.js {@}\" --",
-    "test:oss": "yarn run test -f='!enterprise' --split=8 --preserve-test-name --parallel",
+    "test:oss": "yarn run test -f='!enterprise'",
     "test:ent": "node scripts/start-vault.js -f='enterprise'",
-    "test:quick": "node scripts/start-vault.js --split=8 --preserve-test-name --parallel",
-    "test:quick-oss": "node scripts/start-vault.js -f='!enterprise' --split=8 --preserve-test-name --parallel",
+    "test:quick": "node scripts/start-vault.js",
+    "test:quick-oss": "node scripts/start-vault.js -f='!enterprise'",
     "test:filter": "node scripts/start-vault.js --server -f='!enterprise'",
     "vault": "VAULT_REDIRECT_ADDR=http://127.0.0.1:8200 vault server -log-level=error -dev -dev-root-token-id=root -dev-ha -dev-transactional",
     "vault:cluster": "VAULT_REDIRECT_ADDR=http://127.0.0.1:8202 vault server -log-level=error -dev -dev-root-token-id=root -dev-listen-address=127.0.0.1:8202 -dev-ha -dev-transactional"


### PR DESCRIPTION
### Description
This pr removes the `--split=8 --preserve-test-name --parallel"` commands added onto the test suites. We've been hitting consistently failing test in OIDC/KMIP etc only when we run the tests in parallel. For now, we are removing this line and will revisit for the next release cycle.

These commands were added in PR #24669 

### TODO only if you're a HashiCorp employee
- [x] **Labels:** If this PR is the CE portion of an ENT change, and that ENT change is
  getting backported to N-2, use the new style `backport/ent/x.x.x+ent` labels
  instead of the old style `backport/x.x.x` labels.
- [ ] **Labels:** If this PR is a CE only change, it can only be backported to N, so use
  the normal `backport/x.x.x` label (there should be only 1).
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
