### PR TITLE
Force rotate root to the active node

### DIFF
--- a/changelog/27631.txt
+++ b/changelog/27631.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core: Fixed an issue with performance standbys not being able to handle rotate root requests.
+```

--- a/vault/logical_system_paths.go
+++ b/vault/logical_system_paths.go
@@ -1832,6 +1832,7 @@ func (b *SystemBackend) sealPaths() []*framework.Path {
 							Description: "OK",
 						}},
 					},
+					ForwardPerformanceStandby: true,
 				},
 			},
 


### PR DESCRIPTION
### Description
Force the rotate root (/sys/rotate) api call to the active node. 
ENT portion which includes tests [PR](https://github.com/hashicorp/vault-enterprise/pull/6149)
[JIRA reporting bug](https://hashicorp.atlassian.net/browse/VAULT-20017)

### TODO only if you're a HashiCorp employee
- [x] **Labels:** If this PR is the CE portion of an ENT change, and that ENT change is
  getting backported to N-2, use the new style `backport/ent/x.x.x+ent` labels
  instead of the old style `backport/x.x.x` labels.
- [x] **Labels:** If this PR is a CE only change, it can only be backported to N, so use
  the normal `backport/x.x.x` label (there should be only 1).
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
