### PR TITLE
Update VSO docs for auto CRD upgrade behaviour

### DIFF
--- a/website/content/docs/platform/k8s/vso/installation.mdx
+++ b/website/content/docs/platform/k8s/vso/installation.mdx
@@ -56,10 +56,12 @@ Update Complete. ⎈Happy Helming!⎈
 
 ## Updating CRDs when using Helm
 
-<Note title="">
+<Note title="Important">
+
   As of VSO 0.8.0, VSO will automatically update its CRDs.
-  The manual upgrade step <a href="#updating-crds-when-using-helm-prior-to-vso-0-8-0">Updating CRDs</a> below is no longer required when
+  The manual upgrade step [Updating CRDs](#updating-crds-when-using-helm-prior-to-vso-0-8-0) below is no longer required when
   upgrading to VSO 0.8.0+.
+
 </Note>
 
 The VSO Helm chart will automatically upgrade the CRDs to match the VSO version being deployed.

--- a/website/content/docs/platform/k8s/vso/installation.mdx
+++ b/website/content/docs/platform/k8s/vso/installation.mdx
@@ -54,49 +54,16 @@ Hang tight while we grab the latest from your chart repositories...
 Update Complete. ⎈Happy Helming!⎈
 ```
 
-<Note title="VSO 0.8.0+ automatically updates CRDs">
+## Updating CRDs when using Helm
+
+<Note title="">
   As of VSO 0.8.0, VSO will automatically update its CRDs.
-  The manual upgrade step <a href="#updating-crds">Updating CRDs</a> below is no longer required when
+  The manual upgrade step <a href="#updating-crds-when-using-helm-prior-to-vso-0-8-0">Updating CRDs</a> below is no longer required when
   upgrading to VSO 0.8.0+.
 </Note>
 
-
-## Updating CRDs when using Helm prior to 0.8.0
-
-This step can be skipped if you are upgrading to VSO 0.8.0 or later.
-
-<Note title="Helm does not automatically update CRDs">
-  You must update all CRDs manually before upgrading VSO.
-  Refer to <a href="#updating-crds">Updating CRDs</a>.
-</Note>
-
-You must update the CRDs for VSO manually **before** you upgrade the
- operator when the operator is managed by Helm.
-
-**Any `kubectl` warnings related to `last-applied-configuration` should be safe to ignore.**
-
-To update the VSO CRDs, replace `<TARGET_VSO_VERSION>` with the VSO version you are upgrading to:
-```shell-session
-$ helm show crds --version <TARGET_VSO_VERSION> hashicorp/vault-secrets-operator | kubectl apply -f -
-```
-
-For example, if you are upgrading to VSO 0.7.1:
-```shell-session
-$ helm show crds --version 0.7.1 hashicorp/vault-secrets-operator | kubectl apply -f -
-
-customresourcedefinition.apiextensions.k8s.io/hcpauths.secrets.hashicorp.com created
-customresourcedefinition.apiextensions.k8s.io/hcpvaultsecretsapps.secrets.hashicorp.com created
-Warning: resource customresourcedefinitions/vaultauths.secrets.hashicorp.com is missing the kubectl.kubernetes.io/last-applied-configuration annotation which is required by kubectl apply. kubectl apply should only be used on resources created declaratively by either kubectl create --save-config or kubectl apply. The missing annotation will be patched automatically.
-customresourcedefinition.apiextensions.k8s.io/vaultauths.secrets.hashicorp.com configured
-Warning: resource customresourcedefinitions/vaultconnections.secrets.hashicorp.com is missing the kubectl.kubernetes.io/last-applied-configuration annotation which is required by kubectl apply. kubectl apply should only be used on resources created declaratively by either kubectl create --save-config or kubectl apply. The missing annotation will be patched automatically.
-customresourcedefinition.apiextensions.k8s.io/vaultconnections.secrets.hashicorp.com configured
-Warning: resource customresourcedefinitions/vaultdynamicsecrets.secrets.hashicorp.com is missing the kubectl.kubernetes.io/last-applied-configuration annotation which is required by kubectl apply. kubectl apply should only be used on resources created declaratively by either kubectl create --save-config or kubectl apply. The missing annotation will be patched automatically.
-customresourcedefinition.apiextensions.k8s.io/vaultdynamicsecrets.secrets.hashicorp.com configured
-Warning: resource customresourcedefinitions/vaultpkisecrets.secrets.hashicorp.com is missing the kubectl.kubernetes.io/last-applied-configuration annotation which is required by kubectl apply. kubectl apply should only be used on resources created declaratively by either kubectl create --save-config or kubectl apply. The missing annotation will be patched automatically.
-customresourcedefinition.apiextensions.k8s.io/vaultpkisecrets.secrets.hashicorp.com configured
-Warning: resource customresourcedefinitions/vaultstaticsecrets.secrets.hashicorp.com is missing the kubectl.kubernetes.io/last-applied-configuration annotation which is required by kubectl apply. kubectl apply should only be used on resources created declaratively by either kubectl create --save-config or kubectl apply. The missing annotation will be patched automatically.
-customresourcedefinition.apiextensions.k8s.io/vaultstaticsecrets.secrets.hashicorp.com configured
-```
+The VSO Helm chart will automatically upgrade the CRDs to match the VSO version being deployed.
+There should be no need to manually update the CRDs prior to upgrading VSO using Helm.
 
 ## Chart values
 
@@ -159,3 +126,43 @@ vault-secrets-operator-system   vault-secrets-operator-controller-manager-56754d
 Upgrading using Kustomize is similar to installation: simply download the new release from github and follow
 the same steps as outlined in [Installation using Kustomize](#installation-using-kustomize).
 No additional steps are required to update the CRDs.
+
+## Legacy notes
+
+The following notes provide guidance for installing/upgrading older versions of VSO.
+
+### Updating CRDs when using Helm prior to VSO 0.8.0
+
+This step can be skipped if you are upgrading to VSO 0.8.0 or later.
+
+<Note title="Helm does not automatically update CRDs">
+  You must update all CRDs manually before upgrading VSO to a version prior to 0.8.0.
+</Note>
+
+You must update the CRDs for VSO manually **before** you upgrade the
+operator when the operator is managed by Helm.
+
+**Any `kubectl` warnings related to `last-applied-configuration` should be safe to ignore.**
+
+To update the VSO CRDs, replace `<TARGET_VSO_VERSION>` with the VSO version you are upgrading to:
+```shell-session
+$ helm show crds --version <TARGET_VSO_VERSION> hashicorp/vault-secrets-operator | kubectl apply -f -
+```
+
+For example, if you are upgrading to VSO 0.7.1:
+```shell-session
+$ helm show crds --version 0.7.1 hashicorp/vault-secrets-operator | kubectl apply -f -
+
+customresourcedefinition.apiextensions.k8s.io/hcpauths.secrets.hashicorp.com created
+customresourcedefinition.apiextensions.k8s.io/hcpvaultsecretsapps.secrets.hashicorp.com created
+Warning: resource customresourcedefinitions/vaultauths.secrets.hashicorp.com is missing the kubectl.kubernetes.io/last-applied-configuration annotation which is required by kubectl apply. kubectl apply should only be used on resources created declaratively by either kubectl create --save-config or kubectl apply. The missing annotation will be patched automatically.
+customresourcedefinition.apiextensions.k8s.io/vaultauths.secrets.hashicorp.com configured
+Warning: resource customresourcedefinitions/vaultconnections.secrets.hashicorp.com is missing the kubectl.kubernetes.io/last-applied-configuration annotation which is required by kubectl apply. kubectl apply should only be used on resources created declaratively by either kubectl create --save-config or kubectl apply. The missing annotation will be patched automatically.
+customresourcedefinition.apiextensions.k8s.io/vaultconnections.secrets.hashicorp.com configured
+Warning: resource customresourcedefinitions/vaultdynamicsecrets.secrets.hashicorp.com is missing the kubectl.kubernetes.io/last-applied-configuration annotation which is required by kubectl apply. kubectl apply should only be used on resources created declaratively by either kubectl create --save-config or kubectl apply. The missing annotation will be patched automatically.
+customresourcedefinition.apiextensions.k8s.io/vaultdynamicsecrets.secrets.hashicorp.com configured
+Warning: resource customresourcedefinitions/vaultpkisecrets.secrets.hashicorp.com is missing the kubectl.kubernetes.io/last-applied-configuration annotation which is required by kubectl apply. kubectl apply should only be used on resources created declaratively by either kubectl create --save-config or kubectl apply. The missing annotation will be patched automatically.
+customresourcedefinition.apiextensions.k8s.io/vaultpkisecrets.secrets.hashicorp.com configured
+Warning: resource customresourcedefinitions/vaultstaticsecrets.secrets.hashicorp.com is missing the kubectl.kubernetes.io/last-applied-configuration annotation which is required by kubectl apply. kubectl apply should only be used on resources created declaratively by either kubectl create --save-config or kubectl apply. The missing annotation will be patched automatically.
+customresourcedefinition.apiextensions.k8s.io/vaultstaticsecrets.secrets.hashicorp.com configured
+```

--- a/website/content/docs/platform/k8s/vso/installation.mdx
+++ b/website/content/docs/platform/k8s/vso/installation.mdx
@@ -54,24 +54,21 @@ Hang tight while we grab the latest from your chart repositories...
 Update Complete. ⎈Happy Helming!⎈
 ```
 
+<Note title="VSO 0.8.0+ automatically updates CRDs">
+  As of VSO 0.8.0, VSO will automatically update its CRDs.
+  The manual upgrade step <a href="#updating-crds">Updating CRDs</a> below is no longer required when
+  upgrading to VSO 0.8.0+.
+</Note>
+
+
+## Updating CRDs when using Helm prior to 0.8.0
+
+This step can be skipped if you are upgrading to VSO 0.8.0 or later.
+
 <Note title="Helm does not automatically update CRDs">
   You must update all CRDs manually before upgrading VSO.
   Refer to <a href="#updating-crds">Updating CRDs</a>.
 </Note>
-
-To upgrade your VSO release, replace `<TARGET_VSO_VERSION>` with the VSO version you are upgrading to:
-```shell-session
-$ helm show crds --version <TARGET_VSO_VERSION> hashicorp/vault-secrets-operator | kubectl apply -f -
-$ helm upgrade --version <TARGET_VSO_VERSION> --namespace vault-secrets-operator vault-secrets-operator hashicorp/vault-secrets-operator
-```
-
-For example, if you are upgrading to VSO 0.7.1:
-```shell-session
-$ helm show crds --version 0.7.1 hashicorp/vault-secrets-operator | kubectl apply -f -
-$ helm upgrade --version 0.7.1 --namespace vault-secrets-operator vault-secrets-operator hashicorp/vault-secrets-operator
-```
-
-## Updating CRDs when using Helm
 
 You must update the CRDs for VSO manually **before** you upgrade the
  operator when the operator is managed by Helm.


### PR DESCRIPTION
### Description
Update the VSO docs for the new auto CRD upgrade behaviour being introduced in 0.8.0.

### TODO only if you're a HashiCorp employee
- [x] **Labels:** If this PR is the CE portion of an ENT change, and that ENT change is
  getting backported to N-2, use the new style `backport/ent/x.x.x+ent` labels
  instead of the old style `backport/x.x.x` labels.
- [x] **Labels:** If this PR is a CE only change, it can only be backported to N, so use
  the normal `backport/x.x.x` label (there should be only 1).
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
