### PR TITLE
Return the proper serial number in OCSP verification errors

### DIFF
--- a/builtin/logical/pki/integration_test.go
+++ b/builtin/logical/pki/integration_test.go
@@ -718,6 +718,7 @@ func TestIntegrationOCSPClientWithPKI(t *testing.T) {
 
 		err = ocspClient.VerifyLeafCertificate(context.Background(), cert, issuer, conf)
 		require.Error(t, err)
+		require.Contains(t, err.Error(), serialNumber, "Expected revoked serial number to appear in err")
 	}
 }
 

--- a/changelog/27696.txt
+++ b/changelog/27696.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+auth/cert: Use subject's serial number, not issuer's within error message text in OCSP request errors
+```

--- a/sdk/helper/ocsp/client.go
+++ b/sdk/helper/ocsp/client.go
@@ -702,7 +702,7 @@ func (c *Client) VerifyLeafCertificate(ctx context.Context, subject, issuer *x50
 	if results.code == ocspStatusGood {
 		return nil
 	} else {
-		serial := issuer.SerialNumber
+		serial := subject.SerialNumber
 		serialHex := strings.TrimSpace(certutil.GetHexFormatted(serial.Bytes(), ":"))
 		if results.code == ocspStatusRevoked {
 			return fmt.Errorf("certificate with serial number %s has been revoked", serialHex)

--- a/sdk/helper/ocsp/client.go
+++ b/sdk/helper/ocsp/client.go
@@ -707,7 +707,7 @@ func (c *Client) VerifyLeafCertificate(ctx context.Context, subject, issuer *x50
 		if results.code == ocspStatusRevoked {
 			return fmt.Errorf("certificate with serial number %s has been revoked", serialHex)
 		} else if conf.OcspFailureMode == FailOpenFalse {
-			return fmt.Errorf("unknown OCSP status for cert with serial number %s", strings.TrimSpace(certutil.GetHexFormatted(serial.Bytes(), ":")))
+			return fmt.Errorf("unknown OCSP status for cert with serial number %s", serialHex)
 		} else {
 			c.Logger().Warn("could not validate OCSP status for cert, but continuing in fail open mode", "serial", serialHex)
 		}


### PR DESCRIPTION
### Description
 - We returned the issuer's certificate number instead of the serial number of the actual certificate we validated from an OCSP request that confirmed the certificate was revoked

Fixes #27126

VAULT-28667

### TODO only if you're a HashiCorp employee
- [X] **Labels:** If this PR is the CE portion of an ENT change, and that ENT change is
  getting backported to N-2, use the new style `backport/ent/x.x.x+ent` labels
  instead of the old style `backport/x.x.x` labels.
- [X] **Labels:** If this PR is a CE only change, it can only be backported to N, so use
  the normal `backport/x.x.x` label (there should be only 1).
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
