### PR TITLE
VAULT-27384 Fix faulty assignments and unchecked errors

### DIFF
--- a/builtin/logical/database/secret_creds.go
+++ b/builtin/logical/database/secret_creds.go
@@ -34,6 +34,9 @@ func (b *databaseBackend) secretCredsRenew() framework.OperationFunc {
 			return nil, fmt.Errorf("secret is missing username internal data")
 		}
 		username, ok := usernameRaw.(string)
+		if !ok {
+			return nil, fmt.Errorf("username not a string")
+		}
 
 		roleNameRaw, ok := req.Secret.InternalData["role"]
 		if !ok {
@@ -98,6 +101,9 @@ func (b *databaseBackend) secretCredsRevoke() framework.OperationFunc {
 			return nil, fmt.Errorf("secret is missing username internal data")
 		}
 		username, ok := usernameRaw.(string)
+		if !ok {
+			return nil, fmt.Errorf("username not a string")
+		}
 
 		var resp *logical.Response
 

--- a/command/agentproxyshared/auth/auth.go
+++ b/command/agentproxyshared/auth/auth.go
@@ -313,10 +313,11 @@ func (ah *AuthHandler) Run(ctx context.Context, am AuthMethod) error {
 			isTokenFileMethod = path == "auth/token/lookup-self"
 			if isTokenFileMethod {
 				token, _ := data["token"].(string)
-				lookupSelfClient, err := clientToUse.CloneWithHeaders()
-				if err != nil {
+				// The error is called clientErr as to not shadow the other err above it.
+				lookupSelfClient, clientErr := clientToUse.CloneWithHeaders()
+				if clientErr != nil {
 					ah.logger.Error("failed to clone client to perform token lookup")
-					return err
+					return clientErr
 				}
 				lookupSelfClient.SetToken(token)
 				secret, err = lookupSelfClient.Auth().Token().LookupSelf()

--- a/command/pki_reissue_intermediate.go
+++ b/command/pki_reissue_intermediate.go
@@ -113,6 +113,10 @@ func (c *PKIReIssueCACommand) Run(args []string) int {
 	}
 
 	templateData, err := parseTemplateCertificate(*certificate, useExistingKey, keyRef)
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("Error fetching parsing template certificate: %v", err))
+		return 1
+	}
 	data := updateTemplateWithData(templateData, userData)
 
 	return pkiIssue(c.BaseCommand, parentIssuer, intermediateMount, c.flagNewIssuerName, c.flagKeyStorageSource, data)

--- a/helper/testhelpers/pluginhelpers/pluginhelpers.go
+++ b/helper/testhelpers/pluginhelpers/pluginhelpers.go
@@ -76,15 +76,17 @@ func CompilePlugin(t testing.TB, typ consts.PluginType, pluginVersion string, pl
 	var pluginBytes []byte
 
 	dir := ""
-	var err error
 	pluginRootDir := "builtin"
 	if typ == consts.PluginTypeDatabase {
 		pluginRootDir = "plugins"
 	}
 	for {
-		dir, err = os.Getwd()
-		if err != nil {
-			t.Fatal(err)
+		// So that we can assign to dir without overshadowing the other
+		// err variables.
+		var getWdErr error
+		dir, getWdErr = os.Getwd()
+		if getWdErr != nil {
+			t.Fatal(getWdErr)
 		}
 		// detect if we are in a subdirectory or the root directory and compensate
 		if _, err := os.Stat(pluginRootDir); os.IsNotExist(err) {
@@ -131,12 +133,9 @@ func CompilePlugin(t testing.TB, typ consts.PluginType, pluginVersion string, pl
 	if _, err := os.Stat(pluginPath); os.IsNotExist(err) {
 		err = os.WriteFile(pluginPath, pluginBytes, 0o755)
 	}
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	sha := sha256.New()
-	_, err = sha.Write(pluginBytes)
+	_, err := sha.Write(pluginBytes)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/helper/testhelpers/pluginhelpers/pluginhelpers.go
+++ b/helper/testhelpers/pluginhelpers/pluginhelpers.go
@@ -130,8 +130,16 @@ func CompilePlugin(t testing.TB, typ consts.PluginType, pluginVersion string, pl
 	}
 
 	// write the cached plugin if necessary
-	if _, err := os.Stat(pluginPath); os.IsNotExist(err) {
-		err = os.WriteFile(pluginPath, pluginBytes, 0o755)
+	_, statErr := os.Stat(pluginPath)
+	if os.IsNotExist(statErr) {
+		err := os.WriteFile(pluginPath, pluginBytes, 0o755)
+		if err != nil {
+			t.Fatal(err)
+		}
+	} else {
+		if statErr != nil {
+			t.Fatal(statErr)
+		}
 	}
 
 	sha := sha256.New()

--- a/vault/eventbus/bus.go
+++ b/vault/eventbus/bus.go
@@ -237,6 +237,9 @@ func (bus *EventBus) subscribeInternal(ctx context.Context, namespacePathPattern
 	var filterNode *eventlogger.Filter
 	if cluster != nil {
 		filterNode, err = newClusterFilterNode(bus.filters, clusterID(*cluster))
+		if err != nil {
+			return nil, nil, err
+		}
 	} else {
 		filterNode, err = newFilterNode(namespacePathPatterns, pattern, bexprFilter)
 		if err != nil {


### PR DESCRIPTION
### Description

This fixes a few issues raised by a static analysis tool indicating incorrect assignments, and unchecked errors via shadowing or simply missed checking. 

None of these are security issues or anything like that, but we should definitely clean them up.

I don't think this is worth a changelog, as nothing should really change, this is mostly housekeeping, but if folks feel otherwise I'm all ears.

### TODO only if you're a HashiCorp employee
- [x] **Labels:** If this PR is the CE portion of an ENT change, and that ENT change is
  getting backported to N-2, use the new style `backport/ent/x.x.x+ent` labels
  instead of the old style `backport/x.x.x` labels.
- [x] **Labels:** If this PR is a CE only change, it can only be backported to N, so use
  the normal `backport/x.x.x` label (there should be only 1).
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
