### PR TITLE
refactor external plugin tests

### DIFF
--- a/vault/external_tests/plugin/external_plugin_test.go
+++ b/vault/external_tests/plugin/external_plugin_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -177,7 +178,7 @@ func TestExternalPlugin_ContinueOnError(t *testing.T) {
 
 func testExternalPlugin_ContinueOnError(t *testing.T, mismatch bool, pluginType consts.PluginType) {
 	cluster := getCluster(t, 1, pluginType)
-	defer cluster.Cleanup()
+	t.Cleanup(cluster.Cleanup)
 
 	core := cluster.Cores[0]
 	plugin := cluster.Plugins[0]
@@ -282,10 +283,12 @@ func testExternalPlugin_ContinueOnError(t *testing.T, mismatch bool, pluginType 
 }
 
 // TestExternalPlugin_AuthMethod tests that we can build, register and use an
-// external auth method
+// external auth method (approle)
 func TestExternalPlugin_AuthMethod(t *testing.T) {
+	// getCluster calls pluginhelper.CompilePlugin which builds the approle
+	// auth method as a stand-in for the PluginTypeCredential
 	cluster := getCluster(t, 5, consts.PluginTypeCredential)
-	defer cluster.Cleanup()
+	t.Cleanup(cluster.Cleanup)
 
 	plugin := cluster.Plugins[0]
 	client := cluster.Cores[0].Client
@@ -294,18 +297,27 @@ func TestExternalPlugin_AuthMethod(t *testing.T) {
 	// Register
 	testRegisterVersion(t, client, plugin, plugin.Version)
 
-	// define a group of parallel tests so we wait for their execution before
-	// continuing on to cleanup
-	// see: https://go.dev/blog/subtests
-	t.Run("parallel execution group", func(t *testing.T) {
-		// loop to mount 5 auth methods that will each share a single
-		// plugin process
-		for i := 0; i < 5; i++ {
-			i := i
-			pluginPath := fmt.Sprintf("%s-%d", plugin.Name, i)
-			client := cluster.Cores[i].Client
+	var pluginTest sync.WaitGroup
+	// loop to mount 5 auth methods that will each share a single plugin process
+	for i := 0; i < 5; i++ {
+		i := i
+		pluginTest.Add(1)
+		// We will be making concurrent requests so we grab a unique client per
+		// mount. Otherwise our login requests will overwrite the vault token
+		// for all goroutines.
+		client := cluster.Cores[i].Client
+		pluginPath := fmt.Sprintf("%s-%d", plugin.Name, i)
+		t.Cleanup(func() {
+			if err := client.Sys().DisableAuth(pluginPath); err != nil {
+				t.Fatal(err)
+			}
+		})
+
+		// spin off 5 goroutines to make concurrent requests to the plugin
+		// to simulate a real-world environment
+		go func() {
+			defer pluginTest.Done()
 			t.Run(pluginPath, func(t *testing.T) {
-				t.Parallel()
 				client.SetToken(cluster.RootToken)
 				// Enable
 				if err := client.Sys().EnableAuthWithOptions(pluginPath, &api.EnableAuthOptions{
@@ -375,14 +387,13 @@ func TestExternalPlugin_AuthMethod(t *testing.T) {
 				if err == nil {
 					t.Fatalf("expected error, got nil")
 				}
-
-				// Reset root token
-				client.SetToken(cluster.RootToken)
 			})
-		}
-	})
+		}()
+	}
 
-	// Deregister
+	// wait for goroutine execution before continuing on to cleanup
+	pluginTest.Wait()
+
 	if err := client.Sys().DeregisterPlugin(&api.DeregisterPluginInput{
 		Name:    plugin.Name,
 		Type:    api.PluginType(plugin.Typ),
@@ -396,7 +407,7 @@ func TestExternalPlugin_AuthMethod(t *testing.T) {
 // method after reload
 func TestExternalPlugin_AuthMethodReload(t *testing.T) {
 	cluster := getCluster(t, 1, consts.PluginTypeCredential)
-	defer cluster.Cleanup()
+	t.Cleanup(cluster.Cleanup)
 
 	plugin := cluster.Plugins[0]
 	client := cluster.Cores[0].Client
@@ -457,6 +468,10 @@ func TestExternalPlugin_AuthMethodReload(t *testing.T) {
 	// Reset root token
 	client.SetToken(cluster.RootToken)
 
+	if err := client.Sys().DisableAuth(plugin.Name); err != nil {
+		t.Fatal(err)
+	}
+
 	// Deregister
 	if err := client.Sys().DeregisterPlugin(&api.DeregisterPluginInput{
 		Name:    plugin.Name,
@@ -468,10 +483,13 @@ func TestExternalPlugin_AuthMethodReload(t *testing.T) {
 }
 
 // TestExternalPlugin_SecretsEngine tests that we can build, register and use an
-// external secrets engine
+// external secrets engine (consul)
 func TestExternalPlugin_SecretsEngine(t *testing.T) {
+	t.Parallel()
+	// getCluster calls pluginhelper.CompilePlugin which builds the consul
+	// secrets engine as a stand-in for the PluginTypeSecrets
 	cluster := getCluster(t, 1, consts.PluginTypeSecrets)
-	defer cluster.Cleanup()
+	t.Cleanup(cluster.Cleanup)
 
 	plugin := cluster.Plugins[0]
 	client := cluster.Cores[0].Client
@@ -480,16 +498,24 @@ func TestExternalPlugin_SecretsEngine(t *testing.T) {
 	// Register
 	testRegisterVersion(t, client, plugin, plugin.Version)
 
-	// define a group of parallel tests so we wait for their execution before
-	// continuing on to cleanup
-	// see: https://go.dev/blog/subtests
-	t.Run("parallel execution group", func(t *testing.T) {
-		// loop to mount 5 secrets engines that will each share a single
-		// plugin process
-		for i := 0; i < 5; i++ {
-			pluginPath := fmt.Sprintf("%s-%d", plugin.Name, i)
+	var pluginTest sync.WaitGroup
+	// loop to mount 5 secrets engines that will each share a single plugin process
+	for i := 0; i < 5; i++ {
+		i := i
+		pluginTest.Add(1)
+		pluginPath := fmt.Sprintf("%s-%d", plugin.Name, i)
+		t.Cleanup(func() {
+			if err := client.Sys().Unmount(pluginPath); err != nil {
+				t.Fatal(err)
+			}
+		})
+
+		// spin off 5 goroutines to make concurrent requests to the plugin
+		// to simulate a real-world environment
+		go func() {
+			defer pluginTest.Done()
 			t.Run(pluginPath, func(t *testing.T) {
-				t.Parallel()
+				client.SetToken(cluster.RootToken)
 				// Enable
 				if err := client.Sys().Mount(pluginPath, &api.MountInput{
 					Type: plugin.Name,
@@ -499,7 +525,7 @@ func TestExternalPlugin_SecretsEngine(t *testing.T) {
 
 				// Configure
 				cleanupConsul, consulConfig := consul.PrepareTestContainer(t, "", false, true)
-				defer cleanupConsul()
+				t.Cleanup(cleanupConsul)
 
 				_, err := client.Logical().Write(pluginPath+"/config/access", map[string]interface{}{
 					"address": consulConfig.Address(),
@@ -525,11 +551,37 @@ func TestExternalPlugin_SecretsEngine(t *testing.T) {
 				if resp == nil {
 					t.Fatal("read creds response is nil")
 				}
-			})
-		}
-	})
 
-	// Deregister
+				revokeLease := resp.LeaseID
+				// Lookup - expect SUCCESS
+				resp, err = client.Sys().Lookup(revokeLease)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if resp == nil {
+					t.Fatalf("lease lookup response is nil")
+				}
+
+				// Revoke
+				if err = client.Sys().Revoke(revokeLease); err != nil {
+					t.Fatal(err)
+				}
+
+				// Reset root token
+				client.SetToken(cluster.RootToken)
+
+				// Lookup - expect FAILURE
+				_, err = client.Sys().Lookup(revokeLease)
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+			})
+		}()
+	}
+
+	// wait for goroutine execution before continuing on to cleanup
+	pluginTest.Wait()
+
 	if err := client.Sys().DeregisterPlugin(&api.DeregisterPluginInput{
 		Name:    plugin.Name,
 		Type:    api.PluginType(plugin.Typ),
@@ -542,8 +594,9 @@ func TestExternalPlugin_SecretsEngine(t *testing.T) {
 // TestExternalPlugin_SecretsEngineReload tests that we can use an external
 // secrets engine after reload
 func TestExternalPlugin_SecretsEngineReload(t *testing.T) {
+	t.Parallel()
 	cluster := getCluster(t, 1, consts.PluginTypeSecrets)
-	defer cluster.Cleanup()
+	t.Cleanup(cluster.Cleanup)
 
 	plugin := cluster.Plugins[0]
 	client := cluster.Cores[0].Client
@@ -553,7 +606,7 @@ func TestExternalPlugin_SecretsEngineReload(t *testing.T) {
 
 	// Configure
 	cleanupConsul, consulConfig := consul.PrepareTestContainer(t, "", false, true)
-	defer cleanupConsul()
+	t.Cleanup(cleanupConsul)
 
 	_, err := client.Logical().Write(plugin.Name+"/config/access", map[string]interface{}{
 		"address": consulConfig.Address(),
@@ -595,6 +648,10 @@ func TestExternalPlugin_SecretsEngineReload(t *testing.T) {
 		t.Fatal("read creds response is nil")
 	}
 
+	if err := client.Sys().Unmount(plugin.Name); err != nil {
+		t.Fatal(err)
+	}
+
 	// Deregister
 	if err := client.Sys().DeregisterPlugin(&api.DeregisterPluginInput{
 		Name:    plugin.Name,
@@ -606,10 +663,13 @@ func TestExternalPlugin_SecretsEngineReload(t *testing.T) {
 }
 
 // TestExternalPlugin_Database tests that we can build, register and use an
-// external database secrets engine
+// external database secrets engine (postgres)
 func TestExternalPlugin_Database(t *testing.T) {
+	t.Parallel()
+	// getCluster calls pluginhelper.CompilePlugin which builds the postgres
+	// database engine as a stand-in for the PluginTypeSecrets
 	cluster := getCluster(t, 1, consts.PluginTypeDatabase)
-	defer cluster.Cleanup()
+	t.Cleanup(cluster.Cleanup)
 
 	plugin := cluster.Plugins[0]
 	client := cluster.Cores[0].Client
@@ -618,27 +678,30 @@ func TestExternalPlugin_Database(t *testing.T) {
 	// Register
 	testRegisterVersion(t, client, plugin, plugin.Version)
 
-	// Enable
+	// Enable the database engine
 	if err := client.Sys().Mount(consts.PluginTypeDatabase.String(), &api.MountInput{
 		Type: consts.PluginTypeDatabase.String(),
 	}); err != nil {
 		t.Fatal(err)
 	}
 
-	// define a group of parallel tests so we wait for their execution before
-	// continuing on to cleanup
-	// see: https://go.dev/blog/subtests
-	t.Run("parallel execution group", func(t *testing.T) {
-		// loop to mount 5 database connections that will each share a single
-		// plugin process
-		for i := 0; i < 5; i++ {
-			dbName := fmt.Sprintf("%s-%d", plugin.Name, i)
+	var pluginTest sync.WaitGroup
+	// loop to mount 5 secrets engines that will each share a single plugin process
+	for i := 0; i < 5; i++ {
+		i := i
+		pluginTest.Add(1)
+		dbName := fmt.Sprintf("%s-%d", plugin.Name, i)
+
+		// spin off 5 goroutines to make concurrent requests to the plugin
+		// to simulate a real-world environment
+		go func() {
+			defer pluginTest.Done()
 			t.Run(dbName, func(t *testing.T) {
-				t.Parallel()
+				client.SetToken(cluster.RootToken)
 				roleName := "test-role-" + dbName
 
 				cleanupContainer, connURL := postgreshelper.PrepareTestContainerWithVaultUser(t, context.Background(), "13.4-buster")
-				defer cleanupContainer()
+				t.Cleanup(cleanupContainer)
 
 				_, err := client.Logical().Write("database/config/"+dbName, map[string]interface{}{
 					"connection_url": connURL,
@@ -688,14 +751,6 @@ func TestExternalPlugin_Database(t *testing.T) {
 					t.Fatal("read creds response is nil")
 				}
 
-				resp, err = client.Logical().Read("database/creds/" + roleName)
-				if err != nil {
-					t.Fatal(err)
-				}
-				if resp == nil {
-					t.Fatal("read creds response is nil")
-				}
-
 				revokeLease := resp.LeaseID
 				// Lookup - expect SUCCESS
 				resp, err = client.Sys().Lookup(revokeLease)
@@ -719,11 +774,22 @@ func TestExternalPlugin_Database(t *testing.T) {
 				if err == nil {
 					t.Fatalf("expected error, got nil")
 				}
-			})
-		}
-	})
 
-	// Deregister
+				// Revoke all leases so we don't get errors when we unmount the database engine
+				if err = client.Sys().RevokePrefix("database/creds/" + roleName); err != nil {
+					t.Fatal(err)
+				}
+			})
+		}()
+	}
+
+	// wait for goroutine execution before continuing on to cleanup
+	pluginTest.Wait()
+
+	if err := client.Sys().Unmount(consts.PluginTypeDatabase.String()); err != nil {
+		t.Fatal(err)
+	}
+
 	if err := client.Sys().DeregisterPlugin(&api.DeregisterPluginInput{
 		Name:    plugin.Name,
 		Type:    api.PluginType(plugin.Typ),
@@ -736,8 +802,9 @@ func TestExternalPlugin_Database(t *testing.T) {
 // TestExternalPlugin_DatabaseReload tests that we can use an external database
 // secrets engine after reload
 func TestExternalPlugin_DatabaseReload(t *testing.T) {
+	t.Parallel()
 	cluster := getCluster(t, 1, consts.PluginTypeDatabase)
-	defer cluster.Cleanup()
+	t.Cleanup(cluster.Cleanup)
 
 	plugin := cluster.Plugins[0]
 	client := cluster.Cores[0].Client
@@ -757,7 +824,7 @@ func TestExternalPlugin_DatabaseReload(t *testing.T) {
 	roleName := "test-role-" + dbName
 
 	cleanupContainer, connURL := postgreshelper.PrepareTestContainerWithVaultUser(t, context.Background(), "13.4-buster")
-	defer cleanupContainer()
+	t.Cleanup(cleanupContainer)
 
 	_, err := client.Logical().Write("database/config/"+dbName, map[string]interface{}{
 		"connection_url": connURL,
@@ -803,6 +870,10 @@ func TestExternalPlugin_DatabaseReload(t *testing.T) {
 		t.Fatal("read creds response is nil")
 	}
 
+	if err := client.Sys().Unmount(plugin.Name); err != nil {
+		t.Fatal(err)
+	}
+
 	// Deregister
 	if err := client.Sys().DeregisterPlugin(&api.DeregisterPluginInput{
 		Name:    plugin.Name,
@@ -843,7 +914,7 @@ func testExternalPluginMetadataAuditLog(t *testing.T, log map[string]interface{}
 // in audit log when it is enabled
 func TestExternalPlugin_AuditEnabled_ShouldLogPluginMetadata_Auth(t *testing.T) {
 	cluster := getCluster(t, 1, consts.PluginTypeCredential)
-	defer cluster.Cleanup()
+	t.Cleanup(cluster.Cleanup)
 
 	plugin := cluster.Plugins[0]
 	client := cluster.Cores[0].Client
@@ -914,7 +985,7 @@ func TestExternalPlugin_AuditEnabled_ShouldLogPluginMetadata_Auth(t *testing.T) 
 // in audit log when it is enabled
 func TestExternalPlugin_AuditEnabled_ShouldLogPluginMetadata_Secret(t *testing.T) {
 	cluster := getCluster(t, 1, consts.PluginTypeSecrets)
-	defer cluster.Cleanup()
+	t.Cleanup(cluster.Cleanup)
 
 	plugin := cluster.Plugins[0]
 	client := cluster.Cores[0].Client
@@ -942,7 +1013,7 @@ func TestExternalPlugin_AuditEnabled_ShouldLogPluginMetadata_Secret(t *testing.T
 
 	// Configure
 	cleanupConsul, consulConfig := consul.PrepareTestContainer(t, "", false, true)
-	defer cleanupConsul()
+	t.Cleanup(cleanupConsul)
 	_, err = client.Logical().Write(plugin.Name+"/config/access", map[string]interface{}{
 		"address": consulConfig.Address(),
 		"token":   consulConfig.Token,


### PR DESCRIPTION
This PR proposes some refactoring to the external plugin tests. We use goroutines instead of parallel tests to make the intent clearer; which is to simulate real-world traffic to the plugin.

There are a few other small improvements like making slower tests Parallel and removing unnecessary code.