### PR TITLE
Make mountsLock and authLock in Core configurable

### DIFF
--- a/changelog/27633.txt
+++ b/changelog/27633.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+core: make authLock and mountsLock in Core configurable via the detect_deadlocks configuration parameter.
+```

--- a/vault/core.go
+++ b/vault/core.go
@@ -375,7 +375,7 @@ type Core struct {
 
 	// mountsLock is used to ensure that the mounts table does not
 	// change underneath a calling function
-	mountsLock locking.DeadlockRWMutex
+	mountsLock locking.RWMutex
 
 	// mountMigrationTracker tracks past and ongoing remount operations
 	// against their migration ids
@@ -387,7 +387,7 @@ type Core struct {
 
 	// authLock is used to ensure that the auth table does not
 	// change underneath a calling function
-	authLock locking.DeadlockRWMutex
+	authLock locking.RWMutex
 
 	// audit is loaded after unseal since it is a protected
 	// configuration
@@ -1003,6 +1003,8 @@ func CreateCore(conf *CoreConfig) (*Core, error) {
 
 	detectDeadlocks := locking.ParseDetectDeadlockConfigParameter(conf.DetectDeadlocks)
 	stateLock := locking.CreateConfigurableRWMutex(detectDeadlocks, "statelock")
+	mountsLock := locking.CreateConfigurableRWMutex(detectDeadlocks, "mountsLock")
+	authLock := locking.CreateConfigurableRWMutex(detectDeadlocks, "authLock")
 
 	// Setup the core
 	c := &Core{
@@ -1018,6 +1020,8 @@ func CreateCore(conf *CoreConfig) (*Core, error) {
 		customListenerHeader: new(atomic.Value),
 		seal:                 conf.Seal,
 		stateLock:            stateLock,
+		mountsLock:           mountsLock,
+		authLock:             authLock,
 		router:               NewRouter(),
 		sealed:               new(uint32),
 		sealMigrationDone:    new(uint32),

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -2225,12 +2225,12 @@ func (b *SystemBackend) handleTuneWriteCommon(ctx context.Context, path string, 
 		return nil, logical.ErrReadOnly
 	}
 
-	var lock *locking.DeadlockRWMutex
+	var lock locking.RWMutex
 	switch {
 	case strings.HasPrefix(path, credentialRoutePrefix):
-		lock = &b.Core.authLock
+		lock = b.Core.authLock
 	default:
-		lock = &b.Core.mountsLock
+		lock = b.Core.mountsLock
 	}
 
 	lock.Lock()


### PR DESCRIPTION
### Description
This PR changes the mountsLock and authLock fields in the Core struct from `locking.DeadlockRWMutex` to `locking.RWMutex`. This change allows the fields to be set to either `locking.DeadlockRWMutex` or `locking.SyncRWMutex` (or any other type that fulfills the `locking.RWMutex` interface for that matter).

These fields are now set using the `locking.CreateConfigurableRWMutex` function which selects the `locking.DeadlockRWMutex` implementation if the provided lock type name is present in the provided **detectDeadlocks** slice.

The `detect_deadlocks` configuration parameter is used to specify which locks are configured to use the `locking.DeadlockRWMutex`. If a lock is not specified in that parameter, it is configured to use the `locking.SyncRWMutex` which is an alias for `sync.RWMutex`.

This PR has an accompanying ENT PR: https://github.com/hashicorp/vault-enterprise/pull/6163

### TODO only if you're a HashiCorp employee
- [x] **Labels:** If this PR is the CE portion of an ENT change, and that ENT change is
  getting backported to N-2, use the new style `backport/ent/x.x.x+ent` labels
  instead of the old style `backport/x.x.x` labels.
- [x] **Labels:** If this PR is a CE only change, it can only be backported to N, so use
  the normal `backport/x.x.x` label (there should be only 1).
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
