### PR TITLE
Handle missing serial number more gracefully

### DIFF
--- a/builtin/logical/pki/path_fetch.go
+++ b/builtin/logical/pki/path_fetch.go
@@ -55,7 +55,7 @@ var pathFetchReadSchema = map[int][]framework.Response{
 // Returns the CA in raw format
 func pathFetchCA(b *backend) *framework.Path {
 	return &framework.Path{
-		Pattern: `ca(/pem)?`,
+		Pattern: `ca(/pem)?/?`,
 
 		DisplayAttrs: &framework.DisplayAttributes{
 			OperationPrefix: operationPrefixPKI,
@@ -361,7 +361,9 @@ func (b *backend) pathFetchRead(ctx context.Context, req *logical.Request, data 
 			contentType = "application/pem-certificate-chain"
 		}
 	default:
-		serial = data.Get("serial").(string)
+		if ser, ok := data.GetOk("serial"); ok {
+			serial = ser.(string)
+		}
 		pemType = "CERTIFICATE"
 	}
 	if len(serial) == 0 {

--- a/builtin/logical/pki/path_fetch.go
+++ b/builtin/logical/pki/path_fetch.go
@@ -55,7 +55,7 @@ var pathFetchReadSchema = map[int][]framework.Response{
 // Returns the CA in raw format
 func pathFetchCA(b *backend) *framework.Path {
 	return &framework.Path{
-		Pattern: `ca(/pem)?/?`,
+		Pattern: `ca(/pem)?`,
 
 		DisplayAttrs: &framework.DisplayAttributes{
 			OperationPrefix: operationPrefixPKI,

--- a/changelog/27681.txt
+++ b/changelog/27681.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+secrets/pki: fix lack of serial number to a certificate read resulting in a server side error.
+```


### PR DESCRIPTION
Previously, in the default: case of pathFetchRead, not providing the serial
parameter results in a panic when casting the empty result.