### PR TITLE
UI: Fix ACME Account Safety Buffer not able to be turned off

### DIFF
--- a/changelog/27742.txt
+++ b/changelog/27742.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: fix issue where enabling then disabling "Tidy ACME" in PKI results in failed API call.
+```

--- a/ui/app/models/pki/tidy.js
+++ b/ui/app/models/pki/tidy.js
@@ -21,6 +21,7 @@ export default class PkiTidyModel extends Model {
       'The amount of time that must pass after creation that an account with no orders is marked revoked, and the amount of time after being marked revoked or deactivated.',
     detailsLabel: 'ACME account safety buffer',
     formatTtl: true,
+    defaultValue: '720h',
   })
   acmeAccountSafetyBuffer;
 

--- a/ui/tests/integration/components/pki/pki-tidy-form-test.js
+++ b/ui/tests/integration/components/pki/pki-tidy-form-test.js
@@ -180,7 +180,7 @@ module('Integration | Component | pki tidy form', function (hooks) {
       assert.propEqual(
         JSON.parse(req.requestBody),
         {
-          acme_account_safety_buffer: '60s',
+          acme_account_safety_buffer: '72h',
           enabled: true,
           interval_duration: '10s',
           issuer_safety_buffer: '20s',
@@ -230,7 +230,7 @@ module('Integration | Component | pki tidy form', function (hooks) {
     assert.false(this.autoTidy.tidyAcme, 'tidyAcme is false on model');
 
     await click(PKI_TIDY_FORM.toggleInput('acmeAccountSafetyBuffer'));
-    await fillIn(PKI_TIDY_FORM.acmeAccountSafetyBuffer, 60);
+    await fillIn(PKI_TIDY_FORM.acmeAccountSafetyBuffer, 3); // units are days based on defaultValue
     assert.true(this.autoTidy.tidyAcme, 'tidyAcme toggles to true');
 
     const fillInValues = {
@@ -262,6 +262,7 @@ module('Integration | Component | pki tidy form', function (hooks) {
       assert.propEqual(
         JSON.parse(req.requestBody),
         {
+          acme_account_safety_buffer: '720h',
           enabled: false,
           tidy_acme: false,
         },
@@ -294,7 +295,7 @@ module('Integration | Component | pki tidy form', function (hooks) {
       assert.ok(true, 'Request made to perform manual tidy');
       assert.propEqual(
         JSON.parse(req.requestBody),
-        { tidy_acme: false },
+        { acme_account_safety_buffer: '720h', tidy_acme: false },
         'response contains manual tidy params'
       );
       return { id: 'pki-manual-tidy' };


### PR DESCRIPTION
### Description
This PR fixes a bug where turning on "ACME Account Safety Buffer" in PKI Tidy and then turning it off would not allow to save due to sending the value for `acme_account_safety_buffer` as `0s`. To resolve, I set the default value for this setting to `720h` which is the equivalent of 30 days -- the [default according to the docs](https://developer.hashicorp.com/vault/api-docs/secret/pki#acme_account_safety_buffer). 

**Error on save**
![image](https://github.com/hashicorp/vault/assets/82459713/a35d9659-9798-4f93-a3fb-2a7bda84dd46)

**Success with changes**
![Kapture 2024-07-10 at 10 07 22](https://github.com/hashicorp/vault/assets/82459713/3d8608e4-db0a-4902-b8b3-5cb71785e8af)
