### PR TITLE
Client Count Docs Updates/Cleanup

### DIFF
--- a/website/content/api-docs/system/internal-counters.mdx
+++ b/website/content/api-docs/system/internal-counters.mdx
@@ -223,16 +223,18 @@ Vault lead to the new clients for each month.
 }
 ```
 
-- The response includes the actual time period covered, which may not exactly
-match the query parameters due to the month granularity of data or missing
-months in the requested time range.
+- The response includes month data for the entire queried period, which may
+not exactly match the `start_time` and `end_time` returned in the response.
+The `start_time` in the response is the earliest time there is activity data
+in the queried period. The `end_time` is the end of the final month of the queried
+period.
 
 - If the `end_date` supplied to the API is the current month, exact activity
 information will be returned for all months in the queried period, except for the
 current month. The last element in the `months` response stanza, will signify the current month. Furthermore, the
 `new_clients` counts returned for the current month will be an estimate.
 
-The following is another example of the `months` breakdown.
+The following is another example of the `months` breakdown with just the current month information.
 
 
 ```json

--- a/website/content/api-docs/system/internal-counters.mdx
+++ b/website/content/api-docs/system/internal-counters.mdx
@@ -223,7 +223,7 @@ Vault lead to the new clients for each month.
 }
 ```
 
-- The response includes month data for the entire queried period, which may
+- The response includes month data for the entire queried period, but may
 not exactly match the `start_time` and `end_time` returned in the response.
 The `start_time` in the response is the earliest time there is activity data
 in the queried period. The `end_time` is the end of the final month of the queried

--- a/website/content/api-docs/system/internal-counters.mdx
+++ b/website/content/api-docs/system/internal-counters.mdx
@@ -234,7 +234,7 @@ information will be returned for all months in the queried period, except for th
 current month. The last element in the `months` response stanza, will signify the current month. Furthermore, the
 `new_clients` counts returned for the current month will be an estimate.
 
-The following is another example of the `months` breakdown with just the current month information.
+The following is an example of the `months` breakdown with just the current month information.
 
 
 ```json
@@ -282,7 +282,35 @@ The following is another example of the `months` breakdown with just the current
                "acme_clients":"approx int value",
                "clients":"approx int value"
             },
-            "namespaces":[]
+            "namespaces":[
+               {
+                  "namespace_id":"root",
+                  "namespace_path":"",
+                  "counts":{},
+                  "mounts":[
+                     {
+                        "path":"auth/up2/",
+                        "counts":{
+                          "entity_clients":"approx int value",
+                          "non_entity_clients":"approx int value",
+                          "secret_syncs":"approx int value",
+                          "acme_clients":"approx int value",
+                          "clients":"approx int value"
+                         },
+                     },
+                     {
+                        "path":"auth/up1/",
+                        "counts":{
+                          "entity_clients":"approx int value",
+                          "non_entity_clients":"approx int value",
+                          "secret_syncs":"approx int value",
+                          "acme_clients":"approx int value",
+                          "clients":"approx int value"
+                        }
+                     }
+                  ]
+               }
+            ]
          }
       }
    ],

--- a/website/content/api-docs/system/internal-counters.mdx
+++ b/website/content/api-docs/system/internal-counters.mdx
@@ -90,22 +90,6 @@ $ curl \
 This endpoint returns client activity information for a given billing
 period, which is represented by the `start_time` and `end_time` parameters.
 
-There are a few things to keep in mind while using this API.
-
-- For Vault versions before 1.11, the activity information only accounts for
-the activity of the latest contiguous months in the billing period.
-For example, if the billing period is from Jan 2022 to June 2022, and the
-activity subsystem in Vault was not capturing data for the months Jan to March,
-the response will only include information for May and June. Note that if no
-`start_time` and `end_time` parameters are specified, the billing period defaults
-to 12 months, so the endpoint will return activity information from the end of the
-previous month to the start of 12 months prior to that date.
-
-- As of 1.11, this behavior has been modified to return all available data within
-the specified billing period.
-
-- As of 1.12, the `end_time` can be the current month.
-
 - The response contains the total activity for the billing period and the
 attributions of the total activity against specific components in Vault. This
 helps in understanding the total activity better by knowing which components in
