### PR TITLE
VSO: update docs for VaultAuthGlobals

### DIFF
--- a/website/content/docs/platform/k8s/vso/api-reference.mdx
+++ b/website/content/docs/platform/k8s/vso/api-reference.mdx
@@ -7,7 +7,7 @@ description: >-
 
 <!--
   copied from docs/api/api-reference.md in the vault-secrets-operator repo.
-  commit SHA=c30a82b68399a94b053f98b134f310305936dc27
+  commit SHA=5797542c8e5a476f0985525fbc2368abbde6f3e8
 -->
 # API Reference
 
@@ -740,7 +740,7 @@ _Appears in:_
 | `name` _string_ | Name of the VaultAuthGlobal resource. |  | Pattern: `^([a-z0-9.-]{1,253})$` <br /> |
 | `namespace` _string_ | Namespace of the VaultAuthGlobal resource. If not provided, the namespace of<br />the referring VaultAuth resource is used. |  | Pattern: `^([a-z0-9.-]{1,253})$` <br /> |
 | `mergeStrategy` _[MergeStrategy](#mergestrategy)_ | MergeStrategy configures the merge strategy for HTTP headers and parameters<br />that are included in all Vault authentication requests. |  |  |
-| `allowDefault` _boolean_ | AllowDefault when set to true will use the default VaultAuthGlobal resource<br />as the default if Name is not set. The 'allow-default-globals' option must be<br />set on the operator's '-global-vault-auth-options' flag<br /><br />The default VaultAuthGlobal search is conditional.<br />When a ref Namespace is not set, the search follows the order:<br /> 1. The referring VaultAuth Namespace.<br /> 2. The Operator's namespace.<br />Otherwise, the search follows the order:<br /> 1. The VaultAuthGlobal ref Namespace. |  |  |
+| `allowDefault` _boolean_ | AllowDefault when set to true will use the default VaultAuthGlobal resource<br />as the default if Name is not set. The 'allow-default-globals' option must be<br />set on the operator's '-global-vault-auth-options' flag<br /><br />The default VaultAuthGlobal search is conditional.<br />When a ref Namespace is set, the search for the default<br />VaultAuthGlobal resource is constrained to that namespace.<br />Otherwise, the search order is:<br />1. The default VaultAuthGlobal resource in the referring VaultAuth resource's<br />namespace.<br />2. The default VaultAuthGlobal resource in the Operator's namespace. |  |  |
 
 
 #### VaultAuthGlobalSpec
@@ -1138,7 +1138,3 @@ _Appears in:_
 | `rolloutRestartTargets` _[RolloutRestartTarget](#rolloutrestarttarget) array_ | RolloutRestartTargets should be configured whenever the application(s) consuming the Vault secret does<br />not support dynamically reloading a rotated secret.<br />In that case one, or more RolloutRestartTarget(s) can be configured here. The Operator will<br />trigger a "rollout-restart" for each target whenever the Vault secret changes between reconciliation events.<br />All configured targets wil be ignored if HMACSecretData is set to false.<br />See RolloutRestartTarget for more details. |  |  |
 | `destination` _[Destination](#destination)_ | Destination provides configuration necessary for syncing the Vault secret to Kubernetes. |  |  |
 | `syncConfig` _[SyncConfig](#syncconfig)_ | SyncConfig configures sync behavior from Vault to VSO |  |  |
-
-
-
-

--- a/website/content/docs/platform/k8s/vso/api-reference.mdx
+++ b/website/content/docs/platform/k8s/vso/api-reference.mdx
@@ -27,6 +27,8 @@ Package v1beta1 contains API Schema definitions for the secrets v1beta1 API grou
 - [SecretTransformation](#secrettransformation)
 - [SecretTransformationList](#secrettransformationlist)
 - [VaultAuth](#vaultauth)
+- [VaultAuthGlobal](#vaultauthglobal)
+- [VaultAuthGlobalList](#vaultauthgloballist)
 - [VaultAuthList](#vaultauthlist)
 - [VaultConnection](#vaultconnection)
 - [VaultConnectionList](#vaultconnectionlist)
@@ -200,6 +202,25 @@ _Appears in:_
 
 
 
+#### MergeStrategy
+
+
+
+MergeStrategy provides the configuration for merging HTTP headers and
+parameters from the referring VaultAuth resource and its VaultAuthGlobal
+resource.
+
+
+
+_Appears in:_
+- [VaultAuthGlobalRef](#vaultauthglobalref)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `headers` _string_ | Headers configures the merge strategy for HTTP headers that are included in<br />all Vault requests. Choices are `union`, `replace`, or `none`.<br /><br />If `union` is set, the headers from the VaultAuthGlobal and VaultAuth<br />resources are merged. The headers from the VaultAuth always take precedence.<br /><br />If `replace` is set, the first set of non-empty headers taken in order from:<br />VaultAuth, VaultAuthGlobal auth method, VaultGlobal default headers.<br /><br />If `none` is set, the headers from the<br />VaultAuthGlobal resource are ignored and only the headers from the VaultAuth<br />resource are used. The default is `none`. |  | Enum: [union replace none] <br /> |
+| `params` _string_ | Params configures the merge strategy for HTTP parameters that are included in<br />all Vault requests. Choices are `union`, `replace`, or `none`.<br /><br />If `union` is set, the parameters from the VaultAuthGlobal and VaultAuth<br />resources are merged. The parameters from the VaultAuth always take<br />precedence.<br /><br />If `replace` is set, the first set of non-empty parameters taken in order from:<br />VaultAuth, VaultAuthGlobal auth method, VaultGlobal default parameters.<br /><br />If `none` is set, the parameters from the VaultAuthGlobal resource are ignored<br />and only the parameters from the VaultAuth resource are used. The default is<br />`none`. |  | Enum: [union replace none] <br /> |
+
+
 #### RolloutRestartTarget
 
 
@@ -321,6 +342,22 @@ _Appears in:_
 | `keyName` _string_ | KeyName to use for encrypt/decrypt operations via Vault Transit. |  |  |
 
 
+#### SyncConfig
+
+
+
+SyncConfig configures sync behavior from Vault to VSO
+
+
+
+_Appears in:_
+- [VaultStaticSecretSpec](#vaultstaticsecretspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `instantUpdates` _boolean_ | InstantUpdates is a flag to indicate that event-driven updates are<br />enabled for this VaultStaticSecret |  |  |
+
+
 #### Template
 
 
@@ -431,6 +468,7 @@ authenticate to Vault.
 
 
 _Appears in:_
+- [VaultAuthGlobalConfigAWS](#vaultauthglobalconfigaws)
 - [VaultAuthSpec](#vaultauthspec)
 
 | Field | Description | Default | Validation |
@@ -455,6 +493,7 @@ Vault via an AppRole AuthMethod.
 
 
 _Appears in:_
+- [VaultAuthGlobalConfigAppRole](#vaultauthglobalconfigapprole)
 - [VaultAuthSpec](#vaultauthspec)
 
 | Field | Description | Default | Validation |
@@ -473,6 +512,7 @@ authenticating to Vault via a GCP AuthMethod, using workload identity
 
 
 _Appears in:_
+- [VaultAuthGlobalConfigGCP](#vaultauthglobalconfiggcp)
 - [VaultAuthSpec](#vaultauthspec)
 
 | Field | Description | Default | Validation |
@@ -493,6 +533,7 @@ VaultAuthConfigJWT provides VaultAuth configuration options needed for authentic
 
 
 _Appears in:_
+- [VaultAuthGlobalConfigJWT](#vaultauthglobalconfigjwt)
 - [VaultAuthSpec](#vaultauthspec)
 
 | Field | Description | Default | Validation |
@@ -513,6 +554,7 @@ VaultAuthConfigKubernetes provides VaultAuth configuration options needed for au
 
 
 _Appears in:_
+- [VaultAuthGlobalConfigKubernetes](#vaultauthglobalconfigkubernetes)
 - [VaultAuthSpec](#vaultauthspec)
 
 | Field | Description | Default | Validation |
@@ -521,6 +563,213 @@ _Appears in:_
 | `serviceAccount` _string_ | ServiceAccount to use when authenticating to Vault's<br />authentication backend. This must reside in the consuming secret's (VDS/VSS/PKI) namespace. |  |  |
 | `audiences` _string array_ | TokenAudiences to include in the ServiceAccount token. |  |  |
 | `tokenExpirationSeconds` _integer_ | TokenExpirationSeconds to set the ServiceAccount token. | 600 | Minimum: 600 <br /> |
+
+
+#### VaultAuthGlobal
+
+
+
+VaultAuthGlobal is the Schema for the vaultauthglobals API
+
+
+
+_Appears in:_
+- [VaultAuthGlobalList](#vaultauthgloballist)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `apiVersion` _string_ | `secrets.hashicorp.com/v1beta1` | | |
+| `kind` _string_ | `VaultAuthGlobal` | | |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  |  |
+| `spec` _[VaultAuthGlobalSpec](#vaultauthglobalspec)_ |  |  |  |
+
+
+#### VaultAuthGlobalConfigAWS
+
+
+
+
+
+
+
+_Appears in:_
+- [VaultAuthGlobalSpec](#vaultauthglobalspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `role` _string_ | Vault role to use for authenticating |  |  |
+| `region` _string_ | AWS Region to use for signing the authentication request |  |  |
+| `headerValue` _string_ | The Vault header value to include in the STS signing request |  |  |
+| `sessionName` _string_ | The role session name to use when creating a webidentity provider |  |  |
+| `stsEndpoint` _string_ | The STS endpoint to use; if not set will use the default |  |  |
+| `iamEndpoint` _string_ | The IAM endpoint to use; if not set will use the default |  |  |
+| `secretRef` _string_ | SecretRef is the name of a Kubernetes Secret in the consumer's (VDS/VSS/PKI) namespace<br />which holds credentials for AWS. Expected keys include `access_key_id`, `secret_access_key`,<br />`session_token` |  |  |
+| `irsaServiceAccount` _string_ | IRSAServiceAccount name to use with IAM Roles for Service Accounts<br />(IRSA), and should be annotated with "eks.amazonaws.com/role-arn". This<br />ServiceAccount will be checked for other EKS annotations:<br />eks.amazonaws.com/audience and eks.amazonaws.com/token-expiration |  |  |
+| `namespace` _string_ | Namespace to auth to in Vault |  |  |
+| `mount` _string_ | Mount to use when authenticating to auth method. |  |  |
+| `params` _object (keys:string, values:string)_ | Params to use when authenticating to Vault |  |  |
+| `headers` _object (keys:string, values:string)_ | Headers to be included in all Vault requests. |  |  |
+
+
+#### VaultAuthGlobalConfigAppRole
+
+
+
+
+
+
+
+_Appears in:_
+- [VaultAuthGlobalSpec](#vaultauthglobalspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `roleId` _string_ | RoleID of the AppRole Role to use for authenticating to Vault. |  |  |
+| `secretRef` _string_ | SecretRef is the name of a Kubernetes secret in the consumer's (VDS/VSS/PKI) namespace which<br />provides the AppRole Role's SecretID. The secret must have a key named `id` which holds the<br />AppRole Role's secretID. |  |  |
+| `namespace` _string_ | Namespace to auth to in Vault |  |  |
+| `mount` _string_ | Mount to use when authenticating to auth method. |  |  |
+| `params` _object (keys:string, values:string)_ | Params to use when authenticating to Vault |  |  |
+| `headers` _object (keys:string, values:string)_ | Headers to be included in all Vault requests. |  |  |
+
+
+#### VaultAuthGlobalConfigGCP
+
+
+
+
+
+
+
+_Appears in:_
+- [VaultAuthGlobalSpec](#vaultauthglobalspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `role` _string_ | Vault role to use for authenticating |  |  |
+| `workloadIdentityServiceAccount` _string_ | WorkloadIdentityServiceAccount is the name of a Kubernetes service<br />account (in the same Kubernetes namespace as the Vault*Secret referencing<br />this resource) which has been configured for workload identity in GKE.<br />Should be annotated with "iam.gke.io/gcp-service-account". |  |  |
+| `region` _string_ | GCP Region of the GKE cluster's identity provider. Defaults to the region<br />returned from the operator pod's local metadata server. |  |  |
+| `clusterName` _string_ | GKE cluster name. Defaults to the cluster-name returned from the operator<br />pod's local metadata server. |  |  |
+| `projectID` _string_ | GCP project ID. Defaults to the project-id returned from the operator<br />pod's local metadata server. |  |  |
+| `namespace` _string_ | Namespace to auth to in Vault |  |  |
+| `mount` _string_ | Mount to use when authenticating to auth method. |  |  |
+| `params` _object (keys:string, values:string)_ | Params to use when authenticating to Vault |  |  |
+| `headers` _object (keys:string, values:string)_ | Headers to be included in all Vault requests. |  |  |
+
+
+#### VaultAuthGlobalConfigJWT
+
+
+
+
+
+
+
+_Appears in:_
+- [VaultAuthGlobalSpec](#vaultauthglobalspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `role` _string_ | Role to use for authenticating to Vault. |  |  |
+| `secretRef` _string_ | SecretRef is the name of a Kubernetes secret in the consumer's (VDS/VSS/PKI) namespace which<br />provides the JWT token to authenticate to Vault's JWT authentication backend. The secret must<br />have a key named `jwt` which holds the JWT token. |  |  |
+| `serviceAccount` _string_ | ServiceAccount to use when creating a ServiceAccount token to authenticate to Vault's<br />JWT authentication backend. |  |  |
+| `audiences` _string array_ | TokenAudiences to include in the ServiceAccount token. |  |  |
+| `tokenExpirationSeconds` _integer_ | TokenExpirationSeconds to set the ServiceAccount token. | 600 | Minimum: 600 <br /> |
+| `namespace` _string_ | Namespace to auth to in Vault |  |  |
+| `mount` _string_ | Mount to use when authenticating to auth method. |  |  |
+| `params` _object (keys:string, values:string)_ | Params to use when authenticating to Vault |  |  |
+| `headers` _object (keys:string, values:string)_ | Headers to be included in all Vault requests. |  |  |
+
+
+#### VaultAuthGlobalConfigKubernetes
+
+
+
+
+
+
+
+_Appears in:_
+- [VaultAuthGlobalSpec](#vaultauthglobalspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `role` _string_ | Role to use for authenticating to Vault. |  |  |
+| `serviceAccount` _string_ | ServiceAccount to use when authenticating to Vault's<br />authentication backend. This must reside in the consuming secret's (VDS/VSS/PKI) namespace. |  |  |
+| `audiences` _string array_ | TokenAudiences to include in the ServiceAccount token. |  |  |
+| `tokenExpirationSeconds` _integer_ | TokenExpirationSeconds to set the ServiceAccount token. | 600 | Minimum: 600 <br /> |
+| `namespace` _string_ | Namespace to auth to in Vault |  |  |
+| `mount` _string_ | Mount to use when authenticating to auth method. |  |  |
+| `params` _object (keys:string, values:string)_ | Params to use when authenticating to Vault |  |  |
+| `headers` _object (keys:string, values:string)_ | Headers to be included in all Vault requests. |  |  |
+
+
+#### VaultAuthGlobalList
+
+
+
+VaultAuthGlobalList contains a list of VaultAuthGlobal
+
+
+
+
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `apiVersion` _string_ | `secrets.hashicorp.com/v1beta1` | | |
+| `kind` _string_ | `VaultAuthGlobalList` | | |
+| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#listmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  |  |
+| `items` _[VaultAuthGlobal](#vaultauthglobal) array_ |  |  |  |
+
+
+#### VaultAuthGlobalRef
+
+
+
+VaultAuthGlobalRef is a reference to a VaultAuthGlobal resource. A referring
+VaultAuth resource can use the VaultAuthGlobal resource to share common
+configuration across multiple VaultAuth resources. The VaultAuthGlobal
+resource is used to store global configuration for VaultAuth resources.
+
+
+
+_Appears in:_
+- [VaultAuthSpec](#vaultauthspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `name` _string_ | Name of the VaultAuthGlobal resource. |  | Pattern: `^([a-z0-9.-]{1,253})$` <br /> |
+| `namespace` _string_ | Namespace of the VaultAuthGlobal resource. If not provided, the namespace of<br />the referring VaultAuth resource is used. |  | Pattern: `^([a-z0-9.-]{1,253})$` <br /> |
+| `mergeStrategy` _[MergeStrategy](#mergestrategy)_ | MergeStrategy configures the merge strategy for HTTP headers and parameters<br />that are included in all Vault authentication requests. |  |  |
+| `allowDefault` _boolean_ | AllowDefault when set to true will use the default VaultAuthGlobal resource<br />as the default if Name is not set. The 'allow-default-globals' option must be<br />set on the operator's '-global-vault-auth-options' flag<br /><br />The default VaultAuthGlobal search is conditional.<br />When a ref Namespace is not set, the search follows the order:<br /> 1. The referring VaultAuth Namespace.<br /> 2. The Operator's namespace.<br />Otherwise, the search follows the order:<br /> 1. The VaultAuthGlobal ref Namespace. |  |  |
+
+
+#### VaultAuthGlobalSpec
+
+
+
+VaultAuthGlobalSpec defines the desired state of VaultAuthGlobal
+
+
+
+_Appears in:_
+- [VaultAuthGlobal](#vaultauthglobal)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `allowedNamespaces` _string array_ | AllowedNamespaces Kubernetes Namespaces which are allow-listed for use with<br />this VaultAuthGlobal. This field allows administrators to customize which<br />Kubernetes namespaces are authorized to reference this resource. While Vault<br />will still enforce its own rules, this has the added configurability of<br />restricting which VaultAuthMethods can be used by which namespaces. Accepted<br />values: []{"*"} - wildcard, all namespaces. []{"a", "b"} - list of namespaces.<br />unset - disallow all namespaces except the Operator's and the referring<br />VaultAuthMethod's namespace, this is the default behavior. |  |  |
+| `vaultConnectionRef` _string_ | VaultConnectionRef to the VaultConnection resource, can be prefixed with a namespace,<br />eg: `namespaceA/vaultConnectionRefB`. If no namespace prefix is provided it will default to<br />namespace of the VaultConnection CR. If no value is specified for VaultConnectionRef the<br />Operator will default to the `default` VaultConnection, configured in the operator's namespace. |  |  |
+| `defaultVaultNamespace` _string_ | DefaultVaultNamespace to auth to in Vault, if not specified the namespace of the auth<br />method will be used. This can be used as a default Vault namespace for all<br />auth methods. |  |  |
+| `defaultAuthMethod` _string_ | DefaultAuthMethod to use when authenticating to Vault. |  | Enum: [kubernetes jwt appRole aws gcp] <br /> |
+| `defaultMount` _string_ | DefaultMount to use when authenticating to auth method. If not specified the mount of<br />the auth method configured in Vault will be used. |  |  |
+| `params` _object (keys:string, values:string)_ | DefaultParams to use when authenticating to Vault |  |  |
+| `headers` _object (keys:string, values:string)_ | DefaultHeaders to be included in all Vault requests. |  |  |
+| `kubernetes` _[VaultAuthGlobalConfigKubernetes](#vaultauthglobalconfigkubernetes)_ | Kubernetes specific auth configuration, requires that the Method be set to `kubernetes`. |  |  |
+| `appRole` _[VaultAuthGlobalConfigAppRole](#vaultauthglobalconfigapprole)_ | AppRole specific auth configuration, requires that the Method be set to `appRole`. |  |  |
+| `jwt` _[VaultAuthGlobalConfigJWT](#vaultauthglobalconfigjwt)_ | JWT specific auth configuration, requires that the Method be set to `jwt`. |  |  |
+| `aws` _[VaultAuthGlobalConfigAWS](#vaultauthglobalconfigaws)_ | AWS specific auth configuration, requires that Method be set to `aws`. |  |  |
+| `gcp` _[VaultAuthGlobalConfigGCP](#vaultauthglobalconfiggcp)_ | GCP specific auth configuration, requires that Method be set to `gcp`. |  |  |
+
+
 
 
 #### VaultAuthList
@@ -555,6 +804,7 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `vaultConnectionRef` _string_ | VaultConnectionRef to the VaultConnection resource, can be prefixed with a namespace,<br />eg: `namespaceA/vaultConnectionRefB`. If no namespace prefix is provided it will default to<br />namespace of the VaultConnection CR. If no value is specified for VaultConnectionRef the<br />Operator will default to the `default` VaultConnection, configured in the operator's namespace. |  |  |
+| `vaultAuthGlobalRef` _[VaultAuthGlobalRef](#vaultauthglobalref)_ | VaultAuthGlobalRef. |  |  |
 | `namespace` _string_ | Namespace to auth to in Vault |  |  |
 | `allowedNamespaces` _string array_ | AllowedNamespaces Kubernetes Namespaces which are allow-listed for use with this AuthMethod.<br />This field allows administrators to customize which Kubernetes namespaces are authorized to<br />use with this AuthMethod. While Vault will still enforce its own rules, this has the added<br />configurability of restricting which VaultAuthMethods can be used by which namespaces.<br />Accepted values:<br />[]{"*"} - wildcard, all namespaces.<br />[]{"a", "b"} - list of namespaces.<br />unset - disallow all namespaces except the Operator's the VaultAuthMethod's namespace, this<br />is the default behavior. |  |  |
 | `method` _string_ | Method to use when authenticating to Vault. |  | Enum: [kubernetes jwt appRole aws gcp] <br /> |
@@ -887,3 +1137,8 @@ _Appears in:_
 | `hmacSecretData` _boolean_ | HMACSecretData determines whether the Operator computes the<br />HMAC of the Secret's data. The MAC value will be stored in<br />the resource's Status.SecretMac field, and will be used for drift detection<br />and during incoming Vault secret comparison.<br />Enabling this feature is recommended to ensure that Secret's data stays consistent with Vault. | true |  |
 | `rolloutRestartTargets` _[RolloutRestartTarget](#rolloutrestarttarget) array_ | RolloutRestartTargets should be configured whenever the application(s) consuming the Vault secret does<br />not support dynamically reloading a rotated secret.<br />In that case one, or more RolloutRestartTarget(s) can be configured here. The Operator will<br />trigger a "rollout-restart" for each target whenever the Vault secret changes between reconciliation events.<br />All configured targets wil be ignored if HMACSecretData is set to false.<br />See RolloutRestartTarget for more details. |  |  |
 | `destination` _[Destination](#destination)_ | Destination provides configuration necessary for syncing the Vault secret to Kubernetes. |  |  |
+| `syncConfig` _[SyncConfig](#syncconfig)_ | SyncConfig configures sync behavior from Vault to VSO |  |  |
+
+
+
+

--- a/website/content/docs/platform/k8s/vso/helm.mdx
+++ b/website/content/docs/platform/k8s/vso/helm.mdx
@@ -23,6 +23,7 @@ Use these links to navigate to a particular top-level stanza.
 - [`defaultVaultConnection`](#h-defaultvaultconnection)
 - [`defaultAuthMethod`](#h-defaultauthmethod)
 - [`telemetry`](#h-telemetry)
+- [`hooks`](#h-hooks)
 - [`tests`](#h-tests)
 
 ## All Values
@@ -196,11 +197,19 @@ Use these links to navigate to a particular top-level stanza.
 
       - `maxInterval` ((#v-controller-manager-backoffonsecretsourceerror-maxinterval)) (`duration: 60s`) - Maximum interval between retries.
 
-      - `maxElapsedTime` ((#v-controller-manager-backoffonsecretsourceerror-maxelapsedtime)) (`duration: 0s`) - Maximum elapsed time before giving up.
+      - `maxElapsedTime` ((#v-controller-manager-backoffonsecretsourceerror-maxelapsedtime)) (`duration: 0s`) - Maximum elapsed time without a successful sync from the secret's source.
+        It's important to note that setting this option to anything other than
+        its default will result in the secret sync no longer being retried after
+        reaching the max elapsed time.
 
-      - `randomizationFactor` ((#v-controller-manager-backoffonsecretsourceerror-randomizationfactor)) (`float: 0.5`) - Randomization factor to add jitter to the interval between retries.
+      - `randomizationFactor` ((#v-controller-manager-backoffonsecretsourceerror-randomizationfactor)) (`float: 0.5`) - Randomization factor randomizes the backoff interval between retries.
+        This helps to spread out the retries to avoid a thundering herd.
+        If the value is 0, then the backoff interval will not be randomized.
+        It is recommended to set this to a value that is greater than 0.
 
-      - `multiplier` ((#v-controller-manager-backoffonsecretsourceerror-multiplier)) (`float: 1.5`) - Sets the multiplier for increasing the interval between retries.
+      - `multiplier` ((#v-controller-manager-backoffonsecretsourceerror-multiplier)) (`float: 1.5`) - Sets the multiplier that is used to increase the backoff interval between retries.
+        This value should always be set to a value greater than 0.
+        The value must be greater than zero.
 
     - `clientCache` ((#v-controller-manager-clientcache)) - Configures the client cache which is used by the controller to cache (and potentially persist) vault tokens that
       are the result of using the VaultAuthMethod. This enables re-use of Vault Tokens
@@ -581,6 +590,27 @@ Use these links to navigate to a particular top-level stanza.
     headers:
       X-vault-something1: "foo"
 
+  - `vaultAuthGlobalRef` ((#v-defaultauthmethod-vaultauthglobalref)) - VaultAuthGlobalRef
+
+    - `enabled` ((#v-defaultauthmethod-vaultauthglobalref-enabled)) (`boolean: false`) -  toggles the inclusion of the VaultAuthGlobal configuration in the
+      default VaultAuth CR.
+
+    - `name` ((#v-defaultauthmethod-vaultauthglobalref-name)) (`string: ""`) - Name of the VaultAuthGlobal CR to reference.
+
+    - `namespace` ((#v-defaultauthmethod-vaultauthglobalref-namespace)) (`string: ""`) - Namespace of the VaultAuthGlobal CR to reference.
+
+    - `allowDefault` ((#v-defaultauthmethod-vaultauthglobalref-allowdefault)) (`boolean: ""`) - allow default globals
+
+    - `mergeStrategy` ((#v-defaultauthmethod-vaultauthglobalref-mergestrategy))
+
+      - `headers` ((#v-defaultauthmethod-vaultauthglobalref-mergestrategy-headers)) (`string: none`) - merge strategy for headers
+        Valid values are: "replace", "merge", "none"
+        Default: "replace"
+
+      - `params` ((#v-defaultauthmethod-vaultauthglobalref-mergestrategy-params)) (`string: none`) - merge strategy for params
+        Valid values are: "replace", "merge", "none"
+        Default: "replace"
+
 ### telemetry ((#h-telemetry))
 
 - `telemetry` ((#v-telemetry)) - Configures a Prometheus ServiceMonitor
@@ -614,6 +644,35 @@ Use these links to navigate to a particular top-level stanza.
     - `interval` ((#v-telemetry-servicemonitor-interval)) (`string: 30s`) - Interval at which Prometheus scrapes metrics
 
     - `scrapeTimeout` ((#v-telemetry-servicemonitor-scrapetimeout)) (`string: 10s`) - Timeout for Prometheus scrapes
+
+### hooks ((#h-hooks))
+
+- `hooks` ((#v-hooks)) - Configure the behaviour of Helm hooks.
+
+  - `resources` ((#v-hooks-resources)) - Resources common to all hooks.
+
+    - `limits` ((#v-hooks-resources-limits))
+
+      - `cpu` ((#v-hooks-resources-limits-cpu)) (`string: 500m`)
+
+      - `memory` ((#v-hooks-resources-limits-memory)) (`string: 128Mi`)
+
+    - `requests` ((#v-hooks-resources-requests))
+
+      - `cpu` ((#v-hooks-resources-requests-cpu)) (`string: 10m`)
+
+      - `memory` ((#v-hooks-resources-requests-memory)) (`string: 64Mi`)
+
+  - `upgradeCRDs` ((#v-hooks-upgradecrds)) - Configure the Helm pre-upgrade hook that handles custom resource definition (CRD) upgrades.
+
+    - `enabled` ((#v-hooks-upgradecrds-enabled)) (`boolean: true`) - Set to true to automatically upgrade the CRDs.
+      Disabling this will require manual intervention to upgrade the CRDs, so it is recommended to
+      always leave it enabled.
+
+    - `backoffLimit` ((#v-hooks-upgradecrds-backofflimit)) (`integer: 5`) - Limit the number of retries for the CRD upgrade.
+
+    - `executionTimeout` ((#v-hooks-upgradecrds-executiontimeout)) (`string: 30s`) - Set the timeout for the CRD upgrade. The operation should typically take less than 5s
+      to complete.
 
 ### tests ((#h-tests))
 

--- a/website/content/docs/platform/k8s/vso/installation.mdx
+++ b/website/content/docs/platform/k8s/vso/installation.mdx
@@ -4,6 +4,7 @@ page_title: Vault Secrets Operator Installation
 description: >-
   The Vault Secrets Operator can be installed using Helm.
 ---
+@include 'vso/common-links.mdx'
 
 # Installing and upgrading the Vault Secrets Operator
 
@@ -17,7 +18,7 @@ description: >-
 
 [Install Helm](https://helm.sh/docs/intro/install) before beginning.
 
-The [Vault Secrets Operator Helm chart](/vault/docs/platform/k8s/vso/helm) is the recommended way of
+The [Helm chart][helm] is the recommended way of
 installing and configuring the Vault Secrets Operator.
 
 To install a new instance of the Vault Secrets Operator, first add the
@@ -103,8 +104,7 @@ customresourcedefinition.apiextensions.k8s.io/vaultstaticsecrets.secrets.hashico
 
 ## Chart values
 
-Refer to the [VSO Helm chart](/vault/docs/platform/k8s/vso/helm)
- overview for a full list of supported chart values.
+Refer to the [Helm chart][helm] overview for a full list of supported chart values.
 
 ## Installation using Kustomize
 

--- a/website/content/docs/platform/k8s/vso/openshift.mdx
+++ b/website/content/docs/platform/k8s/vso/openshift.mdx
@@ -26,7 +26,7 @@ Set the following environment variables [on the subscription](https://access.red
 
 ## Helm chart
 
-The Vault Secrets Operator may also be installed in OpenShift using the Helm chart. (See [Installation](/vault/docs/platform/k8s/vso/installation) for an overview of installation using the [Helm chart](/vault/docs/platform/k8s/vso/helm).) The examples below show example [values.yaml files](https://helm.sh/docs/chart_template_guide/values_files/) for each configuration, which would be used with `helm install` as below:
+The Vault Secrets Operator may also be installed in OpenShift using the Helm chart. (See [Helm chart][helm].) The examples below show example [values.yaml files](https://helm.sh/docs/chart_template_guide/values_files/) for each configuration, which would be used with `helm install` as below:
 
 ```shell-session
 $ helm install vault-secrets-operator hashicorp/vault-secrets-operator \

--- a/website/content/docs/platform/k8s/vso/sources/vault/auth/index.mdx
+++ b/website/content/docs/platform/k8s/vso/sources/vault/auth/index.mdx
@@ -11,12 +11,12 @@ description: >-
 
 ## Auth configuration
 
-The Vault Secrets Operator (VSO) relies on VaultAuth resources to authenticate with Vault. It relies on credential
+The Vault Secrets Operator (VSO) relies on `VaultAuth` resources to authenticate with Vault. It relies on credential
 providers to generate the credentials necessary for authentication. For example, when VSO authenticates to a kubernetes
-auth backend, it generates a token using the service account configured in the VaultAuth resource' defined
+auth backend, it generates a token using the Kubernetes service account configured in the VaultAuth resource's defined
 kubernetes auth method. The service account must be configured in the Kubernetes namespace of the requesting resource.
-Meaning, if a resource like a `VaultStaticSecret` is created in the `default` namespace, the service account must be in
-the `default` namespace. The rationale behind this approach is to ensure that cross namespace access is not possible.
+Meaning, if a resource like a `VaultStaticSecret` is created in the `apps` namespace, the service account must be in
+the apps namespace. The rationale behind this approach is to ensure that cross namespace access is not possible.
 
 ## Vault authentication globals
 
@@ -32,7 +32,27 @@ VaultAuth instance, since they are more specific to the application that require
 
 *See [VaultAuthGlobal spec][vag-spec]  and [VaultAuth spec][va-spec] for the complete list of available fields.*
 
+
+## VaultAuthGlobal configuration inheritance
+
+- The configuration in the VaultAuth resource takes precedence over the configuration in the VaultAuthGlobal resource.
+- The VaultAuthGlobal can reside in any namespace, but must allow the namespace of the VaultAuth resource to reference it.
+- Default VaultAuthGlobal resources are denoted by the name `default` and are automatically referenced by all VaultAuth resources
+when `spec.vaultAuthGlobalRef.allowDefault` is set to `true` and VSO is running with the `allow-default-globals`
+option set in the `-global-vault-auth-options` flag (the default).
+- The default VaultAuthGlobal search order is:
+When a `spec.vaultAuthGlobalRef.namespace` is set, the search is constrained to that namespace. Otherwise, the
+search follows the order:
+1. The default VaultAuthGlobal resource in the referring VaultAuth resource's namespace.
+2. The default VaultAuthGlobal resource in the Operator's namespace.
+
+
 ## Sample use cases and configurations
+
+The following sections provide some sample use cases and configurations for the VaultAuthGlobal resource. These
+examples demonstrate how to use the VaultAuthGlobal resource to share a common authentication configuration across a
+set of VaultAuth resources. Like other namespaced VSO custom resource definitions, there can be many VaultAuthGlobal
+resources configured in a single Kubernetes cluster.
 
 ### Multi-tenant application with shared authentication backend
 
@@ -56,15 +76,16 @@ spec:
   kubernetes:
     audiences:
     - vault
-    mount: auth-mount
+    mount: kubernetes
     role: default
     serviceAccount: default
     tokenExpirationSeconds: 600
 ```
 
 A developer creates a `VaultAuth` and VaultStaticSecret resource in their application's namespace with the following
-configuration:
+configurations:
 
+Application 1 would have a configuration like this:
 ```yaml
 ---
 apiVersion: secrets.hashicorp.com/v1beta1
@@ -136,7 +157,9 @@ spec:
   namespace can reference this VaultAuthGlobal resource.
 - The VaultAuth resources in the `apps` namespace reference the VaultAuthGlobal resource. This allows the VaultAuth
   resources to inherit the configuration from the VaultAuthGlobal resource. The `role` and serviceAccount fields are
-  specific to the application and are not inherited from the VaultAuthGlobal resource.
+  specific to the application and are not inherited from the VaultAuthGlobal resource. Since the
+  `.spec.vaultAuthGlobalRef.allowDefault` is set to `true`, the VaultAuth resources will automatically reference the
+  `default` VaultAuthGlobal in defined namespace.
 - The VaultStaticSecret resources in the `apps` namespace reference the VaultAuth resources. This allows the
   VaultStaticSecret resources to authenticate to Vault in order to sync the KV secrets to the destination Kubernetes
   Secret.
@@ -147,7 +170,8 @@ A Vault admin has configured a Kubernetes auth backend in Vault mounted at `kube
 two applications authenticate using a single role, and service account. The admin creates the necessary role in
 Vault bound to the same service account and namespace of the applications.
 
-The admin or developer creates a default VaultAuthGlobal in applications namespace with the following configuration:
+The admin or developer creates a default VaultAuthGlobal in the application's namespace with the following
+configuration:
 
 ```yaml
 ---
@@ -161,7 +185,7 @@ spec:
   kubernetes:
     audiences:
     - vault
-    mount: auth-mount
+    mount: kubernetes
     role: apps
     serviceAccount: apps
     tokenExpirationSeconds: 600
@@ -221,17 +245,113 @@ spec:
 - The VaultStaticSecret resources in the `apps` namespace reference the VaultAuth resource. This allows the VaultStaticSecret
   resources to authenticate to Vault in order to sync the KV secrets to the destination Kubernetes Secret.
 
-## VaultAuthGlobal configuration inheritance
+### Multi-tenant application with multiple authentication backends and roles
 
-- The configuration in the VaultAuth resource takes precedence over the configuration in the VaultAuthGlobal resource.
-- The VaultAuthGlobal can reside in any namespace, but must allow the namespace of the VaultAuth resource to reference it.
-- Default VaultAuthGlobal resources are denoted by the name `default` and are automatically referenced by all VaultAuth resources
-  when `spec.vaultAuthGlobalRef.allowDefault` is set to `true` and VSO is running with the `allow-default-globals`
-  option set in the `-global-vault-auth-options` flag (the default).
-- The default VaultAuthGlobal search order is:
-  1. The VaultAuth resource's `spec.vaultAuthGlobalRef.namespace` (terminates search if defined).
-  2. The VaultAuth resource's namespace.
-  3. The `default` VaultAuthGlobal resource in the Operator's namespace.
+A Vault admin has configured a Kubernetes auth backend in Vault mounted at `kubernetes`. In addition, the Vault
+admin has configured a JWT auth backend mounted at `jwt`. The admin creates the necessary roles in Vault for each
+auth method. The admin expects to have two applications authenticate using each auth method and role.
+
+The admin or developer creates a default VaultAuthGlobal in the application's namespace with the following
+configuration:
+
+```yaml
+---
+apiVersion: secrets.hashicorp.com/v1beta1
+kind: VaultAuthGlobal
+metadata:
+  name: default
+  namespace: apps
+spec:
+  defaultAuthMethod: kubernetes
+  kubernetes:
+    audiences:
+    - vault
+    mount: kubernetes
+    role: apps
+    serviceAccount: apps-k8s
+    tokenExpirationSeconds: 600
+  jwt:
+    audiences:
+    - vault
+    mount: jwt
+    role: apps
+    serviceAccount: apps-jwt
+```
+
+A developer creates a VaultAuth and VaultStaticSecret resource in their application's namespace with the following
+configurations:
+
+Application 1 would have a configuration like this which will be using the kubernetes auth method:
+```yaml
+---
+apiVersion: secrets.hashicorp.com/v1beta1
+kind: VaultAuth
+metadata:
+  name: apps-default
+  namespace: apps
+spec:
+  # uses the default kubernetes auth method as defined in
+  # the VaultAuthGlobal .spec.defaultAuthMethod
+  vaultAuthGlobalRef:
+    allowDefault: true
+---
+apiVersion: secrets.hashicorp.com/v1beta1
+kind: VaultStaticSecret
+metadata:
+  name: app1-secret
+  namespace: apps
+spec:
+  destination:
+    create: true
+    name: app1-secret
+  hmacSecretData: true
+  mount: apps
+  path: app1
+  type: kv-v2
+  vaultAuthRef: apps-default
+```
+
+Application 2 would have a similar configuration, except it will be using the JWT auth method:
+```yaml
+---
+apiVersion: secrets.hashicorp.com/v1beta1
+kind: VaultAuth
+metadata:
+  name: apps-jwt
+  namespace: apps
+spec:
+  method: jwt
+  vaultAuthGlobalRef:
+    allowDefault: true
+---
+apiVersion: secrets.hashicorp.com/v1beta1
+kind: VaultStaticSecret
+metadata:
+  name: app2-secret
+  namespace: apps
+spec:
+  destination:
+    create: true
+    name: app2-secret
+  hmacSecretData: true
+  mount: apps
+  path: app2
+  type: kv-v2
+  vaultAuthRef: apps-jwt
+```
+
+#### Explanation
+
+- The default VaultAuthGlobal resource is created in the `apps` namespace. It provides all the necessary configuration
+  for the VaultAuth resources that reference it. The `defaultAuthMethod` field defines the default auth method to use
+  when authenticating to Vault. The `kubernetes` and `jwt` fields define the configuration for the respective auth
+  method.
+- Application 1 uses the default kubernetes auth method defined in the VaultAuthGlobal resource. The VaultAuth resource
+  references the VaultAuthGlobal resource and inherits the configuration from it.
+- Application 2 uses the JWT auth method defined in the VaultAuthGlobal resource. The VaultAuth resource references the
+  VaultAuthGlobal resource and inherits the configuration from it.
+- Neither VaultAuth resource has a `role` or `serviceAccount` field set. This is because the `role` and `serviceAccount`
+  fields are defined in the VaultAuthGlobal resource and are inherited by the VaultAuth resources.
 
 ## VaultAuthGlobal common errors and troubleshooting
 
@@ -329,8 +449,6 @@ Sample output of the VaultAuth's status (prettified). The `valid` field will be 
     "valid": false
   }
   ```
-
-
 - Situation: The VaultAuthGlobal resource is not found or is invalid for some reason, denoted by error messages like
 `not found...`.
 
@@ -349,6 +467,33 @@ messages like `target namespace "apps" is not allowed...`.
 
   Resolution: Ensure all required fields are set either on the VaultAuth resource or on the inherited
   VaultAuthGlobal.
+
+A successfully merged VaultAuth resource will have the `valid` field set to `true` and the `conditions` will look
+something like:
+  ```json
+  {
+    "conditions": [
+      {
+        "lastTransitionTime": "2024-07-17T13:46:43Z",
+        "message": "VaultAuthGlobal successfully merged, key=admin/default, uid=6aeb3559-8f42-48bf-b16a-2305bc9a9bed, generation=7",
+        "observedGeneration": 1,
+        "reason": "VaultAuthGlobalRef",
+        "status": "True",
+        "type": "Available"
+      }
+    ],
+    "specHash": "5cbe5544d0557926e00002514871b95c49903a9d4496ef9b794c84f1e54db1a0",
+    "valid": true
+  }
+  ```
+
+<Tip>
+
+  The value for the key in the message field is the key to the VaultAuthGlobal object that was successfully merged.
+  This is useful if you want to know which VaultAuthGlobal object was used to merge the VaultAuth object.
+
+</Tip>
+
 
 ### Some authentication engines in detail
 

--- a/website/content/docs/platform/k8s/vso/sources/vault/auth/index.mdx
+++ b/website/content/docs/platform/k8s/vso/sources/vault/auth/index.mdx
@@ -1,0 +1,364 @@
+---
+layout: docs
+page_title: 'Vault Secrets Operator: Vault authentication details'
+description: >-
+  The Vault Secrets Operator allows Pods to consume Vault secrets natively from Kubernetes Secrets.
+---
+
+@include 'vso/common-links.mdx'
+
+# Vault authentication in detail
+
+## Auth configuration
+
+The Vault Secrets Operator (VSO) relies on VaultAuth resources to authenticate with Vault. It relies on credential
+providers to generate the credentials necessary for authentication. For example, when VSO authenticates to a kubernetes
+auth backend, it generates a token using the service account configured in the VaultAuth resource' defined
+kubernetes auth method. The service account must be configured in the Kubernetes namespace of the requesting resource.
+Meaning, if a resource like a `VaultStaticSecret` is created in the `default` namespace, the service account must be in
+the `default` namespace. The rationale behind this approach is to ensure that cross namespace access is not possible.
+
+## Vault authentication globals
+
+The `VaultAuthGlobal` resource is a global configuration that allows you to share a single authentication configuration
+across a set of VaultAuth resources. This is useful when you have multiple VaultAuth resources that share the
+same base configuration. For example, if you have multiple VaultAuth resources that all authenticate to Vault
+using the same auth backend, you can create a single VaultAuthGlobal resource that defines the configuration
+common to all VaultAuth instances. Options like `mount`, `method`, `namespace`, and method specific configuration
+can all be inherited from the VaultAuthGlobal resource. Any field in the VaultAuth resource can be inherited
+from a VaultAuthGlobal instance. Typically, most fields are inherited from the VaultAuthGlobal,
+fields like `role`, and credential provider specific fields like `serviceAccount` are usually set on the referring
+VaultAuth instance, since they are more specific to the application that requires the VaultAuth resource.
+
+*See [VaultAuthGlobal spec][vag-spec]  and [VaultAuth spec][va-spec] for the complete list of available fields.*
+
+## Sample use cases and configurations
+
+### Multi-tenant application with shared authentication backend
+
+A Vault admin has configured a Kubernetes auth backend in Vault mounted at `kubernetes`. The admin expects to have
+two applications authenticate using their own roles, and service accounts. The admin creates the necessary roles in
+Vault bound to the service accounts and namespaces of the applications.
+
+The admin creates a default VaultAuthGlobal with the following configuration:
+
+```yaml
+---
+apiVersion: secrets.hashicorp.com/v1beta1
+kind: VaultAuthGlobal
+metadata:
+  name: default
+  namespace: admin
+spec:
+  allowedNamespaces:
+    - apps
+  defaultAuthMethod: kubernetes
+  kubernetes:
+    audiences:
+    - vault
+    mount: auth-mount
+    role: default
+    serviceAccount: default
+    tokenExpirationSeconds: 600
+```
+
+A developer creates a `VaultAuth` and VaultStaticSecret resource in their application's namespace with the following
+configuration:
+
+```yaml
+---
+apiVersion: secrets.hashicorp.com/v1beta1
+kind: VaultAuth
+metadata:
+  name: app1
+  namespace: apps
+spec:
+  kubernetes:
+    role: app1
+    serviceAccount: app1
+  vaultAuthGlobalRef:
+    allowDefault: true
+    namespace: admin
+---
+apiVersion: secrets.hashicorp.com/v1beta1
+kind: VaultStaticSecret
+metadata:
+  name: app1-secret
+  namespace: apps
+spec:
+  destination:
+    create: true
+    name: app1-secret
+  hmacSecretData: true
+  mount: apps
+  path: app1
+  type: kv-v2
+  vaultAuthRef: app1
+```
+
+Application 2 would have a similar configuration:
+```yaml
+---
+apiVersion: secrets.hashicorp.com/v1beta1
+kind: VaultAuth
+metadata:
+  name: app2
+  namespace: apps
+spec:
+  kubernetes:
+    role: app2
+    serviceAccount: app2
+  vaultAuthGlobalRef:
+    allowDefault: true
+    namespace: admin
+---
+apiVersion: secrets.hashicorp.com/v1beta1
+kind: VaultStaticSecret
+metadata:
+  name: app2-secret
+  namespace: apps
+spec:
+  destination:
+    create: true
+    name: app2-secret
+  hmacSecretData: true
+  mount: apps
+  path: app2
+  type: kv-v2
+  vaultAuthRef: app2
+```
+
+#### Explanation
+
+- The default VaultAuthGlobal resource is created in the `admin` namespace. This resource defines the
+  common configuration for all VaultAuth resources that reference it. The `allowedNamespaces` field restricts the
+  VaultAuth resources that can reference this VaultAuthGlobal resource. In this case, only resources in the `apps`
+  namespace can reference this VaultAuthGlobal resource.
+- The VaultAuth resources in the `apps` namespace reference the VaultAuthGlobal resource. This allows the VaultAuth
+  resources to inherit the configuration from the VaultAuthGlobal resource. The `role` and serviceAccount fields are
+  specific to the application and are not inherited from the VaultAuthGlobal resource.
+- The VaultStaticSecret resources in the `apps` namespace reference the VaultAuth resources. This allows the
+  VaultStaticSecret resources to authenticate to Vault in order to sync the KV secrets to the destination Kubernetes
+  Secret.
+
+### Multi-tenant application with shared authentication backend and role
+
+A Vault admin has configured a Kubernetes auth backend in Vault mounted at `kubernetes`. The admin expects to have
+two applications authenticate using a single role, and service account. The admin creates the necessary role in
+Vault bound to the same service account and namespace of the applications.
+
+The admin or developer creates a default VaultAuthGlobal in applications namespace with the following configuration:
+
+```yaml
+---
+apiVersion: secrets.hashicorp.com/v1beta1
+kind: VaultAuthGlobal
+metadata:
+  name: default
+  namespace: apps
+spec:
+  defaultAuthMethod: kubernetes
+  kubernetes:
+    audiences:
+    - vault
+    mount: auth-mount
+    role: apps
+    serviceAccount: apps
+    tokenExpirationSeconds: 600
+```
+
+A developer creates single VaultAuth and the necessary VaultStatic secrets in their application's namespace with the
+following:
+
+```yaml
+---
+apiVersion: secrets.hashicorp.com/v1beta1
+kind: VaultAuth
+metadata:
+  name: apps
+  namespace: apps
+spec:
+  vaultAuthGlobalRef:
+    allowDefault: true
+---
+apiVersion: secrets.hashicorp.com/v1beta1
+kind: VaultStaticSecret
+metadata:
+  name: app1-secret
+  namespace: apps
+spec:
+  destination:
+    create: true
+    name: app1-secret
+  hmacSecretData: true
+  mount: apps
+  path: app1
+  type: kv-v2
+  vaultAuthRef: apps
+---
+apiVersion: secrets.hashicorp.com/v1beta1
+kind: VaultStaticSecret
+metadata:
+  name: app2-secret
+  namespace: apps
+spec:
+  destination:
+    create: true
+    name: app2-secret
+  hmacSecretData: true
+  mount: apps
+  path: app2
+  type: kv-v2
+  vaultAuthRef: apps
+```
+
+#### Explanation
+
+- The default VaultAuthGlobal resource is created in the `apps` namespace. It provides all the necessary configuration
+  for the VaultAuth resources that reference it.
+- A single VaultAuth resource is created in the `apps` namespace. This resource references the VaultAuthGlobal resource
+  and inherits the configuration from it.
+- The VaultStaticSecret resources in the `apps` namespace reference the VaultAuth resource. This allows the VaultStaticSecret
+  resources to authenticate to Vault in order to sync the KV secrets to the destination Kubernetes Secret.
+
+## VaultAuthGlobal configuration inheritance
+
+- The configuration in the VaultAuth resource takes precedence over the configuration in the VaultAuthGlobal resource.
+- The VaultAuthGlobal can reside in any namespace, but must allow the namespace of the VaultAuth resource to reference it.
+- Default VaultAuthGlobal resources are denoted by the name `default` and are automatically referenced by all VaultAuth resources
+  when `spec.vaultAuthGlobalRef.allowDefault` is set to `true` and VSO is running with the `allow-default-globals`
+  option set in the `-global-vault-auth-options` flag (the default).
+- The default VaultAuthGlobal search order is:
+  1. The VaultAuth resource's `spec.vaultAuthGlobalRef.namespace` (terminates search if defined).
+  2. The VaultAuth resource's namespace.
+  3. The `default` VaultAuthGlobal resource in the Operator's namespace.
+
+## VaultAuthGlobal common errors and troubleshooting
+
+There are few sources for tracking down issues with VaultAuthGlobal resources:
+- Vault Secrets Operator logs
+- Kubernetes events
+- Resource status
+
+Below are examples of errors from each source and how to resolve them:
+
+  Sample error from Kubernetes events:
+  ```
+  apps     2s          Warning   VaultClientConfigError   vaultstaticsecret/app1-secret
+  Failed to get Vault auth login: failed getting demo-ns/vso-auth-global-2, err=VaultAuthGlobal.secrets.hashicorp.com
+  "vso-auth-global-2" not found
+  ```
+
+  Sample output sync failures from the Vault Secrets Operator logs:
+  ```json
+  {
+    "level": "error",
+    "ts": "2024-07-16T17:35:20Z",
+    "logger": "cachingClientFactory",
+    "msg": "Failed to get cacheKey from obj",
+    "controller": "vaultstaticsecret",
+    "controllerGroup": "secrets.hashicorp.com",
+    "controllerKind": "VaultStaticSecret",
+    "VaultStaticSecret": {
+      "name": "app1",
+      "namespace": "apps"
+    },
+    "namespace": "apps",
+    "name": "app1",
+    "reconcileID": "5201f597-6c5d-4d07-ae8f-30a39c80dc54",
+    "error": "failed getting admin/default, err=VaultAuthGlobal.secrets.hashicorp.com \"default\" not found"
+  }
+  ```
+
+  Check for related Kubernetes events:
+
+  ```shell
+  $ kubectl events --types=Warning -n admin --for vaultauths.secrets.hashicorp.com/default -o json
+  ```
+
+  Sample out from the Kubernetes event for the VaultAuth resource:
+
+  ```json
+  {
+    "kind": "Event",
+    "apiVersion": "v1",
+    "metadata": {
+      "name": "default.17e2c0da7b0e36b5",
+      "namespace": "admin",
+      "uid": "3ca6088e-7391-4b76-9443-a790ccae02c0",
+      "resourceVersion": "634396",
+      "creationTimestamp": "2024-07-16T17:14:12Z"
+    },
+    "involvedObject": {
+      "kind": "VaultAuth",
+      "namespace": "admin",
+      "name": "default",
+      "uid": "1dabe3a5-5479-4f5d-ac48-5db7eff7f822",
+      "apiVersion": "secrets.hashicorp.com/v1beta1",
+      "resourceVersion": "631994"
+    },
+    "reason": "Accepted",
+    "message": "Failed to handle VaultAuth resource request: err=failed getting admin/default, err=VaultAuthGlobal.secrets.hashicorp.com \"default\" not found",
+    "source": {
+      "component": "VaultAuth"
+    },
+    "firstTimestamp": "2024-07-16T17:14:12Z",
+    "lastTimestamp": "2024-07-16T17:15:53Z",
+    "count": 25,
+    "type": "Warning",
+    "eventTime": null,
+    "reportingComponent": "VaultAuth",
+    "reportingInstance": ""
+  }
+  ```
+
+Check the conditions on the VaultAuth resource:
+
+  ```shell
+  $ kubectl get vaultauths.secrets.hashicorp.com -n admin default -o jsonpath='{.status}'
+  ```
+
+Sample output of the VaultAuth's status (prettified). The `valid` field will be `false` for the condition reason
+`VaultAuthGlobalRef`:
+  ```json
+  {
+    "conditions": [
+      {
+        "lastTransitionTime": "2024-07-16T15:35:43Z",
+        "message": "failed getting admin/default, err=VaultAuthGlobal.secrets.hashicorp.com \"default\" not found",
+        "observedGeneration": 3,
+        "reason": "VaultAuthGlobalRef",
+        "status": "False",
+        "type": "Available"
+      }
+    ],
+    "specHash": "e264f241cb4ad776802924b6ad2aa272b11cffd570382605d1c2ddbdfd661ad3",
+    "valid": false
+  }
+  ```
+
+
+- Situation: The VaultAuthGlobal resource is not found or is invalid for some reason, denoted by error messages like
+`not found...`.
+
+  Resolution: Ensure that the VaultAuthGlobal resource exists in the namespace specified in the VaultAuth
+resource's or a default VaultAuthGlobal resource exists per
+[VaultAuthGlobal configuration inheritance](#vaultauthglobal-configuration-inheritance)
+
+- Situation: The VaultAuthGlobal is not allowed to be referenced by the VaultAuth resource, denoted by error
+messages like `target namespace "apps" is not allowed...`.
+
+  Resolution: Ensure that the VaultAuthGlobal resource's `spec.allowedNamespaces` field includes the namespace of the
+  VaultAuth resource.
+
+- Situation: The VaultAuth resource is not valid due to missing required fields, denoted by error messages like
+`invalid merge: empty role`.
+
+  Resolution: Ensure all required fields are set either on the VaultAuth resource or on the inherited
+  VaultAuthGlobal.
+
+### Some authentication engines in detail
+
+- [GCP](/vault/docs/auth/gcp)
+
+- [AWS](/vault/docs/auth/aws)

--- a/website/content/docs/platform/k8s/vso/sources/vault/auth/index.mdx
+++ b/website/content/docs/platform/k8s/vso/sources/vault/auth/index.mdx
@@ -38,13 +38,12 @@ VaultAuth instance, since they are more specific to the application that require
 - The configuration in the VaultAuth resource takes precedence over the configuration in the VaultAuthGlobal resource.
 - The VaultAuthGlobal can reside in any namespace, but must allow the namespace of the VaultAuth resource to reference it.
 - Default VaultAuthGlobal resources are denoted by the name `default` and are automatically referenced by all VaultAuth resources
-when `spec.vaultAuthGlobalRef.allowDefault` is set to `true` and VSO is running with the `allow-default-globals`
-option set in the `-global-vault-auth-options` flag (the default).
-- The default VaultAuthGlobal search order is:
-When a `spec.vaultAuthGlobalRef.namespace` is set, the search is constrained to that namespace. Otherwise, the
-search follows the order:
-1. The default VaultAuthGlobal resource in the referring VaultAuth resource's namespace.
-2. The default VaultAuthGlobal resource in the Operator's namespace.
+  when `spec.vaultAuthGlobalRef.allowDefault` is set to `true` and VSO is running with the `allow-default-globals`
+  option set in the `-global-vault-auth-options` flag (the default).
+- When a `spec.vaultAuthGlobalRef.namespace` is set, the search for the default VaultAuthGlobal resource is
+  constrained to that namespace. Otherwise, the search order is:
+  1. The default VaultAuthGlobal resource in the referring VaultAuth resource's namespace.
+  2. The default VaultAuthGlobal resource in the Operator's namespace.
 
 
 ## Sample use cases and configurations

--- a/website/content/docs/platform/k8s/vso/sources/vault/auth/index.mdx
+++ b/website/content/docs/platform/k8s/vso/sources/vault/auth/index.mdx
@@ -2,7 +2,7 @@
 layout: docs
 page_title: 'Vault Secrets Operator: Vault authentication details'
 description: >-
-  The Vault Secrets Operator allows Pods to consume Vault secrets natively from Kubernetes Secrets.
+  Authenticate to Vault with the Vault Secrets Operator.
 ---
 
 @include 'vso/common-links.mdx'
@@ -155,9 +155,9 @@ spec:
   VaultAuth resources that can reference this VaultAuthGlobal resource. In this case, only resources in the `apps`
   namespace can reference this VaultAuthGlobal resource.
 - The VaultAuth resources in the `apps` namespace reference the VaultAuthGlobal resource. This allows the VaultAuth
-  resources to inherit the configuration from the VaultAuthGlobal resource. The `role` and serviceAccount fields are
+  resources to inherit the configuration from the VaultAuthGlobal resource. The `role` and `serviceAccount` fields are
   specific to the application and are not inherited from the VaultAuthGlobal resource. Since the
-  `.spec.vaultAuthGlobalRef.allowDefault` is set to `true`, the VaultAuth resources will automatically reference the
+  `.spec.vaultAuthGlobalRef.allowDefault` field is set to `true`, the VaultAuth resources will automatically reference the
   `default` VaultAuthGlobal in defined namespace.
 - The VaultStaticSecret resources in the `apps` namespace reference the VaultAuth resources. This allows the
   VaultStaticSecret resources to authenticate to Vault in order to sync the KV secrets to the destination Kubernetes
@@ -248,7 +248,7 @@ spec:
 
 A Vault admin has configured a Kubernetes auth backend in Vault mounted at `kubernetes`. In addition, the Vault
 admin has configured a JWT auth backend mounted at `jwt`. The admin creates the necessary roles in Vault for each
-auth method. The admin expects to have two applications authenticate using each auth method and role.
+auth method. The admin expects to have two applications authenticate, one using `kubernetes` auth and the other using `jwt` auth.
 
 The admin or developer creates a default VaultAuthGlobal in the application's namespace with the following
 configuration:
@@ -346,9 +346,9 @@ spec:
   when authenticating to Vault. The `kubernetes` and `jwt` fields define the configuration for the respective auth
   method.
 - Application 1 uses the default kubernetes auth method defined in the VaultAuthGlobal resource. The VaultAuth resource
-  references the VaultAuthGlobal resource and inherits the configuration from it.
+  references the VaultAuthGlobal resource and inherits the kubernetes auth configuration from it.
 - Application 2 uses the JWT auth method defined in the VaultAuthGlobal resource. The VaultAuth resource references the
-  VaultAuthGlobal resource and inherits the configuration from it.
+  VaultAuthGlobal resource and inherits the JWT auth configuration from it.
 - Neither VaultAuth resource has a `role` or `serviceAccount` field set. This is because the `role` and `serviceAccount`
   fields are defined in the VaultAuthGlobal resource and are inherited by the VaultAuth resources.
 
@@ -388,7 +388,7 @@ Below are examples of errors from each source and how to resolve them:
   $ kubectl events --types=Warning -n admin --for vaultauths.secrets.hashicorp.com/default -o json
   ```
 
-  Sample out from the Kubernetes event for the VaultAuth resource:
+  Sample output from the Kubernetes event for the VaultAuth resource:
 
   ```json
   {
@@ -451,14 +451,13 @@ Sample output of the VaultAuth's status (prettified). The `valid` field will be 
 - Situation: The VaultAuthGlobal resource is not found or is invalid for some reason, denoted by error messages like
 `not found...`.
 
-  Resolution: Ensure that the VaultAuthGlobal resource exists in the namespace specified in the VaultAuth
-resource's or a default VaultAuthGlobal resource exists per
-[VaultAuthGlobal configuration inheritance](#vaultauthglobal-configuration-inheritance)
+  Resolution: Ensure that the VaultAuthGlobal resource exists in the referring VaultAuth's namespace or a default
+VaultAuthGlobal resource exists per [VaultAuthGlobal configuration inheritance](#vaultauthglobal-configuration-inheritance)
 
-- Situation: The VaultAuthGlobal is not allowed to be referenced by the VaultAuth resource, denoted by error
+- **Situation**: The VaultAuthGlobal is not allowed to be referenced by the VaultAuth resource, denoted by error
 messages like `target namespace "apps" is not allowed...`.
 
-  Resolution: Ensure that the VaultAuthGlobal resource's `spec.allowedNamespaces` field includes the namespace of the
+  **Resolution**: Ensure that the VaultAuthGlobal resource's `spec.allowedNamespaces` field includes the namespace of the
   VaultAuth resource.
 
 - Situation: The VaultAuth resource is not valid due to missing required fields, denoted by error messages like
@@ -467,8 +466,9 @@ messages like `target namespace "apps" is not allowed...`.
   Resolution: Ensure all required fields are set either on the VaultAuth resource or on the inherited
   VaultAuthGlobal.
 
-A successfully merged VaultAuth resource will have the `valid` field set to `true` and the `conditions` will look
-something like:
+  A successfully merged VaultAuth resource will have the `valid` field set to `true` and the `conditions` will look
+  something like:
+
   ```json
   {
     "conditions": [
@@ -488,14 +488,14 @@ something like:
 
 <Tip>
 
-  The value for the key in the message field is the key to the VaultAuthGlobal object that was successfully merged.
+  The value for the key in the message field is the namespace/name of the VaultAuthGlobal object that was successfully merged.
   This is useful if you want to know which VaultAuthGlobal object was used to merge the VaultAuth object.
 
 </Tip>
 
 
-### Some authentication engines in detail
-
-- [GCP](/vault/docs/auth/gcp)
+## Some authentication engines in detail
 
 - [AWS](/vault/docs/auth/aws)
+
+- [GCP](/vault/docs/auth/gcp)

--- a/website/content/docs/platform/k8s/vso/sources/vault/auth/index.mdx
+++ b/website/content/docs/platform/k8s/vso/sources/vault/auth/index.mdx
@@ -448,22 +448,23 @@ Sample output of the VaultAuth's status (prettified). The `valid` field will be 
     "valid": false
   }
   ```
-- Situation: The VaultAuthGlobal resource is not found or is invalid for some reason, denoted by error messages like
+- **Situation**: The VaultAuthGlobal resource is not found or is invalid for some reason, denoted by error messages like
 `not found...`.
 
-  Resolution: Ensure that the VaultAuthGlobal resource exists in the referring VaultAuth's namespace or a default
-VaultAuthGlobal resource exists per [VaultAuthGlobal configuration inheritance](#vaultauthglobal-configuration-inheritance)
+  **Resolution**: Ensure that the VaultAuthGlobal resource exists in the referring VaultAuth's namespace or a default
+  VaultAuthGlobal resource exists per [VaultAuthGlobal configuration inheritance]
+  (#vaultauthglobal-configuration-inheritance)
 
 - **Situation**: The VaultAuthGlobal is not allowed to be referenced by the VaultAuth resource, denoted by error
-messages like `target namespace "apps" is not allowed...`.
+  messages like `target namespace "apps" is not allowed...`.
 
   **Resolution**: Ensure that the VaultAuthGlobal resource's `spec.allowedNamespaces` field includes the namespace of the
   VaultAuth resource.
 
-- Situation: The VaultAuth resource is not valid due to missing required fields, denoted by error messages like
-`invalid merge: empty role`.
+- **Situation**: The VaultAuth resource is not valid due to missing required fields, denoted by error messages like
+ `invalid merge: empty role`.
 
-  Resolution: Ensure all required fields are set either on the VaultAuth resource or on the inherited
+  **Resolution**: Ensure all required fields are set either on the VaultAuth resource or on the inherited
   VaultAuthGlobal.
 
   A successfully merged VaultAuth resource will have the `valid` field set to `true` and the `conditions` will look

--- a/website/content/docs/platform/k8s/vso/sources/vault/auth/index.mdx
+++ b/website/content/docs/platform/k8s/vso/sources/vault/auth/index.mdx
@@ -53,7 +53,7 @@ examples demonstrate how to use the VaultAuthGlobal resource to share a common a
 set of VaultAuth resources. Like other namespaced VSO custom resource definitions, there can be many VaultAuthGlobal
 resources configured in a single Kubernetes cluster.
 
-### Multi-tenant application with shared authentication backend
+### Multiple applications with shared authentication backend
 
 A Vault admin has configured a Kubernetes auth backend in Vault mounted at `kubernetes`. The admin expects to have
 two applications authenticate using their own roles, and service accounts. The admin creates the necessary roles in
@@ -163,7 +163,7 @@ spec:
   VaultStaticSecret resources to authenticate to Vault in order to sync the KV secrets to the destination Kubernetes
   Secret.
 
-### Multi-tenant application with shared authentication backend and role
+### Multiple applications with shared authentication backend and role
 
 A Vault admin has configured a Kubernetes auth backend in Vault mounted at `kubernetes`. The admin expects to have
 two applications authenticate using a single role, and service account. The admin creates the necessary role in
@@ -244,7 +244,7 @@ spec:
 - The VaultStaticSecret resources in the `apps` namespace reference the VaultAuth resource. This allows the VaultStaticSecret
   resources to authenticate to Vault in order to sync the KV secrets to the destination Kubernetes Secret.
 
-### Multi-tenant application with multiple authentication backends and roles
+### Multiple applications with multiple authentication backends and roles
 
 A Vault admin has configured a Kubernetes auth backend in Vault mounted at `kubernetes`. In addition, the Vault
 admin has configured a JWT auth backend mounted at `jwt`. The admin creates the necessary roles in Vault for each

--- a/website/content/docs/platform/k8s/vso/sources/vault/auth/index.mdx
+++ b/website/content/docs/platform/k8s/vso/sources/vault/auth/index.mdx
@@ -242,13 +242,6 @@ There are few sources for tracking down issues with VaultAuthGlobal resources:
 
 Below are examples of errors from each source and how to resolve them:
 
-  Sample error from Kubernetes events:
-  ```
-  apps     2s          Warning   VaultClientConfigError   vaultstaticsecret/app1-secret
-  Failed to get Vault auth login: failed getting demo-ns/vso-auth-global-2, err=VaultAuthGlobal.secrets.hashicorp.com
-  "vso-auth-global-2" not found
-  ```
-
   Sample output sync failures from the Vault Secrets Operator logs:
   ```json
   {

--- a/website/content/docs/platform/k8s/vso/sources/vault/index.mdx
+++ b/website/content/docs/platform/k8s/vso/sources/vault/index.mdx
@@ -168,16 +168,20 @@ metadata:
 spec:
   vaultAuthGlobalRef:
     name: vault-auth-global
+  kubernetes:
     role: local-role
 ```
 
-### Explanation
+#### Explanation
 
 - The VaultAuthGlobal custom resource defines a default authentication method of kubernetes with the `defaultAuthMethod`
   field.
 - The VaultAuth custom resource inherits the global configuration by referencing the VaultAuthGlobal custom
   resource with the `vaultAuthGlobalRef` field.
-- The `role` field in the VaultAuth custom resource overrides the role field in the VaultAuthGlobal custom resource.
+- The `kubernetes.role` field in the VaultAuth custom resource spec overrides the value of the corresponding field in
+  the VaultAuthGlobal custom resource. All other fields are inherited from the VaultAuthGlobal custom resource `spec.
+  kubernetes` field, e.g., `audiences`, `mount`, `serviceAccount`, `namespace`, etc.
+
 
 ## Vault secret custom resource definitions
 

--- a/website/content/docs/platform/k8s/vso/sources/vault/index.mdx
+++ b/website/content/docs/platform/k8s/vso/sources/vault/index.mdx
@@ -121,12 +121,12 @@ VSO v0.8.0
 
 </Tip>
 
-Provides shared Vault authentication configuration that can be inherited by multiple `VaultAuth` custom resources.
-It supports multiple authentication methods and allows you to define a default authentication method that can be
-overridden by individual VaultAuth custom resources. See `vaultAuthGlobalRef` in [VaultAuth spec][va-spec] for more
-details. The `VaultAuthGlobal` custom resource is optional and can be used to simplify the configuration of multiple
-VaultAuth custom resources by reducing config duplication. See [VaultAuthGlobal spec][vag-spec] for the complete list
-of available fields.
+Namespaced resource that provides shared Vault authentication configuration that can be inherited by multiple
+`VaultAuth` custom resources. It supports multiple authentication methods and allows you to define a default
+authentication method that can be overridden by individual VaultAuth custom resources. See `vaultAuthGlobalRef` in
+the [VaultAuth spec][va-spec] for more details. The `VaultAuthGlobal` custom resource is optional and can be used to
+simplify the configuration of multiple VaultAuth custom resources by reducing config duplication. Like other
+namespaced VSO custom resources, there can be many VaultAuthGlobal resources configured in a single Kubernetes cluster.
 
 For more details on how to integrate VaultAuthGlobals into your workflow, see the detailed [Authentication][auth]
 docs.
@@ -170,6 +170,14 @@ spec:
     name: vault-auth-global
     role: local-role
 ```
+
+### Explanation
+
+- The VaultAuthGlobal custom resource defines a default authentication method of kubernetes with the kubernetes
+  field.
+- The VaultAuth custom resource inherits the global configuration by referencing the VaultAuthGlobal custom
+  resource with the `vaultAuthGlobalRef` field.
+- The `role` field in the VaultAuth custom resource overrides the role field in the VaultAuthGlobal custom resource.
 
 ## Vault secret custom resource definitions
 

--- a/website/content/docs/platform/k8s/vso/sources/vault/index.mdx
+++ b/website/content/docs/platform/k8s/vso/sources/vault/index.mdx
@@ -131,8 +131,6 @@ of available fields.
 For more details on how to integrate VaultAuthGlobals into your workflow, see the detailed [Authentication][auth]
 docs.
 
-```yaml
-
 <Tip>
 
   The VaultAuthGlobal resources shares many of the same fields as the VaultAuth custom resource, but cannot be used

--- a/website/content/docs/platform/k8s/vso/sources/vault/index.mdx
+++ b/website/content/docs/platform/k8s/vso/sources/vault/index.mdx
@@ -179,8 +179,8 @@ spec:
 - The VaultAuth custom resource inherits the global configuration by referencing the VaultAuthGlobal custom
   resource with the `vaultAuthGlobalRef` field.
 - The `kubernetes.role` field in the VaultAuth custom resource spec overrides the value of the corresponding field in
-  the VaultAuthGlobal custom resource. All other fields are inherited from the VaultAuthGlobal custom resource `spec.
-  kubernetes` field, e.g., `audiences`, `mount`, `serviceAccount`, `namespace`, etc.
+  the VaultAuthGlobal custom resource. All other fields are inherited from the VaultAuthGlobal custom resource
+  `spec.kubernetes` field, e.g., `audiences`, `mount`, `serviceAccount`, `namespace`, etc.
 
 
 ## Vault secret custom resource definitions

--- a/website/content/docs/platform/k8s/vso/sources/vault/index.mdx
+++ b/website/content/docs/platform/k8s/vso/sources/vault/index.mdx
@@ -115,7 +115,7 @@ spec:
 
 ### VaultAuthGlobal custom resource
 
-<Tip title={"Feature availability"}>
+<Tip title="Feature availability">
 
 VSO v0.8.0
 
@@ -134,7 +134,7 @@ docs.
 <Tip>
 
   The VaultAuthGlobal resources shares many of the same fields as the VaultAuth custom resource, but cannot be used
-  for authentication directly. It is only used to define shared Vault authentication configuration across a Kubernetes
+  for authentication directly. It is only used to define shared Vault authentication configuration within a Kubernetes
   cluster.
 
 </Tip>
@@ -173,7 +173,7 @@ spec:
 
 ### Explanation
 
-- The VaultAuthGlobal custom resource defines a default authentication method of kubernetes with the kubernetes
+- The VaultAuthGlobal custom resource defines a default authentication method of kubernetes with the `defaultAuthMethod`
   field.
 - The VaultAuth custom resource inherits the global configuration by referencing the VaultAuthGlobal custom
   resource with the `vaultAuthGlobalRef` field.

--- a/website/content/docs/platform/k8s/vso/sources/vault/index.mdx
+++ b/website/content/docs/platform/k8s/vso/sources/vault/index.mdx
@@ -4,6 +4,7 @@ page_title: Vault Secrets Operator
 description: >-
   The Vault Secrets Operator allows Pods to consume Vault secrets natively from Kubernetes Secrets.
 ---
+@include 'vso/common-links.mdx'
 
 # Vault Secrets Operator
 
@@ -110,6 +111,66 @@ spec:
   # params: []
   # HTTP headers to be included in all Vault authentication requests.
   # headers: []
+```
+
+### VaultAuthGlobal custom resource
+
+<Tip title={"Feature availability"}>
+
+VSO v0.8.0
+
+</Tip>
+
+Provides shared Vault authentication configuration that can be inherited by multiple `VaultAuth` custom resources.
+It supports multiple authentication methods and allows you to define a default authentication method that can be
+overridden by individual `VaultAuth` custom resources. See `vaultAuthGlobalRef` in [VaultAuth spec][va-spec] for more
+details. The `VaultAuthGlobal` custom resource is optional and can be used to simplify the configuration of multiple
+`VaultAuth` custom resources by reducing config duplication. See [VaultAuthGlobal spec][vag-spec] for the complete list
+of available fields.
+
+For more details on how to integrate `VaultAuthGlobal`s into your workflow, see the detailed [Authentication][auth]
+documentation.
+
+```yaml
+
+<Tip>
+
+  The `VaultAuthGlobal` resources shares many of the same fields as the `VaultAuth` custom resource, but cannot be used
+  for authentication directly. It is only used to define shared Vault authentication configuration across a Kubernetes
+  cluster.
+
+</Tip>
+
+The example below demonstrates how to define a `VaultAuthGlobal` custom resource with a default authentication method of
+`kubernetes`, along with a `VaultAuth` custom resource that inherits its global configuration.
+
+```yaml
+---
+apiVersion: secrets.hashicorp.com/v1beta1
+kind: VaultAuthGlobal
+metadata:
+  namespace: vso-example
+  name: vault-auth-global
+spec:
+  defaultAuthMethod: kubernetes
+  kubernetes:
+    audiences:
+    - vault
+    mount: kubernetes
+    namespace: example-ns
+    role: auth-role
+    serviceAccount: default
+    tokenExpirationSeconds: 600
+---
+apiVersion: secrets.hashicorp.com/v1beta1
+kind: VaultAuth
+metadata:
+  namespace: vso-example
+  name: vault-auth
+spec:
+  vaultAuthGlobalRef:
+    name: vault-auth-global
+    role: local-role
 ```
 
 ## Vault secret custom resource definitions

--- a/website/content/docs/platform/k8s/vso/sources/vault/index.mdx
+++ b/website/content/docs/platform/k8s/vso/sources/vault/index.mdx
@@ -123,26 +123,26 @@ VSO v0.8.0
 
 Provides shared Vault authentication configuration that can be inherited by multiple `VaultAuth` custom resources.
 It supports multiple authentication methods and allows you to define a default authentication method that can be
-overridden by individual `VaultAuth` custom resources. See `vaultAuthGlobalRef` in [VaultAuth spec][va-spec] for more
+overridden by individual VaultAuth custom resources. See `vaultAuthGlobalRef` in [VaultAuth spec][va-spec] for more
 details. The `VaultAuthGlobal` custom resource is optional and can be used to simplify the configuration of multiple
-`VaultAuth` custom resources by reducing config duplication. See [VaultAuthGlobal spec][vag-spec] for the complete list
+VaultAuth custom resources by reducing config duplication. See [VaultAuthGlobal spec][vag-spec] for the complete list
 of available fields.
 
-For more details on how to integrate `VaultAuthGlobal`s into your workflow, see the detailed [Authentication][auth]
-documentation.
+For more details on how to integrate VaultAuthGlobals into your workflow, see the detailed [Authentication][auth]
+docs.
 
 ```yaml
 
 <Tip>
 
-  The `VaultAuthGlobal` resources shares many of the same fields as the `VaultAuth` custom resource, but cannot be used
+  The VaultAuthGlobal resources shares many of the same fields as the VaultAuth custom resource, but cannot be used
   for authentication directly. It is only used to define shared Vault authentication configuration across a Kubernetes
   cluster.
 
 </Tip>
 
-The example below demonstrates how to define a `VaultAuthGlobal` custom resource with a default authentication method of
-`kubernetes`, along with a `VaultAuth` custom resource that inherits its global configuration.
+The example below demonstrates how to define a VaultAuthGlobal custom resource with a default authentication method of
+`kubernetes`, along with a VaultAuth custom resource that inherits its global configuration.
 
 ```yaml
 ---

--- a/website/content/partials/vso/common-links.mdx
+++ b/website/content/partials/vso/common-links.mdx
@@ -1,0 +1,4 @@
+[va-spec]: /vault/docs/platform/k8s/vso/api-reference#vaultauthspec
+[vag-spec]: /vault/docs/platform/k8s/vso/api-reference#vaultauthglobalspec
+[helm]: /vault/docs/platform/k8s/vso/helm
+[auth]: /vault/docs/platform/k8s/vso/sources/vault/auth

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -376,7 +376,7 @@
           },
           {
             "title": "TCP",
-            "routes": [  
+            "routes": [
               {
                 "title": "Overview",
                 "path": "configuration/listener/tcp"
@@ -1116,7 +1116,7 @@
             "path": "commands/transform/import"
           }
         ]
-      },      
+      },
       {
         "title": "<code>unwrap</code>",
         "path": "commands/unwrap"
@@ -2208,8 +2208,12 @@
                         "path": "platform/k8s/vso/sources/vault"
                       },
                       {
-                        "title": "Auth Methods",
+                        "title": "Authentication",
                         "routes": [
+                          {
+                            "title": "Overview",
+                            "path": "platform/k8s/vso/sources/vault/auth"
+                          },
                           {
                             "title": "AWS",
                             "path": "platform/k8s/vso/sources/vault/auth/aws"


### PR DESCRIPTION
### Description
Documents the newly added VaultAuthGlobals feature for VSO.

### TODO only if you're a HashiCorp employee
- [ ] **Labels:** If this PR is the CE portion of an ENT change, and that ENT change is
  getting backported to N-2, use the new style `backport/ent/x.x.x+ent` labels
  instead of the old style `backport/x.x.x` labels.
- [] **Labels:** If this PR is a CE only change, it can only be backported to N, so use
  the normal `backport/x.x.x` label (there should be only 1).
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
