### PR TITLE
Backport: Docs: fix telemetry docs for Audit into 1.16.x 

### DIFF
--- a/website/content/docs/internals/telemetry/metrics/all.mdx
+++ b/website/content/docs/internals/telemetry/metrics/all.mdx
@@ -80,11 +80,7 @@ alphabetic order by name.
 
 @include 'telemetry-metrics/secrets/pki/tidy/success.mdx'
 
-@include 'telemetry-metrics/vault/audit/device/log_request_failure.mdx'
-
 @include 'telemetry-metrics/vault/audit/device/log_request.mdx'
-
-@include 'telemetry-metrics/vault/audit/device/log_response_failure.mdx'
 
 @include 'telemetry-metrics/vault/audit/device/log_response.mdx'
 

--- a/website/content/partials/telemetry-metrics/vault/audit/device/log_request_failure.mdx
+++ b/website/content/partials/telemetry-metrics/vault/audit/device/log_request_failure.mdx
@@ -1,5 +1,0 @@
-### vault.audit.{DEVICE}.log_request_failure ((#vault-audit-device-log_request_failure))
-
-Metric type | Value   | Description
------------ | ------- | -----------
-counter     | number  | Number of audit log request failures

--- a/website/content/partials/telemetry-metrics/vault/audit/device/log_response_failure.mdx
+++ b/website/content/partials/telemetry-metrics/vault/audit/device/log_response_failure.mdx
@@ -1,5 +1,0 @@
-### vault.audit.{DEVICE}.log_response_failure ((#vault-audit-device-log_response_failure))
-
-Metric type | Value   | Description
------------ | ------- | -----------
-counter     | number  | Number of audit log request failures


### PR DESCRIPTION
### Description

Manual backport of https://github.com/hashicorp/vault-enterprise/pull/6205 based on https://github.com/hashicorp/vault/pull/27698
