### PR TITLE
updated vault helm chart doc with usecase of nlb

### DIFF
--- a/website/content/docs/platform/k8s/helm/index.mdx
+++ b/website/content/docs/platform/k8s/helm/index.mdx
@@ -59,7 +59,14 @@ cluster](https://kubernetes.io/docs/tasks/administer-cluster/securing-a-cluster/
 options](/vault/docs/platform/k8s/helm/configuration), and read the [production deployment
 checklist](/vault/docs/platform/k8s/helm/run#architecture).
 
--> **Important:** This helm chart always provisions Application Load Balancer(ALB) at the AWS side, if you have the requirements of running vault with Network Load Balancer(NLB) then you need to provision NLB in front of your ALB. This special kind of requirement can arise where you need to use AWS PrivateLink with your vault and PrivateLink only works with NLB.
+
+<Important title="Helm chart provisions ALB on AWS side">
+
+  If you use AWS features (e.g, AWS PrivateLink) that require a network load
+  balancer (NLB), you must provision your NLB **before** your application load 
+  balancer (ALB).
+
+</Important>
 
 ## Tutorial
 

--- a/website/content/docs/platform/k8s/helm/index.mdx
+++ b/website/content/docs/platform/k8s/helm/index.mdx
@@ -59,6 +59,8 @@ cluster](https://kubernetes.io/docs/tasks/administer-cluster/securing-a-cluster/
 options](/vault/docs/platform/k8s/helm/configuration), and read the [production deployment
 checklist](/vault/docs/platform/k8s/helm/run#architecture).
 
+-> **Important:** This helm chart always provisions Application Load Balancer(ALB) at the AWS side, if you have the requirements of running vault with Network Load Balancer(NLB) then you need to provision NLB in front of your ALB. This special kind of requirement can arise where you need to use AWS PrivateLink with your vault and PrivateLink only works with NLB.
+
 ## Tutorial
 
 Refer to the [Kubernetes](/vault/tutorials/kubernetes)


### PR DESCRIPTION
### Description
This PR updates the document of vault helm about what needs to be done if there is a special requirement of running vault with NLB.

### TODO only if you're a HashiCorp employee
- [ ] **Labels:** If this PR is the CE portion of an ENT change, and that ENT change is
  getting backported to N-2, use the new style `backport/ent/x.x.x+ent` labels
  instead of the old style `backport/x.x.x` labels.
- [ ] **Labels:** If this PR is a CE only change, it can only be backported to N, so use
  the normal `backport/x.x.x` label (there should be only 1).
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
