### PR TITLE
Audit: explain 'failure' metrics better

### DIFF
--- a/website/content/partials/telemetry-metrics/vault/audit/log_request_failure.mdx
+++ b/website/content/partials/telemetry-metrics/vault/audit/log_request_failure.mdx
@@ -1,15 +1,17 @@
 ### vault.audit.log_request_failure ((#vault-audit-log_request_failure))
 
-| Metric type | Value  | Description                                             |
-|-------------|--------|---------------------------------------------------------|
-| counter     | number | Number of audit log request failures across all devices |
+| Metric type | Value  | Description                                                                               |
+|-------------|--------|-------------------------------------------------------------------------------------------|
+| gauge       | number | Average (mean) number of audit log request failures across all devices during time period |
 
 The number of request failures is a **crucial metric**.
 
-A non-zero value for `vault.audit.log_request_failure` indicates that all your
-configured audit devices failed to log a request (or response). If Vault cannot
+A non-zero value for `vault.audit.log_request_failure` indicates that all
+the configured audit devices failed to log a request (or response). If Vault cannot
 properly audit a request, or the response to a request, the original request
 will fail.
+
+The `mean` value for this metric should be monitored, not the `count` which could be misleading.
 
 Refer to the Vault logs and any device-specific metrics to troubleshoot the
 failing audit log device.

--- a/website/content/partials/telemetry-metrics/vault/audit/log_response_failure.mdx
+++ b/website/content/partials/telemetry-metrics/vault/audit/log_response_failure.mdx
@@ -1,15 +1,17 @@
 ### vault.audit.log_response_failure ((#vault-audit-log_response_failure))
 
-| Metric type | Value  | Description                                             |
-|-------------|--------|---------------------------------------------------------|
-| counter     | number | Number of audit log response failures across all devices |
+| Metric type | Value  | Description                                                                                |
+|-------------|--------|--------------------------------------------------------------------------------------------|
+| gauge       | number | Average (mean) number of audit log response failures across all devices during time period |
 
 The number of request failures is a **crucial metric**.
 
-A non-zero value for `vault.audit.log_response_failure` indicates that all of
-the configured audit log devices failed to log a response to a request to Vault. If Vault cannot
+A non-zero value for `vault.audit.log_response_failure` indicates that all
+the configured audit log devices failed to log a response to a request. If Vault cannot
 properly audit a request, or the response to a request, the original request
 will fail.
+
+The `mean` value for this metric should be monitored, not the `count` which could be misleading.
 
 Refer to the device-specific metrics and logs to troubleshoot the failing audit
 log device.


### PR DESCRIPTION
### Description

There has been confusion around the `vault.audit.log_request_failure` and `vault.audit.log_response_failure` metrics, which are documented as counters.

The metrics emit a number of values that can be checked e.g. `count`, `mean`, `min`... the `count` for this metric just indicates how many times it was called, however Vault will increment the metric on every success or failure (supplying either the value `0` or `1` respectively). This is done so that systems like Prometheus don't 'forget' the metric if they don't see it fail for a while. 

### HashiCorp Checklist

- [x] **Labels:** If this PR is the CE portion of an ENT change, and that ENT change is
  getting backported to N-2, use the new style `backport/ent/x.x.x+ent` labels
  instead of the old style `backport/x.x.x` labels.
- [x] **Labels:** If this PR is a CE only change, it can only be backported to N, so use
  the normal `backport/x.x.x` label (there should be only 1).
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
