### PR TITLE
Backport 1.17.x auto rolling

### DIFF
--- a/changelog/27656.txt
+++ b/changelog/27656.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+license utilization reporting (enterprise): Auto-roll billing start date.
+```

--- a/command/server.go
+++ b/command/server.go
@@ -1703,7 +1703,7 @@ func (c *ServerCommand) Run(args []string) int {
 				sr.NotifyConfigurationReload(srConfig)
 			}
 
-			if err := core.ReloadCensusManager(); err != nil {
+			if err := core.ReloadCensusManager(false); err != nil {
 				c.UI.Error(err.Error())
 			}
 

--- a/command/server.go
+++ b/command/server.go
@@ -1703,7 +1703,7 @@ func (c *ServerCommand) Run(args []string) int {
 				sr.NotifyConfigurationReload(srConfig)
 			}
 
-			if err := core.ReloadCensus(); err != nil {
+			if err := core.ReloadCensusManager(); err != nil {
 				c.UI.Error(err.Error())
 			}
 

--- a/command/server_util.go
+++ b/command/server_util.go
@@ -24,6 +24,10 @@ func (c *ServerCommand) ReloadedCh() chan struct{} {
 	return c.reloadedCh
 }
 
+func (c *ServerCommand) LicenseReloadedCh() chan error {
+	return c.licenseReloadedCh
+}
+
 func testServerCommand(tb testing.TB) (*cli.MockUi, *ServerCommand) {
 	tb.Helper()
 

--- a/helper/timeutil/timeutil.go
+++ b/helper/timeutil/timeutil.go
@@ -179,3 +179,13 @@ func (_ DefaultClock) NewTicker(d time.Duration) *time.Ticker {
 func (_ DefaultClock) NewTimer(d time.Duration) *time.Timer {
 	return time.NewTimer(d)
 }
+
+// NormalizeToYear returns date normalized to the latest date
+// within one year of normal. Assumes the date argument is
+// some date before normal.
+func NormalizeToYear(date, normal time.Time) time.Time {
+	for date.AddDate(1, 0, 0).Compare(normal) <= 0 {
+		date = date.AddDate(1, 0, 0)
+	}
+	return date
+}

--- a/helper/timeutil/timeutil_test.go
+++ b/helper/timeutil/timeutil_test.go
@@ -7,6 +7,8 @@ import (
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestTimeutil_StartOfPreviousMonth(t *testing.T) {
@@ -365,5 +367,96 @@ func TestTimeUtil_ParseTimeFromPath(t *testing.T) {
 		if gotError != tc.expectError {
 			t.Errorf("bad error status on input %q. expected error: %t, got error: %t", tc.input, tc.expectError, gotError)
 		}
+	}
+}
+
+// TestTimeUtil_NormalizeToYear tests NormalizeToYear function which returns the normalized input date wrt to the normal.
+func TestTimeUtil_NormalizeToYear(t *testing.T) {
+	testCases := []struct {
+		inputDate              time.Time
+		normalDate             time.Time
+		expectedNormalizedDate time.Time
+	}{
+		{
+			inputDate:              time.Date(2024, 9, 29, 0, 0, 0, 0, time.UTC),
+			normalDate:             time.Date(2024, 10, 1, 0, 0, 0, 0, time.UTC),
+			expectedNormalizedDate: time.Date(2024, 9, 29, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			inputDate:              time.Date(2024, 9, 29, 0, 0, 0, 0, time.UTC),
+			normalDate:             time.Date(2025, 9, 29, 0, 0, 0, 0, time.UTC),
+			expectedNormalizedDate: time.Date(2025, 9, 29, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			inputDate:              time.Date(2024, 9, 29, 0, 0, 0, 0, time.UTC),
+			normalDate:             time.Date(2025, 10, 1, 0, 0, 0, 0, time.UTC),
+			expectedNormalizedDate: time.Date(2025, 9, 29, 0, 0, 0, 0, time.UTC),
+		},
+		// inputDate more than 2 years prior to normal date
+		{
+			inputDate:              time.Date(2022, 9, 29, 0, 0, 0, 0, time.UTC),
+			normalDate:             time.Date(2024, 6, 15, 0, 0, 0, 0, time.UTC),
+			expectedNormalizedDate: time.Date(2023, 9, 29, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			inputDate:              time.Date(2022, 9, 29, 0, 0, 0, 0, time.UTC),
+			normalDate:             time.Date(2024, 9, 28, 0, 0, 0, 0, time.UTC),
+			expectedNormalizedDate: time.Date(2023, 9, 29, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			inputDate:              time.Date(2022, 9, 29, 0, 0, 0, 0, time.UTC),
+			normalDate:             time.Date(2024, 9, 29, 0, 0, 0, 0, time.UTC),
+			expectedNormalizedDate: time.Date(2024, 9, 29, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			inputDate:              time.Date(2022, 9, 29, 0, 0, 0, 0, time.UTC),
+			normalDate:             time.Date(2024, 9, 30, 0, 0, 0, 0, time.UTC),
+			expectedNormalizedDate: time.Date(2024, 9, 29, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			inputDate:              time.Date(2020, 9, 29, 0, 0, 0, 0, time.UTC),
+			normalDate:             time.Date(2024, 12, 1, 0, 0, 0, 0, time.UTC),
+			expectedNormalizedDate: time.Date(2024, 9, 29, 0, 0, 0, 0, time.UTC),
+		},
+		// leap year test cases
+		{
+			inputDate:              time.Date(2020, 9, 29, 0, 0, 0, 0, time.UTC),
+			normalDate:             time.Date(2024, 9, 28, 0, 0, 0, 0, time.UTC),
+			expectedNormalizedDate: time.Date(2023, 9, 29, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			inputDate:              time.Date(2024, 2, 29, 0, 0, 0, 0, time.UTC),
+			normalDate:             time.Date(2025, 2, 28, 0, 0, 0, 0, time.UTC),
+			expectedNormalizedDate: time.Date(2024, 2, 29, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			inputDate:              time.Date(2024, 2, 29, 0, 0, 0, 0, time.UTC),
+			normalDate:             time.Date(2025, 3, 1, 0, 0, 0, 0, time.UTC),
+			expectedNormalizedDate: time.Date(2025, 3, 1, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			inputDate:              time.Date(2024, 2, 29, 0, 0, 0, 0, time.UTC),
+			normalDate:             time.Date(2025, 3, 2, 0, 0, 0, 0, time.UTC),
+			expectedNormalizedDate: time.Date(2025, 3, 1, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			inputDate:              time.Date(2024, 2, 29, 0, 0, 0, 0, time.UTC),
+			normalDate:             time.Date(2028, 2, 28, 0, 0, 0, 0, time.UTC),
+			expectedNormalizedDate: time.Date(2027, 3, 1, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			inputDate:              time.Date(2024, 2, 29, 0, 0, 0, 0, time.UTC),
+			normalDate:             time.Date(2028, 2, 29, 0, 0, 0, 0, time.UTC),
+			expectedNormalizedDate: time.Date(2027, 3, 1, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			inputDate:              time.Date(2024, 2, 29, 0, 0, 0, 0, time.UTC),
+			normalDate:             time.Date(2028, 3, 1, 0, 0, 0, 0, time.UTC),
+			expectedNormalizedDate: time.Date(2028, 3, 1, 0, 0, 0, 0, time.UTC),
+		},
+	}
+	for _, tc := range testCases {
+		normalizedDate := NormalizeToYear(tc.inputDate, tc.normalDate)
+		require.Equal(t, tc.expectedNormalizedDate, normalizedDate)
 	}
 }

--- a/vault/activity_log.go
+++ b/vault/activity_log.go
@@ -1016,7 +1016,8 @@ func (a *ActivityLog) SetConfigInit(config activityConfig) {
 	a.defaultReportMonths = config.DefaultReportMonths
 	a.retentionMonths = config.RetentionMonths
 
-	if a.retentionMonths < a.configOverrides.MinimumRetentionMonths {
+	// Let tests override the minimum if they want to.
+	if a.configOverrides.MinimumRetentionMonths > 0 {
 		a.retentionMonths = a.configOverrides.MinimumRetentionMonths
 	}
 

--- a/vault/census.go
+++ b/vault/census.go
@@ -14,7 +14,6 @@ func (c *Core) setupCensusManager() error                        { return nil }
 func (c *Core) BillingStart() time.Time                          { return time.Time{} }
 func (c *Core) AutomatedLicenseReportingEnabled() bool           { return false }
 func (c *Core) CensusAgent() CensusReporter                      { return nil }
-func (c *Core) ReloadCensus() error                              { return nil }
 func (c *Core) teardownCensusManager() error                     { return nil }
 func (c *Core) StartManualCensusSnapshots()                      {}
 func (c *Core) ManualLicenseReportingEnabled() bool              { return false }

--- a/vault/census_stubs_oss.go
+++ b/vault/census_stubs_oss.go
@@ -10,4 +10,5 @@ import "context"
 //go:generate go run github.com/hashicorp/vault/tools/stubmaker
 
 func (c *Core) StartCensusReports(ctx context.Context) {}
-func (c *Core) ReloadCensusActivityLog() error         { return nil }
+func (c *Core) SetRetentionMonths(months int) error    { return nil }
+func (c *Core) ReloadCensusManager() error             { return nil }

--- a/vault/census_stubs_oss.go
+++ b/vault/census_stubs_oss.go
@@ -9,6 +9,6 @@ import "context"
 
 //go:generate go run github.com/hashicorp/vault/tools/stubmaker
 
-func (c *Core) StartCensusReports(ctx context.Context) {}
-func (c *Core) SetRetentionMonths(months int) error    { return nil }
-func (c *Core) ReloadCensusManager() error             { return nil }
+func (c *Core) StartCensusReports(ctx context.Context)       {}
+func (c *Core) SetRetentionMonths(months int) error          { return nil }
+func (c *Core) ReloadCensusManager(licenseChange bool) error { return nil }

--- a/vault/core.go
+++ b/vault/core.go
@@ -2458,15 +2458,12 @@ func (s standardUnsealStrategy) unseal(ctx context.Context, logger log.Logger, c
 			return err
 		}
 
-		if !c.perfStandby {
-			if err := c.setupCensusManager(); err != nil {
-				logger.Error("failed to instantiate the license reporting agent", "error", err)
-			}
-
-			c.StartCensusReports(ctx)
-
-			c.StartManualCensusSnapshots()
+		if err := c.setupCensusManager(); err != nil {
+			logger.Error("failed to instantiate the license reporting agent", "error", err)
 		}
+
+		c.StartCensusReports(ctx)
+		c.StartManualCensusSnapshots()
 
 	} else {
 		brokerLogger := logger.Named("audit")
@@ -2861,7 +2858,6 @@ func (c *Core) preSeal() error {
 	if err := c.teardownCensusManager(); err != nil {
 		result = multierror.Append(result, fmt.Errorf("error tearing down reporting agent: %w", err))
 	}
-
 	if err := c.teardownCredentials(context.Background()); err != nil {
 		result = multierror.Append(result, fmt.Errorf("error tearing down credentials: %w", err))
 	}

--- a/vault/logical_system_activity.go
+++ b/vault/logical_system_activity.go
@@ -411,9 +411,6 @@ func (b *SystemBackend) handleActivityConfigUpdate(ctx context.Context, req *log
 		}
 	}
 
-	a.core.activityLogLock.RLock()
-	minimumRetentionMonths := a.configOverrides.MinimumRetentionMonths
-	a.core.activityLogLock.RUnlock()
 	enabled := config.Enabled == "enable"
 	if !enabled && config.Enabled == "default" {
 		enabled = activityLogEnabledDefault
@@ -424,8 +421,8 @@ func (b *SystemBackend) handleActivityConfigUpdate(ctx context.Context, req *log
 	}
 
 	// if manual license reporting is enabled, retention months must at least be 48 months
-	if a.core.ManualLicenseReportingEnabled() && config.RetentionMonths < minimumRetentionMonths {
-		return logical.ErrorResponse("retention_months must be at least %d while Reporting is enabled", minimumRetentionMonths), logical.ErrInvalidRequest
+	if a.core.ManualLicenseReportingEnabled() && config.RetentionMonths < ActivityLogMinimumRetentionMonths {
+		return logical.ErrorResponse("retention_months must be at least %d while Reporting is enabled", ActivityLogMinimumRetentionMonths), logical.ErrInvalidRequest
 	}
 
 	// Store the config
@@ -440,9 +437,9 @@ func (b *SystemBackend) handleActivityConfigUpdate(ctx context.Context, req *log
 	// Set the new config on the activity log
 	a.SetConfig(ctx, config)
 
-	// reload census agent if retention months change during update when reporting is enabled
+	// Update Census agent's metadata if retention months change
 	if prevRetentionMonths != config.RetentionMonths {
-		if err := a.core.ReloadCensusActivityLog(); err != nil {
+		if err := b.Core.SetRetentionMonths(config.RetentionMonths); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
### Description
This PR contains all of the CE backports for the auto-rolling billing start date.

Enterprise PR: https://github.com/hashicorp/vault-enterprise/pull/6279
Addresses: VAULT-28005

### TODO only if you're a HashiCorp employee
- [x] **Labels:** If this PR is the CE portion of an ENT change, and that ENT change is
  getting backported to N-2, use the new style `backport/ent/x.x.x+ent` labels
  instead of the old style `backport/x.x.x` labels.
- [x] **Labels:** If this PR is a CE only change, it can only be backported to N, so use
  the normal `backport/x.x.x` label (there should be only 1).
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
