### PR TITLE
[VAULT-27978] Increase writer request timeout in TestConsulFencing_PartitionedLeaderCantWrite to fix flakiness in CI

### DIFF
--- a/vault/external_tests/consul_fencing_binary/consul_fencing_test.go
+++ b/vault/external_tests/consul_fencing_binary/consul_fencing_test.go
@@ -29,18 +29,17 @@ import (
 // (and Consul lock improvements) and should _never_ fail now we correctly fence
 // writes.
 func TestConsulFencing_PartitionedLeaderCantWrite(t *testing.T) {
-	t.Skip("Skipping the test due to flakiness, it will be resolved in VAULT-27978.")
-
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 
 	consulStorage := consul.NewClusterStorage()
 
-	// Create  cluster logger that will dump cluster logs to stdout for debugging.
+	// Create  cluster logger that will write cluster logs to a file in CI.
 	logger := corehelpers.NewTestLogger(t)
 	logger.SetLevel(hclog.Trace)
 
 	clusterOpts := docker.DefaultOptions(t)
+	// We can use an enterprise image here because we are swapping out the binary anyway.
 	clusterOpts.ImageRepo = "hashicorp/vault-enterprise"
 	clusterOpts.ClusterOptions.Logger = logger
 
@@ -119,7 +118,7 @@ func TestConsulFencing_PartitionedLeaderCantWrite(t *testing.T) {
 	require.NoError(t, err)
 
 	const interval = 500 * time.Millisecond
-
+	const timeout = 4 * time.Second
 	runWriter := func(i int, targetServer testcluster.VaultClusterNode, ctr *uint64) {
 		wg.Add(1)
 		defer wg.Done()
@@ -128,10 +127,13 @@ func TestConsulFencing_PartitionedLeaderCantWrite(t *testing.T) {
 		for {
 			key := fmt.Sprintf("c%d-%08d", i, atomic.LoadUint64(ctr))
 
-			// Use a short timeout. If we don't then the one goroutine writing to the
-			// partitioned active node can get stuck here until the 60 second request
-			// timeout kicks in without issuing another request.
-			reqCtx, cancel := context.WithTimeout(ctx, interval)
+			// Use a short timeout. If we don't then the one goroutine writing
+			// to the partitioned active node can get stuck here until the 60
+			// second request timeout kicks in without issuing another request.
+			// However, this timeout being too short can cause issues too.
+			// Having it set to 500 milliseconds caused the test to
+			// intermittently fail in CI before.
+			reqCtx, cancel := context.WithTimeout(ctx, timeout)
 			logger.Debug("sending patch", "client", i, "key", key)
 			_, err = kv.Patch(reqCtx, "data", map[string]interface{}{
 				key: 1,
@@ -217,7 +219,7 @@ func TestConsulFencing_PartitionedLeaderCantWrite(t *testing.T) {
 			logger.Info("failed write", "write_count", writesAfterPartition, "err", err)
 		default:
 		}
-		require.NoError(t, ctx.Err())
+		require.NoError(t, ctx.Err(), "context error while waiting for writes to new leader")
 	}
 
 	// Heal partition

--- a/vault/external_tests/consul_fencing_binary/consul_fencing_test.go
+++ b/vault/external_tests/consul_fencing_binary/consul_fencing_test.go
@@ -118,7 +118,7 @@ func TestConsulFencing_PartitionedLeaderCantWrite(t *testing.T) {
 	require.NoError(t, err)
 
 	const interval = 500 * time.Millisecond
-	const timeout = 4 * time.Second
+	const timeout = 3 * time.Second
 	runWriter := func(i int, targetServer testcluster.VaultClusterNode, ctr *uint64) {
 		wg.Add(1)
 		defer wg.Done()


### PR DESCRIPTION
### Description
This PR increases the timeout used by the requests by writer goroutines in TestConsulFencing_PartitionedLeaderCantWrite to address the test's flakiness in our enterprise repo's CI.

#### Background
This test used to very frequently fail (flake) in our CI (over 10% runs flaking on long-running branches) in the enterprise repo.  Upon investigation, we've found that the test used to get stuck in the forever loop around line 208, since all of the requests were timing out. We've run the test a few times in our enterprise CI and it passed every time. That does not mean that the flakiness is gone, but the plan going forward is to merge this fix in and monitor the test in CI.

### TODO only if you're a HashiCorp employee
- [x] **Labels:** If this PR is the CE portion of an ENT change, and that ENT change is
  getting backported to N-2, use the new style `backport/ent/x.x.x+ent` labels
  instead of the old style `backport/x.x.x` labels.
- [x] **Labels:** If this PR is a CE only change, it can only be backported to N, so use
  the normal `backport/x.x.x` label (there should be only 1).
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
