### PR TITLE
UI: fix export button tests

### DIFF
--- a/ui/tests/integration/components/clients/export-button-test.js
+++ b/ui/tests/integration/components/clients/export-button-test.js
@@ -114,9 +114,7 @@ module('Integration | Component | clients/export-button', function (hooks) {
     const namespaceSvc = this.owner.lookup('service:namespace');
     namespaceSvc.path = 'foo';
     this.server.get('/sys/internal/counters/activity/export', function (_, req) {
-      assert.deepEqual(req.requestHeaders, {
-        'X-Vault-Namespace': 'foo',
-      });
+      assert.strictEqual(req.requestHeaders['X-Vault-Namespace'], 'foo');
       return new Response(200, { 'Content-Type': 'text/csv' }, '');
     });
 
@@ -133,9 +131,7 @@ module('Integration | Component | clients/export-button', function (hooks) {
   test('it sends the selected namespace in export request', async function (assert) {
     assert.expect(2);
     this.server.get('/sys/internal/counters/activity/export', function (_, req) {
-      assert.deepEqual(req.requestHeaders, {
-        'X-Vault-Namespace': 'foobar',
-      });
+      assert.strictEqual(req.requestHeaders['X-Vault-Namespace'], 'foobar');
       return new Response(200, { 'Content-Type': 'text/csv' }, '');
     });
     this.selectedNamespace = 'foobar/';
@@ -157,9 +153,7 @@ module('Integration | Component | clients/export-button', function (hooks) {
     const namespaceSvc = this.owner.lookup('service:namespace');
     namespaceSvc.path = 'foo';
     this.server.get('/sys/internal/counters/activity/export', function (_, req) {
-      assert.deepEqual(req.requestHeaders, {
-        'X-Vault-Namespace': 'foo/bar',
-      });
+      assert.strictEqual(req.requestHeaders['X-Vault-Namespace'], 'foo/bar');
       return new Response(200, { 'Content-Type': 'text/csv' }, '');
     });
     this.selectedNamespace = 'bar/';

--- a/ui/tests/unit/adapters/clients-activity-test.js
+++ b/ui/tests/unit/adapters/clients-activity-test.js
@@ -194,7 +194,7 @@ module('Unit | Adapter | clients activity', function (hooks) {
       assert.expect(2);
 
       this.server.get('sys/internal/counters/activity/export', (schema, req) => {
-        assert.propEqual(req.requestHeaders, { 'X-Vault-Namespace': 'foo/bar' });
+        assert.strictEqual(req.requestHeaders['X-Vault-Namespace'], 'foo/bar');
         assert.propEqual(req.queryParams, {
           format: 'json',
           start_time: '2024-04-01T00:00:00.000Z',


### PR DESCRIPTION
### Description
After merging some updates to client count exporting, the export-button test started to fail in enterprise CI only. This is an attempt to resolve those failures, or at least make them easier to parse instead of the non-helpful: 
```
[vault]         actual: >
[vault]             [object Object]
[vault]         expected: >
[vault]             [object Object]
``` 
