### PR TITLE
Title case all static breadcrumbs

### DIFF
--- a/ui/app/components/transit-edit.js
+++ b/ui/app/components/transit-edit.js
@@ -60,10 +60,10 @@ export default Component.extend(FocusOnInsertMixin, {
           models: [this.key.backend, this.key.id],
           query: { tab: 'details' },
         },
-        { label: 'edit' },
+        { label: 'Edit' },
       ];
     } else if (this.mode === 'create') {
-      return [...baseCrumbs, { label: 'create' }];
+      return [...baseCrumbs, { label: 'Create' }];
     }
     return baseCrumbs;
   },

--- a/ui/app/controllers/vault/cluster/access/leases/list.js
+++ b/ui/app/controllers/vault/cluster/access/leases/list.js
@@ -26,7 +26,7 @@ export default Controller.extend(ListController, {
 
   backendCrumb: computed('clusterController.model.name', function () {
     return {
-      label: 'leases',
+      label: 'Leases',
       text: 'Leases',
       path: 'vault.cluster.access.leases.list-root',
       model: this.clusterController.model.name,

--- a/ui/app/controllers/vault/cluster/access/leases/show.js
+++ b/ui/app/controllers/vault/cluster/access/leases/show.js
@@ -13,7 +13,7 @@ export default Controller.extend({
 
   backendCrumb: computed('clusterController.model.name', function () {
     return {
-      label: 'leases',
+      label: 'Leases',
       text: 'Leases',
       path: 'vault.cluster.access.leases.list-root',
       model: this.clusterController.model.name,

--- a/ui/app/routes/vault/cluster/secrets/backend/actions.js
+++ b/ui/app/routes/vault/cluster/secrets/backend/actions.js
@@ -47,7 +47,7 @@ export default EditBase.extend({
         models: [model.secret.backend, model.secret.id],
       },
       {
-        label: 'actions',
+        label: 'Actions',
       },
     ]);
   },

--- a/ui/lib/kubernetes/addon/routes/configuration.js
+++ b/ui/lib/kubernetes/addon/routes/configuration.js
@@ -28,7 +28,8 @@ export default class KubernetesConfigureRoute extends Route {
 
     controller.breadcrumbs = [
       { label: 'Secrets', route: 'secrets', linkExternal: true },
-      { label: resolvedModel.backend.id },
+      { label: resolvedModel.backend.id, route: 'overview', model: resolvedModel.backend },
+      { label: 'Configuration' },
     ];
   }
 }

--- a/ui/lib/kubernetes/addon/routes/configure.js
+++ b/ui/lib/kubernetes/addon/routes/configure.js
@@ -23,7 +23,7 @@ export default class KubernetesConfigureRoute extends Route {
     controller.breadcrumbs = [
       { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: resolvedModel.backend, route: 'overview' },
-      { label: 'configure' },
+      { label: 'Configure' },
     ];
   }
 }

--- a/ui/lib/kubernetes/addon/routes/configure.js
+++ b/ui/lib/kubernetes/addon/routes/configure.js
@@ -22,7 +22,7 @@ export default class KubernetesConfigureRoute extends Route {
 
     controller.breadcrumbs = [
       { label: 'Secrets', route: 'secrets', linkExternal: true },
-      { label: resolvedModel.backend, route: 'overview' },
+      { label: resolvedModel.backend, route: 'overview', model: resolvedModel.backend },
       { label: 'Configure' },
     ];
   }

--- a/ui/lib/kubernetes/addon/routes/roles/create.js
+++ b/ui/lib/kubernetes/addon/routes/roles/create.js
@@ -20,8 +20,8 @@ export default class KubernetesRolesCreateRoute extends Route {
 
     controller.breadcrumbs = [
       { label: resolvedModel.backend, route: 'overview' },
-      { label: 'roles', route: 'roles' },
-      { label: 'create' },
+      { label: 'Roles', route: 'roles' },
+      { label: 'Create' },
     ];
   }
 }

--- a/ui/lib/kubernetes/addon/routes/roles/create.js
+++ b/ui/lib/kubernetes/addon/routes/roles/create.js
@@ -20,7 +20,7 @@ export default class KubernetesRolesCreateRoute extends Route {
 
     controller.breadcrumbs = [
       { label: resolvedModel.backend, route: 'overview' },
-      { label: 'Roles', route: 'roles' },
+      { label: 'Roles', route: 'roles', model: resolvedModel.backend },
       { label: 'Create' },
     ];
   }

--- a/ui/lib/kubernetes/addon/routes/roles/index.js
+++ b/ui/lib/kubernetes/addon/routes/roles/index.js
@@ -41,7 +41,8 @@ export default class KubernetesRolesRoute extends Route {
 
     controller.breadcrumbs = [
       { label: 'Secrets', route: 'secrets', linkExternal: true },
-      { label: resolvedModel.backend.id },
+      { label: resolvedModel.backend.id, route: 'overview', model: resolvedModel.backend },
+      { label: 'Roles' },
     ];
   }
 }

--- a/ui/lib/kubernetes/addon/routes/roles/role/credentials.js
+++ b/ui/lib/kubernetes/addon/routes/roles/role/credentials.js
@@ -20,7 +20,7 @@ export default class KubernetesRoleCredentialsRoute extends Route {
 
     controller.breadcrumbs = [
       { label: resolvedModel.backend, route: 'overview' },
-      { label: 'Roles', route: 'roles' },
+      { label: 'Roles', route: 'roles', model: resolvedModel.backend },
       { label: resolvedModel.roleName, route: 'roles.role.details' },
       { label: 'Credentials' },
     ];

--- a/ui/lib/kubernetes/addon/routes/roles/role/credentials.js
+++ b/ui/lib/kubernetes/addon/routes/roles/role/credentials.js
@@ -20,9 +20,9 @@ export default class KubernetesRoleCredentialsRoute extends Route {
 
     controller.breadcrumbs = [
       { label: resolvedModel.backend, route: 'overview' },
-      { label: 'roles', route: 'roles' },
+      { label: 'Roles', route: 'roles' },
       { label: resolvedModel.roleName, route: 'roles.role.details' },
-      { label: 'credentials' },
+      { label: 'Credentials' },
     ];
   }
 }

--- a/ui/lib/kubernetes/addon/routes/roles/role/details.js
+++ b/ui/lib/kubernetes/addon/routes/roles/role/details.js
@@ -21,7 +21,7 @@ export default class KubernetesRoleDetailsRoute extends Route {
 
     controller.breadcrumbs = [
       { label: resolvedModel.backend, route: 'overview' },
-      { label: 'Roles', route: 'roles' },
+      { label: 'Roles', route: 'roles', model: resolvedModel.backend },
       { label: resolvedModel.name },
     ];
   }

--- a/ui/lib/kubernetes/addon/routes/roles/role/details.js
+++ b/ui/lib/kubernetes/addon/routes/roles/role/details.js
@@ -21,7 +21,7 @@ export default class KubernetesRoleDetailsRoute extends Route {
 
     controller.breadcrumbs = [
       { label: resolvedModel.backend, route: 'overview' },
-      { label: 'roles', route: 'roles' },
+      { label: 'Roles', route: 'roles' },
       { label: resolvedModel.name },
     ];
   }

--- a/ui/lib/kubernetes/addon/routes/roles/role/edit.js
+++ b/ui/lib/kubernetes/addon/routes/roles/role/edit.js
@@ -21,7 +21,7 @@ export default class KubernetesRoleEditRoute extends Route {
 
     controller.breadcrumbs = [
       { label: resolvedModel.backend, route: 'overview' },
-      { label: 'Roles', route: 'roles' },
+      { label: 'Roles', route: 'roles', model: resolvedModel.backend },
       { label: resolvedModel.name, route: 'roles.role' },
       { label: 'Edit' },
     ];

--- a/ui/lib/kubernetes/addon/routes/roles/role/edit.js
+++ b/ui/lib/kubernetes/addon/routes/roles/role/edit.js
@@ -21,9 +21,9 @@ export default class KubernetesRoleEditRoute extends Route {
 
     controller.breadcrumbs = [
       { label: resolvedModel.backend, route: 'overview' },
-      { label: 'roles', route: 'roles' },
+      { label: 'Roles', route: 'roles' },
       { label: resolvedModel.name, route: 'roles.role' },
-      { label: 'edit' },
+      { label: 'Edit' },
     ];
   }
 }

--- a/ui/lib/kv/addon/routes/configuration.js
+++ b/ui/lib/kv/addon/routes/configuration.js
@@ -26,7 +26,7 @@ export default class KvConfigurationRoute extends Route {
     controller.breadcrumbs = [
       { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: resolvedModel.mountConfig.id, route: 'list', model: resolvedModel.engineConfig.backend },
-      { label: 'configuration' },
+      { label: 'Configuration' },
     ];
   }
 }

--- a/ui/lib/kv/addon/routes/create.js
+++ b/ui/lib/kv/addon/routes/create.js
@@ -34,7 +34,7 @@ export default class KvSecretsCreateRoute extends Route {
       { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: resolvedModel.backend, route: 'list', model: resolvedModel.backend },
       ...breadcrumbsForSecret(resolvedModel.backend, resolvedModel.path),
-      { label: 'create' },
+      { label: 'Create' },
     ];
     controller.breadcrumbs = crumbs;
   }

--- a/ui/lib/kv/addon/routes/secret/details/edit.js
+++ b/ui/lib/kv/addon/routes/secret/details/edit.js
@@ -38,7 +38,7 @@ export default class KvSecretDetailsEditRoute extends Route {
       { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: resolvedModel.backend, route: 'list', model: resolvedModel.backend },
       ...breadcrumbsForSecret(resolvedModel.backend, resolvedModel.path),
-      { label: 'edit' },
+      { label: 'Edit' },
     ];
   }
 }

