### PR TITLE
enos: support ancient systemd in `vault_upgrade`

### DIFF
--- a/enos/modules/vault_upgrade/scripts/maybe-remove-old-unit-file.sh
+++ b/enos/modules/vault_upgrade/scripts/maybe-remove-old-unit-file.sh
@@ -18,7 +18,9 @@ fi
 
 # Get the unit file for the vault.service that is running. If it's not in /etc/systemd then it
 # should be a package provided unit file so we don't need to delete anything.
-if ! unit_path=$(systemctl show -P FragmentPath vault 2>&1); then
+#
+# Note that we use -p instead of -P so that we support ancient amzn2 systemctl.
+if ! unit_path=$(systemctl show -p FragmentPath vault | cut -d = -f2 2>&1); then
   echo "Skipped removing unit file because and existing path could not be found: $unit_path"
   exit 0
 fi


### PR DESCRIPTION
### Description

Amazon Linux 2 uses an ancient version of Systemd/systemctl so instead of using -P when determining the unit file we use the less convenient -p.

### TODO only if you're a HashiCorp employee
- [x] **Labels:** If this PR is the CE portion of an ENT change, and that ENT change is
  getting backported to N-2, use the new style `backport/ent/x.x.x+ent` labels
  instead of the old style `backport/x.x.x` labels.
- [x] **Labels:** If this PR is a CE only change, it can only be backported to N, so use
  the normal `backport/x.x.x` label (there should be only 1).
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
