### PR TITLE
Add support for blocking profiles

### DIFF
--- a/command/debug.go
+++ b/command/debug.go
@@ -773,7 +773,11 @@ func (c *DebugCommand) collectPprof(ctx context.Context) {
 			wg.Add(1)
 			go func(target string) {
 				defer wg.Done()
-				data, err := pprofTarget(ctx, c.cachedClient, target, nil)
+
+				seconds := int(c.flagInterval.Seconds())
+				secStr := strconv.Itoa(seconds)
+
+				data, err := pprofTarget(ctx, c.cachedClient, target, url.Values{"seconds": []string{secStr}})
 				if err != nil {
 					c.captureError("pprof."+target, err)
 					return

--- a/http/handler.go
+++ b/http/handler.go
@@ -227,7 +227,7 @@ func handler(props *vault.HandlerProperties) http.Handler {
 
 		if props.ListenerConfig != nil && props.ListenerConfig.Profiling.UnauthenticatedPProfAccess {
 			for _, name := range []string{"goroutine", "threadcreate", "heap", "allocs", "block", "mutex"} {
-				mux.Handle("/v1/sys/pprof/"+name, pprof.Handler(name))
+				mux.Handle("/v1/sys/pprof/"+name, handlePprofNamedIndexRequest(core, name))
 			}
 			mux.Handle("/v1/sys/pprof/", http.HandlerFunc(pprof.Index))
 			mux.Handle("/v1/sys/pprof/cmdline", http.HandlerFunc(pprof.Cmdline))

--- a/http/sys_pprof_index_requests.go
+++ b/http/sys_pprof_index_requests.go
@@ -1,0 +1,37 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package http
+
+import (
+	"net/http"
+	"net/http/pprof"
+	"runtime"
+
+	"github.com/hashicorp/vault/vault"
+)
+
+// handlePprofNamedIndexRequest returns an http.Handler that serves the pprof
+// profile corresponding to "name".  The list of valid profiles includes:
+// "cmdline", "profile", "symbol", "trace", "allocs", "block", "goroutine",
+// "heap", "mutex", "threadcreate".
+//
+// Where applicable, we apply runtime settings to ensure the profiles produce
+// output.
+func handlePprofNamedIndexRequest(core *vault.Core, name string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		core.Logger().Debug("handling pprof", "name", name)
+
+		// Blocking profiles need to be provided a sampling rate.
+		switch name {
+		case "block":
+			runtime.SetBlockProfileRate(1)
+			defer runtime.SetBlockProfileRate(0)
+		case "mutex":
+			runtime.SetMutexProfileFraction(1)
+			defer runtime.SetMutexProfileFraction(0)
+		}
+
+		pprof.Handler(name).ServeHTTP(w, r)
+	})
+}


### PR DESCRIPTION
### Description

This PR adds support for blocking profiles to the pprof endpoints. In
order to do this, we introduce a new wrapping handler to set
profile-specific runtime attributes.

While we're at it, add support for the `interval` HTTP parameter, and
add some extra logging.

- [ ] **Labels:** If this PR is the CE portion of an ENT change, and that ENT change is
  getting backported to N-2, use the new style `backport/ent/x.x.x+ent` labels
  instead of the old style `backport/x.x.x` labels.
- [ ] **Labels:** If this PR is a CE only change, it can only be backported to N, so use
  the normal `backport/x.x.x` label (there should be only 1).
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
