### PR TITLE
AWS secrets: add support for STS session tags

### DIFF
--- a/builtin/logical/aws/backend_test.go
+++ b/builtin/logical/aws/backend_test.go
@@ -140,6 +140,7 @@ func TestAcceptanceBackend_basicSTS(t *testing.T) {
 	})
 }
 
+// TestBackend_policyCRUD tests the CRUD operations for a policy.
 func TestBackend_policyCRUD(t *testing.T) {
 	t.Parallel()
 	compacted, err := compactJSON(testDynamoPolicy)
@@ -1245,6 +1246,8 @@ func TestAcceptanceBackend_AssumedRoleWithGroups(t *testing.T) {
 	})
 }
 
+// TestAcceptanceBackend_AssumedRoleWithSessionTags tests that session tags are
+// passed to the assumed role.
 func TestAcceptanceBackend_AssumedRoleWithSessionTags(t *testing.T) {
 	t.Parallel()
 	roleName := generateUniqueRoleName(t.Name())
@@ -1380,6 +1383,7 @@ func TestAcceptanceBackend_FederationTokenWithGroups(t *testing.T) {
 	})
 }
 
+// TestAcceptanceBackend_SessionToken
 func TestAcceptanceBackend_SessionToken(t *testing.T) {
 	t.Parallel()
 	userName := generateUniqueUserName(t.Name())
@@ -1495,6 +1499,7 @@ func TestAcceptanceBackend_RoleDefaultSTSTTL(t *testing.T) {
 	})
 }
 
