### PR TITLE
WIF AWS: Add identity_token_key to model and render

### DIFF
--- a/ui/app/components/mount-backend-form.hbs
+++ b/ui/app/components/mount-backend-form.hbs
@@ -35,7 +35,21 @@
         @modelValidations={{this.modelValidations}}
         @onKeyUp={{this.onKeyUp}}
       />
-      <FormFieldGroups @model={{@mountModel}} @renderGroup="Method Options" />
+
+      <FormFieldGroups @model={{@mountModel}} @renderGroup="Method Options">
+        {{! while identityTokenKey can be set by OSS users, it's only used for the enterprise WIF feature }}
+        {{#if (and this.version.isEnterprise)}}
+          {{! identityTokenKey attr has editType yield, which will render the following component }}
+          <SearchSelectWithModal
+            @id="identityTokenKey"
+            @fallbackComponent="input-search"
+            @onChange={{this.handleIdentityTokenKeyChange}}
+            @models={{array "oidc/key"}}
+            @selectLimit="1"
+            @returnString={{true}}
+          />
+        {{/if}}
+      </FormFieldGroups>
 
       <div class="field is-grouped box is-fullwidth is-bottomless">
         <div class="control">

--- a/ui/app/components/mount-backend-form.hbs
+++ b/ui/app/components/mount-backend-form.hbs
@@ -38,7 +38,7 @@
 
       <FormFieldGroups @model={{@mountModel}} @renderGroup="Method Options">
         {{! while identityTokenKey can be set by OSS users, it's only used for the enterprise WIF feature }}
-        {{#if (and this.version.isEnterprise)}}
+        {{#if this.version.isEnterprise}}
           {{! identityTokenKey attr has editType yield, which will render the following component }}
           <SearchSelectWithModal
             @id="identityTokenKey"

--- a/ui/app/components/mount-backend-form.hbs
+++ b/ui/app/components/mount-backend-form.hbs
@@ -38,7 +38,6 @@
 
       <FormFieldGroups @model={{@mountModel}} @renderGroup="Method Options">
         <:identityTokenKey>
-          {{! while identityTokenKey can be set by OSS users, it's only used for the enterprise WIF feature }}
           <SearchSelectWithModal
             @id="identityTokenKey"
             @fallbackComponent="input-search"

--- a/ui/app/components/mount-backend-form.hbs
+++ b/ui/app/components/mount-backend-form.hbs
@@ -37,9 +37,8 @@
       />
 
       <FormFieldGroups @model={{@mountModel}} @renderGroup="Method Options">
-        {{! while identityTokenKey can be set by OSS users, it's only used for the enterprise WIF feature }}
-        {{#if this.version.isEnterprise}}
-          {{! identityTokenKey attr has editType yield, which will render the following component }}
+        <:identityTokenKey>
+          {{! while identityTokenKey can be set by OSS users, it's only used for the enterprise WIF feature }}
           <SearchSelectWithModal
             @id="identityTokenKey"
             @fallbackComponent="input-search"
@@ -48,7 +47,7 @@
             @selectLimit="1"
             @returnString={{true}}
           />
-        {{/if}}
+        </:identityTokenKey>
       </FormFieldGroups>
 
       <div class="field is-grouped box is-fullwidth is-bottomless">

--- a/ui/app/components/mount-backend-form.ts
+++ b/ui/app/components/mount-backend-form.ts
@@ -14,6 +14,7 @@ import { isAddonEngine, allEngines } from 'vault/helpers/mountable-secret-engine
 
 import type FlashMessageService from 'vault/services/flash-messages';
 import type Store from '@ember-data/store';
+import type VersionService from 'vault/services/version';
 
 import type { AuthEnableModel } from 'vault/routes/vault/cluster/settings/auth/enable';
 import type { MountSecretBackendModel } from 'vault/routes/vault/cluster/settings/mount-secret-backend';
@@ -41,6 +42,7 @@ interface Args {
 export default class MountBackendForm extends Component<Args> {
   @service declare readonly store: Store;
   @service declare readonly flashMessages: FlashMessageService;
+  @service declare readonly version: VersionService;
 
   // validation related properties
   @tracked modelValidations = null;
@@ -189,5 +191,10 @@ export default class MountBackendForm extends Component<Args> {
     this.args.mountModel.type = value;
     this.typeChangeSideEffect(value);
     this.checkPathChange(value);
+  }
+
+  @action
+  handleIdentityTokenKeyChange(value: string[]): void {
+    this.args.mountModel.config.identityTokenKey = value[0];
   }
 }

--- a/ui/app/components/mount-backend-form.ts
+++ b/ui/app/components/mount-backend-form.ts
@@ -14,7 +14,6 @@ import { isAddonEngine, allEngines } from 'vault/helpers/mountable-secret-engine
 
 import type FlashMessageService from 'vault/services/flash-messages';
 import type Store from '@ember-data/store';
-import type VersionService from 'vault/services/version';
 
 import type { AuthEnableModel } from 'vault/routes/vault/cluster/settings/auth/enable';
 import type { MountSecretBackendModel } from 'vault/routes/vault/cluster/settings/mount-secret-backend';
@@ -42,7 +41,6 @@ interface Args {
 export default class MountBackendForm extends Component<Args> {
   @service declare readonly store: Store;
   @service declare readonly flashMessages: FlashMessageService;
-  @service declare readonly version: VersionService;
 
   // validation related properties
   @tracked modelValidations = null;

--- a/ui/app/models/mount-config.js
+++ b/ui/app/models/mount-config.js
@@ -74,6 +74,7 @@ export default class MountConfigModel extends Model {
   })
   pluginVersion;
 
+  // identityTokenKey is yielded in a named block on the mount-backend-form component
   @attr({
     label: 'Identity token key',
     subText: `A named key to sign tokens. If not provided, this will default to Vault's OIDC default key.`,

--- a/ui/app/models/mount-config.js
+++ b/ui/app/models/mount-config.js
@@ -74,6 +74,17 @@ export default class MountConfigModel extends Model {
   })
   pluginVersion;
 
+  @attr({
+    label: 'Identity token key',
+    subText: `A named key to sign tokens. If not provided, this will default to Vault's OIDC default key.`,
+    selectLimit: 1,
+    models: ['oidc/key'],
+    fallbackComponent: 'input-search',
+    returnString: true,
+    editType: 'yield',
+  })
+  identityTokenKey;
+
   // Auth mount userLockoutConfig params, added to user_lockout_config object in saveModel method
   @attr('string', {
     label: 'Lockout threshold',

--- a/ui/app/models/mount-config.js
+++ b/ui/app/models/mount-config.js
@@ -77,10 +77,6 @@ export default class MountConfigModel extends Model {
   @attr({
     label: 'Identity token key',
     subText: `A named key to sign tokens. If not provided, this will default to Vault's OIDC default key.`,
-    selectLimit: 1,
-    models: ['oidc/key'],
-    fallbackComponent: 'input-search',
-    returnString: true,
     editType: 'yield',
   })
   identityTokenKey;

--- a/ui/app/models/secret-engine.js
+++ b/ui/app/models/secret-engine.js
@@ -242,7 +242,14 @@ export default class SecretEngineModel extends Model {
         break;
       case 'aws':
         defaultFields = ['path'];
-        optionFields = ['config.identityTokenKey', ...CORE_OPTIONS, ...STANDARD_CONFIG];
+        optionFields = [
+          ...CORE_OPTIONS,
+          'config.defaultLeaseTtl',
+          'config.maxLeaseTtl',
+          'config.identityTokenKey',
+          'config.allowedManagedKeys',
+          ...STANDARD_CONFIG,
+        ];
         break;
       default:
         defaultFields = ['path'];

--- a/ui/app/models/secret-engine.js
+++ b/ui/app/models/secret-engine.js
@@ -187,6 +187,10 @@ export default class SecretEngineModel extends Model {
     if (type === 'kv' && parseInt(this.version, 10) === 2) {
       fields.push('casRequired', 'deleteVersionAfter', 'maxVersions');
     }
+    // WIF secret engines
+    if (type === 'aws') {
+      fields.push('config.identityTokenKey');
+    }
     return fields;
   }
 
@@ -235,6 +239,10 @@ export default class SecretEngineModel extends Model {
       case 'keymgmt':
         // no ttl options for keymgmt
         optionFields = [...CORE_OPTIONS, 'config.allowedManagedKeys', ...STANDARD_CONFIG];
+        break;
+      case 'aws':
+        defaultFields = ['path'];
+        optionFields = ['config.identityTokenKey', ...CORE_OPTIONS, ...STANDARD_CONFIG];
         break;
       default:
         defaultFields = ['path'];

--- a/ui/lib/core/addon/components/form-field-groups.hbs
+++ b/ui/lib/core/addon/components/form-field-groups.hbs
@@ -62,17 +62,8 @@
                   @modelValidations={{@modelValidations}}
                   @showHelpText={{@showHelpText}}
                 >
-                  {{! while identityTokenKey can be set by OSS users, it's only used for the enterprise WIF feature }}
-                  {{#if (and this.version.isEnterprise (eq attr.name "identityTokenKey"))}}
-                    {{! identityTokenKey attr has editType yield, which will render the following component }}
-                    <SearchSelectWithModal
-                      @id={{attr.name}}
-                      @fallbackComponent={{attr.options.fallbackComponent}}
-                      @onChange={{action (mut @model.config.identityTokenKey)}}
-                      @models={{attr.options.models}}
-                      @selectLimit={{attr.options.selectLimit}}
-                      @returnString={{attr.options.returnString}}
-                    />
+                  {{#if (and (has-block) (eq attr.options.editType "yield"))}}
+                    {{yield}}
                   {{/if}}
                 </FormField>
 

--- a/ui/lib/core/addon/components/form-field-groups.hbs
+++ b/ui/lib/core/addon/components/form-field-groups.hbs
@@ -62,7 +62,7 @@
                   @modelValidations={{@modelValidations}}
                   @showHelpText={{@showHelpText}}
                 >
-                  {{#if (has-block "identityTokenKey")}}
+                  {{#if (and (has-block "identityTokenKey") (eq attr.name "identityTokenKey"))}}
                     {{yield to="identityTokenKey"}}
                   {{/if}}
                 </FormField>

--- a/ui/lib/core/addon/components/form-field-groups.hbs
+++ b/ui/lib/core/addon/components/form-field-groups.hbs
@@ -62,12 +62,12 @@
                   @modelValidations={{@modelValidations}}
                   @showHelpText={{@showHelpText}}
                 >
-                  {{#if (eq attr.name "identityTokenKey")}}
+                  {{! while this field can be set for OSS users, it's only used for the enterprise WIF feature }}
+                  {{#if (and this.version.isEnterprise (eq attr.name "identityTokenKey"))}}
                     {{! identityTokenKey attr has editType yield, which will render the following component }}
                     <SearchSelectWithModal
                       @id={{attr.name}}
                       @fallbackComponent={{attr.options.fallbackComponent}}
-                      {{!-- @inputValue={{@model.policies}} --}}
                       @onChange={{action (mut @model.config.identityTokenKey)}}
                       @models={{attr.options.models}}
                       @selectLimit={{attr.options.selectLimit}}

--- a/ui/lib/core/addon/components/form-field-groups.hbs
+++ b/ui/lib/core/addon/components/form-field-groups.hbs
@@ -62,7 +62,7 @@
                   @modelValidations={{@modelValidations}}
                   @showHelpText={{@showHelpText}}
                 >
-                  {{! while this field can be set for OSS users, it's only used for the enterprise WIF feature }}
+                  {{! while identityTokenKey can be set by OSS users, it's only used for the enterprise WIF feature }}
                   {{#if (and this.version.isEnterprise (eq attr.name "identityTokenKey"))}}
                     {{! identityTokenKey attr has editType yield, which will render the following component }}
                     <SearchSelectWithModal

--- a/ui/lib/core/addon/components/form-field-groups.hbs
+++ b/ui/lib/core/addon/components/form-field-groups.hbs
@@ -61,7 +61,21 @@
                   @onKeyUp={{@onKeyUp}}
                   @modelValidations={{@modelValidations}}
                   @showHelpText={{@showHelpText}}
-                />
+                >
+                  {{#if (eq attr.name "identityTokenKey")}}
+                    {{! identityTokenKey attr has editType yield, which will render the following component }}
+                    <SearchSelectWithModal
+                      @id={{attr.name}}
+                      @fallbackComponent={{attr.options.fallbackComponent}}
+                      {{!-- @inputValue={{@model.policies}} --}}
+                      @onChange={{action (mut @model.config.identityTokenKey)}}
+                      @models={{attr.options.models}}
+                      @selectLimit={{attr.options.selectLimit}}
+                      @returnString={{attr.options.returnString}}
+                    />
+                  {{/if}}
+                </FormField>
+
               {{else}}
                 {{! OTHERWISE WE'RE EDITING }}
                 {{#if (or (eq attr.name "name") (eq attr.options.editDisabled true))}}

--- a/ui/lib/core/addon/components/form-field-groups.hbs
+++ b/ui/lib/core/addon/components/form-field-groups.hbs
@@ -62,8 +62,8 @@
                   @modelValidations={{@modelValidations}}
                   @showHelpText={{@showHelpText}}
                 >
-                  {{#if (and (has-block) (eq attr.options.editType "yield"))}}
-                    {{yield}}
+                  {{#if (has-block "identityTokenKey")}}
+                    {{yield to="identityTokenKey"}}
                   {{/if}}
                 </FormField>
 

--- a/ui/lib/core/addon/components/form-field-groups.ts
+++ b/ui/lib/core/addon/components/form-field-groups.ts
@@ -6,7 +6,6 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
-
 import type { ValidationMap } from 'vault/vault/app-types';
 
 /**

--- a/ui/lib/core/addon/components/form-field-groups.ts
+++ b/ui/lib/core/addon/components/form-field-groups.ts
@@ -6,7 +6,10 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
+import { service } from '@ember/service';
+
 import type { ValidationMap } from 'vault/vault/app-types';
+import type VersionService from 'vault/services/version';
 
 /**
  * @module FormFieldGroups
@@ -33,6 +36,7 @@ interface Args {
 }
 
 export default class FormFieldGroupsComponent extends Component<Args> {
+  @service declare readonly version: VersionService;
   @tracked showGroup: string | null = null;
 
   @action

--- a/ui/lib/core/addon/components/form-field-groups.ts
+++ b/ui/lib/core/addon/components/form-field-groups.ts
@@ -6,10 +6,8 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
-import { service } from '@ember/service';
 
 import type { ValidationMap } from 'vault/vault/app-types';
-import type VersionService from 'vault/services/version';
 
 /**
  * @module FormFieldGroups
@@ -36,7 +34,6 @@ interface Args {
 }
 
 export default class FormFieldGroupsComponent extends Component<Args> {
-  @service declare readonly version: VersionService;
   @tracked showGroup: string | null = null;
 
   @action

--- a/ui/lib/core/addon/components/search-select-with-modal.hbs
+++ b/ui/lib/core/addon/components/search-select-with-modal.hbs
@@ -20,6 +20,7 @@
       helpText=@helpText
       placeholder=@placeholder
       id=@id
+      selectLimit=@selectLimit
     }}
   {{else}}
     {{#if @label}}

--- a/ui/lib/core/addon/components/search-select-with-modal.js
+++ b/ui/lib/core/addon/components/search-select-with-modal.js
@@ -123,7 +123,9 @@ export default class SearchSelectWithModal extends Component {
   @action
   handleChange() {
     if (this.selectedOptions.length && typeof this.selectedOptions[0] === 'object') {
-      this.args.onChange(Array.from(this.selectedOptions, (option) => option.id));
+      const onChangeValue = Array.from(this.selectedOptions, (option) => option.id);
+      this.args.returnString ? this.args.onChange(onChangeValue[0]) : this.args.onChange(onChangeValue);
+      // this.args.onChange(Array.from(this.selectedOptions, (option) => option.id));
     } else {
       this.args.onChange(this.selectedOptions);
     }

--- a/ui/lib/core/addon/components/search-select-with-modal.js
+++ b/ui/lib/core/addon/components/search-select-with-modal.js
@@ -39,6 +39,7 @@ import { addToArray } from 'vault/helpers/add-to-array';
  * @param {string} fallbackComponent - name of component to be rendered if the API call 403s
  * @param {string} [placeholder] - placeholder text to override the default text of "Search"
  * @param {boolean} [displayInherit=false] - if you need the search select component to display inherit instead of box.
+ * @param {number} [selectLimit=1] - if you only want the user to select a limited number of options, add number to this param.
  */
 export default class SearchSelectWithModal extends Component {
   @service store;

--- a/ui/lib/core/addon/components/search-select-with-modal.js
+++ b/ui/lib/core/addon/components/search-select-with-modal.js
@@ -124,8 +124,8 @@ export default class SearchSelectWithModal extends Component {
   handleChange() {
     if (this.selectedOptions.length && typeof this.selectedOptions[0] === 'object') {
       const onChangeValue = Array.from(this.selectedOptions, (option) => option.id);
+      // if returnString is true, the api expects the value to be a string (ex: identityTokenKey) otherwise set the value to an array of strings.
       this.args.returnString ? this.args.onChange(onChangeValue[0]) : this.args.onChange(onChangeValue);
-      // this.args.onChange(Array.from(this.selectedOptions, (option) => option.id));
     } else {
       this.args.onChange(this.selectedOptions);
     }

--- a/ui/lib/core/addon/components/search-select-with-modal.js
+++ b/ui/lib/core/addon/components/search-select-with-modal.js
@@ -124,9 +124,7 @@ export default class SearchSelectWithModal extends Component {
   @action
   handleChange() {
     if (this.selectedOptions.length && typeof this.selectedOptions[0] === 'object') {
-      const onChangeValue = Array.from(this.selectedOptions, (option) => option.id);
-      // if returnString is true, the api expects the value to be a string (ex: identityTokenKey) otherwise set the value to an array of strings.
-      this.args.returnString ? this.args.onChange(onChangeValue[0]) : this.args.onChange(onChangeValue);
+      this.args.onChange(Array.from(this.selectedOptions, (option) => option.id));
     } else {
       this.args.onChange(this.selectedOptions);
     }

--- a/ui/tests/acceptance/settings/mount-secret-backend-test.js
+++ b/ui/tests/acceptance/settings/mount-secret-backend-test.js
@@ -301,56 +301,30 @@ module('Acceptance | settings/mount-secret-backend', function (hooks) {
     );
   });
 
-  module('Community', function (hooks) {
-    hooks.beforeEach(function () {
-      this.version = this.owner.lookup('service:version');
-      this.version.type = 'community';
-      this.store = this.owner.lookup('service:store');
-    });
+  test('it sets identity_token_key when aws is chosen, resets after', async function (assert) {
+    // create an oidc/key
+    await runCmd(`write identity/oidc/key/some-key allowed_client_ids="*"`);
+    await page.visit();
+    await page.selectType('aws');
+    await click('[data-test-toggle-group="Method Options"]');
 
-    test('identity_token_key form field does not show', async function (assert) {
-      await page.visit();
-      await page.selectType('aws');
-      await click('[data-test-toggle-group="Method Options"]');
+    assert.dom('[data-test-search-select-with-modal]').exists('Search select with modal component renders');
 
-      assert
-        .dom('[data-test-search-select-with-modal]')
-        .doesNotExist('Search select with modal component does not show');
-    });
-  });
-
-  module('Enterprise', function (hooks) {
-    hooks.beforeEach(function () {
-      this.version = this.owner.lookup('service:version');
-      this.version.type = 'enterprise';
-      this.store = this.owner.lookup('service:store');
-    });
-
-    test('it sets identity_token_key when aws is chosen, resets after', async function (assert) {
-      // create an oidc/key
-      await runCmd(`write identity/oidc/key/some-key allowed_client_ids="*"`);
-      await page.visit();
-      await page.selectType('aws');
-      await click('[data-test-toggle-group="Method Options"]');
-
-      assert.dom('[data-test-search-select-with-modal]').exists('Search select with modal component renders');
-
-      await clickTrigger();
-      const dropdownOptions = findAll('[data-option-index]').map((o) => o.innerText);
-      assert.deepEqual(
-        ['default', 'some-key'],
-        dropdownOptions,
-        'search select options show default and oidc/keys'
-      );
-      // Go back and choose a non-wif engine type
-      await page.back();
-      await page.selectType('ssh');
-      await click('[data-test-toggle-group="Method Options"]');
-      assert
-        .dom('[data-test-search-select-with-modal]')
-        .doesNotExist('for type ssh, the modal field does not render.');
-      // clean up
-      await runCmd(`delete identity/oidc/key/some-key`);
-    });
+    await clickTrigger();
+    const dropdownOptions = findAll('[data-option-index]').map((o) => o.innerText);
+    assert.deepEqual(
+      ['default', 'some-key'],
+      dropdownOptions,
+      'search select options show default and oidc/keys'
+    );
+    // Go back and choose a non-wif engine type
+    await page.back();
+    await page.selectType('ssh');
+    await click('[data-test-toggle-group="Method Options"]');
+    assert
+      .dom('[data-test-search-select-with-modal]')
+      .doesNotExist('for type ssh, the modal field does not render.');
+    // clean up
+    await runCmd(`delete identity/oidc/key/some-key`);
   });
 });

--- a/ui/tests/acceptance/settings/mount-secret-backend-test.js
+++ b/ui/tests/acceptance/settings/mount-secret-backend-test.js
@@ -308,7 +308,7 @@ module('Acceptance | settings/mount-secret-backend', function (hooks) {
       this.store = this.owner.lookup('service:store');
     });
 
-    test('identity_token_key form field does not show even when oidc key set', async function (assert) {
+    test('identity_token_key form field does not show even when an oidc key exists', async function (assert) {
       // create an oidc/key
       await runCmd(`write identity/oidc/key/some-key allowed_client_ids="*"`);
       await page.visit();

--- a/ui/tests/acceptance/settings/mount-secret-backend-test.js
+++ b/ui/tests/acceptance/settings/mount-secret-backend-test.js
@@ -308,9 +308,7 @@ module('Acceptance | settings/mount-secret-backend', function (hooks) {
       this.store = this.owner.lookup('service:store');
     });
 
-    test('identity_token_key form field does not show even when an oidc key exists', async function (assert) {
-      // create an oidc/key
-      await runCmd(`write identity/oidc/key/some-key allowed_client_ids="*"`);
+    test('identity_token_key form field does not show', async function (assert) {
       await page.visit();
       await page.selectType('aws');
       await click('[data-test-toggle-group="Method Options"]');
@@ -318,8 +316,6 @@ module('Acceptance | settings/mount-secret-backend', function (hooks) {
       assert
         .dom('[data-test-search-select-with-modal]')
         .doesNotExist('Search select with modal component does not show');
-      // clean up
-      await runCmd(`delete identity/oidc/key/some-key`);
     });
   });
 

--- a/ui/tests/acceptance/settings/mount-secret-backend-test.js
+++ b/ui/tests/acceptance/settings/mount-secret-backend-test.js
@@ -3,10 +3,12 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { currentRouteName, currentURL, settled } from '@ember/test-helpers';
+import { currentRouteName, currentURL, settled, click, findAll } from '@ember/test-helpers';
+import { clickTrigger } from 'ember-power-select/test-support/helpers';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { v4 as uuidv4 } from 'uuid';
+import { runCmd } from 'vault/tests/helpers/commands';
 
 import { create } from 'ember-cli-page-object';
 import page from 'vault/tests/pages/settings/mount-secret-backend';
@@ -297,5 +299,62 @@ module('Acceptance | settings/mount-secret-backend', function (hooks) {
       `vault.cluster.secrets.backend.list-root`,
       `${v1} navigates to list route`
     );
+  });
+
+  module('Community', function (hooks) {
+    hooks.beforeEach(function () {
+      this.version = this.owner.lookup('service:version');
+      this.version.type = 'community';
+      this.store = this.owner.lookup('service:store');
+    });
+
+    test('identity_token_key form field does not show even when oidc key set', async function (assert) {
+      // create an oidc/key
+      await runCmd(`write identity/oidc/key/some-key allowed_client_ids="*"`);
+      await page.visit();
+      await page.selectType('aws');
+      await click('[data-test-toggle-group="Method Options"]');
+
+      assert
+        .dom('[data-test-search-select-with-modal]')
+        .doesNotExist('Search select with modal component does not show');
+      // clean up
+      await runCmd(`delete identity/oidc/key/some-key`);
+    });
+  });
+
+  module('Enterprise', function (hooks) {
+    hooks.beforeEach(function () {
+      this.version = this.owner.lookup('service:version');
+      this.version.type = 'enterprise';
+      this.store = this.owner.lookup('service:store');
+    });
+
+    test('it sets identity_token_key when aws is chosen, resets after', async function (assert) {
+      // create an oidc/key
+      await runCmd(`write identity/oidc/key/some-key allowed_client_ids="*"`);
+      await page.visit();
+      await page.selectType('aws');
+      await click('[data-test-toggle-group="Method Options"]');
+
+      assert.dom('[data-test-search-select-with-modal]').exists('Search select with modal component renders');
+
+      await clickTrigger();
+      const dropdownOptions = findAll('[data-option-index]').map((o) => o.innerText);
+      assert.deepEqual(
+        ['default', 'some-key'],
+        dropdownOptions,
+        'search select options show default and oidc/keys'
+      );
+      // Go back and choose a non-wif engine type
+      await page.back();
+      await page.selectType('ssh');
+      await click('[data-test-toggle-group="Method Options"]');
+      assert
+        .dom('[data-test-search-select-with-modal]')
+        .doesNotExist('for type ssh, the modal field does not render.');
+      // clean up
+      await runCmd(`delete identity/oidc/key/some-key`);
+    });
   });
 });

--- a/ui/tests/acceptance/settings/mount-secret-backend-test.js
+++ b/ui/tests/acceptance/settings/mount-secret-backend-test.js
@@ -312,11 +312,7 @@ module('Acceptance | settings/mount-secret-backend', function (hooks) {
 
     await clickTrigger();
     const dropdownOptions = findAll('[data-option-index]').map((o) => o.innerText);
-    assert.deepEqual(
-      ['default', 'some-key'],
-      dropdownOptions,
-      'search select options show default and oidc/keys'
-    );
+    assert.ok(dropdownOptions.includes('some-key'), 'search select options show some-key');
     // Go back and choose a non-wif engine type
     await page.back();
     await page.selectType('ssh');

--- a/ui/tests/integration/components/mount-backend-form-test.js
+++ b/ui/tests/integration/components/mount-backend-form-test.js
@@ -6,9 +6,10 @@
 import { later, _cancelTimers as cancelTimers } from '@ember/runloop';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, settled } from '@ember/test-helpers';
+import { render, settled, click } from '@ember/test-helpers';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { allowAllCapabilitiesStub, noopStub } from 'vault/tests/helpers/stubs';
+import { GENERAL } from 'vault/tests/helpers/general-selectors';
 import hbs from 'htmlbars-inline-precompile';
 
 import { create } from 'ember-cli-page-object';
@@ -189,6 +190,25 @@ module('Integration | Component | mount backend form', function (hooks) {
         this.flashSuccessSpy.calledWith('Successfully mounted the ssh secrets engine at foo.'),
         'Renders correct flash message'
       );
+    });
+
+    test('it shows identityTokenKey when type is aws and hides when its not', async function (assert) {
+      await render(
+        hbs`<MountBackendForm @mountType="secret" @mountModel={{this.model}} @onMountSuccess={{this.onMountSuccess}} />`
+      );
+      await component.selectType('ldap');
+
+      await click('[data-test-toggle-group="Method Options"]');
+      assert
+        .dom(GENERAL.fieldByAttr('identityTokenKey'))
+        .doesNotExist(`Identity token key field hidden when type=${this.model.type}`);
+
+      await component.back();
+      await component.selectType('aws');
+      await click('[data-test-toggle-group="Method Options"]');
+      assert
+        .dom(GENERAL.fieldByAttr('identityTokenKey'))
+        .exists(`Identity token key field shows when type=${this.model.type}`);
     });
   });
 });

--- a/ui/tests/unit/adapters/secret-engine-test.js
+++ b/ui/tests/unit/adapters/secret-engine-test.js
@@ -65,9 +65,7 @@ module('Unit | Adapter | secret engine', function (hooks) {
 
   module('WIF secret engines', function (hooks) {
     hooks.beforeEach(function () {
-      this.version = this.owner.lookup('service:version');
       this.store = this.owner.lookup('service:store');
-      this.version.type = 'enterprise';
     });
 
     test('it should make request to correct endpoint when creating new record', async function (assert) {

--- a/ui/tests/unit/adapters/secret-engine-test.js
+++ b/ui/tests/unit/adapters/secret-engine-test.js
@@ -62,4 +62,40 @@ module('Unit | Adapter | secret engine', function (hooks) {
     const response = adapter.findRecord(storeStub, 'aws', { path: 'aws' }, snapshot);
     assert.propEqual(response, { data: {} }, 'returns empty data object');
   });
+
+  module('WIF secret engines', function (hooks) {
+    hooks.beforeEach(function () {
+      this.version = this.owner.lookup('service:version');
+      this.store = this.owner.lookup('service:store');
+      this.version.type = 'enterprise';
+    });
+
+    test('it should make request to correct endpoint when creating new record', async function (assert) {
+      assert.expect(1);
+      this.server.post('/sys/mounts/aws-wif', (schema, req) => {
+        assert.deepEqual(
+          JSON.parse(req.requestBody),
+          {
+            path: 'aws-wif',
+            type: 'aws',
+            generate_signing_key: true,
+            config: { id: 'aws-wif', identity_token_key: 'test-key', listing_visibility: 'hidden' },
+          },
+          'Correct payload is sent when adding aws secret engine with identity token key set'
+        );
+        return {};
+      });
+      const mountData = {
+        id: 'aws-wif',
+        path: 'aws-wif',
+        type: 'aws',
+        config: this.store.createRecord('mount-config', {
+          identityTokenKey: 'test-key',
+        }),
+        uuid: 'f1739f9d-dfc0-83c8-011f-ec17103a06c2',
+      };
+      const record = this.store.createRecord('secret-engine', mountData);
+      await record.save();
+    });
+  });
 });

--- a/ui/tests/unit/adapters/secret-engine-test.js
+++ b/ui/tests/unit/adapters/secret-engine-test.js
@@ -81,7 +81,7 @@ module('Unit | Adapter | secret engine', function (hooks) {
             generate_signing_key: true,
             config: { id: 'aws-wif', identity_token_key: 'test-key', listing_visibility: 'hidden' },
           },
-          'Correct payload is sent when adding aws secret engine with identity token key set'
+          'Correct payload is sent when adding aws secret engine with identity_token_key set'
         );
         return {};
       });
@@ -91,6 +91,34 @@ module('Unit | Adapter | secret engine', function (hooks) {
         type: 'aws',
         config: this.store.createRecord('mount-config', {
           identityTokenKey: 'test-key',
+        }),
+        uuid: 'f1739f9d-dfc0-83c8-011f-ec17103a06c2',
+      };
+      const record = this.store.createRecord('secret-engine', mountData);
+      await record.save();
+    });
+
+    test('it should not send identity_token_key if not set', async function (assert) {
+      assert.expect(1);
+      this.server.post('/sys/mounts/aws-wif', (schema, req) => {
+        assert.deepEqual(
+          JSON.parse(req.requestBody),
+          {
+            path: 'aws-wif',
+            type: 'aws',
+            generate_signing_key: true,
+            config: { id: 'aws-wif', max_lease_ttl: '125h', listing_visibility: 'hidden' },
+          },
+          'Correct payload is sent when adding aws secret engine with no identity_token_key set'
+        );
+        return {};
+      });
+      const mountData = {
+        id: 'aws-wif',
+        path: 'aws-wif',
+        type: 'aws',
+        config: this.store.createRecord('mount-config', {
+          maxLeaseTtl: '125h',
         }),
         uuid: 'f1739f9d-dfc0-83c8-011f-ec17103a06c2',
       };

--- a/ui/tests/unit/models/secret-engine-test.js
+++ b/ui/tests/unit/models/secret-engine-test.js
@@ -109,13 +109,39 @@ module('Unit | Model | secret-engine', function (hooks) {
         'config.allowedResponseHeaders',
       ]);
     });
+
+    test('it returns correct fields for aws', function (assert) {
+      // config.identityTokenKey will only render on mount-secret-backend the if version is enterprise
+      // however, similar to other enterprise only attr (ex: sealWrap), we set the attr on the model regardless of version
+      assert.expect(1);
+      const model = this.store.createRecord('secret-engine', {
+        type: 'aws',
+      });
+
+      assert.deepEqual(model.get('formFields'), [
+        'type',
+        'path',
+        'description',
+        'accessor',
+        'local',
+        'sealWrap',
+        'config.defaultLeaseTtl',
+        'config.maxLeaseTtl',
+        'config.allowedManagedKeys',
+        'config.auditNonHmacRequestKeys',
+        'config.auditNonHmacResponseKeys',
+        'config.passthroughRequestHeaders',
+        'config.allowedResponseHeaders',
+        'config.identityTokenKey',
+      ]);
+    });
   });
 
   module('formFieldGroups', function () {
     test('returns correct values by default', function (assert) {
       assert.expect(1);
       const model = this.store.createRecord('secret-engine', {
-        type: 'aws',
+        type: 'cubbyhole',
       });
 
       assert.deepEqual(model.get('formFieldGroups'), [
@@ -252,6 +278,33 @@ module('Unit | Model | secret-engine', function (hooks) {
             'config.listingVisibility',
             'local',
             'sealWrap',
+            'config.allowedManagedKeys',
+            'config.auditNonHmacRequestKeys',
+            'config.auditNonHmacResponseKeys',
+            'config.passthroughRequestHeaders',
+            'config.allowedResponseHeaders',
+          ],
+        },
+      ]);
+    });
+
+    test('returns correct values for aws', function (assert) {
+      assert.expect(1);
+      const model = this.store.createRecord('secret-engine', {
+        type: 'aws',
+      });
+
+      assert.deepEqual(model.get('formFieldGroups'), [
+        { default: ['path'] },
+        {
+          'Method Options': [
+            'description',
+            'config.listingVisibility',
+            'local',
+            'sealWrap',
+            'config.defaultLeaseTtl',
+            'config.maxLeaseTtl',
+            'config.identityTokenKey',
             'config.allowedManagedKeys',
             'config.auditNonHmacRequestKeys',
             'config.auditNonHmacResponseKeys',

--- a/ui/tests/unit/models/secret-engine-test.js
+++ b/ui/tests/unit/models/secret-engine-test.js
@@ -111,8 +111,6 @@ module('Unit | Model | secret-engine', function (hooks) {
     });
 
     test('it returns correct fields for aws', function (assert) {
-      // config.identityTokenKey will only render on mount-secret-backend the if version is enterprise
-      // however, similar to other enterprise only attr (ex: sealWrap), we set the attr on the model regardless of version
       assert.expect(1);
       const model = this.store.createRecord('secret-engine', {
         type: 'aws',


### PR DESCRIPTION
- [x] enterprise test pass locally

### Description
- adds the `identity_token_key` to the mount-config model. API [here](https://developer.hashicorp.com/vault/api-docs/system/mounts#identity_token_key)
- adds the `config.identityTokenKey` param to the secret-engine model to render under optional form fields. 
- renders the field in a named-block. UPDATE: will show if community and or enterprise. Following convention of other enterprise only fields.
- adds test coverage: field renders only for aws and payload is correct for when identity_token_key is set.

This PR does not add the modal functionality (e.g. creating an oidc/key). That will come in the next PR.
