### PR TITLE
Audit: un-export `hashstructure.go` funcs

### DIFF
--- a/audit/broker.go
+++ b/audit/broker.go
@@ -448,7 +448,7 @@ func (b *Broker) GetHash(ctx context.Context, name string, input string) (string
 		return "", fmt.Errorf("unknown audit backend %q", name)
 	}
 
-	return HashString(ctx, be.backend, input)
+	return hashString(ctx, be.backend, input)
 }
 
 // IsRegistered is used to check if a given audit backend is registered.

--- a/audit/entry_formatter.go
+++ b/audit/entry_formatter.go
@@ -242,12 +242,12 @@ func (f *entryFormatter) formatRequest(ctx context.Context, in *logical.LogInput
 
 	if !f.config.raw {
 		var err error
-		auth, err = HashAuth(ctx, f.salter, auth, f.config.hmacAccessor)
+		auth, err = hashAuth(ctx, f.salter, auth, f.config.hmacAccessor)
 		if err != nil {
 			return nil, err
 		}
 
-		req, err = HashRequest(ctx, f.salter, req, f.config.hmacAccessor, in.NonHMACReqDataKeys)
+		req, err = hashRequest(ctx, f.salter, req, f.config.hmacAccessor, in.NonHMACReqDataKeys)
 		if err != nil {
 			return nil, err
 		}
@@ -379,7 +379,7 @@ func (f *entryFormatter) formatResponse(ctx context.Context, in *logical.LogInpu
 
 	var respData map[string]interface{}
 	if f.config.raw {
-		// In the non-raw case, elision of list response data occurs inside HashResponse, to avoid redundant deep
+		// In the non-raw case, elision of list response data occurs inside hashResponse, to avoid redundant deep
 		// copies and hashing of data only to elide it later. In the raw case, we need to do it here.
 		if elideListResponseData && resp.Data != nil {
 			// Copy the data map before making changes, but we only need to go one level deep in this case
@@ -394,17 +394,17 @@ func (f *entryFormatter) formatResponse(ctx context.Context, in *logical.LogInpu
 		}
 	} else {
 		var err error
-		auth, err = HashAuth(ctx, f.salter, auth, f.config.hmacAccessor)
+		auth, err = hashAuth(ctx, f.salter, auth, f.config.hmacAccessor)
 		if err != nil {
 			return nil, err
 		}
 
-		req, err = HashRequest(ctx, f.salter, req, f.config.hmacAccessor, in.NonHMACReqDataKeys)
+		req, err = hashRequest(ctx, f.salter, req, f.config.hmacAccessor, in.NonHMACReqDataKeys)
 		if err != nil {
 			return nil, err
 		}
 
-		resp, err = HashResponse(ctx, f.salter, resp, f.config.hmacAccessor, in.NonHMACRespDataKeys, elideListResponseData)
+		resp, err = hashResponse(ctx, f.salter, resp, f.config.hmacAccessor, in.NonHMACRespDataKeys, elideListResponseData)
 		if err != nil {
 			return nil, err
 		}

--- a/audit/hashstructure.go
+++ b/audit/hashstructure.go
@@ -17,8 +17,8 @@ import (
 	"github.com/mitchellh/reflectwalk"
 )
 
-// HashString hashes the given opaque string and returns it
-func HashString(ctx context.Context, salter Salter, data string) (string, error) {
+// hashString hashes the given opaque string and returns it
+func hashString(ctx context.Context, salter Salter, data string) (string, error) {
 	salt, err := salter.Salt(ctx)
 	if err != nil {
 		return "", err
@@ -27,8 +27,8 @@ func HashString(ctx context.Context, salter Salter, data string) (string, error)
 	return salt.GetIdentifiedHMAC(data), nil
 }
 
-// HashAuth returns a hashed copy of the logical.Auth input.
-func HashAuth(ctx context.Context, salter Salter, in *logical.Auth, HMACAccessor bool) (*logical.Auth, error) {
+// hashAuth returns a hashed copy of the logical.Auth input.
+func hashAuth(ctx context.Context, salter Salter, in *logical.Auth, HMACAccessor bool) (*logical.Auth, error) {
 	if in == nil {
 		return nil, nil
 	}
@@ -50,8 +50,8 @@ func HashAuth(ctx context.Context, salter Salter, in *logical.Auth, HMACAccessor
 	return &auth, nil
 }
 
-// HashRequest returns a hashed copy of the logical.Request input.
-func HashRequest(ctx context.Context, salter Salter, in *logical.Request, HMACAccessor bool, nonHMACDataKeys []string) (*logical.Request, error) {
+// hashRequest returns a hashed copy of the logical.Request input.
+func hashRequest(ctx context.Context, salter Salter, in *logical.Request, HMACAccessor bool, nonHMACDataKeys []string) (*logical.Request, error) {
 	if in == nil {
 		return nil, nil
 	}
@@ -70,7 +70,7 @@ func HashRequest(ctx context.Context, salter Salter, in *logical.Request, HMACAc
 			return nil, err
 		}
 
-		req.Auth, err = HashAuth(ctx, salter, cp.(*logical.Auth), HMACAccessor)
+		req.Auth, err = hashAuth(ctx, salter, cp.(*logical.Auth), HMACAccessor)
 		if err != nil {
 			return nil, err
 		}
@@ -99,7 +99,7 @@ func HashRequest(ctx context.Context, salter Salter, in *logical.Request, HMACAc
 	return &req, nil
 }
 
-func hashMap(hashFunc HashCallback, data map[string]interface{}, nonHMACDataKeys []string) error {
+func hashMap(hashFunc hashCallback, data map[string]interface{}, nonHMACDataKeys []string) error {
 	for k, v := range data {
 		if o, ok := v.(logical.OptMarshaler); ok {
 			marshaled, err := o.MarshalJSONWithOptions(&logical.MarshalOptions{
@@ -115,8 +115,8 @@ func hashMap(hashFunc HashCallback, data map[string]interface{}, nonHMACDataKeys
 	return HashStructure(data, hashFunc, nonHMACDataKeys)
 }
 
-// HashResponse returns a hashed copy of the logical.Request input.
-func HashResponse(ctx context.Context, salter Salter, in *logical.Response, HMACAccessor bool, nonHMACDataKeys []string, elideListResponseData bool) (*logical.Response, error) {
+// hashResponse returns a hashed copy of the logical.Request input.
+func hashResponse(ctx context.Context, salter Salter, in *logical.Response, HMACAccessor bool, nonHMACDataKeys []string, elideListResponseData bool) (*logical.Response, error) {
 	if in == nil {
 		return nil, nil
 	}
@@ -135,7 +135,7 @@ func HashResponse(ctx context.Context, salter Salter, in *logical.Response, HMAC
 			return nil, err
 		}
 
-		resp.Auth, err = HashAuth(ctx, salter, cp.(*logical.Auth), HMACAccessor)
+		resp.Auth, err = hashAuth(ctx, salter, cp.(*logical.Auth), HMACAccessor)
 		if err != nil {
 			return nil, err
 		}
@@ -178,7 +178,7 @@ func HashResponse(ctx context.Context, salter Salter, in *logical.Response, HMAC
 }
 
 // hashWrapInfo returns a hashed copy of the wrapping.ResponseWrapInfo input.
-func hashWrapInfo(hashFunc HashCallback, in *wrapping.ResponseWrapInfo, HMACAccessor bool) (*wrapping.ResponseWrapInfo, error) {
+func hashWrapInfo(hashFunc hashCallback, in *wrapping.ResponseWrapInfo, HMACAccessor bool) (*wrapping.ResponseWrapInfo, error) {
 	if in == nil {
 		return nil, nil
 	}
@@ -201,15 +201,15 @@ func hashWrapInfo(hashFunc HashCallback, in *wrapping.ResponseWrapInfo, HMACAcce
 // HashStructure takes an interface and hashes all the values within
 // the structure. Only _values_ are hashed: keys of objects are not.
 //
-// For the HashCallback, see the built-in HashCallbacks below.
-func HashStructure(s interface{}, cb HashCallback, ignoredKeys []string) error {
+// For the hashCallback, see the built-in HashCallbacks below.
+func HashStructure(s interface{}, cb hashCallback, ignoredKeys []string) error {
 	walker := &hashWalker{Callback: cb, IgnoredKeys: ignoredKeys}
 	return reflectwalk.Walk(s, walker)
 }
 
-// HashCallback is the callback called for HashStructure to hash
+// hashCallback is the callback called for HashStructure to hash
 // a value.
-type HashCallback func(string) string
+type hashCallback func(string) string
 
 // hashWalker implements interfaces for the reflectwalk package
 // (github.com/mitchellh/reflectwalk) that can be used to automatically
@@ -218,8 +218,8 @@ type hashWalker struct {
 	// Callback is the function to call with the primitive that is
 	// to be hashed. If there is an error, walking will be halted
 	// immediately and the error returned.
-	Callback HashCallback
-	// IgnoreKeys are the keys that wont have the HashCallback applied
+	Callback hashCallback
+	// IgnoreKeys are the keys that wont have the hashCallback applied
 	IgnoredKeys []string
 	// MapElem appends the key itself (not the reflect.Value) to key.
 	// The last element in key is the most recently entered map key.

--- a/audit/hashstructure_test.go
+++ b/audit/hashstructure_test.go
@@ -119,12 +119,12 @@ func (*TestSalter) Salt(ctx context.Context) (*salt.Salt, error) {
 func TestHashString(t *testing.T) {
 	salter := &TestSalter{}
 
-	out, err := HashString(context.Background(), salter, "foo")
+	out, err := hashString(context.Background(), salter, "foo")
 	if err != nil {
 		t.Fatalf("Error instantiating salt: %s", err)
 	}
 	if out != "hmac-sha256:08ba357e274f528065766c770a639abf6809b39ccfd37c2a3157c7f51954da0a" {
-		t.Fatalf("err: HashString output did not match expected")
+		t.Fatalf("err: hashString output did not match expected")
 	}
 }
 
@@ -166,7 +166,7 @@ func TestHashAuth(t *testing.T) {
 	salter := &TestSalter{}
 	for _, tc := range cases {
 		input := fmt.Sprintf("%#v", tc.Input)
-		out, err := HashAuth(context.Background(), salter, tc.Input, tc.HMACAccessor)
+		out, err := hashAuth(context.Background(), salter, tc.Input, tc.HMACAccessor)
 		if err != nil {
 			t.Fatalf("err: %s\n\n%s", err, input)
 		}
@@ -224,7 +224,7 @@ func TestHashRequest(t *testing.T) {
 	salter := &TestSalter{}
 	for _, tc := range cases {
 		input := fmt.Sprintf("%#v", tc.Input)
-		out, err := HashRequest(context.Background(), salter, tc.Input, tc.HMACAccessor, tc.NonHMACDataKeys)
+		out, err := hashRequest(context.Background(), salter, tc.Input, tc.HMACAccessor, tc.NonHMACDataKeys)
 		if err != nil {
 			t.Fatalf("err: %s\n\n%s", err, input)
 		}
@@ -289,7 +289,7 @@ func TestHashResponse(t *testing.T) {
 	salter := &TestSalter{}
 	for _, tc := range cases {
 		input := fmt.Sprintf("%#v", tc.Input)
-		out, err := HashResponse(context.Background(), salter, tc.Input, tc.HMACAccessor, tc.NonHMACDataKeys, false)
+		out, err := hashResponse(context.Background(), salter, tc.Input, tc.HMACAccessor, tc.NonHMACDataKeys, false)
 		if err != nil {
 			t.Fatalf("err: %s\n\n%s", err, input)
 		}

--- a/audit/headers.go
+++ b/audit/headers.go
@@ -248,7 +248,7 @@ func (a *HeadersConfig) ApplyConfig(ctx context.Context, headers map[string][]st
 			// Optionally hmac the values
 			if settings.HMAC {
 				for i, el := range hVals {
-					hVal, err := HashString(ctx, salter, el)
+					hVal, err := hashString(ctx, salter, el)
 					if err != nil {
 						return nil, err
 					}

--- a/audit/headers_test.go
+++ b/audit/headers_test.go
@@ -364,7 +364,7 @@ func (s *FailingSalter) Salt(context.Context) (*salt.Salt, error) {
 }
 
 // TestAuditedHeadersConfig_ApplyConfig_HashStringError tests the case where
-// an error is returned from HashString instead of a map of headers.
+// an error is returned from hashString instead of a map of headers.
 func TestAuditedHeadersConfig_ApplyConfig_HashStringError(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
### Description

un-exports functions used for hashing e.g. hash: auth, request, response and string from the audit package, so they cannot be used elsewhere.

### HashiCorp Checklist

- [x] **Labels:** If this PR is the CE portion of an ENT change, and that ENT change is
  getting backported to N-2, use the new style `backport/ent/x.x.x+ent` labels
  instead of the old style `backport/x.x.x` labels.
- [x] **Labels:** If this PR is a CE only change, it can only be backported to N, so use
  the normal `backport/x.x.x` label (there should be only 1).
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
