### PR TITLE
Add expected and default values for the `vault.hashicorp.com/agent-pre-populate` annotation

### DIFF
--- a/website/content/docs/platform/k8s/injector/annotations.mdx
+++ b/website/content/docs/platform/k8s/injector/annotations.mdx
@@ -171,7 +171,8 @@ them, optional commands to run, etc.
 
 - `vault.hashicorp.com/agent-pre-populate` - configures whether an init container
   is included to pre-populate the shared memory volume with secrets prior to the
-  containers starting.
+  containers starting. This should be set to a `true` or `false` value. Defaults
+  to `true`.
 
 - `vault.hashicorp.com/agent-pre-populate-only` - configures whether an init container
   is the only injected container. If true, no sidecar container will be injected


### PR DESCRIPTION
### Description

Update the documentation of the `vault.hashicorp.com/agent-pre-populate` to describe:

1. The accepted values.
2. What the default value is.

I sourced this info from https://github.com/hashicorp/vault-k8s/blob/6b9d13434ddac091684c61946d978767b9abbb77/agent-inject/agent/annotations.go#L703-L710. 