### PR TITLE
VAULT-28677: Fix dangling entity-aliases in MemDB after invalidation

### DIFF
--- a/changelog/27750.txt
+++ b/changelog/27750.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core/identity: Fixed an issue where deleted/reassigned entity-aliases were not removed from in-memory database.
+```

--- a/vault/identity_store.go
+++ b/vault/identity_store.go
@@ -731,11 +731,12 @@ func (i *IdentityStore) invalidateEntityBucket(ctx context.Context, key string) 
 			}
 
 			// If the entity exists in MemDB it must differ from the entity in
-			// the storage bucket because of above test. Go through all of the
-			// aliases currently set in the memDB entity and check if any of
-			// those are not in the bucket entity. Those aliases that are only
-			// found in the memDB entity, need to be deleted from MemDB because
-			// the upsertEntityInTxn function does not delete those aliases.
+			// the storage bucket because of above test. Blindly delete the
+			// current aliases associated with the MemDB entity. The correct set
+			// of aliases will be created in MemDB by the upsertEntityInTxn
+			// function. We need to do this because the upsertEntityInTxn
+			// function does not delete those aliases, it only creates missing
+			// ones.
 			if memDBEntity != nil {
 				if err := i.deleteAliasesInEntityInTxn(txn, memDBEntity, memDBEntity.Aliases); err != nil {
 					i.logger.Error("failed to remove entity aliases from changed entity", "entity_id", memDBEntity.ID, "error", err)

--- a/vault/identity_store.go
+++ b/vault/identity_store.go
@@ -742,6 +742,11 @@ func (i *IdentityStore) invalidateEntityBucket(ctx context.Context, key string) 
 					i.logger.Error("failed to remove entity aliases from changed entity", "entity_id", memDBEntity.ID, "error", err)
 					return
 				}
+
+				if err := i.MemDBDeleteEntityByIDInTxn(txn, memDBEntity.ID); err != nil {
+					i.logger.Error("failed to delete changed entity", "entity_id", memDBEntity.ID, "error", err)
+					return
+				}
 			}
 
 			err = i.upsertEntityInTxn(ctx, txn, bucketEntity, nil, false)

--- a/vault/identity_store_test.go
+++ b/vault/identity_store_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 )
 
@@ -1052,7 +1053,6 @@ func TestIdentityStoreInvalidate_EntityAliasDelete(t *testing.T) {
 
 	entityID := resp.Data["id"].(string)
 
-	// Create two entity-aliases
 	createEntityAlias := func(name, mountAccessor string) string {
 		req = &logical.Request{
 			ClientToken: root,
@@ -1102,6 +1102,153 @@ func TestIdentityStoreInvalidate_EntityAliasDelete(t *testing.T) {
 	require.NoError(t, err)
 
 	require.NoError(t, c.identityStore.entityPacker.PutItem(context.Background(), bucketEntityItem))
+
+	c.identityStore.Invalidate(context.Background(), bucketKey)
+
+	alias1, err := c.identityStore.MemDBAliasByID(alias1ID, false, false)
+	assert.NoError(t, err)
+	assert.NotNil(t, alias1)
+
+	alias2, err := c.identityStore.MemDBAliasByID(alias2ID, false, false)
+	assert.NoError(t, err)
+	assert.Nil(t, alias2)
+
+	alias3, err := c.identityStore.MemDBAliasByID(alias3ID, false, false)
+	assert.NoError(t, err)
+	assert.NotNil(t, alias3)
+}
+
+// TestIdentityStoreInvalidate_EntityLocalAliasDelete verifies that the
+// invalidateLocalAliasesBucket method properly cleans up aliases from
+// MemDB that are no longer associated with the entity in the
+// storage bucket.
+func TestIdentityStoreInvalidate_EntityLocalAliasDelete(t *testing.T) {
+	ctx := namespace.ContextWithNamespace(context.Background(), namespace.RootNamespace)
+	c, _, root := TestCoreUnsealed(t)
+
+	// Enable a No-Op auth method
+	c.credentialBackends["noop"] = func(context.Context, *logical.BackendConfig) (logical.Backend, error) {
+		return &NoopBackend{
+			BackendType: logical.TypeCredential,
+		}, nil
+	}
+	mountAccessor1 := "noop-accessor1"
+	mountAccessor2 := "noop-accessor2"
+	mountAccessor3 := "noon-accessor3"
+
+	createMountEntry := func(path, uuid, mountAccessor string, local bool) *MountEntry {
+		return &MountEntry{
+			Table:            credentialTableType,
+			Path:             path,
+			Type:             "noop",
+			UUID:             uuid,
+			Accessor:         mountAccessor,
+			BackendAwareUUID: uuid + "backend",
+			NamespaceID:      namespace.RootNamespaceID,
+			namespace:        namespace.RootNamespace,
+			Local:            local,
+		}
+	}
+
+	c.auth = &MountTable{
+		Type: credentialTableType,
+		Entries: []*MountEntry{
+			createMountEntry("/noop1", "abcd", mountAccessor1, true),
+			createMountEntry("/noop2", "ghij", mountAccessor2, true),
+			createMountEntry("/noop3", "mnop", mountAccessor3, true),
+		},
+	}
+
+	require.NoError(t, c.setupCredentials(context.Background()))
+
+	// Create an entity
+	req := &logical.Request{
+		ClientToken: root,
+		Operation:   logical.UpdateOperation,
+		Path:        "entity",
+		Data: map[string]interface{}{
+			"name": "alice",
+		},
+	}
+
+	resp, err := c.identityStore.HandleRequest(ctx, req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Contains(t, resp.Data, "id")
+
+	entityID := resp.Data["id"].(string)
+
+	createEntityAlias := func(name, mountAccessor string) string {
+		req = &logical.Request{
+			ClientToken: root,
+			Operation:   logical.UpdateOperation,
+			Path:        "entity-alias",
+			Data: map[string]interface{}{
+				"name":           name,
+				"canonical_id":   entityID,
+				"mount_accessor": mountAccessor,
+			},
+		}
+
+		resp, err = c.identityStore.HandleRequest(ctx, req)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.Contains(t, resp.Data, "id")
+
+		return resp.Data["id"].(string)
+	}
+
+	alias1ID := createEntityAlias("alias1", mountAccessor1)
+	alias2ID := createEntityAlias("alias2", mountAccessor2)
+	alias3ID := createEntityAlias("alias3", mountAccessor3)
+
+	for i, aliasID := range []string{alias1ID, alias2ID, alias3ID} {
+		alias, err := c.identityStore.MemDBAliasByID(aliasID, false, false)
+		require.NoError(t, err, i)
+		require.NotNil(t, alias, i)
+	}
+
+	// // Update the entity in storage only to remove alias2 then call invalidate
+	bucketKey := c.identityStore.entityPacker.BucketKey(entityID)
+	bucket, err := c.identityStore.entityPacker.GetBucket(context.Background(), bucketKey)
+	require.NoError(t, err)
+	require.NotNil(t, bucket)
+
+	bucketEntityItem := bucket.Items[0] // since there's only 1 entity
+	bucketEntity, err := c.identityStore.parseEntityFromBucketItem(context.Background(), bucketEntityItem)
+	require.NoError(t, err)
+	require.NotNil(t, bucketEntity)
+
+	bucketKey = c.identityStore.localAliasPacker.BucketKey(entityID)
+	bucketLocalAlias, err := c.identityStore.localAliasPacker.GetBucket(context.Background(), bucketKey)
+	require.NoError(t, err)
+	require.NotNil(t, bucketLocalAlias)
+
+	bucketLocalAliasItem := bucketLocalAlias.Items[0]
+	require.Equal(t, entityID, bucketLocalAliasItem.ID)
+
+	var localAliases identity.LocalAliases
+
+	err = anypb.UnmarshalTo(bucketLocalAliasItem.Message, &localAliases, proto.UnmarshalOptions{})
+	require.NoError(t, err)
+
+	memDBEntity, err := c.identityStore.MemDBEntityByID(entityID, false)
+	require.NoError(t, err)
+	require.NotNil(t, memDBEntity)
+
+	replacementAliases := make([]*identity.Alias, 0)
+	for _, a := range memDBEntity.Aliases {
+		if a.ID != alias2ID {
+			replacementAliases = append(replacementAliases, a)
+		}
+	}
+
+	localAliases.Aliases = replacementAliases
+
+	bucketLocalAliasItem.Message, err = anypb.New(&localAliases)
+	require.NoError(t, err)
+
+	require.NoError(t, c.identityStore.localAliasPacker.PutItem(context.Background(), bucketLocalAliasItem))
 
 	c.identityStore.Invalidate(context.Background(), bucketKey)
 

--- a/website/content/docs/release-notes/1.16.1.mdx
+++ b/website/content/docs/release-notes/1.16.1.mdx
@@ -24,7 +24,7 @@ description: |-
 | 1.16.1 - 1.16.3 | [New nodes added by autopilot upgrades provisioned with the wrong version](/vault/docs/upgrading/upgrade-to-1.15.x#new-nodes-added-by-autopilot-upgrades-provisioned-with-the-wrong-version) |
 | 1.15.8+         | [Autopilot upgrade for Vault Enterprise fails](/vault/docs/upgrading/upgrade-to-1.15.x#autopilot)                                                                                            |
 | 1.16.5          | [Listener stops listening on untrusted upstream connection with particular config settings](/vault/docs/upgrading/upgrade-to-1.16.x#listener-proxy-protocol-config)                          |
-| 1.16.3 - 1.16.7 | [Vault standby nodes not deleting removed entity-aliases from in-memory database](/vault/docs/upgrade-to-1.16.x#dangling-entity-alias-in-memory)                                             |
+| 1.16.3 - 1.16.6 | [Vault standby nodes not deleting removed entity-aliases from in-memory database](/vault/docs/upgrade-to-1.16.x#dangling-entity-alias-in-memory)                                             |
 
 ## Vault companion updates
 

--- a/website/content/docs/release-notes/1.16.1.mdx
+++ b/website/content/docs/release-notes/1.16.1.mdx
@@ -24,6 +24,7 @@ description: |-
 | 1.16.1 - 1.16.3 | [New nodes added by autopilot upgrades provisioned with the wrong version](/vault/docs/upgrading/upgrade-to-1.15.x#new-nodes-added-by-autopilot-upgrades-provisioned-with-the-wrong-version) |
 | 1.15.8+         | [Autopilot upgrade for Vault Enterprise fails](/vault/docs/upgrading/upgrade-to-1.15.x#autopilot)                                                                                            |
 | 1.16.5          | [Listener stops listening on untrusted upstream connection with particular config settings](/vault/docs/upgrading/upgrade-to-1.16.x#listener-proxy-protocol-config)                          |
+| 1.16.3 - 1.16.7 | [Vault standby nodes not deleting removed entity-aliases from in-memory database](/vault/docs/upgrade-to-1.16.x#dangling-entity-alias-in-memory)                                             |
 
 ## Vault companion updates
 

--- a/website/content/docs/release-notes/1.17.0.mdx
+++ b/website/content/docs/release-notes/1.17.0.mdx
@@ -22,6 +22,7 @@ description: |-
 | Known issue (1.17.0)           | [Vault Agent and Vault Proxy consume excessive amounts of CPU](/vault/docs/upgrading/upgrade-to-1.17.x#agent-proxy-cpu-1-17)                                        |
 | Known issue (1.15.8+)          | [Autopilot upgrade for Vault Enterprise fails](/vault/docs/upgrading/upgrade-to-1.15.x#autopilot)                                                                   |
 | Known issue (1.17.1)           | [Listener stops listening on untrusted upstream connection with particular config settings](/vault/docs/upgrading/upgrade-to-1.17.x#listener-proxy-protocol-config) |
+| Known issue (1.17.0 - 1.17.2)  | [Vault standby nodes not deleting removed entity-aliases from in-memory database](/vault/docs/upgrade-to-1.17.x#dangling-entity-alias-in-memory)
 
 ## Vault companion updates
 

--- a/website/content/docs/upgrading/upgrade-to-1.16.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.16.x.mdx
@@ -115,3 +115,5 @@ decides to trigger the flag. More information can be found in the
 @include 'known-issues/1_16_secrets-sync-chroot-activation.mdx'
 
 @include 'known-issues/config_listener_proxy_protocol_behavior_issue.mdx'
+
+@include 'known-issues/dangling-entity-aliases-in-memory.mdx'

--- a/website/content/docs/upgrading/upgrade-to-1.17.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.17.x.mdx
@@ -90,3 +90,5 @@ incorrectly. For additional details, refer to the
 @include 'known-issues/config_listener_proxy_protocol_behavior_issue.mdx'
 
 @include 'known-issues/transit-input-on-cmac-response.mdx'
+
+@include 'known-issues/dangling-entity-aliases-in-memory.mdx'

--- a/website/content/partials/known-issues/dangling-entity-aliases-in-memory.mdx
+++ b/website/content/partials/known-issues/dangling-entity-aliases-in-memory.mdx
@@ -1,0 +1,24 @@
+<a id="dangling-entity-alias-in-memory" />
+
+### Deleting an entity-aliases does not remove it from the in-memory database on standby nodes
+
+#### Affected versions
+
+##### Vault Community Edition
+
+- 1.16.3
+- 1.17.0 - 1.17.2
+
+##### Enterprise
+
+- 1.16.3+ent - 1.16.6+ent
+- 1.17.0+ent - 1.17.2+ent
+
+#### Issue
+
+Entity-aliases deleted from Vault are not removed from the in-memory database on
+standby nodes within a cluster. As a result, API requests to create a new
+entity-alias with the same mount accessor and name sent to a standby node will
+fail.
+
+This bug is fixed in Vault 1.16.7+ent, 1.17.3, 1.17.3+ent and later.


### PR DESCRIPTION
### Description
This change corrects a regression that was introduced by #27184.

When an entity has been modified in a storage bucket such that one or more aliases has been removed, those removed aliases were not being deleted from the MemDB table containing them. This change corrects this by scanning all associated aliases with entities that have been determined to be modified in the storage bucket, and deleting any associated aliases from MemDB that are no longer associated with the entity in the storage bucket.

### TODO only if you're a HashiCorp employee
- [ ] **Labels:** If this PR is the CE portion of an ENT change, and that ENT change is
  getting backported to N-2, use the new style `backport/ent/x.x.x+ent` labels
  instead of the old style `backport/x.x.x` labels.
- [x] **Labels:** If this PR is a CE only change, it can only be backported to N, so use
  the normal `backport/x.x.x` label (there should be only 1).
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
