### PR TITLE
UI: Remove deprecated Client Count keys

### DIFF
--- a/ui/app/serializers/clients/activity.js
+++ b/ui/app/serializers/clients/activity.js
@@ -5,7 +5,7 @@
 
 import ApplicationSerializer from '../application';
 import { formatISO } from 'date-fns';
-import { formatByMonths, formatByNamespace, destructureClientCounts } from 'core/utils/client-count-utils';
+import { formatByMonths, formatByNamespace } from 'core/utils/client-count-utils';
 import timestamp from 'core/utils/timestamp';
 
 // see tests/helpers/clients/client-count-helpers for sample API response (ACTIVITY_RESPONSE_STUB)
@@ -21,7 +21,7 @@ export default class ActivitySerializer extends ApplicationSerializer {
       response_timestamp,
       by_namespace: formatByNamespace(payload.data.by_namespace),
       by_month: formatByMonths(payload.data.months),
-      total: destructureClientCounts(payload.data.total),
+      total: payload.data.total,
     };
     delete payload.data.by_namespace;
     delete payload.data.months;

--- a/ui/app/serializers/clients/activity.js
+++ b/ui/app/serializers/clients/activity.js
@@ -5,7 +5,7 @@
 
 import ApplicationSerializer from '../application';
 import { formatISO } from 'date-fns';
-import { formatByMonths, formatByNamespace } from 'core/utils/client-count-utils';
+import { formatByMonths, formatByNamespace, destructureClientCounts } from 'core/utils/client-count-utils';
 import timestamp from 'core/utils/timestamp';
 
 // see tests/helpers/clients/client-count-helpers for sample API response (ACTIVITY_RESPONSE_STUB)
@@ -21,7 +21,7 @@ export default class ActivitySerializer extends ApplicationSerializer {
       response_timestamp,
       by_namespace: formatByNamespace(payload.data.by_namespace),
       by_month: formatByMonths(payload.data.months),
-      total: payload.data.total,
+      total: destructureClientCounts(payload.data.total),
     };
     delete payload.data.by_namespace;
     delete payload.data.months;

--- a/ui/lib/core/addon/utils/client-count-utils.ts
+++ b/ui/lib/core/addon/utils/client-count-utils.ts
@@ -103,14 +103,14 @@ export const formatByMonths = (
         newClients = {
           month,
           timestamp,
-          ...(m?.new_clients?.counts || {}),
+          ...destructureClientCounts(m?.new_clients?.counts),
           namespaces: formatByNamespace(m.new_clients?.namespaces),
         };
       }
       return {
         month,
         timestamp,
-        ...m.counts,
+        ...destructureClientCounts(m.counts),
         namespaces: formatByNamespace(m.namespaces),
         namespaces_by_key: namespaceArrayToObject(
           totalClientsByNamespace,
@@ -142,14 +142,27 @@ export const formatByNamespace = (namespaceArray: NamespaceObject[] | null): ByN
     // transform to an empty array for type consistency
     let mounts: MountClients[] | [] = [];
     if (Array.isArray(ns.mounts)) {
-      mounts = ns.mounts.map((m) => ({ label: m.mount_path, ...m.counts }));
+      mounts = ns.mounts.map((m) => ({ label: m.mount_path, ...destructureClientCounts(m.counts) }));
     }
     return {
       label,
-      ...ns.counts,
+      ...destructureClientCounts(ns.counts),
       mounts,
     };
   });
