### PR TITLE
Add docs note about Windows paths

### DIFF
--- a/website/content/docs/agent-and-proxy/agent/winsvc.mdx
+++ b/website/content/docs/agent-and-proxy/agent/winsvc.mdx
@@ -15,7 +15,10 @@ While this guide focuses on an example for Vault Agent, this example can be easi
 [Vault Proxy](/vault/docs/agent-and-proxy/proxy) by changing the config and subcommand
 given to `vault.exe` as appropriate.
 
-**Note:** These commands should be run in a PowerShell session with Administrator capabilities.
+~> Note: The commands on this page should be run in a PowerShell session with Administrator capabilities.
+
+~> Note: When specifying Windows file paths in config files, they should be formatted like this: `C:/foo/bar/file.txt`
+instead of using backslashes.
 
 ## Register Vault Agent as a Windows service
 


### PR DESCRIPTION
### Description

This has been causing some confusion in the field, and seemed to be an easy fix.

https://vault-rih9vxiie-hashicorp.vercel.app/vault/docs/agent-and-proxy/agent/winsvc

<img width="708" alt="image" src="https://github.com/user-attachments/assets/387a92d0-af71-42ec-9d55-51f14446f4db">


### TODO only if you're a HashiCorp employee
- [x] **Labels:** If this PR is the CE portion of an ENT change, and that ENT change is
  getting backported to N-2, use the new style `backport/ent/x.x.x+ent` labels
  instead of the old style `backport/x.x.x` labels.
- [x] **Labels:** If this PR is a CE only change, it can only be backported to N, so use
  the normal `backport/x.x.x` label (there should be only 1).
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
