### PR TITLE
UI: update overview card action handling

### DIFF
--- a/ui/app/templates/vault/cluster/secrets/backend/overview.hbs
+++ b/ui/app/templates/vault/cluster/secrets/backend/overview.hbs
@@ -41,6 +41,7 @@
               @query={{hash itemType="connection"}}
               @icon="plus"
               @iconPosition="trailing"
+              data-test-action-text="Configure new"
             />
           </:action>
           <:content>
@@ -59,6 +60,7 @@
               @query={{hash itemType="role"}}
               @icon="plus"
               @iconPosition="trailing"
+              data-test-action-text="Create new"
             />
           </:action>
           <:content>

--- a/ui/app/templates/vault/cluster/secrets/backend/overview.hbs
+++ b/ui/app/templates/vault/cluster/secrets/backend/overview.hbs
@@ -33,26 +33,39 @@
         <OverviewCard
           @cardTitle="Connections"
           @subText="The total number of connections to external databases that you have access to."
-          @actionText="Configure new"
-          @actionTo="vault.cluster.secrets.backend.create-root"
-          @actionQuery={{hash itemType="connection"}}
         >
-          <Hds::Text::Display class="has-top-padding-m" @tag="h2" @size="500">
-            {{format-number (if (eq this.model.connections 404) 0 this.model.connections.length)}}
-          </Hds::Text::Display>
+          <:action>
+            <Hds::Link::Standalone
+              @text="Configure new"
+              @route="vault.cluster.secrets.backend.create-root"
+              @query={{hash itemType="connection"}}
+              @icon="plus"
+              @iconPosition="trailing"
+            />
+          </:action>
+          <:content>
+            <Hds::Text::Display class="has-top-padding-m" @tag="h2" @size="500">
+              {{format-number (if (eq this.model.connections 404) 0 this.model.connections.length)}}
+            </Hds::Text::Display>
+          </:content>
         </OverviewCard>
       {{/if}}
       {{#if (or this.model.roleCapabilities.canList this.model.staticRoleCapabilities.canList)}}
-        <OverviewCard
-          @cardTitle="Roles"
-          @subText="The total number of roles configured that you have permissions to list."
-          @actionText="Create new"
-          @actionTo="vault.cluster.secrets.backend.create-root"
-          @actionQuery={{hash itemType="role"}}
-        >
-          <Hds::Text::Display class="has-top-padding-m" @tag="h2" @size="500">
-            {{format-number (if (eq this.model.roles 404) 0 this.model.roles.length)}}
-          </Hds::Text::Display>
+        <OverviewCard @cardTitle="Roles" @subText="The total number of roles configured that you have permissions to list.">
+          <:action>
+            <Hds::Link::Standalone
+              @text="Create new"
+              @route="vault.cluster.secrets.backend.create-root"
+              @query={{hash itemType="role"}}
+              @icon="plus"
+              @iconPosition="trailing"
+            />
+          </:action>
+          <:content>
+            <Hds::Text::Display class="has-top-padding-m" @tag="h2" @size="500">
+              {{format-number (if (eq this.model.roles 404) 0 this.model.roles.length)}}
+            </Hds::Text::Display>
+          </:content>
         </OverviewCard>
       {{/if}}
       <GetCredentialsCard

--- a/ui/lib/core/addon/components/overview-card.hbs
+++ b/ui/lib/core/addon/components/overview-card.hbs
@@ -14,25 +14,21 @@
     <Hds::Text::Display @weight="bold" @size="300" data-test-overview-card-title={{@cardTitle}}>
       {{@cardTitle}}
     </Hds::Text::Display>
-    {{#if @actionText}}
-      <Hds::Link::Standalone
-        @icon={{or @actionIcon "chevron-right"}}
-        @iconPosition="trailing"
-        @text={{@actionText}}
-        @route={{@actionTo}}
-        @model={{@actionModel}}
-        @isRouteExternal={{@actionExternal}}
-        @query={{@actionQuery}}
-        data-test-action-text={{@actionText}}
-      />
+
+    {{#if (has-block "action")}}
+      {{yield to="action"}}
     {{/if}}
   </div>
+
   <Hds::Text::Body
     @color="faint"
-    class="{{unless @actionText 'has-top-margin-s'}}"
+    class="{{unless (has-block 'action') 'has-top-margin-s'}}"
     data-test-overview-card-subtitle={{@cardTitle}}
   >
     {{@subText}}
   </Hds::Text::Body>
-  {{yield}}
+
+  {{#if (has-block "content")}}
+    {{yield to="content"}}
+  {{/if}}
 </Hds::Card::Container>

--- a/ui/lib/core/addon/components/overview-card.hbs
+++ b/ui/lib/core/addon/components/overview-card.hbs
@@ -20,11 +20,7 @@
     {{/if}}
   </div>
 
-  <Hds::Text::Body
-    @color="faint"
-    class="{{unless (has-block 'action') 'has-top-margin-s'}}"
-    data-test-overview-card-subtitle={{@cardTitle}}
-  >
+  <Hds::Text::Body @color="faint" data-test-overview-card-subtitle={{@cardTitle}}>
     {{@subText}}
   </Hds::Text::Body>
 

--- a/ui/lib/kubernetes/addon/components/page/overview.hbs
+++ b/ui/lib/kubernetes/addon/components/page/overview.hbs
@@ -11,39 +11,46 @@
   <ConfigCta />
 {{else}}
   <div class="is-grid has-top-margin-l grid-2-columns grid-gap-2">
-    <OverviewCard
-      @cardTitle="Roles"
-      @subText="The number of Vault roles being used to generate Kubernetes credentials."
-      @actionText={{if @roles.length "View Roles" "Create Role"}}
-      @actionTo={{if @roles.length "roles" "roles.create"}}
-    >
-      <h2 class="title is-2 has-font-weight-normal has-top-margin-m" data-test-roles-card-overview-num>{{or
-          @roles.length
-          "None"
-        }}</h2>
+    <OverviewCard @cardTitle="Roles" @subText="The number of Vault roles being used to generate Kubernetes credentials.">
+      <:action>
+        <Hds::Link::Standalone
+          @text={{if @roles.length "View Roles" "Create Role"}}
+          @route={{if @roles.length "roles" "roles.create"}}
+          @icon={{if @roles.length "chevron-right" "plus"}}
+          @iconPosition="trailing"
+        />
+      </:action>
+      <:content>
+        <h2 class="title is-2 has-font-weight-normal has-top-margin-m" data-test-roles-card-overview-num>{{or
+            @roles.length
+            "None"
+          }}</h2>
+      </:content>
     </OverviewCard>
     <OverviewCard @cardTitle="Generate credentials" @subText="Quickly generate credentials by typing the role name.">
-      <div class="has-top-margin-m is-flex">
-        <SearchSelect
-          class="is-flex-grow-1"
-          @ariaLabel="Role"
-          @placeholder="Type to find a role..."
-          @disallowNewItems={{true}}
-          @options={{this.roleOptions}}
-          @selectLimit="1"
-          @fallbackComponent="input-search"
-          @onChange={{this.selectRole}}
-          @renderInPlace={{true}}
-        />
-        <Hds::Button
-          @text="Generate"
-          @color="secondary"
-          class="has-left-margin-s"
-          disabled={{not this.selectedRole}}
-          {{on "click" this.generateCredential}}
-          data-test-generate-credential-button
-        />
-      </div>
+      <:content>
+        <div class="has-top-margin-m is-flex">
+          <SearchSelect
+            class="is-flex-grow-1"
+            @ariaLabel="Role"
+            @placeholder="Type to find a role..."
+            @disallowNewItems={{true}}
+            @options={{this.roleOptions}}
+            @selectLimit="1"
+            @fallbackComponent="input-search"
+            @onChange={{this.selectRole}}
+            @renderInPlace={{true}}
+          />
+          <Hds::Button
+            @text="Generate"
+            @color="secondary"
+            class="has-left-margin-s"
+            disabled={{not this.selectedRole}}
+            {{on "click" this.generateCredential}}
+            data-test-generate-credential-button
+          />
+        </div>
+      </:content>
     </OverviewCard>
   </div>
 {{/if}}

--- a/ui/lib/kv/addon/components/page/list.hbs
+++ b/ui/lib/kv/addon/components/page/list.hbs
@@ -44,25 +44,30 @@
         @cardTitle="View secret"
         @subText="Type the path of the secret you want to view. Include a trailing slash to navigate to the list view."
       >
-        <form {{on "submit" this.transitionToSecretDetail}} class="has-top-margin-m">
-          <InputSearch
-            @id="search-input-kv-secret"
-            @initialValue={{@pathToSecret}}
-            @onChange={{this.handleSecretPathInput}}
-            @placeholder="secret/"
-            data-test-view-secret
-          />
-          <Hds::Button
-            @text={{this.buttonText}}
-            @color="secondary"
-            type="submit"
-            disabled={{not this.secretPath}}
-            data-test-get-secret-detail
-          />
-        </form>
-        {{#if @failedDirectoryQuery}}
-          <AlertInline @type="danger" @message="You do not have the required permissions or the directory does not exist." />
-        {{/if}}
+        <:content>
+          <form {{on "submit" this.transitionToSecretDetail}} class="has-top-margin-m">
+            <InputSearch
+              @id="search-input-kv-secret"
+              @initialValue={{@pathToSecret}}
+              @onChange={{this.handleSecretPathInput}}
+              @placeholder="secret/"
+              data-test-view-secret
+            />
+            <Hds::Button
+              @text={{this.buttonText}}
+              @color="secondary"
+              type="submit"
+              disabled={{not this.secretPath}}
+              data-test-get-secret-detail
+            />
+          </form>
+          {{#if @failedDirectoryQuery}}
+            <AlertInline
+              @type="danger"
+              @message="You do not have the required permissions or the directory does not exist."
+            />
+          {{/if}}
+        </:content>
       </OverviewCard>
     </div>
   </div>

--- a/ui/lib/ldap/addon/components/accounts-checked-out.hbs
+++ b/ui/lib/ldap/addon/components/accounts-checked-out.hbs
@@ -9,36 +9,38 @@
   class="has-padding-l"
   ...attributes
 >
-  <hr class="has-background-gray-200" />
+  <:content>
+    <hr class="has-background-gray-200" />
 
-  {{#if this.filteredAccounts}}
-    <Hds::Table @model={{this.filteredAccounts}} @columns={{this.columns}}>
-      <:body as |Body|>
-        <Body.Tr>
-          <Body.Td data-test-checked-out-account={{Body.data.account}}>{{Body.data.account}}</Body.Td>
-          {{#if @showLibraryColumn}}
-            <Body.Td data-test-checked-out-library={{Body.data.account}}>{{Body.data.library}}</Body.Td>
-          {{/if}}
-          <Body.Td>
-            <Hds::Button
-              @icon="queue"
-              @text="Check-in"
-              @color="tertiary"
-              disabled={{this.disableCheckIn Body.data.library}}
-              data-test-checked-out-account-action={{Body.data.account}}
-              {{on "click" (fn (mut this.selectedStatus) Body.data)}}
-            />
-          </Body.Td>
-        </Body.Tr>
-      </:body>
-    </Hds::Table>
-  {{else}}
-    <EmptyState
-      @title="No accounts checked out yet"
-      @message="There is no account that is currently in use."
-      class="is-shadowless"
-    />
-  {{/if}}
+    {{#if this.filteredAccounts}}
+      <Hds::Table @model={{this.filteredAccounts}} @columns={{this.columns}}>
+        <:body as |Body|>
+          <Body.Tr>
+            <Body.Td data-test-checked-out-account={{Body.data.account}}>{{Body.data.account}}</Body.Td>
+            {{#if @showLibraryColumn}}
+              <Body.Td data-test-checked-out-library={{Body.data.account}}>{{Body.data.library}}</Body.Td>
+            {{/if}}
+            <Body.Td>
+              <Hds::Button
+                @icon="queue"
+                @text="Check-in"
+                @color="tertiary"
+                disabled={{this.disableCheckIn Body.data.library}}
+                data-test-checked-out-account-action={{Body.data.account}}
+                {{on "click" (fn (mut this.selectedStatus) Body.data)}}
+              />
+            </Body.Td>
+          </Body.Tr>
+        </:body>
+      </Hds::Table>
+    {{else}}
+      <EmptyState
+        @title="No accounts checked out yet"
+        @message="There is no account that is currently in use."
+        class="is-shadowless"
+      />
+    {{/if}}
+  </:content>
 </OverviewCard>
 
 {{#if this.selectedStatus}}

--- a/ui/lib/ldap/addon/components/page/library/details/accounts.hbs
+++ b/ui/lib/ldap/addon/components/page/library/details/accounts.hbs
@@ -52,14 +52,16 @@
       @subText="Use the CLI command below:"
       class="has-padding-l has-top-margin-l"
     >
-      <Hds::CodeBlock
-        class="has-top-margin-s"
-        data-test-accounts-code-block
-        @language="bash"
-        @hasLineNumbers={{false}}
-        @hasCopyButton={{true}}
-        @value={{this.cliCommand}}
-      />
+      <:content>
+        <Hds::CodeBlock
+          class="has-top-margin-s"
+          data-test-accounts-code-block
+          @language="bash"
+          @hasLineNumbers={{false}}
+          @hasCopyButton={{true}}
+          @value={{this.cliCommand}}
+        />
+      </:content>
     </OverviewCard>
   </div>
 </div>

--- a/ui/lib/ldap/addon/components/page/overview.hbs
+++ b/ui/lib/ldap/addon/components/page/overview.hbs
@@ -20,22 +20,28 @@
     <OverviewCard
       @cardTitle="Roles"
       @subText="The total number of roles that have been set up in this secret engine in order to generate credentials."
-      @actionText="Create new"
-      @actionTo="roles.create"
     >
-      <h2 class="title is-2 has-font-weight-normal has-top-margin-m" data-test-roles-count>
-        {{or @roles.length "None"}}
-      </h2>
+      <:action>
+        <Hds::Link::Standalone @text="Create new" @route="roles.create" @icon="plus" @iconPosition="trailing" />
+      </:action>
+      <:content>
+        <h2 class="title is-2 has-font-weight-normal has-top-margin-m" data-test-roles-count>
+          {{or @roles.length "None"}}
+        </h2>
+      </:content>
     </OverviewCard>
     <OverviewCard
       @cardTitle="Libraries"
       @subText="The total number of libraries that have been created for service account management."
-      @actionText="Create new"
-      @actionTo="libraries.create"
     >
-      <h2 class="title is-2 has-font-weight-normal has-top-margin-m" data-test-libraries-count>
-        {{or @libraries.length "None"}}
-      </h2>
+      <:action>
+        <Hds::Link::Standalone @text="Create new" @route="libraries.create" @icon="plus" @iconPosition="trailing" />
+      </:action>
+      <:content>
+        <h2 class="title is-2 has-font-weight-normal has-top-margin-m" data-test-libraries-count>
+          {{or @libraries.length "None"}}
+        </h2>
+      </:content>
     </OverviewCard>
   </div>
   <div class="is-grid has-top-margin-l grid-2-columns grid-gap-2">

--- a/ui/lib/ldap/addon/components/page/overview.hbs
+++ b/ui/lib/ldap/addon/components/page/overview.hbs
@@ -54,29 +54,31 @@
     />
     <div>
       <OverviewCard @cardTitle="Generate credentials" @subText="Quickly generate credentials by typing the role name.">
-        <div class="has-top-margin-m is-flex">
-          <SearchSelect
-            class="is-flex-1"
-            @ariaLabel="Role"
-            @placeholder="Select a role"
-            @disallowNewItems={{true}}
-            @options={{@roles}}
-            @selectLimit="1"
-            @fallbackComponent="input-search"
-            @onChange={{this.selectRole}}
-            @renderInPlace={{true}}
-          />
-          <div>
-            <Hds::Button
-              @text="Get credentials"
-              @color="secondary"
-              class="has-left-margin-s"
-              disabled={{not this.selectedRole}}
-              {{on "click" this.generateCredentials}}
-              data-test-generate-credential-button
+        <:content>
+          <div class="has-top-margin-m is-flex">
+            <SearchSelect
+              class="is-flex-1"
+              @ariaLabel="Role"
+              @placeholder="Select a role"
+              @disallowNewItems={{true}}
+              @options={{@roles}}
+              @selectLimit="1"
+              @fallbackComponent="input-search"
+              @onChange={{this.selectRole}}
+              @renderInPlace={{true}}
             />
+            <div>
+              <Hds::Button
+                @text="Get credentials"
+                @color="secondary"
+                class="has-left-margin-s"
+                disabled={{not this.selectedRole}}
+                {{on "click" this.generateCredentials}}
+                data-test-generate-credential-button
+              />
+            </div>
           </div>
-        </div>
+        </:content>
       </OverviewCard>
     </div>
   </div>

--- a/ui/lib/pki/addon/components/page/pki-overview.hbs
+++ b/ui/lib/pki/addon/components/page/pki-overview.hbs
@@ -7,25 +7,41 @@
   <OverviewCard
     @cardTitle="Issuers"
     @subText="The total number of issuers in this PKI mount. Includes both root and intermediate certificates."
-    @actionText="View issuers"
-    @actionTo="issuers"
-    @actionModel={{@engine.id}}
   >
-    <Hds::Text::Display @tag="h2" @size="500">
-      {{format-number (if (eq @issuers 404) 0 @issuers.length)}}
-    </Hds::Text::Display>
+    <:action>
+      <Hds::Link::Standalone
+        @text="View issuers"
+        @route="issuers"
+        @model={{@engine.id}}
+        @icon="chevron-right"
+        @iconPosition="trailing"
+      />
+    </:action>
+    <:content>
+      <Hds::Text::Display @tag="h2" @size="500">
+        {{format-number (if (eq @issuers 404) 0 @issuers.length)}}
+      </Hds::Text::Display>
+    </:content>
   </OverviewCard>
   {{#if (not-eq @roles 403)}}
     <OverviewCard
       @cardTitle="Roles"
       @subText="The total number of roles in this PKI mount that have been created to generate certificates."
-      @actionText="View roles"
-      @actionTo="roles"
-      @actionModel={{@engine.id}}
     >
-      <Hds::Text::Display @tag="h2" @size="500">
-        {{format-number (if (eq @roles 404) 0 @roles.length)}}
-      </Hds::Text::Display>
+      <:action>
+        <Hds::Link::Standalone
+          @text="View roles"
+          @route='="roles"'
+          @model={{@engine.id}}
+          @icon="chevron-right"
+          @iconPosition="trailing"
+        />
+      </:action>
+      <:content>
+        <Hds::Text::Display @tag="h2" @size="500">
+          {{format-number (if (eq @roles 404) 0 @roles.length)}}
+        </Hds::Text::Display>
+      </:content>
     </OverviewCard>
   {{/if}}
   <OverviewCard @cardTitle="Issue certificate" @subText="Begin issuing a certificate by choosing a role.">

--- a/ui/lib/pki/addon/components/page/pki-overview.hbs
+++ b/ui/lib/pki/addon/components/page/pki-overview.hbs
@@ -31,7 +31,7 @@
       <:action>
         <Hds::Link::Standalone
           @text="View roles"
-          @route='="roles"'
+          @route="roles"
           @model={{@engine.id}}
           @icon="chevron-right"
           @iconPosition="trailing"

--- a/ui/lib/pki/addon/components/page/pki-overview.hbs
+++ b/ui/lib/pki/addon/components/page/pki-overview.hbs
@@ -45,84 +45,90 @@
     </OverviewCard>
   {{/if}}
   <OverviewCard @cardTitle="Issue certificate" @subText="Begin issuing a certificate by choosing a role.">
-    <div class="has-top-margin-m is-flex">
-      <SearchSelect
-        class="is-flex-grow-1"
-        @ariaLabel="Role"
-        @selectLimit="1"
-        @models={{array "pki/role"}}
-        @backend={{@engine.id}}
-        @placeholder="Type to find a role..."
-        @disallowNewItems={{true}}
-        @onChange={{this.handleRolesInput}}
-        @fallbackComponent="input-search"
-        @renderInPlace={{true}}
-        data-test-issue-certificate-input
-      />
-      <Hds::Button
-        @text="Issue"
-        @color="secondary"
-        class="has-left-margin-s align-self-baseline"
-        type="submit"
-        disabled={{unless this.rolesValue true}}
-        {{on "click" this.transitionToIssueCertificates}}
-        data-test-issue-certificate-button
-      />
-    </div>
+    <:content>
+      <div class="has-top-margin-m is-flex">
+        <SearchSelect
+          class="is-flex-grow-1"
+          @ariaLabel="Role"
+          @selectLimit="1"
+          @models={{array "pki/role"}}
+          @backend={{@engine.id}}
+          @placeholder="Type to find a role..."
+          @disallowNewItems={{true}}
+          @onChange={{this.handleRolesInput}}
+          @fallbackComponent="input-search"
+          @renderInPlace={{true}}
+          data-test-issue-certificate-input
+        />
+        <Hds::Button
+          @text="Issue"
+          @color="secondary"
+          class="has-left-margin-s align-self-baseline"
+          type="submit"
+          disabled={{unless this.rolesValue true}}
+          {{on "click" this.transitionToIssueCertificates}}
+          data-test-issue-certificate-button
+        />
+      </div>
+    </:content>
   </OverviewCard>
 
   <OverviewCard @cardTitle="View certificate" @subText="Quickly view a certificate by typing its serial number.">
-    <div class="has-top-margin-m {{unless this.certificateValue 'is-flex'}}">
-      <SearchSelect
-        class="is-flex-grow-1"
-        @ariaLabel="Certificate serial number"
-        @selectLimit="1"
-        @models={{array "pki/certificate/base"}}
-        @backend={{@engine.id}}
-        @placeholder="33:a3:..."
-        @disallowNewItems={{true}}
-        @onChange={{this.handleCertificateInput}}
-        @fallbackComponent="input-search"
-        @renderInPlace={{true}}
-        data-test-view-certificate-input
-      />
-      <Hds::Button
-        @text="View"
-        @color="secondary"
-        class="align-self-baseline {{unless this.certificateValue 'has-left-margin-s'}}"
-        disabled={{unless this.certificateValue true}}
-        {{on "click" this.transitionToViewCertificates}}
-        data-test-view-certificate-button
-      />
-    </div>
+    <:content>
+      <div class="has-top-margin-m {{unless this.certificateValue 'is-flex'}}">
+        <SearchSelect
+          class="is-flex-grow-1"
+          @ariaLabel="Certificate serial number"
+          @selectLimit="1"
+          @models={{array "pki/certificate/base"}}
+          @backend={{@engine.id}}
+          @placeholder="33:a3:..."
+          @disallowNewItems={{true}}
+          @onChange={{this.handleCertificateInput}}
+          @fallbackComponent="input-search"
+          @renderInPlace={{true}}
+          data-test-view-certificate-input
+        />
+        <Hds::Button
+          @text="View"
+          @color="secondary"
+          class="align-self-baseline {{unless this.certificateValue 'has-left-margin-s'}}"
+          disabled={{unless this.certificateValue true}}
+          {{on "click" this.transitionToViewCertificates}}
+          data-test-view-certificate-button
+        />
+      </div>
+    </:content>
   </OverviewCard>
 
   <OverviewCard @cardTitle="View issuer" @subText="Choose or type an issuer name or ID to view its details">
-    <div class="has-top-margin-m is-flex">
-      <SearchSelect
-        class="is-flex-grow-1"
-        @ariaLabel="Issuer name or ID"
-        @selectLimit="1"
-        @models={{array "pki/issuer"}}
-        @backend={{@engine.id}}
-        @placeholder="Type to find an issuer..."
-        @disallowNewItems={{true}}
-        @onChange={{this.handleIssuerSearch}}
-        @fallbackComponent="input-search"
-        @shouldRenderName={{true}}
-        @nameKey="issuerName"
-        @renderInPlace={{true}}
-        data-test-issue-issuer-input
-      />
-      <Hds::Button
-        @text="View"
-        @color="secondary"
-        class="has-left-margin-s align-self-baseline"
-        type="submit"
-        disabled={{unless this.issuerValue true}}
-        {{on "click" this.transitionToIssuerDetails}}
-        data-test-view-issuer-button
-      />
-    </div>
+    <:content>
+      <div class="has-top-margin-m is-flex">
+        <SearchSelect
+          class="is-flex-grow-1"
+          @ariaLabel="Issuer name or ID"
+          @selectLimit="1"
+          @models={{array "pki/issuer"}}
+          @backend={{@engine.id}}
+          @placeholder="Type to find an issuer..."
+          @disallowNewItems={{true}}
+          @onChange={{this.handleIssuerSearch}}
+          @fallbackComponent="input-search"
+          @shouldRenderName={{true}}
+          @nameKey="issuerName"
+          @renderInPlace={{true}}
+          data-test-issue-issuer-input
+        />
+        <Hds::Button
+          @text="View"
+          @color="secondary"
+          class="has-left-margin-s align-self-baseline"
+          type="submit"
+          disabled={{unless this.issuerValue true}}
+          {{on "click" this.transitionToIssuerDetails}}
+          data-test-view-issuer-button
+        />
+      </div>
+    </:content>
   </OverviewCard>
 </div>

--- a/ui/lib/sync/addon/components/secrets/page/overview.hbs
+++ b/ui/lib/sync/addon/components/secrets/page/overview.hbs
@@ -170,7 +170,11 @@
   </OverviewCard>
 
   <div class="is-grid grid-2-columns grid-gap-2 has-top-margin-l has-bottom-margin-l">
-    <OverviewCard @cardTitle="Total destinations" @subText="The total number of connected destinations" class="is-flex-half">
+    <OverviewCard
+      @cardTitle="Total destinations"
+      @subText="The total number of connected destinations."
+      class="is-flex-half"
+    >
       <:action>
         <Hds::Link::Standalone
           @text="Create new"

--- a/ui/lib/sync/addon/components/secrets/page/overview.hbs
+++ b/ui/lib/sync/addon/components/secrets/page/overview.hbs
@@ -168,28 +168,40 @@
   </OverviewCard>
 
   <div class="is-grid grid-2-columns grid-gap-2 has-top-margin-l has-bottom-margin-l">
-    <OverviewCard
-      @cardTitle="Total destinations"
-      @subText="The total number of connected destinations"
-      @actionText="Create new"
-      @actionTo="secrets.destinations.create"
-      class="is-flex-half"
-    >
-      <h2 class="title is-2 has-font-weight-normal has-top-margin-m" data-test-overview-card-content="Total destinations">
-        {{or @destinations.length "None"}}
-      </h2>
+    <OverviewCard @cardTitle="Total destinations" @subText="The total number of connected destinations" class="is-flex-half">
+      <:action>
+        <Hds::Link::Standalone
+          @text="Create new"
+          @route="secrets.destinations.create"
+          @icon="plus"
+          @iconPosition="trailing"
+        />
+      </:action>
+      <:content>
+        <h2 class="title is-2 has-font-weight-normal has-top-margin-m" data-test-overview-card-content="Total destinations">
+          {{or @destinations.length "None"}}
+        </h2>
+      </:content>
     </OverviewCard>
     <OverviewCard
       @cardTitle="Total secrets"
       @subText="The total number of secrets that have been synced from Vault over time. One secret will be counted as one sync client."
-      @actionText="View billing"
-      @actionTo="clientCountOverview"
-      @actionExternal={{true}}
       class="is-flex-half"
     >
-      <h2 class="title is-2 has-font-weight-normal has-top-margin-m" data-test-overview-card-content="Total secrets">
-        {{or @totalVaultSecrets "None"}}
-      </h2>
+      <:action>
+        <Hds::Link::Standalone
+          @text="View billing"
+          @route="clientCountOverview"
+          @isRouteExternal={{true}}
+          @icon="chevron-right"
+          @iconPosition="trailing"
+        />
+      </:action>
+      <:content>
+        <h2 class="title is-2 has-font-weight-normal has-top-margin-m" data-test-overview-card-content="Total secrets">
+          {{or @totalVaultSecrets "None"}}
+        </h2>
+      </:content>
     </OverviewCard>
   </div>
 {{else}}

--- a/ui/lib/sync/addon/components/secrets/page/overview.hbs
+++ b/ui/lib/sync/addon/components/secrets/page/overview.hbs
@@ -181,6 +181,7 @@
           @route="secrets.destinations.create"
           @icon="plus"
           @iconPosition="trailing"
+          data-test-action-text="Create new"
         />
       </:action>
       <:content>

--- a/ui/lib/sync/addon/components/secrets/page/overview.hbs
+++ b/ui/lib/sync/addon/components/secrets/page/overview.hbs
@@ -202,6 +202,7 @@
           @isRouteExternal={{true}}
           @icon="chevron-right"
           @iconPosition="trailing"
+          data-test-action-text
         />
       </:action>
       <:content>

--- a/ui/lib/sync/addon/components/secrets/page/overview.hbs
+++ b/ui/lib/sync/addon/components/secrets/page/overview.hbs
@@ -69,102 +69,104 @@
   </Toolbar>
 
   <OverviewCard @cardTitle="Secrets by destination" class="has-top-margin-l">
-    {{#if this.fetchAssociationsForDestinations.isRunning}}
-      <div data-test-sync-overview-loading>
-        <Icon @name="loading" @size="24" />
-        Loading destinations...
-      </div>
-    {{else if (not this.destinationMetrics)}}
-      <EmptyState
-        @title="Error fetching information"
-        @message="Ensure that the policy has access to read sync associations."
-      >
-        <Hds::Link::Standalone
-          @icon="docs-link"
-          @iconPosition="trailing"
-          @text="Secrets Sync association API docs"
-          @href={{doc-link "/vault/api-docs/system/secrets-sync#read-associations"}}
-        />
-      </EmptyState>
-    {{else}}
-      <Hds::Table>
-        <:head as |H|>
-          <H.Tr>
-            <H.Th>Sync destination</H.Th>
-            <H.Th @align="right">
-              # of external secrets
-              <Hds::TooltipButton
-                @text="Number of secrets created at the destination"
-                aria-label="More information"
-                class="is-v-centered"
-              >
-                <FlightIcon @name="info" />
-              </Hds::TooltipButton>
-            </H.Th>
-            <H.Th @align="right">Last updated</H.Th>
-            <H.Th @align="right">Actions</H.Th>
-          </H.Tr>
-        </:head>
-        <:body as |B|>
-          {{#each this.destinationMetrics as |data index|}}
-            <B.Tr data-test-overview-table-row>
-              <B.Td>
-                <Icon @name={{data.icon}} data-test-overview-table-icon={{index}} />
-                <span data-test-overview-table-name={{index}}>{{data.name}}</span>
-                {{#if data.status}}
-                  <Hds::Badge
-                    @text={{data.status}}
-                    @color={{if (eq data.status "All synced") "success"}}
-                    data-test-overview-table-badge={{index}}
-                  />
-                {{/if}}
-              </B.Td>
-              <B.Td @align="right" data-test-overview-table-total={{index}}>
-                {{data.associationCount}}
-              </B.Td>
-              <B.Td @align="right" data-test-overview-table-updated={{index}}>
-                {{#if data.lastUpdated}}
-                  {{date-format data.lastUpdated "MMMM do yyyy, h:mm:ss a"}}
-                {{else}}
-                  &mdash;
-                {{/if}}
-              </B.Td>
-              <B.Td @align="right">
-                <Hds::Dropdown @isInline={{true}} @listPosition="bottom-right" as |dd|>
-                  <dd.ToggleIcon
-                    @icon="more-horizontal"
-                    @text="Actions"
-                    @hasChevron={{false}}
-                    @size="small"
-                    data-test-overview-table-action-toggle={{index}}
-                  />
-                  <dd.Interactive
-                    @route="secrets.destinations.destination.sync"
-                    @models={{array data.type data.name}}
-                    @text="Sync secrets"
-                    data-test-overview-table-action="sync"
-                  />
-                  <dd.Interactive
-                    @route="secrets.destinations.destination.secrets"
-                    @models={{array data.type data.name}}
-                    @text="View synced secrets"
-                    data-test-overview-table-action="details"
-                  />
-                </Hds::Dropdown>
-              </B.Td>
-            </B.Tr>
-          {{/each}}
-        </:body>
-      </Hds::Table>
+    <:content>
+      {{#if this.fetchAssociationsForDestinations.isRunning}}
+        <div data-test-sync-overview-loading>
+          <Icon @name="loading" @size="24" />
+          Loading destinations...
+        </div>
+      {{else if (not this.destinationMetrics)}}
+        <EmptyState
+          @title="Error fetching information"
+          @message="Ensure that the policy has access to read sync associations."
+        >
+          <Hds::Link::Standalone
+            @icon="docs-link"
+            @iconPosition="trailing"
+            @text="Secrets Sync association API docs"
+            @href={{doc-link "/vault/api-docs/system/secrets-sync#read-associations"}}
+          />
+        </EmptyState>
+      {{else}}
+        <Hds::Table>
+          <:head as |H|>
+            <H.Tr>
+              <H.Th>Sync destination</H.Th>
+              <H.Th @align="right">
+                # of external secrets
+                <Hds::TooltipButton
+                  @text="Number of secrets created at the destination"
+                  aria-label="More information"
+                  class="is-v-centered"
+                >
+                  <FlightIcon @name="info" />
+                </Hds::TooltipButton>
+              </H.Th>
+              <H.Th @align="right">Last updated</H.Th>
+              <H.Th @align="right">Actions</H.Th>
+            </H.Tr>
+          </:head>
+          <:body as |B|>
+            {{#each this.destinationMetrics as |data index|}}
+              <B.Tr data-test-overview-table-row>
+                <B.Td>
+                  <Icon @name={{data.icon}} data-test-overview-table-icon={{index}} />
+                  <span data-test-overview-table-name={{index}}>{{data.name}}</span>
+                  {{#if data.status}}
+                    <Hds::Badge
+                      @text={{data.status}}
+                      @color={{if (eq data.status "All synced") "success"}}
+                      data-test-overview-table-badge={{index}}
+                    />
+                  {{/if}}
+                </B.Td>
+                <B.Td @align="right" data-test-overview-table-total={{index}}>
+                  {{data.associationCount}}
+                </B.Td>
+                <B.Td @align="right" data-test-overview-table-updated={{index}}>
+                  {{#if data.lastUpdated}}
+                    {{date-format data.lastUpdated "MMMM do yyyy, h:mm:ss a"}}
+                  {{else}}
+                    &mdash;
+                  {{/if}}
+                </B.Td>
+                <B.Td @align="right">
+                  <Hds::Dropdown @isInline={{true}} @listPosition="bottom-right" as |dd|>
+                    <dd.ToggleIcon
+                      @icon="more-horizontal"
+                      @text="Actions"
+                      @hasChevron={{false}}
+                      @size="small"
+                      data-test-overview-table-action-toggle={{index}}
+                    />
+                    <dd.Interactive
+                      @route="secrets.destinations.destination.sync"
+                      @models={{array data.type data.name}}
+                      @text="Sync secrets"
+                      data-test-overview-table-action="sync"
+                    />
+                    <dd.Interactive
+                      @route="secrets.destinations.destination.secrets"
+                      @models={{array data.type data.name}}
+                      @text="View synced secrets"
+                      data-test-overview-table-action="details"
+                    />
+                  </Hds::Dropdown>
+                </B.Td>
+              </B.Tr>
+            {{/each}}
+          </:body>
+        </Hds::Table>
 
-      <Hds::Pagination::Numbered
-        @totalItems={{@destinations.length}}
-        @currentPage={{this.page}}
-        @currentPageSize={{this.pageSize}}
-        @showSizeSelector={{false}}
-        @onPageChange={{perform this.fetchAssociationsForDestinations}}
-      />
-    {{/if}}
+        <Hds::Pagination::Numbered
+          @totalItems={{@destinations.length}}
+          @currentPage={{this.page}}
+          @currentPageSize={{this.pageSize}}
+          @showSizeSelector={{false}}
+          @onPageChange={{perform this.fetchAssociationsForDestinations}}
+        />
+      {{/if}}
+    </:content>
   </OverviewCard>
 
   <div class="is-grid grid-2-columns grid-gap-2 has-top-margin-l has-bottom-margin-l">

--- a/ui/tests/integration/components/overview-card-test.js
+++ b/ui/tests/integration/components/overview-card-test.js
@@ -44,6 +44,7 @@ module('Integration | Component overview-card', function (hooks) {
         {{this.actionText}}
         </div>
         </:action>
+      </OverviewCard
       `
     );
     assert.dom(SELECTORS.action).hasText('View card');

--- a/ui/tests/integration/components/overview-card-test.js
+++ b/ui/tests/integration/components/overview-card-test.js
@@ -37,7 +37,14 @@ module('Integration | Component overview-card', function (hooks) {
   });
   test('it returns card action text', async function (assert) {
     await render(
-      hbs`<OverviewCard @cardTitle={{this.cardTitle}} @actionText={{this.actionText}} @actionTo="route"/>`
+      hbs`
+      <OverviewCard @cardTitle={{this.cardTitle}}>
+        <:action>
+        <div data-test-action-text>
+        {{this.actionText}}
+        </div>
+        </:action>
+      `
     );
     assert.dom(SELECTORS.action).hasText('View card');
   });

--- a/ui/tests/integration/components/overview-card-test.js
+++ b/ui/tests/integration/components/overview-card-test.js
@@ -44,7 +44,7 @@ module('Integration | Component overview-card', function (hooks) {
         {{this.actionText}}
         </div>
         </:action>
-      </OverviewCard
+      </OverviewCard>
       `
     );
     assert.dom(SELECTORS.action).hasText('View card');

--- a/ui/tests/integration/components/sync/secrets/page/overview-test.js
+++ b/ui/tests/integration/components/sync/secrets/page/overview-test.js
@@ -362,7 +362,7 @@ module('Integration | Component | sync | Page::Overview', function (hooks) {
       const cardData = [
         {
           cardTitle: 'Total destinations',
-          subText: 'The total number of connected destinations',
+          subText: 'The total number of connected destinations.',
           actionText: 'Create new',
           count: '6',
         },


### PR DESCRIPTION
### Description
Yields actions to the `OverviewCard` template so multiple can be passed. There are no user facing changes

### TODO only if you're a HashiCorp employee
- [ ] **Labels:** If this PR is the CE portion of an ENT change, and that ENT change is
  getting backported to N-2, use the new style `backport/ent/x.x.x+ent` labels
  instead of the old style `backport/x.x.x` labels.
- [ ] **Labels:** If this PR is a CE only change, it can only be backported to N, so use
  the normal `backport/x.x.x` label (there should be only 1).
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
