### PR TITLE
actions: use the Github API for pull request labels

### DIFF
--- a/.github/actions/metadata/action.yml
+++ b/.github/actions/metadata/action.yml
@@ -102,10 +102,11 @@ runs:
         if [ '${{ github.event_name }}' = 'pull_request' ]; then
           is_draft='${{ github.event.pull_request.draft }}'
 
-          # Determine our labels. If our event type is pull_request this is rather straight forward. If
-          # our even_type is push (merge) we'll need to look up the pull request associated with the
-          # commit and get the labels. This will return the label names as an array.
-          labels=$(jq -rc <<< '${{ toJSON(github.event.pull_request.labels.*.name) }}')
+          # Determine our pull request labels. We specifically look them up via the pulls API
+          # because at some point they stopped being reliable in the
+          # github.event.pull_request.labels.*.name context.
+
+          labels=$(gh api "/repos/${{ github.repository }}/issues/${{ github.event.number }}/labels" | jq -erc '. | map(.name)')
         else
           is_draft='false'
 


### PR DESCRIPTION
### Description
We have seen instances where the `github.event.pull_request.labels.*.name` context in Github Actions doesn't actually include the labels. I suspect this is due to an incomplete webhook. Instead of relying on that context we'll query the API for labels ourselves. 


### TODO only if you're a HashiCorp employee
- [x] **Labels:** If this PR is the CE portion of an ENT change, and that ENT change is
  getting backported to N-2, use the new style `backport/ent/x.x.x+ent` labels
  instead of the old style `backport/x.x.x` labels.
- [x] **Labels:** If this PR is a CE only change, it can only be backported to N, so use
  the normal `backport/x.x.x` label (there should be only 1).
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
