### PR TITLE
Remove link to static role tutorial

### DIFF
--- a/website/content/docs/secrets/databases/index.mdx
+++ b/website/content/docs/secrets/databases/index.mdx
@@ -347,7 +347,6 @@ Refer to the following step-by-step tutorials for more information:
 
 - [Secrets as a Service: Dynamic Secrets](/vault/tutorials/db-credentials/database-secrets)
 - [Database Root Credential Rotation](/vault/tutorials/db-credentials/database-root-rotation)
-- [Database Static Roles and Credential Rotation](/vault/tutorials/db-credentials/database-creds-rotation)
 
 ## API
 

--- a/website/content/docs/secrets/databases/index.mdx
+++ b/website/content/docs/secrets/databases/index.mdx
@@ -40,22 +40,21 @@ With static roles, anyone with the proper Vault policies can access the
 associated user account in the database.
 
 <Warning title="Do not use static roles for root database credentials">
-   Do not manage the same root database credentials that you provide to Vault in
-   <tt>config/</tt> with static roles.
 
-   Vault does not distinguish between standard credentials and root credentials
-   when rotating passwords. If you assign your root credentials to a static
-   role, any dynamic or static users managed by that database configuration will
-   fail after rotation because the password for <tt>config/</tt> is no longer
-   valid.
+Do not manage the same root database credentials that you provide to Vault in
+<tt>config/</tt> with static roles.
 
-   If you need to rotate root credentials, use the
-   [Rotate root credentials](/vault/api-docs/secret/databases#rotate-root-credentials)
-   API endpoint.
+Vault does not distinguish between standard credentials and root credentials
+when rotating passwords. If you assign your root credentials to a static
+role, any dynamic or static users managed by that database configuration will
+fail after rotation because the password for <tt>config/</tt> is no longer
+valid.
+
+If you need to rotate root credentials, use the
+[Rotate root credentials](/vault/api-docs/secret/databases#rotate-root-credentials)
+API endpoint.
+
 </Warning>
-
-Consult the [database capabilities table](#db-capabilities-table) to determine
-if your chosen database backend supports static roles.
 
 ## Setup
 


### PR DESCRIPTION
### Description

🎟️ [Jira tickert](https://hashicorp.atlassian.net/browse/SPE-837?atlOrigin=eyJpIjoiNDdlODc3YjRkYzQ0NGI4YWJiMmI0Y2UxZTNjNjJlZTUiLCJwIjoiaiJ9)

Remove link to deprecated tutorial (static roles)

### TODO only if you're a HashiCorp employee
- [ ] **Labels:** If this PR is the CE portion of an ENT change, and that ENT change is
  getting backported to N-2, use the new style `backport/ent/x.x.x+ent` labels
  instead of the old style `backport/x.x.x` labels.
- [x] **Labels:** If this PR is a CE only change, it can only be backported to N, so use
  the normal `backport/x.x.x` label (there should be only 1).
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
