### PR TITLE
Update VSO docs for v0.8.1

### DIFF
--- a/website/content/docs/platform/k8s/vso/api-reference.mdx
+++ b/website/content/docs/platform/k8s/vso/api-reference.mdx
@@ -7,7 +7,7 @@ description: >-
 
 <!--
   copied from docs/api/api-reference.md in the vault-secrets-operator repo.
-  commit SHA=5797542c8e5a476f0985525fbc2368abbde6f3e8
+  commit SHA=98556e448df1eec4edec6d3f43e403f87fff313a
 -->
 # API Reference
 
@@ -894,6 +894,7 @@ _Appears in:_
 | `tlsServerName` _string_ | TLSServerName to use as the SNI host for TLS connections. |  |  |
 | `caCertSecretRef` _string_ | CACertSecretRef is the name of a Kubernetes secret containing the trusted PEM encoded CA certificate chain as `ca.crt`. |  |  |
 | `skipTLSVerify` _boolean_ | SkipTLSVerify for TLS connections. | false |  |
+| `timeout` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#duration-v1-meta)_ | Timeout applied to all Vault requests for this connection. If not set, the<br />default timeout from the Vault API client config is used. |  | Pattern: `^([0-9]+(\.[0-9]+)?(s|m|h))$` <br />Type: string <br /> |
 
 
 

--- a/website/content/docs/platform/k8s/vso/helm.mdx
+++ b/website/content/docs/platform/k8s/vso/helm.mdx
@@ -4,14 +4,18 @@ page_title: Vault Secrets Operator Helm Chart Configuration
 description: >-
   Configuration for the Vault Secrets Operator Helm chart.
 ---
+<!-- DO NOT EDIT.
+Generated from chart/values.yaml in the vault-secrets-operator repo.
+commit SHA=c97a61487462dfc2ded7e7d80bb2061624cedc2a
+
+To update run 'make gen-helm-docs' from the vault-secrets-operator repo.
+-->
 
 # Vault Secrets Operator helm chart
 
 The chart is customizable using
 [Helm configuration values](https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing).
 
-<!-- DO NOT EDIT. The docs below are generated automatically. To change, edit
-                  the vault-secrets-operator repo's values.yaml: file commit=bf1746f1937f25b4cb28f15d4b818303f3a78dd9 -->
 <!-- codegen: start -->
 
 ## Top-Level Stanzas
@@ -117,6 +121,15 @@ Use these links to navigate to a particular top-level stanza.
         - "VaultAuth"
         - "HCPAuth"
 
