### PR TITLE
Add note requiring GOBIN to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,9 +72,9 @@ If you wish to work on Vault itself or any of its built-in systems, you'll
 first need [Go](https://www.golang.org) installed on your machine.
 
 For local dev first make sure Go is properly installed, including setting up a
-[GOPATH](https://golang.org/doc/code.html#GOPATH). You must also set the 
-[GOBIN](https://pkg.go.dev/cmd/go#hdr-Environment_variables) variable. Ensure that 
-`$GOPATH/bin` is in your path as some distributions bundle the old version 
+[GOPATH](https://golang.org/doc/code.html#GOPATH), then setting the 
+[GOBIN](https://pkg.go.dev/cmd/go#hdr-Environment_variables) variable to `$GOPATH/bin`. 
+Ensure that `$GOPATH/bin` is in your path as some distributions bundle the old version 
 of build tools. 
 
 Next, clone this repository. Vault uses [Go Modules](https://github.com/golang/go/wiki/Modules),

--- a/README.md
+++ b/README.md
@@ -72,9 +72,12 @@ If you wish to work on Vault itself or any of its built-in systems, you'll
 first need [Go](https://www.golang.org) installed on your machine.
 
 For local dev first make sure Go is properly installed, including setting up a
-[GOPATH](https://golang.org/doc/code.html#GOPATH). Ensure that `$GOPATH/bin` is in
-your path as some distributions bundle the old version of build tools. Next, clone this
-repository. Vault uses [Go Modules](https://github.com/golang/go/wiki/Modules),
+[GOPATH](https://golang.org/doc/code.html#GOPATH). You must also set the 
+[GOBIN](https://pkg.go.dev/cmd/go#hdr-Environment_variables) variable. Ensure that 
+`$GOPATH/bin` is in your path as some distributions bundle the old version 
+of build tools. 
+
+Next, clone this repository. Vault uses [Go Modules](https://github.com/golang/go/wiki/Modules),
 so it is recommended that you clone the repository ***outside*** of the GOPATH.
 You can then download any required build tools by bootstrapping your environment:
 


### PR DESCRIPTION
### Description
I am on a fresh new laptop, getting the vault repo set up again. When I run `make bootstrap`, it no longer seems to work just with `$GOPATH` set and `$GOPATH/bin` added to the path like in the original instructions. Now, the external tools installation step will fail with the following message:

```
==> Running go generate...
builtin/logical/pki/path_config_acme.go:420: running "enumer": exec: "enumer": executable file not found in $PATH
command/operator_generate_root.go:26: running "enumer": exec: "enumer": executable file not found in $PATH
...
```

Explicitly setting the GOBIN variable in my `~/.zshrc` fixes the problem.

The difference between whether it works or not is literally in whether I comment out the below GOBIN line:
```
export PATH="$PATH:$GOPATH/bin"

# go
GOPATH="$HOME/go"
GOBIN="$GOPATH/bin"
```

### TODO only if you're a HashiCorp employee
- [N/A] **Labels:** If this PR is the CE portion of an ENT change, and that ENT change is
  getting backported to N-2, use the new style `backport/ent/x.x.x+ent` labels
  instead of the old style `backport/x.x.x` labels.
- [N/A] **Labels:** If this PR is a CE only change, it can only be backported to N, so use
  the normal `backport/x.x.x` label (there should be only 1).
- [N/A] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [N/A] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [N/A] **RFC:** If this change has an associated RFC, please link it in the description.
- [N/A] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