--- a/ui/lib/kv/addon/routes/secret/metadata/diff.js
+++ b/ui/lib/kv/addon/routes/secret/metadata/diff.js
@@ -15,8 +15,8 @@ export default class KvSecretMetadataDiffRoute extends Route {
       { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: resolvedModel.backend, route: 'list', model: resolvedModel.backend },
       ...breadcrumbsForSecret(resolvedModel.backend, resolvedModel.path),
-      { label: 'version history', route: 'secret.metadata.versions' },
-      { label: 'diff' },
+      { label: 'Version History', route: 'secret.metadata.versions' },
+      { label: 'Diff' },
     ];
     controller.set('breadcrumbs', breadcrumbsArray);
   }

--- a/ui/lib/kv/addon/routes/secret/metadata/edit.js
+++ b/ui/lib/kv/addon/routes/secret/metadata/edit.js
@@ -16,8 +16,8 @@ export default class KvSecretMetadataEditRoute extends Route {
       { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: resolvedModel.backend, route: 'list', model: resolvedModel.backend },
       ...breadcrumbsForSecret(resolvedModel.backend, resolvedModel.path),
-      { label: 'metadata', route: 'secret.metadata' },
-      { label: 'edit' },
+      { label: 'Metadata', route: 'secret.metadata' },
+      { label: 'Edit' },
     ];
 
     controller.set('breadcrumbs', breadcrumbsArray);

--- a/ui/lib/kv/addon/routes/secret/metadata/index.js
+++ b/ui/lib/kv/addon/routes/secret/metadata/index.js
@@ -16,7 +16,7 @@ export default class KvSecretMetadataIndexRoute extends Route {
       { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: resolvedModel.backend, route: 'list', model: resolvedModel.backend },
       ...breadcrumbsForSecret(resolvedModel.backend, resolvedModel.path),
-      { label: 'metadata' },
+      { label: 'Metadata' },
     ];
 
     controller.set('breadcrumbs', breadcrumbsArray);

