### PR TITLE
docker: add upgrade notes for curl removal

### DIFF
--- a/website/content/docs/upgrading/upgrade-to-1.15.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.15.x.mdx
@@ -45,6 +45,12 @@ option.
 
 @include 'application-of-sentinel-rgps-via-identity-groups.mdx'
 
+### Docker image no longer contains `curl`
+
+As of 1.15.13 and later, the `curl` binary is no longer included in the published Docker container images
+for Vault and Vault Enterprise. If your workflow depends on `curl` in the image you can dynamically
+install it using `apk`, e.g.: `docker exec <CONTAINER-ID> apk add curl` or `kubectl exec -ti <NAME> -- apk add curl`.
+
 ## Known issues and workarounds
 
 @include 'known-issues/1_15-auto-upgrade.mdx'

--- a/website/content/docs/upgrading/upgrade-to-1.16.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.16.x.mdx
@@ -90,7 +90,13 @@ decides to trigger the flag. More information can be found in the
 
 ### Auto-rolled billing start date
 
-As of 1.16.7 and later, the billing start date (license start date if not configured) automatically rolls over to the latest billing year at the end of the last cycle. 
+As of 1.16.7 and later, the billing start date (license start date if not configured) automatically rolls over to the latest billing year at the end of the last cycle.
+
+### Docker image no longer contains `curl`
+
+As of 1.16.7 and later, the `curl` binary is no longer included in the published Docker container images
+for Vault and Vault Enterprise. If your workflow depends on `curl` in the image you can dynamically
+install it using `apk`, e.g.: `docker exec <CONTAINER-ID> apk add curl` or `kubectl exec -ti <NAME> -- apk add curl`.
 
 @include 'auto-roll-billing-start.mdx'
 

--- a/website/content/docs/upgrading/upgrade-to-1.17.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.17.x.mdx
@@ -83,11 +83,17 @@ incorrectly. For additional details, refer to the
 
 ### Auto-rolled billing start date
 
-As of 1.17.3 and later, the billing start date (license start date if not configured) rolls over to the latest billing year at the end of the last cycle. 
+As of 1.17.3 and later, the billing start date (license start date if not configured) rolls over to the latest billing year at the end of the last cycle.
 
 @include 'auto-roll-billing-start.mdx'
 
 @include 'auto-roll-billing-start-example.mdx'
+
+### Docker image no longer contains `curl`
+
+As of 1.17.3 and later, the `curl` binary is no longer included in the published Docker container images
+for Vault and Vault Enterprise. If your workflow depends on `curl` in the image you can dynamically
+install it using `apk`, e.g.: `docker exec <CONTAINER-ID> apk add curl` or `kubectl exec -ti <NAME> -- apk add curl`.
 
 ## Known issues and workarounds
 

--- a/website/content/docs/upgrading/upgrade-to-1.18.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.18.x.mdx
@@ -57,3 +57,9 @@ WARNING! The following warnings were returned from Vault:
 ```
 
 </CodeBlockConfig>
+
+### Docker image no longer contains `curl`
+
+The `curl` binary is no longer included in the published Docker container images for Vault and Vault
+Enterprise. If your workflow depends on `curl` in the image you can dynamically install it using
+`apk`, e.g.: `docker exec <CONTAINER-ID> apk add curl` or `kubectl exec -ti <NAME> -- apk add curl`.


### PR DESCRIPTION
### Description
Adds upgrade notes for the removal of `curl` in the Docker container images.

### TODO only if you're a HashiCorp employee
- [x] **Labels:** If this PR is the CE portion of an ENT change, and that ENT change is
  getting backported to N-2, use the new style `backport/ent/x.x.x+ent` labels
  instead of the old style `backport/x.x.x` labels.
- [x] **Labels:** If this PR is a CE only change, it can only be backported to N, so use
  the normal `backport/x.x.x` label (there should be only 1).
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
