### PR TITLE
Send warning and do not return error on group update if cluster is a PR secondary and RPC client is nil

### DIFF
--- a/vault/identity_store_util.go
+++ b/vault/identity_store_util.go
@@ -176,12 +176,15 @@ func (i *IdentityStore) loadGroups(ctx context.Context) error {
 				// This is an imperfect solution to unblock customers who are running into
 				// a readonly error during a DR failover (jira #28191). More specifically, if there
 				// are duplicate aliases in storage then they are merged during loadEntities. Vault
-				// attempts to remove the deleted duplicate entities from their groups to clean up. 
-				// If the node is a PR secondary though it will fail because the RPC client 
-				// is not yet initialized and the storage is read-only. This prevents the cluster from 
+				// attempts to remove the deleted duplicate entities from their groups to clean up.
+				// If the node is a PR secondary though it will fail because the RPC client
+				// is not yet initialized and the storage is read-only. This prevents the cluster from
 				// unsealing entirely and can potentially block a DR failover from succeeding.
 				i.logger.Warn("received a read only error while trying to upsert group to storage")
-			} else if err != nil {
+				err = nil
+			}
+
+			if err != nil {
 				txn.Abort()
 				return fmt.Errorf("failed to update group in memdb: %w", err)
 			}

--- a/vault/testing.go
+++ b/vault/testing.go
@@ -31,6 +31,7 @@ import (
 	"time"
 
 	"github.com/armon/go-metrics"
+	"github.com/golang/protobuf/ptypes"
 	"github.com/hashicorp/go-cleanhttp"
 	log "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-secure-stdlib/reloadutil"
@@ -39,8 +40,10 @@ import (
 	"github.com/hashicorp/vault/audit"
 	"github.com/hashicorp/vault/command/server"
 	"github.com/hashicorp/vault/helper/constants"
+	"github.com/hashicorp/vault/helper/identity"
 	"github.com/hashicorp/vault/helper/metricsutil"
 	"github.com/hashicorp/vault/helper/namespace"
+	"github.com/hashicorp/vault/helper/storagepacker"
 	"github.com/hashicorp/vault/helper/testhelpers/corehelpers"
 	"github.com/hashicorp/vault/helper/testhelpers/pluginhelpers"
 	"github.com/hashicorp/vault/internalshared/configutil"
@@ -57,6 +60,7 @@ import (
 	"github.com/mitchellh/copystructure"
 	"golang.org/x/crypto/ed25519"
 	"golang.org/x/net/http2"
+	"google.golang.org/protobuf/types/known/anypb"
 )
 
 // This file contains a number of methods that are useful for unit
@@ -2193,3 +2197,85 @@ var (
 	_ testcluster.VaultCluster     = &TestCluster{}
 	_ testcluster.VaultClusterNode = &TestClusterCore{}
 )
+
+// TestCreateDuplicateEntityAliasesInStorage creates n entities with a duplicate alias in storage
+// This should only be used in testing
+func TestCreateDuplicateEntityAliasesInStorage(ctx context.Context, c *Core, n int) ([]string, error) {
+	userpassMe := &MountEntry{
+		Table:       credentialTableType,
+		Path:        "userpass/",
+		Type:        "userpass",
+		Description: "userpass",
+		Accessor:    "userpass1",
+	}
+	err := c.enableCredential(namespace.RootContext(nil), userpassMe)
+	if err != nil {
+		return nil, err
+	}
+
+	var entityIDs []string
+	for i := 0; i < n; i++ {
+		entityID := fmt.Sprintf("e%d", i)
+		entityIDs = append(entityIDs, entityID)
+		a := &identity.Alias{
+			ID:            entityID,
+			CanonicalID:   entityID,
+			MountType:     "userpass",
+			MountAccessor: userpassMe.Accessor,
+			Name:          "alias-dup",
+		}
+		e := &identity.Entity{
+			ID:   entityID,
+			Name: "entity-dup",
+			Aliases: []*identity.Alias{
+				a,
+			},
+			NamespaceID: namespace.RootNamespaceID,
+			BucketKey:   c.identityStore.entityPacker.BucketKey(entityID),
+		}
+
+		entity, err := ptypes.MarshalAny(e)
+		if err != nil {
+			return nil, err
+		}
+		item := &storagepacker.Item{
+			ID:      e.ID,
+			Message: entity,
+		}
+		if err = c.identityStore.entityPacker.PutItem(ctx, item); err != nil {
+			return nil, err
+		}
+	}
+
+	return entityIDs, nil
+}
+
+// TestCreateStorageGroup creates a group in storage only to bypass checks that the entities exist in memdb
+// Should only be used in testing
+func TestCreateStorageGroup(ctx context.Context, c *Core, entityIDs []string) error {
+	// generate random int
+	i := mathrand.Intn(100)
+
+	key := fmt.Sprintf("testgroupid-%d", i)
+
+	group := &identity.Group{
+		ID:              key,
+		Name:            "testgroupname",
+		Policies:        []string{"testgrouppolicy"},
+		MemberEntityIDs: entityIDs,
+		BucketKey:       c.identityStore.groupPacker.BucketKey(key),
+	}
+	groupAsAny, err := anypb.New(group)
+	if err != nil {
+		return err
+	}
+	item := &storagepacker.Item{
+		ID:      group.ID,
+		Message: groupAsAny,
+	}
+	err = c.identityStore.groupPacker.PutItem(ctx, item)
+	if err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
### Description
If a DR secondary is promoted to become a DR Primary as well as a PR secondary, the promotion will fail and the cluster will never become available. This is because of an ongoing issue with duplicate aliases. If vault detects duplicate aliases, it will merge them, causing vault to update it's groups with the new entity members. However, the newly promoted DR primary/PR secondary fails to persist the group change to storage because it's rpc client has not been initialized yet.

To avoid this failure, we check if `UpsertGroupInTxn` returns an ErrReadOnly error, and instead log a warning message.

[Jira](https://hashicorp.atlassian.net/browse/VAULT-28191)

### TODO only if you're a HashiCorp employee
- [x] **Labels:** If this PR is the CE portion of an ENT change, and that ENT change is
  getting backported to N-2, use the new style `backport/ent/x.x.x+ent` labels
  instead of the old style `backport/x.x.x` labels.
- [x] **Labels:** If this PR is a CE only change, it can only be backported to N, so use
  the normal `backport/x.x.x` label (there should be only 1).
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