+// TestBackend_policyArnCRUD test the CRUD operations for policy ARNs.
 func TestBackend_policyArnCRUD(t *testing.T) {
 	t.Parallel()
 	logicaltest.Test(t, logicaltest.TestCase{
@@ -1557,6 +1562,7 @@ func testAccStepWriteArnRoleRef(t *testing.T, vaultRoleName, awsRoleName, awsAcc
 	}
 }
 
+// TestBackend_iamGroupsCRUD tests CRUD operations for IAM groups.
 func TestBackend_iamGroupsCRUD(t *testing.T) {
 	t.Parallel()
 	logicaltest.Test(t, logicaltest.TestCase{
@@ -1620,6 +1626,7 @@ func testAccStepReadIamGroups(t *testing.T, name string, groups []string) logica
 	}
 }
 
+// TestBackend_iamTagsCRUD tests the CRUD operations for IAM tags.
 func TestBackend_iamTagsCRUD(t *testing.T) {
 	logicaltest.Test(t, logicaltest.TestCase{
 		AcceptanceTest: false,
@@ -1682,6 +1689,7 @@ func testAccStepReadIamTags(t *testing.T, name string, tags map[string]string) l
 	}
 }
 
+// TestBackend_stsSessionTagsCRUD tests the CRUD operations for STS session tags.
 func TestBackend_stsSessionTagsCRUD(t *testing.T) {
 	t.Parallel()
 

--- a/builtin/logical/aws/path_user.go
+++ b/builtin/logical/aws/path_user.go
@@ -157,7 +157,7 @@ func (b *backend) pathCredsRead(ctx context.Context, req *logical.Request, d *fr
 		case !strutil.StrListContains(role.RoleArns, roleArn):
 			return logical.ErrorResponse(fmt.Sprintf("role_arn %q not in allowed role arns for Vault role %q", roleArn, roleName)), nil
 		}
-		return b.assumeRole(ctx, req.Storage, req.DisplayName, roleName, roleArn, role.PolicyDocument, role.PolicyArns, role.IAMGroups, ttl, roleSessionName)
+		return b.assumeRole(ctx, req.Storage, req.DisplayName, roleName, roleArn, role.PolicyDocument, role.PolicyArns, role.IAMGroups, ttl, roleSessionName, role.SessionTags, role.ExternalID)
 	case federationTokenCred:
 		return b.getFederationToken(ctx, req.Storage, req.DisplayName, roleName, role.PolicyDocument, role.PolicyArns, role.IAMGroups, ttl)
 	case sessionTokenCred:

--- a/changelog/27620.txt
+++ b/changelog/27620.txt
@@ -1,0 +1,5 @@
+```release-note:feature
+**AWS secrets engine STS session tags support**: Adds support for setting STS
+session tags when generating temporary credentials using the AWS secrets
+engine.
+```

--- a/website/content/api-docs/secret/aws.mdx
+++ b/website/content/api-docs/secret/aws.mdx
@@ -31,7 +31,7 @@ files, or IAM/ECS instances.
 
 - Static credentials provided to the API as a payload
 
-- [Plugin workload identity federation](/vault/docs/secrets/aws#plugin-workload-identity-federation-wif) 
+- [Plugin workload identity federation](/vault/docs/secrets/aws#plugin-workload-identity-federation-wif)
   credentials
 
 - Credentials in the `AWS_ACCESS_KEY`, `AWS_SECRET_KEY`, and `AWS_REGION`
@@ -60,15 +60,15 @@ valid AWS credentials with proper permissions.
 - `secret_key` `(string: "")` – Specifies the AWS secret access key. Must be provided with
   `access_key`.
 
-- `role_arn` `(string: "")` – <EnterpriseAlert product="vault" inline /> Role ARN to assume 
+- `role_arn` `(string: "")` – <EnterpriseAlert product="vault" inline /> Role ARN to assume
   for plugin workload identity federation. Required with `identity_token_audience`.
 
-- `identity_token_audience` `(string: "")` - <EnterpriseAlert product="vault" inline /> The 
-  audience claim value for plugin identity tokens. Must match an allowed audience configured 
+- `identity_token_audience` `(string: "")` - <EnterpriseAlert product="vault" inline /> The
+  audience claim value for plugin identity tokens. Must match an allowed audience configured
   for the target [IAM OIDC identity provider](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc.html#manage-oidc-provider-console).
   Mutually exclusive with `access_key`.
 
-- `identity_token_ttl` `(string/int: 3600)` - <EnterpriseAlert product="vault" inline /> The 
+- `identity_token_ttl` `(string/int: 3600)` - <EnterpriseAlert product="vault" inline /> The
   TTL of generated tokens. Defaults to 1 hour. Uses [duration format strings](/vault/docs/concepts/duration-format).
 
 - `region` `(string: <optional>)` – Specifies the AWS region. If not set it
@@ -315,6 +315,13 @@ updated with the new attributes.
 - `max_sts_ttl` `(string)` - The max allowed TTL for STS credentials (credentials
   TTL are capped to `max_sts_ttl`). Valid only when `credential_type` is one of
   `assumed_role` or `federation_token`.
+
+- `session_tags` `(list: [])` - The set of key-value pairs to be included as tags for the STS session.
+  Allowed formats are a map of strings or a list of strings in the format `key=value`.
+  Valid only when `credential_type` is set to `assumed_role`.
+
+- `external_id` `(string)` -  The external ID to use when assuming the role.
+  Valid only when `credential_type` is set to `assumed_role`.
 
 - `user_path` `(string)` - The path for the user name. Valid only when
   `credential_type` is `iam_user`. Default is `/`
@@ -645,7 +652,7 @@ $ curl \
   "data": {
     "access_key": "AKIA...",
     "secret_key": "xlCs...",
-    "session_token": "FwoG...",
+    "session_token": "FwoG..."
   }
 }
 ```
@@ -658,12 +665,9 @@ to the configured `rotation_period`.
 <Note>
 
   Vault will create a new credential upon configuration, and if the maximum number of access keys already exist,
-  Vault will rotate the oldest one. Vault must do this to know the credential. At each rotation period, Vault will
-  continue to prioritize rotating the oldest-existing credential.
-  
-  For example, if an IAM User has no access keys when onboarded into Vault, then Vault will generate its first access
-  key for the user. On the first rotation, Vault will generate a second access key for the user. It is only upon the
-  next rotation cycle that the first access key will now be rotated.
+  Vault will rotate the oldest one. Vault must do this to know the credential.
+
+  At each rotation, Vault will rotate the oldest existing credential.
 
 </Note>
 

--- a/website/content/api-docs/secret/aws.mdx
+++ b/website/content/api-docs/secret/aws.mdx
@@ -665,9 +665,12 @@ to the configured `rotation_period`.
 <Note>
 
   Vault will create a new credential upon configuration, and if the maximum number of access keys already exist,
-  Vault will rotate the oldest one. Vault must do this to know the credential.
+  Vault will rotate the oldest one. Vault must do this to know the credential. At each rotation period, Vault will
+  continue to prioritize rotating the oldest-existing credential.
 
-  At each rotation, Vault will rotate the oldest existing credential.
+  For example, if an IAM User has no access keys when onboarded into Vault, then Vault will generate its first access
+  key for the user. On the first rotation, Vault will generate a second access key for the user. It is only upon the
+  next rotation cycle that the first access key will now be rotated.
 
 </Note>
 


### PR DESCRIPTION
Adds support for configuring session tags for assume role operations.

This PR takes over the work started in #18813

See https://github.com/hashicorp/vault/pull/18813#issue-1554095028 for details.

### TODO only if you're a HashiCorp employee
- [x] **Labels:** If this PR is the CE portion of an ENT change, and that ENT change is
  getting backported to N-2, use the new style `backport/ent/x.x.x+ent` labels
  instead of the old style `backport/x.x.x` labels.
- [x] **Labels:** If this PR is a CE only change, it can only be backported to N, so use
  the normal `backport/x.x.x` label (there should be only 1).
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.