### PR TITLE
Add auto-roll billing start date changes CE changes

### DIFF
--- a/changelog/27656.txt
+++ b/changelog/27656.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+license utilization reporting (enterprise): Auto-roll billing start date.
+```

--- a/helper/timeutil/timeutil.go
+++ b/helper/timeutil/timeutil.go
@@ -179,3 +179,13 @@ func (_ DefaultClock) NewTicker(d time.Duration) *time.Ticker {
 func (_ DefaultClock) NewTimer(d time.Duration) *time.Timer {
 	return time.NewTimer(d)
 }
+
+// NormalizeToYear returns date normalized to the latest date
+// within one year of normal. Assumes the date argument is
+// some date before normal.
+func NormalizeToYear(date, normal time.Time) time.Time {
+	for date.AddDate(1, 0, 0).Compare(normal) <= 0 {
+		date = date.AddDate(1, 0, 0)
+	}
+	return date
+}

--- a/helper/timeutil/timeutil_test.go
+++ b/helper/timeutil/timeutil_test.go
@@ -7,6 +7,8 @@ import (
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestTimeutil_StartOfPreviousMonth(t *testing.T) {
@@ -365,5 +367,96 @@ func TestTimeUtil_ParseTimeFromPath(t *testing.T) {
 		if gotError != tc.expectError {
 			t.Errorf("bad error status on input %q. expected error: %t, got error: %t", tc.input, tc.expectError, gotError)
 		}
+	}
+}
+
+// TestNormalizeToYear tests NormalizeToYear function which returns the normalized input date wrt to the normal.
+func TestNormalizeToYear(t *testing.T) {
+	testCases := []struct {
+		inputDate              time.Time
+		normalDate             time.Time
+		expectedNormalizedDate time.Time
+	}{
+		{
+			inputDate:              time.Date(2024, 9, 29, 0, 0, 0, 0, time.UTC),
+			normalDate:             time.Date(2024, 10, 1, 0, 0, 0, 0, time.UTC),
+			expectedNormalizedDate: time.Date(2024, 9, 29, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			inputDate:              time.Date(2024, 9, 29, 0, 0, 0, 0, time.UTC),
+			normalDate:             time.Date(2025, 9, 29, 0, 0, 0, 0, time.UTC),
+			expectedNormalizedDate: time.Date(2025, 9, 29, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			inputDate:              time.Date(2024, 9, 29, 0, 0, 0, 0, time.UTC),
+			normalDate:             time.Date(2025, 10, 1, 0, 0, 0, 0, time.UTC),
+			expectedNormalizedDate: time.Date(2025, 9, 29, 0, 0, 0, 0, time.UTC),
+		},
+		// inputDate more than 2 years prior to normal date
+		{
+			inputDate:              time.Date(2022, 9, 29, 0, 0, 0, 0, time.UTC),
+			normalDate:             time.Date(2024, 6, 15, 0, 0, 0, 0, time.UTC),
+			expectedNormalizedDate: time.Date(2023, 9, 29, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			inputDate:              time.Date(2022, 9, 29, 0, 0, 0, 0, time.UTC),
+			normalDate:             time.Date(2024, 9, 28, 0, 0, 0, 0, time.UTC),
+			expectedNormalizedDate: time.Date(2023, 9, 29, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			inputDate:              time.Date(2022, 9, 29, 0, 0, 0, 0, time.UTC),
+			normalDate:             time.Date(2024, 9, 29, 0, 0, 0, 0, time.UTC),
+			expectedNormalizedDate: time.Date(2024, 9, 29, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			inputDate:              time.Date(2022, 9, 29, 0, 0, 0, 0, time.UTC),
+			normalDate:             time.Date(2024, 9, 30, 0, 0, 0, 0, time.UTC),
+			expectedNormalizedDate: time.Date(2024, 9, 29, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			inputDate:              time.Date(2020, 9, 29, 0, 0, 0, 0, time.UTC),
+			normalDate:             time.Date(2024, 12, 1, 0, 0, 0, 0, time.UTC),
+			expectedNormalizedDate: time.Date(2024, 9, 29, 0, 0, 0, 0, time.UTC),
+		},
+		// leap year test cases
+		{
+			inputDate:              time.Date(2020, 9, 29, 0, 0, 0, 0, time.UTC),
+			normalDate:             time.Date(2024, 9, 28, 0, 0, 0, 0, time.UTC),
+			expectedNormalizedDate: time.Date(2023, 9, 29, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			inputDate:              time.Date(2024, 2, 29, 0, 0, 0, 0, time.UTC),
+			normalDate:             time.Date(2025, 2, 28, 0, 0, 0, 0, time.UTC),
+			expectedNormalizedDate: time.Date(2024, 2, 29, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			inputDate:              time.Date(2024, 2, 29, 0, 0, 0, 0, time.UTC),
+			normalDate:             time.Date(2025, 3, 1, 0, 0, 0, 0, time.UTC),
+			expectedNormalizedDate: time.Date(2025, 3, 1, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			inputDate:              time.Date(2024, 2, 29, 0, 0, 0, 0, time.UTC),
+			normalDate:             time.Date(2025, 3, 2, 0, 0, 0, 0, time.UTC),
+			expectedNormalizedDate: time.Date(2025, 3, 1, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			inputDate:              time.Date(2024, 2, 29, 0, 0, 0, 0, time.UTC),
+			normalDate:             time.Date(2028, 2, 28, 0, 0, 0, 0, time.UTC),
+			expectedNormalizedDate: time.Date(2027, 3, 1, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			inputDate:              time.Date(2024, 2, 29, 0, 0, 0, 0, time.UTC),
+			normalDate:             time.Date(2028, 2, 29, 0, 0, 0, 0, time.UTC),
+			expectedNormalizedDate: time.Date(2027, 3, 1, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			inputDate:              time.Date(2024, 2, 29, 0, 0, 0, 0, time.UTC),
+			normalDate:             time.Date(2028, 3, 1, 0, 0, 0, 0, time.UTC),
+			expectedNormalizedDate: time.Date(2028, 3, 1, 0, 0, 0, 0, time.UTC),
+		},
+	}
+	for _, tc := range testCases {
+		normalizedDate := NormalizeToYear(tc.inputDate, tc.normalDate)
+		require.Equal(t, tc.expectedNormalizedDate, normalizedDate)
 	}
 }

--- a/helper/timeutil/timeutil_test.go
+++ b/helper/timeutil/timeutil_test.go
@@ -370,8 +370,8 @@ func TestTimeUtil_ParseTimeFromPath(t *testing.T) {
 	}
 }
 
-// TestNormalizeToYear tests NormalizeToYear function which returns the normalized input date wrt to the normal.
-func TestNormalizeToYear(t *testing.T) {
+// TestTimeUtil_NormalizeToYear tests NormalizeToYear function which returns the normalized input date wrt to the normal.
+func TestTimeUtil_NormalizeToYear(t *testing.T) {
 	testCases := []struct {
 		inputDate              time.Time
 		normalDate             time.Time


### PR DESCRIPTION
### Description
What does this PR do?
Adding CE changes for ENT PR https://github.com/hashicorp/vault-enterprise/pull/5681/files that auto-rolls billing start date. 
JIRA: https://hashicorp.atlassian.net/browse/VAULT-24059

### TODO only if you're a HashiCorp employee
- [ ] **Labels:** If this PR is the CE portion of an ENT change, and that ENT change is
  getting backported to N-2, use the new style `backport/ent/x.x.x+ent` labels
  instead of the old style `backport/x.x.x` labels.
- [ ] **Labels:** If this PR is a CE only change, it can only be backported to N, so use
  the normal `backport/x.x.x` label (there should be only 1).
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
