### PR TITLE
Allow SignCert callers to override CSR signature checks

### DIFF
--- a/builtin/logical/pki/cert_util.go
+++ b/builtin/logical/pki/cert_util.go
@@ -468,6 +468,10 @@ func (i SignCertInputFromDataFields) GetPermittedDomains() []string {
 	return i.data.Get("permitted_dns_domains").([]string)
 }
 
+func (i SignCertInputFromDataFields) IgnoreCSRSignature() bool {
+	return false
+}
+
 func signCert(sysView logical.SystemView, data *inputBundle, caSign *certutil.CAInfoBundle, isCA bool, useCSRValues bool) (*certutil.ParsedCertBundle, []string, error) {
 	if data.role == nil {
 		return nil, nil, errutil.InternalError{Err: "no role found in data bundle"}
@@ -496,6 +500,10 @@ func NewCreationBundleInputFromFieldData(data *framework.FieldData) CreationBund
 type CreationBundleInputFromFieldData struct {
 	CertNotAfterInputFromFieldData
 	data *framework.FieldData
+}
+
+func (cb CreationBundleInputFromFieldData) IgnoreCSRSignature() bool {
+	return false
 }
 
 func (cb CreationBundleInputFromFieldData) GetCommonName() string {

--- a/builtin/logical/pki/issuing/issue_common.go
+++ b/builtin/logical/pki/issuing/issue_common.go
@@ -91,6 +91,7 @@ type CreationBundleInput interface {
 	GetOptionalSkid() (interface{}, bool)
 	IsUserIdInSchema() (interface{}, bool)
 	GetUserIds() []string
+	IgnoreCSRSignature() bool
 }
 
 // GenerateCreationBundle is a shared function that reads parameters supplied
@@ -428,6 +429,7 @@ func GenerateCreationBundle(b logical.SystemView, role *RoleEntry, entityInfo En
 			NotBeforeDuration:             role.NotBeforeDuration,
 			ForceAppendCaChain:            caSign != nil,
 			SKID:                          skid,
+			IgnoreCSRSignature:            cb.IgnoreCSRSignature(),
 		},
 		SigningBundle: caSign,
 		CSR:           csr,

--- a/builtin/logical/pki/issuing/sign_cert.go
+++ b/builtin/logical/pki/issuing/sign_cert.go
@@ -23,20 +23,26 @@ type SignCertInput interface {
 	GetPermittedDomains() []string
 }
 
-func NewBasicSignCertInput(csr *x509.CertificateRequest, isCA bool, useCSRValues bool) BasicSignCertInput {
+func NewBasicSignCertInput(csr *x509.CertificateRequest, isCA, useCSRValues bool) BasicSignCertInput {
+	return NewBasicSignCertInputWithIgnore(csr, isCA, useCSRValues, false)
+}
+
+func NewBasicSignCertInputWithIgnore(csr *x509.CertificateRequest, isCA, useCSRValues, ignoreCsrSignature bool) BasicSignCertInput {
 	return BasicSignCertInput{
-		isCA:         isCA,
-		useCSRValues: useCSRValues,
-		csr:          csr,
+		isCA:               isCA,
+		useCSRValues:       useCSRValues,
+		csr:                csr,
+		ignoreCsrSignature: ignoreCsrSignature,
 	}
 }
 
 var _ SignCertInput = BasicSignCertInput{}
 
 type BasicSignCertInput struct {
-	isCA         bool
-	useCSRValues bool
-	csr          *x509.CertificateRequest
+	isCA               bool
+	useCSRValues       bool
+	csr                *x509.CertificateRequest
+	ignoreCsrSignature bool
 }
 
 func (b BasicSignCertInput) GetTTL() int {
@@ -89,6 +95,10 @@ func (b BasicSignCertInput) GetUserIds() []string {
 
 func (b BasicSignCertInput) GetCSR() (*x509.CertificateRequest, error) {
 	return b.csr, nil
+}
+
+func (b BasicSignCertInput) IgnoreCSRSignature() bool {
+	return b.ignoreCsrSignature
 }
 
 func (b BasicSignCertInput) IsCA() bool {

--- a/sdk/helper/certutil/helpers.go
+++ b/sdk/helper/certutil/helpers.go
@@ -1186,9 +1186,10 @@ func signCertificate(data *CreationBundle, randReader io.Reader) (*ParsedCertBun
 		return nil, errutil.UserError{Err: "nil csr given to signCertificate"}
 	}
 
-	err := data.CSR.CheckSignature()
-	if err != nil {
-		return nil, errutil.UserError{Err: "request signature invalid"}
+	if !data.Params.IgnoreCSRSignature {
+		if err := data.CSR.CheckSignature(); err != nil {
+			return nil, errutil.UserError{Err: "request signature invalid"}
+		}
 	}
 
 	result := &ParsedCertBundle{}

--- a/sdk/helper/certutil/types.go
+++ b/sdk/helper/certutil/types.go
@@ -819,6 +819,11 @@ type CreationParameters struct {
 
 	// The explicit SKID to use; especially useful for cross-signing.
 	SKID []byte
+
+	// Ignore validating the CSR's signature. This should only be enabled if the
+	// sender of the CSR has proven proof of possession of the associated
+	// private key by some other means, otherwise keep this set to false.
+	IgnoreCSRSignature bool
 }
 
 type CreationBundle struct {


### PR DESCRIPTION
### Description

Allow callers of the SignCertificate method to disable the signature verification within the passed in CSR. We are leveraging this new feature flag as we are constructing a CSR based on the information from a CMPv2 message where we have access to the public key but not the private key, but have validated proof of possession through the CMPv2 popo signatures.

This was easily then adapting the flows for creating certificates as that flow assumes a private key is present during construction. 

### TODO only if you're a HashiCorp employee
- [] **Labels:** If this PR is the CE portion of an ENT change, and that ENT change is
  getting backported to N-2, use the new style `backport/ent/x.x.x+ent` labels
  instead of the old style `backport/x.x.x` labels.
- [ ] **Labels:** If this PR is a CE only change, it can only be backported to N, so use
  the normal `backport/x.x.x` label (there should be only 1).
- [X] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [X] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [X] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
