### PR TITLE
[VAULT-2937] Verify the `/sys/version-history` in enos scenarios

### DIFF
--- a/enos/enos-descriptions.hcl
+++ b/enos/enos-descriptions.hcl
@@ -180,7 +180,8 @@ globals {
     EOF
 
     verify_vault_version = <<-EOF
-      Verify that the Vault cluster has the correct embedded version metadata. This metadata includes
+      Verify that the Vault CLI has the correct embedded version metadata and that the Vault Cluster
+      verision history includes our expected version. The CLI metadata that is validated includes
       the Vault version, edition, build date, and any special prerelease metadata.
     EOF
 

--- a/enos/enos-qualities.hcl
+++ b/enos/enos-qualities.hcl
@@ -250,6 +250,21 @@ quality "vault_api_sys_storage_raft_remove_peer_write_removes_peer" {
   EOF
 }
 
+quality "vault_api_sys_version_history_keys" {
+  description = <<-EOF
+    The v1/sys/version-history Vault API returns the cluster version history and the 'keys' data
+    includes our target version
+  EOF
+}
+
+quality "vault_api_sys_version_history_key_info" {
+  description = <<-EOF
+    The v1/sys/version-history Vault API returns the cluster version history and the
+    'key_info["$expected_version]' data is present for the expected version and the 'build_date'
+    matches the expected build_date.
+  EOF
+}
+
 quality "vault_artifact_bundle" {
   description = "The candidate binary packaged as a zip bundle is used for testing"
 }

--- a/enos/enos-scenario-autopilot.hcl
+++ b/enos/enos-scenario-autopilot.hcl
@@ -685,6 +685,8 @@ scenario "autopilot" {
     }
 
     verifies = [
+      quality.vault_api_sys_version_history_keys,
+      quality.vault_api_sys_version_history_key_info,
       quality.vault_version_build_date,
       quality.vault_version_edition,
       quality.vault_version_release,

--- a/enos/enos-scenario-proxy.hcl
+++ b/enos/enos-scenario-proxy.hcl
@@ -388,33 +388,6 @@ scenario "proxy" {
     }
   }
 
-  step "verify_vault_version" {
-    description = global.description.verify_vault_version
-    module      = module.vault_verify_version
-    depends_on  = [step.create_vault_cluster]
-
-    providers = {
-      enos = local.enos_provider[matrix.distro]
-    }
-
-    verifies = [
-      quality.vault_version_build_date,
-      quality.vault_version_edition,
-      quality.vault_version_release,
-    ]
-
-    variables {
-      hosts                 = step.create_vault_cluster_targets.hosts
-      vault_addr            = step.create_vault_cluster.api_addr_localhost
-      vault_edition         = matrix.edition
-      vault_install_dir     = global.vault_install_dir[matrix.artifact_type]
-      vault_product_version = matrix.artifact_source == "local" ? step.get_local_metadata.version : var.vault_product_version
-      vault_revision        = matrix.artifact_source == "local" ? step.get_local_metadata.revision : var.vault_revision
-      vault_build_date      = matrix.artifact_source == "local" ? step.get_local_metadata.build_date : var.vault_build_date
-      vault_root_token      = step.create_vault_cluster.root_token
-    }
-  }
-
   step "verify_vault_unsealed" {
     description = global.description.verify_vault_unsealed
     module      = module.vault_verify_unsealed
@@ -437,13 +410,39 @@ scenario "proxy" {
     }
   }
 
+  step "verify_vault_version" {
+    description = global.description.verify_vault_version
+    module      = module.vault_verify_version
+    depends_on  = [step.verify_vault_unsealed]
+
+    providers = {
+      enos = local.enos_provider[matrix.distro]
+    }
+
+    verifies = [
+      quality.vault_api_sys_version_history_keys,
+      quality.vault_api_sys_version_history_key_info,
+      quality.vault_version_build_date,
+      quality.vault_version_edition,
+      quality.vault_version_release,
+    ]
+
+    variables {
+      hosts                 = step.create_vault_cluster_targets.hosts
+      vault_addr            = step.create_vault_cluster.api_addr_localhost
+      vault_edition         = matrix.edition
+      vault_install_dir     = global.vault_install_dir[matrix.artifact_type]
+      vault_product_version = matrix.artifact_source == "local" ? step.get_local_metadata.version : var.vault_product_version
+      vault_revision        = matrix.artifact_source == "local" ? step.get_local_metadata.revision : var.vault_revision
+      vault_build_date      = matrix.artifact_source == "local" ? step.get_local_metadata.build_date : var.vault_build_date
+      vault_root_token      = step.create_vault_cluster.root_token
+    }
+  }
+
   step "verify_write_test_data" {
     description = global.description.verify_write_test_data
     module      = module.vault_verify_write_data
-    depends_on = [
-      step.create_vault_cluster,
-      step.get_vault_cluster_ips
-    ]
+    depends_on  = [step.verify_vault_unsealed]
 
     providers = {
       enos = local.enos_provider[matrix.distro]
@@ -469,7 +468,7 @@ scenario "proxy" {
     description = global.description.verify_raft_cluster_all_nodes_are_voters
     skip_step   = matrix.backend != "raft"
     module      = module.vault_verify_raft_auto_join_voter
-    depends_on  = [step.create_vault_cluster]
+    depends_on  = [step.verify_vault_unsealed]
 
     providers = {
       enos = local.enos_provider[matrix.distro]
@@ -489,7 +488,7 @@ scenario "proxy" {
   step "verify_replication" {
     description = global.description.verify_replication_status
     module      = module.vault_verify_replication
-    depends_on  = [step.create_vault_cluster]
+    depends_on  = [step.verify_vault_unsealed]
 
     providers = {
       enos = local.enos_provider[matrix.distro]
@@ -532,7 +531,7 @@ scenario "proxy" {
   step "verify_ui" {
     description = global.description.verify_ui
     module      = module.vault_verify_ui
-    depends_on  = [step.create_vault_cluster]
+    depends_on  = [step.verify_vault_unsealed]
 
     providers = {
       enos = local.enos_provider[matrix.distro]

--- a/enos/enos-scenario-replication.hcl
+++ b/enos/enos-scenario-replication.hcl
@@ -603,6 +603,8 @@ scenario "replication" {
     }
 
     verifies = [
+      quality.vault_api_sys_version_history_keys,
+      quality.vault_api_sys_version_history_key_info,
       quality.vault_version_build_date,
       quality.vault_version_edition,
       quality.vault_version_release,

--- a/enos/enos-scenario-seal-ha.hcl
+++ b/enos/enos-scenario-seal-ha.hcl
@@ -700,6 +700,8 @@ scenario "seal_ha" {
     }
 
     verifies = [
+      quality.vault_api_sys_version_history_keys,
+      quality.vault_api_sys_version_history_key_info,
       quality.vault_version_build_date,
       quality.vault_version_edition,
       quality.vault_version_release,

--- a/enos/enos-scenario-smoke.hcl
+++ b/enos/enos-scenario-smoke.hcl
@@ -430,33 +430,6 @@ scenario "smoke" {
     }
   }
 
-  step "verify_vault_version" {
-    description = global.description.verify_vault_version
-    module      = module.vault_verify_version
-    depends_on  = [step.create_vault_cluster]
-
-    providers = {
-      enos = local.enos_provider[matrix.distro]
-    }
-
-    verifies = [
-      quality.vault_version_build_date,
-      quality.vault_version_edition,
-      quality.vault_version_release,
-    ]
-
-    variables {
-      hosts                 = step.create_vault_cluster_targets.hosts
-      vault_addr            = step.create_vault_cluster.api_addr_localhost
-      vault_edition         = matrix.edition
-      vault_install_dir     = global.vault_install_dir[matrix.artifact_type]
-      vault_product_version = matrix.artifact_source == "local" ? step.get_local_metadata.version : var.vault_product_version
-      vault_revision        = matrix.artifact_source == "local" ? step.get_local_metadata.revision : var.vault_revision
-      vault_build_date      = matrix.artifact_source == "local" ? step.get_local_metadata.build_date : var.vault_build_date
-      vault_root_token      = step.create_vault_cluster.root_token
-    }
-  }
-
   step "verify_vault_unsealed" {
     description = global.description.verify_vault_unsealed
     module      = module.vault_verify_unsealed
@@ -479,13 +452,39 @@ scenario "smoke" {
     }
   }
 
+  step "verify_vault_version" {
+    description = global.description.verify_vault_version
+    module      = module.vault_verify_version
+    depends_on  = [step.verify_vault_unsealed]
+
+    providers = {
+      enos = local.enos_provider[matrix.distro]
+    }
+
+    verifies = [
+      quality.vault_api_sys_version_history_keys,
+      quality.vault_api_sys_version_history_key_info,
+      quality.vault_version_build_date,
+      quality.vault_version_edition,
+      quality.vault_version_release,
+    ]
+
+    variables {
+      hosts                 = step.create_vault_cluster_targets.hosts
+      vault_addr            = step.create_vault_cluster.api_addr_localhost
+      vault_edition         = matrix.edition
+      vault_install_dir     = global.vault_install_dir[matrix.artifact_type]
+      vault_product_version = matrix.artifact_source == "local" ? step.get_local_metadata.version : var.vault_product_version
+      vault_revision        = matrix.artifact_source == "local" ? step.get_local_metadata.revision : var.vault_revision
+      vault_build_date      = matrix.artifact_source == "local" ? step.get_local_metadata.build_date : var.vault_build_date
+      vault_root_token      = step.create_vault_cluster.root_token
+    }
+  }
+
   step "verify_write_test_data" {
     description = global.description.verify_write_test_data
     module      = module.vault_verify_write_data
-    depends_on = [
-      step.create_vault_cluster,
-      step.get_vault_cluster_ips
-    ]
+    depends_on  = [step.verify_vault_unsealed]
 
     providers = {
       enos = local.enos_provider[matrix.distro]
@@ -511,10 +510,7 @@ scenario "smoke" {
     description = global.description.verify_raft_cluster_all_nodes_are_voters
     skip_step   = matrix.backend != "raft"
     module      = module.vault_verify_raft_auto_join_voter
-    depends_on = [
-      step.create_vault_cluster,
-      step.get_vault_cluster_ips
-    ]
+    depends_on  = [step.verify_vault_unsealed]
 
     providers = {
       enos = local.enos_provider[matrix.distro]
@@ -534,10 +530,7 @@ scenario "smoke" {
   step "verify_replication" {
     description = global.description.verify_replication_status
     module      = module.vault_verify_replication
-    depends_on = [
-      step.create_vault_cluster,
-      step.get_vault_cluster_ips
-    ]
+    depends_on  = [step.verify_vault_unsealed]
 
     providers = {
       enos = local.enos_provider[matrix.distro]
@@ -580,10 +573,7 @@ scenario "smoke" {
   step "verify_ui" {
     description = global.description.verify_ui
     module      = module.vault_verify_ui
-    depends_on = [
-      step.create_vault_cluster,
-      step.get_vault_cluster_ips
-    ]
+    depends_on  = [step.verify_vault_unsealed]
 
     providers = {
       enos = local.enos_provider[matrix.distro]

--- a/enos/enos-scenario-upgrade.hcl
+++ b/enos/enos-scenario-upgrade.hcl
@@ -576,35 +576,6 @@ scenario "upgrade" {
     }
   }
 
-  step "verify_vault_version" {
-    description = global.description.verify_vault_version
-    module      = module.vault_verify_version
-    depends_on = [
-      step.get_updated_vault_cluster_ips,
-    ]
-
-    providers = {
-      enos = local.enos_provider[matrix.distro]
-    }
-
-    verifies = [
-      quality.vault_version_build_date,
-      quality.vault_version_edition,
-      quality.vault_version_release,
-    ]
-
-    variables {
-      hosts                 = step.create_vault_cluster_targets.hosts
-      vault_addr            = step.create_vault_cluster.api_addr_localhost
-      vault_edition         = matrix.edition
-      vault_install_dir     = global.vault_install_dir[matrix.artifact_type]
-      vault_product_version = matrix.artifact_source == "local" ? step.get_local_metadata.version : var.vault_product_version
-      vault_revision        = matrix.artifact_source == "local" ? step.get_local_metadata.revision : var.vault_revision
-      vault_build_date      = matrix.artifact_source == "local" ? step.get_local_metadata.build_date : var.vault_build_date
-      vault_root_token      = step.create_vault_cluster.root_token
-    }
-  }
-
   step "verify_vault_unsealed" {
     description = global.description.verify_vault_unsealed
     module      = module.vault_verify_unsealed
@@ -629,11 +600,39 @@ scenario "upgrade" {
     }
   }
 
+  step "verify_vault_version" {
+    description = global.description.verify_vault_version
+    module      = module.vault_verify_version
+    depends_on  = [step.verify_vault_unsealed]
+
+    providers = {
+      enos = local.enos_provider[matrix.distro]
+    }
+
+    verifies = [
+      quality.vault_api_sys_version_history_keys,
+      quality.vault_api_sys_version_history_key_info,
+      quality.vault_version_build_date,
+      quality.vault_version_edition,
+      quality.vault_version_release,
+    ]
+
+    variables {
+      hosts                 = step.create_vault_cluster_targets.hosts
+      vault_addr            = step.create_vault_cluster.api_addr_localhost
+      vault_edition         = matrix.edition
+      vault_install_dir     = global.vault_install_dir[matrix.artifact_type]
+      vault_product_version = matrix.artifact_source == "local" ? step.get_local_metadata.version : var.vault_product_version
+      vault_revision        = matrix.artifact_source == "local" ? step.get_local_metadata.revision : var.vault_revision
+      vault_build_date      = matrix.artifact_source == "local" ? step.get_local_metadata.build_date : var.vault_build_date
+      vault_root_token      = step.create_vault_cluster.root_token
+    }
+  }
+
   step "verify_read_test_data" {
     description = global.description.verify_write_test_data
     module      = module.vault_verify_read_data
     depends_on = [
-      step.get_updated_vault_cluster_ips,
       step.verify_write_test_data,
       step.verify_vault_unsealed
     ]
@@ -660,9 +659,7 @@ scenario "upgrade" {
     description = global.description.verify_raft_cluster_all_nodes_are_voters
     skip_step   = matrix.backend != "raft"
     module      = module.vault_verify_raft_auto_join_voter
-    depends_on = [
-      step.get_updated_vault_cluster_ips,
-    ]
+    depends_on  = [step.verify_vault_unsealed]
 
     providers = {
       enos = local.enos_provider[matrix.distro]
@@ -682,9 +679,7 @@ scenario "upgrade" {
   step "verify_replication" {
     description = global.description.verify_replication_status
     module      = module.vault_verify_replication
-    depends_on = [
-      step.get_updated_vault_cluster_ips,
-    ]
+    depends_on  = [step.verify_vault_unsealed]
 
     providers = {
       enos = local.enos_provider[matrix.distro]
@@ -706,9 +701,7 @@ scenario "upgrade" {
   step "verify_ui" {
     description = global.description.verify_ui
     module      = module.vault_verify_ui
-    depends_on = [
-      step.get_updated_vault_cluster_ips,
-    ]
+    depends_on  = [step.verify_vault_unsealed]
 
     providers = {
       enos = local.enos_provider[matrix.distro]

--- a/enos/modules/vault_upgrade/scripts/maybe-remove-old-unit-file.sh
+++ b/enos/modules/vault_upgrade/scripts/maybe-remove-old-unit-file.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+set -e
+
+fail() {
+  echo "$1" 1>&2
+  exit 1
+}
+
+[[ -z "$ARTIFACT_NAME" ]] && fail "ARTIFACT_NAME env variable has not been set"
+
+if [ "${ARTIFACT_NAME##*.}" == "zip" ];  then
+  echo "Skipped removing unit file because new artifact is a zip bundle"
+  exit 0
+fi
+
+# Get the unit file for the vault.service that is running. If it's not in /etc/systemd then it
+# should be a package provided unit file so we don't need to delete anything.
+if ! unit_path=$(systemctl show -P FragmentPath vault 2>&1); then
+  echo "Skipped removing unit file because and existing path could not be found: $unit_path"
+  exit 0
+fi
+
+if [[ "$unit_path" == *"/etc/systemd"* ]]; then
+  if [ -f "$unit_path" ]; then
+    echo "Removing old systemd unit file: $unit_path"
+    if ! out=$(sudo rm "$unit_path" 2>&1); then
+      fail "Failed to remove old unit file: $unit_path: $out"
+    fi
+  else
+    echo "Skipped removing old systemd unit file because it no longer exists: $unit_path"
+  fi
+else
+  echo "Skipped removing old systemd unit file because it was not created in /etc/systemd/: $unit_path"
+fi

--- a/enos/modules/vault_upgrade/scripts/restart-vault.sh
+++ b/enos/modules/vault_upgrade/scripts/restart-vault.sh
@@ -12,11 +12,15 @@ binpath=${VAULT_INSTALL_DIR}/vault
 test -x "$binpath" || fail "unable to locate vault binary at $binpath"
 
 if ! out=$(sudo systemctl stop vault 2>&1); then
-  echo "failed to stop vault: $out: $(sudo systemctl status vault)" 1>&2
+  fail "failed to stop vault: $out: $(sudo systemctl status vault)"
+fi
+
+if ! out=$(sudo systemctl daemon-reload 2>&1); then
+  fail "failed to daemon-reload systemd: $out" 1>&2
 fi
 
 if ! out=$(sudo systemctl start vault 2>&1); then
-  echo "failed to start vault: $out: $(sudo systemctl status vault)" 1>&2
+  fail "failed to start vault: $out: $(sudo systemctl status vault)"
 fi
 
 count=0

--- a/enos/modules/vault_verify_version/main.tf
+++ b/enos/modules/vault_verify_version/main.tf
@@ -58,7 +58,7 @@ variable "vault_root_token" {
   default     = null
 }
 
-resource "enos_remote_exec" "verify_all_nodes_have_updated_version" {
+resource "enos_remote_exec" "verify_cli_version" {
   for_each = var.hosts
 
   environment = {
@@ -69,6 +69,25 @@ resource "enos_remote_exec" "verify_all_nodes_have_updated_version" {
     VAULT_REVISION    = var.vault_revision,
     VAULT_TOKEN       = var.vault_root_token,
     VAULT_VERSION     = var.vault_product_version,
+  }
+
+  scripts = [abspath("${path.module}/scripts/verify-cli-version.sh")]
+
+  transport = {
+    ssh = {
+      host = each.value.public_ip
+    }
+  }
+}
+
+resource "enos_remote_exec" "verify_cluster_version" {
+  for_each = var.hosts
+
+  environment = {
+    VAULT_ADDR       = var.vault_addr,
+    VAULT_BUILD_DATE = var.vault_build_date,
+    VAULT_TOKEN      = var.vault_root_token,
+    VAULT_VERSION    = var.vault_product_version,
   }
 
   scripts = [abspath("${path.module}/scripts/verify-cluster-version.sh")]

--- a/enos/modules/vault_verify_version/scripts/verify-cli-version.sh
+++ b/enos/modules/vault_verify_version/scripts/verify-cli-version.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+# Verify the Vault "version" includes the correct base version, build date,
+# revision SHA, and edition metadata.
+set -e
+
+fail() {
+  echo "$1" 1>&2
+  exit 1
+}
+
+[[ -z "$VAULT_ADDR" ]] && fail "VAULT_ADDR env variable has not been set"
+[[ -z "$VAULT_BUILD_DATE" ]] && fail "VAULT_BUILD_DATE env variable has not been set"
+[[ -z "$VAULT_EDITION" ]] && fail "VAULT_EDITION env variable has not been set"
+[[ -z "$VAULT_INSTALL_DIR" ]] && fail "VAULT_INSTALL_DIR env variable has not been set"
+[[ -z "$VAULT_REVISION" ]] && fail "VAULT_REVISION env variable has not been set"
+[[ -z "$VAULT_TOKEN" ]] && fail "VAULT_TOKEN env variable has not been set"
+[[ -z "$VAULT_VERSION" ]] && fail "VAULT_VERSION env variable has not been set"
+
+binpath=${VAULT_INSTALL_DIR}/vault
+edition=${VAULT_EDITION}
+version=${VAULT_VERSION}
+sha=${VAULT_REVISION}
+build_date=${VAULT_BUILD_DATE}
+
+test -x "$binpath" || fail "unable to locate vault binary at $binpath"
+version_expected="Vault v$version ($sha), built $build_date"
+
+case "$edition" in
+  *ce) ;;
+  *ent) ;;
+  *ent.hsm) version_expected="$version_expected (cgo)";;
+  *ent.fips1402) version_expected="$version_expected (cgo)" ;;
+  *ent.hsm.fips1402) version_expected="$version_expected (cgo)" ;;
+  *) fail "Unknown Vault edition: ($edition)" ;;
+esac
+
+version_expected_nosha=$(echo "$version_expected" | awk '!($3="")' | sed 's/  / /' | sed -e 's/[[:space:]]*$//')
+version_output=$("$binpath" version)
+
+if [[ "$version_output" == "$version_expected_nosha" ]] || [[ "$version_output" == "$version_expected" ]]; then
+  echo "Version verification succeeded!"
+else
+  fail "expected Version=$version_expected or $version_expected_nosha, got: $version_output"
+fi


### PR DESCRIPTION
### Description
When verifying the Vault version, in addition to verifying the CLI version we also check that the `/sys/version-history` contains the expected version.

As part of this we also fix a bug where when doing an in-place upgrade with a Debian or Redhat package we also remove the self-managed `vault.service` systemd unit to ensure that correctly start up using the new version of Vault.

### TODO only if you're a HashiCorp employee
- [x] **Labels:** If this PR is the CE portion of an ENT change, and that ENT change is
  getting backported to N-2, use the new style `backport/ent/x.x.x+ent` labels
  instead of the old style `backport/x.x.x` labels.
- [x] **Labels:** If this PR is a CE only change, it can only be backported to N, so use
  the normal `backport/x.x.x` label (there should be only 1).
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
