### PR TITLE
Update azure docs to include new param

### DIFF
--- a/website/content/api-docs/secret/azure.mdx
+++ b/website/content/api-docs/secret/azure.mdx
@@ -216,6 +216,8 @@ information about roles.
   Accepts time suffixed strings ("1h") or an integer number of seconds. Defaults to the system/engine default TTL time.
 - `max_ttl` (`string: ""`) – Specifies the maximum TTL for service principals generated using this role. Accepts time
   suffixed strings ("1h") or an integer number of seconds. Defaults to the system/engine max TTL time.
+- `explicit_max_ttl` (`string: ""`) – Specifies the explicit maximum lifetime of the lease and service principal.
+  If not set or set to 0, will use the system default.
 - `permanently_delete` (`bool: false`) - Specifies whether to permanently delete Applications and Service Principals that are dynamically
   created by Vault. If `application_object_id` is present, `permanently_delete` must be `false`.
 - `sign_in_audience` (`string: ""`) - Specifies the security principal types that are allowed to sign in to the application.
@@ -237,8 +239,8 @@ information about roles.
     }
   ]",
   "ttl": 3600,
-  "max_ttl": "24h"
-  "sign_in_audience": "AzureADMyOrg"
+  "max_ttl": "24h",
+  "sign_in_audience": "AzureADMyOrg",
   "tags": "team:engineering","environment:development"
 }
 ```

--- a/website/content/api-docs/secret/azure.mdx
+++ b/website/content/api-docs/secret/azure.mdx
@@ -217,7 +217,7 @@ information about roles.
 - `max_ttl` (`string: ""`) – Specifies the maximum TTL for service principals generated using this role. Accepts time
   suffixed strings ("1h") or an integer number of seconds. Defaults to the system/engine max TTL time.
 - `explicit_max_ttl` (`string: ""`) – Specifies the explicit maximum lifetime of the lease and service principal.
-  If not set or set to 0, will use the system default.
+  If not set or set to 0, will use the system default (10 years).
 - `permanently_delete` (`bool: false`) - Specifies whether to permanently delete Applications and Service Principals that are dynamically
   created by Vault. If `application_object_id` is present, `permanently_delete` must be `false`.
 - `sign_in_audience` (`string: ""`) - Specifies the security principal types that are allowed to sign in to the application.


### PR DESCRIPTION
Very small PR to update azure docs to include new param `explicit_max_ttl`. 
PR: https://github.com/hashicorp/vault-plugin-secrets-azure/pull/199