### PR TITLE
[VAULT-28666] Retry staticcheck download on failure in GitHub Actions (GHA)

### DIFF
--- a/.github/actions/set-up-staticcheck/action.yml
+++ b/.github/actions/set-up-staticcheck/action.yml
@@ -57,7 +57,7 @@ runs:
         fi
 
         mkdir -p tmp
-        gh release download "$VERSION" -p "staticcheck_${OS}_${ARCH}.tar.gz" -O tmp/staticcheck.tgz -R dominikh/go-tools
+        ./.github/scripts/retry-command.sh gh release download "$VERSION" -p "staticcheck_${OS}_${ARCH}.tar.gz" -O tmp/staticcheck.tgz -R dominikh/go-tools
         pushd tmp && tar -xvf staticcheck.tgz && popd
         mv tmp/staticcheck/staticcheck "$DESTINATION"
         rm -rf tmp


### PR DESCRIPTION
### Description
The `staticcheck` download intermittently fails with network issues. Let's automatically retry it when things go wrong.

### TODO only if you're a HashiCorp employee
- [x] **Labels:** If this PR is the CE portion of an ENT change, and that ENT change is
  getting backported to N-2, use the new style `backport/ent/x.x.x+ent` labels
  instead of the old style `backport/x.x.x` labels.
- [x] **Labels:** If this PR is a CE only change, it can only be backported to N, so use
  the normal `backport/x.x.x` label (there should be only 1).
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.