### PR TITLE
Audit: log 'warnings' from eventlogger even if audit is deemed a success

### DIFF
--- a/audit/broker.go
+++ b/audit/broker.go
@@ -315,6 +315,12 @@ func (b *Broker) LogRequest(ctx context.Context, in *logical.LogInput) (ret erro
 
 	// Audit event ended up in at least 1 sink.
 	if len(status.CompleteSinks()) > 0 {
+		// We should log warnings to the operational logs regardless of whether
+		// we consider the overall auditing attempt to be successful.
+		if len(status.Warnings) > 0 {
+			b.logger.Error("log request underlying pipeline error(s)", "error", &multierror.Error{Errors: status.Warnings})
+		}
+
 		return retErr.ErrorOrNil()
 	}
 
@@ -397,6 +403,12 @@ func (b *Broker) LogResponse(ctx context.Context, in *logical.LogInput) (ret err
 
 	// Audit event ended up in at least 1 sink.
 	if len(status.CompleteSinks()) > 0 {
+		// We should log warnings to the operational logs regardless of whether
+		// we consider the overall auditing attempt to be successful.
+		if len(status.Warnings) > 0 {
+			b.logger.Error("log response underlying pipeline error(s)", "error", &multierror.Error{Errors: status.Warnings})
+		}
+
 		return retErr.ErrorOrNil()
 	}
 

--- a/changelog/27809.txt
+++ b/changelog/27809.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+audit: Ensure that any underyling errors from audit devices are logged even if we consider auditing to be a success.
+```


### PR DESCRIPTION
### Description

Within `audit` there exists an scenario where the `eventlogger` broker reports that audit was deemed a success (because it managed to successfully log to at least 1 sink node), but there were warnings (errors) that came back from other audit devices where audit failed. 

We want to ensure that we capture these warnings in the server log so that they don't go missing because we managed to log to a single device.

This PR has ENT and CE components.

### HashiCorp Checklist

- [ ] **Labels:** If this PR is the CE portion of an ENT change, and that ENT change is
  getting backported to N-2, use the new style `backport/ent/x.x.x+ent` labels
  instead of the old style `backport/x.x.x` labels.
- [ ] **Labels:** If this PR is a CE only change, it can only be backported to N, so use
  the normal `backport/x.x.x` label (there should be only 1).
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] ~**Jira:** If this change has an associated Jira, it's referenced either~
  in the PR description, commit message, or branch name.
- [ ] ~**RFC:** If this change has an associated RFC, please link it in the description.~
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
