### PR TITLE
Docs: Add a Priority matching policy example using Namespaces

### DIFF
--- a/website/content/docs/concepts/policies.mdx
+++ b/website/content/docs/concepts/policies.mdx
@@ -194,7 +194,7 @@ segments while the former has zero. So we end at rule (3), and give `"secret/+/+
 _lower_ priority.
 
 Another example utilizing Vault [namespaces](/vault/docs/enterprise/namespaces), given [nested](/vault/tutorials/enterprise/namespace-structure) namespaces `ns1/ns2/ns3` and two paths, 
-`"secret/*"` and `"ns1/ns2/ns3/secret/apps/*"`, `secret` is a mountpoint in namespace `ns3`, the first path is
+`"secret/*"` and `"ns1/ns2/ns3/secret/apps/*"` where `secret` is a mountpoint in namespace `ns3`. The first path is
 defined in a policy inside/relative to namespace `ns3` while the second path is defined in a policy in the `root` namespace. 
 Both paths end in `*` but the first is shorter. So we end at rule (4), and give `"secret/*"` _lower_ priority.
 

--- a/website/content/docs/concepts/policies.mdx
+++ b/website/content/docs/concepts/policies.mdx
@@ -193,6 +193,11 @@ wildcard appears in the same place, both end in `*` and the latter has two wildc
 segments while the former has zero. So we end at rule (3), and give `"secret/+/+/foo/*"`
 _lower_ priority.
 
+Another example utilizing Vault [namespaces](/vault/docs/enterprise/namespaces), given [nested](/vault/tutorials/enterprise/namespace-structure) namespaces `ns1/ns2/ns3` and two paths, 
+`"secret/*"` and `"ns1/ns2/ns3/secret/apps/*"`, `secret` is a mountpoint in namespace `ns3`, the first path is
+defined in a policy inside/relative to namespace `ns3` while the second path is defined in a policy in the `root` namespace. 
+Both paths end in `*` but the first is shorter. So we end at rule (4), and give `"secret/*"` _lower_ priority.
+
 !> **Informational:**The glob character referred to in this documentation is the asterisk (`*`).
 It _is not a regular expression_ and is only supported **as the last character of the path**!
 


### PR DESCRIPTION
🔍 [Deploy preview](https://vault-git-docs-priority-matching-example-hashicorp.vercel.app/vault/docs/concepts/policies#priority-matching)


### Description
This PR adds an additional example to the Priority matching [section](https://developer.hashicorp.com/vault/docs/concepts/policies#priority-matching) showing the Priority matching rules when using a fully-qualified path in a policy defined in the `root` namespace vs a relative path defined in a policy in the nested namespace itself.

### TODO only if you're a HashiCorp employee
- [x] **Labels:** If this PR is the CE portion of an ENT change, and that ENT change is
  getting backported to N-2, use the new style `backport/ent/x.x.x+ent` labels
  instead of the old style `backport/x.x.x` labels.
- [x] **Labels:** If this PR is a CE only change, it can only be backported to N, so use
  the normal `backport/x.x.x` label (there should be only 1).
- [ ] ~~**ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.~~
- [ ] ~~**Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.~~
- [ ] ~~**RFC:** If this change has an associated RFC, please link it in the description.~~
- [ ] ~~**ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.~~
