### PR TITLE
[Docs] Add a warning about namespace info for HVD

### DIFF
--- a/website/content/api-docs/index.mdx
+++ b/website/content/api-docs/index.mdx
@@ -54,6 +54,8 @@ in periods. Otherwise, Vault will return a 404 unsupported path error.
 
 ## Namespaces
 
+@include 'alerts/enterprise-and-hcp.mdx'
+
 When using [Namespaces](/vault/docs/enterprise/namespaces) the final path of the API
 request is relative to the `X-Vault-Namespace` header. For instance, if a
 request URI is `secret/foo` with the `X-Vault-Namespace` header set as `ns1/ns2/`,
@@ -82,6 +84,19 @@ $ curl \
     -X GET \
     http://127.0.0.1:8200/v1/ns1/ns2/secret/foo
 ```
+
+<Warning title="HCP Vault Dedicated">
+
+When you are working with HCP Vault Dedicated, the API request must specify the
+target namespace. In absence of an explicit namespace, Vault tries to send
+the request to `root` namespace which results in an error. 
+
+The top-level namespace for HCP Vault Dedicated clusters is `admin`, so the
+requests must include `-H "X-Vault-Namespace: admin"` header or `admin` in the
+API endpoint path.
+
+</Warning>
+
 
 ## API operations
 

--- a/website/content/api-docs/index.mdx
+++ b/website/content/api-docs/index.mdx
@@ -87,7 +87,7 @@ $ curl \
 
 <Warning title="HCP Vault Dedicated">
 
-When you are working with HCP Vault Dedicated, the API request must specify the
+When you are working with HCP Vault Dedicated, your request must specify the
 target namespace. In absence of an explicit namespace, Vault tries to send
 the request to `root` namespace which results in an error. 
 


### PR DESCRIPTION
### Description

🧵 [Slack thread](https://hashicorp.slack.com/archives/C8DK5PR0B/p1721200987445919)

It was reported that the given example API call does not work due to missing `X-Vault-Namespace` header when you're working with HCP Vault Dedicated. 

Although it was reported specifically with AppRole auth API doc, it is relevant to all API calls --> I cannot just update the AppRole API doc. 

So, this PR adds a callout note to the API doc landing page.


### TODO only if you're a HashiCorp employee
- [ ] **Labels:** If this PR is the CE portion of an ENT change, and that ENT change is
  getting backported to N-2, use the new style `backport/ent/x.x.x+ent` labels
  instead of the old style `backport/x.x.x` labels.
- [x] **Labels:** If this PR is a CE only change, it can only be backported to N, so use
  the normal `backport/x.x.x` label (there should be only 1).
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
