### PR TITLE
Update userpass CLI doc for custom path flag

### DIFF
--- a/website/content/docs/auth/userpass.mdx
+++ b/website/content/docs/auth/userpass.mdx
@@ -18,6 +18,10 @@ passwords from an external source.
 The method lowercases all submitted usernames, e.g. `Mary` and `mary` are the
 same entry.
 
+This documentation assumes the Username & Password method is mounted at the default `/auth/userpass`
+path in Vault. Since it is possible to enable auth methods at any location,
+please update your CLI calls accordingly with the `-path` flag.
+
 ## Authentication
 
 ### Via the CLI


### PR DESCRIPTION

### Description
It's not clear from the get go how to use the userpass auth method with a custom path. Hence why this change brings clarity recycling the wording from the API page. An example could be added, but that would mean change the whole page not to use the default path, which would be inconsistent with the rest of the docs.

