### PR TITLE
VAULT-28255: Fix namespaced redirects

### DIFF
--- a/changelog/27660.txt
+++ b/changelog/27660.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core (enterprise): Fix HTTP redirects in namespaces to use the correct path and (in the case of event subscriptions) the correct URI scheme.
+```

--- a/http/help.go
+++ b/http/help.go
@@ -40,7 +40,7 @@ func handleHelp(core *vault.Core, w http.ResponseWriter, r *http.Request) {
 		respondError(w, http.StatusNotFound, errors.New("Missing /v1/ prefix in path. Use vault path-help command to retrieve API help for paths"))
 		return
 	}
-	path := trimPath(ns, r.URL.Path) 
+	path := trimPath(ns, r.URL.Path)
 
 	req := &logical.Request{
 		Operation:  logical.HelpOperation,

--- a/http/help.go
+++ b/http/help.go
@@ -40,7 +40,7 @@ func handleHelp(core *vault.Core, w http.ResponseWriter, r *http.Request) {
 		respondError(w, http.StatusNotFound, errors.New("Missing /v1/ prefix in path. Use vault path-help command to retrieve API help for paths"))
 		return
 	}
-	path := ns.TrimmedPath(r.URL.Path[len("/v1/"):])
+	path := trimPath(ns, r.URL.Path) 
 
 	req := &logical.Request{
 		Operation:  logical.HelpOperation,

--- a/http/logical.go
+++ b/http/logical.go
@@ -50,8 +50,7 @@ func buildLogicalRequestNoAuth(perfStandby bool, ra *vault.RouterAccess, w http.
 	if err != nil {
 		return nil, nil, http.StatusBadRequest, nil
 	}
-	path := ns.TrimmedPath(r.URL.Path[len("/v1/"):])
-
+	path := trimPath(ns, r.URL.Path)
 	var data map[string]interface{}
 	var origBody io.ReadCloser
 	var passHTTPReq bool
@@ -361,11 +360,13 @@ func handleLogicalInternal(core *vault.Core, injectDataIntoTopLevel bool, noForw
 			respondError(w, http.StatusInternalServerError, err)
 			return
 		}
+		trimmedPath := trimPath(ns, r.URL.Path)
+
 		nsPath := ns.Path
 		if ns.ID == namespace.RootNamespaceID {
 			nsPath = ""
 		}
-		if strings.HasPrefix(r.URL.Path, fmt.Sprintf("/v1/%ssys/events/subscribe/", nsPath)) {
+		if websocketPaths.HasPath(trimmedPath) {
 			handler := entHandleEventsSubscribe(core, req)
 			if handler != nil {
 				handler.ServeHTTP(w, r)

--- a/http/sys_rekey.go
+++ b/http/sys_rekey.go
@@ -20,7 +20,7 @@ func handleSysRekeyInit(core *vault.Core, recovery bool) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		standby, _ := core.Standby()
 		if standby {
-			respondStandby(core, w, r.URL)
+			respondStandby(core, w, r)
 			return
 		}
 
@@ -155,7 +155,7 @@ func handleSysRekeyUpdate(core *vault.Core, recovery bool) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		standby, _ := core.Standby()
 		if standby {
-			respondStandby(core, w, r.URL)
+			respondStandby(core, w, r)
 			return
 		}
 
@@ -228,7 +228,7 @@ func handleSysRekeyVerify(core *vault.Core, recovery bool) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		standby, _ := core.Standby()
 		if standby {
-			respondStandby(core, w, r.URL)
+			respondStandby(core, w, r)
 			return
 		}
 


### PR DESCRIPTION
### Description
Fix redirects when a namespace is included in the namespace header, or for events when it's included in the path.
Fixes #27551. 

### TODO only if you're a HashiCorp employee
- [x] **Labels:** If this PR is the CE portion of an ENT change, and that ENT change is
  getting backported to N-2, use the new style `backport/ent/x.x.x+ent` labels
  instead of the old style `backport/x.x.x` labels.
- [x] **Labels:** If this PR is a CE only change, it can only be backported to N, so use
  the normal `backport/x.x.x` label (there should be only 1).
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
