### PR TITLE
#27768 issue - ember-a11y-refocus new version 4.1.1

### DIFF
--- a/changelog/27832.txt
+++ b/changelog/27832.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: New version of ember-a11y-refocus to solve issue #27768
+```

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -2471,7 +2471,7 @@ __metadata:
     "@hashicorp/ember-flight-icons": ^5.1.2
     "@oddbird/popover-polyfill": ^0.4.3
     decorator-transforms: ^1.1.0
-    ember-a11y-refocus: ^4.1.0
+    ember-a11y-refocus: ^4.1.1
     ember-cli-sass: ^11.0.1
     ember-composable-helpers: ^5.0.0
     ember-element-helper: ^0.8.5


### PR DESCRIPTION
### Description
New version of  ember-a11y-refocus to solve issue #27768 

[dependencies](https://github.com/hashicorp/vault/labels/dependencies)
[bug](https://github.com/hashicorp/vault/labels/bug)