### PR TITLE
WIF AWS: add create functionality to SearchSelectWithModal for identity_token_key (take 2)

### DIFF
--- a/ui/app/components/modal-form/oidc-key-template.hbs
+++ b/ui/app/components/modal-form/oidc-key-template.hbs
@@ -1,0 +1,6 @@
+{{!
+  Copyright (c) HashiCorp, Inc.
+  SPDX-License-Identifier: BUSL-1.1
+~}}
+
+<Oidc::KeyForm @onSave={{this.onSave}} @model={{this.key}} @onCancel={{@onCancel}} @isModalForm={{true}} />

--- a/ui/app/components/modal-form/oidc-key-template.js
+++ b/ui/app/components/modal-form/oidc-key-template.js
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+
+/**
+ * @module ModalForm::OidcKeyTemplate
+ * ModalForm::OidcKeyTemplate components render within a modal and create a model using the input from the search select. The model is passed to the oidc/key-form.
+ *
+ * @example
+ *  <ModalForm::OidcKeyTemplate
+ *    @nameInput="new-key-name"
+ *    @onSave={{this.closeModal}}
+ *    @onCancel={{@onCancel}}
+ *  />
+ *
+ * @callback onCancel - callback triggered when cancel button is clicked
+ * @callback onSave - callback triggered when save button is clicked
+ * @param {string} nameInput - the name of the newly created key
+ */
+
+export default class OidcKeyTemplate extends Component {
+  @service store;
+  @tracked key = null; // model record passed to oidc/key-form
+
+  constructor() {
+    super(...arguments);
+    this.key = this.store.createRecord('oidc/key', { name: this.args.nameInput });
+  }
+
+  @action onSave(keyModel) {
+    this.args.onSave(keyModel);
+    // Reset component key for next use
+    this.key = null;
+  }
+}

--- a/ui/app/components/mount-backend-form.hbs
+++ b/ui/app/components/mount-backend-form.hbs
@@ -45,11 +45,10 @@
             @onChange={{this.handleIdentityTokenKeyChange}}
             @models={{array "oidc/key"}}
             @selectLimit="1"
-            @returnString={{true}}
             @modalFormTemplate="modal-form/oidc-key-template"
-            @placeholder="Search for an existing oidc/key, or type a new key name to create it."
+            @placeholder="Search for an existing OIDC key, or type a new key name to create it."
             @fallbackComponentPlaceholder="Input a key name"
-            @modalSubtext="This key will be created in the oidc/key path."
+            @modalSubtext="This key will be created in the OIDC key path."
           />
         </:identityTokenKey>
       </FormFieldGroups>

--- a/ui/app/components/mount-backend-form.hbs
+++ b/ui/app/components/mount-backend-form.hbs
@@ -35,18 +35,25 @@
         @modelValidations={{this.modelValidations}}
         @onKeyUp={{this.onKeyUp}}
       />
+
       <FormFieldGroups @model={{@mountModel}} @renderGroup="Method Options">
         <:identityTokenKey>
           <SearchSelectWithModal
-            @id="identityTokenKey"
+            @id="key"
             @fallbackComponent="input-search"
+            @inputValue={{@mountModel.config.identityTokenKey}}
             @onChange={{this.handleIdentityTokenKeyChange}}
             @models={{array "oidc/key"}}
             @selectLimit="1"
             @returnString={{true}}
+            @modalFormTemplate="modal-form/oidc-key-template"
+            @placeholder="Search for an existing oidc/key, or type a new key name to create it."
+            @fallbackComponentPlaceholder="Input a key name"
+            @modalSubtext="This key will be created in the oidc/key path."
           />
         </:identityTokenKey>
       </FormFieldGroups>
+
       <div class="field is-grouped box is-fullwidth is-bottomless">
         <div class="control">
           <Hds::Button

--- a/ui/app/components/mount-backend-form.ts
+++ b/ui/app/components/mount-backend-form.ts
@@ -192,7 +192,8 @@ export default class MountBackendForm extends Component<Args> {
   }
 
   @action
-  handleIdentityTokenKeyChange(value: string[]): void {
-    this.args.mountModel.config.identityTokenKey = value[0];
+  handleIdentityTokenKeyChange(value: string[] | string): void {
+    // if array, it's coming from the search-select component, otherwise it hit the fallback component and will come in as a string.
+    this.args.mountModel.config.identityTokenKey = Array.isArray(value) ? value[0] : value;
   }
 }

--- a/ui/app/components/oidc/key-form.js
+++ b/ui/app/components/oidc/key-form.js
@@ -84,7 +84,9 @@ export default class OidcKeyForm extends Component {
           `Successfully ${isNew ? 'created' : 'updated'} the key
           ${name}.`
         );
