### PR TITLE
Increase cert auth role cache max size

### DIFF
--- a/builtin/credential/cert/backend.go
+++ b/builtin/credential/cert/backend.go
@@ -29,7 +29,7 @@ const (
 
 	defaultRoleCacheSize  = 200
 	defaultOcspMaxRetries = 4
-	maxRoleCacheSize      = 10000
+	maxRoleCacheSize      = 100000
 )
 
 func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend, error) {


### PR DESCRIPTION
To 100k.  Note that it is very unusual to need many cert auth roles, and may
be indicative of an inoptimal PKI architecture.