### PR TITLE
enos: don't expect curl available in docker image

### DIFF
--- a/enos/k8s/enos-scenario-k8s.hcl
+++ b/enos/k8s/enos-scenario-k8s.hcl
@@ -99,19 +99,6 @@ scenario "k8s" {
     depends_on = [step.deploy_vault]
   }
 
-  step "verify_ui" {
-    module    = module.k8s_verify_ui
-    skip_step = matrix.edition == "ce"
-
-    variables {
-      vault_pods        = step.deploy_vault.vault_pods
-      kubeconfig_base64 = step.create_kind_cluster.kubeconfig_base64
-      context_name      = step.create_kind_cluster.context_name
-    }
-
-    depends_on = [step.deploy_vault]
-  }
-
   step "verify_version" {
     module = module.k8s_verify_version
 


### PR DESCRIPTION
### Description
Remove checking the UI via curl for now as it will no longer be part of the enterprise container.

### TODO only if you're a HashiCorp employee
- [x] **Labels:** If this PR is the CE portion of an ENT change, and that ENT change is
  getting backported to N-2, use the new style `backport/ent/x.x.x+ent` labels
  instead of the old style `backport/x.x.x` labels.
- [x] **Labels:** If this PR is a CE only change, it can only be backported to N, so use
  the normal `backport/x.x.x` label (there should be only 1).
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
