### PR TITLE
Clarify audit log failure telemetry docs.

### DIFF
--- a/website/content/partials/telemetry-metrics/vault/audit/log_request_failure.mdx
+++ b/website/content/partials/telemetry-metrics/vault/audit/log_request_failure.mdx
@@ -2,16 +2,19 @@
 
 | Metric type | Value  | Description                                                                               |
 |-------------|--------|-------------------------------------------------------------------------------------------|
-| gauge       | number | Average (mean) number of audit log request failures across all devices during time period |
+| counter     | number | The number of audit log request failures across all devices                               |
 
 The number of request failures is a **crucial metric**.
 
-A non-zero value for `vault.audit.log_request_failure` indicates that all
-the configured audit devices failed to log a request (or response). If Vault cannot
-properly audit a request, or the response to a request, the original request
-will fail.
+When using Prometheus sink use `rate` or `irate` to convert this into the number of failures
+over a specific time period.
 
-The `mean` value for this metric should be monitored, not the `count` which could be misleading.
+When using Vault's built-in `/metrics` output format, counters are reported aggregated over 
+the metrics interval which defaults to 10 seconds. The `count` is the total number of errors that occured 
+during the interval while the `mean` is normalized to the per-second rate of errors during the interval. 
+
+Any increase in this counter indicates that all the configured audit devices failed to log a request (or response). 
+If Vault cannot properly audit a request, or the response to a request, the original request will fail.
 
 Refer to the Vault logs and any device-specific metrics to troubleshoot the
 failing audit log device.

--- a/website/content/partials/telemetry-metrics/vault/audit/log_request_failure.mdx
+++ b/website/content/partials/telemetry-metrics/vault/audit/log_request_failure.mdx
@@ -6,15 +6,19 @@
 
 The number of request failures is a **crucial metric**.
 
-When using Prometheus sink use `rate` or `irate` to convert this into the number of failures
-over a specific time period.
+When using Prometheus sink use `rate` or `irate` to convert this into the number
+of failures over a specific time period.
 
-When using Vault's built-in `/metrics` output format, counters are reported aggregated over 
-the metrics interval which defaults to 10 seconds. The `count` is the total number of errors that occured 
-during the interval while the `mean` is normalized to the per-second rate of errors during the interval. 
+When using Vault's built-in `/metrics` output format, counters are reported
+aggregated over the metrics interval which defaults to 10 seconds. Due to
+historical reasons, this counter is recorded in a way that makes the `count`
+field misleading - it counts every request whether it failed or not. The `mean`
+value however will correctly record the normalized per-second rate at which
+audit errors have occurred over the interval.
 
-Any increase in this counter indicates that all the configured audit devices failed to log a request (or response). 
-If Vault cannot properly audit a request, or the response to a request, the original request will fail.
+Any increase in this counter indicates that all the configured audit devices
+failed to log a request (or response). If Vault cannot properly audit a request,
+or the response to a request, the original request will fail.
 
 Refer to the Vault logs and any device-specific metrics to troubleshoot the
 failing audit log device.

--- a/website/content/partials/telemetry-metrics/vault/audit/log_response_failure.mdx
+++ b/website/content/partials/telemetry-metrics/vault/audit/log_response_failure.mdx
@@ -1,17 +1,20 @@
 ### vault.audit.log_response_failure ((#vault-audit-log_response_failure))
 
-| Metric type | Value  | Description                                                                                |
-|-------------|--------|--------------------------------------------------------------------------------------------|
-| gauge       | number | Average (mean) number of audit log response failures across all devices during time period |
+| Metric type | Value  | Description                                                                               |
+|-------------|--------|-------------------------------------------------------------------------------------------|
+| counter     | number | The number of audit log response failures across all devices                              |
 
-The number of request failures is a **crucial metric**.
+The number of response failures is a **crucial metric**.
 
-A non-zero value for `vault.audit.log_response_failure` indicates that all
-the configured audit log devices failed to log a response to a request. If Vault cannot
-properly audit a request, or the response to a request, the original request
-will fail.
+When using Prometheus sink use `rate` or `irate` to convert this into the number of failures
+over a specific time period.
 
-The `mean` value for this metric should be monitored, not the `count` which could be misleading.
+When using Vault's built-in `/metrics` output format, counters are reported aggregated over 
+the metrics interval which defaults to 10 seconds. The `count` is the total number of errors that occured 
+during the interval while the `mean` is normalized to the per-second rate of errors during the interval. 
 
-Refer to the device-specific metrics and logs to troubleshoot the failing audit
-log device.
+Any increase in this counter indicates that all the configured audit devices failed to log a request (or response). 
+If Vault cannot properly audit a request, or the response to a request, the original request will fail.
+
+Refer to the Vault logs and any device-specific metrics to troubleshoot the
+failing audit log device.

--- a/website/content/partials/telemetry-metrics/vault/audit/log_response_failure.mdx
+++ b/website/content/partials/telemetry-metrics/vault/audit/log_response_failure.mdx
@@ -6,15 +6,19 @@
 
 The number of response failures is a **crucial metric**.
 
-When using Prometheus sink use `rate` or `irate` to convert this into the number of failures
-over a specific time period.
+When using Prometheus sink use `rate` or `irate` to convert this into the number
+of failures over a specific time period.
 
-When using Vault's built-in `/metrics` output format, counters are reported aggregated over 
-the metrics interval which defaults to 10 seconds. The `count` is the total number of errors that occured 
-during the interval while the `mean` is normalized to the per-second rate of errors during the interval. 
+When using Vault's built-in `/metrics` output format, counters are reported
+aggregated over the metrics interval which defaults to 10 seconds. Due to
+historical reasons, this counter is recorded in a way that makes the `count`
+field misleading - it counts every request whether it failed or not. The `mean`
+value however will correctly record the normalized per-second rate at which
+audit errors have occurred over the interval.
 
-Any increase in this counter indicates that all the configured audit devices failed to log a request (or response). 
-If Vault cannot properly audit a request, or the response to a request, the original request will fail.
+Any increase in this counter indicates that all the configured audit devices
+failed to log a request (or response). If Vault cannot properly audit a request,
+or the response to a request, the original request will fail.
 
 Refer to the Vault logs and any device-specific metrics to troubleshoot the
 failing audit log device.


### PR DESCRIPTION
### Description
We recently changed the docs for these metrics to try to clarify how to actually monitor them usefully. Unfortunately the clarification only makes sense for the in-memory sink which could further confuse Prometheus or other metrics Sink users.

This attempts to clarify how to correctly monitor this metric.

### TODO only if you're a HashiCorp employee
- [x] **Labels:** If this PR is the CE portion of an ENT change, and that ENT change is
  getting backported to N-2, use the new style `backport/ent/x.x.x+ent` labels
  instead of the old style `backport/x.x.x` labels.
- [x] **Labels:** If this PR is a CE only change, it can only be backported to N, so use
  the normal `backport/x.x.x` label (there should be only 1).
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
