### PR TITLE
Add 'how to run' instructions for each Enos scenario

### DIFF
--- a/enos/enos-dev-scenario-pr-replication.hcl
+++ b/enos/enos-dev-scenario-pr-replication.hcl
@@ -66,11 +66,10 @@ scenario "dev_pr_replication" {
       c. 'artifact:zip'
       This will download a Vault .zip bundle from releases.hashicorp.com with the version and
       edition you specify.
-
-      TODO: add required variable
-    
+      
     5. If you don't know yet what combination of matrix variants you want to use for your scenario, you 
-    can view all the possible combinations through the `list` command:
+    can view all the possible combinations through the `list` command. You can also reduce the list by
+    adding one or more filter items, e.g. 'arch:amd64' to get just the scenario combinations that use amd64.
 
       $ enos scenario list dev_single_cluster
     
@@ -81,7 +80,7 @@ scenario "dev_pr_replication" {
 
     Notes:
     - To learn more about any Enos command, use the `--help` flag, e.g.:
-    
+
         $ enos scenario launch --help
 
     - Enos will run all matrix variant combinations that match your filter. If you specify one
@@ -108,94 +107,6 @@ scenario "dev_pr_replication" {
     7. When you're done, destroy the scenario and associated infrastructure:
 
       $ enos scenario destroy dev_pr_replication <filter>
-
-
-
-
-    PREREQUISITES
-    
-    In order to execute this scenario you'll need:
-    
-    1. To install the enos CLI:
-      - $ brew tap hashicorp/tap && brew update && brew install hashicorp/tap/enos
-
-    2. Authenticate to an AWS account via Doormat and export the credentials locally. Follow the guide here:
-      https://eng-handbook.hashicorp.services/internal-tools/enos/getting-started/#authenticate-to-aws-with-doormat
-
-    3. An SSH keypair set up in your AWS account:
-      https://eng-handbook.hashicorp.services/internal-tools/enos/getting-started/#set-your-aws-key-pair-name-and-private-key
-
-    RUNNING THIS SCENARIO
-
-    1. Set input variables
-
-    This scenario requires several input variables to be set in order to function
-    properly. While not all variants will require all variables, it's suggested that you look over
-    the scenario outline to determine which variables affect which steps and which have inputs that
-    you should set. You can use the following command to get a textual outline of the entire
-    scenario:
-      enos scenario outline dev_pr_replication
-
-    You can also create an HTML version that is suitable for viewing in web browsers:
-      enos scenario outline dev_pr_replication --format html > index.html
-      open index.html
-
-    There are two main options for setting these input variables:
-    
-    * Create an 'enos-local.vars' file in the same 'enos' directory where this scenario is defined.
-    Declare your desired variable values in this file. For example, you could copy the following content
-    and then set the values as necessary:
-
-    (Note: Artifactory credentials are only required if you are using `artifact:deb` or `artifact:rpm`,
-    as Enos will download these from Artifactory)
-    artifactory_username      = "username@hashicorp.com"
-    artifactory_token         = "<ARTIFACTORY TOKEN VALUE>
-    aws_region                = "us-west-2"
-    aws_ssh_keypair_name      = "<YOUR REGION SPECIFIC KEYPAIR NAME>"
-    aws_ssh_keypair_key_path  = "/path/to/your/private/key.pem"
-    dev_build_local_ui        = false
-    dev_consul_version        = "1.18.1"
-    vault_license_path        = "./support/vault.hclic"
-    vault_product_version     = "1.16.2"
-
-    * Set them as environment variables:
-
-    export ENOS_VAR_aws_region="us-west-2"
-    export ENOS_VAR_vault_license_path="./support/vault.hclic"
-
-    2. Launch the scenario
-    
-    After you've configured your inputs, you can list and filter the available scenarios and then
-    subsequently launch your desired one.
-
-    Note: To learn more about any Enos command, use the `--help` flag, e.g.:
-      enos scenario launch --help
-
-    If you don't know yet what combination of matrix variants you want to use for your scenario, 
-    can view all the possible combinations through the `list` command:
-      enos scenario list dev_pr_replication
-    
-
-    Once you know what filter you want to use to obtain your desired combination of matrix variants,
-    use the `launch` command with that filter to launch your scenario.
-      enos scenario launch dev_pr_replication arch:amd64 artifact:deb distro:ubuntu edition:ent.hsm primary_backend:raft primary_seal:awskms secondary_backend:raft secondary_seal:pkcs11
-
-      Note: In this scenario, the artifact:local variant builds
-
-    3. Inspect your cluster if necessary
-
-    When the scenario is finished launching, refer to the scenario outputs to see information
-    related to your cluster. You can use this information to SSH into nodes and/or to interact
-    with vault. If using Ubuntu, your SSH user will be `ubuntu`; if using any of the other
-    supported distros, it will be `ec2-user`.
-      enos scenario output dev_pr_replication arch:amd64 artifact:deb distro:ubuntu edition:ent.hsm primary_backend:raft primary_seal:awskms secondary_backend:raft secondary_seal:pkcs11
-      ssh -i /path/to/your/private/key.pem <SSH_USER>@<PUBLIC_IP>
-      vault status
-
-    4. Destroy your resources
-
-    After you've finished, destroy the cluster.
-      enos scenario destroy dev_pr_replication arch:amd64 artifact:deb distro:ubuntu edition:ent.hsm primary_backend:raft primary_seal:awskms secondary_backend:raft secondary_seal:pkcs11
   EOF
 
   // The matrix is where we define all the baseline combinations that enos can utilize to customize

--- a/enos/enos-dev-scenario-pr-replication.hcl
+++ b/enos/enos-dev-scenario-pr-replication.hcl
@@ -13,16 +13,24 @@ scenario "dev_pr_replication" {
     artifact as long as its version is >= 1.8. You can also use the 'artifact:local' variant to
     build and deploy the current branch!
 
-    In order to execute this scenario you'll need to install the enos CLI:
+    PREREQUISITES
+    
+    In order to execute this scenario you'll need:
+    
+    1. To install the enos CLI:
       - $ brew tap hashicorp/tap && brew update && brew install hashicorp/tap/enos
 
-    You'll also need access to an AWS account via Doormat, follow the guide here:
-      https://eng-handbook.hashicorp.services/internal-tools/enos/common-setup-steps/#authenticate-with-doormat
+    2. Authenticate to an AWS account via Doormat and export the credentials locally. Follow the guide here:
+      https://eng-handbook.hashicorp.services/internal-tools/enos/getting-started/#authenticate-to-aws-with-doormat
 
-    Follow this guide to get an SSH keypair set up in the AWS account:
-      https://eng-handbook.hashicorp.services/internal-tools/enos/common-setup-steps/#set-your-aws-key-pair-name-and-private-key
+    3. An SSH keypair set up in your AWS account:
+      https://eng-handbook.hashicorp.services/internal-tools/enos/getting-started/#set-your-aws-key-pair-name-and-private-key
 
-    Please note that this scenario requires several inputs variables to be set in order to function
+    RUNNING THIS SCENARIO
+
+    1. Set input variables
+
+    Next, this scenario requires several input variables to be set in order to function
     properly. While not all variants will require all variables, it's suggested that you look over
     the scenario outline to determine which variables affect which steps and which have inputs that
     you should set. You can use the following command to get a textual outline of the entire
@@ -33,11 +41,14 @@ scenario "dev_pr_replication" {
       enos scenario outline dev_pr_replication --format html > index.html
       open index.html
 
-    To configure the required variables you have a couple of choices. You can create an
-    'enos-local.vars' file in the same 'enos' directory where this scenario is defined. In it you
-    declare your desired variable values. For example, you could copy the following content and
-    then set the values as necessary:
+    There are two main options for setting these input variables:
+    
+    * Create an 'enos-local.vars' file in the same 'enos' directory where this scenario is defined.
+    Declare your desired variable values in this file. For example, you could copy the following content
+    and then set the values as necessary:
 
+    (Note: Artifactory credentials are only required if you are using `artifact:deb` or `artifact:rpm`,
+    as Enos will download these from Artifactory)
     artifactory_username      = "username@hashicorp.com"
     artifactory_token         = "<ARTIFACTORY TOKEN VALUE>
     aws_region                = "us-west-2"
@@ -48,25 +59,43 @@ scenario "dev_pr_replication" {
     vault_license_path        = "./support/vault.hclic"
     vault_product_version     = "1.16.2"
 
-    Alternatively, you can set them in your environment:
+    * Set them as environment variables:
+
     export ENOS_VAR_aws_region="us-west-2"
     export ENOS_VAR_vault_license_path="./support/vault.hclic"
 
-    After you've configured your inputs you can list and filter the available scenarios and then
-    subsequently launch and destroy them.
-      enos scenario list --help
+    2. Launch the scenario
+    
+    After you've configured your inputs, you can list and filter the available scenarios and then
+    subsequently launch your desired one.
+
+    Note: To learn more about any Enos command, use the `--help` flag, e.g.:
       enos scenario launch --help
+
+    If you don't know yet what combination of matrix variants you want to use for your scenario, 
+    can view all the possible combinations through the `list` command:
       enos scenario list dev_pr_replication
+    
+
+    Once you know what filter you want to use to obtain your desired combination of matrix variants,
+    use the `launch` command with that filter to launch your scenario.
       enos scenario launch dev_pr_replication arch:amd64 artifact:deb distro:ubuntu edition:ent.hsm primary_backend:raft primary_seal:awskms secondary_backend:raft secondary_seal:pkcs11
 
-    When the scenario is finished launching you refer to the scenario outputs to see information
+      Note: In this scenario, the artifact:local variant builds
+
+    3. Inspect your cluster if necessary
+
+    When the scenario is finished launching, refer to the scenario outputs to see information
     related to your cluster. You can use this information to SSH into nodes and/or to interact
-    with vault.
+    with vault. If using Ubuntu, your SSH user will be `ubuntu`; if using any of the other
+    supported distros, it will be `ec2-user`.
       enos scenario output dev_pr_replication arch:amd64 artifact:deb distro:ubuntu edition:ent.hsm primary_backend:raft primary_seal:awskms secondary_backend:raft secondary_seal:pkcs11
-      ssh -i /path/to/your/private/key.pem <PUBLIC_IP>
+      ssh -i /path/to/your/private/key.pem <SSH_USER>@<PUBLIC_IP>
       vault status
 
-    After you've finished you can tear down the cluster
+    4. Destroy your resources
+
+    After you've finished, destroy the cluster.
       enos scenario destroy dev_pr_replication arch:amd64 artifact:deb distro:ubuntu edition:ent.hsm primary_backend:raft primary_seal:awskms secondary_backend:raft secondary_seal:pkcs11
   EOF
 

--- a/enos/enos-dev-scenario-single-cluster.hcl
+++ b/enos/enos-dev-scenario-single-cluster.hcl
@@ -12,6 +12,107 @@ scenario "dev_single_cluster" {
     artifact as long as its version is >= 1.8. You can also use the 'artifact:local' variant to
     build and deploy the current branch!
 
+    You can use the following command to get a textual outline of the entire
+    scenario:
+
+      $ enos scenario outline dev_single_cluster
+
+    You can also create an HTML version that is suitable for viewing in web browsers:
+
+      $ enos scenario outline dev_single_cluster --format html > index.html
+      $ open index.html
+
+    # How to run this scenario
+
+    1. Install Enos (more info: https://eng-handbook.hashicorp.services/internal-tools/enos/getting-started/)
+    
+      $ brew tap hashicorp/tap && brew update && brew install hashicorp/tap/enos
+
+    2. Authenticate to AWS with Doormat (more info: https://eng-handbook.hashicorp.services/internal-tools/enos/getting-started/#authenticate-to-aws-with-doormat)
+    
+      $ doormat login && eval $(doormat aws -a <your_aws_account_name> export)
+
+    3. Set the following variables either as environment variables (`export ENOS_VAR_var_name=value`)
+    or by creating a 'enos-local.vars' file and setting it there (see enos.vars.hcl for examples):
+
+    Required variables
+      - aws_ssh_private_key_path (more info about AWS SSH keypairs: https://eng-handbook.hashicorp.services/internal-tools/enos/getting-started/#set-your-aws-key-pair-name-and-private-key)
+      - aws_ssh_keypair_name
+
+    Optional variables
+      - aws_region (set if different from the default value in enos-variables.hcl)
+      - dev_build_local_ui (set if different from the default value in enos-dev-variables.hcl)
+      - dev_consul_version (set if different from the default value in enos-dev-variables.hcl)
+      - distro_version_<distro> (set if different from the default version for your target
+        distro in enos-globals.hcl)
+      - vault_license_path (set if using an ENT edition of Vault)
+      - consul_license_path (set if using an ENT edition of Consul, according to var.backend_edition)
+    
+    4. Choose what type of Vault artifact you want to use, and set the appropriate variables.
+
+      a. 'artifact:local'
+      This will build a Vault .zip bundle from your local branch. Set the following variable:
+
+      vault_artifact_path = path/to/where/vault-should-be-built.zip
+
+      b. 'artifact:deb' or 'artifact:rpm'
+      This will download a Vault .deb or .rpm package from Artifactory with the version and
+      edition you specify. To do this, you will need to set your Artifactory credentials:
+
+      artifactory_username = your-user
+      artifactory_token = your-token
+
+      c. 'artifact:zip'
+      This will download a Vault .zip bundle from releases.hashicorp.com with the version and
+      edition you specify.
+
+      TODO: add required variable
+    
+    5. If you don't know yet what combination of matrix variants you want to use for your scenario, you 
+    can view all the possible combinations through the `list` command.
+
+      $ enos scenario list dev_single_cluster
+    
+    Once you know what filter you want to use to obtain your desired combination of matrix variants,
+    use the `launch` command with that filter to launch your scenario, e.g.:
+
+      $ enos scenario launch dev_single_cluster arch:amd64 artifact:zip backend:consul distro:ubuntu edition:ent seal:awskms
+
+    Notes:
+    - To learn more about any Enos command, use the `--help` flag, e.g.:
+    
+        $ enos scenario launch --help
+
+    - Enos will run all matrix variant combinations that match your filter. If you specify one
+      variant for each matrix item, only one combination of variants will match the filter, and
+      therefore Enos will run only one scenario.
+
+    - If you want to use the 'distro:leap' variant you must first accept SUSE's terms for the AWS
+      account. To verify that your account has agreed, sign-in to your AWS through Doormat,
+      and visit the following links to verify your subscription or subscribe:
+        - arm64 AMI: https://aws.amazon.com/marketplace/server/procurement?productId=a516e959-df54-4035-bb1a-63599b7a6df9
+        - amd64 AMI: https://aws.amazon.com/marketplace/server/procurement?productId=5535c495-72d4-4355-b169-54ffa874f849
+
+    6. When the scenario is finished launching, refer to the scenario outputs to see information
+    related to your cluster, including public IPs. You can use this information to SSH into nodes
+    and/or to interact with Vault. If using Ubuntu, your SSH user will be `ubuntu`; if using any
+    of the other supported distros, it will be `ec2-user`.
+
+      $ enos scenario output dev_single_cluster <filter>
+      $ ssh -i /path/to/your/ssh-private-key.pem <ssh-user>@<public-ip>
+      $ vault status
+
+    For Enos troubleshooting tips, see https://eng-handbook.hashicorp.services/internal-tools/enos/troubleshooting/.
+
+    7. When you're done, destroy the scenario and associated infrastructure:
+
+      $ enos scenario destroy dev_single_cluster <filter>
+
+
+
+
+
+
     In order to execute this scenario you'll need: 
     
     1. To install the enos CLI:

--- a/enos/enos-dev-scenario-single-cluster.hcl
+++ b/enos/enos-dev-scenario-single-cluster.hcl
@@ -12,14 +12,18 @@ scenario "dev_single_cluster" {
     artifact as long as its version is >= 1.8. You can also use the 'artifact:local' variant to
     build and deploy the current branch!
 
-    In order to execute this scenario you'll need to install the enos CLI:
-      brew tap hashicorp/tap && brew update && brew install hashicorp/tap/enos
+    In order to execute this scenario you'll need: 
+    
+    1. To install the enos CLI:
+      - $ brew tap hashicorp/tap && brew update && brew install hashicorp/tap/enos
 
-    You'll also need access to an AWS account with an SSH keypair.
-    Perform the steps here to get AWS access with Doormat https://eng-handbook.hashicorp.services/internal-tools/enos/common-setup-steps/#authenticate-with-doormat
-    Perform the steps here to get an AWS keypair set up: https://eng-handbook.hashicorp.services/internal-tools/enos/common-setup-steps/#set-your-aws-key-pair-name-and-private-key
+    2. Access to an AWS account via Doormat. Follow the guide here:
+      https://eng-handbook.hashicorp.services/internal-tools/enos/getting-started/#authenticate-to-aws-with-doormat
 
-    Please note that this scenario requires several inputs variables to be set in order to function
+    3. An SSH keypair set up in your AWS account:
+      https://eng-handbook.hashicorp.services/internal-tools/enos/getting-started/#set-your-aws-key-pair-name-and-private-key
+
+    Please note that this scenario requires several input variables to be set in order to function
     properly. While not all variants will require all variables, it's suggested that you look over
     the scenario outline to determine which variables affect which steps and which have inputs that
     you should set. You can use the following command to get a textual outline of the entire

--- a/enos/enos-dev-scenario-single-cluster.hcl
+++ b/enos/enos-dev-scenario-single-cluster.hcl
@@ -65,11 +65,10 @@ scenario "dev_single_cluster" {
       c. 'artifact:zip'
       This will download a Vault .zip bundle from releases.hashicorp.com with the version and
       edition you specify.
-
-      TODO: add required variable
     
     5. If you don't know yet what combination of matrix variants you want to use for your scenario, you 
-    can view all the possible combinations through the `list` command.
+    can view all the possible combinations through the `list` command. You can also reduce the list by
+    adding one or more filter items, e.g. 'arch:amd64' to get just the scenario combinations that use amd64.
 
       $ enos scenario list dev_single_cluster
     
@@ -80,7 +79,7 @@ scenario "dev_single_cluster" {
 
     Notes:
     - To learn more about any Enos command, use the `--help` flag, e.g.:
-    
+
         $ enos scenario launch --help
 
     - Enos will run all matrix variant combinations that match your filter. If you specify one
@@ -107,69 +106,6 @@ scenario "dev_single_cluster" {
     7. When you're done, destroy the scenario and associated infrastructure:
 
       $ enos scenario destroy dev_single_cluster <filter>
-
-
-
-
-
-
-    In order to execute this scenario you'll need: 
-    
-    1. To install the enos CLI:
-      - $ brew tap hashicorp/tap && brew update && brew install hashicorp/tap/enos
-
-    2. Access to an AWS account via Doormat. Follow the guide here:
-      https://eng-handbook.hashicorp.services/internal-tools/enos/getting-started/#authenticate-to-aws-with-doormat
-
-    3. An SSH keypair set up in your AWS account:
-      https://eng-handbook.hashicorp.services/internal-tools/enos/getting-started/#set-your-aws-key-pair-name-and-private-key
-
-    Please note that this scenario requires several input variables to be set in order to function
-    properly. While not all variants will require all variables, it's suggested that you look over
-    the scenario outline to determine which variables affect which steps and which have inputs that
-    you should set. You can use the following command to get a textual outline of the entire
-    scenario:
-      enos scenario outline dev_single_cluster
-
-    You can also create an HTML version that is suitable for viewing in web browsers:
-      enos scenario outline dev_single_cluster --format html > index.html
-      open index.html
-
-    To configure the required variables you have a couple of choices. You can create an
-    'enos-local.vars' file in the same 'enos' directory where this scenario is defined. In it you
-    declare your desired variable values. For example, you could copy the following content and
-    then set the values as necessary:
-
-    artifactory_username      = "username@hashicorp.com"
-    artifactory_token         = "<ARTIFACTORY TOKEN VALUE>
-    aws_region                = "us-west-2"
-    aws_ssh_keypair_name      = "<YOUR REGION SPECIFIC KEYPAIR NAME>"
-    aws_ssh_keypair_key_path  = "/path/to/your/private/key.pem"
-    dev_build_local_ui        = false
-    dev_consul_version        = "1.18.1"
-    vault_license_path        = "./support/vault.hclic"
-    vault_product_version     = "1.16.2"
-
-    Alternatively, you can set them in your environment:
-    export ENOS_VAR_aws_region="us-west-2"
-    export ENOS_VAR_vault_license_path="./support/vault.hclic"
-
-    After you've configured your inputs you can list and filter the available scenarios and then
-    subsequently launch and destroy them.
-      enos scenario list --help
-      enos scenario launch --help
-      enos scenario list dev_single_cluster
-      enos scenario launch dev_single_cluster arch:arm64 artifact:local backend:raft distro:ubuntu edition:ce seal:awskms
-
-    When the scenario is finished launching you refer to the scenario outputs to see information
-    related to your cluster. You can use this information to SSH into nodes and/or to interact
-    with vault.
-      enos scenario output dev_single_cluster arch:arm64 artifact:local backend:raft distro:ubuntu edition:ce seal:awskms
-      ssh -i /path/to/your/private/key.pem <PUBLIC_IP>
-      vault status
-
-    After you've finished you can tear down the cluster
-      enos scenario destroy dev_single_cluster arch:arm64 artifact:local backend:raft distro:ubuntu edition:ce seal:awskms
   EOF
 
   // The matrix is where we define all the baseline combinations that enos can utilize to customize

--- a/enos/enos-scenario-agent.hcl
+++ b/enos/enos-scenario-agent.hcl
@@ -9,18 +9,23 @@ scenario "agent" {
     build in Agent mode and verifies behavior against the Vault cluster. The scenario also performs
     standard baseline verification that is not specific to the Agent mode deployment.
 
+    You can use the following command to get a textual outline of the entire
+    scenario:
+    
+      $ enos scenario outline agent
+
     # How to run this scenario
 
     1. Install Enos (more info: https://eng-handbook.hashicorp.services/internal-tools/enos/getting-started/)
     
-    $ brew tap hashicorp/tap && brew update && brew install hashicorp/tap/enos
+      $ brew tap hashicorp/tap && brew update && brew install hashicorp/tap/enos
 
     2. Authenticate to AWS with Doormat (more info: https://eng-handbook.hashicorp.services/internal-tools/enos/getting-started/#authenticate-to-aws-with-doormat)
     
-    $ doormat login && eval $(doormat aws -a <your_aws_account_name> export)
+      $ doormat login && eval $(doormat aws -a <your_aws_account_name> export)
 
     3. Set the following variables either as environment variables (`export ENOS_VAR_var_name=value`)
-    or in your 'enos-local.vars' file:
+    or by creating a 'enos-local.vars' file and setting it there (see enos.vars.hcl for examples):
 
     Required variables
       - aws_ssh_private_key_path (more info about AWS SSH keypairs: https://eng-handbook.hashicorp.services/internal-tools/enos/getting-started/#set-your-aws-key-pair-name-and-private-key)
@@ -41,24 +46,24 @@ scenario "agent" {
       a. 'artifact_source:crt'
       This will use a Vault artifact that you have already downloaded. Set the following variable:
 
-      ENOS_VAR_vault_artifact_path=path/to/existing-vault-artifact.[zip | rpm | deb]
+        vault_artifact_path = path/to/existing-vault-artifact.[zip | rpm | deb]
 
       b. 'artifact_source:local'
       This will build a Vault .zip bundle from your local branch. Set the following variable:
 
-      ENOS_VAR_vault_artifact_path=path/to/where/vault-should-be-built.zip
+        vault_artifact_path = path/to/where/vault-should-be-built.zip
 
       c. 'artifact_source:artifactory'
       This will download a Vault artifact of the specified version, edition, and revision SHA
       from the 'stable' repo in Artifactory. Set the following variables:
 
-      export ENOS_VAR_artifactory_username=your-user
-      export ENOS_VAR_artifactory_token=your-token
+        artifactory_username = your-user
+        artifactory_token = your-token
     
     5. Choose the matrix variants you want to use, and launch the scenario with the appropriate
     filter for those variants, e.g.:
 
-    $ enos scenario launch agent arch:amd64 artifact_source:crt artifact_type:bundle backend:consul config_mode:env consul_edition:ent consul_version:1.16.3 distro:ubuntu edition:ent.hsm.fips1402 seal:pkcs11
+      $ enos scenario launch agent arch:amd64 artifact_source:crt artifact_type:bundle backend:consul config_mode:env consul_edition:ent consul_version:1.16.3 distro:ubuntu edition:ent.hsm.fips1402 seal:pkcs11
 
     Notes:
     - Enos will run all matrix variant combinations that match your filter. If you specify one
@@ -76,8 +81,8 @@ scenario "agent" {
     6. If necessary, get the public IPs of your cluster from the Enos scenario output and SSH in,
     using 'ubuntu' for the SSH user with 'distro:ubuntu', or 'ec2-user' with all other supported Linux distros:
 
-    $ enos scenario output <filter>
-    $ ssh -i /path/to/your/ssh-private-key.pem <ssh-user>@<public-ip>
+      $ enos scenario output <filter>
+      $ ssh -i /path/to/your/ssh-private-key.pem <ssh-user>@<public-ip>
 
     For Enos troubleshooting tips, see https://eng-handbook.hashicorp.services/internal-tools/enos/troubleshooting/.
   EOF

--- a/enos/enos-scenario-agent.hcl
+++ b/enos/enos-scenario-agent.hcl
@@ -68,7 +68,8 @@ scenario "agent" {
         artifactory_token = your-token
     
     5. If you don't know yet what combination of matrix variants you want to use for your scenario, you 
-    can view all the possible combinations through the `list` command:
+    can view all the possible combinations through the `list` command. You can also reduce the list by
+    adding one or more filter items, e.g. 'arch:amd64' to get just the scenario combinations that use amd64.
 
       $ enos scenario list agent
     
@@ -81,7 +82,7 @@ scenario "agent" {
     - To learn more about any Enos command, use the `--help` flag, e.g.:
     
         $ enos scenario launch --help
-        
+
     - Enos will run all matrix variant combinations that match your filter. If you specify one
       variant for each matrix item, the filter will produce and run only one scenario. Even if you are
       using a Raft backend, you may want to specify a consul_version (though it functionally will not

--- a/enos/enos-scenario-agent.hcl
+++ b/enos/enos-scenario-agent.hcl
@@ -9,10 +9,17 @@ scenario "agent" {
     build in Agent mode and verifies behavior against the Vault cluster. The scenario also performs
     standard baseline verification that is not specific to the Agent mode deployment.
 
+    # How to view an outline of this scenario
+
     You can use the following command to get a textual outline of the entire
     scenario:
     
       $ enos scenario outline agent
+
+    You can also create an HTML version that is suitable for viewing in web browsers:
+
+      $ enos scenario outline agent --format html > index.html
+      $ open index.html
 
     # How to run this scenario
 
@@ -60,12 +67,21 @@ scenario "agent" {
         artifactory_username = your-user
         artifactory_token = your-token
     
-    5. Choose the matrix variants you want to use, and launch the scenario with the appropriate
-    filter for those variants, e.g.:
+    5. If you don't know yet what combination of matrix variants you want to use for your scenario, you 
+    can view all the possible combinations through the `list` command:
+
+      $ enos scenario list agent
+    
+    Once you know what filter you want to use to obtain your desired combination of matrix variants,
+    use the `launch` command with that filter to launch your scenario.
 
       $ enos scenario launch agent arch:amd64 artifact_source:crt artifact_type:bundle backend:consul config_mode:env consul_edition:ent consul_version:1.16.3 distro:ubuntu edition:ent.hsm.fips1402 seal:pkcs11
 
     Notes:
+    - To learn more about any Enos command, use the `--help` flag, e.g.:
+    
+        $ enos scenario launch --help
+        
     - Enos will run all matrix variant combinations that match your filter. If you specify one
       variant for each matrix item, the filter will produce and run only one scenario. Even if you are
       using a Raft backend, you may want to specify a consul_version (though it functionally will not
@@ -85,6 +101,10 @@ scenario "agent" {
       $ ssh -i /path/to/your/ssh-private-key.pem <ssh-user>@<public-ip>
 
     For Enos troubleshooting tips, see https://eng-handbook.hashicorp.services/internal-tools/enos/troubleshooting/.
+
+    7. When you're done, destroy the scenario and associated infrastructure:
+
+      $ enos scenario destroy agent <filter>
   EOF
 
   matrix {

--- a/enos/enos-scenario-agent.hcl
+++ b/enos/enos-scenario-agent.hcl
@@ -3,13 +3,44 @@
 
 scenario "agent" {
   description = <<-EOF
-    The agent scenario verifies Vault when running in Agent mode. The build can be a local branch,
+    The agent scenario verifies Vault when running in Agent mode. The scenario creates a new Vault Cluster
+    using the candidate build and then runs the same Vault build in Agent mode and verifies behavior
+    against the Vault cluster. The scenario also performs standard baseline verification that is not
+    specific to the Agent mode deployment.
+
+    # How to run this scenario
+
+    1. Install Enos
+    $ brew tap hashicorp/tap && brew update && brew install hashicorp/tap/enos
+
+    2. Authenticate to AWS with Doormat (see details here: https://eng-handbook.hashicorp.services/internal-tools/enos/getting-started/#authenticate-to-aws-with-doormat)
+    $ doormat login && eval $(doormat aws -a <your_aws_account_name> export)
+    
+    3. Decide how you will get a Vault artifact:
+      - 
+    Set the following variables either as environment variables (`export ENOS_VAR_var_name=value`)
+    or in your 'enos-local.vars' file:
+      Required variables
+        - aws_ssh_private_key_path
+        - aws_ssh_keypair_name
+        - vault_build_date
+        - vault_product_version
+        - vault_revision
+    
+      Optional variables
+        - artifactory_username (if using 'artifact_source:artifactory')
+        - artifactory_token (if using 'artifact_source:artifactory')
+        - aws_region (if different from the default value in enos-variables.hcl)
+        - consul_license_path (if using an ENT edition of Consul)
+        - distro_version_<distro> (if different from the default version for your target
+        distro; see list of supported distros and versions in enos-globals.hcl)
+        - vault_license_path (if using an ENT edition of Vault)
+        - vault_artifact_path (if using `artifact_source:crt`, set to the path to your
+        downloaded .zip, .deb, or .rpm artifact)
+        
+    The build can be a local branch,
     any CRT built Vault artifact saved to the local machine, or any CRT built Vault artifact in the
     stable channel in Artifactory.
-
-    The scenario creates a new Vault Cluster using the candidate build and then runs the same Vault
-    build in Agent mode and verifies behavior against the Vault cluster. The scenario also performs
-    standard baseline verification that is not specific to the Agent mode deployment.
 
     If you want to use the 'distro:leap' variant you must first accept SUSE's terms for the AWS
     account. To verify that your account has agreed, sign-in to your AWS through Doormat,

--- a/enos/enos-scenario-autopilot.hcl
+++ b/enos/enos-scenario-autopilot.hcl
@@ -11,18 +11,23 @@ scenario "autopilot" {
     The scenario also performs standard baseline verification that is not specific to the autopilot
     upgrade.
 
+    You can use the following command to get a textual outline of the entire
+    scenario:
+    
+      $ enos scenario outline autopilot
+
     # How to run this scenario
 
     1. Install Enos (more info: https://eng-handbook.hashicorp.services/internal-tools/enos/getting-started/)
     
-    $ brew tap hashicorp/tap && brew update && brew install hashicorp/tap/enos
+      $ brew tap hashicorp/tap && brew update && brew install hashicorp/tap/enos
 
     2. Authenticate to AWS with Doormat (more info: https://eng-handbook.hashicorp.services/internal-tools/enos/getting-started/#authenticate-to-aws-with-doormat)
     
-    $ doormat login && eval $(doormat aws -a <your_aws_account_name> export)
+      $ doormat login && eval $(doormat aws -a <your_aws_account_name> export)
 
     3. Set the following variables either as environment variables (`export ENOS_VAR_var_name=value`)
-    or in your 'enos-local.vars' file:
+    or by creating a 'enos-local.vars' file and setting it there (see enos.vars.hcl for examples):
 
     Required variables
       - aws_ssh_private_key_path (more info about AWS SSH keypairs: https://eng-handbook.hashicorp.services/internal-tools/enos/getting-started/#set-your-aws-key-pair-name-and-private-key)
@@ -45,24 +50,24 @@ scenario "autopilot" {
       a. 'artifact_source:crt'
       This will use a Vault artifact that you have already downloaded. Set the following variable:
 
-      ENOS_VAR_vault_artifact_path=path/to/existing-vault-artifact.[zip | rpm | deb]
+        vault_artifact_path = path/to/existing-vault-artifact.[zip | rpm | deb]
 
       b. 'artifact_source:local'
       This will build a Vault .zip bundle from your local branch. Set the following variable:
 
-      ENOS_VAR_vault_artifact_path=path/to/where/vault-should-be-built.zip
+        vault_artifact_path = path/to/where/vault-should-be-built.zip
 
       c. 'artifact_source:artifactory'
       This will download a Vault artifact of the specified version, edition, and revision SHA
       from the 'stable' repo in Artifactory. Set the following variables:
 
-      export ENOS_VAR_artifactory_username=your-user
-      export ENOS_VAR_artifactory_token=your-token
+        artifactory_username = your-user
+        artifactory_token = your-token
     
     5. Choose the matrix variants you want to use, and launch the scenario with the appropriate
     filter for those variants, e.g.:
 
-    $ enos scenario launch autopilot arch:arm64 artifact_source:artifactory artifact_type:bundle config_mode:file distro:rhel edition:ent initial_version:1.12.11 seal:shamir
+      $ enos scenario launch autopilot arch:arm64 artifact_source:artifactory artifact_type:bundle config_mode:file distro:rhel edition:ent initial_version:1.12.11 seal:shamir
 
     Notes:
     - Enos will run all matrix variant combinations that match your filter. If you specify one
@@ -71,14 +76,14 @@ scenario "autopilot" {
     - If you want to use the 'distro:leap' variant you must first accept SUSE's terms for the AWS
       account. To verify that your account has agreed, sign-in to your AWS through Doormat,
       and visit the following links to verify your subscription or subscribe:
-        arm64 AMI: https://aws.amazon.com/marketplace/server/procurement?productId=a516e959-df54-4035-bb1a-63599b7a6df9
-        amd64 AMI: https://aws.amazon.com/marketplace/server/procurement?productId=5535c495-72d4-4355-b169-54ffa874f849
+        - arm64 AMI: https://aws.amazon.com/marketplace/server/procurement?productId=a516e959-df54-4035-bb1a-63599b7a6df9
+        - amd64 AMI: https://aws.amazon.com/marketplace/server/procurement?productId=5535c495-72d4-4355-b169-54ffa874f849
 
     6. If necessary, get the public IPs of your cluster from the Enos scenario output and SSH in,
     using 'ubuntu' for the SSH user with 'distro:ubuntu', or 'ec2-user' with all other supported Linux distros:
 
-    $ enos scenario output <filter>
-    $ ssh -i /path/to/your/ssh-private-key.pem <ssh-user>@<public-ip>
+      $ enos scenario output <filter>
+      $ ssh -i /path/to/your/ssh-private-key.pem <ssh-user>@<public-ip>
 
     For Enos troubleshooting tips, see https://eng-handbook.hashicorp.services/internal-tools/enos/troubleshooting/.
   EOF

--- a/enos/enos-scenario-autopilot.hcl
+++ b/enos/enos-scenario-autopilot.hcl
@@ -4,20 +4,83 @@
 scenario "autopilot" {
   description = <<-EOF
     The autopilot scenario verifies autopilot upgrades between previously released versions of
-    Vault Enterprise against another candidate build. The build can be a local branch, any CRT built
-    Vault Enterprise artifact saved to the local machine, or any CRT built Vault Enterprise artifact
-    in the stable channel in Artifactory.
+    Vault Enterprise against another candidate build.
 
     The scenario creates a new Vault Cluster with a previously released version of Vault, mounts
     various engines and creates data, then perform an Autopilot upgrade with any candidate build.
     The scenario also performs standard baseline verification that is not specific to the autopilot
     upgrade.
 
-    If you want to use the 'distro:leap' variant you must first accept SUSE's terms for the AWS
-    account. To verify that your account has agreed, sign-in to your AWS through Doormat,
-    and visit the following links to verify your subscription or subscribe:
-      arm64 AMI: https://aws.amazon.com/marketplace/server/procurement?productId=a516e959-df54-4035-bb1a-63599b7a6df9
-      amd64 AMI: https://aws.amazon.com/marketplace/server/procurement?productId=5535c495-72d4-4355-b169-54ffa874f849
+    # How to run this scenario
+
+    1. Install Enos (more info: https://eng-handbook.hashicorp.services/internal-tools/enos/getting-started/)
+    
+    $ brew tap hashicorp/tap && brew update && brew install hashicorp/tap/enos
+
+    2. Authenticate to AWS with Doormat (more info: https://eng-handbook.hashicorp.services/internal-tools/enos/getting-started/#authenticate-to-aws-with-doormat)
+    
+    $ doormat login && eval $(doormat aws -a <your_aws_account_name> export)
+
+    3. Set the following variables either as environment variables (`export ENOS_VAR_var_name=value`)
+    or in your 'enos-local.vars' file:
+
+    Required variables
+      - aws_ssh_private_key_path (more info about AWS SSH keypairs: https://eng-handbook.hashicorp.services/internal-tools/enos/getting-started/#set-your-aws-key-pair-name-and-private-key)
+      - aws_ssh_keypair_name
+      - vault_build_date
+      - vault_product_version
+      - vault_revision
+
+    Optional variables
+      - aws_region (if different from the default value in enos-variables.hcl)
+      - consul_license_path (if using an ENT edition of Consul)
+      - distro_version_<distro> (if different from the default version for your target
+      distro; see list of supported distros and versions in enos-globals.hcl)
+      - vault_license_path (if using an ENT edition of Vault)
+    
+    4. Choose one of the following ways to get a Vault artifact and set the appropriate variables.
+    This will be the Vault artifact that we upgrade to; 'matrix.initial_version' will be the Vault
+    version we start from.
+
+      a. 'artifact_source:crt'
+      This will use a Vault artifact that you have already downloaded. Set the following variable:
+
+      ENOS_VAR_vault_artifact_path=path/to/existing-vault-artifact.[zip | rpm | deb]
+
+      b. 'artifact_source:local'
+      This will build a Vault .zip bundle from your local branch. Set the following variable:
+
+      ENOS_VAR_vault_artifact_path=path/to/where/vault-should-be-built.zip
+
+      c. 'artifact_source:artifactory'
+      This will download a Vault artifact of the specified version, edition, and revision SHA
+      from the 'stable' repo in Artifactory. Set the following variables:
+
+      export ENOS_VAR_artifactory_username=your-user
+      export ENOS_VAR_artifactory_token=your-token
+    
+    5. Choose the matrix variants you want to use, and launch the scenario with the appropriate
+    filter for those variants, e.g.:
+
+    $ enos scenario launch autopilot arch:arm64 artifact_source:artifactory artifact_type:bundle config_mode:file distro:rhel edition:ent initial_version:1.12.11 seal:shamir
+
+    Notes:
+    - Enos will run all matrix variant combinations that match your filter. If you specify one
+      variant for each matrix item, the filter will produce and run only one scenario.
+
+    - If you want to use the 'distro:leap' variant you must first accept SUSE's terms for the AWS
+      account. To verify that your account has agreed, sign-in to your AWS through Doormat,
+      and visit the following links to verify your subscription or subscribe:
+        arm64 AMI: https://aws.amazon.com/marketplace/server/procurement?productId=a516e959-df54-4035-bb1a-63599b7a6df9
+        amd64 AMI: https://aws.amazon.com/marketplace/server/procurement?productId=5535c495-72d4-4355-b169-54ffa874f849
+
+    6. If necessary, get the public IPs of your cluster from the Enos scenario output and SSH in,
+    using 'ubuntu' for the SSH user with 'distro:ubuntu', or 'ec2-user' with all other supported Linux distros:
+
+    $ enos scenario output <filter>
+    $ ssh -i /path/to/your/ssh-private-key.pem <ssh-user>@<public-ip>
+
+    For Enos troubleshooting tips, see https://eng-handbook.hashicorp.services/internal-tools/enos/troubleshooting/.
   EOF
 
   matrix {

--- a/enos/enos-scenario-autopilot.hcl
+++ b/enos/enos-scenario-autopilot.hcl
@@ -72,7 +72,8 @@ scenario "autopilot" {
         artifactory_token = your-token
     
     5. If you don't know yet what combination of matrix variants you want to use for your scenario, you 
-    can view all the possible combinations through the `list` command:
+    can view all the possible combinations through the `list` command. You can also reduce the list by
+    adding one or more filter items, e.g. 'arch:amd64' to get just the scenario combinations that use amd64.
 
       $ enos scenario list autopilot
     

--- a/enos/enos-scenario-autopilot.hcl
+++ b/enos/enos-scenario-autopilot.hcl
@@ -11,10 +11,17 @@ scenario "autopilot" {
     The scenario also performs standard baseline verification that is not specific to the autopilot
     upgrade.
 
+    # How to view an outline of this scenario
+
     You can use the following command to get a textual outline of the entire
     scenario:
     
       $ enos scenario outline autopilot
+
+    You can also create an HTML version that is suitable for viewing in web browsers:
+
+      $ enos scenario outline autopilot --format html > index.html
+      $ open index.html
 
     # How to run this scenario
 
@@ -64,12 +71,21 @@ scenario "autopilot" {
         artifactory_username = your-user
         artifactory_token = your-token
     
-    5. Choose the matrix variants you want to use, and launch the scenario with the appropriate
-    filter for those variants, e.g.:
+    5. If you don't know yet what combination of matrix variants you want to use for your scenario, you 
+    can view all the possible combinations through the `list` command:
+
+      $ enos scenario list autopilot
+    
+    Once you know what filter you want to use to obtain your desired combination of matrix variants,
+    use the `launch` command with that filter to launch your scenario.
 
       $ enos scenario launch autopilot arch:arm64 artifact_source:artifactory artifact_type:bundle config_mode:file distro:rhel edition:ent initial_version:1.12.11 seal:shamir
 
     Notes:
+    - To learn more about any Enos command, use the `--help` flag, e.g.:
+    
+        $ enos scenario launch --help
+    
     - Enos will run all matrix variant combinations that match your filter. If you specify one
       variant for each matrix item, the filter will produce and run only one scenario.
 
@@ -86,6 +102,10 @@ scenario "autopilot" {
       $ ssh -i /path/to/your/ssh-private-key.pem <ssh-user>@<public-ip>
 
     For Enos troubleshooting tips, see https://eng-handbook.hashicorp.services/internal-tools/enos/troubleshooting/.
+
+    7. When you're done, destroy the scenario and associated infrastructure:
+
+      $ enos scenario destroy autopilot <filter>
   EOF
 
   matrix {

--- a/enos/enos-scenario-proxy.hcl
+++ b/enos/enos-scenario-proxy.hcl
@@ -68,7 +68,8 @@ scenario "proxy" {
       artifactory_token = your-token
   
   5. If you don't know yet what combination of matrix variants you want to use for your scenario, you 
-    can view all the possible combinations through the `list` command:
+    can view all the possible combinations through the `list` command. You can also reduce the list by
+    adding one or more filter items, e.g. 'arch:amd64' to get just the scenario combinations that use amd64.
 
       $ enos scenario list proxy
     

--- a/enos/enos-scenario-proxy.hcl
+++ b/enos/enos-scenario-proxy.hcl
@@ -9,10 +9,17 @@ scenario "proxy" {
   build in Proxy mode and verifies behavior against the Vault cluster. The scenario also performs
   standard baseline verification that is not specific to the Proxy mode deployment.
 
+  # How to view an outline of this scenario
+
   You can use the following command to get a textual outline of the entire
   scenario:
   
     $ enos scenario outline proxy
+
+  You can also create an HTML version that is suitable for viewing in web browsers:
+
+    $ enos scenario outline proxy --format html > index.html
+    $ open index.html
 
   # How to run this scenario
 
@@ -60,13 +67,22 @@ scenario "proxy" {
       artifactory_username = your-user
       artifactory_token = your-token
   
-  5. Choose the matrix variants you want to use, and launch the scenario with the appropriate
-  filter for those variants, e.g.:
+  5. If you don't know yet what combination of matrix variants you want to use for your scenario, you 
+    can view all the possible combinations through the `list` command:
+
+      $ enos scenario list proxy
+    
+    Once you know what filter you want to use to obtain your desired combination of matrix variants,
+    use the `launch` command with that filter to launch your scenario.
 
     $ enos scenario launch proxy arch:arm64 artifact_source:artifactory artifact_type:bundle backend:raft config_mode:file consul_edition:ce consul_version:1.17.0 distro:leap edition:ent seal:shamir
 
   Notes:
-  - Note: Enos will run all matrix variant combinations that match your filter. If you specify one
+  - To learn more about any Enos command, use the `--help` flag, e.g.:
+    
+        $ enos scenario launch --help
+
+  - Enos will run all matrix variant combinations that match your filter. If you specify one
     variant for each matrix item, the filter will produce and run only one scenario. Even if you are
     using a Raft backend, you may want to specify a consul_version (though it functionally will not
     do anything since you're not using Consul) so that Enos does not run multiple scenarios (one for
@@ -85,6 +101,10 @@ scenario "proxy" {
     $ ssh -i /path/to/your/ssh-private-key.pem <ssh-user>@<public-ip>
 
   For Enos troubleshooting tips, see https://eng-handbook.hashicorp.services/internal-tools/enos/troubleshooting/.
+
+  7. When you're done, destroy the scenario and associated infrastructure:
+
+      $ enos scenario destroy proxy <filter>
   
   EOF
 

--- a/enos/enos-scenario-proxy.hcl
+++ b/enos/enos-scenario-proxy.hcl
@@ -9,18 +9,23 @@ scenario "proxy" {
   build in Proxy mode and verifies behavior against the Vault cluster. The scenario also performs
   standard baseline verification that is not specific to the Proxy mode deployment.
 
+  You can use the following command to get a textual outline of the entire
+  scenario:
+  
+    $ enos scenario outline proxy
+
   # How to run this scenario
 
   1. Install Enos (more info: https://eng-handbook.hashicorp.services/internal-tools/enos/getting-started/)
   
-  $ brew tap hashicorp/tap && brew update && brew install hashicorp/tap/enos
+    $ brew tap hashicorp/tap && brew update && brew install hashicorp/tap/enos
 
   2. Authenticate to AWS with Doormat (more info: https://eng-handbook.hashicorp.services/internal-tools/enos/getting-started/#authenticate-to-aws-with-doormat)
   
-  $ doormat login && eval $(doormat aws -a <your_aws_account_name> export)
+    $ doormat login && eval $(doormat aws -a <your_aws_account_name> export)
 
   3. Set the following variables either as environment variables (`export ENOS_VAR_var_name=value`)
-  or in your 'enos-local.vars' file:
+  or by creating a 'enos-local.vars' file and setting it there (see enos.vars.hcl for examples):
 
   Required variables
     - aws_ssh_private_key_path (more info about AWS SSH keypairs: https://eng-handbook.hashicorp.services/internal-tools/enos/getting-started/#set-your-aws-key-pair-name-and-private-key)
@@ -37,30 +42,28 @@ scenario "proxy" {
     - vault_license_path (if using an ENT edition of Vault)
   
   4. Choose one of the following ways to get a Vault artifact and set the appropriate variables.
-  This will be the Vault artifact that we upgrade to; 'matrix.initial_version' will be the Vault
-  version we start from.
 
     a. 'artifact_source:crt'
     This will use a Vault artifact that you have already downloaded. Set the following variable:
 
-    ENOS_VAR_vault_artifact_path=path/to/existing-vault-artifact.[zip | rpm | deb]
+      vault_artifact_path = path/to/existing-vault-artifact.[zip | rpm | deb]
 
     b. 'artifact_source:local'
     This will build a Vault .zip bundle from your local branch. Set the following variable:
 
-    ENOS_VAR_vault_artifact_path=path/to/where/vault-should-be-built.zip
+      vault_artifact_path = path/to/where/vault-should-be-built.zip
 
     c. 'artifact_source:artifactory'
     This will download a Vault artifact of the specified version, edition, and revision SHA
     from the 'stable' repo in Artifactory. Set the following variables:
 
-    export ENOS_VAR_artifactory_username=your-user
-    export ENOS_VAR_artifactory_token=your-token
+      artifactory_username = your-user
+      artifactory_token = your-token
   
   5. Choose the matrix variants you want to use, and launch the scenario with the appropriate
   filter for those variants, e.g.:
 
-  $ enos scenario launch proxy arch:arm64 artifact_source:artifactory artifact_type:bundle backend:raft config_mode:file consul_edition:ce consul_version:1.17.0 distro:leap edition:ent seal:shamir
+    $ enos scenario launch proxy arch:arm64 artifact_source:artifactory artifact_type:bundle backend:raft config_mode:file consul_edition:ce consul_version:1.17.0 distro:leap edition:ent seal:shamir
 
   Notes:
   - Note: Enos will run all matrix variant combinations that match your filter. If you specify one
@@ -72,14 +75,14 @@ scenario "proxy" {
   - If you want to use the 'distro:leap' variant you must first accept SUSE's terms for the AWS
     account. To verify that your account has agreed, sign-in to your AWS through Doormat,
     and visit the following links to verify your subscription or subscribe:
-      arm64 AMI: https://aws.amazon.com/marketplace/server/procurement?productId=a516e959-df54-4035-bb1a-63599b7a6df9
-      amd64 AMI: https://aws.amazon.com/marketplace/server/procurement?productId=5535c495-72d4-4355-b169-54ffa874f849
+      - arm64 AMI: https://aws.amazon.com/marketplace/server/procurement?productId=a516e959-df54-4035-bb1a-63599b7a6df9
+      - amd64 AMI: https://aws.amazon.com/marketplace/server/procurement?productId=5535c495-72d4-4355-b169-54ffa874f849
 
   6. If necessary, get the public IPs of your cluster from the Enos scenario output and SSH in,
   using 'ubuntu' for the SSH user with 'distro:ubuntu', or 'ec2-user' with all other supported Linux distros:
 
-  $ enos scenario output <filter>
-  $ ssh -i /path/to/your/ssh-private-key.pem <ssh-user>@<public-ip>
+    $ enos scenario output <filter>
+    $ ssh -i /path/to/your/ssh-private-key.pem <ssh-user>@<public-ip>
 
   For Enos troubleshooting tips, see https://eng-handbook.hashicorp.services/internal-tools/enos/troubleshooting/.
   

--- a/enos/enos-scenario-proxy.hcl
+++ b/enos/enos-scenario-proxy.hcl
@@ -3,19 +3,86 @@
 
 scenario "proxy" {
   description = <<-EOF
-  The agent scenario verifies Vault when running in Proxy mode. The build can be a local branch,
-    any CRT built Vault artifact saved to the local machine, or any CRT built Vault artifact in the
-    stable channel in Artifactory.
+  The proxy scenario verifies Vault when running in Proxy mode.
 
-    The scenario creates a new Vault Cluster using the candidate build and then runs the same Vault
-    build in Proxy mode and verifies behavior against the Vault cluster. The scenario also performs
-    standard baseline verification that is not specific to the Proxy mode deployment.
+  The scenario creates a new Vault Cluster using the candidate build and then runs the same Vault
+  build in Proxy mode and verifies behavior against the Vault cluster. The scenario also performs
+  standard baseline verification that is not specific to the Proxy mode deployment.
 
-    If you want to use the 'distro:leap' variant you must first accept SUSE's terms for the AWS
+  # How to run this scenario
+
+  1. Install Enos (more info: https://eng-handbook.hashicorp.services/internal-tools/enos/getting-started/)
+  
+  $ brew tap hashicorp/tap && brew update && brew install hashicorp/tap/enos
+
+  2. Authenticate to AWS with Doormat (more info: https://eng-handbook.hashicorp.services/internal-tools/enos/getting-started/#authenticate-to-aws-with-doormat)
+  
+  $ doormat login && eval $(doormat aws -a <your_aws_account_name> export)
+
+  3. Set the following variables either as environment variables (`export ENOS_VAR_var_name=value`)
+  or in your 'enos-local.vars' file:
+
+  Required variables
+    - aws_ssh_private_key_path (more info about AWS SSH keypairs: https://eng-handbook.hashicorp.services/internal-tools/enos/getting-started/#set-your-aws-key-pair-name-and-private-key)
+    - aws_ssh_keypair_name
+    - vault_build_date
+    - vault_product_version
+    - vault_revision
+
+  Optional variables
+    - aws_region (if different from the default value in enos-variables.hcl)
+    - consul_license_path (if using an ENT edition of Consul)
+    - distro_version_<distro> (if different from the default version for your target
+    distro; see list of supported distros and versions in enos-globals.hcl)
+    - vault_license_path (if using an ENT edition of Vault)
+  
+  4. Choose one of the following ways to get a Vault artifact and set the appropriate variables.
+  This will be the Vault artifact that we upgrade to; 'matrix.initial_version' will be the Vault
+  version we start from.
+
+    a. 'artifact_source:crt'
+    This will use a Vault artifact that you have already downloaded. Set the following variable:
+
+    ENOS_VAR_vault_artifact_path=path/to/existing-vault-artifact.[zip | rpm | deb]
+
+    b. 'artifact_source:local'
+    This will build a Vault .zip bundle from your local branch. Set the following variable:
+
+    ENOS_VAR_vault_artifact_path=path/to/where/vault-should-be-built.zip
+
+    c. 'artifact_source:artifactory'
+    This will download a Vault artifact of the specified version, edition, and revision SHA
+    from the 'stable' repo in Artifactory. Set the following variables:
+
+    export ENOS_VAR_artifactory_username=your-user
+    export ENOS_VAR_artifactory_token=your-token
+  
+  5. Choose the matrix variants you want to use, and launch the scenario with the appropriate
+  filter for those variants, e.g.:
+
+  $ enos scenario launch proxy arch:arm64 artifact_source:artifactory artifact_type:bundle backend:raft config_mode:file consul_edition:ce consul_version:1.17.0 distro:leap edition:ent seal:shamir
+
+  Notes:
+  - Note: Enos will run all matrix variant combinations that match your filter. If you specify one
+    variant for each matrix item, the filter will produce and run only one scenario. Even if you are
+    using a Raft backend, you may want to specify a consul_version (though it functionally will not
+    do anything since you're not using Consul) so that Enos does not run multiple scenarios (one for
+    each Consul version in the matrix).
+
+  - If you want to use the 'distro:leap' variant you must first accept SUSE's terms for the AWS
     account. To verify that your account has agreed, sign-in to your AWS through Doormat,
     and visit the following links to verify your subscription or subscribe:
       arm64 AMI: https://aws.amazon.com/marketplace/server/procurement?productId=a516e959-df54-4035-bb1a-63599b7a6df9
       amd64 AMI: https://aws.amazon.com/marketplace/server/procurement?productId=5535c495-72d4-4355-b169-54ffa874f849
+
+  6. If necessary, get the public IPs of your cluster from the Enos scenario output and SSH in,
+  using 'ubuntu' for the SSH user with 'distro:ubuntu', or 'ec2-user' with all other supported Linux distros:
+
+  $ enos scenario output <filter>
+  $ ssh -i /path/to/your/ssh-private-key.pem <ssh-user>@<public-ip>
+
+  For Enos troubleshooting tips, see https://eng-handbook.hashicorp.services/internal-tools/enos/troubleshooting/.
+  
   EOF
 
   matrix {

--- a/enos/enos-scenario-replication.hcl
+++ b/enos/enos-scenario-replication.hcl
@@ -73,7 +73,8 @@ scenario "replication" {
         artifactory_token = your-token
     
     5. If you don't know yet what combination of matrix variants you want to use for your scenario, you 
-    can view all the possible combinations through the `list` command:
+    can view all the possible combinations through the `list` command. You can also reduce the list by
+    adding one or more filter items, e.g. 'arch:amd64' to get just the scenario combinations that use amd64.
 
       $ enos scenario list replication
     

--- a/enos/enos-scenario-replication.hcl
+++ b/enos/enos-scenario-replication.hcl
@@ -14,18 +14,23 @@ scenario "replication" {
     primary leader. The scenario also performs standard baseline verification that is not specific
     to performance replication.
 
+    You can use the following command to get a textual outline of the entire
+    scenario:
+  
+    $ enos scenario outline replication
+
     # How to run this scenario
 
     1. Install Enos (more info: https://eng-handbook.hashicorp.services/internal-tools/enos/getting-started/)
     
-    $ brew tap hashicorp/tap && brew update && brew install hashicorp/tap/enos
+      $ brew tap hashicorp/tap && brew update && brew install hashicorp/tap/enos
 
     2. Authenticate to AWS with Doormat (more info: https://eng-handbook.hashicorp.services/internal-tools/enos/getting-started/#authenticate-to-aws-with-doormat)
     
-    $ doormat login && eval $(doormat aws -a <your_aws_account_name> export)
+      $ doormat login && eval $(doormat aws -a <your_aws_account_name> export)
 
     3. Set the following variables either as environment variables (`export ENOS_VAR_var_name=value`)
-    or in your 'enos-local.vars' file:
+    or by creating a 'enos-local.vars' file and setting it there (see enos.vars.hcl for examples):
 
     Required variables
       - aws_ssh_private_key_path (more info about AWS SSH keypairs: https://eng-handbook.hashicorp.services/internal-tools/enos/getting-started/#set-your-aws-key-pair-name-and-private-key)
@@ -42,30 +47,28 @@ scenario "replication" {
       - vault_license_path (if using an ENT edition of Vault)
     
     4. Choose one of the following ways to get a Vault artifact and set the appropriate variables.
-    This will be the Vault artifact that we upgrade to; 'matrix.initial_version' will be the Vault
-    version we start from.
 
       a. 'artifact_source:crt'
       This will use a Vault artifact that you have already downloaded. Set the following variable:
 
-      ENOS_VAR_vault_artifact_path=path/to/existing-vault-artifact.[zip | rpm | deb]
+        vault_artifact_path = path/to/existing-vault-artifact.[zip | rpm | deb]
 
       b. 'artifact_source:local'
       This will build a Vault .zip bundle from your local branch. Set the following variable:
 
-      ENOS_VAR_vault_artifact_path=path/to/where/vault-should-be-built.zip
+        vault_artifact_path = path/to/where/vault-should-be-built.zip
 
       c. 'artifact_source:artifactory'
       This will download a Vault artifact of the specified version, edition, and revision SHA
       from the 'stable' repo in Artifactory. Set the following variables:
 
-      export ENOS_VAR_artifactory_username=your-user
-      export ENOS_VAR_artifactory_token=your-token
+        artifactory_username = your-user
+        artifactory_token = your-token
     
     5. Choose the matrix variants you want to use, and launch the scenario with the appropriate
     filter for those variants, e.g.:
 
-    $ enos scenario launch replication arch:amd64 artifact_source:artifactory artifact_type:bundle config_mode:env consul_edition:ce consul_version:1.16.3 distro:sles edition:ent primary_backend:raft primary_seal:shamir secondary_backend:raft secondary_seal:shamir
+      $ enos scenario launch replication arch:amd64 artifact_source:artifactory artifact_type:bundle config_mode:env consul_edition:ce consul_version:1.16.3 distro:sles edition:ent primary_backend:raft primary_seal:shamir secondary_backend:raft secondary_seal:shamir
 
     Notes:
     - Note: Enos will run all matrix variant combinations that match your filter. If you specify one
@@ -77,14 +80,14 @@ scenario "replication" {
     - If you want to use the 'distro:leap' variant you must first accept SUSE's terms for the AWS
       account. To verify that your account has agreed, sign-in to your AWS through Doormat,
       and visit the following links to verify your subscription or subscribe:
-        arm64 AMI: https://aws.amazon.com/marketplace/server/procurement?productId=a516e959-df54-4035-bb1a-63599b7a6df9
-        amd64 AMI: https://aws.amazon.com/marketplace/server/procurement?productId=5535c495-72d4-4355-b169-54ffa874f849
+        - arm64 AMI: https://aws.amazon.com/marketplace/server/procurement?productId=a516e959-df54-4035-bb1a-63599b7a6df9
+        - amd64 AMI: https://aws.amazon.com/marketplace/server/procurement?productId=5535c495-72d4-4355-b169-54ffa874f849
 
     6. If necessary, get the public IPs of your cluster from the Enos scenario output and SSH in,
     using 'ubuntu' for the SSH user with 'distro:ubuntu', or 'ec2-user' with all other supported Linux distros:
 
-    $ enos scenario output <filter>
-    $ ssh -i /path/to/your/ssh-private-key.pem <ssh-user>@<public-ip>
+      $ enos scenario output <filter>
+      $ ssh -i /path/to/your/ssh-private-key.pem <ssh-user>@<public-ip>
 
     For Enos troubleshooting tips, see https://eng-handbook.hashicorp.services/internal-tools/enos/troubleshooting/.
   EOF

--- a/enos/enos-scenario-replication.hcl
+++ b/enos/enos-scenario-replication.hcl
@@ -4,23 +4,89 @@
 scenario "replication" {
   description = <<-EOF
     The replication scenario configures performance replication between two Vault clusters and
-    verifies behavior and failure tolerance. The build can be a local branch, any CRT built Vault
-    Enterprise artifact saved to the local machine, or any CRT built Vault Enterprise artifact in
-    the stable channel in Artifactory.
+    verifies behavior and failure tolerance.
 
     The scenario deploys two Vault Enterprise clusters and establishes performance replication
-    between the primary cluster and the performance replication secondary cluster. Next, we simulate
-    a catastrophic failure event whereby the primary leader and a primary follower as ungracefully
+    between the primary cluster and the performance replication secondary cluster. Next, it simulates
+    a catastrophic failure event whereby the primary leader and a primary follower are ungracefully
     removed from the cluster while running. This forces a leader election in the primary cluster
     and requires the secondary cluster to recover replication and establish replication to the new
     primary leader. The scenario also performs standard baseline verification that is not specific
     to performance replication.
 
-    If you want to use the 'distro:leap' variant you must first accept SUSE's terms for the AWS
-    account. To verify that your account has agreed, sign-in to your AWS through Doormat,
-    and visit the following links to verify your subscription or subscribe:
-      arm64 AMI: https://aws.amazon.com/marketplace/server/procurement?productId=a516e959-df54-4035-bb1a-63599b7a6df9
-      amd64 AMI: https://aws.amazon.com/marketplace/server/procurement?productId=5535c495-72d4-4355-b169-54ffa874f849
+    # How to run this scenario
+
+    1. Install Enos (more info: https://eng-handbook.hashicorp.services/internal-tools/enos/getting-started/)
+    
+    $ brew tap hashicorp/tap && brew update && brew install hashicorp/tap/enos
+
+    2. Authenticate to AWS with Doormat (more info: https://eng-handbook.hashicorp.services/internal-tools/enos/getting-started/#authenticate-to-aws-with-doormat)
+    
+    $ doormat login && eval $(doormat aws -a <your_aws_account_name> export)
+
+    3. Set the following variables either as environment variables (`export ENOS_VAR_var_name=value`)
+    or in your 'enos-local.vars' file:
+
+    Required variables
+      - aws_ssh_private_key_path (more info about AWS SSH keypairs: https://eng-handbook.hashicorp.services/internal-tools/enos/getting-started/#set-your-aws-key-pair-name-and-private-key)
+      - aws_ssh_keypair_name
+      - vault_build_date
+      - vault_product_version
+      - vault_revision
+
+    Optional variables
+      - aws_region (if different from the default value in enos-variables.hcl)
+      - consul_license_path (if using an ENT edition of Consul)
+      - distro_version_<distro> (if different from the default version for your target
+      distro; see list of supported distros and versions in enos-globals.hcl)
+      - vault_license_path (if using an ENT edition of Vault)
+    
+    4. Choose one of the following ways to get a Vault artifact and set the appropriate variables.
+    This will be the Vault artifact that we upgrade to; 'matrix.initial_version' will be the Vault
+    version we start from.
+
+      a. 'artifact_source:crt'
+      This will use a Vault artifact that you have already downloaded. Set the following variable:
+
+      ENOS_VAR_vault_artifact_path=path/to/existing-vault-artifact.[zip | rpm | deb]
+
+      b. 'artifact_source:local'
+      This will build a Vault .zip bundle from your local branch. Set the following variable:
+
+      ENOS_VAR_vault_artifact_path=path/to/where/vault-should-be-built.zip
+
+      c. 'artifact_source:artifactory'
+      This will download a Vault artifact of the specified version, edition, and revision SHA
+      from the 'stable' repo in Artifactory. Set the following variables:
+
+      export ENOS_VAR_artifactory_username=your-user
+      export ENOS_VAR_artifactory_token=your-token
+    
+    5. Choose the matrix variants you want to use, and launch the scenario with the appropriate
+    filter for those variants, e.g.:
+
+    $ enos scenario launch replication arch:amd64 artifact_source:artifactory artifact_type:bundle config_mode:env consul_edition:ce consul_version:1.16.3 distro:sles edition:ent primary_backend:raft primary_seal:shamir secondary_backend:raft secondary_seal:shamir
+
+    Notes:
+    - Note: Enos will run all matrix variant combinations that match your filter. If you specify one
+      variant for each matrix item, the filter will produce and run only one scenario. Even if you are
+      using a Raft backend, you may want to specify a consul_version (though it functionally will not
+      do anything since you're not using Consul) so that Enos does not run multiple scenarios (one for
+      each Consul version in the matrix).
+
+    - If you want to use the 'distro:leap' variant you must first accept SUSE's terms for the AWS
+      account. To verify that your account has agreed, sign-in to your AWS through Doormat,
+      and visit the following links to verify your subscription or subscribe:
+        arm64 AMI: https://aws.amazon.com/marketplace/server/procurement?productId=a516e959-df54-4035-bb1a-63599b7a6df9
+        amd64 AMI: https://aws.amazon.com/marketplace/server/procurement?productId=5535c495-72d4-4355-b169-54ffa874f849
+
+    6. If necessary, get the public IPs of your cluster from the Enos scenario output and SSH in,
+    using 'ubuntu' for the SSH user with 'distro:ubuntu', or 'ec2-user' with all other supported Linux distros:
+
+    $ enos scenario output <filter>
+    $ ssh -i /path/to/your/ssh-private-key.pem <ssh-user>@<public-ip>
+
+    For Enos troubleshooting tips, see https://eng-handbook.hashicorp.services/internal-tools/enos/troubleshooting/.
   EOF
 
   matrix {

--- a/enos/enos-scenario-replication.hcl
+++ b/enos/enos-scenario-replication.hcl
@@ -14,10 +14,17 @@ scenario "replication" {
     primary leader. The scenario also performs standard baseline verification that is not specific
     to performance replication.
 
+    # How to view an outline of this scenario
+
     You can use the following command to get a textual outline of the entire
     scenario:
-  
-    $ enos scenario outline replication
+    
+      $ enos scenario outline replication
+
+    You can also create an HTML version that is suitable for viewing in web browsers:
+
+      $ enos scenario outline replication --format html > index.html
+      $ open index.html
 
     # How to run this scenario
 
@@ -65,13 +72,22 @@ scenario "replication" {
         artifactory_username = your-user
         artifactory_token = your-token
     
-    5. Choose the matrix variants you want to use, and launch the scenario with the appropriate
-    filter for those variants, e.g.:
+    5. If you don't know yet what combination of matrix variants you want to use for your scenario, you 
+    can view all the possible combinations through the `list` command:
+
+      $ enos scenario list replication
+    
+    Once you know what filter you want to use to obtain your desired combination of matrix variants,
+    use the `launch` command with that filter to launch your scenario.
 
       $ enos scenario launch replication arch:amd64 artifact_source:artifactory artifact_type:bundle config_mode:env consul_edition:ce consul_version:1.16.3 distro:sles edition:ent primary_backend:raft primary_seal:shamir secondary_backend:raft secondary_seal:shamir
 
     Notes:
-    - Note: Enos will run all matrix variant combinations that match your filter. If you specify one
+    - To learn more about any Enos command, use the `--help` flag, e.g.:
+    
+        $ enos scenario launch --help
+
+    - Enos will run all matrix variant combinations that match your filter. If you specify one
       variant for each matrix item, the filter will produce and run only one scenario. Even if you are
       using a Raft backend, you may want to specify a consul_version (though it functionally will not
       do anything since you're not using Consul) so that Enos does not run multiple scenarios (one for
@@ -90,6 +106,10 @@ scenario "replication" {
       $ ssh -i /path/to/your/ssh-private-key.pem <ssh-user>@<public-ip>
 
     For Enos troubleshooting tips, see https://eng-handbook.hashicorp.services/internal-tools/enos/troubleshooting/.
+
+    7. When you're done, destroy the scenario and associated infrastructure:
+
+      $ enos scenario destroy replication <filter>
   EOF
 
   matrix {

--- a/enos/enos-scenario-seal-ha.hcl
+++ b/enos/enos-scenario-seal-ha.hcl
@@ -14,10 +14,17 @@ scenario "seal_ha" {
     seal rewrap. The scenario also performs standard baseline verification that is not specific to
     seal_ha.
 
+    # How to view an outline of this scenario
+
     You can use the following command to get a textual outline of the entire
     scenario:
-  
+    
       $ enos scenario outline seal_ha
+
+    You can also create an HTML version that is suitable for viewing in web browsers:
+
+      $ enos scenario outline seal_ha --format html > index.html
+      $ open index.html
 
     # How to run this scenario
 
@@ -65,13 +72,22 @@ scenario "seal_ha" {
         artifactory_username = your-user
         artifactory_token = your-token
     
-    5. Choose the matrix variants you want to use, and launch the scenario with the appropriate
-    filter for those variants, e.g.:
+    5. If you don't know yet what combination of matrix variants you want to use for your scenario, you 
+    can view all the possible combinations through the `list` command:
+
+      $ enos scenario list seal_ha
+    
+    Once you know what filter you want to use to obtain your desired combination of matrix variants,
+    use the `launch` command with that filter to launch your scenario.
 
       $ enos scenario launch seal_ha arch:amd64 artifact_source:artifactory artifact_type:package distro:rhel edition:ent.hsm.fips1402 backend:raft config_mode:file consul_edition:ce consul_version:1.17.0 primary_seal:pkcs11 secondary_seal:pkcs11
 
     Notes:
-    - Note: Enos will run all matrix variant combinations that match your filter. If you specify one
+    - To learn more about any Enos command, use the `--help` flag, e.g.:
+    
+        $ enos scenario launch --help
+
+    - Enos will run all matrix variant combinations that match your filter. If you specify one
       variant for each matrix item, the filter will produce and run only one scenario. Even if you are
       using a Raft backend, you may want to specify a consul_version (though it functionally will not
       do anything since you're not using Consul) so that Enos does not run multiple scenarios (one for
@@ -90,6 +106,10 @@ scenario "seal_ha" {
       $ ssh -i /path/to/your/ssh-private-key.pem <ssh-user>@<public-ip>
 
     For Enos troubleshooting tips, see https://eng-handbook.hashicorp.services/internal-tools/enos/troubleshooting/.
+
+    7. When you're done, destroy the scenario and associated infrastructure:
+
+      $ enos scenario destroy seal_ha <filter>
   EOF
 
   matrix {

--- a/enos/enos-scenario-seal-ha.hcl
+++ b/enos/enos-scenario-seal-ha.hcl
@@ -14,18 +14,23 @@ scenario "seal_ha" {
     seal rewrap. The scenario also performs standard baseline verification that is not specific to
     seal_ha.
 
+    You can use the following command to get a textual outline of the entire
+    scenario:
+  
+      $ enos scenario outline seal_ha
+
     # How to run this scenario
 
     1. Install Enos (more info: https://eng-handbook.hashicorp.services/internal-tools/enos/getting-started/)
     
-    $ brew tap hashicorp/tap && brew update && brew install hashicorp/tap/enos
+      $ brew tap hashicorp/tap && brew update && brew install hashicorp/tap/enos
 
     2. Authenticate to AWS with Doormat (more info: https://eng-handbook.hashicorp.services/internal-tools/enos/getting-started/#authenticate-to-aws-with-doormat)
     
-    $ doormat login && eval $(doormat aws -a <your_aws_account_name> export)
+      $ doormat login && eval $(doormat aws -a <your_aws_account_name> export)
 
     3. Set the following variables either as environment variables (`export ENOS_VAR_var_name=value`)
-    or in your 'enos-local.vars' file:
+    or by creating a 'enos-local.vars' file and setting it there (see enos.vars.hcl for examples):
 
     Required variables
       - aws_ssh_private_key_path (more info about AWS SSH keypairs: https://eng-handbook.hashicorp.services/internal-tools/enos/getting-started/#set-your-aws-key-pair-name-and-private-key)
@@ -42,30 +47,28 @@ scenario "seal_ha" {
       - vault_license_path (if using an ENT edition of Vault)
     
     4. Choose one of the following ways to get a Vault artifact and set the appropriate variables.
-    This will be the Vault artifact that we upgrade to; 'matrix.initial_version' will be the Vault
-    version we start from.
 
       a. 'artifact_source:crt'
       This will use a Vault artifact that you have already downloaded. Set the following variable:
 
-      ENOS_VAR_vault_artifact_path=path/to/existing-vault-artifact.[zip | rpm | deb]
+        vault_artifact_path = path/to/existing-vault-artifact.[zip | rpm | deb]
 
       b. 'artifact_source:local'
       This will build a Vault .zip bundle from your local branch. Set the following variable:
 
-      ENOS_VAR_vault_artifact_path=path/to/where/vault-should-be-built.zip
+        vault_artifact_path = path/to/where/vault-should-be-built.zip
 
       c. 'artifact_source:artifactory'
       This will download a Vault artifact of the specified version, edition, and revision SHA
       from the 'stable' repo in Artifactory. Set the following variables:
 
-      export ENOS_VAR_artifactory_username=your-user
-      export ENOS_VAR_artifactory_token=your-token
+        artifactory_username = your-user
+        artifactory_token = your-token
     
     5. Choose the matrix variants you want to use, and launch the scenario with the appropriate
     filter for those variants, e.g.:
 
-    $ enos scenario launch seal_ha arch:amd64 artifact_source:artifactory artifact_type:package distro:rhel edition:ent.hsm.fips1402 backend:raft config_mode:file consul_edition:ce consul_version:1.17.0 primary_seal:pkcs11 secondary_seal:pkcs11
+      $ enos scenario launch seal_ha arch:amd64 artifact_source:artifactory artifact_type:package distro:rhel edition:ent.hsm.fips1402 backend:raft config_mode:file consul_edition:ce consul_version:1.17.0 primary_seal:pkcs11 secondary_seal:pkcs11
 
     Notes:
     - Note: Enos will run all matrix variant combinations that match your filter. If you specify one
@@ -77,14 +80,14 @@ scenario "seal_ha" {
     - If you want to use the 'distro:leap' variant you must first accept SUSE's terms for the AWS
       account. To verify that your account has agreed, sign-in to your AWS through Doormat,
       and visit the following links to verify your subscription or subscribe:
-        arm64 AMI: https://aws.amazon.com/marketplace/server/procurement?productId=a516e959-df54-4035-bb1a-63599b7a6df9
-        amd64 AMI: https://aws.amazon.com/marketplace/server/procurement?productId=5535c495-72d4-4355-b169-54ffa874f849
+        - arm64 AMI: https://aws.amazon.com/marketplace/server/procurement?productId=a516e959-df54-4035-bb1a-63599b7a6df9
+        - amd64 AMI: https://aws.amazon.com/marketplace/server/procurement?productId=5535c495-72d4-4355-b169-54ffa874f849
 
     6. If necessary, get the public IPs of your cluster from the Enos scenario output and SSH in,
     using 'ubuntu' for the SSH user with 'distro:ubuntu', or 'ec2-user' with all other supported Linux distros:
 
-    $ enos scenario output <filter>
-    $ ssh -i /path/to/your/ssh-private-key.pem <ssh-user>@<public-ip>
+      $ enos scenario output <filter>
+      $ ssh -i /path/to/your/ssh-private-key.pem <ssh-user>@<public-ip>
 
     For Enos troubleshooting tips, see https://eng-handbook.hashicorp.services/internal-tools/enos/troubleshooting/.
   EOF

--- a/enos/enos-scenario-seal-ha.hcl
+++ b/enos/enos-scenario-seal-ha.hcl
@@ -73,7 +73,8 @@ scenario "seal_ha" {
         artifactory_token = your-token
     
     5. If you don't know yet what combination of matrix variants you want to use for your scenario, you 
-    can view all the possible combinations through the `list` command:
+    can view all the possible combinations through the `list` command. You can also reduce the list by
+    adding one or more filter items, e.g. 'arch:amd64' to get just the scenario combinations that use amd64.
 
       $ enos scenario list seal_ha
     

--- a/enos/enos-scenario-seal-ha.hcl
+++ b/enos/enos-scenario-seal-ha.hcl
@@ -9,16 +9,84 @@ scenario "seal_ha" {
 
     The scenario deploys a Vault Enterprise cluster with the candidate build and enables a single
     primary seal, mounts various engines and writes data, then establishes seal HA with a secondary
-    seal, the removes the primary and verifies data integrity and seal data migration. It also
+    seal, then removes the primary and verifies data integrity and seal data migration. It also
     verifies that the cluster is able to recover from a forced leader election after the initial
     seal rewrap. The scenario also performs standard baseline verification that is not specific to
     seal_ha.
 
-    If you want to use the 'distro:leap' variant you must first accept SUSE's terms for the AWS
-    account. To verify that your account has agreed, sign-in to your AWS through Doormat,
-    and visit the following links to verify your subscription or subscribe:
-      arm64 AMI: https://aws.amazon.com/marketplace/server/procurement?productId=a516e959-df54-4035-bb1a-63599b7a6df9
-      amd64 AMI: https://aws.amazon.com/marketplace/server/procurement?productId=5535c495-72d4-4355-b169-54ffa874f849
+    # How to run this scenario
+
+    1. Install Enos (more info: https://eng-handbook.hashicorp.services/internal-tools/enos/getting-started/)
+    
+    $ brew tap hashicorp/tap && brew update && brew install hashicorp/tap/enos
+
+    2. Authenticate to AWS with Doormat (more info: https://eng-handbook.hashicorp.services/internal-tools/enos/getting-started/#authenticate-to-aws-with-doormat)
+    
+    $ doormat login && eval $(doormat aws -a <your_aws_account_name> export)
+
+    3. Set the following variables either as environment variables (`export ENOS_VAR_var_name=value`)
+    or in your 'enos-local.vars' file:
+
+    Required variables
+      - aws_ssh_private_key_path (more info about AWS SSH keypairs: https://eng-handbook.hashicorp.services/internal-tools/enos/getting-started/#set-your-aws-key-pair-name-and-private-key)
+      - aws_ssh_keypair_name
+      - vault_build_date
+      - vault_product_version
+      - vault_revision
+
+    Optional variables
+      - aws_region (if different from the default value in enos-variables.hcl)
+      - consul_license_path (if using an ENT edition of Consul)
+      - distro_version_<distro> (if different from the default version for your target
+      distro; see list of supported distros and versions in enos-globals.hcl)
+      - vault_license_path (if using an ENT edition of Vault)
+    
+    4. Choose one of the following ways to get a Vault artifact and set the appropriate variables.
+    This will be the Vault artifact that we upgrade to; 'matrix.initial_version' will be the Vault
+    version we start from.
+
+      a. 'artifact_source:crt'
+      This will use a Vault artifact that you have already downloaded. Set the following variable:
+
+      ENOS_VAR_vault_artifact_path=path/to/existing-vault-artifact.[zip | rpm | deb]
+
+      b. 'artifact_source:local'
+      This will build a Vault .zip bundle from your local branch. Set the following variable:
+
+      ENOS_VAR_vault_artifact_path=path/to/where/vault-should-be-built.zip
+
+      c. 'artifact_source:artifactory'
+      This will download a Vault artifact of the specified version, edition, and revision SHA
+      from the 'stable' repo in Artifactory. Set the following variables:
+
+      export ENOS_VAR_artifactory_username=your-user
+      export ENOS_VAR_artifactory_token=your-token
+    
+    5. Choose the matrix variants you want to use, and launch the scenario with the appropriate
+    filter for those variants, e.g.:
+
+    $ enos scenario launch seal_ha arch:amd64 artifact_source:artifactory artifact_type:package distro:rhel edition:ent.hsm.fips1402 backend:raft config_mode:file consul_edition:ce consul_version:1.17.0 primary_seal:pkcs11 secondary_seal:pkcs11
+
+    Notes:
+    - Note: Enos will run all matrix variant combinations that match your filter. If you specify one
+      variant for each matrix item, the filter will produce and run only one scenario. Even if you are
+      using a Raft backend, you may want to specify a consul_version (though it functionally will not
+      do anything since you're not using Consul) so that Enos does not run multiple scenarios (one for
+      each Consul version in the matrix).
+
+    - If you want to use the 'distro:leap' variant you must first accept SUSE's terms for the AWS
+      account. To verify that your account has agreed, sign-in to your AWS through Doormat,
+      and visit the following links to verify your subscription or subscribe:
+        arm64 AMI: https://aws.amazon.com/marketplace/server/procurement?productId=a516e959-df54-4035-bb1a-63599b7a6df9
+        amd64 AMI: https://aws.amazon.com/marketplace/server/procurement?productId=5535c495-72d4-4355-b169-54ffa874f849
+
+    6. If necessary, get the public IPs of your cluster from the Enos scenario output and SSH in,
+    using 'ubuntu' for the SSH user with 'distro:ubuntu', or 'ec2-user' with all other supported Linux distros:
+
+    $ enos scenario output <filter>
+    $ ssh -i /path/to/your/ssh-private-key.pem <ssh-user>@<public-ip>
+
+    For Enos troubleshooting tips, see https://eng-handbook.hashicorp.services/internal-tools/enos/troubleshooting/.
   EOF
 
   matrix {

--- a/enos/enos-scenario-smoke.hcl
+++ b/enos/enos-scenario-smoke.hcl
@@ -8,18 +8,23 @@ scenario "smoke" {
     The scenario deploys a Vault cluster with the candidate build and performs an extended
     set of baseline verification.
 
+    You can use the following command to get a textual outline of the entire
+    scenario:
+  
+      $ enos scenario outline smoke
+
     # How to run this scenario
 
     1. Install Enos (more info: https://eng-handbook.hashicorp.services/internal-tools/enos/getting-started/)
     
-    $ brew tap hashicorp/tap && brew update && brew install hashicorp/tap/enos
+      $ brew tap hashicorp/tap && brew update && brew install hashicorp/tap/enos
 
     2. Authenticate to AWS with Doormat (more info: https://eng-handbook.hashicorp.services/internal-tools/enos/getting-started/#authenticate-to-aws-with-doormat)
     
-    $ doormat login && eval $(doormat aws -a <your_aws_account_name> export)
+      $ doormat login && eval $(doormat aws -a <your_aws_account_name> export)
 
     3. Set the following variables either as environment variables (`export ENOS_VAR_var_name=value`)
-    or in your 'enos-local.vars' file:
+    or by creating a 'enos-local.vars' file and setting it there (see enos.vars.hcl for examples):
 
     Required variables
       - aws_ssh_private_key_path (more info about AWS SSH keypairs: https://eng-handbook.hashicorp.services/internal-tools/enos/getting-started/#set-your-aws-key-pair-name-and-private-key)
@@ -36,30 +41,28 @@ scenario "smoke" {
       - vault_license_path (if using an ENT edition of Vault)
     
     4. Choose one of the following ways to get a Vault artifact and set the appropriate variables.
-    This will be the Vault artifact that we upgrade to; 'matrix.initial_version' will be the Vault
-    version we start from.
 
       a. 'artifact_source:crt'
       This will use a Vault artifact that you have already downloaded. Set the following variable:
 
-      ENOS_VAR_vault_artifact_path=path/to/existing-vault-artifact.[zip | rpm | deb]
+        vault_artifact_path = path/to/existing-vault-artifact.[zip | rpm | deb]
 
       b. 'artifact_source:local'
       This will build a Vault .zip bundle from your local branch. Set the following variable:
 
-      ENOS_VAR_vault_artifact_path=path/to/where/vault-should-be-built.zip
+        vault_artifact_path = path/to/where/vault-should-be-built.zip
 
       c. 'artifact_source:artifactory'
       This will download a Vault artifact of the specified version, edition, and revision SHA
       from the 'stable' repo in Artifactory. Set the following variables:
 
-      export ENOS_VAR_artifactory_username=your-user
-      export ENOS_VAR_artifactory_token=your-token
+        artifactory_username = your-user
+        artifactory_token = your-token
     
     5. Choose the matrix variants you want to use, and launch the scenario with the appropriate
     filter for those variants, e.g.:
 
-    $  enos scenario launch smoke arch:amd64 artifact_source:artifactory artifact_type:package distro:rhel edition:ent backend:raft config_mode:file consul_edition:ce consul_version:1.17.0 seal:awskms
+      $ enos scenario launch smoke arch:amd64 artifact_source:artifactory artifact_type:package distro:rhel edition:ent backend:raft config_mode:file consul_edition:ce consul_version:1.17.0 seal:awskms
 
     Notes:
     - Note: Enos will run all matrix variant combinations that match your filter. If you specify one

--- a/enos/enos-scenario-smoke.hcl
+++ b/enos/enos-scenario-smoke.hcl
@@ -65,7 +65,8 @@ scenario "smoke" {
         artifactory_token = your-token
     
     5. If you don't know yet what combination of matrix variants you want to use for your scenario, you 
-    can view all the possible combinations through the `list` command:
+    can view all the possible combinations through the `list` command. You can also reduce the list by
+    adding one or more filter items, e.g. 'arch:amd64' to get just the scenario combinations that use amd64.
 
       $ enos scenario list smoke
     

--- a/enos/enos-scenario-smoke.hcl
+++ b/enos/enos-scenario-smoke.hcl
@@ -3,18 +3,84 @@
 
 scenario "smoke" {
   description = <<-EOF
-    The smoke scenario verifies a Vault cluster in a fresh installation. The build can be a local
-    branch, any CRT built Vault artifact saved to the local machine, or any CRT built Vault artifact
-    in the stable channel in Artifactory.
+    The smoke scenario verifies a Vault cluster in a fresh installation.
 
-    The scenario deploys a Vault cluster with the candidate build performs an extended set of
-    baseline verification.
+    The scenario deploys a Vault cluster with the candidate build and performs an extended
+    set of baseline verification.
 
-    If you want to use the 'distro:leap' variant you must first accept SUSE's terms for the AWS
-    account. To verify that your account has agreed, sign-in to your AWS through Doormat,
-    and visit the following links to verify your subscription or subscribe:
-      arm64 AMI: https://aws.amazon.com/marketplace/server/procurement?productId=a516e959-df54-4035-bb1a-63599b7a6df9
-      amd64 AMI: https://aws.amazon.com/marketplace/server/procurement?productId=5535c495-72d4-4355-b169-54ffa874f849
+    # How to run this scenario
+
+    1. Install Enos (more info: https://eng-handbook.hashicorp.services/internal-tools/enos/getting-started/)
+    
+    $ brew tap hashicorp/tap && brew update && brew install hashicorp/tap/enos
+
+    2. Authenticate to AWS with Doormat (more info: https://eng-handbook.hashicorp.services/internal-tools/enos/getting-started/#authenticate-to-aws-with-doormat)
+    
+    $ doormat login && eval $(doormat aws -a <your_aws_account_name> export)
+
+    3. Set the following variables either as environment variables (`export ENOS_VAR_var_name=value`)
+    or in your 'enos-local.vars' file:
+
+    Required variables
+      - aws_ssh_private_key_path (more info about AWS SSH keypairs: https://eng-handbook.hashicorp.services/internal-tools/enos/getting-started/#set-your-aws-key-pair-name-and-private-key)
+      - aws_ssh_keypair_name
+      - vault_build_date
+      - vault_product_version
+      - vault_revision
+
+    Optional variables
+      - aws_region (if different from the default value in enos-variables.hcl)
+      - consul_license_path (if using an ENT edition of Consul)
+      - distro_version_<distro> (if different from the default version for your target
+      distro; see list of supported distros and versions in enos-globals.hcl)
+      - vault_license_path (if using an ENT edition of Vault)
+    
+    4. Choose one of the following ways to get a Vault artifact and set the appropriate variables.
+    This will be the Vault artifact that we upgrade to; 'matrix.initial_version' will be the Vault
+    version we start from.
+
+      a. 'artifact_source:crt'
+      This will use a Vault artifact that you have already downloaded. Set the following variable:
+
+      ENOS_VAR_vault_artifact_path=path/to/existing-vault-artifact.[zip | rpm | deb]
+
+      b. 'artifact_source:local'
+      This will build a Vault .zip bundle from your local branch. Set the following variable:
+
+      ENOS_VAR_vault_artifact_path=path/to/where/vault-should-be-built.zip
+
+      c. 'artifact_source:artifactory'
+      This will download a Vault artifact of the specified version, edition, and revision SHA
+      from the 'stable' repo in Artifactory. Set the following variables:
+
+      export ENOS_VAR_artifactory_username=your-user
+      export ENOS_VAR_artifactory_token=your-token
+    
+    5. Choose the matrix variants you want to use, and launch the scenario with the appropriate
+    filter for those variants, e.g.:
+
+    $  enos scenario launch smoke arch:amd64 artifact_source:artifactory artifact_type:package distro:rhel edition:ent backend:raft config_mode:file consul_edition:ce consul_version:1.17.0 seal:awskms
+
+    Notes:
+    - Note: Enos will run all matrix variant combinations that match your filter. If you specify one
+      variant for each matrix item, the filter will produce and run only one scenario. Even if you are
+      using a Raft backend, you may want to specify a consul_version (though it functionally will not
+      do anything since you're not using Consul) so that Enos does not run multiple scenarios (one for
+      each Consul version in the matrix).
+
+    - If you want to use the 'distro:leap' variant you must first accept SUSE's terms for the AWS
+      account. To verify that your account has agreed, sign-in to your AWS through Doormat,
+      and visit the following links to verify your subscription or subscribe:
+        arm64 AMI: https://aws.amazon.com/marketplace/server/procurement?productId=a516e959-df54-4035-bb1a-63599b7a6df9
+        amd64 AMI: https://aws.amazon.com/marketplace/server/procurement?productId=5535c495-72d4-4355-b169-54ffa874f849
+
+    6. If necessary, get the public IPs of your cluster from the Enos scenario output and SSH in,
+    using 'ubuntu' for the SSH user with 'distro:ubuntu', or 'ec2-user' with all other supported Linux distros:
+
+    $ enos scenario output <filter>
+    $ ssh -i /path/to/your/ssh-private-key.pem <ssh-user>@<public-ip>
+
+    For Enos troubleshooting tips, see https://eng-handbook.hashicorp.services/internal-tools/enos/troubleshooting/.
   EOF
 
   matrix {

--- a/enos/enos-scenario-smoke.hcl
+++ b/enos/enos-scenario-smoke.hcl
@@ -12,6 +12,11 @@ scenario "smoke" {
     scenario:
   
       $ enos scenario outline smoke
+    
+    You can also create an HTML version that is suitable for viewing in web browsers:
+
+      $ enos scenario outline smoke --format html > index.html
+      $ open index.html
 
     # How to run this scenario
 
@@ -59,13 +64,22 @@ scenario "smoke" {
         artifactory_username = your-user
         artifactory_token = your-token
     
-    5. Choose the matrix variants you want to use, and launch the scenario with the appropriate
-    filter for those variants, e.g.:
+    5. If you don't know yet what combination of matrix variants you want to use for your scenario, you 
+    can view all the possible combinations through the `list` command:
+
+      $ enos scenario list smoke
+    
+    Once you know what filter you want to use to obtain your desired combination of matrix variants,
+    use the `launch` command with that filter to launch your scenario.
 
       $ enos scenario launch smoke arch:amd64 artifact_source:artifactory artifact_type:package distro:rhel edition:ent backend:raft config_mode:file consul_edition:ce consul_version:1.17.0 seal:awskms
 
     Notes:
-    - Note: Enos will run all matrix variant combinations that match your filter. If you specify one
+    - To learn more about any Enos command, use the `--help` flag, e.g.:
+    
+        $ enos scenario launch --help
+
+    - Enos will run all matrix variant combinations that match your filter. If you specify one
       variant for each matrix item, the filter will produce and run only one scenario. Even if you are
       using a Raft backend, you may want to specify a consul_version (though it functionally will not
       do anything since you're not using Consul) so that Enos does not run multiple scenarios (one for
@@ -74,8 +88,8 @@ scenario "smoke" {
     - If you want to use the 'distro:leap' variant you must first accept SUSE's terms for the AWS
       account. To verify that your account has agreed, sign-in to your AWS through Doormat,
       and visit the following links to verify your subscription or subscribe:
-        arm64 AMI: https://aws.amazon.com/marketplace/server/procurement?productId=a516e959-df54-4035-bb1a-63599b7a6df9
-        amd64 AMI: https://aws.amazon.com/marketplace/server/procurement?productId=5535c495-72d4-4355-b169-54ffa874f849
+        - arm64 AMI: https://aws.amazon.com/marketplace/server/procurement?productId=a516e959-df54-4035-bb1a-63599b7a6df9
+        - amd64 AMI: https://aws.amazon.com/marketplace/server/procurement?productId=5535c495-72d4-4355-b169-54ffa874f849
 
     6. If necessary, get the public IPs of your cluster from the Enos scenario output and SSH in,
     using 'ubuntu' for the SSH user with 'distro:ubuntu', or 'ec2-user' with all other supported Linux distros:
@@ -84,6 +98,10 @@ scenario "smoke" {
     $ ssh -i /path/to/your/ssh-private-key.pem <ssh-user>@<public-ip>
 
     For Enos troubleshooting tips, see https://eng-handbook.hashicorp.services/internal-tools/enos/troubleshooting/.
+
+    7. When you're done, destroy the scenario and associated infrastructure:
+
+      $ enos scenario destroy smoke <filter>
   EOF
 
   matrix {

--- a/enos/enos-scenario-ui.hcl
+++ b/enos/enos-scenario-ui.hcl
@@ -6,10 +6,17 @@ scenario "ui" {
     The UI scenario creates a new cluster and runs the existing Ember test suite
     against a live Vault cluster instead of a binary in dev mode.
 
+    # How to view an outline of this scenario
+
     You can use the following command to get a textual outline of the entire
     scenario:
-  
+    
       $ enos scenario outline ui
+
+    You can also create an HTML version that is suitable for viewing in web browsers:
+
+      $ enos scenario outline ui --format html > index.html
+      $ open index.html
 
     # How to run this scenario
 
@@ -38,12 +45,21 @@ scenario "ui" {
       distro; see list of supported distros and versions in enos-globals.hcl)
       - vault_license_path (if using an ENT edition of Vault)
     
-    4. Choose the matrix variants you want to use, and launch the scenario with the appropriate
-    filter for those variants, e.g.:
+    4. If you don't know yet what combination of matrix variants you want to use for your scenario, you 
+    can view all the possible combinations through the `list` command:
+
+      $ enos scenario list ui
+    
+    Once you know what filter you want to use to obtain your desired combination of matrix variants,
+    use the `launch` command with that filter to launch your scenario.
 
       $ enos scenario launch ui backend:raft consul_edition:ent edition:ce
 
     Notes:
+    - To learn more about any Enos command, use the `--help` flag, e.g.:
+    
+        $ enos scenario launch --help
+
     - Enos will run all matrix variant combinations that match your filter. If you specify one
       variant for each matrix item, the filter will produce and run only one scenario.
 
@@ -54,6 +70,10 @@ scenario "ui" {
       $ ssh -i /path/to/your/ssh-private-key.pem <ssh-user>@<public-ip>
 
     For Enos troubleshooting tips, see https://eng-handbook.hashicorp.services/internal-tools/enos/troubleshooting/.
+
+    6. When you're done, destroy the scenario and associated infrastructure:
+
+      $ enos scenario destroy ui <filter>
 
   EOF
   matrix {

--- a/enos/enos-scenario-ui.hcl
+++ b/enos/enos-scenario-ui.hcl
@@ -6,18 +6,23 @@ scenario "ui" {
     The UI scenario creates a new cluster and runs the existing Ember test suite
     against a live Vault cluster instead of a binary in dev mode.
 
+    You can use the following command to get a textual outline of the entire
+    scenario:
+  
+      $ enos scenario outline ui
+
     # How to run this scenario
 
     1. Install Enos (more info: https://eng-handbook.hashicorp.services/internal-tools/enos/getting-started/)
     
-    $ brew tap hashicorp/tap && brew update && brew install hashicorp/tap/enos
+      $ brew tap hashicorp/tap && brew update && brew install hashicorp/tap/enos
 
     2. Authenticate to AWS with Doormat (more info: https://eng-handbook.hashicorp.services/internal-tools/enos/getting-started/#authenticate-to-aws-with-doormat)
     
-    $ doormat login && eval $(doormat aws -a <your_aws_account_name> export)
+      $ doormat login && eval $(doormat aws -a <your_aws_account_name> export)
 
     3. Set the following variables either as environment variables (`export ENOS_VAR_var_name=value`)
-    or in your 'enos-local.vars' file:
+    or by creating a 'enos-local.vars' file and setting it there (see enos.vars.hcl for examples):
 
     Required variables
       - aws_ssh_private_key_path (more info about AWS SSH keypairs: https://eng-handbook.hashicorp.services/internal-tools/enos/getting-started/#set-your-aws-key-pair-name-and-private-key)
@@ -36,7 +41,7 @@ scenario "ui" {
     4. Choose the matrix variants you want to use, and launch the scenario with the appropriate
     filter for those variants, e.g.:
 
-    $ enos scenario launch ui backend:raft consul_edition:ent edition:ce
+      $ enos scenario launch ui backend:raft consul_edition:ent edition:ce
 
     Notes:
     - Enos will run all matrix variant combinations that match your filter. If you specify one
@@ -45,8 +50,8 @@ scenario "ui" {
     5. If necessary, get the public IPs of your cluster from the Enos scenario output and SSH in,
     using 'ubuntu' for the SSH user with 'distro:ubuntu', or 'ec2-user' with all other supported Linux distros:
 
-    $ enos scenario output <filter>
-    $ ssh -i /path/to/your/ssh-private-key.pem <ssh-user>@<public-ip>
+      $ enos scenario output <filter>
+      $ ssh -i /path/to/your/ssh-private-key.pem <ssh-user>@<public-ip>
 
     For Enos troubleshooting tips, see https://eng-handbook.hashicorp.services/internal-tools/enos/troubleshooting/.
 

--- a/enos/enos-scenario-ui.hcl
+++ b/enos/enos-scenario-ui.hcl
@@ -46,7 +46,8 @@ scenario "ui" {
       - vault_license_path (if using an ENT edition of Vault)
     
     4. If you don't know yet what combination of matrix variants you want to use for your scenario, you 
-    can view all the possible combinations through the `list` command:
+    can view all the possible combinations through the `list` command. You can also reduce the list by
+    adding one or more filter items, e.g. 'arch:amd64' to get just the scenario combinations that use amd64.
 
       $ enos scenario list ui
     

--- a/enos/enos-scenario-upgrade.hcl
+++ b/enos/enos-scenario-upgrade.hcl
@@ -10,18 +10,23 @@ scenario "upgrade" {
     mount engines and create data, then perform an in-place upgrade with any candidate built and
     perform quality verification.
 
+    You can use the following command to get a textual outline of the entire
+    scenario:
+  
+      $ enos scenario outline upgrade
+
     # How to run this scenario
 
     1. Install Enos (more info: https://eng-handbook.hashicorp.services/internal-tools/enos/getting-started/)
     
-    $ brew tap hashicorp/tap && brew update && brew install hashicorp/tap/enos
+      $ brew tap hashicorp/tap && brew update && brew install hashicorp/tap/enos
 
     2. Authenticate to AWS with Doormat (more info: https://eng-handbook.hashicorp.services/internal-tools/enos/getting-started/#authenticate-to-aws-with-doormat)
     
-    $ doormat login && eval $(doormat aws -a <your_aws_account_name> export)
+      $ doormat login && eval $(doormat aws -a <your_aws_account_name> export)
 
     3. Set the following variables either as environment variables (`export ENOS_VAR_var_name=value`)
-    or in your 'enos-local.vars' file:
+    or by creating a 'enos-local.vars' file and setting it there (see enos.vars.hcl for examples):
 
     Required variables
       - aws_ssh_private_key_path (more info about AWS SSH keypairs: https://eng-handbook.hashicorp.services/internal-tools/enos/getting-started/#set-your-aws-key-pair-name-and-private-key)
@@ -44,24 +49,24 @@ scenario "upgrade" {
       a. 'artifact_source:crt'
       This will use a Vault artifact that you have already downloaded. Set the following variable:
 
-      ENOS_VAR_vault_artifact_path=path/to/existing-vault-artifact.[zip | rpm | deb]
+        vault_artifact_path = path/to/existing-vault-artifact.[zip | rpm | deb]
 
       b. 'artifact_source:local'
       This will build a Vault .zip bundle from your local branch. Set the following variable:
 
-      ENOS_VAR_vault_artifact_path=path/to/where/vault-should-be-built.zip
+        vault_artifact_path = path/to/where/vault-should-be-built.zip
 
       c. 'artifact_source:artifactory'
       This will download a Vault artifact of the specified version, edition, and revision SHA
       from the 'stable' repo in Artifactory. Set the following variables:
 
-      export ENOS_VAR_artifactory_username=your-user
-      export ENOS_VAR_artifactory_token=your-token
+        artifactory_username = your-user
+        artifactory_token = your-token
     
     5. Choose the matrix variants you want to use, and launch the scenario with the appropriate
     filter for those variants, e.g.:
 
-    $ enos scenario launch upgrade arch:amd64 artifact_source:artifactory artifact_type:package backend:raft config_mode:file consul_edition:ce consul_version:1.17.0 distro:rhel edition:ce initial_version:1.13.13 seal:awskms
+      $ enos scenario launch upgrade arch:amd64 artifact_source:artifactory artifact_type:package backend:raft config_mode:file consul_edition:ce consul_version:1.17.0 distro:rhel edition:ce initial_version:1.13.13 seal:awskms
 
     Notes:
     - Enos will run all matrix variant combinations that match your filter. If you specify one
@@ -73,14 +78,14 @@ scenario "upgrade" {
     - If you want to use the 'distro:leap' variant you must first accept SUSE's terms for the AWS
       account. To verify that your account has agreed, sign-in to your AWS through Doormat,
       and visit the following links to verify your subscription or subscribe:
-        arm64 AMI: https://aws.amazon.com/marketplace/server/procurement?productId=a516e959-df54-4035-bb1a-63599b7a6df9
-        amd64 AMI: https://aws.amazon.com/marketplace/server/procurement?productId=5535c495-72d4-4355-b169-54ffa874f849
+        - arm64 AMI: https://aws.amazon.com/marketplace/server/procurement?productId=a516e959-df54-4035-bb1a-63599b7a6df9
+        - amd64 AMI: https://aws.amazon.com/marketplace/server/procurement?productId=5535c495-72d4-4355-b169-54ffa874f849
 
     6. If necessary, get the public IPs of your cluster from the Enos scenario output and SSH in,
     using 'ubuntu' for the SSH user with 'distro:ubuntu', or 'ec2-user' with all other supported Linux distros:
 
-    $ enos scenario output <filter>
-    $ ssh -i /path/to/your/ssh-private-key.pem <ssh-user>@<public-ip>
+      $ enos scenario output <filter>
+      $ ssh -i /path/to/your/ssh-private-key.pem <ssh-user>@<public-ip>
 
     For Enos troubleshooting tips, see https://eng-handbook.hashicorp.services/internal-tools/enos/troubleshooting/.
 

--- a/enos/enos-scenario-upgrade.hcl
+++ b/enos/enos-scenario-upgrade.hcl
@@ -59,9 +59,7 @@ scenario "upgrade" {
         vault_artifact_path = path/to/existing-vault-artifact.[zip | rpm | deb]
 
       b. 'artifact_source:local'
-      This will build a Vault .zip bundle from your local branch. Set the following variable:
-
-        vault_artifact_path = path/to/where/vault-should-be-built.zip
+      This will build a Vault .zip bundle from your local branch. No variables required.
 
       c. 'artifact_source:artifactory'
       This will download a Vault artifact of the specified version, edition, and revision SHA
@@ -71,7 +69,8 @@ scenario "upgrade" {
         artifactory_token = your-token
     
     5. If you don't know yet what combination of matrix variants you want to use for your scenario, you 
-    can view all the possible combinations through the `list` command:
+    can view all the possible combinations through the `list` command. You can also reduce the list by
+    adding one or more filter items, e.g. 'arch:amd64' to get just the scenario combinations that use amd64.
 
       $ enos scenario list upgrade
     

--- a/enos/enos-scenario-upgrade.hcl
+++ b/enos/enos-scenario-upgrade.hcl
@@ -10,10 +10,17 @@ scenario "upgrade" {
     mount engines and create data, then perform an in-place upgrade with any candidate built and
     perform quality verification.
 
+    # How to view an outline of this scenario
+
     You can use the following command to get a textual outline of the entire
     scenario:
-  
+    
       $ enos scenario outline upgrade
+
+    You can also create an HTML version that is suitable for viewing in web browsers:
+
+      $ enos scenario outline upgrade --format html > index.html
+      $ open index.html
 
     # How to run this scenario
 
@@ -63,12 +70,21 @@ scenario "upgrade" {
         artifactory_username = your-user
         artifactory_token = your-token
     
-    5. Choose the matrix variants you want to use, and launch the scenario with the appropriate
-    filter for those variants, e.g.:
+    5. If you don't know yet what combination of matrix variants you want to use for your scenario, you 
+    can view all the possible combinations through the `list` command:
+
+      $ enos scenario list upgrade
+    
+    Once you know what filter you want to use to obtain your desired combination of matrix variants,
+    use the `launch` command with that filter to launch your scenario.
 
       $ enos scenario launch upgrade arch:amd64 artifact_source:artifactory artifact_type:package backend:raft config_mode:file consul_edition:ce consul_version:1.17.0 distro:rhel edition:ce initial_version:1.13.13 seal:awskms
 
     Notes:
+    - To learn more about any Enos command, use the `--help` flag, e.g.:
+    
+        $ enos scenario launch --help
+
     - Enos will run all matrix variant combinations that match your filter. If you specify one
       variant for each matrix item, the filter will produce and run only one scenario. Even if you are
       using a Raft backend, you may want to specify a consul_version (though it functionally will not
@@ -88,6 +104,10 @@ scenario "upgrade" {
       $ ssh -i /path/to/your/ssh-private-key.pem <ssh-user>@<public-ip>
 
     For Enos troubleshooting tips, see https://eng-handbook.hashicorp.services/internal-tools/enos/troubleshooting/.
+
+    7. When you're done, destroy the scenario and associated infrastructure:
+
+      $ enos scenario destroy upgrade <filter>
 
   EOF
 


### PR DESCRIPTION
### Description
Adds 'how to run' instructions for each Enos scenario. https://hashicorp.atlassian.net/browse/VAULT-29011?atlOrigin=eyJpIjoiZjYyN2JiN2YwMDcyNDM0NTg0Zjk2MzkzNzZkMGEyNTciLCJwIjoiaiJ9

### TODO only if you're a HashiCorp employee
- [x] **Labels:** If this PR is the CE portion of an ENT change, and that ENT change is
  getting backported to N-2, use the new style `backport/ent/x.x.x+ent` labels
  instead of the old style `backport/x.x.x` labels.
- [x] **Labels:** If this PR is a CE only change, it can only be backported to N, so use
  the normal `backport/x.x.x` label (there should be only 1).
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
