### PR TITLE
Audit: comment updates and conditional merge

### DIFF
--- a/audit/entry_formatter.go
+++ b/audit/entry_formatter.go
@@ -199,11 +199,7 @@ func remotePort(req *logical.Request) int {
 // clientCertSerialNumber attempts the retrieve the serial number of the peer
 // certificate from the specified tls.ConnectionState.
 func clientCertSerialNumber(req *logical.Request) string {
-	if req == nil {
-		return ""
-	}
-
-	if req.Connection == nil {
+	if req == nil || req.Connection == nil {
 		return ""
 	}
 
@@ -261,8 +257,8 @@ func clone[V any](s V) (V, error) {
 // an audit Auth.
 // tokenRemainingUses should be the client token remaining uses to include in auth.
 // This usually can be found in logical.Request.ClientTokenRemainingUses.
-// NOTE: supplying a nil value for auth will result in a nil return value and error.
-// The caller should check the return value before attempting to use it.
+// NOTE: supplying a nil value for auth will result in a nil return value and
+// (nil) error. The caller should check the return value before attempting to use it.
 func newAuth(auth *logical.Auth, tokenRemainingUses int) (*Auth, error) {
 	if auth == nil {
 		return nil, nil
@@ -399,6 +395,8 @@ func newRequest(req *logical.Request, ns *namespace.Namespace) (*Request, error)
 // newResponse takes a logical.Response and logical.Request, transforms and
 // aggregates them into an audit Response.
 // isElisionRequired is used to indicate that response 'Data' should be elided.
+// NOTE: supplying a nil value for response will result in a nil return value and
+// (nil) error. The caller should check the return value before attempting to use it.
 func newResponse(resp *logical.Response, req *logical.Request, isElisionRequired bool) (*Response, error) {
 	if resp == nil {
 		return nil, nil


### PR DESCRIPTION
### Description

* updates comments to inform callers about the `nil, nil` potential return value.
* merges two consecutive `if` conditions in `clientCertSerialNumber` func 

### HashiCorp Checklist

- [x] **Labels:** If this PR is the CE portion of an ENT change, and that ENT change is
  getting backported to N-2, use the new style `backport/ent/x.x.x+ent` labels
  instead of the old style `backport/x.x.x` labels.
- [x] **Labels:** If this PR is a CE only change, it can only be backported to N, so use
  the normal `backport/x.x.x` label (there should be only 1).
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
