### PR TITLE
agent: templates_done_command to run after templates rendered

### DIFF
--- a/command/agent/config/config.go
+++ b/command/agent/config/config.go
@@ -50,6 +50,7 @@ type Config struct {
 	DisableKeepAlivesAutoAuth   bool                       `hcl:"-"`
 	Exec                        *ExecConfig                `hcl:"exec,optional"`
 	EnvTemplates                []*ctconfig.TemplateConfig `hcl:"env_template,optional"`
+	TemplatesDoneCommand        []string                   `hcl:"templates_done_command,optional"`
 }
 
 const (
@@ -288,6 +289,12 @@ func (c *Config) Merge(c2 *Config) *Config {
 
 	for _, envTmpl := range c2.EnvTemplates {
 		result.EnvTemplates = append(result.EnvTemplates, envTmpl)
+	}
+
+	result.TemplatesDoneCommand = append(result.TemplatesDoneCommand, c.TemplatesDoneCommand...)
+	if len(c2.TemplatesDoneCommand) > 0 {
+		result.TemplatesDoneCommand = nil
+		result.TemplatesDoneCommand = append(result.TemplatesDoneCommand, c2.TemplatesDoneCommand...)
 	}
 
 	return result

--- a/command/agent/template/template.go
+++ b/command/agent/template/template.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"os/exec"
 	"strings"
 	sync "sync/atomic"
 	"time"
@@ -236,6 +237,17 @@ func (ts *Server) Run(ctx context.Context, incoming chan string, templates []*ct
 				// This template hasn't been rendered
 				if event.LastWouldRender.IsZero() {
 					doneRendering = false
+				}
+			}
+
+			if doneRendering && len(ts.config.AgentConfig.TemplatesDoneCommand) > 0 {
+				// Run a command if defined
+				ts.logger.Debug("template server: all templates rendered, running a command", "command", ts.config.AgentConfig.TemplatesDoneCommand)
+				err := exec.Command(
+					ts.config.AgentConfig.TemplatesDoneCommand[0],
+					ts.config.AgentConfig.TemplatesDoneCommand[1:]...).Run()
+				if err != nil {
+					ts.logger.Error("template server: error running command", "error", err, "command", ts.config.AgentConfig.TemplatesDoneCommand)
 				}
 			}
 


### PR DESCRIPTION
### Description
Adds an agent config option `templates_done_command` to run a command after all templates are rendered. Part of a native sidecar PoC in https://github.com/hashicorp/vault-k8s/pull/659.

### TODO only if you're a HashiCorp employee
- [ ] **Labels:** If this PR is the CE portion of an ENT change, and that ENT change is
  getting backported to N-2, use the new style `backport/ent/x.x.x+ent` labels
  instead of the old style `backport/x.x.x` labels.
- [ ] **Labels:** If this PR is a CE only change, it can only be backported to N, so use
  the normal `backport/x.x.x` label (there should be only 1).
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
