### PR TITLE
[VAULT-28664] Enable the --rerun-fails option in gotestsum for enterprise to reduce the impact of flaky tests on the CI

### DIFF
--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -422,7 +422,7 @@ jobs:
           fi
 
           # If running Go Test 32bit nightly tests, add a flag to rerun failed tests
-          if [[  "${{inputs.name}}" == 'i386' ]]; then
+          if [[  "${{github.repository}}" == 'hashicorp/vault-enterprise' ]]; then
               RERUN_FAILS="--rerun-fails"
           fi
 

--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -421,7 +421,8 @@ jobs:
             package_parallelism="-p 2"
           fi
 
-          # If running Go Test 32bit nightly tests, add a flag to rerun failed tests
+          # If running Go tests on the enterprise repo, add a flag to rerun failed tests.
+          # This is to address the issues with flaky tests affecting the reliability of CI.
           if [[  "${{github.repository}}" == 'hashicorp/vault-enterprise' ]]; then
               RERUN_FAILS="--rerun-fails"
           fi


### PR DESCRIPTION
### Description
This PR enables the `--rerun-fails` option for all Go tests in our enterprise repo. This is to reduce the impact of individual flaky tests on the CI reliability.

### TODO only if you're a HashiCorp employee
- [ ] **Labels:** If this PR is the CE portion of an ENT change, and that ENT change is
  getting backported to N-2, use the new style `backport/ent/x.x.x+ent` labels
  instead of the old style `backport/x.x.x` labels.
- [ ] **Labels:** If this PR is a CE only change, it can only be backported to N, so use
  the normal `backport/x.x.x` label (there should be only 1).
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
