### PR TITLE
Update docs around dead_server_last_contact_threshold

### DIFF
--- a/website/content/api-docs/system/storage/raftautopilot.mdx
+++ b/website/content/api-docs/system/storage/raftautopilot.mdx
@@ -213,7 +213,7 @@ This endpoint is used to modify the configuration of the autopilot subsystem of 
 - `dead_server_last_contact_threshold` `(string: "24h")` - Limit on the amount of time
   a server can go without leader contact before being considered failed. This
   takes effect only when `cleanup_dead_servers` is `true`. This can not be set to a value
-  smaller than 1m. **We strongly recommend that this is kept as a high duration, such as a day,
+  smaller than 1m. **We strongly recommend that this is kept at a high duration, such as a day,
   as it being too low could result in removal of nodes that aren't actually dead.**
 
 - `max_trailing_logs` `(int: 1000)` - Amount of entries in the Raft Log that a server

--- a/website/content/api-docs/system/storage/raftautopilot.mdx
+++ b/website/content/api-docs/system/storage/raftautopilot.mdx
@@ -213,7 +213,8 @@ This endpoint is used to modify the configuration of the autopilot subsystem of 
 - `dead_server_last_contact_threshold` `(string: "24h")` - Limit on the amount of time
   a server can go without leader contact before being considered failed. This
   takes effect only when `cleanup_dead_servers` is `true`. This can not be set to a value
-  smaller than 1m.
+  smaller than 1m. **We strongly recommend that this is kept as a high duration, such as a day,
+  as it being too low could result in removal of nodes that aren't actually dead.**
 
 - `max_trailing_logs` `(int: 1000)` - Amount of entries in the Raft Log that a server
   can be behind before being considered unhealthy.

--- a/website/content/docs/concepts/integrated-storage/autopilot.mdx
+++ b/website/content/docs/concepts/integrated-storage/autopilot.mdx
@@ -63,7 +63,7 @@ behavior. Autopilot gets initialized with the following default values. If these
   - Limit on the amount of time
     a server can go without leader contact before being considered failed. This
     takes effect only when `cleanup_dead_servers` is set. **We strongly recommend
-    that this is kept as a high duration, such as a day, as it being too low could
+    that this is kept at a high duration, such as a day, as it being too low could
     result in removal of nodes that aren't actually dead.**
 
 - `min_quorum` - This doesn't default to anything and should be set to the expected

--- a/website/content/docs/concepts/integrated-storage/autopilot.mdx
+++ b/website/content/docs/concepts/integrated-storage/autopilot.mdx
@@ -62,7 +62,9 @@ behavior. Autopilot gets initialized with the following default values. If these
 - `dead_server_last_contact_threshold` - `24h`
   - Limit on the amount of time
     a server can go without leader contact before being considered failed. This
-    takes effect only when `cleanup_dead_servers` is set.
+    takes effect only when `cleanup_dead_servers` is set. **We strongly recommend
+    that this is kept as a high duration, such as a day, as it being too low could
+    result in removal of nodes that aren't actually dead.**
 
 - `min_quorum` - This doesn't default to anything and should be set to the expected
   number of voters in your cluster when `cleanup_dead_servers` is set as `true`.


### PR DESCRIPTION
### Description

@mpalmi and I responded to a sev0 over the weekend that was caused by Dead Server Last Contact Threshold being set to 1m. The customer wasn't sure why, but I figured bolstering our docs to make it clear that this is a bad idea would be good.

See also: https://github.com/hashicorp/tutorials/pull/2174

### TODO only if you're a HashiCorp employee
- [x] **Labels:** If this PR is the CE portion of an ENT change, and that ENT change is
  getting backported to N-2, use the new style `backport/ent/x.x.x+ent` labels
  instead of the old style `backport/x.x.x` labels.
- [x] **Labels:** If this PR is a CE only change, it can only be backported to N, so use
  the normal `backport/x.x.x` label (there should be only 1).
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
