### PR TITLE
Backport of Auto-rolling billing start docs PR into release/1.16.x

### DIFF
--- a/website/content/api-docs/system/internal-counters.mdx
+++ b/website/content/api-docs/system/internal-counters.mdx
@@ -263,6 +263,8 @@ not have namespace attribution for the `new_clients` stanza. Furthermore, the
 `new_clients` counts returned for the current month will be an approximation.
 That is to say, the response will appear as follows.
 
+  @include 'auto-roll-billing-start-example.mdx'
+
 ```json
 {
    "months":[
@@ -342,8 +344,13 @@ This endpoint was added in Vault 1.6.
 ### Parameters
 
 - `start_time` `(string, optional)` - An RFC3339 timestamp or Unix epoch time. Specifies the start of the
+<<<<<<< HEAD
   period for which client counts will be reported. If no start time is specified, the `default_report_months`
   prior to the `end_time` will be used.
+=======
+  period for which client counts will be reported. If no start time is specified, the billing start date will be used.
+  The [billing start date](/vault/docs/concepts/billing-start-date) automatically rolls over to the latest billing year at the end of the last cycle.
+>>>>>>> e1d3c322e7 (Auto-rolling billing start docs PR  (#27926))
 - `end_time` `(string, optional)` - An RFC3339 timestamp or Unix epoch time. Specifies the end of the period
   for which client counts will be reported. If no end time is specified, the end of the previous calendar
   month will be used.
@@ -1071,6 +1078,18 @@ $ curl \
   "warnings": null
 }
 ```