@@ -250,8 +234,7 @@ match the query parameters due to the month granularity of data or missing
 months in the requested time range.
 
 - Note that if the `end_date` specified is the current month,
-the last element in the `months` response stanza, signifying the current month, will
-not have namespace attribution for the `new_clients` stanza. Furthermore, the
+the last element in the `months` response stanza, will signify the current month. Furthermore, the
 `new_clients` counts returned for the current month will be an approximation.
 That is to say, the response will appear as follows.
 
@@ -1066,7 +1049,6 @@ months in the requested time range.
 information returned by this API will include activity for this month, however
 it may be up to 20 minutes delayed.
 
-This endpoint was added in Vault 1.11.
 
 @include 'alerts/restricted-root.mdx'
 

--- a/website/content/api-docs/system/internal-counters.mdx
+++ b/website/content/api-docs/system/internal-counters.mdx
@@ -231,7 +231,7 @@ period.
 
 - If the `end_date` supplied to the API is the current month, exact activity
 information will be returned for all months in the queried period, except for the
-current month. The last element in the `months` response stanza, will signify the current month. Furthermore, the
+current month. The last element in the `months` response stanza will signify the current month. Furthermore, the
 `new_clients` counts returned for the current month will be an estimate.
 
 The following is an example of the `months` breakdown with just the current month information.

--- a/website/content/api-docs/system/internal-counters.mdx
+++ b/website/content/api-docs/system/internal-counters.mdx
@@ -223,20 +223,17 @@ Vault lead to the new clients for each month.
 }
 ```
 
-- If the `end_date` supplied to the API is for the current month, the activity
-information returned by this API will only be till the previous month. The
-activity system is designed to process the accumulated activity only at the end
-of the month. Since the system does not fully process the current month's
-information, it will not be added to the API response.
-
 - The response includes the actual time period covered, which may not exactly
 match the query parameters due to the month granularity of data or missing
 months in the requested time range.
 
-- Note that if the `end_date` specified is the current month,
-the last element in the `months` response stanza, will signify the current month. Furthermore, the
-`new_clients` counts returned for the current month will be an approximation.
-That is to say, the response will appear as follows.
+- If the `end_date` supplied to the API is the current month, exact activity
+information will be returned for all months in the queried period, except for the
+current month. The last element in the `months` response stanza, will signify the current month. Furthermore, the
+`new_clients` counts returned for the current month will be an estimate.
+
+The following is another example of the `months` breakdown.
+
 
 ```json
 {
@@ -302,7 +299,6 @@ be listed as "deleted namespace :ID:." Deleted namespaces are reported only for
 queries in the root namespace because the information about the namespace path
 is unknown.
 
-This endpoint was added in Vault 1.6.
 
 @include 'alerts/restricted-root.mdx'
 
@@ -817,8 +813,6 @@ this request was made.
 Note: the client count may be inaccurate in the moments following a Vault
 reboot, or leadership change. The estimate will stabilize when background
 loading of client data has completed.
-
-This endpoint was added in Vault 1.7.
 
 @include 'alerts/restricted-root.mdx'
 


### PR DESCRIPTION
### Description
Client count documentation updates. 

The main objectives:
- Remove any version related descriptions; the docs team wants to train customers to use the versioned docs for this information.
- Try to condense multiple bullets into as few as possible.
- Remove repetitive information, and remedy any incorrect information.

### TODO only if you're a HashiCorp employee
- [ ] **Labels:** If this PR is the CE portion of an ENT change, and that ENT change is
  getting backported to N-2, use the new style `backport/ent/x.x.x+ent` labels
  instead of the old style `backport/x.x.x` labels.
- [ ] **Labels:** If this PR is a CE only change, it can only be backported to N, so use
  the normal `backport/x.x.x` label (there should be only 1).
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
