### PR TITLE
update MountEntry.Type to plugin name on mount tune for mounts created in Vault pre-v1.0.0

### DIFF
--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -2421,6 +2421,17 @@ func (b *SystemBackend) handleTuneWriteCommon(ctx context.Context, path string, 
 			pluginType = consts.PluginTypeCredential
 		}
 
+		// Update MountEntry.Type of external plugins registered in Vault pre-v1.0.0 to the plugin binary name
+		// stored in MountEntry.Config.PluginName
+		// Previously, when upgrading Vault from pre-v1.0.0 to post-v1.0.0, MountEntry.Type of external plugins
+		// remained "plugin" where it should follow the new scheme and be updated to the plugin binary name.
+		// https://hashicorp.atlassian.net/browse/VAULT-21999
+		if mountEntry.Config.PluginName != "" {
+			if mountEntry.Config.PluginName != mountEntry.Type && mountEntry.Type == "plugin" {
+				mountEntry.Type = mountEntry.Config.PluginName
+			}
+		}
+
 		pinnedVersion, err := b.Core.pluginCatalog.GetPinnedVersion(ctx, pluginType, mountEntry.Type)
 		if err != nil && !errors.Is(err, pluginutil.ErrPinnedVersionNotFound) {
 			return nil, err


### PR DESCRIPTION
### Description
This PR fixes `MountEntry.Type` of mounts that were created in Vault pre-v1.0.0 on mount tune after Vault upgrade to post-v1.0.0. On mount tune with `plugin_version`, if `MountEntry.Type` has "plugin" value and `MountEntry.Config.PluginName` has a different value, `MountEntry.Type` is updated to match.

### TODO only if you're a HashiCorp employee
- [x ]**Labels:** If this PR is the CE portion of an ENT change, and that ENT change is
  getting backported to N-2, use the new style `backport/ent/x.x.x+ent` labels
  instead of the old style `backport/x.x.x` labels.
- [x] **Labels:** If this PR is a CE only change, it can only be backported to N, so use
  the normal `backport/x.x.x` label (there should be only 1).
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
