### PR TITLE
add namespace ID to loading groups debug message on unseal

### DIFF
--- a/vault/identity_store_util.go
+++ b/vault/identity_store_util.go
@@ -148,7 +148,7 @@ func (i *IdentityStore) loadGroups(ctx context.Context) error {
 			}
 
 			if i.logger.IsDebug() {
-				i.logger.Debug("loading group", "name", group.Name, "id", group.ID)
+				i.logger.Debug("loading group", "namespace", ns.ID, "name", group.Name, "id", group.ID)
 			}
 
 			txn := i.db.Txn(true)


### PR DESCRIPTION
### Description
When debugging duplicate groups, it would be really helpful to check the unseal debug logs to check which groups are duplicates. Right now, this is difficult because we don't know which namespace each group lives in. 
[Jira](https://hashicorp.atlassian.net/browse/VAULT-29193)

Based on these previous logs its hard to tell if these are duplicate groups. They have the same name `group1`, but they have different IDs. 

Previous Logs: 
```
2024-07-31T15:25:09.909Z [DEBUG] identity: loading group: name=group1 id=aa8bff0b-5978-c1a9-f45b-f7e0ec655408
2024-07-31T15:25:09.909Z [DEBUG] identity: loading group: name=group1 id=e68144b7-8c19-add8-2f8a-a51e08a1732c
```

In the new logs, it is easy to discern that the group names are the same, but that it is not a problem because they are in different namespaces. 
New Logs:
```
2024-07-31T15:43:18.648Z [DEBUG] identity: loading group: namespace=PzDRv name=group1 id=0cd2293c-6749-5601-3691-b76c3a289bbd
2024-07-31T15:43:18.648Z [DEBUG] identity: loading group: namespace=root name=group1 id=7269c4c9-3a2e-4734-0e0f-c1be4dbd6899
```

### TODO only if you're a HashiCorp employee
- [x] **Labels:** If this PR is the CE portion of an ENT change, and that ENT change is
  getting backported to N-2, use the new style `backport/ent/x.x.x+ent` labels
  instead of the old style `backport/x.x.x` labels.
- [x] **Labels:** If this PR is a CE only change, it can only be backported to N, so use
  the normal `backport/x.x.x` label (there should be only 1).
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
