### PR TITLE
Audit: Remove multi-errors and update expected error msg in tests

### DIFF
--- a/audit/broker.go
+++ b/audit/broker.go
@@ -15,7 +15,6 @@ import (
 	"github.com/armon/go-metrics"
 	"github.com/hashicorp/eventlogger"
 	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/vault/helper/namespace"
 	"github.com/hashicorp/vault/internal/observability/event"
 	"github.com/hashicorp/vault/sdk/logical"
@@ -253,7 +252,7 @@ func (b *Broker) Deregister(ctx context.Context, name string) error {
 
 // LogRequest is used to ensure all the audit backends have an opportunity to
 // log the given request and that *at least one* succeeds.
-func (b *Broker) LogRequest(ctx context.Context, in *logical.LogInput) (ret error) {
+func (b *Broker) LogRequest(ctx context.Context, in *logical.LogInput) (retErr error) {
 	b.RLock()
 	defer b.RUnlock()
 
@@ -265,18 +264,15 @@ func (b *Broker) LogRequest(ctx context.Context, in *logical.LogInput) (ret erro
 	defer metrics.MeasureSince([]string{"audit", "log_request"}, time.Now())
 	defer func() {
 		metricVal := float32(0.0)
-		if ret != nil {
+		if retErr != nil {
 			metricVal = 1.0
 		}
 		metrics.IncrCounter([]string{"audit", "log_request_failure"}, metricVal)
 	}()
 
-	var retErr *multierror.Error
-
 	e, err := NewEvent(RequestType)
 	if err != nil {
-		retErr = multierror.Append(retErr, err)
-		return retErr.ErrorOrNil()
+		return err
 	}
 
 	e.Data = in
@@ -295,8 +291,7 @@ func (b *Broker) LogRequest(ctx context.Context, in *logical.LogInput) (ret erro
 		// cancelled context and refuse to process the nodes further.
 		ns, err := namespace.FromContext(ctx)
 		if err != nil {
-			retErr = multierror.Append(retErr, fmt.Errorf("namespace missing from context: %w", err))
-			return retErr.ErrorOrNil()
+			return fmt.Errorf("namespace missing from context: %w", err)
 		}
 
 		tempContext, auditCancel := context.WithTimeout(context.Background(), timeout)
@@ -308,8 +303,7 @@ func (b *Broker) LogRequest(ctx context.Context, in *logical.LogInput) (ret erro
 	if hasAuditPipelines(b.broker) {
 		status, err = b.broker.Send(auditContext, event.AuditType.AsEventType(), e)
 		if err != nil {
-			retErr = multierror.Append(retErr, multierror.Append(err, status.Warnings...))
-			return retErr.ErrorOrNil()
+			return fmt.Errorf("%w: %w", err, errors.Join(status.Warnings...))
 		}
 	}
 
@@ -318,30 +312,29 @@ func (b *Broker) LogRequest(ctx context.Context, in *logical.LogInput) (ret erro
 		// We should log warnings to the operational logs regardless of whether
 		// we consider the overall auditing attempt to be successful.
 		if len(status.Warnings) > 0 {
-			b.logger.Error("log request underlying pipeline error(s)", "error", &multierror.Error{Errors: status.Warnings})
+			b.logger.Error("log request underlying pipeline error(s)", "error", errors.Join(status.Warnings...))
 		}
 
-		return retErr.ErrorOrNil()
+		return nil
 	}
 
 	// There were errors from inside the pipeline and we didn't write to a sink.
 	if len(status.Warnings) > 0 {
-		retErr = multierror.Append(retErr, multierror.Append(errors.New("error during audit pipeline processing"), status.Warnings...))
-		return retErr.ErrorOrNil()
+		return fmt.Errorf("error during audit pipeline processing: %w", errors.Join(status.Warnings...))
 	}
 
 	// Handle any additional audit that is required (Enterprise/CE dependant).
 	err = b.handleAdditionalAudit(auditContext, e)
 	if err != nil {
-		retErr = multierror.Append(retErr, err)
+		return err
 	}
 
-	return retErr.ErrorOrNil()
+	return nil
 }
 
 // LogResponse is used to ensure all the audit backends have an opportunity to
 // log the given response and that *at least one* succeeds.
-func (b *Broker) LogResponse(ctx context.Context, in *logical.LogInput) (ret error) {
+func (b *Broker) LogResponse(ctx context.Context, in *logical.LogInput) (retErr error) {
 	b.RLock()
 	defer b.RUnlock()
 
@@ -353,18 +346,15 @@ func (b *Broker) LogResponse(ctx context.Context, in *logical.LogInput) (ret err
 	defer metrics.MeasureSince([]string{"audit", "log_response"}, time.Now())
 	defer func() {
 		metricVal := float32(0.0)
-		if ret != nil {
+		if retErr != nil {
 			metricVal = 1.0
 		}
 		metrics.IncrCounter([]string{"audit", "log_response_failure"}, metricVal)
 	}()
 
-	var retErr *multierror.Error
-
 	e, err := NewEvent(ResponseType)
 	if err != nil {
-		retErr = multierror.Append(retErr, err)
-		return retErr.ErrorOrNil()
+		return err
 	}
 
 	e.Data = in
@@ -383,8 +373,7 @@ func (b *Broker) LogResponse(ctx context.Context, in *logical.LogInput) (ret err
 		// cancelled context and refuse to process the nodes further.
 		ns, err := namespace.FromContext(ctx)
 		if err != nil {
-			retErr = multierror.Append(retErr, fmt.Errorf("namespace missing from context: %w", err))
-			return retErr.ErrorOrNil()
+			return fmt.Errorf("namespace missing from context: %w", err)
 		}
 
 		tempContext, auditCancel := context.WithTimeout(context.Background(), timeout)
@@ -396,8 +385,7 @@ func (b *Broker) LogResponse(ctx context.Context, in *logical.LogInput) (ret err
 	if hasAuditPipelines(b.broker) {
 		status, err = b.broker.Send(auditContext, event.AuditType.AsEventType(), e)
 		if err != nil {
-			retErr = multierror.Append(retErr, multierror.Append(err, status.Warnings...))
-			return retErr.ErrorOrNil()
+			return fmt.Errorf("%w: %w", err, errors.Join(status.Warnings...))
 		}
 	}
 
@@ -406,25 +394,24 @@ func (b *Broker) LogResponse(ctx context.Context, in *logical.LogInput) (ret err
 		// We should log warnings to the operational logs regardless of whether
 		// we consider the overall auditing attempt to be successful.
 		if len(status.Warnings) > 0 {
-			b.logger.Error("log response underlying pipeline error(s)", "error", &multierror.Error{Errors: status.Warnings})
+			b.logger.Error("log response underlying pipeline error(s)", "error", errors.Join(status.Warnings...))
 		}
 
-		return retErr.ErrorOrNil()
+		return nil
 	}
 
 	// There were errors from inside the pipeline and we didn't write to a sink.
 	if len(status.Warnings) > 0 {
-		retErr = multierror.Append(retErr, multierror.Append(errors.New("error during audit pipeline processing"), status.Warnings...))
-		return retErr.ErrorOrNil()
+		return fmt.Errorf("error during audit pipeline processing: %w", errors.Join(status.Warnings...))
 	}
 
 	// Handle any additional audit that is required (Enterprise/CE dependant).
 	err = b.handleAdditionalAudit(auditContext, e)
 	if err != nil {
-		retErr = multierror.Append(retErr, err)
+		return err
 	}
 
-	return retErr.ErrorOrNil()
+	return nil
 }
 
 func (b *Broker) Invalidate(ctx context.Context, _ string) {

--- a/vault/audit_test.go
+++ b/vault/audit_test.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/errwrap"
 	log "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/vault/audit"
@@ -442,9 +441,9 @@ func TestAuditBroker_LogRequest(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
-	// Should FAIL work with both failing backends
+	// Should FAIL when both backends fail
 	a2.ReqErr = fmt.Errorf("failed")
-	if err := b.LogRequest(ctx, logInput); !errwrap.Contains(err, "event not processed by enough 'sink' nodes") {
+	if err = b.LogRequest(ctx, logInput); err != nil && !strings.HasPrefix(err.Error(), "event not processed by enough 'sink' nodes") {
 		t.Fatalf("err: %v", err)
 	}
 }
@@ -630,8 +629,7 @@ func TestAuditBroker_AuditHeaders(t *testing.T) {
 
 	// Should FAIL work with both failing backends
 	a2.ReqErr = fmt.Errorf("failed")
-	err = b.LogRequest(ctx, logInput)
-	if !errwrap.Contains(err, "event not processed by enough 'sink' nodes") {
+	if err = b.LogRequest(ctx, logInput); err != nil && !strings.HasPrefix(err.Error(), "event not processed by enough 'sink' nodes") {
 		t.Fatalf("err: %v", err)
 	}
 }


### PR DESCRIPTION
### Description

Removes the use of multierror and instead uses the Go stdlib errors join.

ENT PR: https://github.com/hashicorp/vault-enterprise/pull/6285

### HashiCorp Checklist 

- [x] **Labels:** If this PR is the CE portion of an ENT change, and that ENT change is
  getting backported to N-2, use the new style `backport/ent/x.x.x+ent` labels
  instead of the old style `backport/x.x.x` labels.
- [x] **Labels:** If this PR is a CE only change, it can only be backported to N, so use
  the normal `backport/x.x.x` label (there should be only 1).
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
