### PR TITLE
Docs: PGP & gpg version requirements with ECDH & Vault 1.13.x or higher

### DIFF
--- a/website/content/docs/concepts/pgp-gpg-keybase.mdx
+++ b/website/content/docs/concepts/pgp-gpg-keybase.mdx
@@ -115,7 +115,7 @@ manual](https://gnupg.org/gph/en/manual.html).
 
 <Note>
 
-GnuPGP 2.2.21 or a more recent version is required when using ECHD keys with Vault 1.13.x or higher.
+To use ECHD keys with Vault you must use GnuPGP 2.2.21 or  newer.
 Refer to the [GnuPG/NEWS](https://dev.gnupg.org/source/gnupg/browse/master/NEWS) for further details.
 
 </Note>

--- a/website/content/docs/concepts/pgp-gpg-keybase.mdx
+++ b/website/content/docs/concepts/pgp-gpg-keybase.mdx
@@ -113,6 +113,13 @@ GnuPG is an open-source implementation of the OpenPGP standard and is available
 on nearly every platform. For more information, please see the [GnuPG
 manual](https://gnupg.org/gph/en/manual.html).
 
+<Note>
+
+GnuPGP 2.2.21 or a more recent version is required when using ECHD keys with Vault 1.13.x or higher.
+Refer to the [GnuPG/NEWS](https://dev.gnupg.org/source/gnupg/browse/master/NEWS) for further details.
+
+</Note>
+
 To create a new PGP key, run, following the prompts:
 
 ```shell-session


### PR DESCRIPTION
Added notes in [Developer / Vault / Documentation / Concepts / **PGP, GnuPG, and Keybase**](https://developer.hashicorp.com/vault/docs/concepts/pgp-gpg-keybase) regarding GnuGPG versions 2.2.21 or higher being required where padding differences with ECDH keys used in Vault versions 1.12.x or earlier work with older GPG versions but newer Vault versions encounter the generic error: `gpg: decryption failed: No secret key`

Fixes #25965 

<img width="1000" alt="Screenshot 2024-07-11 at 21 49 03" src="https://github.com/user-attachments/assets/56cbe1b7-fe22-4219-920d-a146bdd8991e">