--- a/ui/lib/kv/addon/routes/secret/metadata/versions.js
+++ b/ui/lib/kv/addon/routes/secret/metadata/versions.js
@@ -13,7 +13,7 @@ export default class KvSecretMetadataVersionsRoute extends Route {
       { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: resolvedModel.backend, route: 'list', model: resolvedModel.backend },
       ...breadcrumbsForSecret(resolvedModel.backend, resolvedModel.path),
-      { label: 'version history' },
+      { label: 'Version History' },
     ];
 
     controller.set('breadcrumbs', breadcrumbsArray);

--- a/ui/lib/kv/addon/routes/secret/paths.js
+++ b/ui/lib/kv/addon/routes/secret/paths.js
@@ -14,7 +14,7 @@ export default class KvSecretPathsRoute extends Route {
       { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: resolvedModel.backend, route: 'list', model: resolvedModel.backend },
       ...breadcrumbsForSecret(resolvedModel.backend, resolvedModel.path),
-      { label: 'paths' },
+      { label: 'Paths' },
     ];
   }
 }

--- a/ui/lib/ldap/addon/routes/configuration.ts
+++ b/ui/lib/ldap/addon/routes/configuration.ts
@@ -51,7 +51,8 @@ export default class LdapConfigurationRoute extends Route {
 
     controller.breadcrumbs = [
       { label: 'Secrets', route: 'secrets', linkExternal: true },
-      { label: resolvedModel.backendModel.id },
+      { label: resolvedModel.backendModel.id, route: 'overview', model: resolvedModel.backend },
+      { label: 'Configuration' },
     ];
   }
 }

--- a/ui/lib/ldap/addon/routes/libraries/create.ts
+++ b/ui/lib/ldap/addon/routes/libraries/create.ts
@@ -36,8 +36,8 @@ export default class LdapLibrariesCreateRoute extends Route {
 
     controller.breadcrumbs = [
       { label: resolvedModel.backend, route: 'overview' },
-      { label: 'libraries', route: 'libraries' },
-      { label: 'create' },
+      { label: 'Libraries', route: 'libraries' },
+      { label: 'Create' },
     ];
   }
 }

--- a/ui/lib/ldap/addon/routes/libraries/index.ts
+++ b/ui/lib/ldap/addon/routes/libraries/index.ts
@@ -51,7 +51,8 @@ export default class LdapLibrariesRoute extends Route {
 
     controller.breadcrumbs = [
       { label: 'Secrets', route: 'secrets', linkExternal: true },
-      { label: resolvedModel.backendModel.id },
+      { label: resolvedModel.backendModel.id, route: 'overview', model: resolvedModel.backend },
+      { label: 'Libraries' },
     ];
   }
 }

--- a/ui/lib/ldap/addon/routes/roles/create.ts
+++ b/ui/lib/ldap/addon/routes/roles/create.ts
@@ -36,8 +36,8 @@ export default class LdapRolesCreateRoute extends Route {
 
     controller.breadcrumbs = [
       { label: resolvedModel.backend, route: 'overview' },
-      { label: 'roles', route: 'roles' },
-      { label: 'create' },
+      { label: 'Roles', route: 'roles' },
+      { label: 'Create' },
     ];
   }
 }

--- a/ui/lib/ldap/addon/routes/roles/index.ts
+++ b/ui/lib/ldap/addon/routes/roles/index.ts
@@ -76,7 +76,8 @@ export default class LdapRolesRoute extends Route {
 
     controller.breadcrumbs = [
       { label: 'Secrets', route: 'secrets', linkExternal: true },
-      { label: resolvedModel.backendModel.id },
+      { label: resolvedModel.backendModel.id, route: 'overview', model: resolvedModel.backend },
+      { label: 'Roles' },
     ];
   }
 

--- a/ui/lib/pki/addon/routes/certificates/certificate/details.js
+++ b/ui/lib/pki/addon/routes/certificates/certificate/details.js
@@ -19,7 +19,7 @@ export default class PkiCertificateDetailsRoute extends Route {
     controller.breadcrumbs = [
       { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: this.secretMountPath.currentPath, route: 'overview', model: this.secretMountPath.currentPath },
-      { label: 'certificates', route: 'certificates.index', model: this.secretMountPath.currentPath },
+      { label: 'Certificates', route: 'certificates.index', model: this.secretMountPath.currentPath },
       { label: model.id },
     ];
   }

--- a/ui/lib/pki/addon/routes/configuration/create.js
+++ b/ui/lib/pki/addon/routes/configuration/create.js
@@ -25,7 +25,7 @@ export default class PkiConfigurationCreateRoute extends Route {
     controller.breadcrumbs = [
       { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: this.secretMountPath.currentPath, route: 'overview', model: this.secretMountPath.currentPath },
-      { label: 'configure' },
+      { label: 'Configure' },
     ];
   }
 }

--- a/ui/lib/pki/addon/routes/configuration/edit.js
+++ b/ui/lib/pki/addon/routes/configuration/edit.js
@@ -27,8 +27,8 @@ export default class PkiConfigurationEditRoute extends Route {
     controller.breadcrumbs = [
       { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: this.secretMountPath.currentPath, route: 'overview', model: this.secretMountPath.currentPath },
-      { label: 'configuration', route: 'configuration.index', model: this.secretMountPath.currentPath },
-      { label: 'edit' },
+      { label: 'Configuration', route: 'configuration.index', model: this.secretMountPath.currentPath },
+      { label: 'Edit' },
     ];
   }
 }

--- a/ui/lib/pki/addon/routes/issuers/generate-intermediate.js
+++ b/ui/lib/pki/addon/routes/issuers/generate-intermediate.js
@@ -21,8 +21,8 @@ export default class PkiIssuersGenerateIntermediateRoute extends Route {
     controller.breadcrumbs = [
       { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: this.secretMountPath.currentPath, route: 'overview', model: this.secretMountPath.currentPath },
-      { label: 'issuers', route: 'issuers.index', model: this.secretMountPath.currentPath },
-      { label: 'generate CSR' },
+      { label: 'Issuers', route: 'issuers.index', model: this.secretMountPath.currentPath },
+      { label: 'Generate CSR' },
     ];
   }
 }