-        this.args.onSave();
+        // this form is sometimes used in a modal, passing the model notifies
+        // the parent if the save was successful
+        this.args.onSave(this.args.model);
       }
     } catch (error) {
       const message = error.errors ? error.errors.join('. ') : error.message;

--- a/ui/app/components/oidc/key-form.js
+++ b/ui/app/components/oidc/key-form.js
@@ -22,6 +22,7 @@ import { task } from 'ember-concurrency';
  * @param {Object} model - oidc client model
  * @param {onCancel} onCancel - callback triggered when cancel button is clicked
  * @param {onSave} onSave - callback triggered on save success
+ * @param {boolean} [isModalForm=false] - boolean to determine if form should render a limited set of options. Used when rendered outside of OIDC provider workflow (ex: SearchSelectWithModal when mounting a WIF secret engine).
  */
 
 export default class OidcKeyForm extends Component {

--- a/ui/app/components/oidc/key-form.js
+++ b/ui/app/components/oidc/key-form.js
@@ -22,7 +22,7 @@ import { task } from 'ember-concurrency';
  * @param {Object} model - oidc client model
  * @param {onCancel} onCancel - callback triggered when cancel button is clicked
  * @param {onSave} onSave - callback triggered on save success
- * @param {boolean} [isModalForm=false] - boolean to determine if form should render a limited set of options. Used when rendered outside of OIDC provider workflow (ex: SearchSelectWithModal when mounting a WIF secret engine).
+ * @param {boolean} [isModalForm=false] - if true, hides inputs related to selecting an application which is only relevant to the OIDC provider workflow.
  */
 
 export default class OidcKeyForm extends Component {

--- a/ui/app/helpers/mountable-secret-engines.js
+++ b/ui/app/helpers/mountable-secret-engines.js
@@ -135,7 +135,11 @@ const MOUNTABLE_SECRET_ENGINES = [
 ];
 
 // A list of Workflow Identity Federation engines. Will eventually include Azure and GCP.
-export const wifEngines = ['aws'];
+export const WIF_ENGINES = ['aws'];
+
+export function wifEngines() {
+  return WIF_ENGINES.slice();
+}
 
 export function mountableEngines() {
   return MOUNTABLE_SECRET_ENGINES.slice();

--- a/ui/app/helpers/mountable-secret-engines.js
+++ b/ui/app/helpers/mountable-secret-engines.js
@@ -134,6 +134,9 @@ const MOUNTABLE_SECRET_ENGINES = [
   },
 ];
 
+// A list of Workflow Identity Federation engines. Will eventually include Azure and GCP.
+export const wifEngines = ['aws'];
+
 export function mountableEngines() {
   return MOUNTABLE_SECRET_ENGINES.slice();
 }

--- a/ui/app/serializers/secret-engine.js
+++ b/ui/app/serializers/secret-engine.js
@@ -5,6 +5,7 @@
 
 import ApplicationSerializer from './application';
 import { EmbeddedRecordsMixin } from '@ember-data/serializer/rest';
+import { wifEngines } from 'vault/helpers/mountable-secret-engines';
 
 export default ApplicationSerializer.extend(EmbeddedRecordsMixin, {
   attrs: {
@@ -83,6 +84,13 @@ export default ApplicationSerializer.extend(EmbeddedRecordsMixin, {
     // move version back to options
     data.options = data.version ? { version: data.version } : {};
     delete data.version;
+
+    if (!wifEngines.includes(type)) {
+      // only send identity_token_key if it's set on a WIF secret engine.
+      // because of issues with the model unloading with a belongsTo relationships
+      // identity_token_key can accidentally carry over if a user backs out of the form and changes the type from WIF to non-WIF.
+      delete data.config.identity_token_key;
+    }
 
     if (type !== 'kv' || data.options.version === 1) {
       // These items are on the model, but used by the kv-v2 config endpoint only

--- a/ui/app/serializers/secret-engine.js
+++ b/ui/app/serializers/secret-engine.js
@@ -5,7 +5,7 @@
 
 import ApplicationSerializer from './application';
 import { EmbeddedRecordsMixin } from '@ember-data/serializer/rest';
-import { wifEngines } from 'vault/helpers/mountable-secret-engines';
+import { WIF_ENGINES } from 'vault/helpers/mountable-secret-engines';
 
 export default ApplicationSerializer.extend(EmbeddedRecordsMixin, {
   attrs: {
@@ -85,7 +85,7 @@ export default ApplicationSerializer.extend(EmbeddedRecordsMixin, {
     data.options = data.version ? { version: data.version } : {};
     delete data.version;
 
-    if (!wifEngines.includes(type)) {
+    if (!WIF_ENGINES.includes(type)) {
       // only send identity_token_key if it's set on a WIF secret engine.
       // because of issues with the model unloading with a belongsTo relationships
       // identity_token_key can accidentally carry over if a user backs out of the form and changes the type from WIF to non-WIF.

--- a/ui/app/templates/components/oidc/key-form.hbs
+++ b/ui/app/templates/components/oidc/key-form.hbs
@@ -10,47 +10,49 @@
       <FormField @attr={{attr}} @model={{@model}} @modelValidations={{this.modelValidations}} />
     {{/each}}
   </div>
-  {{! RADIO CARD + SEARCH SELECT }}
-  <div class="box is-sideless is-fullwidth is-marginless has-top-padding-xxl">
-    <Hds::Text::Display @tag="h2" @size="400">Allowed applications</Hds::Text::Display>
-    <div class="is-flex-row">
-      <RadioCard
-        data-test-oidc-radio="allow-all"
-        @title="Allow every application to use"
-        @description="All applications can use this key for authentication requests."
-        @icon="globe"
-        @value="allow_all"
-        @groupValue={{this.radioCardGroupValue}}
-        @onChange={{this.handleClientSelection}}
-      />
-      <RadioCard
-        data-test-oidc-radio="limited"
-        @title="Limit access to selected application"
-        @description="Only selected applications can use this key for authentication requests."
-        @icon="globe-private"
-        @value="limited"
-        @groupValue={{this.radioCardGroupValue}}
-        @onChange={{this.handleClientSelection}}
-        @disabled={{@model.isNew}}
-        @disabledTooltipMessage="This option has been disabled for now. To limit access, you must first create an application that references this key."
-      />
+  {{#unless @isModalForm}}
+    {{! RADIO CARD + SEARCH SELECT }}
+    <div class="box is-sideless is-fullwidth is-marginless has-top-padding-xxl">
+      <Hds::Text::Display @tag="h2" @size="400">Allowed applications</Hds::Text::Display>
+      <div class="is-flex-row">
+        <RadioCard
+          data-test-oidc-radio="allow-all"
+          @title="Allow every application to use"
+          @description="All applications can use this key for authentication requests."
+          @icon="globe"
+          @value="allow_all"
+          @groupValue={{this.radioCardGroupValue}}
+          @onChange={{this.handleClientSelection}}
+        />
+        <RadioCard
+          data-test-oidc-radio="limited"
+          @title="Limit access to selected application"
+          @description="Only selected applications can use this key for authentication requests."
+          @icon="globe-private"
+          @value="limited"
+          @groupValue={{this.radioCardGroupValue}}
+          @onChange={{this.handleClientSelection}}
+          @disabled={{@model.isNew}}
+          @disabledTooltipMessage="This option has been disabled for now. To limit access, you must first create an application that references this key."
+        />
+      </div>
+      {{#if (eq this.radioCardGroupValue "limited")}}
+        <SearchSelect
+          @id="allowedClientIds"
+          @label="Application name"
+          @subText="Select which applications are allowed to use this key. Only applications that currently reference this key will appear in the dropdown."
+          @models={{array "oidc/client"}}
+          @inputValue={{@model.allowedClientIds}}
+          @onChange={{this.handleClientSelection}}
+          @disallowNewItems={{true}}
+          @fallbackComponent="string-list"
+          @passObject={{true}}
+          @objectKeys={{array "clientId"}}
+          @queryObject={{this.filterDropdownOptions}}
+        />
+      {{/if}}
     </div>
-    {{#if (eq this.radioCardGroupValue "limited")}}
-      <SearchSelect
-        @id="allowedClientIds"
-        @label="Application name"
-        @subText="Select which applications are allowed to use this key. Only applications that currently reference this key will appear in the dropdown."
-        @models={{array "oidc/client"}}
-        @inputValue={{@model.allowedClientIds}}
-        @onChange={{this.handleClientSelection}}
-        @disallowNewItems={{true}}
-        @fallbackComponent="string-list"
-        @passObject={{true}}
-        @objectKeys={{array "clientId"}}
-        @queryObject={{this.filterDropdownOptions}}
-      />
-    {{/if}}
-  </div>
+  {{/unless}}
   <div class="field box is-fullwidth is-bottomless">
     <div class="control">
       <Hds::Button

--- a/ui/lib/core/addon/components/input-search.hbs
+++ b/ui/lib/core/addon/components/input-search.hbs
@@ -19,6 +19,7 @@
       {{on "keyup" this.inputChanged}}
       placeholder={{@placeholder}}
       autocomplete="off"
+      data-test-input-search={{@id}}
     />
   </div>
 </div>

--- a/ui/lib/core/addon/components/search-select-with-modal.hbs
+++ b/ui/lib/core/addon/components/search-select-with-modal.hbs
@@ -18,7 +18,7 @@
       onChange=@onChange
       inputValue=@inputValue
       helpText=@helpText
-      placeholder=@placeholder
+      placeholder=(or @fallbackComponentPlaceholder @placeholder)
       id=@id
       selectLimit=@selectLimit
     }}

--- a/ui/lib/core/addon/components/search-select-with-modal.js
+++ b/ui/lib/core/addon/components/search-select-with-modal.js
@@ -38,6 +38,7 @@ import { addToArray } from 'vault/helpers/add-to-array';
  * @param {string} [subText] - Text to be displayed below the label
  * @param {string} fallbackComponent - name of component to be rendered if the API call 403s
  * @param {string} [placeholder] - placeholder text to override the default text of "Search"
+ * @param {string} [fallbackComponentPlaceholder] - specific placeholder text relevant to fallback component. In some cases, the placeholder text does not make sense for both the search-select and the fallback component. Ex: "Input key name" for input-search and "Search or type to create a new item" for search-select.
  * @param {boolean} [displayInherit=false] - if you need the search select component to display inherit instead of box.
  * @param {number} [selectLimit=1] - if you only want the user to select a limited number of options, add number to this param.
  */

--- a/ui/tests/acceptance/settings/mount-secret-backend-test.js
+++ b/ui/tests/acceptance/settings/mount-secret-backend-test.js
@@ -3,12 +3,21 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { currentRouteName, currentURL, settled, click, findAll } from '@ember/test-helpers';
+import {
+  currentRouteName,
+  currentURL,
+  settled,
+  click,
+  findAll,
+  fillIn,
+  visit,
+  typeIn,
+} from '@ember/test-helpers';
 import { clickTrigger } from 'ember-power-select/test-support/helpers';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { v4 as uuidv4 } from 'uuid';
-import { runCmd } from 'vault/tests/helpers/commands';
+import { runCmd, tokenWithPolicyCmd } from 'vault/tests/helpers/commands';
 
 import { create } from 'ember-cli-page-object';
 import page from 'vault/tests/pages/settings/mount-secret-backend';
@@ -19,6 +28,10 @@ import logout from 'vault/tests/pages/logout';
 import mountSecrets from 'vault/tests/pages/settings/mount-secret-backend';
 import { mountableEngines } from 'vault/helpers/mountable-secret-engines'; // allEngines() includes enterprise engines, those are tested elsewhere
 import { supportedSecretBackends } from 'vault/helpers/supported-secret-backends';
+import { GENERAL } from 'vault/tests/helpers/general-selectors';
+import { SELECTORS as OIDC } from 'vault/tests/helpers/oidc-config';
+import { adminOidcCreateRead, adminOidcCreate } from 'vault/tests/helpers/secrets/policy-generator';
+import { wifEngines } from 'vault/helpers/mountable-secret-engines';
 
 const consoleComponent = create(consoleClass);
 
@@ -301,26 +314,123 @@ module('Acceptance | settings/mount-secret-backend', function (hooks) {
     );
   });
 
-  test('it sets identity_token_key when aws is chosen, resets after', async function (assert) {
-    // create an oidc/key
-    await runCmd(`write identity/oidc/key/some-key allowed_client_ids="*"`);
-    await page.visit();
-    await page.selectType('aws');
-    await click('[data-test-toggle-group="Method Options"]');
+  module('WIF secret engines', function () {
+    test('it sets identity_token_key on mount config using search select list, resets after', async function (assert) {
+      // create an oidc/key
+      await runCmd(`write identity/oidc/key/some-key allowed_client_ids="*"`);
 
-    assert.dom('[data-test-search-select-with-modal]').exists('Search select with modal component renders');
+      for (const engine of wifEngines) {
+        await page.visit();
+        await page.selectType(engine);
+        await click(GENERAL.toggleGroup('Method Options'));
+        assert
+          .dom('[data-test-search-select-with-modal]')
+          .exists('Search select with modal component renders');
+        await clickTrigger('#key');
+        const dropdownOptions = findAll('[data-option-index]').map((o) => o.innerText);
+        assert.ok(dropdownOptions.includes('some-key'), 'search select options show some-key');
+        await click(GENERAL.searchSelect.option(GENERAL.searchSelect.optionIndex('some-key')));
+        assert
+          .dom(GENERAL.searchSelect.selectedOption())
+          .hasText('some-key', 'some-key was selected and displays in the search select');
+      }
+      // Go back and choose a non-wif engine type
+      await page.back();
+      await page.selectType('ssh');
+      assert
+        .dom('[data-test-search-select-with-modal]')
+        .doesNotExist('for type ssh, the modal field does not render.');
+      // cleanup
+      await runCmd(`delete identity/oidc/key/some-key`);
+    });
 
-    await clickTrigger();
-    const dropdownOptions = findAll('[data-option-index]').map((o) => o.innerText);
-    assert.ok(dropdownOptions.includes('some-key'), 'search select options show some-key');
-    // Go back and choose a non-wif engine type
-    await page.back();
-    await page.selectType('ssh');
-    await click('[data-test-toggle-group="Method Options"]');
-    assert
-      .dom('[data-test-search-select-with-modal]')
-      .doesNotExist('for type ssh, the modal field does not render.');
-    // clean up
-    await runCmd(`delete identity/oidc/key/some-key`);
+    test('it allows a user with permissions to oidc/key to create an identity_token_key', async function (assert) {
+      for (const engine of wifEngines) {
+        const path = `secrets-adminPolicy-${engine}`;
+        const secrets_admin_policy = adminOidcCreateRead(path);
+        const secretsAdminToken = await runCmd(
+          tokenWithPolicyCmd(`secrets-admin-${path}`, secrets_admin_policy)
+        );
+
+        await logout.visit();
+        await authPage.login(secretsAdminToken);
+        await page.visit();
+        await page.selectType(engine);
+        await page.path(path);
+        await click(GENERAL.toggleGroup('Method Options'));
+        await clickTrigger('#key');
+        // create new key
+        await fillIn(GENERAL.searchSelect.searchInput, 'new-key');
+        await click(GENERAL.searchSelect.options);
+        assert.dom('#search-select-modal').exists('modal with form opens');
+        assert.dom('[data-test-modal-title]').hasText('Create new key', 'Create key modal renders');
+
+        await click(OIDC.keySaveButton);
+        assert.dom('#search-select-modal').doesNotExist('modal disappears onSave');
+        assert.dom(GENERAL.searchSelect.selectedOption()).hasText('new-key', 'new-key is now selected');
+
+        await page.submit();
+        assert
+          .dom(GENERAL.latestFlashContent)
+          .hasText(`Successfully mounted the aws secrets engine at ${path}.`);
+
+        await visit(`/vault/secrets/${path}/configuration`);
+        assert
+          .dom(GENERAL.infoRowValue('Identity token key'))
+          .hasText('new-key', 'shows identity token key on configuration page');
+
+        // ARG TODO should redirect to the mount config page. Later PR to address this.
+        // assert.strictEqual(
+        //   currentURL(),
+        //   `/vault/cluster/secrets/backend/${path}/configuration`,
+        //   'After mounting, redirects to secrets configuration page.'
+        // );
+
+        // cleanup
+        await runCmd(`delete sys/mounts/${path}`);
+        await runCmd(`delete identity/oidc/key/some-key`);
+        await runCmd(`delete identity/oidc/key/new-key`);
+      }
+    });
+
+    test('it allows user with NO access to oidc/key to manually input an identity_token_key', async function (assert) {
+      for (const engine of wifEngines) {
+        const path = `secrets-noOidcAdmin-${engine}`;
+        const secretsNoOidcAdminPolicy = adminOidcCreate(path);
+        const secretsNoOidcAdminToken = await runCmd(
+          tokenWithPolicyCmd(`secrets-noOidcAdmin-${path}`, secretsNoOidcAdminPolicy)
+        );
+        // create an oidc/key that they can then use even if they can't read it.
+        await runCmd(`write identity/oidc/key/general-key allowed_client_ids="*"`);
+
+        await logout.visit();
+        await authPage.login(secretsNoOidcAdminToken);
+        await page.visit();
+        await page.selectType(engine);
+        await page.path(path);
+        await click(GENERAL.toggleGroup('Method Options'));
+        // type-in fallback component to create new key
+        await typeIn(GENERAL.inputSearch('key'), 'general-key');
+        await page.submit();
+        assert
+          .dom(GENERAL.latestFlashContent)
+          .hasText(`Successfully mounted the aws secrets engine at ${path}.`);
+
+        await visit(`/vault/secrets/${path}/configuration`);
+
+        assert
+          .dom(GENERAL.infoRowValue('Identity token key'))
+          .hasText('general-key', 'shows identity token key on configuration page');
+        // ARG TODO should redirect to the mount config page. Later PR to address this.
+        // assert.strictEqual(
+        //   currentURL(),
+        //   `/vault/cluster/secrets/backend/${path}/configuration`,
+        //   'After mounting, redirects to secrets configuration page.'
+        // );
+
+        // cleanup
+        await runCmd(`delete sys/mounts/${path}`);
+      }
+    });
   });
 });

--- a/ui/tests/acceptance/settings/mount-secret-backend-test.js
+++ b/ui/tests/acceptance/settings/mount-secret-backend-test.js
@@ -31,7 +31,7 @@ import { supportedSecretBackends } from 'vault/helpers/supported-secret-backends
 import { GENERAL } from 'vault/tests/helpers/general-selectors';
 import { SELECTORS as OIDC } from 'vault/tests/helpers/oidc-config';
 import { adminOidcCreateRead, adminOidcCreate } from 'vault/tests/helpers/secrets/policy-generator';
-import { wifEngines } from 'vault/helpers/mountable-secret-engines';
+import { WIF_ENGINES } from 'vault/helpers/mountable-secret-engines';
 
 const consoleComponent = create(consoleClass);
 
@@ -319,7 +319,7 @@ module('Acceptance | settings/mount-secret-backend', function (hooks) {
       // create an oidc/key
       await runCmd(`write identity/oidc/key/some-key allowed_client_ids="*"`);
 
-      for (const engine of wifEngines) {
+      for (const engine of WIF_ENGINES) {
         await page.visit();
         await page.selectType(engine);
         await click(GENERAL.toggleGroup('Method Options'));
@@ -345,7 +345,7 @@ module('Acceptance | settings/mount-secret-backend', function (hooks) {
     });
 
     test('it allows a user with permissions to oidc/key to create an identity_token_key', async function (assert) {
-      for (const engine of wifEngines) {
+      for (const engine of WIF_ENGINES) {
         const path = `secrets-adminPolicy-${engine}`;
         const secrets_admin_policy = adminOidcCreateRead(path);
         const secretsAdminToken = await runCmd(
@@ -394,7 +394,7 @@ module('Acceptance | settings/mount-secret-backend', function (hooks) {
     });
 
     test('it allows user with NO access to oidc/key to manually input an identity_token_key', async function (assert) {
-      for (const engine of wifEngines) {
+      for (const engine of WIF_ENGINES) {
         const path = `secrets-noOidcAdmin-${engine}`;
         const secretsNoOidcAdminPolicy = adminOidcCreate(path);
         const secretsNoOidcAdminToken = await runCmd(

--- a/ui/tests/helpers/general-selectors.ts
+++ b/ui/tests/helpers/general-selectors.ts
@@ -21,6 +21,7 @@ export const GENERAL = {
 
   filter: (name: string) => `[data-test-filter="${name}"]`,
   filterInput: '[data-test-filter-input]',
+  inputSearch: (attr: string) => `[data-test-input-search="${attr}"]`,
   filterInputExplicit: '[data-test-filter-input-explicit]',
   filterInputExplicitSearch: '[data-test-filter-input-explicit-search]',
   confirmModalInput: '[data-test-confirmation-modal-input]',
@@ -41,6 +42,7 @@ export const GENERAL = {
   inputByAttr: (attr: string) => `[data-test-input="${attr}"]`,
   selectByAttr: (attr: string) => `[data-test-select="${attr}"]`,
   toggleInput: (attr: string) => `[data-test-toggle-input="${attr}"]`,
+  toggleGroup: (attr: string) => `[data-test-toggle-group="${attr}"]`,
   ttl: {
     toggle: (attr: string) => `[data-test-toggle-label="${attr}"]`,
     input: (attr: string) => `[data-test-ttl-value="${attr}"]`,
@@ -61,6 +63,7 @@ export const GENERAL = {
     selectedOption: (index = 0) => `[data-test-selected-option="${index}"]`,
     noMatch: '.ember-power-select-option--no-matches-message',
     removeSelected: '[data-test-selected-list-button="delete"]',
+    searchInput: '.ember-power-select-search-input',
   },
   overviewCard: {
     title: (title: string) => `[data-test-overview-card-title="${title}"]`,

--- a/ui/tests/helpers/secrets/policy-generator.ts
+++ b/ui/tests/helpers/secrets/policy-generator.ts
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-// This is a policy can both mount a secret engine
-// and list and create oidc keys, relevant for setting identity_key_token for WIF
+// This is a policy that can mount a secret engine and list and create oidc keys
+// Relevant for setting identity_key_token for WIF
 export const adminPolicy = () => {
   return `
     path "sys/mounts/*" {
@@ -16,8 +16,8 @@ export const adminPolicy = () => {
   `;
 };
 
-// user can mount the engine
-// but does not have access to oidc/key list or create
+// User can mount the engine
+// But does not have access to oidc/key list or create
 export const noOidcAdminPolicy = () => {
   return `
     path "sys/mounts/*" {

--- a/ui/tests/helpers/secrets/policy-generator.ts
+++ b/ui/tests/helpers/secrets/policy-generator.ts
@@ -3,8 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-// returns a string with each capability wrapped in double quotes => ["create", "read"]
-// This is a policy can both mount a secret engine
+// This is policy can mount a secret engine
 // and list and create oidc keys, relevant for setting identity_key_token for WIF
 export const adminOidcCreateRead = (mountPath: string) => {
   return `
@@ -20,8 +19,8 @@ export const adminOidcCreateRead = (mountPath: string) => {
   `;
 };
 
-// user can mount the engine
-// but does not have access to oidc/key list or create
+// This policy can mount the engine
+// But does not have access to oidc/key list or read
 export const adminOidcCreate = (mountPath: string) => {
   return `
     path "sys/mounts/*" {

--- a/ui/tests/helpers/secrets/policy-generator.ts
+++ b/ui/tests/helpers/secrets/policy-generator.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+// This is a policy can both mount a secret engine
+// and list and create oidc keys, relevant for setting identity_key_token for WIF
+export const adminPolicy = () => {
+  return `
+    path "sys/mounts/*" {
+      capabilities = ["create", "read", "update", "delete", "list"]
+    },
+    path "identity/oidc/key/*" {
+      capabilities = ["create", "read", "update", "delete", "list"]
+    },
+  `;
+};
+
+// user can mount the engine
+// but does not have access to oidc/key list or create
+export const noOidcAdminPolicy = () => {
+  return `
+    path "sys/mounts/*" {
+      capabilities = ["create", "read", "update", "delete", "list"]
+    },
+  `;
+};

--- a/ui/tests/helpers/secrets/policy-generator.ts
+++ b/ui/tests/helpers/secrets/policy-generator.ts
@@ -3,9 +3,10 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-// This is a policy that can mount a secret engine and list and create oidc keys
-// Relevant for setting identity_key_token for WIF
-export const adminPolicy = () => {
+// returns a string with each capability wrapped in double quotes => ["create", "read"]
+// This is a policy can both mount a secret engine
+// and list and create oidc keys, relevant for setting identity_key_token for WIF
+export const adminOidcCreateRead = (mountPath: string) => {
   return `
     path "sys/mounts/*" {
       capabilities = ["create", "read", "update", "delete", "list"]
@@ -13,15 +14,24 @@ export const adminPolicy = () => {
     path "identity/oidc/key/*" {
       capabilities = ["create", "read", "update", "delete", "list"]
     },
+   path "${mountPath}/*" {
+      capabilities = ["create", "read", "update", "delete", "list"]
+    },
   `;
 };
 
-// User can mount the engine
-// But does not have access to oidc/key list or create
-export const noOidcAdminPolicy = () => {
+// user can mount the engine
+// but does not have access to oidc/key list or create
+export const adminOidcCreate = (mountPath: string) => {
   return `
     path "sys/mounts/*" {
       capabilities = ["create", "read", "update", "delete", "list"]
+    },
+    path "${mountPath}/*" {
+      capabilities = ["create", "read", "update", "delete", "list"]
+    },
+    path "identity/oidc/key/*" {
+      capabilities = ["create", "update"]
     },
   `;
 };

--- a/ui/tests/integration/components/mount-backend-form-test.js
+++ b/ui/tests/integration/components/mount-backend-form-test.js
@@ -6,7 +6,7 @@
 import { later, _cancelTimers as cancelTimers } from '@ember/runloop';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, settled, click } from '@ember/test-helpers';
+import { render, settled, click, typeIn } from '@ember/test-helpers';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { allowAllCapabilitiesStub, noopStub } from 'vault/tests/helpers/stubs';
 import { GENERAL } from 'vault/tests/helpers/general-selectors';
@@ -191,24 +191,46 @@ module('Integration | Component | mount backend form', function (hooks) {
         'Renders correct flash message'
       );
     });
-  });
 
-  test('it shows identityTokenKey when type is aws and hides when its not', async function (assert) {
-    await render(
-      hbs`<MountBackendForm @mountType="secret" @mountModel={{this.model}} @onMountSuccess={{this.onMountSuccess}} />`
-    );
-    await component.selectType('ldap');
+    module('WIF secret engines', function () {
+      test('it shows identityTokenKey when type is aws and hides when its not', async function (assert) {
+        await render(
+          hbs`<MountBackendForm @mountType="secret" @mountModel={{this.model}} @onMountSuccess={{this.onMountSuccess}} />`
+        );
+        await component.selectType('ldap');
 
-    await click('[data-test-toggle-group="Method Options"]');
-    assert
-      .dom(GENERAL.fieldByAttr('identityTokenKey'))
-      .doesNotExist(`Identity token key field hidden when type=${this.model.type}`);
+        await click(GENERAL.toggleGroup('Method Options'));
+        assert
+          .dom(GENERAL.fieldByAttr('identityTokenKey'))
+          .doesNotExist(`Identity token key field hidden when type=${this.model.type}`);
 
-    await component.back();
-    await component.selectType('aws');
-    await click('[data-test-toggle-group="Method Options"]');
-    assert
-      .dom(GENERAL.fieldByAttr('identityTokenKey'))
-      .exists(`Identity token key field shows when type=${this.model.type}`);
+        await component.back();
+        await component.selectType('aws');
+        await click(GENERAL.toggleGroup('Method Options'));
+        assert
+          .dom(GENERAL.fieldByAttr('identityTokenKey'))
+          .exists(`Identity token key field shows when type=${this.model.type}`);
+      });
+
+      test('it updates identityTokeKey if user has changed it', async function (assert) {
+        await render(
+          hbs`<MountBackendForm @mountType="secret" @mountModel={{this.model}} @onMountSuccess={{this.onMountSuccess}} />`
+        );
+        await component.selectType('aws');
+        assert.strictEqual(
+          this.model.config.identityTokenKey,
+          undefined,
+          'On init identityTokenKey is not set on the model'
+        );
+
+        await click(GENERAL.toggleGroup('Method Options'));
+        await typeIn(GENERAL.inputSearch('key'), 'default');
+        assert.strictEqual(
+          this.model.config.identityTokenKey,
+          'default',
+          'updates model with default identityTokenKey'
+        );
+      });
+    });
   });
 });

--- a/ui/tests/unit/adapters/secret-engine-test.js
+++ b/ui/tests/unit/adapters/secret-engine-test.js
@@ -123,5 +123,34 @@ module('Unit | Adapter | secret engine', function (hooks) {
       const record = this.store.createRecord('secret-engine', mountData);
       await record.save();
     });
+
+    test('it should not send identity_token_key if set on a non-WIF secret engine', async function (assert) {
+      assert.expect(1);
+      this.server.post('/sys/mounts/cubbyhole-test', (schema, req) => {
+        assert.deepEqual(
+          JSON.parse(req.requestBody),
+          {
+            path: 'cubbyhole-test',
+            type: 'aws',
+            generate_signing_key: true,
+            config: { id: 'cubbyhole-test', max_lease_ttl: '125h', listing_visibility: 'hidden' },
+          },
+          'Correct payload is sent when sending a non-wif secret engine with identity_token_key accidentally set'
+        );
+        return {};
+      });
+      const mountData = {
+        id: 'cubbyhole-test',
+        path: 'cubbyhole-test',
+        type: 'aws',
+        config: this.store.createRecord('mount-config', {
+          maxLeaseTtl: '125h',
+          identity_token_key: 'test-key',
+        }),
+        uuid: 'f1739f9d-dfc0-83c8-011f-ec17103a06c4',
+      };
+      const record = this.store.createRecord('secret-engine', mountData);
+      await record.save();
+    });
   });
 });


### PR DESCRIPTION
### Description
This PR adds the modal/create part to the aws secret engine mount. 

- [x] enterprise test pass.

* if a user has read access it `identity/oidc/key` they can either search existing oidc/keys or they can create one. 
* if a user does _not_ have read access they can type a key into an input box. If the key does not exist then the API will surface an error.
* **FYI**: We are surfacing about half the fields used to create an `identity/oidc/key` (at the very bottom I'll provide a screenshot of that full form). Design would like to only include a limited / required set of form fields to create an identity_token_key here. This has been cleared with the backend as well. 
* It's important that a user is given the ability to add a key at the mounting stage of an engine because they cannot add this later via the UI. 

## Screenshots

#### Admin user with full access to `identity/oidc/key`
![image](https://github.com/user-attachments/assets/76a65c92-c043-4789-855e-8e9fcbf67c5a)

![image](https://github.com/user-attachments/assets/d11636f3-05df-4939-acdd-7b29a6e58420)

**If they created a key**
_(I have a nice to have ticket to fix the styling of the flash message. That was an existing issue and trying to keep scope tight)_
![image](https://github.com/user-attachments/assets/76bf9c95-170d-4568-8911-3980ae0991ba)


#### Admin user _without_ access to `identity/oidc/key`
![image](https://github.com/user-attachments/assets/2cb02896-5669-4883-9a0b-f849be600551)

**If they enter a key that does not exist, the API will surface the following error:**
![image](https://github.com/user-attachments/assets/f86a1bf3-0029-429a-a3e9-3789effd8092)

#### The full form to create an `identity/oidc/key` found via the OIDC provider workflow. 
![image](https://github.com/user-attachments/assets/f17f602a-eb9a-4723-91fb-cd2eaf27c9c9)
