### PR TITLE
UI: Fix namespace picker in small screens

### DIFF
--- a/changelog/27728.txt
+++ b/changelog/27728.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: fix namespace picker not working when in small screen where the sidebar is collapsed by default.
+```

--- a/ui/app/styles/components/namespace-picker.scss
+++ b/ui/app/styles/components/namespace-picker.scss
@@ -6,7 +6,6 @@
 .namespace-picker {
   position: relative;
   color: var(--token-color-palette-neutral-300);
-  display: flex;
   padding: $spacing-4 $spacing-8;
   width: 100%;
 }
@@ -23,12 +22,14 @@
   height: 2rem;
   justify-content: space-between;
   margin-right: $spacing-4;
+  width: 100%;
 }
 
 .namespace-picker-content {
   width: 250px;
   max-height: 300px;
   overflow: auto;
+  color: var(--token-color-foreground-primary);
   border-radius: $radius;
   box-shadow: $box-shadow, $box-shadow-high;
 

--- a/ui/app/templates/components/namespace-picker.hbs
+++ b/ui/app/templates/components/namespace-picker.hbs
@@ -4,7 +4,7 @@
 ~}}
 
 <div class="namespace-picker" ...attributes>
-  <BasicDropdown @horizontalPosition="left" @verticalPosition="above" as |D|>
+  <BasicDropdown @horizontalPosition="left" @verticalPosition="above" @renderInPlace={{true}} as |D|>
     <D.Trigger
       @htmlTag="button"
       class="button is-transparent namespace-picker-trigger has-current-color"


### PR DESCRIPTION
### Description
In small screens where the navbar gets collapsed by default, the namespace picker was broken in that nothing would happen when you open the sidebar, click the dropdown, and try to navigate to one of the namespace options. With this PR, the namespace picker dropdown is fully functional even in screens where the side nav is collapsed by default. 

`renderInPlace` is what fixed the behavior, but some CSS changes were necessary to make sure visually it looks the same as before:
<img width="1840" alt="Before and after -- same same!" src="https://github.com/hashicorp/vault/assets/82459713/6c2d5d05-3a61-415d-9bab-4231b3bf8061">