--- a/ui/lib/pki/addon/routes/issuers/generate-root.js
+++ b/ui/lib/pki/addon/routes/issuers/generate-root.js
@@ -21,7 +21,7 @@ export default class PkiIssuersGenerateRootRoute extends Route {
     controller.breadcrumbs = [
       { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: this.secretMountPath.currentPath, route: 'overview', model: this.secretMountPath.currentPath },
-      { label: 'generate root' },
+      { label: 'Generate Root' },
     ];
   }
 }

--- a/ui/lib/pki/addon/routes/issuers/import.js
+++ b/ui/lib/pki/addon/routes/issuers/import.js
@@ -21,8 +21,8 @@ export default class PkiIssuersImportRoute extends Route {
     controller.breadcrumbs = [
       { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: this.secretMountPath.currentPath, route: 'overview', model: this.secretMountPath.currentPath },
-      { label: 'issuers', route: 'issuers.index', model: this.secretMountPath.currentPath },
-      { label: 'import' },
+      { label: 'Issuers', route: 'issuers.index', model: this.secretMountPath.currentPath },
+      { label: 'Import' },
     ];
   }
 }

--- a/ui/lib/pki/addon/routes/issuers/index.js
+++ b/ui/lib/pki/addon/routes/issuers/index.js
@@ -37,7 +37,7 @@ export default class PkiIssuersListRoute extends Route {
     controller.breadcrumbs = [
       { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: this.secretMountPath.currentPath, route: 'overview', model: this.secretMountPath.currentPath },
-      { label: 'issuers', route: 'issuers.index', model: this.secretMountPath.currentPath },
+      { label: 'Issuers', route: 'issuers.index', model: this.secretMountPath.currentPath },
     ];
   }
 

--- a/ui/lib/pki/addon/routes/issuers/issuer.js
+++ b/ui/lib/pki/addon/routes/issuers/issuer.js
@@ -23,7 +23,7 @@ export default class PkiIssuerIndexRoute extends Route {
     controller.breadcrumbs = [
       { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: this.secretMountPath.currentPath, route: 'overview', model: this.secretMountPath.currentPath },
-      { label: 'issuers', route: 'issuers.index', model: this.secretMountPath.currentPath },
+      { label: 'Issuers', route: 'issuers.index', model: this.secretMountPath.currentPath },
     ];
   }
 }

--- a/ui/lib/pki/addon/routes/issuers/issuer/cross-sign.js
+++ b/ui/lib/pki/addon/routes/issuers/issuer/cross-sign.js
@@ -22,13 +22,13 @@ export default class PkiIssuerCrossSignRoute extends Route {
     controller.breadcrumbs = [
       { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: this.secretMountPath.currentPath, route: 'overview', model: this.secretMountPath.currentPath },
-      { label: 'issuers', route: 'issuers.index', model: this.secretMountPath.currentPath },
+      { label: 'Issuers', route: 'issuers.index', model: this.secretMountPath.currentPath },
       {
         label: resolvedModel.id,
         route: 'issuers.issuer.details',
         models: [this.secretMountPath.currentPath, resolvedModel.id],
       },
-      { label: 'cross-sign' },
+      { label: 'Cross-sign' },
     ];
   }
 }

--- a/ui/lib/pki/addon/routes/issuers/issuer/details.js
+++ b/ui/lib/pki/addon/routes/issuers/issuer/details.js
@@ -28,7 +28,7 @@ export default class PkiIssuerDetailsRoute extends Route {
     controller.breadcrumbs = [
       { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: this.secretMountPath.currentPath, route: 'overview', model: resolvedModel.backend },
-      { label: 'issuers', route: 'issuers.index', model: resolvedModel.backend },
+      { label: 'Issuers', route: 'issuers.index', model: resolvedModel.backend },
       { label: resolvedModel.issuer.id },
     ];
   }

--- a/ui/lib/pki/addon/routes/issuers/issuer/edit.js
+++ b/ui/lib/pki/addon/routes/issuers/issuer/edit.js
@@ -25,13 +25,13 @@ export default class PkiIssuerEditRoute extends Route {
     controller.breadcrumbs = [
       { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: this.secretMountPath.currentPath, route: 'overview', model: this.secretMountPath.currentPath },
-      { label: 'issuers', route: 'issuers.index', model: this.secretMountPath.currentPath },
+      { label: 'Issuers', route: 'issuers.index', model: this.secretMountPath.currentPath },
       {
         label: resolvedModel.id,
         route: 'issuers.issuer.details',
         models: [this.secretMountPath.currentPath, resolvedModel.id],
       },
-      { label: 'update' },
+      { label: 'Update' },
     ];
   }
 }

--- a/ui/lib/pki/addon/routes/issuers/issuer/rotate-root.js
+++ b/ui/lib/pki/addon/routes/issuers/issuer/rotate-root.js
@@ -41,13 +41,13 @@ export default class PkiIssuerRotateRootRoute extends Route {
     controller.breadcrumbs = [
       { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: this.secretMountPath.currentPath, route: 'overview', model: resolvedModel.oldRoot.backend },
-      { label: 'issuers', route: 'issuers.index', model: resolvedModel.oldRoot.backend },
+      { label: 'Issuers', route: 'issuers.index', model: resolvedModel.oldRoot.backend },
       {
         label: resolvedModel.oldRoot.id,
         route: 'issuers.issuer.details',
         models: [resolvedModel.oldRoot.backend, resolvedModel.oldRoot.id],
       },
-      { label: 'rotate root' },
+      { label: 'Rotate Root' },
     ];
   }
 }

--- a/ui/lib/pki/addon/routes/issuers/issuer/sign.js
+++ b/ui/lib/pki/addon/routes/issuers/issuer/sign.js
@@ -21,13 +21,13 @@ export default class PkiIssuerSignRoute extends Route {
     controller.breadcrumbs = [
       { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: this.secretMountPath.currentPath, route: 'overview', model: this.secretMountPath.currentPath },
-      { label: 'issuers', route: 'issuers.index', model: this.secretMountPath.currentPath },
+      { label: 'Issuers', route: 'issuers.index', model: this.secretMountPath.currentPath },
       {
         label: resolvedModel.issuerRef,
         route: 'issuers.issuer.details',
         models: [this.secretMountPath.currentPath, resolvedModel.issuerRef],
       },
-      { label: 'sign intermediate' },
+      { label: 'Sign Intermediate' },
     ];
   }
 }

