### PR TITLE
add retry logic in ldap.PrepareTestContainer

### DIFF
--- a/helper/testhelpers/ldap/ldaphelper.go
+++ b/helper/testhelpers/ldap/ldaphelper.go
@@ -49,35 +49,47 @@ func PrepareTestContainer(t *testing.T, version string) (cleanup func(), cfg *ld
 	cfg.RequestTimeout = 60
 	cfg.MaximumPageSize = 1000
 
-	svc, err := runner.StartService(context.Background(), func(ctx context.Context, host string, port int) (docker.ServiceConfig, error) {
-		connURL := fmt.Sprintf("ldap://%s:%d", host, port)
-		cfg.Url = connURL
+	var started bool
 
-		client, err := ldap.NewClient(ctx, ldaputil.ConvertConfig(cfg))
+	for i := 0; i < 3; i++ {
+		svc, err := runner.StartService(context.Background(), func(ctx context.Context, host string, port int) (docker.ServiceConfig, error) {
+			connURL := fmt.Sprintf("ldap://%s:%d", host, port)
+			cfg.Url = connURL
+
+			client, err := ldap.NewClient(ctx, ldaputil.ConvertConfig(cfg))
+			if err != nil {
+				return nil, err
+			}
+
+			defer client.Close(ctx)
+
+			_, err = client.Authenticate(ctx, "Philip J. Fry", "fry")
+			if err != nil {
+				return nil, err
+			}
+
+			return docker.NewServiceURLParse(connURL)
+		})
 		if err != nil {
-			return nil, err
+			t.Logf("could not start local LDAP docker container: %s", err)
+			t.Log("Docker container logs: ")
+			t.Log(logsWriter.String())
+			continue
 		}
 
-		defer client.Close(ctx)
-
-		_, err = client.Authenticate(ctx, "Philip J. Fry", "fry")
-		if err != nil {
-			return nil, err
+		started = true
+		cleanup = func() {
+			if t.Failed() {
+				t.Log(logsWriter.String())
+			}
+			svc.Cleanup()
 		}
+		break
+	}
 
-		return docker.NewServiceURLParse(connURL)
-	})
-	if err != nil {
-		t.Logf("could not start local LDAP docker container: %s", err)
-		t.Log("Docker container logs: ")
-		t.Log(logsWriter.String())
+	if !started {
 		t.FailNow()
 	}
 
-	return func() {
-		if t.Failed() {
-			t.Log(logsWriter.String())
-		}
-		svc.Cleanup()
-	}, cfg
+	return cleanup, cfg
 }


### PR DESCRIPTION
### Description
This PR adds a for loop to try up to 3 times to call runner.StartService successfully in the helper/testhelpers/ldap package. This function is used by testing functions.

### TODO only if you're a HashiCorp employee
- [x] **Labels:** If this PR is the CE portion of an ENT change, and that ENT change is
  getting backported to N-2, use the new style `backport/ent/x.x.x+ent` labels
  instead of the old style `backport/x.x.x` labels.
- [x] **Labels:** If this PR is a CE only change, it can only be backported to N, so use
  the normal `backport/x.x.x` label (there should be only 1).
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
