### PR TITLE
UI: Move OIDC key header out of form component

### DIFF
--- a/ui/app/templates/components/oidc/key-form.hbs
+++ b/ui/app/templates/components/oidc/key-form.hbs
@@ -3,25 +3,6 @@
   SPDX-License-Identifier: BUSL-1.1
 ~}}
 
-<PageHeader as |p|>
-  <p.top>
-    <Hds::Breadcrumb>
-      {{#if @model.isNew}}
-        <Hds::Breadcrumb::Item @text="Keys" @route="vault.cluster.access.oidc.keys" />
-      {{else}}
-        <Hds::Breadcrumb::Item @text="Details" @route="vault.cluster.access.oidc.keys.key.details" @model={{@model.name}} />
-      {{/if}}
-      <Hds::Breadcrumb::Item @text="{{if @model.isNew 'Create' 'Edit'}} Key" @current={{true}} />
-    </Hds::Breadcrumb>
-  </p.top>
-  <p.levelLeft>
-    <h1 class="title is-3" data-test-oidc-key-title>
-      {{if @model.isNew "Create" "Edit"}}
-      Key
-    </h1>
-  </p.levelLeft>
-</PageHeader>
-
 <form {{on "submit" (perform this.save)}}>
   <div class="box is-sideless is-fullwidth is-bottomless">
     <MessageError @errorMessage={{this.errorBanner}} />

--- a/ui/app/templates/vault/cluster/access/oidc/keys/create.hbs
+++ b/ui/app/templates/vault/cluster/access/oidc/keys/create.hbs
@@ -3,6 +3,20 @@
   SPDX-License-Identifier: BUSL-1.1
 ~}}
 
+<PageHeader as |p|>
+  <p.top>
+    <Hds::Breadcrumb>
+      <Hds::Breadcrumb::Item @text="Keys" @route="vault.cluster.access.oidc.keys" />
+      <Hds::Breadcrumb::Item @text="Create Key" @current={{true}} />
+    </Hds::Breadcrumb>
+  </p.top>
+  <p.levelLeft>
+    <h1 class="title is-3" data-test-oidc-key-title>
+      Create Key
+    </h1>
+  </p.levelLeft>
+</PageHeader>
+
 <Oidc::KeyForm
   @model={{this.model}}
   @onCancel={{transition-to "vault.cluster.access.oidc.keys"}}

--- a/ui/app/templates/vault/cluster/access/oidc/keys/create.hbs
+++ b/ui/app/templates/vault/cluster/access/oidc/keys/create.hbs
@@ -11,7 +11,7 @@
     </Hds::Breadcrumb>
   </p.top>
   <p.levelLeft>
-    <h1 class="title is-3" data-test-oidc-key-title>
+    <h1 class="title is-3">
       Create Key
     </h1>
   </p.levelLeft>

--- a/ui/app/templates/vault/cluster/access/oidc/keys/key/edit.hbs
+++ b/ui/app/templates/vault/cluster/access/oidc/keys/key/edit.hbs
@@ -6,7 +6,11 @@
 <PageHeader as |p|>
   <p.top>
     <Hds::Breadcrumb>
-      <Hds::Breadcrumb::Item @text="Details" @route="vault.cluster.access.oidc.keys.key.details" @model={{@model.name}} />
+      <Hds::Breadcrumb::Item
+        @text="Details"
+        @route="vault.cluster.access.oidc.keys.key.details"
+        @model={{this.model.name}}
+      />
       <Hds::Breadcrumb::Item @text="Edit Key" @current={{true}} />
     </Hds::Breadcrumb>
   </p.top>

--- a/ui/app/templates/vault/cluster/access/oidc/keys/key/edit.hbs
+++ b/ui/app/templates/vault/cluster/access/oidc/keys/key/edit.hbs
@@ -15,7 +15,7 @@
     </Hds::Breadcrumb>
   </p.top>
   <p.levelLeft>
-    <h1 class="title is-3" data-test-oidc-key-title>
+    <h1 class="title is-3">
       Edit Key
     </h1>
   </p.levelLeft>

