### PR TITLE
Pin protoc-gen-go-grpc to 1.4.0

### DIFF
--- a/.github/actions/install-external-tools/action.yml
+++ b/.github/actions/install-external-tools/action.yml
@@ -23,7 +23,7 @@ runs:
       # up here.
     - run: ./.github/scripts/retry-command.sh go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
       shell: bash
-    - run: ./.github/scripts/retry-command.sh go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
+    - run: ./.github/scripts/retry-command.sh go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.4.0
       shell: bash
     - run: ./.github/scripts/retry-command.sh go install github.com/favadi/protoc-go-inject-tag@latest
       shell: bash

--- a/tools/tools.sh
+++ b/tools/tools.sh
@@ -34,7 +34,8 @@ check_tool() {
 install_external() {
   local tools
   # If you update this please update check_external below as well as our external tools
-  # install action ./github/actions/install-external-tools.yml
+  # install action .github/actions/install-external-tools/action.yml
+  #
   tools=(
     github.com/bufbuild/buf/cmd/buf@v1.25.0
     github.com/favadi/protoc-go-inject-tag@latest
@@ -43,7 +44,7 @@ install_external() {
     github.com/rinchsan/gosimports/cmd/gosimports@latest
     golang.org/x/tools/cmd/goimports@latest
     google.golang.org/protobuf/cmd/protoc-gen-go@latest
-    google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
+    google.golang.org/grpc/cmd/protoc-gen-go-grpc@1.4.0
     gotest.tools/gotestsum@latest
     honnef.co/go/tools/cmd/staticcheck@latest
     mvdan.cc/gofumpt@latest

--- a/tools/tools.sh
+++ b/tools/tools.sh
@@ -44,7 +44,7 @@ install_external() {
     github.com/rinchsan/gosimports/cmd/gosimports@latest
     golang.org/x/tools/cmd/goimports@latest
     google.golang.org/protobuf/cmd/protoc-gen-go@latest
-    google.golang.org/grpc/cmd/protoc-gen-go-grpc@1.4.0
+    google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.4.0
     gotest.tools/gotestsum@latest
     honnef.co/go/tools/cmd/staticcheck@latest
     mvdan.cc/gofumpt@latest


### PR DESCRIPTION
### Description

They introduced a replace statement within the go.mod file which causes failures running `go install protoc-gen-go-grpc@latest`

```
Run ./.github/scripts/retry-command.sh go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
go: downloading google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.5.0
go: downloading google.golang.org/grpc v1.65.0
go: google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest (in google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.5.0):
	The go.mod file for the module providing named packages contains one or
	more replace directives. It must not contain directives that would cause
	it to be interpreted differently than if it were the main module.
```

Workaround for now is to pin to the previous version

See https://github.com/grpc/grpc-go/issues/7448

### TODO only if you're a HashiCorp employee
- [ ] **Labels:** If this PR is the CE portion of an ENT change, and that ENT change is
  getting backported to N-2, use the new style `backport/ent/x.x.x+ent` labels
  instead of the old style `backport/x.x.x` labels.
- [x] **Labels:** If this PR is a CE only change, it can only be backported to N, so use
  the normal `backport/x.x.x` label (there should be only 1).
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
