### PR TITLE
Add custom tags section to sync overview, denote normalized values

### DIFF
--- a/website/content/docs/sync/index.mdx
+++ b/website/content/docs/sync/index.mdx
@@ -88,8 +88,8 @@ association object returned by the endpoint and, upon failure, includes an error
 ## Name template
 
 By default, the name of synced secrets follows this format: `vault/<accessor>/<secret-path>`. The casing and delimiters
-may change according to the valid character set of each destination type. This pattern was chosen to prevent accidental
-name collisions and to clearly identify where the secret is coming from.
+may change as they are normalized according to the valid character set of each destination type. This pattern was chosen to
+prevent accidental name collisions and to clearly identify where the secret is coming from.
 
 Every destination allows you to customize this name pattern by configuring a `secret_name_template` field to best suit
 individual use cases. The templates use a subset of the go-template syntax for extra flexibility.
@@ -141,6 +141,12 @@ Let's look at some name template examples and the resulting secret name at the s
 Name templates can be updated. The new template is only effective for new secrets associated with the destination and does
 not affect the secrets synced with the previous template. It is possible to update an association to force a recreate operation.
 The secret synced with the old template will be deleted and a new secret using the new template version will be synced.
+
+## Custom tags
+
+Destinations can also have custom tags so that every secret association to it that gets synced will share that same set of tags.
+Additionally, a default tag value of `hashicorp:vault` is used to denote any secret that is synced via Vault Enterprise. Similar
+to secret names, tag keys and values are normalized according to the valid character set of each destination type.
 
 ## Granularity
 

--- a/website/content/docs/sync/index.mdx
+++ b/website/content/docs/sync/index.mdx
@@ -144,7 +144,7 @@ The secret synced with the old template will be deleted and a new secret using t
 
 ## Custom tags
 
-A destination can also have custom tags so that every secret association to it that is synced will share that same set of tags.
+A destination can also have custom tags so that every secret associated to it that is synced will share that same set of tags.
 Additionally, a default tag value of `hashicorp:vault` is used to denote any secret that is synced via Vault Enterprise. Similar
 to secret names, tag keys and values are normalized according to the valid character set of each destination type.
 

--- a/website/content/docs/sync/index.mdx
+++ b/website/content/docs/sync/index.mdx
@@ -144,7 +144,7 @@ The secret synced with the old template will be deleted and a new secret using t
 
 ## Custom tags
 
-Destinations can also have custom tags so that every secret association to it that gets synced will share that same set of tags.
+A destination can also have custom tags so that every secret association to it that is synced will share that same set of tags.
 Additionally, a default tag value of `hashicorp:vault` is used to denote any secret that is synced via Vault Enterprise. Similar
 to secret names, tag keys and values are normalized according to the valid character set of each destination type.
 


### PR DESCRIPTION
### Description
Add a section about custom tags to the secrets sync overview. Also specifically calls out text that is normalized for syncing (secret names, tag keys and values).

### TODO only if you're a HashiCorp employee
- [x] **Labels:** If this PR is the CE portion of an ENT change, and that ENT change is
  getting backported to N-2, use the new style `backport/ent/x.x.x+ent` labels
  instead of the old style `backport/x.x.x` labels.
- [ ] **Labels:** If this PR is a CE only change, it can only be backported to N, so use
  the normal `backport/x.x.x` label (there should be only 1).
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
