### PR TITLE
add a retry-command script

### DIFF
--- a/.github/actions/install-external-tools/action.yml
+++ b/.github/actions/install-external-tools/action.yml
@@ -21,15 +21,15 @@ runs:
     - uses: ./.github/actions/set-up-staticcheck
       # We assume that the Go toolchain will be managed by the caller workflow so we don't set one
       # up here.
-    - run: go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
+    - run: ./.github/scripts/retry-command.sh go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
       shell: bash
-    - run: go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
+    - run: ./.github/scripts/retry-command.sh go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
       shell: bash
-    - run: go install github.com/favadi/protoc-go-inject-tag@latest
+    - run: ./.github/scripts/retry-command.sh go install github.com/favadi/protoc-go-inject-tag@latest
       shell: bash
-    - run: go install golang.org/x/tools/cmd/goimports@latest
+    - run: ./.github/scripts/retry-command.sh go install golang.org/x/tools/cmd/goimports@latest
       shell: bash
-    - run: go install github.com/golangci/revgrep/cmd/revgrep@latest
+    - run: ./.github/scripts/retry-command.sh go install github.com/golangci/revgrep/cmd/revgrep@latest
       shell: bash
-    - run: go install github.com/loggerhead/enumer@latest
+    - run: ./.github/scripts/retry-command.sh go install github.com/loggerhead/enumer@latest
       shell: bash

--- a/.github/scripts/retry-command.sh
+++ b/.github/scripts/retry-command.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
 set -euo pipefail
 
 tries=5

--- a/.github/scripts/retry-command.sh
+++ b/.github/scripts/retry-command.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+tries=5
+count=0
+
+until "$@"
+do
+  if [ $count -eq $tries ]; then
+    echo "tried $count times, exiting"
+    exit 1
+  fi
+  ((count++))
+  echo "trying again, attempt $count"
+  sleep 2
+done


### PR DESCRIPTION
### Description
This PR adds a shell script called `retry-command.sh` to allow retrying things up to 5 times. I'm not a GHA wizard, so maybe there's a better way to do this. @kubawi kindly pointed out https://github.com/nick-fields/retry which serves this purpose and is already vetted apparently, but has the downside of being another external dependency to deal with. But, if people think using that is better, I'm happy to make the switch. I'm not married to this particular approach by any means.

### TODO only if you're a HashiCorp employee
- [ ] **Labels:** If this PR is the CE portion of an ENT change, and that ENT change is
  getting backported to N-2, use the new style `backport/ent/x.x.x+ent` labels
  instead of the old style `backport/x.x.x` labels.
- [x] **Labels:** If this PR is a CE only change, it can only be backported to N, so use
  the normal `backport/x.x.x` label (there should be only 1).
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
