### PR TITLE
raft/autopilot: fix panic during autopilot shutdown

### DIFF
--- a/changelog/27726.txt
+++ b/changelog/27726.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+raft/autopilot: Fixed panic that may occur during shutdown
+```

--- a/physical/raft/raft_autopilot.go
+++ b/physical/raft/raft_autopilot.go
@@ -636,7 +636,8 @@ func (b *RaftBackend) StopAutopilot() {
 	if b.autopilot == nil {
 		return
 	}
-	b.autopilot.Stop()
+	stopCh := b.autopilot.Stop()
+	<-stopCh
 	b.autopilot = nil
 	b.followerHeartbeatTicker.Stop()
 }


### PR DESCRIPTION
Sometimes autopilot can cause a panic when shutdown logic is triggered (stepping down from active duty) because we aren't waiting for autopilot to shutdown gracefully.

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x78 pc=0x1c66537]

goroutine 907 [running]:
github.com/hashicorp/raft-autopilot.(*Autopilot).GetState(0xc0005ec850?)
    /home/runner/go/pkg/mod/github.com/hashicorp/raft-autopilot@v0.2.0/autopilot.go:222 +0x37
github.com/hashicorp/vault/physical/raft.(*Delegate).KnownServers(0xc006eca120)
    /home/runner/actions-runner/_work/vault-enterprise/vault-enterprise/physical/raft/raft_autopilot.go:389 +0xfc
github.com/hashicorp/raft-autopilot.(*Autopilot).gatherNextStateInputs(0xc006ecc000, {0x89cd4b8, 0xc006e92370})
    /home/runner/go/pkg/mod/github.com/hashicorp/raft-autopilot@v0.2.0/state.go:115 +0x27c
github.com/hashicorp/raft-autopilot.(*Autopilot).nextState(0xc005f96f70?, {0x89cd4b8?, 0xc006e92370?})
    /home/runner/go/pkg/mod/github.com/hashicorp/raft-autopilot@v0.2.0/state.go:185 +0x28
github.com/hashicorp/raft-autopilot.(*Autopilot).updateState(0xc006ecc000, {0x89cd4b8?, 0xc006e92370?})
    /home/runner/go/pkg/mod/github.com/hashicorp/raft-autopilot@v0.2.0/state.go:403 +0x46
github.com/hashicorp/raft-autopilot.(*Autopilot).runStateUpdater(0xc006ecc000, {0x89cd4b8, 0xc006e92370}, 0xc006ec4540)
    /home/runner/go/pkg/mod/github.com/hashicorp/raft-autopilot@v0.2.0/run.go:190 +0x114
created by github.com/hashicorp/raft-autopilot.(*Autopilot).beginExecution
    /home/runner/go/pkg/mod/github.com/hashicorp/raft-autopilot@v0.2.0/run.go:121 +0x13d
```