--- a/ui/lib/pki/addon/routes/keys/create.js
+++ b/ui/lib/pki/addon/routes/keys/create.js
@@ -21,8 +21,8 @@ export default class PkiKeysCreateRoute extends Route {
     controller.breadcrumbs = [
       { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: this.secretMountPath.currentPath, route: 'overview', model: this.secretMountPath.currentPath },
-      { label: 'keys', route: 'keys.index', model: this.secretMountPath.currentPath },
-      { label: 'generate' },
+      { label: 'Keys', route: 'keys.index', model: this.secretMountPath.currentPath },
+      { label: 'Generate' },
     ];
   }
 }

--- a/ui/lib/pki/addon/routes/keys/import.js
+++ b/ui/lib/pki/addon/routes/keys/import.js
@@ -21,8 +21,8 @@ export default class PkiKeysImportRoute extends Route {
     controller.breadcrumbs = [
       { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: this.secretMountPath.currentPath, route: 'overview', model: this.secretMountPath.currentPath },
-      { label: 'keys', route: 'keys.index', model: this.secretMountPath.currentPath },
-      { label: 'import' },
+      { label: 'Keys', route: 'keys.index', model: this.secretMountPath.currentPath },
+      { label: 'Import' },
     ];
   }
 }

--- a/ui/tests/acceptance/secrets/backend/kv/kv-v2-workflow-navigation-test.js
+++ b/ui/tests/acceptance/secrets/backend/kv/kv-v2-workflow-navigation-test.js
@@ -277,7 +277,7 @@ module('Acceptance | kv-v2 workflow | navigation', function (hooks) {
         `/vault/secrets/${backend}/kv/${secretPathUrlEncoded}/metadata`,
         `goes to metadata page`
       );
-      assertCorrectBreadcrumbs(assert, ['Secrets', backend, secretPath, 'metadata']);
+      assertCorrectBreadcrumbs(assert, ['Secrets', backend, secretPath, 'Metadata']);
       assert.dom(PAGE.title).hasText(secretPath);
       assert
         .dom(`${PAGE.metadata.customMetadataSection} ${PAGE.emptyStateTitle}`)
@@ -293,7 +293,7 @@ module('Acceptance | kv-v2 workflow | navigation', function (hooks) {
         `/vault/secrets/${backend}/kv/${secretPathUrlEncoded}/metadata/edit`,
         `goes to metadata edit page`
       );
-      assertCorrectBreadcrumbs(assert, ['Secrets', backend, secretPath, 'metadata', 'edit']);
+      assertCorrectBreadcrumbs(assert, ['Secrets', backend, secretPath, 'Metadata', 'Edit']);
       await click(FORM.cancelBtn);
       assert.strictEqual(
         currentURL(),
@@ -306,7 +306,7 @@ module('Acceptance | kv-v2 workflow | navigation', function (hooks) {
       const backend = this.backend;
       await navToBackend(backend);
       await click(PAGE.secretTab('Configuration'));
-      assertCorrectBreadcrumbs(assert, ['Secrets', backend, 'configuration']);
+      assertCorrectBreadcrumbs(assert, ['Secrets', backend, 'Configuration']);
       assert.dom(PAGE.title).hasText(`${backend} version 2`, 'correct page title for configuration');
 
       await click(PAGE.secretTab('Secrets'));
@@ -318,25 +318,25 @@ module('Acceptance | kv-v2 workflow | navigation', function (hooks) {
       assert.dom(PAGE.title).hasText(secretPath, 'correct page title for secret detail');
 
       await click(PAGE.detail.createNewVersion);
-      assertCorrectBreadcrumbs(assert, ['Secrets', backend, secretPath, 'edit']);
+      assertCorrectBreadcrumbs(assert, ['Secrets', backend, secretPath, 'Edit']);
       assert.dom(PAGE.title).hasText('Create New Version', 'correct page title for secret edit');
 
       await click(PAGE.breadcrumbAtIdx(2));
       await click(PAGE.secretTab('Metadata'));
-      assertCorrectBreadcrumbs(assert, ['Secrets', backend, secretPath, 'metadata']);
+      assertCorrectBreadcrumbs(assert, ['Secrets', backend, secretPath, 'Metadata']);
       assert.dom(PAGE.title).hasText(secretPath, 'correct page title for metadata');
 
       await click(PAGE.metadata.editBtn);
-      assertCorrectBreadcrumbs(assert, ['Secrets', backend, secretPath, 'metadata', 'edit']);
+      assertCorrectBreadcrumbs(assert, ['Secrets', backend, secretPath, 'Metadata', 'Edit']);
       assert.dom(PAGE.title).hasText('Edit Secret Metadata', 'correct page title for metadata edit');
 
       await click(PAGE.breadcrumbAtIdx(3));
       await click(PAGE.secretTab('Paths'));
-      assertCorrectBreadcrumbs(assert, ['Secrets', backend, secretPath, 'paths']);
+      assertCorrectBreadcrumbs(assert, ['Secrets', backend, secretPath, 'Paths']);
       assert.dom(PAGE.title).hasText(secretPath, 'correct page title for paths');
 
       await click(PAGE.secretTab('Version History'));
-      assertCorrectBreadcrumbs(assert, ['Secrets', backend, secretPath, 'version history']);
+      assertCorrectBreadcrumbs(assert, ['Secrets', backend, secretPath, 'Version History']);
       assert.dom(PAGE.title).hasText(secretPath, 'correct page title for version history');
     });
   });
@@ -477,7 +477,7 @@ module('Acceptance | kv-v2 workflow | navigation', function (hooks) {
         `/vault/secrets/${backend}/kv/${secretPathUrlEncoded}/metadata`,
         `goes to metadata page`
       );
-      assertCorrectBreadcrumbs(assert, ['Secrets', backend, secretPath, 'metadata']);
+      assertCorrectBreadcrumbs(assert, ['Secrets', backend, secretPath, 'Metadata']);
       assert.dom(PAGE.title).hasText(secretPath);
       assert.dom(PAGE.toolbarAction).doesNotExist('no toolbar actions available on metadata');
       assert
@@ -493,7 +493,7 @@ module('Acceptance | kv-v2 workflow | navigation', function (hooks) {
       const backend = this.backend;
       await navToBackend(backend);
       await click(PAGE.secretTab('Configuration'));
-      assertCorrectBreadcrumbs(assert, ['Secrets', backend, 'configuration']);
+      assertCorrectBreadcrumbs(assert, ['Secrets', backend, 'Configuration']);
       assert.dom(PAGE.title).hasText(`${backend} version 2`, 'title correct on config page');
 
       await click(PAGE.secretTab('Secrets'));
@@ -508,13 +508,13 @@ module('Acceptance | kv-v2 workflow | navigation', function (hooks) {
       assert.dom(PAGE.detail.createNewVersion).doesNotExist('cannot create new version');
 
       await click(PAGE.secretTab('Metadata'));
-      assertCorrectBreadcrumbs(assert, ['Secrets', backend, 'app', 'nested', 'secret', 'metadata']);
+      assertCorrectBreadcrumbs(assert, ['Secrets', backend, 'app', 'nested', 'secret', 'Metadata']);
       assert.dom(PAGE.title).hasText('app/nested/secret', 'title correct on metadata');
 
       assert.dom(PAGE.metadata.editBtn).doesNotExist('cannot edit metadata');
 
       await click(PAGE.secretTab('Paths'));
-      assertCorrectBreadcrumbs(assert, ['Secrets', backend, 'app', 'nested', 'secret', 'paths']);
+      assertCorrectBreadcrumbs(assert, ['Secrets', backend, 'app', 'nested', 'secret', 'Paths']);
       assert.dom(PAGE.title).hasText('app/nested/secret', 'correct page title for paths');
 
       assert.dom(PAGE.secretTab('Version History')).doesNotExist('Version History tab not shown');
@@ -650,7 +650,7 @@ module('Acceptance | kv-v2 workflow | navigation', function (hooks) {
         `/vault/secrets/${backend}/kv/${secretPathUrlEncoded}/metadata`,
         `goes to metadata page`
       );
-      assertCorrectBreadcrumbs(assert, ['Secrets', backend, secretPath, 'metadata']);
+      assertCorrectBreadcrumbs(assert, ['Secrets', backend, secretPath, 'Metadata']);
       assert.dom(PAGE.title).hasText(secretPath);
       assert
         .dom(`${PAGE.metadata.customMetadataSection} ${PAGE.emptyStateTitle}`)
@@ -666,7 +666,7 @@ module('Acceptance | kv-v2 workflow | navigation', function (hooks) {
       await navToBackend(backend);
 
       await click(PAGE.secretTab('Configuration'));
-      assertCorrectBreadcrumbs(assert, ['Secrets', backend, 'configuration']);
+      assertCorrectBreadcrumbs(assert, ['Secrets', backend, 'Configuration']);
       assert.dom(PAGE.title).hasText(`${backend} version 2`, 'correct page title for configuration');
 
       await click(PAGE.secretTab('Secrets'));
@@ -680,13 +680,13 @@ module('Acceptance | kv-v2 workflow | navigation', function (hooks) {
       assert.dom(PAGE.detail.createNewVersion).doesNotExist('cannot create new version');
 
       await click(PAGE.secretTab('Metadata'));
-      assertCorrectBreadcrumbs(assert, ['Secrets', backend, secretPath, 'metadata']);
+      assertCorrectBreadcrumbs(assert, ['Secrets', backend, secretPath, 'Metadata']);
       assert.dom(PAGE.title).hasText(secretPath, 'correct page title for metadata');
 
       assert.dom(PAGE.metadata.editBtn).doesNotExist('cannot edit metadata');
 
       await click(PAGE.secretTab('Paths'));
-      assertCorrectBreadcrumbs(assert, ['Secrets', backend, secretPath, 'paths']);
+      assertCorrectBreadcrumbs(assert, ['Secrets', backend, secretPath, 'Paths']);
       assert.dom(PAGE.title).hasText(secretPath, 'correct page title for paths');
 
       assert.dom(PAGE.secretTab('Version History')).doesNotExist('Version History tab not shown');
@@ -837,7 +837,7 @@ module('Acceptance | kv-v2 workflow | navigation', function (hooks) {
         `/vault/secrets/${backend}/kv/${secretPathUrlEncoded}/metadata`,
         `goes to metadata page`
       );
-      assertCorrectBreadcrumbs(assert, ['Secrets', backend, secretPath, 'metadata']);
+      assertCorrectBreadcrumbs(assert, ['Secrets', backend, secretPath, 'Metadata']);
       assert.dom(PAGE.title).hasText(secretPath);
       assert
         .dom(`${PAGE.metadata.customMetadataSection} ${PAGE.emptyStateTitle}`)
@@ -853,7 +853,7 @@ module('Acceptance | kv-v2 workflow | navigation', function (hooks) {
         `/vault/secrets/${backend}/kv/${secretPathUrlEncoded}/metadata/edit`,
         `goes to metadata edit page`
       );
-      assertCorrectBreadcrumbs(assert, ['Secrets', backend, secretPath, 'metadata', 'edit']);
+      assertCorrectBreadcrumbs(assert, ['Secrets', backend, secretPath, 'Metadata', 'Edit']);
       await click(FORM.cancelBtn);
       assert.strictEqual(
         currentURL(),
@@ -866,7 +866,7 @@ module('Acceptance | kv-v2 workflow | navigation', function (hooks) {
       const backend = this.backend;
       await navToBackend(backend);
       await click(PAGE.secretTab('Configuration'));
-      assertCorrectBreadcrumbs(assert, ['Secrets', backend, 'configuration']);
+      assertCorrectBreadcrumbs(assert, ['Secrets', backend, 'Configuration']);
       assert.dom(PAGE.title).hasText(`${backend} version 2`, 'correct page title for configuration');
 
       await click(PAGE.secretTab('Secrets'));
@@ -878,20 +878,20 @@ module('Acceptance | kv-v2 workflow | navigation', function (hooks) {
       assert.dom(PAGE.title).hasText(secretPath, 'correct page title for secret detail');
 
       await click(PAGE.secretTab('Metadata'));
-      assertCorrectBreadcrumbs(assert, ['Secrets', backend, secretPath, 'metadata']);
+      assertCorrectBreadcrumbs(assert, ['Secrets', backend, secretPath, 'Metadata']);
       assert.dom(PAGE.title).hasText(secretPath, 'correct page title for metadata');
 
       await click(PAGE.metadata.editBtn);
-      assertCorrectBreadcrumbs(assert, ['Secrets', backend, secretPath, 'metadata', 'edit']);
+      assertCorrectBreadcrumbs(assert, ['Secrets', backend, secretPath, 'Metadata', 'Edit']);
       assert.dom(PAGE.title).hasText('Edit Secret Metadata', 'correct page title for metadata edit');
 
       await click(PAGE.breadcrumbAtIdx(3));
       await click(PAGE.secretTab('Paths'));
-      assertCorrectBreadcrumbs(assert, ['Secrets', backend, secretPath, 'paths']);
+      assertCorrectBreadcrumbs(assert, ['Secrets', backend, secretPath, 'Paths']);
       assert.dom(PAGE.title).hasText(secretPath, 'correct page title for paths');
 
       await click(PAGE.secretTab('Version History'));
-      assertCorrectBreadcrumbs(assert, ['Secrets', backend, secretPath, 'version history']);
+      assertCorrectBreadcrumbs(assert, ['Secrets', backend, secretPath, 'Version History']);
       assert.dom(PAGE.title).hasText(secretPath, 'correct page title for version history');
     });
   });
@@ -1052,7 +1052,7 @@ module('Acceptance | kv-v2 workflow | navigation', function (hooks) {
         `/vault/secrets/${backend}/kv/${secretPathUrlEncoded}/metadata`,
         `goes to metadata page`
       );
-      assertCorrectBreadcrumbs(assert, ['Secrets', backend, secretPath, 'metadata']);
+      assertCorrectBreadcrumbs(assert, ['Secrets', backend, secretPath, 'Metadata']);
       assert.dom(PAGE.title).hasText(secretPath);
       assert
         .dom(`${PAGE.metadata.customMetadataSection} ${PAGE.emptyStateTitle}`)
@@ -1064,7 +1064,7 @@ module('Acceptance | kv-v2 workflow | navigation', function (hooks) {
       const backend = this.backend;
       await navToBackend(backend);
       await click(PAGE.secretTab('Configuration'));
-      assertCorrectBreadcrumbs(assert, ['Secrets', backend, 'configuration']);
+      assertCorrectBreadcrumbs(assert, ['Secrets', backend, 'Configuration']);
       assert.dom(PAGE.title).hasText(`${backend} version 2`, 'correct page title for configuration');
 
       await click(PAGE.secretTab('Secrets'));
@@ -1077,19 +1077,19 @@ module('Acceptance | kv-v2 workflow | navigation', function (hooks) {
       assert.dom(PAGE.title).hasText(secretPath, 'correct page title for secret detail');
 
       await click(PAGE.detail.createNewVersion);
-      assertCorrectBreadcrumbs(assert, ['Secrets', backend, secretPath, 'edit']);
+      assertCorrectBreadcrumbs(assert, ['Secrets', backend, secretPath, 'Edit']);
       assert.dom(PAGE.title).hasText('Create New Version', 'correct page title for secret edit');
 
       await click(PAGE.breadcrumbAtIdx(2));
       await click(PAGE.secretTab('Metadata'));
-      assertCorrectBreadcrumbs(assert, ['Secrets', backend, secretPath, 'metadata']);
+      assertCorrectBreadcrumbs(assert, ['Secrets', backend, secretPath, 'Metadata']);
       assert.dom(PAGE.title).hasText(secretPath, 'correct page title for metadata');
 
       assert.dom(PAGE.metadata.editBtn).doesNotExist('cannot edit metadata');
 
       await click(PAGE.breadcrumbAtIdx(2));
       await click(PAGE.secretTab('Paths'));
-      assertCorrectBreadcrumbs(assert, ['Secrets', backend, secretPath, 'paths']);
+      assertCorrectBreadcrumbs(assert, ['Secrets', backend, secretPath, 'Paths']);
       assert.dom(PAGE.title).hasText(secretPath, 'correct page title for paths');
 
       assert.dom(PAGE.secretTab('Version History')).doesNotExist('Version History tab not shown');
@@ -1197,7 +1197,7 @@ path "${this.backend}/*" {
       const backend = this.backend;
       await navToBackend(backend);
       await click(PAGE.secretTab('Configuration'));
-      assertCorrectBreadcrumbs(assert, ['Secrets', backend, 'configuration']);
+      assertCorrectBreadcrumbs(assert, ['Secrets', backend, 'Configuration']);
       assert.dom(PAGE.title).hasText(`${backend} version 2`, 'correct page title for configuration');
 
       await click(PAGE.secretTab('Secrets'));
@@ -1228,21 +1228,21 @@ path "${this.backend}/*" {
       assert.dom(PAGE.title).hasText(secretPath, 'correct page title for secret detail');
 
       await click(PAGE.secretTab('Metadata'));
-      assertCorrectBreadcrumbs(assert, ['Secrets', backend, secretPath, 'metadata']);
+      assertCorrectBreadcrumbs(assert, ['Secrets', backend, secretPath, 'Metadata']);
       assert.dom(PAGE.title).hasText(secretPath, 'correct page title for metadata');
 
       assert.dom(PAGE.metadata.editBtn).doesNotExist('cannot edit metadata');
 
       await click(PAGE.breadcrumbAtIdx(2));
       await click(PAGE.secretTab('Paths'));
-      assertCorrectBreadcrumbs(assert, ['Secrets', backend, secretPath, 'paths']);
+      assertCorrectBreadcrumbs(assert, ['Secrets', backend, secretPath, 'Paths']);
       assert.dom(PAGE.title).hasText(secretPath, 'correct page title for paths');
 
       assert.dom(PAGE.secretTab('Version History')).doesNotExist('Version History tab not shown');
 
       await click(PAGE.secretTab('Secret'));
       await click(PAGE.detail.createNewVersion);
-      assertCorrectBreadcrumbs(assert, ['Secrets', backend, secretPath, 'edit']);
+      assertCorrectBreadcrumbs(assert, ['Secrets', backend, secretPath, 'Edit']);
       assert.dom(PAGE.title).hasText('Create New Version', 'correct page title for secret edit');
     });
   });

--- a/ui/tests/integration/components/kv/page/kv-page-metadata-edit-test.js
+++ b/ui/tests/integration/components/kv/page/kv-page-metadata-edit-test.js
@@ -44,7 +44,7 @@ module('Integration | Component | kv | Page::Secret::Metadata::Edit', function (
       { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: this.metadataModelCreate.backend, route: 'list' },
       { label: this.metadataModelCreate.path, route: 'secret.details', model: this.metadataModelCreate.path },
-      { label: 'metadata' },
+      { label: 'Metadata' },
     ];
     await render(
       hbs`
@@ -74,7 +74,7 @@ module('Integration | Component | kv | Page::Secret::Metadata::Edit', function (
       { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: this.metadataModelEdit.backend, route: 'list' },
       { label: this.metadataModelEdit.path, route: 'secret.details', model: this.metadataModelEdit.path },
-      { label: 'metadata' },
+      { label: 'Metadata' },
     ];
     await render(
       hbs`
@@ -131,7 +131,7 @@ module('Integration | Component | kv | Page::Secret::Metadata::Edit', function (
       { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: this.metadataModelEdit.backend, route: 'list' },
       { label: this.metadataModelEdit.path, route: 'secret.details', model: this.metadataModelEdit.path },
-      { label: 'metadata' },
+      { label: 'Metadata' },
     ];
     await render(
       hbs`
@@ -162,7 +162,7 @@ module('Integration | Component | kv | Page::Secret::Metadata::Edit', function (
       { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: this.metadataModelEdit.backend, route: 'list' },
       { label: this.metadataModelEdit.path, route: 'secret.details', model: this.metadataModelEdit.path },
-      { label: 'metadata' },
+      { label: 'Metadata' },
     ];
     await render(
       hbs`

--- a/ui/tests/integration/components/kv/page/kv-page-version-diff-test.js
+++ b/ui/tests/integration/components/kv/page/kv-page-version-diff-test.js
@@ -21,7 +21,7 @@ module('Integration | Component | kv | Page::Secret::Metadata::VersionDiff', fun
   hooks.beforeEach(async function () {
     this.backend = 'kv-engine';
     this.path = 'my-secret';
-    this.breadcrumbs = [{ label: 'version history', route: 'secret.metadata.versions' }, { label: 'diff' }];
+    this.breadcrumbs = [{ label: 'Version History', route: 'secret.metadata.versions' }, { label: 'Diff' }];
 
     this.store = this.owner.lookup('service:store');
     this.server.post('/sys/capabilities-self', allowAllCapabilitiesStub());

--- a/ui/tests/integration/components/kv/page/kv-page-version-history-test.js
+++ b/ui/tests/integration/components/kv/page/kv-page-version-history-test.js
@@ -39,7 +39,7 @@ module('Integration | Component | kv | Page::Secret::Metadata::Version-History',
       { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: this.metadata.backend, route: 'list' },
       { label: this.metadata.path, route: 'secret.details', model: this.metadata.path },
-      { label: 'version history' },
+      { label: 'Version History' },
     ];
   });
 

--- a/ui/tests/integration/components/ldap/page/library/create-and-edit-test.js
+++ b/ui/tests/integration/components/ldap/page/library/create-and-edit-test.js
@@ -37,8 +37,8 @@ module('Integration | Component | ldap | Page::Library::CreateAndEdit', function
 
     this.breadcrumbs = [
       { label: 'ldap', route: 'overview' },
-      { label: 'libraries', route: 'libraries' },
-      { label: 'create' },
+      { label: 'Libraries', route: 'libraries' },
+      { label: 'Create' },
     ];
 
     this.renderComponent = () => {

--- a/ui/tests/integration/components/ldap/page/role/create-and-edit-test.js
+++ b/ui/tests/integration/components/ldap/page/role/create-and-edit-test.js
@@ -40,8 +40,8 @@ module('Integration | Component | ldap | Page::Role::CreateAndEdit', function (h
 
     this.breadcrumbs = [
       { label: 'ldap', route: 'overview' },
-      { label: 'roles', route: 'roles' },
-      { label: 'create' },
+      { label: 'Roles', route: 'roles' },
+      { label: 'Create' },
     ];
 
     this.renderComponent = () => {


### PR DESCRIPTION
- [x] enterprise test pass

### Description
This PR Title Cases all static (aka non-user inputed) labels. This aligns with the design patterns. Not backporting as this is not a bug fix. There will be a follow up PR that address AWS' missing create and configure breadcrumbs. Both will be merged to main, but keeping separate for scope reasons.

**After**
![image](https://github.com/user-attachments/assets/d2c4e0a2-f288-46c8-b1ae-4e5cc6d5be12)

**Before**
![image](https://github.com/user-attachments/assets/ae94b545-d2cc-4872-adf3-19956019d7d9)


### TODO only if you're a HashiCorp employee
- [ ] **Labels:** If this PR is the CE portion of an ENT change, and that ENT change is
  getting backported to N-2, use the new style `backport/ent/x.x.x+ent` labels
  instead of the old style `backport/x.x.x` labels.
- [ ] **Labels:** If this PR is a CE only change, it can only be backported to N, so use
  the normal `backport/x.x.x` label (there should be only 1).
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
