### PR TITLE
Document the Transit AES CMAC known issue

### DIFF
--- a/website/content/docs/upgrading/upgrade-to-1.17.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.17.x.mdx
@@ -88,3 +88,5 @@ incorrectly. For additional details, refer to the
 @include 'known-issues/agent-and-proxy-excessive-cpu-1-17.mdx'
 
 @include 'known-issues/config_listener_proxy_protocol_behavior_issue.mdx'
+
+@include 'known-issues/transit-input-on-cmac-response.mdx'

--- a/website/content/partials/known-issues/transit-input-on-cmac-response.mdx
+++ b/website/content/partials/known-issues/transit-input-on-cmac-response.mdx
@@ -1,0 +1,13 @@
+<a id="transit-cmac-input-response" />
+
+### Input data on Transit Generate CMAC Response
+
+CMAC support in the Transit engine has a known issue that causes it to return
+the original input along with the computed CMAC value in the CMAC field of the
+response.
+
+We recommend waiting until version 1.17.2+ent for using this feature.
+
+#### Impacted versions
+
+Affects 1.17.0+ent and1.17.1+ent.


### PR DESCRIPTION

### Description

Add a section to the 1.17 upgrade guide documenting the known issue in Transit's Generate CMAC.

### TODO only if you're a HashiCorp employee
- [ ] **Labels:** If this PR is the CE portion of an ENT change, and that ENT change is
  getting backported to N-2, use the new style `backport/ent/x.x.x+ent` labels
  instead of the old style `backport/x.x.x` labels.
- [ ] **Labels:** If this PR is a CE only change, it can only be backported to N, so use
  the normal `backport/x.x.x` label (there should be only 1).
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [X] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