+      - `userFacingRoles` ((#v-controller-rbac-clusterroleaggregation-userfacingroles)) (`object: ""`) - userFacingRoles is a map of roles that will be aggregated into the viewer and editor ClusterRoles.
+        See https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles for more information.
+
+        - `view` ((#v-controller-rbac-clusterroleaggregation-userfacingroles-view)) (`boolean: false`) - view controls whether the aggregated viewer ClusterRole will be made available to the user-facing
+          'view' ClusterRole. Requires the viewerRoles to be set.
+
+        - `edit` ((#v-controller-rbac-clusterroleaggregation-userfacingroles-edit)) (`boolean: false`) - view controls whether the aggregated editor ClusterRole will be made available to the user-facing
+          'edit' ClusterRole. Requires the editorRoles to be set.
+
   - `kubeRbacProxy` ((#v-controller-kuberbacproxy)) - Settings related to the kubeRbacProxy container. This container is an HTTP proxy for the
     controller manager which performs RBAC authorization against the Kubernetes API using SubjectAccessReviews.
 
@@ -166,7 +179,7 @@ Use these links to navigate to a particular top-level stanza.
 
       - `repository` ((#v-controller-manager-image-repository)) (`string: hashicorp/vault-secrets-operator`)
 
-      - `tag` ((#v-controller-manager-image-tag)) (`string: 0.8.0`)
+      - `tag` ((#v-controller-manager-image-tag)) (`string: 0.8.1`)
 
     - `logging` ((#v-controller-manager-logging)) - logging
 
@@ -190,8 +203,25 @@ Use these links to navigate to a particular top-level stanza.
       - `excludeRaw` ((#v-controller-manager-globaltransformationoptions-excluderaw)) (`boolean: false`) - excludeRaw directs the operator to prevent _raw secret data being stored
         in the destination K8s Secret.
 
-    - `backoffOnSecretSourceError` ((#v-controller-manager-backoffonsecretsourceerror)) - Backoff settings for the controller manager. These settings control the backoff behavior
+    - `globalVaultAuthOptions` ((#v-controller-manager-globalvaultauthoptions)) - Global Vault auth options. In addition to the boolean options
+      below, these options may be set via the
+      `VSO_GLOBAL_VAULT_OPTION_OPTIONS` environment variable as a
+      comma-separated list. Valid values are: `allow-default-globals`
+
+      - `allowDefaultGlobals` ((#v-controller-manager-globalvaultauthoptions-allowdefaultglobals)) (`boolean: true`) - allowDefaultGlobals directs the operator search for a "default"
+        VaultAuthGlobal if none is specified on the referring VaultAuth CR.
+        Default: true
+
+    - `backoffOnSecretSourceError` ((#v-controller-manager-backoffonsecretsourceerror)) (`object: ""`) - Backoff settings for the controller manager. These settings control the backoff behavior
       when the controller encounters an error while fetching secrets from the SecretSource.
+      For example given the following settings:
+        initialInterval: 5s
+        maxInterval: 60s
+        randomizationFactor: 0.5
+        multiplier: 1.5
+
+      The backoff retry sequence might be something like:
+       5.5s, 7.5s, 11.25s, 16.87s, 25.3125s, 37.96s, 56.95, 60.95s...
 
       - `initialInterval` ((#v-controller-manager-backoffonsecretsourceerror-initialinterval)) (`duration: 5s`) - Initial interval between retries.
 

--- a/website/content/docs/platform/k8s/vso/installation.mdx
+++ b/website/content/docs/platform/k8s/vso/installation.mdx
@@ -32,13 +32,13 @@ $ helm repo add hashicorp https://helm.releases.hashicorp.com
 ```shell-session
 $ helm search repo hashicorp/vault-secrets-operator
 NAME           	CHART VERSION	APP VERSION	DESCRIPTION
-hashicorp/vault-secrets-operator	0.8.0       	0.8.0     	Official HashiCorp Vault Secrets Operator Chart
+hashicorp/vault-secrets-operator	0.8.1       	0.8.1     	Official HashiCorp Vault Secrets Operator Chart
 ```
 
 Then install the Operator:
 
 ```shell-session
-$ helm install --version 0.8.0 --create-namespace --namespace vault-secrets-operator vault-secrets-operator hashicorp/vault-secrets-operator
+$ helm install --version 0.8.1 --create-namespace --namespace vault-secrets-operator vault-secrets-operator hashicorp/vault-secrets-operator
 ```
 
 ## Upgrading using Helm
@@ -78,9 +78,9 @@ You can install and update your installation using `kustomize` which allows you 
 
 To install using Kustomize, download and untar/unzip the latest release from the [Releases Page](https://github.com/hashicorp/vault-secrets-operator/releases).
 ```shell-session
-$ wget -q https://github.com/hashicorp/vault-secrets-operator/archive/refs/tags/v0.8.0.tar.gz
-$ tar -zxf v0.8.0.tar.gz
-$ cd vault-secrets-operator-0.8.0/
+$ wget -q https://github.com/hashicorp/vault-secrets-operator/archive/refs/tags/v0.8.1.tar.gz
+$ tar -zxf v0.8.1.tar.gz
+$ cd vault-secrets-operator-0.8.1/
 ```
 
 Next install using `kustomize build`:

--- a/website/content/docs/platform/k8s/vso/openshift.mdx
+++ b/website/content/docs/platform/k8s/vso/openshift.mdx
@@ -32,7 +32,7 @@ The Vault Secrets Operator may also be installed in OpenShift using the Helm cha
 $ helm install vault-secrets-operator hashicorp/vault-secrets-operator \
   --create-namespace \
   --namespace vault-secrets-operator \
-  --version 0.8.0 \
+  --version 0.8.1 \
   --values values.yaml
 ```
 
@@ -65,7 +65,7 @@ controller:
   manager:
     image:
       repository: registry.connect.redhat.com/hashicorp/vault-secrets-operator
-      tag: 0.8.0-ubi
+      tag: 0.8.1-ubi
     resources:
       limits:
         memory: 256Mi

--- a/website/content/docs/platform/k8s/vso/sources/vault/index.mdx
+++ b/website/content/docs/platform/k8s/vso/sources/vault/index.mdx
@@ -379,6 +379,11 @@ The Vault Secrets Operator can optionally cache Vault client information such as
 The [Encrypted client cache](/vault/docs/platform/k8s/vso/sources/vault/client-cache) guide will walk you through the steps to enable and configure client cache encryption.
 
 ## Instant updates <EnterpriseAlert inline="true" />
+<Tip title="Feature availability">
+
+  VSO v0.8.0
+
+</Tip>
 
 The Vault Secrets Operator can instantly update Kubernetes Secrets when changes
 are made in Vault, by subscribing to [Vault Events][vault-events] for change


### PR DESCRIPTION
Other fixes:
- Including missing Helm documentation.
- Add feature availability tip for `Instant updates` feature.

### Description
What does this PR do?

### TODO only if you're a HashiCorp employee
- [ ] **Labels:** If this PR is the CE portion of an ENT change, and that ENT change is
  getting backported to N-2, use the new style `backport/ent/x.x.x+ent` labels
  instead of the old style `backport/x.x.x` labels.
- [x] **Labels:** If this PR is a CE only change, it can only be backported to N, so use
  the normal `backport/x.x.x` label (there should be only 1).
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
