### PR TITLE
Add section clarifying Agent and Proxy availability

### DIFF
--- a/website/content/docs/agent-and-proxy/index.mdx
+++ b/website/content/docs/agent-and-proxy/index.mdx
@@ -84,6 +84,9 @@ obtain secrets and provide them to applications, and Vault Proxy can act as
 a proxy between Vault and the application, optionally simplifying the authentication process
 and caching requests.
 
+As with most other CLI commands for the Vault binary, neither Vault Agent nor Vault Proxy
+require a Vault Enterprise license, and are available in all Vault binaries and images.
+
 
 | Capability                                                                               |    Vault Agent     | Vault Proxy |
 |------------------------------------------------------------------------------------------|:------------------:|:-----------:|

--- a/website/content/docs/agent-and-proxy/index.mdx
+++ b/website/content/docs/agent-and-proxy/index.mdx
@@ -85,8 +85,9 @@ a proxy between Vault and the application, optionally simplifying the authentica
 and caching requests.
 
 As with most other CLI commands for the Vault binary, neither Vault Agent nor Vault Proxy
-require a Vault Enterprise license, and are available in all Vault binaries and images.
-
+require a Vault Enterprise license, and are available in all Vault binaries and images. Note
+however that some features, such as [static secret caching][static-secret-caching] are only
+available when connected to a Vault Enterprise server.
 
 | Capability                                                                               |    Vault Agent     | Vault Proxy |
 |------------------------------------------------------------------------------------------|:------------------:|:-----------:|
@@ -95,6 +96,7 @@ require a Vault Enterprise license, and are available in all Vault binaries and 
 | Run as a [Windows Service][winsvc]                                                       |         x          |      x      |
 | [Templating][template] to render user-supplied templates                                 |         x          |             |
 | [API Proxy][apiproxy] to act as a proxy for Vault API                                    | Will be deprecated |      x      |
+| [Static secret caching][static-secret-caching] for KV secrets                            |                    |      x      |
 | [Process Supervisor][exec] for injecting secrets as environment variables into a process |         x          |             |
 
 To learn more, refer to the [Vault Agent][vaultagent] or [Vault
@@ -102,7 +104,8 @@ Proxy][vaultproxy] documentation page.
 
 
 [autoauth]: /vault/docs/agent-and-proxy/autoauth
-[caching]: /vault/docs/agent-and-proxy/agent/caching
+[caching]: /vault/docs/agent-and-proxy/proxy/caching
+[static-secret-caching]: /vault/docs/agent-and-proxy/static-secret-caching/caching/static-secret-caching
 [apiproxy]: /vault/docs/agent-and-proxy/proxy/apiproxy
 [template]: /vault/docs/agent-and-proxy/agent/template
 [exec]: /vault/docs/agent-and-proxy/agent/process-supervisor

--- a/website/content/docs/agent-and-proxy/index.mdx
+++ b/website/content/docs/agent-and-proxy/index.mdx
@@ -86,7 +86,7 @@ and caching requests.
 
 As with most other CLI commands for the Vault binary, neither Vault Agent nor Vault Proxy
 require a Vault Enterprise license, and are available in all Vault binaries and images. Note
-however that some features, such as [static secret caching][static-secret-caching] are only
+however that some features, such as [static secret caching][static-secret-caching], are only
 available when connected to a Vault Enterprise server.
 
 | Capability                                                                               |    Vault Agent     | Vault Proxy |

--- a/website/content/docs/agent-and-proxy/index.mdx
+++ b/website/content/docs/agent-and-proxy/index.mdx
@@ -92,12 +92,12 @@ available when connected to a Vault Enterprise server.
 | Capability                                                                               |    Vault Agent     | Vault Proxy |
 |------------------------------------------------------------------------------------------|:------------------:|:-----------:|
 | [Auto-Auth][autoauth] to authenticate with Vault                                         |         x          |      x      |
-| [Caching][caching] the newly created tokens and leases                                   |         x          |      x      |
 | Run as a [Windows Service][winsvc]                                                       |         x          |      x      |
+| [Caching][caching] the newly created tokens and leases                                   |         x          |      x      |
 | [Templating][template] to render user-supplied templates                                 |         x          |             |
+| [Process Supervisor][exec] for injecting secrets as environment variables into a process |         x          |             |
 | [API Proxy][apiproxy] to act as a proxy for Vault API                                    | Will be deprecated |      x      |
 | [Static secret caching][static-secret-caching] for KV secrets                            |                    |      x      |
-| [Process Supervisor][exec] for injecting secrets as environment variables into a process |         x          |             |
 
 To learn more, refer to the [Vault Agent][vaultagent] or [Vault
 Proxy][vaultproxy] documentation page.

--- a/website/content/docs/agent-and-proxy/index.mdx
+++ b/website/content/docs/agent-and-proxy/index.mdx
@@ -105,7 +105,7 @@ Proxy][vaultproxy] documentation page.
 
 [autoauth]: /vault/docs/agent-and-proxy/autoauth
 [caching]: /vault/docs/agent-and-proxy/proxy/caching
-[static-secret-caching]: /vault/docs/agent-and-proxy/static-secret-caching/caching/static-secret-caching
+[static-secret-caching]: /vault/docs/agent-and-proxy/proxy/caching/static-secret-caching
 [apiproxy]: /vault/docs/agent-and-proxy/proxy/apiproxy
 [template]: /vault/docs/agent-and-proxy/agent/template
 [exec]: /vault/docs/agent-and-proxy/agent/process-supervisor


### PR DESCRIPTION
### Description

Clarifies that Agent and Proxy are available in both CE/ent binaries/images as this has been confusing in the field.

I also updated and re-ordered the table to make it a little nicer.

See and interact here: https://vault-git-violethynes-clarify-agent-proxy-cli-usage-hashicorp.vercel.app/vault/docs/agent-and-proxy

<img width="721" alt="image" src="https://github.com/hashicorp/vault/assets/1594272/ecdd189e-cae6-451b-9c87-ba913a9de43b">

### TODO only if you're a HashiCorp employee
- [x] **Labels:** If this PR is the CE portion of an ENT change, and that ENT change is
  getting backported to N-2, use the new style `backport/ent/x.x.x+ent` labels
  instead of the old style `backport/x.x.x` labels.
- [x] **Labels:** If this PR is a CE only change, it can only be backported to N, so use
  the normal `backport/x.x.x` label (there should be only 1).
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
