### PR TITLE
Audit: optional logger for sinks will log on errors when context is done

### DIFF
--- a/audit/backend_file.go
+++ b/audit/backend_file.go
@@ -76,12 +76,12 @@ func newFileBackend(conf *BackendConfig, headersConfig HeaderFormatter) (*FileBa
 		return nil, err
 	}
 
-	var opt []event.Option
+	sinkOpts := []event.Option{event.WithLogger(conf.Logger)}
 	if mode, ok := conf.Config[optionMode]; ok {
-		opt = append(opt, event.WithFileMode(mode))
+		sinkOpts = append(sinkOpts, event.WithFileMode(mode))
 	}
 
-	err = b.configureSinkNode(conf.MountPath, filePath, cfg.requiredFormat, opt...)
+	err = b.configureSinkNode(conf.MountPath, filePath, cfg.requiredFormat, sinkOpts...)
 	if err != nil {
 		return nil, err
 	}

--- a/audit/backend_socket.go
+++ b/audit/backend_socket.go
@@ -70,6 +70,7 @@ func newSocketBackend(conf *BackendConfig, headersConfig HeaderFormatter) (*Sock
 	sinkOpts := []event.Option{
 		event.WithSocketType(socketType),
 		event.WithMaxDuration(writeDeadline),
+		event.WithLogger(conf.Logger),
 	}
 
 	err = event.ValidateOptions(sinkOpts...)

--- a/audit/backend_syslog.go
+++ b/audit/backend_syslog.go
@@ -60,6 +60,7 @@ func newSyslogBackend(conf *BackendConfig, headersConfig HeaderFormatter) (*Sysl
 	sinkOpts := []event.Option{
 		event.WithFacility(facility),
 		event.WithTag(tag),
+		event.WithLogger(conf.Logger),
 	}
 
 	err = event.ValidateOptions(sinkOpts...)

--- a/changelog/27859.txt
+++ b/changelog/27859.txt
@@ -1,0 +1,4 @@
+```release-note:improvement
+audit: sinks (file, socket, syslog) will attempt to log errors to the server operational 
+log before returning (if there are errors to log, and the context is done).
+```

--- a/internal/observability/event/options.go
+++ b/internal/observability/event/options.go
@@ -6,10 +6,12 @@ package event
 import (
 	"fmt"
 	"os"
+	"reflect"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-secure-stdlib/parseutil"
 	"github.com/hashicorp/go-uuid"
 )
@@ -26,6 +28,7 @@ type options struct {
 	withSocketType  string
 	withMaxDuration time.Duration
 	withFileMode    *os.FileMode
+	withLogger      hclog.Logger
 }
 
 // getDefaultOptions returns Options with their default values.
@@ -196,6 +199,18 @@ func WithFileMode(mode string) Option {
 		default:
 			m := os.FileMode(raw)
 			o.withFileMode = &m
+		}
+
+		return nil
+	}
+}
+
+// WithLogger provides an Option to supply a logger which will be used to write logs.
+// NOTE: If no logger is supplied then logging may not be possible.
+func WithLogger(l hclog.Logger) Option {
+	return func(o *options) error {
+		if l != nil && !reflect.ValueOf(l).IsNil() {
+			o.withLogger = l
 		}
 
 		return nil

--- a/internal/observability/event/options_test.go
+++ b/internal/observability/event/options_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/go-hclog"
 	"github.com/stretchr/testify/require"
 )
 
@@ -419,6 +420,40 @@ func TestOptions_WithFileMode(t *testing.T) {
 					// Dereference the pointer, so we can examine the file mode.
 					require.Equal(t, tc.ExpectedValue, *opts.withFileMode)
 				}
+			}
+		})
+	}
+}
+
+// TestOptions_WithLogger exercises WithLogger Option to ensure it performs as expected.
+func TestOptions_WithLogger(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		value         hclog.Logger
+		isNilExpected bool
+	}{
+		"nil-pointer": {
+			value:         nil,
+			isNilExpected: true,
+		},
+		"logger": {
+			value: hclog.NewNullLogger(),
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			opts := &options{}
+			applyOption := WithLogger(tc.value)
+			err := applyOption(opts)
+			require.NoError(t, err)
+			if tc.isNilExpected {
+				require.Nil(t, opts.withLogger)
+			} else {
+				require.NotNil(t, opts.withLogger)
 			}
 		})
 	}

--- a/internal/observability/event/sink_file.go
+++ b/internal/observability/event/sink_file.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 
 	"github.com/hashicorp/eventlogger"
+	"github.com/hashicorp/go-hclog"
 )
 
 // defaultFileMode is the default file permissions (read/write for everyone).
@@ -31,6 +32,7 @@ type FileSink struct {
 	fileMode       os.FileMode
 	path           string
 	requiredFormat string
+	logger         hclog.Logger
 }
 
 // NewFileSink should be used to create a new FileSink.
@@ -69,6 +71,7 @@ func NewFileSink(path string, format string, opt ...Option) (*FileSink, error) {
 		fileMode:       mode,
 		requiredFormat: format,
 		path:           p,
+		logger:         opts.withLogger,
 	}
 
 	// Ensure that the file can be successfully opened for writing;
@@ -82,12 +85,21 @@ func NewFileSink(path string, format string, opt ...Option) (*FileSink, error) {
 }
 
 // Process handles writing the event to the file sink.
-func (s *FileSink) Process(ctx context.Context, e *eventlogger.Event) (*eventlogger.Event, error) {
+func (s *FileSink) Process(ctx context.Context, e *eventlogger.Event) (_ *eventlogger.Event, retErr error) {
 	select {
 	case <-ctx.Done():
 		return nil, ctx.Err()
 	default:
 	}
+
+	defer func() {
+		// If the context is errored (cancelled), and we were planning to return
+		// an error, let's also log (if we have a logger) in case the eventlogger's
+		// status channel and errors propagated.
+		if err := ctx.Err(); err != nil && retErr != nil && s.logger != nil {
+			s.logger.Error("file sink error", "context", err, "error", retErr)
+		}
+	}()
 
 	if e == nil {
 		return nil, fmt.Errorf("event is nil: %w", ErrInvalidParameter)

--- a/vault/audit.go
+++ b/vault/audit.go
@@ -160,7 +160,6 @@ func (c *Core) enableAudit(ctx context.Context, entry *MountEntry, updateStorage
 		if err != nil {
 			c.logger.Error("new audit backend failed test", "path", entry.Path, "type", entry.Type, "error", err)
 			return fmt.Errorf("audit backend failed test message: %w", err)
-
 		}
 	}
 


### PR DESCRIPTION
### Description

Allows audit sink nodes to receive an optional `logger` which is then used if an error is intended to be returned, but the context is already done. In this case it will log the error before returning.

### HashiCorp Checklist

- [x] **Labels:** If this PR is the CE portion of an ENT change, and that ENT change is
  getting backported to N-2, use the new style `backport/ent/x.x.x+ent` labels
  instead of the old style `backport/x.x.x` labels.
- [x] **Labels:** If this PR is a CE only change, it can only be backported to N, so use
  the normal `backport/x.x.x` label (there should be only 1).
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