+};
+
+// This method returns only client types from the passed object, excluding other keys such as "label".
+// when querying historical data the response will always contain the latest client type keys because the activity log is
+// constructed based on the version of Vault the user is on (key values will be 0)
+export const destructureClientCounts = (verboseObject: Counts | ByNamespaceClients) => {
+  return CLIENT_TYPES.reduce(
+    (newObj: Record<ClientTypes, Counts[ClientTypes]>, clientType: ClientTypes) => {
+      newObj[clientType] = verboseObject[clientType];
+      return newObj;
+    },
+    {} as Record<ClientTypes, Counts[ClientTypes]>
+  );
 };
 
 export const sortMonthsByTimestamp = (
@@ -173,7 +186,7 @@ export const namespaceArrayToObject = (
   // and values include new and total client counts for that namespace in that month
   const namespaces_by_key = monthTotals.reduce((nsObject: { [key: string]: NamespaceByKey }, ns) => {
     const keyedNs: NamespaceByKey = {
-      ...ns, // counts
+      ...destructureClientCounts(ns),
       timestamp,
       month,
       mounts_by_key: {},

--- a/ui/lib/core/addon/utils/client-count-utils.ts
+++ b/ui/lib/core/addon/utils/client-count-utils.ts
@@ -344,9 +344,7 @@ export interface EmptyActivityMonthBlock {
 export interface Counts {
   acme_clients: number;
   clients: number;
-  distinct_entities: number;
   entity_clients: number;
   non_entity_clients: number;
-  non_entity_tokens: number;
   secret_syncs: number;
 }

--- a/ui/mirage/handlers/clients.js
+++ b/ui/mirage/handlers/clients.js
@@ -49,17 +49,10 @@ function getSum(array, key) {
 }
 
 function getTotalCounts(array) {
-  const counts = CLIENT_TYPES.reduce((obj, key) => {
+  return CLIENT_TYPES.reduce((obj, key) => {
     obj[key] = getSum(array, key);
     return obj;
   }, {});
-
-  // add deprecated keys
-  return {
-    ...counts,
-    distinct_entities: counts.entity_clients,
-    non_entity_tokens: counts.non_entity_clients,
-  };
 }
 
 function randomBetween(min, max) {
@@ -75,8 +68,6 @@ function generateMountBlock(path, counts) {
     mount_path: path,
     counts: {
       ...baseObject,
-      distinct_entities: 0,
-      non_entity_tokens: 0,
       // object contains keys for which 0-values of base object to overwrite
       ...counts,
     },

--- a/ui/mirage/handlers/sync.js
+++ b/ui/mirage/handlers/sync.js
@@ -276,30 +276,24 @@ export default function (server) {
         end_time, // set by query params
         total: {
           clients: 15,
-          distinct_entities: 0,
           entity_clients: 0,
           non_entity_clients: 0,
-          non_entity_tokens: 0,
           secret_syncs: 15,
         },
         by_namespace: [
           {
             counts: {
               clients: 15,
-              distinct_entities: 0,
               entity_clients: 0,
               non_entity_clients: 0,
-              non_entity_tokens: 0,
               secret_syncs: 15,
             },
             mounts: [
               {
                 counts: {
                   clients: 15,
-                  distinct_entities: 0,
                   entity_clients: 0,
                   non_entity_clients: 0,
-                  non_entity_tokens: 0,
                   secret_syncs: 15,
                 },
                 mount_path: 'sys/',
@@ -314,30 +308,24 @@ export default function (server) {
           {
             counts: {
               clients: 10,
-              distinct_entities: 0,
               entity_clients: 0,
               non_entity_clients: 0,
-              non_entity_tokens: 0,
               secret_syncs: 10,
             },
             namespaces: [
               {
                 counts: {
                   clients: 10,
-                  distinct_entities: 0,
                   entity_clients: 0,
                   non_entity_clients: 0,
-                  non_entity_tokens: 0,
                   secret_syncs: 10,
                 },
                 mounts: [
                   {
                     counts: {
                       clients: 10,
-                      distinct_entities: 0,
                       entity_clients: 0,
                       non_entity_clients: 0,
-                      non_entity_tokens: 0,
                       secret_syncs: 10,
                     },
                     mount_path: 'sys/',
@@ -350,30 +338,24 @@ export default function (server) {
             new_clients: {
               counts: {
                 clients: 10,
-                distinct_entities: 0,
                 entity_clients: 0,
                 non_entity_clients: 0,
-                non_entity_tokens: 0,
                 secret_syncs: 10,
               },
               namespaces: [
                 {
                   counts: {
                     clients: 10,
-                    distinct_entities: 0,
                     entity_clients: 0,
                     non_entity_clients: 0,
-                    non_entity_tokens: 0,
                     secret_syncs: 10,
                   },
                   mounts: [
                     {
                       counts: {
                         clients: 10,
-                        distinct_entities: 0,
                         entity_clients: 0,
                         non_entity_clients: 0,
-                        non_entity_tokens: 0,
                         secret_syncs: 10,
                       },
                       mount_path: 'sys/',
@@ -389,30 +371,24 @@ export default function (server) {
           {
             counts: {
               clients: 7,
-              distinct_entities: 0,
               entity_clients: 0,
               non_entity_clients: 0,
-              non_entity_tokens: 0,
               secret_syncs: 7,
             },
             namespaces: [
               {
                 counts: {
                   clients: 7,
-                  distinct_entities: 0,
                   entity_clients: 0,
                   non_entity_clients: 0,
-                  non_entity_tokens: 0,
                   secret_syncs: 7,
                 },
                 mounts: [
                   {
                     counts: {
                       clients: 7,
-                      distinct_entities: 0,
                       entity_clients: 0,
                       non_entity_clients: 0,
-                      non_entity_tokens: 0,
                       secret_syncs: 7,
                     },
                     mount_path: 'sys/',
@@ -425,30 +401,24 @@ export default function (server) {
             new_clients: {
               counts: {
                 clients: 3,
-                distinct_entities: 0,
                 entity_clients: 0,
                 non_entity_clients: 0,
-                non_entity_tokens: 0,
                 secret_syncs: 3,
               },
               namespaces: [
                 {
                   counts: {
                     clients: 3,
-                    distinct_entities: 0,
                     entity_clients: 0,
                     non_entity_clients: 0,
-                    non_entity_tokens: 0,
                     secret_syncs: 3,
                   },
                   mounts: [
                     {
                       counts: {
                         clients: 3,
-                        distinct_entities: 0,
                         entity_clients: 0,
                         non_entity_clients: 0,
-                        non_entity_tokens: 0,
                         secret_syncs: 3,
                       },
                       mount_path: 'sys/',
@@ -464,30 +434,24 @@ export default function (server) {
           {
             counts: {
               clients: 7,
-              distinct_entities: 0,
               entity_clients: 0,
               non_entity_clients: 0,
-              non_entity_tokens: 0,
               secret_syncs: 7,
             },
             namespaces: [
               {
                 counts: {
                   clients: 7,
-                  distinct_entities: 0,
                   entity_clients: 0,
                   non_entity_clients: 0,
-                  non_entity_tokens: 0,
                   secret_syncs: 7,
                 },
                 mounts: [
                   {
                     counts: {
                       clients: 7,
-                      distinct_entities: 0,
                       entity_clients: 0,
                       non_entity_clients: 0,
-                      non_entity_tokens: 0,
                       secret_syncs: 7,
                     },
                     mount_path: 'sys/',
@@ -500,30 +464,24 @@ export default function (server) {
             new_clients: {
               counts: {
                 clients: 2,
-                distinct_entities: 0,
                 entity_clients: 0,
                 non_entity_clients: 0,
-                non_entity_tokens: 0,
                 secret_syncs: 2,
               },
               namespaces: [
                 {
                   counts: {
                     clients: 2,
-                    distinct_entities: 0,
                     entity_clients: 0,
                     non_entity_clients: 0,
-                    non_entity_tokens: 0,
                     secret_syncs: 2,
                   },
                   mounts: [
                     {
                       counts: {
                         clients: 2,
-                        distinct_entities: 0,
                         entity_clients: 0,
                         non_entity_clients: 0,
-                        non_entity_tokens: 0,
                         secret_syncs: 2,
                       },
                       mount_path: 'sys/',

--- a/ui/tests/helpers/clients/client-count-helpers.js
+++ b/ui/tests/helpers/clients/client-count-helpers.js
@@ -42,8 +42,6 @@ export const ACTIVITY_RESPONSE_STUB = {
         entity_clients: 4256,
         non_entity_clients: 4138,
         secret_syncs: 4810,
-        distinct_entities: 4256,
-        non_entity_tokens: 4138,
       },
       mounts: [
         {
@@ -54,8 +52,6 @@ export const ACTIVITY_RESPONSE_STUB = {
             entity_clients: 4256,
             non_entity_clients: 4138,
             secret_syncs: 0,
-            distinct_entities: 4256,
-            non_entity_tokens: 4138,
           },
         },
         {
@@ -66,8 +62,6 @@ export const ACTIVITY_RESPONSE_STUB = {
             entity_clients: 0,
             non_entity_clients: 0,
             secret_syncs: 4810,
-            distinct_entities: 0,
-            non_entity_tokens: 0,
           },
         },
         {
@@ -78,8 +72,6 @@ export const ACTIVITY_RESPONSE_STUB = {
             entity_clients: 0,
             non_entity_clients: 0,
             secret_syncs: 0,
-            distinct_entities: 0,
-            non_entity_tokens: 0,
           },
         },
       ],
@@ -93,8 +85,6 @@ export const ACTIVITY_RESPONSE_STUB = {
         entity_clients: 4002,
         non_entity_clients: 4089,
         secret_syncs: 4290,
-        distinct_entities: 4002,
-        non_entity_tokens: 4089,
       },
       mounts: [
         {
@@ -105,8 +95,6 @@ export const ACTIVITY_RESPONSE_STUB = {
             entity_clients: 4002,
             non_entity_clients: 4089,
             secret_syncs: 0,
-            distinct_entities: 4002,
-            non_entity_tokens: 4089,
           },
         },
         {
@@ -117,8 +105,6 @@ export const ACTIVITY_RESPONSE_STUB = {
             entity_clients: 0,
             non_entity_clients: 0,
             secret_syncs: 4290,
-            distinct_entities: 0,
-            non_entity_tokens: 0,
           },
         },
         {
@@ -129,8 +115,6 @@ export const ACTIVITY_RESPONSE_STUB = {
             entity_clients: 0,
             non_entity_clients: 0,
             secret_syncs: 0,
-            distinct_entities: 0,
-            non_entity_tokens: 0,
           },
         },
       ],
@@ -151,8 +135,6 @@ export const ACTIVITY_RESPONSE_STUB = {
         entity_clients: 100,
         non_entity_clients: 100,
         secret_syncs: 100,
-        distinct_entities: 100,
-        non_entity_tokens: 100,
       },
       namespaces: [
         {
@@ -164,8 +146,6 @@ export const ACTIVITY_RESPONSE_STUB = {
             entity_clients: 100,
             non_entity_clients: 100,
             secret_syncs: 100,
-            distinct_entities: 100,
-            non_entity_tokens: 100,
           },
           mounts: [
             {
@@ -176,8 +156,6 @@ export const ACTIVITY_RESPONSE_STUB = {
                 entity_clients: 0,
                 non_entity_clients: 0,
                 secret_syncs: 0,
-                distinct_entities: 0,
-                non_entity_tokens: 0,
               },
             },
             {
@@ -188,8 +166,6 @@ export const ACTIVITY_RESPONSE_STUB = {
                 entity_clients: 100,
                 non_entity_clients: 100,
                 secret_syncs: 0,
-                distinct_entities: 0,
-                non_entity_tokens: 0,
               },
             },
             {
@@ -200,8 +176,6 @@ export const ACTIVITY_RESPONSE_STUB = {
                 entity_clients: 0,
                 non_entity_clients: 0,
                 secret_syncs: 100,
-                distinct_entities: 0,
-                non_entity_tokens: 0,
               },
             },
           ],
@@ -214,8 +188,6 @@ export const ACTIVITY_RESPONSE_STUB = {
           entity_clients: 100,
           non_entity_clients: 100,
           secret_syncs: 100,
-          distinct_entities: 100,
-          non_entity_tokens: 100,
         },
         namespaces: [
           {
@@ -227,8 +199,6 @@ export const ACTIVITY_RESPONSE_STUB = {
               entity_clients: 100,
               non_entity_clients: 100,
               secret_syncs: 100,
-              distinct_entities: 100,
-              non_entity_tokens: 100,
             },
             mounts: [
               {
@@ -239,8 +209,6 @@ export const ACTIVITY_RESPONSE_STUB = {
                   entity_clients: 0,
                   non_entity_clients: 0,
                   secret_syncs: 0,
-                  distinct_entities: 0,
-                  non_entity_tokens: 0,
                 },
               },
               {
@@ -251,8 +219,6 @@ export const ACTIVITY_RESPONSE_STUB = {
                   entity_clients: 100,
                   non_entity_clients: 100,
                   secret_syncs: 0,
-                  distinct_entities: 0,
-                  non_entity_tokens: 0,
                 },
               },
               {
@@ -263,8 +229,6 @@ export const ACTIVITY_RESPONSE_STUB = {
                   entity_clients: 0,
                   non_entity_clients: 0,
                   secret_syncs: 100,
-                  distinct_entities: 0,
-                  non_entity_tokens: 0,
                 },
               },
             ],
@@ -280,8 +244,6 @@ export const ACTIVITY_RESPONSE_STUB = {
         entity_clients: 100,
         non_entity_clients: 100,
         secret_syncs: 100,
-        distinct_entities: 100,
-        non_entity_tokens: 100,
       },
       namespaces: [
         {
@@ -293,8 +255,6 @@ export const ACTIVITY_RESPONSE_STUB = {
             entity_clients: 100,
             non_entity_clients: 100,
             secret_syncs: 100,
-            distinct_entities: 100,
-            non_entity_tokens: 100,
           },
           mounts: [
             {
@@ -305,8 +265,6 @@ export const ACTIVITY_RESPONSE_STUB = {
                 entity_clients: 0,
                 non_entity_clients: 0,
                 secret_syncs: 0,
-                distinct_entities: 0,
-                non_entity_tokens: 0,
               },
             },
             {
@@ -317,8 +275,6 @@ export const ACTIVITY_RESPONSE_STUB = {
                 entity_clients: 100,
                 non_entity_clients: 100,
                 secret_syncs: 0,
-                distinct_entities: 0,
-                non_entity_tokens: 0,
               },
             },
             {
@@ -329,8 +285,6 @@ export const ACTIVITY_RESPONSE_STUB = {
                 entity_clients: 0,
                 non_entity_clients: 0,
                 secret_syncs: 100,
-                distinct_entities: 0,
-                non_entity_tokens: 0,
               },
             },
           ],
@@ -349,8 +303,6 @@ export const ACTIVITY_RESPONSE_STUB = {
         entity_clients: 832,
         non_entity_clients: 930,
         secret_syncs: 238,
-        distinct_entities: 832,
-        non_entity_tokens: 930,
       },
       namespaces: [
         {
@@ -362,8 +314,6 @@ export const ACTIVITY_RESPONSE_STUB = {
             entity_clients: 708,
             non_entity_clients: 182,
             secret_syncs: 157,
-            distinct_entities: 708,
-            non_entity_tokens: 182,
           },
           mounts: [
             {
@@ -374,8 +324,6 @@ export const ACTIVITY_RESPONSE_STUB = {
                 entity_clients: 0,
                 non_entity_clients: 0,
                 secret_syncs: 0,
-                distinct_entities: 0,
-                non_entity_tokens: 0,
               },
             },
             {
@@ -386,8 +334,6 @@ export const ACTIVITY_RESPONSE_STUB = {
                 entity_clients: 708,
                 non_entity_clients: 182,
                 secret_syncs: 0,
-                distinct_entities: 0,
-                non_entity_tokens: 0,
               },
             },
             {
@@ -398,8 +344,6 @@ export const ACTIVITY_RESPONSE_STUB = {
                 entity_clients: 0,
                 non_entity_clients: 0,
                 secret_syncs: 157,
-                distinct_entities: 0,
-                non_entity_tokens: 0,
               },
             },
           ],
@@ -413,8 +357,6 @@ export const ACTIVITY_RESPONSE_STUB = {
             entity_clients: 124,
             non_entity_clients: 748,
             secret_syncs: 81,
-            distinct_entities: 124,
-            non_entity_tokens: 748,
           },
           mounts: [
             {
@@ -425,8 +367,6 @@ export const ACTIVITY_RESPONSE_STUB = {
                 entity_clients: 0,
                 non_entity_clients: 0,
                 secret_syncs: 0,
-                distinct_entities: 0,
-                non_entity_tokens: 0,
               },
             },
             {
@@ -437,8 +377,6 @@ export const ACTIVITY_RESPONSE_STUB = {
                 entity_clients: 124,
                 non_entity_clients: 748,
                 secret_syncs: 0,
-                distinct_entities: 0,
-                non_entity_tokens: 0,
               },
             },
             {
@@ -449,8 +387,6 @@ export const ACTIVITY_RESPONSE_STUB = {
                 entity_clients: 0,
                 non_entity_clients: 0,
                 secret_syncs: 81,
-                distinct_entities: 0,
-                non_entity_tokens: 0,
               },
             },
           ],
@@ -463,8 +399,6 @@ export const ACTIVITY_RESPONSE_STUB = {
           entity_clients: 59,
           non_entity_clients: 112,
           secret_syncs: 49,
-          distinct_entities: 59,
-          non_entity_tokens: 112,
         },
         namespaces: [
           {
@@ -476,8 +410,6 @@ export const ACTIVITY_RESPONSE_STUB = {
               entity_clients: 25,
               non_entity_clients: 50,
               secret_syncs: 25,
-              distinct_entities: 25,
-              non_entity_tokens: 50,
             },
             mounts: [
               {
@@ -488,8 +420,6 @@ export const ACTIVITY_RESPONSE_STUB = {
                   entity_clients: 0,
                   non_entity_clients: 0,
                   secret_syncs: 0,
-                  distinct_entities: 0,
-                  non_entity_tokens: 0,
                 },
               },
               {
@@ -500,8 +430,6 @@ export const ACTIVITY_RESPONSE_STUB = {
                   entity_clients: 25,
                   non_entity_clients: 50,
                   secret_syncs: 0,
-                  distinct_entities: 0,
-                  non_entity_tokens: 0,
                 },
               },
               {
@@ -512,8 +440,6 @@ export const ACTIVITY_RESPONSE_STUB = {
                   entity_clients: 0,
                   non_entity_clients: 0,
                   secret_syncs: 25,
-                  distinct_entities: 0,
-                  non_entity_tokens: 0,
                 },
               },
             ],
@@ -527,8 +453,6 @@ export const ACTIVITY_RESPONSE_STUB = {
               entity_clients: 34,
               non_entity_clients: 62,
               secret_syncs: 24,
-              distinct_entities: 34,
-              non_entity_tokens: 62,
             },
             mounts: [
               {
@@ -539,8 +463,6 @@ export const ACTIVITY_RESPONSE_STUB = {
                   entity_clients: 34,
                   non_entity_clients: 62,
                   secret_syncs: 0,
-                  distinct_entities: 0,
-                  non_entity_tokens: 0,
                 },
               },
               {
@@ -551,8 +473,6 @@ export const ACTIVITY_RESPONSE_STUB = {
                   entity_clients: 0,
                   non_entity_clients: 0,
                   secret_syncs: 0,
-                  distinct_entities: 0,
-                  non_entity_tokens: 0,
                 },
               },
               {
@@ -563,8 +483,6 @@ export const ACTIVITY_RESPONSE_STUB = {
                   entity_clients: 0,
                   non_entity_clients: 0,
                   secret_syncs: 24,
-                  distinct_entities: 0,
-                  non_entity_tokens: 0,
                 },
               },
             ],
@@ -579,8 +497,6 @@ export const ACTIVITY_RESPONSE_STUB = {
     entity_clients: 8258,
     non_entity_clients: 8227,
     secret_syncs: 9100,
-    distinct_entities: 8258,
-    non_entity_tokens: 8227,
   },
 };
 
@@ -591,10 +507,8 @@ export const MIXED_ACTIVITY_RESPONSE_STUB = {
   total: {
     acme_clients: 0,
     clients: 3,
-    distinct_entities: 3,
     entity_clients: 3,
     non_entity_clients: 0,
-    non_entity_tokens: 0,
     secret_syncs: 0,
   },
   by_namespace: [
@@ -602,10 +516,8 @@ export const MIXED_ACTIVITY_RESPONSE_STUB = {
       counts: {
         acme_clients: 0,
         clients: 3,
-        distinct_entities: 3,
         entity_clients: 3,
         non_entity_clients: 0,
-        non_entity_tokens: 0,
         secret_syncs: 0,
       },
       mounts: [
@@ -613,10 +525,8 @@ export const MIXED_ACTIVITY_RESPONSE_STUB = {
           counts: {
             acme_clients: 0,
             clients: 2,
-            distinct_entities: 2,
             entity_clients: 2,
             non_entity_clients: 0,
-            non_entity_tokens: 0,
             secret_syncs: 0,
           },
           mount_path: 'no mount accessor (pre-1.10 upgrade?)',
@@ -625,10 +535,8 @@ export const MIXED_ACTIVITY_RESPONSE_STUB = {
           counts: {
             acme_clients: 0,
             clients: 1,
-            distinct_entities: 1,
             entity_clients: 1,
             non_entity_clients: 0,
-            non_entity_tokens: 0,
             secret_syncs: 0,
           },
           mount_path: 'auth/u/',
@@ -649,10 +557,8 @@ export const MIXED_ACTIVITY_RESPONSE_STUB = {
       counts: {
         acme_clients: 0,
         clients: 3,
-        distinct_entities: 0,
         entity_clients: 3,
         non_entity_clients: 0,
-        non_entity_tokens: 0,
         secret_syncs: 0,
       },
       namespaces: [
@@ -660,10 +566,8 @@ export const MIXED_ACTIVITY_RESPONSE_STUB = {
           counts: {
             acme_clients: 0,
             clients: 3,
-            distinct_entities: 0,
             entity_clients: 3,
             non_entity_clients: 0,
-            non_entity_tokens: 0,
             secret_syncs: 0,
           },
           mounts: [
@@ -671,10 +575,8 @@ export const MIXED_ACTIVITY_RESPONSE_STUB = {
               counts: {
                 acme_clients: 0,
                 clients: 2,
-                distinct_entities: 0,
                 entity_clients: 2,
                 non_entity_clients: 0,
-                non_entity_tokens: 0,
                 secret_syncs: 0,
               },
               mount_path: 'no mount accessor (pre-1.10 upgrade?)',
@@ -683,10 +585,8 @@ export const MIXED_ACTIVITY_RESPONSE_STUB = {
               counts: {
                 acme_clients: 0,
                 clients: 1,
-                distinct_entities: 0,
                 entity_clients: 1,
                 non_entity_clients: 0,
-                non_entity_tokens: 0,
                 secret_syncs: 0,
               },
               mount_path: 'auth/u/',
@@ -700,10 +600,8 @@ export const MIXED_ACTIVITY_RESPONSE_STUB = {
         counts: {
           acme_clients: 0,
           clients: 3,
-          distinct_entities: 0,
           entity_clients: 3,
           non_entity_clients: 0,
-          non_entity_tokens: 0,
           secret_syncs: 0,
         },
         namespaces: [
@@ -711,10 +609,8 @@ export const MIXED_ACTIVITY_RESPONSE_STUB = {
             counts: {
               acme_clients: 0,
               clients: 3,
-              distinct_entities: 0,
               entity_clients: 3,
               non_entity_clients: 0,
-              non_entity_tokens: 0,
               secret_syncs: 0,
             },
             mounts: [
@@ -722,10 +618,8 @@ export const MIXED_ACTIVITY_RESPONSE_STUB = {
                 counts: {
                   acme_clients: 0,
                   clients: 2,
-                  distinct_entities: 0,
                   entity_clients: 2,
                   non_entity_clients: 0,
-                  non_entity_tokens: 0,
                   secret_syncs: 0,
                 },
                 mount_path: 'no mount accessor (pre-1.10 upgrade?)',
@@ -734,10 +628,8 @@ export const MIXED_ACTIVITY_RESPONSE_STUB = {
                 counts: {
                   acme_clients: 0,
                   clients: 1,
-                  distinct_entities: 0,
                   entity_clients: 1,
                   non_entity_clients: 0,
-                  non_entity_tokens: 0,
                   secret_syncs: 0,
                 },
                 mount_path: 'auth/u/',

--- a/ui/tests/integration/utils/client-count-utils-test.js
+++ b/ui/tests/integration/utils/client-count-utils-test.js
@@ -10,6 +10,7 @@ import {
   filterVersionHistory,
   formatByMonths,
   formatByNamespace,
+  destructureClientCounts,
   namespaceArrayToObject,
   sortMonthsByTimestamp,
   setStartTimeQuery,
@@ -22,7 +23,7 @@ import {
 } from 'vault/tests/helpers/clients/client-count-helpers';
 
 /*
-formatByNamespace, formatByMonths are utils
+formatByNamespace, formatByMonths, destructureClientCounts are utils
 used to normalize the sys/counters/activity response in the clients/activity
 serializer. these functions are tested individually here, instead of all at once
 in a serializer test for easier debugging
@@ -169,6 +170,20 @@ module('Integration | Util | client count utils', function (hooks) {
       assert.propEqual(Object.keys(mount), Object.keys(expectedMount), `${mount} as expected keys`);
       assert.propEqual(Object.values(mount), Object.values(expectedMount), `${mount} as expected values`);
     });
+  });
+
+  test('destructureClientCounts: it returns relevant key names when both old and new keys exist', async function (assert) {
+    assert.expect(2);
+    const original = { ...RESPONSE.total };
+    const expected = {
+      acme_clients: 9702,
+      clients: 35287,
+      entity_clients: 8258,
+      non_entity_clients: 8227,
+      secret_syncs: 9100,
+    };
+    assert.propEqual(destructureClientCounts(RESPONSE.total), expected);
+    assert.propEqual(RESPONSE.total, original, 'it does not modify original object');
   });
 
   test('sortMonthsByTimestamp: sorts timestamps chronologically, oldest to most recent', async function (assert) {

--- a/ui/tests/integration/utils/client-count-utils-test.js
+++ b/ui/tests/integration/utils/client-count-utils-test.js
@@ -10,7 +10,6 @@ import {
   filterVersionHistory,
   formatByMonths,
   formatByNamespace,
-  destructureClientCounts,
   namespaceArrayToObject,
   sortMonthsByTimestamp,
   setStartTimeQuery,
@@ -23,7 +22,7 @@ import {
 } from 'vault/tests/helpers/clients/client-count-helpers';
 
 /*
-formatByNamespace, formatByMonths, destructureClientCounts are utils
+formatByNamespace, formatByMonths are utils
 used to normalize the sys/counters/activity response in the clients/activity
 serializer. these functions are tested individually here, instead of all at once
 in a serializer test for easier debugging
@@ -170,20 +169,6 @@ module('Integration | Util | client count utils', function (hooks) {
       assert.propEqual(Object.keys(mount), Object.keys(expectedMount), `${mount} as expected keys`);
       assert.propEqual(Object.values(mount), Object.values(expectedMount), `${mount} as expected values`);
     });
-  });
-
-  test('destructureClientCounts: it returns relevant key names when both old and new keys exist', async function (assert) {
-    assert.expect(2);
-    const original = { ...RESPONSE.total };
-    const expected = {
-      acme_clients: 9702,
-      clients: 35287,
-      entity_clients: 8258,
-      non_entity_clients: 8227,
-      secret_syncs: 9100,
-    };
-    assert.propEqual(destructureClientCounts(RESPONSE.total), expected);
-    assert.propEqual(RESPONSE.total, original, 'it does not modify original object');
   });
 
   test('sortMonthsByTimestamp: sorts timestamps chronologically, oldest to most recent', async function (assert) {

--- a/ui/tests/integration/utils/client-count-utils-test.js
+++ b/ui/tests/integration/utils/client-count-utils-test.js
@@ -216,9 +216,7 @@ module('Integration | Util | client count utils', function (hooks) {
         namespace_id: 'root',
         namespace_path: '',
         counts: {
-          distinct_entities: 10,
           entity_clients: 10,
-          non_entity_tokens: 20,
           non_entity_clients: 20,
           secret_syncs: 0,
           acme_clients: 0,
@@ -227,9 +225,7 @@ module('Integration | Util | client count utils', function (hooks) {
         mounts: [
           {
             counts: {
-              distinct_entities: 10,
               entity_clients: 10,
-              non_entity_tokens: 20,
               non_entity_clients: 20,
               secret_syncs: 0,
               acme_clients: 0,


### PR DESCRIPTION
### Description
This PR removes references and expectations around deprecated keys in the client count activity response, namely `distinct_entities` and `non_entity_tokens`. This PR has no user-facing changes, as we were already filtering out the deprecated values from the API response. 
