### PR TITLE
docs: add missing rotation_statements to mssql api docs

### DIFF
--- a/website/content/api-docs/secret/databases/mssql.mdx
+++ b/website/content/api-docs/secret/databases/mssql.mdx
@@ -127,3 +127,10 @@ list the plugin does not support that statement type.
   base64-encoded semicolon-separated string, a serialized JSON string array, or
   a base64-encoded serialized JSON string array. The `{{name}}` value will be
   substituted. If not provided defaults to a generic drop user statement.
+
+- `rotation_statements` `(list: [])` – Specifies the database statements to be
+  executed to rotate the password for a given username. Must be a
+  semicolon-separated string, a base64-encoded semicolon-separated string, a
+  serialized JSON string array, or a base64-encoded serialized JSON string
+  array. The `{{name}}` and `{{password}}` values will be substituted. The
+  generated password will be a random alphanumeric 20 character string.


### PR DESCRIPTION
We can see it is supported here: https://github.com/hashicorp/vault/blob/b9c892f8aa37c130dbb46c39972dccbaed42ba1b/plugins/database/mssql/mssql.go#L347 
and we have test coverage for the field in https://github.com/hashicorp/vault/blob/e88b6b117e3e9288352518f37a716013991afcc3/plugins/database/mssql/mssql_test.go#L188