### PR TITLE
[VAULT-28666] Enable the --clobber flag on GitHub CLI release downloads in CI to avoid errors when retrying

### DIFF
--- a/.github/actions/set-up-buf/action.yml
+++ b/.github/actions/set-up-buf/action.yml
@@ -60,7 +60,7 @@ runs:
         fi
 
         mkdir -p tmp
-        ./.github/scripts/retry-command.sh gh release download "$VERSION" -p "buf-${OS}-${ARCH}.tar.gz" -O tmp/buf.tgz -R bufbuild/buf
+        ./.github/scripts/retry-command.sh gh release download "$VERSION" --clobber -p "buf-${OS}-${ARCH}.tar.gz" -O tmp/buf.tgz -R bufbuild/buf
         pushd tmp && tar -xvf buf.tgz && popd
         mv tmp/buf/bin/buf "$DESTINATION"
         rm -rf tmp

--- a/.github/actions/set-up-gofumpt/action.yml
+++ b/.github/actions/set-up-gofumpt/action.yml
@@ -56,6 +56,6 @@ runs:
           export OS="darwin"
         fi
 
-        ./.github/scripts/retry-command.sh gh release download "$VERSION" -p "gofumpt_*_${OS}_${ARCH}" -O gofumpt -R mvdan/gofumpt
+        ./.github/scripts/retry-command.sh gh release download "$VERSION" --clobber -p "gofumpt_*_${OS}_${ARCH}" -O gofumpt -R mvdan/gofumpt
         chmod +x gofumpt
         mv gofumpt "$DESTINATION"

--- a/.github/actions/set-up-gosimports/action.yml
+++ b/.github/actions/set-up-gosimports/action.yml
@@ -57,7 +57,7 @@ runs:
         fi
 
         mkdir -p tmp
-        ./.github/scripts/retry-command.sh gh release download "$VERSION" -p "gosimports_*_${OS}_${ARCH}.tar.gz" -O tmp/gosimports.tgz -R rinchsan/gosimports
+        ./.github/scripts/retry-command.sh gh release download "$VERSION" --clobber -p "gosimports_*_${OS}_${ARCH}.tar.gz" -O tmp/gosimports.tgz -R rinchsan/gosimports
         pushd tmp && tar -xvf gosimports.tgz && popd
         mv tmp/gosimports "$DESTINATION"
         rm -rf tmp

--- a/.github/actions/set-up-gotestsum/action.yml
+++ b/.github/actions/set-up-gotestsum/action.yml
@@ -54,7 +54,7 @@ runs:
         fi
 
         mkdir -p tmp
-        ./.github/scripts/retry-command.sh gh release download "$VERSION" -p "*${OS}_${ARCH}.tar.gz" -O tmp/gotestsum.tgz -R gotestyourself/gotestsum
+        ./.github/scripts/retry-command.sh gh release download "$VERSION" --clobber -p "*${OS}_${ARCH}.tar.gz" -O tmp/gotestsum.tgz -R gotestyourself/gotestsum
         pushd tmp && tar -xvf gotestsum.tgz && popd
         mv tmp/gotestsum "$DESTINATION"
         rm -rf tmp

--- a/.github/actions/set-up-misspell/action.yml
+++ b/.github/actions/set-up-misspell/action.yml
@@ -57,7 +57,7 @@ runs:
         fi
 
         mkdir -p tmp
-        ./.github/scripts/retry-command.sh gh release download "$VERSION" -p "misspell_*_${OS}_${ARCH}.tar.gz" -O tmp/misspell.tgz -R golangci/misspell
+        ./.github/scripts/retry-command.sh gh release download "$VERSION" --clobber -p "misspell_*_${OS}_${ARCH}.tar.gz" -O tmp/misspell.tgz -R golangci/misspell
         pushd tmp && tar -xvf misspell.tgz && popd
         mv tmp/misspell_"$(echo "$VERSION" | tr -d v)"_${OS}_${ARCH}/misspell "$DESTINATION"
         rm -rf tmp

--- a/.github/actions/set-up-staticcheck/action.yml
+++ b/.github/actions/set-up-staticcheck/action.yml
@@ -57,7 +57,7 @@ runs:
         fi
 
         mkdir -p tmp
-        ./.github/scripts/retry-command.sh gh release download "$VERSION" -p "staticcheck_${OS}_${ARCH}.tar.gz" -O tmp/staticcheck.tgz -R dominikh/go-tools
+        ./.github/scripts/retry-command.sh gh release download "$VERSION" --clobber -p "staticcheck_${OS}_${ARCH}.tar.gz" -O tmp/staticcheck.tgz -R dominikh/go-tools
         pushd tmp && tar -xvf staticcheck.tgz && popd
         mv tmp/staticcheck/staticcheck "$DESTINATION"
         rm -rf tmp


### PR DESCRIPTION
### Description
See title. 

### TODO only if you're a HashiCorp employee
- [x] **Labels:** If this PR is the CE portion of an ENT change, and that ENT change is
  getting backported to N-2, use the new style `backport/ent/x.x.x+ent` labels
  instead of the old style `backport/x.x.x` labels.
- [ ] **Labels:** If this PR is a CE only change, it can only be backported to N, so use
  the normal `backport/x.x.x` label (there should be only 1).
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