--- a/ui/app/templates/vault/cluster/access/oidc/keys/key/edit.hbs
+++ b/ui/app/templates/vault/cluster/access/oidc/keys/key/edit.hbs
@@ -6,6 +6,7 @@
 <PageHeader as |p|>
   <p.top>
     <Hds::Breadcrumb>
+      <Hds::Breadcrumb::Item @text="Keys" @route="vault.cluster.access.oidc.keys" />
       <Hds::Breadcrumb::Item
         @text="Details"
         @route="vault.cluster.access.oidc.keys.key.details"

--- a/ui/app/templates/vault/cluster/access/oidc/keys/key/edit.hbs
+++ b/ui/app/templates/vault/cluster/access/oidc/keys/key/edit.hbs
@@ -3,6 +3,20 @@
   SPDX-License-Identifier: BUSL-1.1
 ~}}
 
+<PageHeader as |p|>
+  <p.top>
+    <Hds::Breadcrumb>
+      <Hds::Breadcrumb::Item @text="Details" @route="vault.cluster.access.oidc.keys.key.details" @model={{@model.name}} />
+      <Hds::Breadcrumb::Item @text="Edit Key" @current={{true}} />
+    </Hds::Breadcrumb>
+  </p.top>
+  <p.levelLeft>
+    <h1 class="title is-3" data-test-oidc-key-title>
+      Edit Key
+    </h1>
+  </p.levelLeft>
+</PageHeader>
+
 <Oidc::KeyForm
   @model={{this.model}}
   @onCancel={{transition-to "vault.cluster.access.oidc.keys.key.details" this.model.name}}

--- a/ui/tests/integration/components/oidc/key-form-test.js
+++ b/ui/tests/integration/components/oidc/key-form-test.js
@@ -49,7 +49,6 @@ module('Integration | Component | oidc/key-form', function (hooks) {
     />
     `);
 
-    assert.dom('[data-test-oidc-key-title]').hasText('Create Key', 'Form title renders correct text');
     assert.dom(SELECTORS.keySaveButton).hasText('Create', 'Save button has correct text');
     assert.dom('[data-test-input="algorithm"]').hasValue('RS256', 'default algorithm is correct');
     assert.strictEqual(findAll('[data-test-field]').length, 4, 'renders all input fields');
@@ -94,7 +93,6 @@ module('Integration | Component | oidc/key-form', function (hooks) {
       />
     `);
 
-    assert.dom('[data-test-oidc-key-title]').hasText('Edit Key', 'Title renders correct text');
     assert.dom(SELECTORS.keySaveButton).hasText('Update', 'Save button has correct text');
     assert.dom('[data-test-input="name"]').isDisabled('Name input is disabled when editing');
     assert.dom('[data-test-input="name"]').hasValue('test-key', 'Name input is populated with model value');

--- a/ui/tests/integration/components/oidc/key-form-test.js
+++ b/ui/tests/integration/components/oidc/key-form-test.js
@@ -34,7 +34,7 @@ module('Integration | Component | oidc/key-form', function (hooks) {
   });
 
   test('it should save new key', async function (assert) {
-    assert.expect(9);
+    assert.expect(8);
     this.server.post('/identity/oidc/key/test-key', (schema, req) => {
       assert.ok(true, 'Request made to save key');
       return JSON.parse(req.requestBody);
@@ -69,7 +69,7 @@ module('Integration | Component | oidc/key-form', function (hooks) {
   });
 
   test('it should update key and limit access to selected applications', async function (assert) {
-    assert.expect(12);
+    assert.expect(11);
 
     this.server.post('/identity/oidc/key/test-key', (schema, req) => {
       assert.ok(true, 'Request made to update key');


### PR DESCRIPTION
### Description
Moves the form page header to the route component, this supports the WIF work so that the form can be rendered in a search select modal. There are no user facing changes

### TODO only if you're a HashiCorp employee
- [ ] **Labels:** If this PR is the CE portion of an ENT change, and that ENT change is
  getting backported to N-2, use the new style `backport/ent/x.x.x+ent` labels
  instead of the old style `backport/x.x.x` labels.
- [ ] **Labels:** If this PR is a CE only change, it can only be backported to N, so use
  the normal `backport/x.x.x` label (there should be only 1).
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
