### PR TITLE
UI: Move useOpenApi and getHelpUrl methods to util

### DIFF
--- a/ui/app/models/auth-config.js
+++ b/ui/app/models/auth-config.js
@@ -7,7 +7,4 @@ import Model, { belongsTo } from '@ember-data/model';
 
 export default Model.extend({
   backend: belongsTo('auth-method', { inverse: 'authConfigs', readOnly: true, async: false }),
-  getHelpUrl: function (backend) {
-    return `/v1/auth/${backend}/config?help=1`;
-  },
 });

--- a/ui/app/models/auth-config/azure.js
+++ b/ui/app/models/auth-config/azure.js
@@ -10,7 +10,6 @@ import { combineFieldGroups } from 'vault/utils/openapi-to-attrs';
 import fieldToAttrs from 'vault/utils/field-to-attrs';
 
 export default AuthConfig.extend({
-  useOpenAPI: true,
   tenantId: attr('string', {
     label: 'Tenant ID',
     helpText: 'The tenant ID for the Azure Active Directory organization',

--- a/ui/app/models/auth-config/gcp.js
+++ b/ui/app/models/auth-config/gcp.js
@@ -10,7 +10,6 @@ import { combineFieldGroups } from 'vault/utils/openapi-to-attrs';
 import fieldToAttrs from 'vault/utils/field-to-attrs';
 
 export default AuthConfig.extend({
-  useOpenAPI: true,
   // We have to leave this here because the backend doesn't support the file type yet.
   credentials: attr('string', {
     editType: 'file',

--- a/ui/app/models/auth-config/github.js
+++ b/ui/app/models/auth-config/github.js
@@ -10,7 +10,6 @@ import fieldToAttrs from 'vault/utils/field-to-attrs';
 import { combineFieldGroups } from 'vault/utils/openapi-to-attrs';
 
 export default AuthConfig.extend({
-  useOpenAPI: true,
   organization: attr('string'),
   baseUrl: attr('string', {
     label: 'Base URL',

--- a/ui/app/models/auth-config/jwt.js
+++ b/ui/app/models/auth-config/jwt.js
@@ -10,7 +10,6 @@ import fieldToAttrs from 'vault/utils/field-to-attrs';
 import { combineFieldGroups } from 'vault/utils/openapi-to-attrs';
 
 export default AuthConfig.extend({
-  useOpenAPI: true,
   oidcDiscoveryUrl: attr('string', {
     label: 'OIDC discovery URL',
     helpText:

--- a/ui/app/models/auth-config/kubernetes.js
+++ b/ui/app/models/auth-config/kubernetes.js
@@ -11,7 +11,6 @@ import { combineFieldGroups } from 'vault/utils/openapi-to-attrs';
 import fieldToAttrs from 'vault/utils/field-to-attrs';
 
 export default AuthConfig.extend({
-  useOpenAPI: true,
   kubernetesHost: attr('string', {
     helpText:
       'Host must be a host string, a host:port pair, or a URL to the base of the Kubernetes API server.',

--- a/ui/app/models/auth-config/ldap.js
+++ b/ui/app/models/auth-config/ldap.js
@@ -11,7 +11,6 @@ import fieldToAttrs from 'vault/utils/field-to-attrs';
 import { combineFieldGroups } from 'vault/utils/openapi-to-attrs';
 
 export default AuthConfig.extend({
-  useOpenAPI: true,
   certificate: attr({
     label: 'Certificate',
     editType: 'file',

--- a/ui/app/models/auth-config/okta.js
+++ b/ui/app/models/auth-config/okta.js
@@ -10,7 +10,6 @@ import fieldToAttrs from 'vault/utils/field-to-attrs';
 import { combineFieldGroups } from 'vault/utils/openapi-to-attrs';
 
 export default AuthConfig.extend({
-  useOpenAPI: true,
   orgName: attr('string', {
     helpText: 'Name of the organization to be used in the Okta API',
   }),

--- a/ui/app/models/auth-config/radius.js
+++ b/ui/app/models/auth-config/radius.js
@@ -10,7 +10,6 @@ import { combineFieldGroups } from 'vault/utils/openapi-to-attrs';
 import fieldToAttrs from 'vault/utils/field-to-attrs';
 
 export default AuthConfig.extend({
-  useOpenAPI: true,
   host: attr('string'),
   secret: attr('string'),
 

--- a/ui/app/models/kmip/config.js
+++ b/ui/app/models/kmip/config.js
@@ -9,11 +9,7 @@ import { combineFieldGroups } from 'vault/utils/openapi-to-attrs';
 import fieldToAttrs from 'vault/utils/field-to-attrs';
 
 export default Model.extend({
-  useOpenAPI: true,
   ca: belongsTo('kmip/ca', { async: false, inverse: 'config' }),
-  getHelpUrl(path) {
-    return `/v1/${path}/config?help=1`;
-  },
 
   fieldGroups: computed('newFields', function () {
     let groups = [{ default: ['listenAddrs', 'connectionTimeout'] }];

--- a/ui/app/models/kmip/role.js
+++ b/ui/app/models/kmip/role.js
@@ -36,13 +36,10 @@ export const COMPUTEDS = {
 };
 
 export default Model.extend(COMPUTEDS, {
-  useOpenAPI: true,
   backend: attr({ readOnly: true }),
   scope: attr({ readOnly: true }),
   name: attr({ readOnly: true }),
-  getHelpUrl(path) {
-    return `/v1/${path}/scope/example/role/example?help=1`;
-  },
+
   fieldGroups: computed('fields', 'defaultFields.length', 'tlsFields', function () {
     const groups = [{ TLS: this.tlsFields }];
     if (this.defaultFields.length) {

--- a/ui/app/models/pki/certificate/base.js
+++ b/ui/app/models/pki/certificate/base.js
@@ -4,7 +4,6 @@
  */
 
 import Model, { attr } from '@ember-data/model';
-import { assert } from '@ember/debug';
 import { service } from '@ember/service';
 import { withFormFields } from 'vault/decorators/model-form-fields';
 import lazyCapabilities, { apiPath } from 'vault/macros/lazy-capabilities';
@@ -25,14 +24,8 @@ const certDisplayFields = ['certificate', 'commonName', 'revocationTime', 'seria
 export default class PkiCertificateBaseModel extends Model {
   @service secretMountPath;
 
-  get useOpenAPI() {
-    return true;
-  }
   get backend() {
     return this.secretMountPath.currentPath;
-  }
-  getHelpUrl() {
-    assert('You must provide a helpUrl for OpenAPI', true);
   }
 
   // The attributes parsed from parse-pki-cert util live here

--- a/ui/app/models/pki/certificate/generate.js
+++ b/ui/app/models/pki/certificate/generate.js
@@ -34,8 +34,5 @@ const certDisplayFields = [
 ];
 @withFormFields(certDisplayFields, generateFromRole)
 export default class PkiCertificateGenerateModel extends PkiCertificateBaseModel {
-  getHelpUrl(backend) {
-    return `/v1/${backend}/issue/example?help=1`;
-  }
   @attr('string') role; // role name to issue certificate against for request URL
 }

--- a/ui/app/models/pki/certificate/sign.js
+++ b/ui/app/models/pki/certificate/sign.js
@@ -23,9 +23,6 @@ const generateFromRole = [
 ];
 @withFormFields(null, generateFromRole)
 export default class PkiCertificateSignModel extends PkiCertificateBaseModel {
-  getHelpUrl(backend) {
-    return `/v1/${backend}/sign/example?help=1`;
-  }
   @attr('string') role; // role name to create certificate against for request URL
 
   @attr('string', {

--- a/ui/app/models/pki/config/acme.js
+++ b/ui/app/models/pki/config/acme.js
@@ -10,16 +10,8 @@ import lazyCapabilities, { apiPath } from 'vault/macros/lazy-capabilities';
 @withFormFields()
 export default class PkiConfigAcmeModel extends Model {
   // This model uses the backend value as the model ID
-  get useOpenAPI() {
-    return true;
-  }
-
-  getHelpUrl(backendPath) {
-    return `/v1/${backendPath}/config/acme?help=1`;
-  }
 
   // attrs order in the form is determined by order here
-
   @attr('boolean', {
     label: 'ACME enabled',
     subText: 'When ACME is disabled, all requests to ACME directory URLs will return 404.',

--- a/ui/app/models/pki/config/cluster.js
+++ b/ui/app/models/pki/config/cluster.js
@@ -10,13 +10,6 @@ import lazyCapabilities, { apiPath } from 'vault/macros/lazy-capabilities';
 @withFormFields()
 export default class PkiConfigClusterModel extends Model {
   // This model uses the backend value as the model ID
-  get useOpenAPI() {
-    return true;
-  }
-
-  getHelpUrl(backendPath) {
-    return `/v1/${backendPath}/config/cluster?help=1`;
-  }
 
   @attr('string', {
     label: "Mount's API path",

--- a/ui/app/models/pki/config/urls.js
+++ b/ui/app/models/pki/config/urls.js
@@ -10,12 +10,6 @@ import lazyCapabilities, { apiPath } from 'vault/macros/lazy-capabilities';
 @withFormFields()
 export default class PkiConfigUrlsModel extends Model {
   // This model uses the backend value as the model ID
-  get useOpenAPI() {
-    return true;
-  }
-  getHelpUrl(backendPath) {
-    return `/v1/${backendPath}/config/urls?help=1`;
-  }
 
   @attr({
     label: 'Issuing certificates',

--- a/ui/app/models/pki/issuer.js
+++ b/ui/app/models/pki/issuer.js
@@ -27,10 +27,7 @@ const displayFields = [
 @withFormFields(inputFields, displayFields)
 export default class PkiIssuerModel extends Model {
   @service secretMountPath;
-  // TODO use openAPI after removing route extension (see pki/roles route for example)
-  get useOpenAPI() {
-    return false;
-  }
+
   get backend() {
     return this.secretMountPath.currentPath;
   }

--- a/ui/app/models/pki/role.js
+++ b/ui/app/models/pki/role.js
@@ -18,14 +18,6 @@ const validations = {
 export default class PkiRoleModel extends Model {
   @service version; // noStoreMetadata is enterprise-only, so we need this available
 
-  get useOpenAPI() {
-    // must be a getter so it can be accessed in path-help.js
-    return true;
-  }
-  getHelpUrl(backend) {
-    return `/v1/${backend}/roles/example?help=1`;
-  }
-
   @attr('string', { readOnly: true }) backend;
 
   get formFieldGroups() {

--- a/ui/app/models/pki/sign-intermediate.js
+++ b/ui/app/models/pki/sign-intermediate.js
@@ -25,10 +25,6 @@ const validations = {
   'maxPathLength',
 ])
 export default class PkiSignIntermediateModel extends PkiCertificateBaseModel {
-  getHelpUrl(backend) {
-    return `/v1/${backend}/issuer/example/sign-intermediate?help=1`;
-  }
-
   @attr issuerRef;
 
   @attr('string', {

--- a/ui/app/models/pki/tidy.js
+++ b/ui/app/models/pki/tidy.js
@@ -125,14 +125,6 @@ export default class PkiTidyModel extends Model {
   })
   tidyRevokedCerts;
 
-  get useOpenAPI() {
-    return true;
-  }
-
-  getHelpUrl(backend) {
-    return `/v1/${backend}/config/auto-tidy?help=1`;
-  }
-
   get allGroups() {
     const groups = [{ autoTidy: ['enabled', 'intervalDuration'] }, ...this.sharedFields];
     return this._expandGroups(groups);

--- a/ui/app/models/role-ssh.js
+++ b/ui/app/models/role-ssh.js
@@ -47,10 +47,6 @@ const CA_FIELDS = [
 ];
 
 export default Model.extend({
-  useOpenAPI: true,
-  getHelpUrl: function (backend) {
-    return `/v1/${backend}/roles/example?help=1`;
-  },
   zeroAddress: attr('boolean', {
     readOnly: true,
   }),

--- a/ui/app/utils/openapi-helpers.ts
+++ b/ui/app/utils/openapi-helpers.ts
@@ -139,6 +139,7 @@ export function filterPathsByItemType(pathInfo: PathsInfo, itemType: string): Pa
 const OPENAPI_POWERED_MODELS = {
   'role-ssh': (backend: string) => `/v1/${backend}/roles/example?help=1`,
   'auth-config/azure': (backend: string) => `/v1/auth/${backend}/config?help=1`,
+  'auth-config/cert': (backend: string) => `/v1/auth/${backend}/config?help=1`,
   'auth-config/gcp': (backend: string) => `/v1/auth/${backend}/config?help=1`,
   'auth-config/github': (backend: string) => `/v1/auth/${backend}/config?help=1`,
   'auth-config/jwt': (backend: string) => `/v1/auth/${backend}/config?help=1`,

--- a/ui/app/utils/openapi-helpers.ts
+++ b/ui/app/utils/openapi-helpers.ts
@@ -132,3 +132,36 @@ export function filterPathsByItemType(pathInfo: PathsInfo, itemType: string): Pa
     return itemType === path.itemType;
   });
 }
+
+/**
+ * This object maps model names to the openAPI path that hydrates the model, given the backend path.
+ */
+const OPENAPI_POWERED_MODELS = {
+  'role-ssh': (backend: string) => `/v1/${backend}/roles/example?help=1`,
+  'auth-config/azure': (backend: string) => `/v1/auth/${backend}/config?help=1`,
+  'auth-config/gcp': (backend: string) => `/v1/auth/${backend}/config?help=1`,
+  'auth-config/github': (backend: string) => `/v1/auth/${backend}/config?help=1`,
+  'auth-config/jwt': (backend: string) => `/v1/auth/${backend}/config?help=1`,
+  'auth-config/kubernetes': (backend: string) => `/v1/auth/${backend}/config?help=1`,
+  'auth-config/ldap': (backend: string) => `/v1/auth/${backend}/config?help=1`,
+  'auth-config/okta': (backend: string) => `/v1/auth/${backend}/config?help=1`,
+  'auth-config/radius': (backend: string) => `/v1/auth/${backend}/config?help=1`,
+  'kmip/config': (backend: string) => `/v1/${backend}/config?help=1`,
+  'kmip/role': (backend: string) => `/v1/${backend}/scope/example/role/example?help=1`,
+  'pki/role': (backend: string) => `/v1/${backend}/roles/example?help=1`,
+  'pki/tidy': (backend: string) => `/v1/${backend}/config/auto-tidy?help=1`,
+  'pki/sign-intermediate': (backend: string) => `/v1/${backend}/issuer/example/sign-intermediate?help=1`,
+  'pki/certificate/generate': (backend: string) => `/v1/${backend}/issue/example?help=1`,
+  'pki/certificate/sign': (backend: string) => `/v1/${backend}/sign/example?help=1`,
+  'pki/config/acme': (backend: string) => `/v1/${backend}/config/acme?help=1`,
+  'pki/config/cluster': (backend: string) => `/v1/${backend}/config/cluster?help=1`,
+  'pki/config/urls': (backend: string) => `/v1/${backend}/config/urls?help=1`,
+};
+
+export function getHelpUrlForModel(modelType: string, backend: string) {
+  const urlFn = OPENAPI_POWERED_MODELS[modelType as keyof typeof OPENAPI_POWERED_MODELS] as (
+    backend: string
+  ) => string;
+  if (!urlFn) return null;
+  return urlFn(backend);
+}

--- a/ui/tests/acceptance/open-api-path-help-test.js
+++ b/ui/tests/acceptance/open-api-path-help-test.js
@@ -9,6 +9,7 @@ import authPage from 'vault/tests/pages/auth';
 import { deleteAuthCmd, deleteEngineCmd, mountAuthCmd, mountEngineCmd, runCmd } from '../helpers/commands';
 import expectedSecretAttrs from 'vault/tests/helpers/openapi/expected-secret-attrs';
 import expectedAuthAttrs from 'vault/tests/helpers/openapi/expected-auth-attrs';
+import { getHelpUrlForModel } from 'vault/utils/openapi-helpers';
 
 /**
  * This set of tests is for ensuring that backend changes to the OpenAPI spec
@@ -72,8 +73,7 @@ function secretEngineHelper(test, secretEngine) {
   // A given secret engine might have multiple models that are openApi driven
   modelNames.forEach((modelName) => {
     test(`${modelName} model getProps returns correct attributes`, async function (assert) {
-      const model = this.store.createRecord(modelName, {});
-      const helpUrl = model.getHelpUrl(this.backend);
+      const helpUrl = getHelpUrlForModel(modelName, this.backend);
       const result = await this.pathHelp.getProps(helpUrl, this.backend);
       const expected = engineData[modelName];
       // Expected values should be updated to match "actual" (result)
@@ -98,8 +98,7 @@ function authEngineHelper(test, authBackend) {
     if (itemName.startsWith('auth-config/')) {
       // Config test doesn't need to instantiate a new model
       test(`${itemName} model`, async function (assert) {
-        const model = this.store.createRecord(itemName, {});
-        const helpUrl = model.getHelpUrl(this.mount);
+        const helpUrl = getHelpUrlForModel(itemName, this.mount);
         const result = await this.pathHelp.getProps(helpUrl, this.mount);
         const expected = authData[itemName];
         assert.deepEqual(
@@ -116,9 +115,8 @@ function authEngineHelper(test, authBackend) {
         const modelName = `generated-${itemName}-${authBackend}`;
         // Generated items need to instantiate the model first via getNewModel
         await this.pathHelp.getNewModel(modelName, this.mount, `auth/${this.mount}/`, itemName);
-        const model = this.store.createRecord(modelName, {});
-        // Generated items don't have this method -- helpUrl is calculated in path-help.js line 101
-        const helpUrl = model.getHelpUrl(this.mount);
+        // Generated items don't have helpUrl method -- helpUrl is calculated in path-help.js line 101
+        const helpUrl = `/v1/auth/${this.mount}?help=1`;
         const result = await this.pathHelp.getProps(helpUrl, this.mount);
         const expected = authData[modelName];
         assert.deepEqual(result, expected, `getProps returns expected attributes for ${modelName}`);

--- a/ui/tests/unit/utils/openapi-helpers-test.js
+++ b/ui/tests/unit/utils/openapi-helpers-test.js
@@ -4,11 +4,10 @@
  */
 
 import { module, test } from 'qunit';
-import { _getPathParam, pathToHelpUrlSegment } from 'vault/utils/openapi-helpers';
+import { _getPathParam, getHelpUrlForModel, pathToHelpUrlSegment } from 'vault/utils/openapi-helpers';
 
 module('Unit | Utility | OpenAPI helper utils', function () {
   test(`pathToHelpUrlSegment`, function (assert) {
-    assert.expect(5);
     [
       { path: '/auth/{username}', result: '/auth/example' },
       { path: '{username}/foo', result: 'example/foo' },
@@ -21,7 +20,6 @@ module('Unit | Utility | OpenAPI helper utils', function () {
   });
 
   test(`_getPathParam`, function (assert) {
-    assert.expect(7);
     [
       { path: '/auth/{username}', result: 'username' },
       { path: '{unicorn}/foo', result: 'unicorn' },
@@ -32,6 +30,22 @@ module('Unit | Utility | OpenAPI helper utils', function () {
       { path: undefined, result: false },
     ].forEach((test) => {
       assert.strictEqual(_getPathParam(test.path), test.result, `returns first param for ${test.path}`);
+    });
+  });
+
+  test(`getHelpUrlForModel`, function (assert) {
+    [
+      { modelType: 'kmip/config', result: '/v1/foobar/config?help=1' },
+      { modelType: 'does-not-exist', result: null },
+      { modelType: 4, result: null },
+      { modelType: '', result: null },
+      { modelType: undefined, result: null },
+    ].forEach((test) => {
+      assert.strictEqual(
+        getHelpUrlForModel(test.modelType, 'foobar'),
+        test.result,
+        `returns first param for ${test.path}`
+      );
     });
   });
 });

--- a/ui/types/vault/models/pki/certificate/base.d.ts
+++ b/ui/types/vault/models/pki/certificate/base.d.ts
@@ -6,9 +6,7 @@
 import Model from '@ember-data/model';
 export default class PkiCertificateBaseModel extends Model {
   secretMountPath: class;
-  get useOpenAPI(): boolean;
   get backend(): string;
-  getHelpUrl(): void;
   altNames: string;
   commonName: string;
   caChain: string;

--- a/ui/types/vault/models/pki/config/urls.d.ts
+++ b/ui/types/vault/models/pki/config/urls.d.ts
@@ -6,8 +6,6 @@
 import Model from '@ember-data/model';
 
 export default class PkiConfigUrlsModel extends Model {
-  get useOpenAPI(): boolean;
-  getHelpUrl(backendPath: string): string;
   issuingCertificates: array;
   crlDistributionPoints: array;
   ocspServers: array;

--- a/ui/types/vault/models/pki/issuer.d.ts
+++ b/ui/types/vault/models/pki/issuer.d.ts
@@ -8,7 +8,6 @@ import { FormField, FormFieldGroups, ModelValidations } from 'vault/app-types';
 import { ParsedCertificateData } from 'vault/vault/utils/parse-pki-cert';
 export default class PkiIssuerModel extends Model {
   secretMountPath: class;
-  get useOpenAPI(): boolean;
   get backend(): string;
   get issuerRef(): string;
   certificate: string;

--- a/ui/types/vault/models/pki/role.d.ts
+++ b/ui/types/vault/models/pki/role.d.ts
@@ -7,10 +7,8 @@ import Model from '@ember-data/model';
 import { ModelValidations } from 'vault/app-types';
 
 export default class PkiRoleModel extends Model {
-  get useOpenAPI(): boolean;
   name: string;
   issuerRef: string;
-  getHelpUrl(backendPath: string): string;
   validate(): ModelValidations;
   isNew: boolean;
   keyType: string;

--- a/ui/types/vault/models/pki/tidy.d.ts
+++ b/ui/types/vault/models/pki/tidy.d.ts
@@ -24,8 +24,6 @@ export default class PkiTidyModel extends Model {
   tidyRevocationQueue: boolean;
   tidyRevokedCertIssuerAssociations: boolean;
   tidyRevokedCerts: boolean;
-  get useOpenAPI(): boolean;
-  getHelpUrl(backend: string): string;
   allByKey: {
     intervalDuration: FormField[];
   };


### PR DESCRIPTION
### Description
This is a cleanup item to remove `useOpenApi` and `getHelpUrl` from the models (which don't have anything to do with the shape of the data) and into a util that the `path-help` service can then utilize to get the appropriate data based on the model type and backend path. There should be no user-facing changes with this PR, but is foundation work for eventually upgrading to Ember Data 5

- [x] Ent tests pass
