### PR TITLE
VAULT-28329: Fix `months` activity log counts when querying for a namespace

### DIFF
--- a/changelog/27790.txt
+++ b/changelog/27790.txt
@@ -1,3 +1,3 @@
-```release-note:improvement
+```release-note:change
 activity (enterprise): filter all fields in client count responses by the request namespace  
 ```

--- a/changelog/27790.txt
+++ b/changelog/27790.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+activity (enterprise): filter all fields in client count responses by the request namespace  
+```

--- a/vault/activity_log.go
+++ b/vault/activity_log.go
@@ -2779,11 +2779,11 @@ func (a *ActivityLog) prepareMonthsResponseForQuery(ctx context.Context, byMonth
 	for _, monthsRecord := range byMonth {
 		newClientsResponse := &ResponseNewClients{}
 		if monthsRecord.NewClients.Counts.HasCounts() {
-			newClientsNSResponse, err := a.prepareNamespaceResponse(ctx, monthsRecord.NewClients.Namespaces)
+			newClientsTotal, newClientsNSResponse, err := a.prepareNamespaceResponse(ctx, monthsRecord.NewClients.Namespaces)
 			if err != nil {
 				return nil, err
 			}
-			newClientsResponse.Counts = a.countsRecordToCountsResponse(monthsRecord.NewClients.Counts, false)
+			newClientsResponse.Counts = newClientsTotal
 			newClientsResponse.Namespaces = newClientsNSResponse
 		}
 
@@ -2791,11 +2791,11 @@ func (a *ActivityLog) prepareMonthsResponseForQuery(ctx context.Context, byMonth
 			Timestamp: time.Unix(monthsRecord.Timestamp, 0).UTC().Format(time.RFC3339),
 		}
 		if monthsRecord.Counts.HasCounts() {
-			nsResponse, err := a.prepareNamespaceResponse(ctx, monthsRecord.Namespaces)
+			monthTotal, nsResponse, err := a.prepareNamespaceResponse(ctx, monthsRecord.Namespaces)
 			if err != nil {
 				return nil, err
 			}
-			monthResponse.Counts = a.countsRecordToCountsResponse(monthsRecord.Counts, false)
+			monthResponse.Counts = monthTotal
 			monthResponse.Namespaces = nsResponse
 			monthResponse.NewClients = newClientsResponse
 			months = append(months, monthResponse)
@@ -2804,14 +2804,16 @@ func (a *ActivityLog) prepareMonthsResponseForQuery(ctx context.Context, byMonth
 	return months, nil
 }
 
-// prepareNamespaceResponse populates the namespace portion of the activity log response struct
-// from
-func (a *ActivityLog) prepareNamespaceResponse(ctx context.Context, nsRecords []*activity.MonthlyNamespaceRecord) ([]*ResponseNamespace, error) {
+// prepareNamespaceResponse takes monthly namespace records and converts them
+// into the response namespace format. The function also returns counts for the
+// total number of clients per type seen that month.
+func (a *ActivityLog) prepareNamespaceResponse(ctx context.Context, nsRecords []*activity.MonthlyNamespaceRecord) (*ResponseCounts, []*ResponseNamespace, error) {
 	queryNS, err := namespace.FromContext(ctx)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	nsResponse := make([]*ResponseNamespace, 0, len(nsRecords))
+	totalCounts := &ResponseCounts{}
+	nsResponses := make([]*ResponseNamespace, 0, len(nsRecords))
 	for _, nsRecord := range nsRecords {
 		if !nsRecord.Counts.HasCounts() {
 			continue
@@ -2819,7 +2821,7 @@ func (a *ActivityLog) prepareNamespaceResponse(ctx context.Context, nsRecords []
 
 		ns, err := NamespaceByID(ctx, nsRecord.NamespaceID, a.core)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		if a.includeInResponse(queryNS, ns) {
 			mountResponse := make([]*ResponseMount, 0, len(nsRecord.Mounts))
@@ -2840,15 +2842,18 @@ func (a *ActivityLog) prepareNamespaceResponse(ctx context.Context, nsRecords []
 			} else {
 				displayPath = ns.Path
 			}
-			nsResponse = append(nsResponse, &ResponseNamespace{
+			nsResponse := &ResponseNamespace{
 				NamespaceID:   nsRecord.NamespaceID,
 				NamespacePath: displayPath,
 				Counts:        *a.countsRecordToCountsResponse(nsRecord.Counts, false),
 				Mounts:        mountResponse,
-			})
+			}
+			nsResponses = append(nsResponses, nsResponse)
+
+			totalCounts.Add(&nsResponse.Counts)
 		}
 	}
-	return nsResponse, nil
+	return totalCounts, nsResponses, nil
 }
 
 // partialMonthClientCount returns the number of clients used so far this month.


### PR DESCRIPTION
### Description
Previously, when you queried the activity log from a namespace you would get the following responses:
```
{
  "by_namespace": [{...}], // filtered by the request namespace
  "months": [{
    "counts": {...}, // NOT filtered
    "namespaces": [{...}], // filtered by the request namespace
    "new_clients": {
      "counts: {...}, // NOT filtered
      "namespaces": [{...}], // filtered by the request namespace
    }
  }],
  "total": {...} // filtered by the request namespace
}
```
This was very confusing, and also makes the UI a bad experience if you try to look at only one namespace.

This PR fixes this for the /activity and /activity/monthly endpoints.

Ent PR: https://github.com/hashicorp/vault-enterprise/pull/6260

### TODO only if you're a HashiCorp employee
- [x] **Labels:** If this PR is the CE portion of an ENT change, and that ENT change is
  getting backported to N-2, use the new style `backport/ent/x.x.x+ent` labels
  instead of the old style `backport/x.x.x` labels.
- [ ] **Labels:** If this PR is a CE only change, it can only be backported to N, so use
  the normal `backport/x.x.x` label (there should be only 1).
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
