### PR TITLE
Add CE plumbing for CensusManager reload

### DIFF
--- a/command/server.go
+++ b/command/server.go
@@ -1711,7 +1711,7 @@ func (c *ServerCommand) Run(args []string) int {
 				sr.NotifyConfigurationReload(srConfig)
 			}
 
-			if err := core.ReloadCensusManager(); err != nil {
+			if err := core.ReloadCensusManager(false); err != nil {
 				c.UI.Error(err.Error())
 			}
 

--- a/command/server_util.go
+++ b/command/server_util.go
@@ -24,6 +24,10 @@ func (c *ServerCommand) ReloadedCh() chan struct{} {
 	return c.reloadedCh
 }
 
+func (c *ServerCommand) LicenseReloadedCh() chan error {
+	return c.licenseReloadedCh
+}
+
 func testServerCommand(tb testing.TB) (*cli.MockUi, *ServerCommand) {
 	tb.Helper()
 

--- a/vault/census_stubs_oss.go
+++ b/vault/census_stubs_oss.go
@@ -9,6 +9,6 @@ import "context"
 
 //go:generate go run github.com/hashicorp/vault/tools/stubmaker
 
-func (c *Core) StartCensusReports(ctx context.Context) {}
-func (c *Core) SetRetentionMonths(months int) error    { return nil }
-func (c *Core) ReloadCensusManager() error             { return nil }
+func (c *Core) StartCensusReports(ctx context.Context)       {}
+func (c *Core) SetRetentionMonths(months int) error          { return nil }
+func (c *Core) ReloadCensusManager(licenseChange bool) error { return nil }


### PR DESCRIPTION
This PR adds the CE plumbing and stubs for forcing agent instantiation whenever the Vault license changes.

Resolves: VAULT-28583
Enterprise PR: hashicorp/vault-enterprise#6168

- [x] **Labels:** If this PR is the CE portion of an ENT change, and that ENT change is
  getting backported to N-2, use the new style `backport/ent/x.x.x+ent` labels
  instead of the old style `backport/x.x.x` labels.
- [x] **Labels:** If this PR is a CE only change, it can only be backported to N, so use
  the normal `backport/x.x.x` label (there should be only 1).
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
