### PR TITLE
UI: update getOwner import

### DIFF
--- a/ui/app/components/console/ui-panel.js
+++ b/ui/app/components/console/ui-panel.js
@@ -6,7 +6,7 @@
 import { service } from '@ember/service';
 import { alias, or } from '@ember/object/computed';
 import Component from '@ember/component';
-import { getOwner } from '@ember/application';
+import { getOwner } from '@ember/owner';
 import { schedule } from '@ember/runloop';
 import { camelize } from '@ember/string';
 import { task } from 'ember-concurrency';

--- a/ui/app/components/generated-item-list.js
+++ b/ui/app/components/generated-item-list.js
@@ -6,7 +6,7 @@
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
-import { getOwner } from '@ember/application';
+import { getOwner } from '@ember/owner';
 import { tracked } from '@glimmer/tracking';
 
 /**

--- a/ui/app/components/raft-storage-overview.js
+++ b/ui/app/components/raft-storage-overview.js
@@ -4,7 +4,7 @@
  */
 
 import Component from '@ember/component';
-import { getOwner } from '@ember/application';
+import { getOwner } from '@ember/owner';
 import config from '../config/environment';
 import { service } from '@ember/service';
 

--- a/ui/app/components/raft-storage-restore.js
+++ b/ui/app/components/raft-storage-restore.js
@@ -5,7 +5,7 @@
 
 import Component from '@ember/component';
 import { task } from 'ember-concurrency';
-import { getOwner } from '@ember/application';
+import { getOwner } from '@ember/owner';
 import { service } from '@ember/service';
 import { alias } from '@ember/object/computed';
 import { AbortController } from 'fetch';

--- a/ui/app/services/auth.js
+++ b/ui/app/services/auth.js
@@ -5,7 +5,7 @@
 
 import Ember from 'ember';
 import { task, timeout } from 'ember-concurrency';
-import { getOwner } from '@ember/application';
+import { getOwner } from '@ember/owner';
 import { isArray } from '@ember/array';
 import { computed, get } from '@ember/object';
 import { alias } from '@ember/object/computed';

--- a/ui/app/services/console.js
+++ b/ui/app/services/console.js
@@ -6,7 +6,7 @@
 // Low level service that allows users to input paths to make requests to vault
 // this service provides the UI synecdote to the cli commands read, write, delete, and list
 import Service from '@ember/service';
-import { getOwner } from '@ember/application';
+import { getOwner } from '@ember/owner';
 import { shiftCommandIndex } from 'vault/lib/console-helpers';
 import { encodePath } from 'vault/utils/path-encoding-helpers';
 import { sanitizePath, ensureTrailingSlash } from 'core/utils/sanitize-path';

--- a/ui/lib/kmip/addon/controllers/credentials/index.js
+++ b/ui/lib/kmip/addon/controllers/credentials/index.js
@@ -6,7 +6,7 @@
 import ListController from 'core/mixins/list-controller';
 import Controller from '@ember/controller';
 import { computed } from '@ember/object';