+
+<Note title="Important change to supported versions">
+   As of 1.16.7, 1.17.3 and later, 
+   the <a href="/vault/docs/concepts/billing-start-date">billing start date</a> automatically 
+   rolls over to the latest billing year at the end of the last cycle.
+        
+   For more information, refer to the upgrade guide for your Vault version:
+
+   [Vault v1.16.x](/vault/docs/upgrading/upgrade-to-1.16.x#auto-rolled-billing-start-date),
+   [Vault v1.17.x](/vault/docs/upgrading/upgrade-to-1.17.x#auto-rolled-billing-start-date)
+
+</Note>
 
 ## Activity export
 

--- a/website/content/api-docs/system/internal-counters.mdx
+++ b/website/content/api-docs/system/internal-counters.mdx
@@ -344,13 +344,8 @@ This endpoint was added in Vault 1.6.
 ### Parameters
 
 - `start_time` `(string, optional)` - An RFC3339 timestamp or Unix epoch time. Specifies the start of the
-<<<<<<< HEAD
-  period for which client counts will be reported. If no start time is specified, the `default_report_months`
-  prior to the `end_time` will be used.
-=======
   period for which client counts will be reported. If no start time is specified, the billing start date will be used.
   The [billing start date](/vault/docs/concepts/billing-start-date) automatically rolls over to the latest billing year at the end of the last cycle.
->>>>>>> e1d3c322e7 (Auto-rolling billing start docs PR  (#27926))
 - `end_time` `(string, optional)` - An RFC3339 timestamp or Unix epoch time. Specifies the end of the period
   for which client counts will be reported. If no end time is specified, the end of the previous calendar
   month will be used.

--- a/website/content/docs/concepts/billing-start-date.mdx
+++ b/website/content/docs/concepts/billing-start-date.mdx
@@ -1,0 +1,21 @@
+---
+layout: docs
+page_title: Billing start date
+description: >-
+   A description of Vault cluster's billing start date used throughout Vault.
+---
+
+# Billing start date
+
+It is the start of the period for which [automated](/vault/docs/enterprise/license/utilization-reporting) and [manual](/vault/docs/enterprise/license/manual-reporting) license utilization data will be reported for a cluster. This is the license start date if you do not have an explicit
+billing start date configured. 
+
+Vault also uses the billing start date as a default start timestamp for:
+- [Direct queries via the activity log API](/vault/api-docs/system/internal-counters)
+- [Activity export CLI](/vault/api-docs/system/internal-counters#activity-export)
+
+As of 1.16.7, 1.17.3 and later, Vault clusters will automatically adjust the billing start date to provide a year's worth of utilization data. 
+
+@include 'auto-roll-billing-start.mdx'
+
+@include 'auto-roll-billing-start-example.mdx'

--- a/website/content/docs/enterprise/license/utilization-reporting.mdx
+++ b/website/content/docs/enterprise/license/utilization-reporting.mdx
@@ -227,7 +227,21 @@ HashiCorp collects the following utilization data as JSON payloads:
          - `entity` - The sum of tokens generated for a unique client identifier
          - `nonentity` - The sum of tokens without an entity attached
 - `metadata` - Optional product-specific metadata
-   - `billing_start` - The billing start date associated with the reporting cluster (license start date if not configured)
+   - `billing_start` - The billing start date associated with the reporting cluster (license start date if not configured).
+   
+   <Note title="Important change to supported versions">
+      
+      As of 1.16.7, 1.17.3 and later, 
+      the <a href="/vault/docs/concepts/billing-start-date">billing start date</a> automatically 
+      rolls over to the latest billing year at the end of the last cycle.
+        
+      For more information, refer to the upgrade guide for your Vault version:
+
+      [Vault v1.16.x](/vault/docs/upgrading/upgrade-to-1.16.x#auto-rolled-billing-start-date),
+      [Vault v1.17.x](/vault/docs/upgrading/upgrade-to-1.17.x#auto-rolled-billing-start-date)
+
+    </Note> 
+    
    - `cluster_id` - The cluster UUID as shown by `vault status` on the reporting
      cluster
    

--- a/website/content/docs/upgrading/upgrade-to-1.16.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.16.x.mdx
@@ -88,6 +88,14 @@ operation called an activation-flag. The feature is gated until a Vault operator
 decides to trigger the flag. More information can be found in the
 [secrets sync documentation](/vault/docs/sync#activating-the-feature).
 
+### Auto-rolled billing start date
+
+As of 1.16.7 and later, the billing start date (license start date if not configured) automatically rolls over to the latest billing year at the end of the last cycle. 
+
+@include 'auto-roll-billing-start.mdx'
+
+@include 'auto-roll-billing-start-example.mdx'
+
 ## Known issues and workarounds
 
 @include 'known-issues/1_16-jwt_auth_bound_audiences.mdx'

--- a/website/content/partials/auto-roll-billing-start-example.mdx
+++ b/website/content/partials/auto-roll-billing-start-example.mdx
@@ -1,0 +1,8 @@
+
+The default billing start date used in queries and license utilization reporting will be automatically adjusted to the latest billing year. Past year billing information will still be retained.
+
+For example, assume a customer has signed a deal for 3 years with a license start date of Dec 1, 2023. After upgrading to the version with this change, the billing start date 
+auto-rolls to the most recent year.
+- If the upgrade happens on Sept 1, 2024, the billing start date will continue to be Dec 1, 2023. Once we reach Dec 1, 2024, the billing start date 
+will automatically roll to Dec 1, 2024. 
+- If the upgrade happens on Dec 15, 2024, the billing start date should automatically roll to Dec 1, 2024 after upgrade.

--- a/website/content/partials/auto-roll-billing-start.mdx
+++ b/website/content/partials/auto-roll-billing-start.mdx
@@ -1,0 +1,3 @@
+
+This means that the billing start dates from earlier years will get updated to current calendar year, unless the date has not yet occured this year, in which case 
+it will remain in the last calendar year. The billing start date will adjust accordingly for leap years.

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -258,6 +258,10 @@
         "path": "concepts/resource-quotas"
       },
       {
+        "title": "Billing Start Date",
+        "path": "concepts/billing-start-date"
+      },
+      {
         "title": "Client count",
         "routes": [
           {


### PR DESCRIPTION
* auto-roll docs changes

* addressing comments

* address comments

* Update website/content/api-docs/system/internal-counters.mdx



* addressing some changes

* update docs

* update docs with common explanation file

* updated note info

* fix 1.18 upgrade doc

* fix content-check error

* Update website/content/partials/auto-roll-billing-start-example.mdx



---------

### Description
What does this PR do?

### TODO only if you're a HashiCorp employee
- [ ] **Labels:** If this PR is the CE portion of an ENT change, and that ENT change is
  getting backported to N-2, use the new style `backport/ent/x.x.x+ent` labels
  instead of the old style `backport/x.x.x` labels.
- [ ] **Labels:** If this PR is a CE only change, it can only be backported to N, so use
  the normal `backport/x.x.x` label (there should be only 1).
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
