### PR TITLE
docs: add note on microsoft's saml auth bound attributes syntax

### DIFF
--- a/website/content/docs/auth/saml.mdx
+++ b/website/content/docs/auth/saml.mdx
@@ -175,6 +175,18 @@ Whether it should be an exact match or interpret `*` as a wildcard can be
 controlled by the [`bound_subjects_type`](/vault/api-docs/auth/saml#bound_subjects_type) and
 [`bound_attributes_type`](/vault/api-docs/auth/saml#bound_attributes_type) parameters.
 
+### Bound attributes for the Microsoft identity platform
+
+The bound attributes for the Microsoft identity platform requires
+`http://schemas.microsoft.com/ws/2008/06/identity/claims/groups` as the
+attribute name along with your group membership values. For example, a role with
+`bound_attributes=http://schemas.microsoft.com/ws/2008/06/identity/claims/groups="GROUP1_OBJECT_ID,GROUP2_OBJECT_ID"`
+will only authorize users that are in either the `GROUP1_OBJECT_ID` or
+`GROUP2_OBJECT_ID` group.
+
+You can read more at the Microsoft identity platform's
+[SAML token claims reference](https://learn.microsoft.com/en-us/entra/identity-platform/reference-saml-tokens).
+
 ## API
 
 The SAML authentication plugin has a full HTTP API. Refer to the


### PR DESCRIPTION
Backporting to 1.17.x so this change will go live asap