-import { getOwner } from '@ember/application';
+import { getOwner } from '@ember/owner';
 
 export default Controller.extend(ListController, {
   mountPoint: computed(function () {

--- a/ui/lib/kmip/addon/controllers/scope/roles.js
+++ b/ui/lib/kmip/addon/controllers/scope/roles.js
@@ -6,7 +6,7 @@
 import ListController from 'core/mixins/list-controller';
 import Controller from '@ember/controller';
 import { computed } from '@ember/object';
-import { getOwner } from '@ember/application';
+import { getOwner } from '@ember/owner';
 
 export default Controller.extend(ListController, {
   mountPoint: computed(function () {

--- a/ui/lib/kmip/addon/controllers/scopes/index.js
+++ b/ui/lib/kmip/addon/controllers/scopes/index.js
@@ -6,7 +6,7 @@
 import ListController from 'core/mixins/list-controller';
 import Controller from '@ember/controller';
 import { computed } from '@ember/object';
-import { getOwner } from '@ember/application';
+import { getOwner } from '@ember/owner';
 
 export default Controller.extend(ListController, {
   mountPoint: computed(function () {

--- a/ui/lib/kubernetes/addon/components/page/roles.js
+++ b/ui/lib/kubernetes/addon/components/page/roles.js
@@ -6,7 +6,7 @@
 import Component from '@glimmer/component';
 import { service } from '@ember/service';
 import { action } from '@ember/object';
-import { getOwner } from '@ember/application';
+import { getOwner } from '@ember/owner';
 import errorMessage from 'vault/utils/error-message';
 import { tracked } from '@glimmer/tracking';
 import keys from 'core/utils/key-codes';

--- a/ui/lib/kv/addon/components/page/list.js
+++ b/ui/lib/kv/addon/components/page/list.js
@@ -7,7 +7,7 @@ import Component from '@glimmer/component';
 import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
-import { getOwner } from '@ember/application';
+import { getOwner } from '@ember/owner';
 import { ancestorKeysForKey } from 'core/utils/key-utils';
 import errorMessage from 'vault/utils/error-message';
 import { pathIsDirectory } from 'kv/utils/kv-breadcrumbs';

--- a/ui/lib/ldap/addon/components/page/libraries.ts
+++ b/ui/lib/ldap/addon/components/page/libraries.ts
@@ -7,7 +7,7 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { service } from '@ember/service';
 import { action } from '@ember/object';
-import { getOwner } from '@ember/application';
+import { getOwner } from '@ember/owner';
 import errorMessage from 'vault/utils/error-message';
 
 import type LdapLibraryModel from 'vault/models/ldap/library';

--- a/ui/lib/ldap/addon/components/page/roles.ts
+++ b/ui/lib/ldap/addon/components/page/roles.ts
@@ -6,7 +6,7 @@
 import Component from '@glimmer/component';
 import { service } from '@ember/service';
 import { action } from '@ember/object';
-import { getOwner } from '@ember/application';
+import { getOwner } from '@ember/owner';
 import errorMessage from 'vault/utils/error-message';
 
 import type LdapRoleModel from 'vault/models/ldap/role';

--- a/ui/lib/pki/addon/controllers/certificates/index.js
+++ b/ui/lib/pki/addon/controllers/certificates/index.js
@@ -4,7 +4,7 @@
  */
 
 import Controller from '@ember/controller';
-import { getOwner } from '@ember/application';
+import { getOwner } from '@ember/owner';
 import { action } from '@ember/object';
 
 export default class PkiCertificatesIndexController extends Controller {

--- a/ui/lib/pki/addon/controllers/issuers/index.js
+++ b/ui/lib/pki/addon/controllers/issuers/index.js
@@ -4,7 +4,7 @@
  */
 
 import Controller from '@ember/controller';
-import { getOwner } from '@ember/application';
+import { getOwner } from '@ember/owner';
 
 export default class PkiIssuerIndexController extends Controller {
   queryParams = ['page'];

--- a/ui/lib/pki/addon/controllers/keys/index.js
+++ b/ui/lib/pki/addon/controllers/keys/index.js
@@ -4,7 +4,7 @@
  */
 
 import Controller from '@ember/controller';
-import { getOwner } from '@ember/application';
+import { getOwner } from '@ember/owner';
 
 export default class PkiKeysIndexController extends Controller {
   queryParams = ['page'];

--- a/ui/lib/pki/addon/controllers/roles/index.js
+++ b/ui/lib/pki/addon/controllers/roles/index.js
@@ -4,7 +4,7 @@
  */
 
 import Controller from '@ember/controller';
-import { getOwner } from '@ember/application';
+import { getOwner } from '@ember/owner';
 
 export default class PkiRolesIndexController extends Controller {
   queryParams = ['page'];

--- a/ui/lib/sync/addon/components/secrets/page/destinations.ts
+++ b/ui/lib/sync/addon/components/secrets/page/destinations.ts
@@ -7,7 +7,7 @@ import Component from '@glimmer/component';
 import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
-import { getOwner } from '@ember/application';
+import { getOwner } from '@ember/owner';
 import errorMessage from 'vault/utils/error-message';
 import { findDestination, syncDestinations } from 'core/helpers/sync-destinations';
 import { next } from '@ember/runloop';

--- a/ui/lib/sync/addon/components/secrets/page/destinations/destination/secrets.ts
+++ b/ui/lib/sync/addon/components/secrets/page/destinations/destination/secrets.ts
@@ -7,7 +7,7 @@ import Component from '@glimmer/component';
 import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
-import { getOwner } from '@ember/application';
+import { getOwner } from '@ember/owner';
 import errorMessage from 'vault/utils/error-message';
 
 import SyncDestinationModel from 'vault/vault/models/sync/destination';


### PR DESCRIPTION
### Description
Updates the import of getOwner from `@ember/application`, where it is deprecated, to `@ember/owner`. This should have no user-facing changes
