### PR TITLE
Docs: Add "administrative_namespace_path" as an available parameter in Vault config

### DIFF
--- a/website/content/docs/configuration/index.mdx
+++ b/website/content/docs/configuration/index.mdx
@@ -284,6 +284,9 @@ The following parameters are only used with Vault Enterprise
   provided via the environment variable `VAULT_LICENSE_PATH`, or the license
   itself can be provided in the environment variable `VAULT_LICENSE`.
 
+- `administrative_namespace_path` `(string: "")` - Specifies the absolute path 
+  to the Vault namespace to be used as an [Administrative namespace](/vault/docs/enterprise/namespaces/create-admin-namespace).
+
 [storage-backend]: /vault/docs/configuration/storage
 [listener]: /vault/docs/configuration/listener
 [seal]: /vault/docs/configuration/seal


### PR DESCRIPTION

### Description
This PR adds a mention to the `administrative_namespace_path` in the Configuration section as this is the go-to document when a user wants to modify the `config.hcl` file.

Details about the parameter is available here https://developer.hashicorp.com/vault/docs/enterprise/namespaces/create-admin-namespace but it needs to be available under the Configuration section as well.

### TODO only if you're a HashiCorp employee
- [x] **Labels:** If this PR is the CE portion of an ENT change, and that ENT change is
  getting backported to N-2, use the new style `backport/ent/x.x.x+ent` labels
  instead of the old style `backport/x.x.x` labels.
- [x] **Labels:** If this PR is a CE only change, it can only be backported to N, so use
  the normal `backport/x.x.x` label (there should be only 1).
- [ ] ~~**ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.~~
- [ ] ~~**Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.~~
- [ ] ~~**RFC:** If this change has an associated RFC, please link it in the description.~~
- [ ] ~~**ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.~~
