### PR TITLE
Add api/auth tests

### DIFF
--- a/api/auth_test.go
+++ b/api/auth_test.go
@@ -47,6 +47,13 @@ func TestAuth_Login(t *testing.T) {
 			return
 		}
 	})
+
+	t.Run("Login with nil AuthMethod should return error", func(t *testing.T) {
+		_, err := a.Login(context.Background(), nil)
+		if err == nil {
+			t.Errorf("expected error when AuthMethod is nil, got none")
+		}
+	})
 }
 
 func TestAuth_MFALoginSinglePhase(t *testing.T) {
@@ -74,6 +81,33 @@ func TestAuth_MFALoginSinglePhase(t *testing.T) {
 			return
 		}
 	})
+
+	t.Run("MFALogin() with empty credentials should assume two-phase", func(t *testing.T) {
+		a := &Auth{
+			c: &Client{},
+		}
+
+		m := mockAuthMethod{
+			mockedSecret: &Secret{
+				Auth: &SecretAuth{
+					MFARequirement: &MFARequirement{
+						MFARequestID: "a-req-id",
+					},
+				},
+			},
+			mockedError: nil,
+		}
+
+		secret, err := a.MFALogin(context.Background(), &m)
+		if err != nil {
+			t.Errorf("MFALogin() error %v", err)
+			return
+		}
+
+		if secret.Auth.MFARequirement.MFARequestID != "a-req-id" {
+			t.Errorf("MFARequirement ID was %v expected %v", secret.Auth.MFARequirement.MFARequestID, "a-req-id")
+		}
+	})
 }
 
 func TestAuth_MFALoginTwoPhase(t *testing.T) {
@@ -81,7 +115,6 @@ func TestAuth_MFALoginTwoPhase(t *testing.T) {
 		name    string
 		a       *Auth
 		m       *mockAuthMethod
-		creds   *string
 		wantErr bool
 	}{
 		{
@@ -122,10 +155,63 @@ func TestAuth_MFALoginTwoPhase(t *testing.T) {
 				return
 			}
 
+			if tt.wantErr {
+				if secret != nil {
+					t.Errorf("MFALogin() returned non-nil secret when error was expected")
+				}
+				return
+			}
+
 			if secret.Auth.MFARequirement != tt.m.mockedSecret.Auth.MFARequirement {
 				t.Errorf("MFALogin() returned %v, expected %v", secret.Auth.MFARequirement, tt.m.mockedSecret.Auth.MFARequirement)
 				return
 			}
 		})
 	}
+}
+
+func TestAuth_MFAValidate(t *testing.T) {
+	a := &Auth{
+		c: &Client{},
+	}
+
+	t.Run("MFAValidate should return error if secret is nil", func(t *testing.T) {
+		_, err := a.MFAValidate(context.Background(), nil, nil)
+		if err == nil {
+			t.Errorf("expected error when secret is nil, got none")
+		}
+	})
+
+	t.Run("MFAValidate should return error if MFARequirement is nil", func(t *testing.T) {
+		secret := &Secret{
+			Auth: &SecretAuth{},
+		}
+		_, err := a.MFAValidate(context.Background(), secret, nil)
+		if err == nil {
+			t.Errorf("expected error when MFARequirement is nil, got none")
+		}
+	})
+}
+
+func TestCheckAndSetToken(t *testing.T) {
+	a := &Auth{
+		c: &Client{},
+	}
+
+	t.Run("checkAndSetToken should return error if secret is nil", func(t *testing.T) {
+		_, err := a.checkAndSetToken(nil)
+		if err == nil {
+			t.Errorf("expected error when secret is nil, got none")
+		}
+	})
+
+	t.Run("checkAndSetToken should return error if ClientToken is missing", func(t *testing.T) {
+		secret := &Secret{
+			Auth: &SecretAuth{},
+		}
+		_, err := a.checkAndSetToken(secret)
+		if err == nil {
+			t.Errorf("expected error when ClientToken is missing, got none")
+		}
+	})
 }


### PR DESCRIPTION
### Description
What does this PR do?
Add more tests to api/auth

### TODO only if you're a HashiCorp employee
- [ ] **Labels:** If this PR is the CE portion of an ENT change, and that ENT change is
  getting backported to N-2, use the new style `backport/ent/x.x.x+ent` labels
  instead of the old style `backport/x.x.x` labels.
- [ ] **Labels:** If this PR is a CE only change, it can only be backported to N, so use
  the normal `backport/x.x.x` label (there should be only 1).
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
