### PR TITLE
Remove distinct_entities and non_entity_tokens from ResponseCounts and update docs

### DIFF
--- a/vault/activity_log.go
+++ b/vault/activity_log.go
@@ -1685,9 +1685,7 @@ func (a *ActivityLog) receivedFragment(fragment *activity.LogFragment) {
 }
 
 type ResponseCounts struct {
-	DistinctEntities int `json:"distinct_entities" mapstructure:"distinct_entities"`
 	EntityClients    int `json:"entity_clients" mapstructure:"entity_clients"`
-	NonEntityTokens  int `json:"non_entity_tokens" mapstructure:"non_entity_tokens"`
 	NonEntityClients int `json:"non_entity_clients" mapstructure:"non_entity_clients"`
 	Clients          int `json:"clients"`
 	SecretSyncs      int `json:"secret_syncs" mapstructure:"secret_syncs"`

--- a/vault/activity_log.go
+++ b/vault/activity_log.go
@@ -2885,9 +2885,7 @@ func (a *ActivityLog) partialMonthClientCount(ctx context.Context) (map[string]i
 	// Now populate the response based on breakdowns.
 	responseData := make(map[string]interface{})
 	responseData["by_namespace"] = byNamespaceResponse
-	responseData["distinct_entities"] = totalCounts.EntityClients
 	responseData["entity_clients"] = totalCounts.EntityClients
-	responseData["non_entity_tokens"] = totalCounts.NonEntityClients
 	responseData["non_entity_clients"] = totalCounts.NonEntityClients
 	responseData["clients"] = totalCounts.Clients
 	responseData["secret_syncs"] = totalCounts.SecretSyncs

--- a/website/content/api-docs/system/internal-counters.mdx
+++ b/website/content/api-docs/system/internal-counters.mdx
@@ -239,14 +239,6 @@ Vault lead to the new clients for each month.
 }
 ```
 
-- The `distinct_entities` field name has been deprecated since Vault 1.10. Refer to
-`entity_clients` field instead. The `distinct_entities` field is currently
-returned by the API for backward compatibility and it may be removed in the future.
-
-- The `non_entity_tokens` field name has been deprecated since Vault 1.10. Refer to
-`non_entity_clients` field instead. The `non_entity_tokens` field is currently
-returned by the API for backward compatibility, and it may be removed in the future.
-
 - If the `end_date` supplied to the API is for the current month, the activity
 information returned by this API will only be till the previous month. The
 activity system is designed to process the accumulated activity only at the end
@@ -269,9 +261,7 @@ That is to say, the response will appear as follows.
       {
          "timestamp":"current_month_timestamp",
          "counts":{
-            "distinct_entities":"exact int value",
             "entity_clients":"exact int value",
-            "non_entity_tokens":"exact int value",
             "non_entity_clients":"exact int value",
             "secret_syncs":"exact int value",
             "acme_clients":"exact int value",
@@ -282,9 +272,7 @@ That is to say, the response will appear as follows.
                   "namespace_id":"root",
                   "namespace_path":"path",
                   "counts":{
-                     "distinct_entities":"exact int value",
                      "entity_clients":"exact int value",
-                     "non_entity_tokens":"exact int value",
                      "non_entity_clients":"exact int value",
                      "secret_syncs":"exact int value",
                      "acme_clients":"exact int value",
@@ -294,9 +282,7 @@ That is to say, the response will appear as follows.
                      {
                         "path":"auth/up2/",
                         "counts":{
-                           "distinct_entities":"exact int value",
                            "entity_clients":"exact int value",
-                           "non_entity_tokens":"exact int value",
                            "non_entity_clients":"exact int value",
                            "secret_syncs":"exact int value",
                            "acme_clients":"exact int value",
@@ -308,9 +294,7 @@ That is to say, the response will appear as follows.
          ],
          "new_clients":{
             "counts":{
-               "distinct_entities":"approx int value",
                "entity_clients":"approx int value",
-               "non_entity_tokens":"approx int value",
                "non_entity_clients":"approx int value",
                "secret_syncs":"approx int value",
                "acme_clients":"approx int value",
@@ -381,9 +365,7 @@ $ curl \
             "namespace_id":"root",
             "namespace_path":"",
             "counts":{
-               "distinct_entities":20,
                "entity_clients":20,
-               "non_entity_tokens":10,
                "non_entity_clients":10,
                "secret_syncs": 5,
                "acme_clients": 3,
@@ -393,9 +375,7 @@ $ curl \
                {
                   "path":"auth/up1/",
                   "counts":{
-                     "distinct_entities":10,
                      "entity_clients":10,
-                     "non_entity_tokens":10,
                      "non_entity_clients":10,
                      "secret_syncs": 0,
                      "acme_clients": 0,
@@ -405,9 +385,7 @@ $ curl \
                {
                   "path":"auth/up2/",
                   "counts":{
-                     "distinct_entities":5,
                      "entity_clients":5,
-                     "non_entity_tokens":5,
                      "non_entity_clients":5,
                      "secret_syncs": 0,
                      "acme_clients": 0,
@@ -417,9 +395,7 @@ $ curl \
                {
                   "path":"secrets/kv1/",
                   "counts":{
-                     "distinct_entities":0,
                      "entity_clients":0,
-                     "non_entity_tokens":0,
                      "non_entity_clients":0,
                      "secret_syncs":3,
                      "acme_clients": 0,
@@ -429,9 +405,7 @@ $ curl \
                {
                   "path":"secrets/kv2/",
                   "counts":{
-                     "distinct_entities":0,
                      "entity_clients":0,
-                     "non_entity_tokens":0,
                      "non_entity_clients":0,
                      "secret_syncs":0,
                      "acme_clients": 0,
@@ -441,9 +415,7 @@ $ curl \
                {
                   "path":"secrets/pki/",
                   "counts":{
-                     "distinct_entities":0,
                      "entity_clients":0,
-                     "non_entity_tokens":0,
                      "non_entity_clients":0,
                      "secret_syncs":0,
                      "acme_clients": 3,
@@ -456,9 +428,7 @@ $ curl \
             "namespace_id":"s07UR",
             "namespace_path":"ns1/",
             "counts":{
-               "distinct_entities":5,
                "entity_clients":5,
-               "non_entity_tokens":5,
                "non_entity_clients":5,
                "secret_syncs":0,
                "acme_clients":0,
@@ -468,9 +438,7 @@ $ curl \
                {
                   "path":"auth/up1/",
                   "counts":{
-                     "distinct_entities":0,
                      "entity_clients":0,
-                     "non_entity_tokens":5,
                      "non_entity_clients":5,
                      "secret_syncs":0,
                      "acme_clients":0,
@@ -480,9 +448,7 @@ $ curl \
                {
                   "path":"auth/up2/",
                   "counts":{
-                     "distinct_entities":5,
                      "entity_clients":5,
-                     "non_entity_tokens":0,
                      "non_entity_clients":0,
                      "secret_syncs":0,
                      "acme_clients":0,
@@ -497,9 +463,7 @@ $ curl \
          {
             "timestamp":"2021-05-01T00:00:00Z",
             "counts":{
-               "distinct_entities":20,
                "entity_clients":20,
-               "non_entity_tokens":10,
                "non_entity_clients":10,
                "secret_syncs":5,
                "acme_clients":3,
@@ -510,9 +474,7 @@ $ curl \
                   "namespace_id":"root",
                   "namespace_path":"",
                   "counts":{
-                     "distinct_entities":15,
                      "entity_clients":15,
-                     "non_entity_tokens":5,
                      "non_entity_clients":5,
                      "secret_syncs":5,
                      "acme_clients":3,
@@ -522,9 +484,7 @@ $ curl \
                      {
                         "path":"auth/up2/",
                         "counts":{
-                           "distinct_entities":10,
                            "entity_clients":10,
-                           "non_entity_tokens":5,
                            "non_entity_clients":5,
                            "secret_syncs":0,
                            "acme_clients":0,
@@ -534,9 +494,7 @@ $ curl \
                      {
                         "path":"auth/up1/",
                         "counts":{
-                           "distinct_entities":3,
                            "entity_clients":3,
-                           "non_entity_tokens":2,
                            "non_entity_clients":2,
                            "secret_syncs":0,
                            "acme_clients":0,
@@ -546,9 +504,7 @@ $ curl \
                      {
                         "path":"secrets/kv1/",
                         "counts":{
-                           "distinct_entities":0,
                            "entity_clients":0,
-                           "non_entity_tokens":0,
                            "non_entity_clients":0,
                            "secret_syncs":3,
                            "acme_clients":0,
@@ -558,9 +514,7 @@ $ curl \
                      {
                         "path":"secrets/kv2/",
                         "counts":{
-                           "distinct_entities":0,
                            "entity_clients":0,
-                           "non_entity_tokens":0,
                            "non_entity_clients":0,
                            "secret_syncs":2,
                            "acme_clients":0,
@@ -570,9 +524,7 @@ $ curl \
                      {
                         "path":"secrets/pki/",
                         "counts":{
-                           "distinct_entities":0,
                            "entity_clients":0,
-                           "non_entity_tokens":0,
                            "non_entity_clients":0,
                            "secret_syncs":0,
                            "acme_clients":3,
@@ -585,9 +537,7 @@ $ curl \
                   "namespace_id":"s07UR",
                   "namespace_path":"ns1/",
                   "counts":{
-                     "distinct_entities":5,
                      "entity_clients":5,
-                     "non_entity_tokens":5,
                      "non_entity_clients":5,
                      "secret_syncs":0,
                      "acme_clients":0,
@@ -597,9 +547,7 @@ $ curl \
                      {
                         "path":"auth/up1/",
                         "counts":{
-                           "distinct_entities":0,
                            "entity_clients":0,
-                           "non_entity_tokens":5,
                            "non_entity_clients":5,
                            "secret_syncs":0,
                            "acme_clients":0,
@@ -609,9 +557,7 @@ $ curl \
                      {
                         "path":"auth/up2/",
                         "counts":{
-                           "distinct_entities":5,
                            "entity_clients":5,
-                           "non_entity_tokens":0,
                            "non_entity_clients":0,
                            "secret_syncs":0,
                            "acme_clients":0,
@@ -623,9 +569,7 @@ $ curl \
             ],
             "new_clients":{
                "counts":{
-                  "distinct_entities":10,
                   "entity_clients":10,
-                  "non_entity_tokens":10,
                   "non_entity_clients":10,
                   "secret_syncs":2,
                   "acme_clients":1,
@@ -636,9 +580,7 @@ $ curl \
                      "namespace_id":"root",
                      "namespace_path":"",
                      "counts":{
-                        "distinct_entities":5,
                         "entity_clients":5,
-                        "non_entity_tokens":5,
                         "non_entity_clients":5,
                         "secret_syncs":2,
                         "acme_clients":1,
@@ -648,9 +590,7 @@ $ curl \
                         {
                            "path":"auth/up2/",
                            "counts":{
-                              "distinct_entities":0,
                               "entity_clients":0,
-                              "non_entity_tokens":5,
                               "non_entity_clients":5,
                               "clients":5
                            }
@@ -658,9 +598,7 @@ $ curl \
                         {
                            "path":"auth/up1/",
                            "counts":{
-                              "distinct_entities":5,
                               "entity_clients":5,
-                              "non_entity_tokens":0,
                               "non_entity_clients":0,
                               "clients":5
                            }
@@ -668,9 +606,7 @@ $ curl \
                         {
                            "path":"secrets/kv1/",
                            "counts":{
-                              "distinct_entities":0,
                               "entity_clients":0,
-                              "non_entity_tokens":0,
                               "non_entity_clients":0,
                               "secret_syncs":1,
                               "clients":1
@@ -679,9 +615,7 @@ $ curl \
                         {
                            "path":"secrets/kv2/",
                            "counts":{
-                              "distinct_entities":0,
                               "entity_clients":0,
-                              "non_entity_tokens":0,
                               "non_entity_clients":0,
                               "secret_syncs":1,
                               "clients":1
@@ -690,9 +624,7 @@ $ curl \
                         {
                            "path":"secrets/pki/",
                            "counts":{
-                              "distinct_entities":0,
                               "entity_clients":0,
-                              "non_entity_tokens":0,
                               "non_entity_clients":0,
                               "secret_syncs":0,
                               "acme_clients":1,
@@ -705,9 +637,7 @@ $ curl \
                      "namespace_id":"s07UR",
                      "namespace_path":"ns1/",
                      "counts":{
-                        "distinct_entities":5,
                         "entity_clients":5,
-                        "non_entity_tokens":5,
                         "non_entity_clients":5,
                         "secret_syncs":0,
                         "acme_clients":0,
@@ -717,9 +647,7 @@ $ curl \
                         {
                            "path":"auth/up1/",
                            "counts":{
-                              "distinct_entities":0,
                               "entity_clients":0,
-                              "non_entity_tokens":5,
                               "non_entity_clients":5,
                               "secret_syncs":0,
                               "acme_clients":0,
@@ -729,9 +657,7 @@ $ curl \
                         {
                            "path":"auth/up2/",
                            "counts":{
-                              "distinct_entities":5,
                               "entity_clients":5,
-                              "non_entity_tokens":0,
                               "non_entity_clients":0,
                               "secret_syncs":0,
                               "acme_clients":0,
@@ -746,9 +672,7 @@ $ curl \
          {
             "timestamp":"2021-04-01T00:00:00Z",
             "counts":{
-               "distinct_entities":5,
                "entity_clients":5,
-               "non_entity_tokens":5,
                "non_entity_clients":5,
                "secret_syncs":3,
                "acme_clients":1,
@@ -759,9 +683,7 @@ $ curl \
                   "namespace_id":"root",
                   "namespace_path":"",
                   "counts":{
-                     "distinct_entities":5,
                      "entity_clients":5,
-                     "non_entity_tokens":5,
                      "non_entity_clients":5,
                      "secret_syncs":0,
                      "acme_clients":0,
@@ -771,9 +693,7 @@ $ curl \
                      {
                         "path":"auth/up1/",
                         "counts":{
-                           "distinct_entities":0,
                            "entity_clients":0,
-                           "non_entity_tokens":5,
                            "non_entity_clients":5,
                            "secret_syncs":0,
                            "acme_clients":0,
@@ -783,9 +703,7 @@ $ curl \
                      {
                         "path":"auth/up2/",
                         "counts":{
-                           "distinct_entities":5,
                            "entity_clients":5,
-                           "non_entity_tokens":0,
                            "non_entity_clients":0,
                            "secret_syncs":0,
                            "acme_clients":0,
@@ -797,9 +715,7 @@ $ curl \
             ],
             "new_clients":{
                "counts":{
-                  "distinct_entities":5,
                   "entity_clients":5,
-                  "non_entity_tokens":5,
                   "non_entity_clients":5,
                   "secret_syncs":3,
                   "acme_clients":1,
@@ -810,9 +726,7 @@ $ curl \
                      "namespace_id":"root",
                      "namespace_path":"",
                      "counts":{
-                        "distinct_entities":5,
                         "entity_clients":5,
-                        "non_entity_tokens":5,
                         "non_entity_clients":5,
                         "secret_syncs":3,
                         "acme_clients":1,
@@ -822,9 +736,7 @@ $ curl \
                         {
                            "path":"auth/up1/",
                            "counts":{
-                              "distinct_entities":0,
                               "entity_clients":0,
-                              "non_entity_tokens":5,
                               "non_entity_clients":5,
                               "secret_syncs":0,
                               "acme_clients":0,
@@ -834,9 +746,7 @@ $ curl \
                         {
                            "path":"auth/up2/",
                            "counts":{
-                              "distinct_entities":5,
                               "entity_clients":5,
-                              "non_entity_tokens":0,
                               "non_entity_clients":0,
                               "secret_syncs":0,
                               "acme_clients":0,
@@ -846,9 +756,7 @@ $ curl \
                         {
                            "path":"secrets/kv1/",
                            "counts":{
-                              "distinct_entities":0,
                               "entity_clients":0,
-                              "non_entity_tokens":0,
                               "non_entity_clients":0,
                               "secret_syncs":2,
                               "acme_clients":0,
@@ -858,9 +766,7 @@ $ curl \
                         {
                            "path":"secrets/kv2/",
                            "counts":{
-                              "distinct_entities":0,
                               "entity_clients":0,
-                              "non_entity_tokens":0,
                               "non_entity_clients":0,
                               "secret_syncs":1,
                               "acme_clients":0,
@@ -870,9 +776,7 @@ $ curl \
                         {
                            "path":"secrets/pki/",
                            "counts":{
-                              "distinct_entities":0,
                               "entity_clients":0,
-                              "non_entity_tokens":0,
                               "non_entity_clients":0,
                               "secret_syncs":0,
                               "acme_clients":1,
@@ -887,9 +791,7 @@ $ curl \
       ],
       "start_time":"2021-01-01T00:00:00Z",
       "total":{
-         "distinct_entities":20,
          "entity_clients":20,
-         "non_entity_tokens":20,
          "non_entity_clients":20,
          "secret_syncs":5,
          "acme_clients":3,
@@ -965,10 +867,8 @@ $ curl \
         "counts": {
           "acme_clients": 0,
           "clients": 1,
-          "distinct_entities": 0,
           "entity_clients": 0,
           "non_entity_clients": 1,
-          "non_entity_tokens": 1,
           "secret_syncs": 0
         },
         "mounts": [
@@ -976,10 +876,8 @@ $ curl \
             "counts": {
               "acme_clients": 0,
               "clients": 1,
-              "distinct_entities": 0,
               "entity_clients": 0,
               "non_entity_clients": 1,
-              "non_entity_tokens": 0,
               "secret_syncs": 0
             },
             "mount_path": "auth_token_0747d59c"
@@ -990,17 +888,14 @@ $ curl \
       }
     ],
     "clients": 1,
-    "distinct_entities": 0,
     "entity_clients": 0,
     "months": [
       {
         "counts": {
           "acme_clients": 0,
           "clients": 1,
-          "distinct_entities": 0,
           "entity_clients": 0,
           "non_entity_clients": 1,
-          "non_entity_tokens": 0,
           "secret_syncs": 0
         },
         "namespaces": [
@@ -1008,10 +903,8 @@ $ curl \
             "counts": {
               "acme_clients": 0,
               "clients": 1,
-              "distinct_entities": 0,
               "entity_clients": 0,
               "non_entity_clients": 1,
-              "non_entity_tokens": 0,
               "secret_syncs": 0
             },
             "mounts": [
@@ -1019,10 +912,8 @@ $ curl \
                 "counts": {
                   "acme_clients": 0,
                   "clients": 1,
-                  "distinct_entities": 0,
                   "entity_clients": 0,
                   "non_entity_clients": 1,
-                  "non_entity_tokens": 0,
                   "secret_syncs": 0
                 },
                 "mount_path": "auth_token_0747d59c"
@@ -1036,10 +927,8 @@ $ curl \
           "counts": {
             "acme_clients": 0,
             "clients": 1,
-            "distinct_entities": 0,
             "entity_clients": 0,
             "non_entity_clients": 1,
-            "non_entity_tokens": 0,
             "secret_syncs": 0
           },
           "namespaces": [
@@ -1047,10 +936,8 @@ $ curl \
               "counts": {
                 "acme_clients": 0,
                 "clients": 1,
-                "distinct_entities": 0,
                 "entity_clients": 0,
                 "non_entity_clients": 1,
-                "non_entity_tokens": 0,
                 "secret_syncs": 0
               },
               "mounts": [
@@ -1058,10 +945,8 @@ $ curl \
                   "counts": {
                     "acme_clients": 0,
                     "clients": 1,
-                    "distinct_entities": 0,
                     "entity_clients": 0,
                     "non_entity_clients": 1,
-                    "non_entity_tokens": 0,
                     "secret_syncs": 0
                   },
                   "mount_path": "auth_token_0747d59c"
@@ -1076,7 +961,6 @@ $ curl \
       }
     ],
     "non_entity_clients": 1,
-    "non_entity_tokens": 1,
     "secret_syncs": 0
   },
   "warnings": null


### PR DESCRIPTION
### Description
Remove fields `distinct_entities` and `non_entity_tokens` from RespounseCounts structure, so that this is completely removed from the response. This change is NOT backwards compatible. This change follows the major change (https://github.com/hashicorp/vault/commit/b32231a9eb14e19b81e9a04f017d0ea783ddbcda) which contains the changelog. 

ENT PR: https://github.com/hashicorp/vault-enterprise/pull/6280

### TODO only if you're a HashiCorp employee
- [ ] **Labels:** If this PR is the CE portion of an ENT change, and that ENT change is
  getting backported to N-2, use the new style `backport/ent/x.x.x+ent` labels
  instead of the old style `backport/x.x.x` labels.
- [ ] **Labels:** If this PR is a CE only change, it can only be backported to N, so use
  the normal `backport/x.x.x` label (there should be only 1).
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
