### PR TITLE
Added PSC Private Service Connect for GCP CloudSQL

### DIFF
--- a/plugins/database/mysql/connection_producer.go
+++ b/plugins/database/mysql/connection_producer.go
@@ -37,6 +37,8 @@ type mySQLConnectionProducer struct {
 	Password                 string      `json:"password" mapstructure:"password" structs:"password"`
 	AuthType                 string      `json:"auth_type" mapstructure:"auth_type" structs:"auth_type"`
 	ServiceAccountJSON       string      `json:"service_account_json" mapstructure:"service_account_json" structs:"service_account_json"`
+	usePrivateIP             bool        `json:"use_private_ip" mapstructure:"use_private_ip" structs:"use_private_ip"`
+	usePSC                   bool        `json:"use_psc" mapstructure:"use_psc" structs:"use_psc"`
 
 	TLSCertificateKeyData []byte `json:"tls_certificate_key" mapstructure:"tls_certificate_key" structs:"-"`
 	TLSCAData             []byte `json:"tls_ca"              mapstructure:"tls_ca"              structs:"-"`
@@ -140,7 +142,7 @@ func (c *mySQLConnectionProducer) Init(ctx context.Context, conf map[string]inte
 		// however, the driver might store a credentials file, in which case the state stored by the driver is in
 		// fact critical to the proper function of the connection. So it needs to be registered here inside the
 		// ConnectionProducer init.
-		dialerCleanup, err := registerDriverMySQL(c.cloudDriverName, c.ServiceAccountJSON)
+		dialerCleanup, err := registerDriverMySQL(c.cloudDriverName, c.ServiceAccountJSON, c.usePrivateIP, c.usePSC)
 		if err != nil {
 			return nil, err
 		}
@@ -321,8 +323,8 @@ func (c *mySQLConnectionProducer) rewriteProtocolForGCP(inDSN string) (string, e
 	return config.FormatDSN(), nil
 }
 
-func registerDriverMySQL(driverName, credentials string) (cleanup func() error, err error) {
-	opts, err := connutil.GetCloudSQLAuthOptions(credentials, false)
+func registerDriverMySQL(driverName, credentials string, usePrivateIP bool, usePSC bool) (cleanup func() error, err error) {
+	opts, err := connutil.GetCloudSQLAuthOptions(credentials, usePrivateIP, usePSC)
 	if err != nil {
 		return nil, err
 	}

--- a/sdk/database/helper/connutil/cloudsql.go
+++ b/sdk/database/helper/connutil/cloudsql.go
@@ -27,13 +27,13 @@ func (c *SQLConnectionProducer) getCloudSQLDriverType() (string, error) {
 	return driverType, nil
 }
 
-func (c *SQLConnectionProducer) registerDrivers(driverName string, credentials string, usePrivateIP bool) (func() error, error) {
+func (c *SQLConnectionProducer) registerDrivers(driverName string, credentials string, usePrivateIP bool, usePSC bool) (func() error, error) {
 	typ, err := c.getCloudSQLDriverType()
 	if err != nil {
 		return nil, err
 	}
 
-	opts, err := GetCloudSQLAuthOptions(credentials, usePrivateIP)
+	opts, err := GetCloudSQLAuthOptions(credentials, usePrivateIP, usePSC)
 	if err != nil {
 		return nil, err
 	}
@@ -49,7 +49,7 @@ func (c *SQLConnectionProducer) registerDrivers(driverName string, credentials s
 
 // GetCloudSQLAuthOptions takes a credentials JSON and returns
 // a set of GCP CloudSQL options - always WithIAMAUthN, and then the appropriate file/JSON option.
-func GetCloudSQLAuthOptions(credentials string, usePrivateIP bool) ([]cloudsqlconn.Option, error) {
+func GetCloudSQLAuthOptions(credentials string, usePrivateIP bool, usePSC bool) ([]cloudsqlconn.Option, error) {
 	opts := []cloudsqlconn.Option{cloudsqlconn.WithIAMAuthN()}
 
 	if credentials != "" {
@@ -58,6 +58,10 @@ func GetCloudSQLAuthOptions(credentials string, usePrivateIP bool) ([]cloudsqlco
 
 	if usePrivateIP {
 		opts = append(opts, cloudsqlconn.WithDefaultDialOptions(cloudsqlconn.WithPrivateIP()))
+	}
+
+	if usePSC {
+		opts = append(opts, cloudsqlconn.WithDefaultDialOptions(cloudsqlconn.WithPSC()))
 	}
 
 	return opts, nil

--- a/sdk/database/helper/connutil/sql.go
+++ b/sdk/database/helper/connutil/sql.go
@@ -41,6 +41,7 @@ type SQLConnectionProducer struct {
 	ServiceAccountJSON       string      `json:"service_account_json" mapstructure:"service_account_json" structs:"service_account_json"`
 	DisableEscaping          bool        `json:"disable_escaping" mapstructure:"disable_escaping" structs:"disable_escaping"`
 	usePrivateIP             bool        `json:"use_private_ip" mapstructure:"use_private_ip" structs:"use_private_ip"`
+	usePSC                   bool        `json:"use_psc" mapstructure:"use_psc" structs:"use_psc"`
 
 	// cloud options here - cloudDriverName is globally unique, but only needs to be retained for the lifetime
 	// of driver registration, not across plugin restarts.
@@ -141,7 +142,7 @@ func (c *SQLConnectionProducer) Init(ctx context.Context, conf map[string]interf
 		// however, the driver might store a credentials file, in which case the state stored by the driver is in
 		// fact critical to the proper function of the connection. So it needs to be registered here inside the
 		// ConnectionProducer init.
-		dialerCleanup, err := c.registerDrivers(c.cloudDriverName, c.ServiceAccountJSON, c.usePrivateIP)
+		dialerCleanup, err := c.registerDrivers(c.cloudDriverName, c.ServiceAccountJSON, c.usePrivateIP, c.usePSC)
 		if err != nil {
 			return nil, err
 		}

--- a/website/content/api-docs/secret/databases/mysql-maria.mdx
+++ b/website/content/api-docs/secret/databases/mysql-maria.mdx
@@ -53,6 +53,12 @@ has a number of parameters to further configure a connection.
 - `service_account_json` `(string: "")` - JSON encoded credentials for a GCP Service Account to use
   for IAM authentication. Requires `auth_type` to be `gcp_iam`.
 
+- `use_private_ip` `(boolean: false)` - Enables the option to connect to CloudSQL Instances with Private IP.
+   Requires `auth_type` to be `gcp_iam`.
+
+- `use_psc` `(boolean: false)` - Enables the option to connect to CloudSQL Instances with Private Service Connect.
+   Requires `auth_type` to be `gcp_iam`.
+
 - `tls_certificate_key` `(string: "")` - x509 certificate for connecting to the database.
   This must be a PEM encoded version of the private key and the certificate combined.
 

--- a/website/content/api-docs/secret/databases/postgresql.mdx
+++ b/website/content/api-docs/secret/databases/postgresql.mdx
@@ -61,6 +61,9 @@ has a number of parameters to further configure a connection.
 - `use_private_ip` `(boolean: false)` - Enables the option to connect to CloudSQL Instances with Private IP.
    Requires `auth_type` to be `gcp_iam`.
 
+- `use_psc` `(boolean: false)` - Enables the option to connect to CloudSQL Instances with Private Service Connect.
+   Requires `auth_type` to be `gcp_iam`.
+
 - `username_template` `(string)` - [Template](/vault/docs/concepts/username-templating) describing how
   dynamic usernames are generated.
 

--- a/website/content/docs/secrets/databases/mysql-maria.mdx
+++ b/website/content/docs/secrets/databases/mysql-maria.mdx
@@ -202,6 +202,8 @@ GRANT SELECT, CREATE, CREATE USER ON <database>.<object> TO "test-user"@"%" WITH
         plugin_name="mysql-database-plugin" \
         allowed_roles="my-role" \
         connection_url="user@cloudsql-mysql(project:region:instance)/mysql" \
+        use_private_ip="false" \
+        use_psc="false" \
         auth_type="gcp_iam"
     ```
 
@@ -214,6 +216,8 @@ GRANT SELECT, CREATE, CREATE USER ON <database>.<object> TO "test-user"@"%" WITH
         allowed_roles="my-role" \
         connection_url="user@cloudsql-mysql(project:region:instance)/mysql" \
         auth_type="gcp_iam" \
+        use_private_ip="false" \
+        use_psc="false" \
         service_account_json="@my_credentials.json"
     ```
 

--- a/website/content/docs/secrets/databases/postgresql.mdx
+++ b/website/content/docs/secrets/databases/postgresql.mdx
@@ -129,6 +129,7 @@ ALTER USER "<YOUR DB USERNAME>" WITH CREATEROLE;
         allowed_roles="my-role" \
         connection_url="host=project:us-west1:mydb user=test-user@project.iam dbname=postgres sslmode=disable" \
         use_private_ip="false" \
+        use_psc="false" \
         auth_type="gcp_iam"
     ```
 
@@ -141,6 +142,7 @@ ALTER USER "<YOUR DB USERNAME>" WITH CREATEROLE;
         allowed_roles="my-role" \
         connection_url="host=project:region:instance user=test-user@project.iam dbname=postgres sslmode=disable" \
         use_private_ip="false" \
+        use_psc="false" \
         auth_type="gcp_iam" \
         service_account_json="@my_credentials.json"
     ```


### PR DESCRIPTION
Added PrivateIP support for GCP MySQL

### Description
This PR add Private Service Connect for CloudSQL (MySQL and PostgresSQL), this PR also add PrivateIP  support for MySQL, previous PR( #26827) just added to Postgres.

Close #27867 


### TODO only if you're a HashiCorp employee
- [N/A] **Labels:** If this PR is the CE portion of an ENT change, and that ENT change is
  getting backported to N-2, use the new style `backport/ent/x.x.x+ent` labels
  instead of the old style `backport/x.x.x` labels.
-[N/A] **Labels:** If this PR is a CE only change, it can only be backported to N, so use
  the normal `backport/x.x.x` label (there should be only 1).
- [N/A] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [N/A] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [N/A]  **RFC:** If this change has an associated RFC, please link it in the description.
- [N/A] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
