### PR TITLE
VAULT-29583: Modernize default distributions in enos scenarios

### DIFF
--- a/.github/workflows/test-run-enos-scenario-matrix.yml
+++ b/.github/workflows/test-run-enos-scenario-matrix.yml
@@ -98,7 +98,7 @@ jobs:
       ENOS_VAR_vault_revision: ${{ inputs.vault-revision }}
       ENOS_VAR_consul_license_path: ./support/consul.hclic
       ENOS_VAR_vault_license_path: ./support/vault.hclic
-      ENOS_VAR_distro_version_amzn2: ${{ matrix.attributes.distro_version_amzn2 }}
+      ENOS_VAR_distro_version_amzz: ${{ matrix.attributes.distro_version_amzn }}
       ENOS_VAR_distro_version_leap: ${{ matrix.attributes.distro_version_leap }}
       ENOS_VAR_distro_version_rhel: ${{ matrix.attributes.distro_version_rhel }}
       ENOS_VAR_distro_version_sles: ${{ matrix.attributes.distro_version_sles }}

--- a/enos/enos-dev-scenario-pr-replication.hcl
+++ b/enos/enos-dev-scenario-pr-replication.hcl
@@ -77,7 +77,7 @@ scenario "dev_pr_replication" {
   matrix {
     arch              = ["amd64", "arm64"]
     artifact          = ["local", "deb", "rpm", "zip"]
-    distro            = ["amzn2", "leap", "rhel", "sles", "ubuntu"]
+    distro            = ["amzn", "leap", "rhel", "sles", "ubuntu"]
     edition           = ["ent", "ent.fips1402", "ent.hsm", "ent.hsm.fips1402"]
     primary_backend   = ["consul", "raft"]
     primary_seal      = ["awskms", "pkcs11", "shamir"]
@@ -129,7 +129,7 @@ scenario "dev_pr_replication" {
     // The enos provider uses different ssh transport configs for different distros (as
     // specified in enos-providers.hcl), and we need to be able to access both of those here.
     enos_provider = {
-      amzn2  = provider.enos.ec2_user
+      amzn   = provider.enos.ec2_user
       leap   = provider.enos.ec2_user
       rhel   = provider.enos.ec2_user
       sles   = provider.enos.ec2_user
@@ -373,7 +373,7 @@ scenario "dev_pr_replication" {
     }
 
     variables {
-      ami_id          = step.ec2_info.ami_ids["arm64"]["ubuntu"]["22.04"]
+      ami_id          = step.ec2_info.ami_ids["arm64"]["ubuntu"][global.distro_version["ubuntu"]]
       cluster_tag_key = global.backend_tag_key
       common_tags     = global.tags
       seal_key_names  = step.create_primary_seal_key.resource_names
@@ -419,7 +419,7 @@ scenario "dev_pr_replication" {
     }
 
     variables {
-      ami_id          = step.ec2_info.ami_ids["arm64"]["ubuntu"]["22.04"]
+      ami_id          = step.ec2_info.ami_ids["arm64"]["ubuntu"][global.distro_version["ubuntu"]]
       cluster_tag_key = global.backend_tag_key
       common_tags     = global.tags
       seal_key_names  = step.create_secondary_seal_key.resource_names
@@ -523,7 +523,7 @@ scenario "dev_pr_replication" {
       license              = step.read_vault_license.license
       local_artifact_path  = matrix.artifact == "local" ? abspath(var.vault_artifact_path) : null
       manage_service       = local.manage_service
-      packages             = concat(global.packages, global.distro_packages[matrix.distro])
+      packages             = concat(global.packages, global.distro_packages[matrix.distro][global.distro_version[matrix.distro]])
       release              = matrix.artifact == "zip" ? { version = var.vault_product_version, edition = matrix.edition } : null
       seal_attributes      = step.create_primary_seal_key.attributes
       seal_type            = matrix.primary_seal
@@ -626,7 +626,7 @@ scenario "dev_pr_replication" {
       license              = step.read_vault_license.license
       local_artifact_path  = matrix.artifact == "local" ? abspath(var.vault_artifact_path) : null
       manage_service       = local.manage_service
-      packages             = concat(global.packages, global.distro_packages[matrix.distro])
+      packages             = concat(global.packages, global.distro_packages[matrix.distro][global.distro_version[matrix.distro]])
       release              = matrix.artifact == "zip" ? { version = var.vault_product_version, edition = matrix.edition } : null
       seal_attributes      = step.create_secondary_seal_key.attributes
       seal_type            = matrix.secondary_seal

--- a/enos/enos-dev-scenario-single-cluster.hcl
+++ b/enos/enos-dev-scenario-single-cluster.hcl
@@ -75,7 +75,7 @@ scenario "dev_single_cluster" {
     arch     = ["amd64", "arm64"]
     artifact = ["local", "deb", "rpm", "zip"]
     backend  = ["consul", "raft"]
-    distro   = ["amzn2", "leap", "rhel", "sles", "ubuntu"]
+    distro   = ["amzn", "leap", "rhel", "sles", "ubuntu"]
     edition  = ["ce", "ent", "ent.fips1402", "ent.hsm", "ent.hsm.fips1402"]
     seal     = ["awskms", "pkcs11", "shamir"]
 
@@ -121,7 +121,7 @@ scenario "dev_single_cluster" {
     // The enos provider uses different ssh transport configs for different distros (as
     // specified in enos-providers.hcl), and we need to be able to access both of those here.
     enos_provider = {
-      amzn2  = provider.enos.ec2_user
+      amzn   = provider.enos.ec2_user
       leap   = provider.enos.ec2_user
       rhel   = provider.enos.ec2_user
       sles   = provider.enos.ec2_user
@@ -341,7 +341,7 @@ scenario "dev_single_cluster" {
     }
 
     variables {
-      ami_id          = step.ec2_info.ami_ids["arm64"]["ubuntu"]["22.04"]
+      ami_id          = step.ec2_info.ami_ids["arm64"]["ubuntu"][global.distro_version["ubuntu"]]
       cluster_tag_key = global.backend_tag_key
       common_tags     = global.tags
       seal_key_names  = step.create_seal_key.resource_names
@@ -445,7 +445,7 @@ scenario "dev_single_cluster" {
       license              = matrix.edition != "ce" ? step.read_vault_license.license : null
       local_artifact_path  = matrix.artifact == "local" ? abspath(var.vault_artifact_path) : null
       manage_service       = local.manage_service
-      packages             = concat(global.packages, global.distro_packages[matrix.distro])
+      packages             = concat(global.packages, global.distro_packages[matrix.distro][global.distro_version[matrix.distro]])
       release              = matrix.artifact == "zip" ? { version = var.vault_product_version, edition = matrix.edition } : null
       seal_attributes      = step.create_seal_key.attributes
       seal_type            = matrix.seal

--- a/enos/enos-globals.hcl
+++ b/enos/enos-globals.hcl
@@ -18,20 +18,34 @@ globals {
   config_modes    = ["env", "file"]
   consul_editions = ["ce", "ent"]
   consul_versions = ["1.14.11", "1.15.7", "1.16.3", "1.17.0"]
-  distros         = ["amzn2", "leap", "rhel", "sles", "ubuntu"]
+  distros         = ["amzn", "leap", "rhel", "sles", "ubuntu"]
   // Different distros may require different packages, or use different aliases for the same package
   distro_packages = {
-    amzn2 = ["nc"]
-    leap  = ["netcat", "openssl"]
-    rhel  = ["nc"]
-    // When installing Vault RPM packages on a SLES AMI, the openssl package provided
-    // isn't named "openssl, which rpm doesn't know how to handle. Therefore we add the
-    // "correctly" named one in our package installation before installing Vault.
-    sles   = ["netcat-openbsd", "openssl"]
-    ubuntu = ["netcat"]
+    amzn = {
+      "2"    = ["nc"]
+      "2023" = ["nc"]
+    }
+    leap = {
+      "15.6" = ["netcat", "openssl"]
+    }
+    rhel = {
+      "8.10" = ["nc"]
+      "9.4"  = ["nc"]
+    }
+    sles = {
+      // When installing Vault RPM packages on a SLES AMI, the openssl package provided
+      // isn't named "openssl, which rpm doesn't know how to handle. Therefore we add the
+      // "correctly" named one in our package installation before installing Vault.
+      "15.6" = ["netcat-openbsd", "openssl"]
+    }
+    ubuntu = {
+      "20.04" = ["netcat"]
+      "22.04" = ["netcat"]
+      "24.04" = ["netcat-openbsd"]
+    }
   }
   distro_version = {
-    amzn2  = var.distro_version_amzn2
+    amzn   = var.distro_version_amzn
     leap   = var.distro_version_leap
     rhel   = var.distro_version_rhel
     sles   = var.distro_version_sles
@@ -41,7 +55,7 @@ globals {
   enterprise_editions = [for e in global.editions : e if e != "ce"]
   ip_versions         = ["4", "6"]
   package_manager = {
-    "amzn2"  = "yum"
+    "amzn"   = "yum"
     "leap"   = "zypper"
     "rhel"   = "yum"
     "sles"   = "zypper"
@@ -134,11 +148,11 @@ globals {
   }
   sample_attributes = {
     aws_region            = ["us-east-1", "us-west-2"]
-    distro_version_amzn2  = ["2"]
-    distro_version_leap   = ["15.5"]
-    distro_version_rhel   = ["8.9", "9.3"]
-    distro_version_sles   = ["v15_sp5_standard"]
-    distro_version_ubuntu = ["20.04", "22.04"]
+    distro_version_amzn   = ["2023"]
+    distro_version_leap   = ["15.6"]
+    distro_version_rhel   = ["8.10", "9.4"]
+    distro_version_sles   = ["15.6"]
+    distro_version_ubuntu = ["20.04", "24.04"]
   }
   seals = ["awskms", "pkcs11", "shamir"]
   tags = merge({

--- a/enos/enos-samples-ce-build.hcl
+++ b/enos/enos-samples-ce-build.hcl
@@ -97,7 +97,7 @@ sample "build_ce_linux_arm64_rpm" {
       arch            = ["arm64"]
       artifact_source = ["crt"]
       artifact_type   = ["package"]
-      distro          = ["amzn2", "rhel", "sles"]
+      distro          = ["amzn", "rhel", "sles"]
       edition         = ["ce"]
     }
   }
@@ -107,7 +107,7 @@ sample "build_ce_linux_arm64_rpm" {
       arch            = ["arm64"]
       artifact_source = ["crt"]
       artifact_type   = ["package"]
-      distro          = ["amzn2", "rhel", "sles"]
+      distro          = ["amzn", "rhel", "sles"]
       edition         = ["ce"]
     }
   }
@@ -117,7 +117,7 @@ sample "build_ce_linux_arm64_rpm" {
       arch            = ["arm64"]
       artifact_source = ["crt"]
       artifact_type   = ["package"]
-      distro          = ["amzn2", "rhel", "sles"]
+      distro          = ["amzn", "rhel", "sles"]
       edition         = ["ce"]
     }
   }
@@ -127,7 +127,7 @@ sample "build_ce_linux_arm64_rpm" {
       arch            = ["arm64"]
       artifact_source = ["crt"]
       artifact_type   = ["package"]
-      distro          = ["amzn2", "rhel", "sles"]
+      distro          = ["amzn", "rhel", "sles"]
       edition         = ["ce"]
     }
   }
@@ -141,7 +141,7 @@ sample "build_ce_linux_amd64_rpm" {
       arch            = ["amd64"]
       artifact_source = ["crt"]
       artifact_type   = ["package"]
-      distro          = ["amzn2", "leap", "rhel", "sles"]
+      distro          = ["amzn", "leap", "rhel", "sles"]
       edition         = ["ce"]
     }
   }
@@ -151,7 +151,7 @@ sample "build_ce_linux_amd64_rpm" {
       arch            = ["amd64"]
       artifact_source = ["crt"]
       artifact_type   = ["package"]
-      distro          = ["amzn2", "leap", "rhel", "sles"]
+      distro          = ["amzn", "leap", "rhel", "sles"]
       edition         = ["ce"]
     }
   }
@@ -161,7 +161,7 @@ sample "build_ce_linux_amd64_rpm" {
       arch            = ["amd64"]
       artifact_source = ["crt"]
       artifact_type   = ["package"]
-      distro          = ["amzn2", "leap", "rhel", "sles"]
+      distro          = ["amzn", "leap", "rhel", "sles"]
       edition         = ["ce"]
     }
   }
@@ -171,7 +171,7 @@ sample "build_ce_linux_amd64_rpm" {
       arch            = ["amd64"]
       artifact_source = ["crt"]
       artifact_type   = ["package"]
-      distro          = ["amzn2", "leap", "rhel", "sles"]
+      distro          = ["amzn", "leap", "rhel", "sles"]
       edition         = ["ce"]
 
       exclude {
@@ -191,7 +191,7 @@ sample "build_ce_linux_amd64_zip" {
       arch            = ["amd64"]
       artifact_type   = ["bundle"]
       artifact_source = ["crt"]
-      distro          = ["amzn2", "ubuntu"]
+      distro          = ["amzn", "ubuntu"]
       edition         = ["ce"]
     }
   }
@@ -201,7 +201,7 @@ sample "build_ce_linux_amd64_zip" {
       arch            = ["amd64"]
       artifact_type   = ["bundle"]
       artifact_source = ["crt"]
-      distro          = ["amzn2", "ubuntu"]
+      distro          = ["amzn", "ubuntu"]
       edition         = ["ce"]
     }
   }
@@ -211,7 +211,7 @@ sample "build_ce_linux_amd64_zip" {
       arch            = ["amd64"]
       artifact_type   = ["bundle"]
       artifact_source = ["crt"]
-      distro          = ["amzn2", "ubuntu"]
+      distro          = ["amzn", "ubuntu"]
       edition         = ["ce"]
     }
   }
@@ -221,7 +221,7 @@ sample "build_ce_linux_amd64_zip" {
       arch            = ["amd64"]
       artifact_type   = ["bundle"]
       artifact_source = ["crt"]
-      distro          = ["amzn2", "ubuntu"]
+      distro          = ["amzn", "ubuntu"]
       edition         = ["ce"]
     }
   }
@@ -235,7 +235,7 @@ sample "build_ce_linux_arm64_zip" {
       arch            = ["arm64"]
       artifact_source = ["crt"]
       artifact_type   = ["bundle"]
-      distro          = ["amzn2", "ubuntu"]
+      distro          = ["amzn", "ubuntu"]
       edition         = ["ce"]
     }
   }
@@ -245,7 +245,7 @@ sample "build_ce_linux_arm64_zip" {
       arch            = ["arm64"]
       artifact_source = ["crt"]
       artifact_type   = ["bundle"]
-      distro          = ["amzn2", "ubuntu"]
+      distro          = ["amzn", "ubuntu"]
       edition         = ["ce"]
     }
   }
@@ -255,7 +255,7 @@ sample "build_ce_linux_arm64_zip" {
       arch            = ["arm64"]
       artifact_source = ["crt"]
       artifact_type   = ["bundle"]
-      distro          = ["amzn2", "ubuntu"]
+      distro          = ["amzn", "ubuntu"]
       edition         = ["ce"]
     }
   }
@@ -265,7 +265,7 @@ sample "build_ce_linux_arm64_zip" {
       arch            = ["arm64"]
       artifact_source = ["crt"]
       artifact_type   = ["bundle"]
-      distro          = ["amzn2", "ubuntu"]
+      distro          = ["amzn", "ubuntu"]
       edition         = ["ce"]
     }
   }

--- a/enos/enos-samples-ce-release.hcl
+++ b/enos/enos-samples-ce-release.hcl
@@ -97,7 +97,7 @@ sample "release_ce_linux_arm64_rpm" {
       arch            = ["arm64"]
       artifact_source = ["artifactory"]
       artifact_type   = ["package"]
-      distro          = ["amzn2", "rhel", "sles"]
+      distro          = ["amzn", "rhel", "sles"]
       edition         = ["ce"]
     }
   }
@@ -107,7 +107,7 @@ sample "release_ce_linux_arm64_rpm" {
       arch            = ["arm64"]
       artifact_source = ["artifactory"]
       artifact_type   = ["package"]
-      distro          = ["amzn2", "rhel", "sles"]
+      distro          = ["amzn", "rhel", "sles"]
       edition         = ["ce"]
     }
   }
@@ -117,7 +117,7 @@ sample "release_ce_linux_arm64_rpm" {
       arch            = ["arm64"]
       artifact_source = ["artifactory"]
       artifact_type   = ["package"]
-      distro          = ["amzn2", "rhel", "sles"]
+      distro          = ["amzn", "rhel", "sles"]
       edition         = ["ce"]
     }
   }
@@ -127,7 +127,7 @@ sample "release_ce_linux_arm64_rpm" {
       arch            = ["arm64"]
       artifact_source = ["artifactory"]
       artifact_type   = ["package"]
-      distro          = ["amzn2", "rhel", "sles"]
+      distro          = ["amzn", "rhel", "sles"]
       edition         = ["ce"]
     }
   }
@@ -141,7 +141,7 @@ sample "release_ce_linux_amd64_rpm" {
       arch            = ["amd64"]
       artifact_source = ["artifactory"]
       artifact_type   = ["package"]
-      distro          = ["amzn2", "leap", "rhel", "sles"]
+      distro          = ["amzn", "leap", "rhel", "sles"]
       edition         = ["ce"]
     }
   }
@@ -151,7 +151,7 @@ sample "release_ce_linux_amd64_rpm" {
       arch            = ["amd64"]
       artifact_source = ["artifactory"]
       artifact_type   = ["package"]
-      distro          = ["amzn2", "leap", "rhel", "sles"]
+      distro          = ["amzn", "leap", "rhel", "sles"]
       edition         = ["ce"]
     }
   }
@@ -161,7 +161,7 @@ sample "release_ce_linux_amd64_rpm" {
       arch            = ["amd64"]
       artifact_source = ["artifactory"]
       artifact_type   = ["package"]
-      distro          = ["amzn2", "leap", "rhel", "sles"]
+      distro          = ["amzn", "leap", "rhel", "sles"]
       edition         = ["ce"]
     }
   }
@@ -171,7 +171,7 @@ sample "release_ce_linux_amd64_rpm" {
       arch            = ["amd64"]
       artifact_source = ["artifactory"]
       artifact_type   = ["package"]
-      distro          = ["amzn2", "leap", "rhel", "sles"]
+      distro          = ["amzn", "leap", "rhel", "sles"]
       edition         = ["ce"]
     }
   }
@@ -185,7 +185,7 @@ sample "release_ce_linux_amd64_zip" {
       arch            = ["amd64"]
       artifact_type   = ["bundle"]
       artifact_source = ["artifactory"]
-      distro          = ["amzn2", "ubuntu"]
+      distro          = ["amzn", "ubuntu"]
       edition         = ["ce"]
     }
   }
@@ -195,7 +195,7 @@ sample "release_ce_linux_amd64_zip" {
       arch            = ["amd64"]
       artifact_type   = ["bundle"]
       artifact_source = ["artifactory"]
-      distro          = ["amzn2", "ubuntu"]
+      distro          = ["amzn", "ubuntu"]
       edition         = ["ce"]
     }
   }
@@ -205,7 +205,7 @@ sample "release_ce_linux_amd64_zip" {
       arch            = ["amd64"]
       artifact_type   = ["bundle"]
       artifact_source = ["artifactory"]
-      distro          = ["amzn2", "ubuntu"]
+      distro          = ["amzn", "ubuntu"]
       edition         = ["ce"]
     }
   }
@@ -215,7 +215,7 @@ sample "release_ce_linux_amd64_zip" {
       arch            = ["amd64"]
       artifact_type   = ["bundle"]
       artifact_source = ["artifactory"]
-      distro          = ["amzn2", "ubuntu"]
+      distro          = ["amzn", "ubuntu"]
       edition         = ["ce"]
     }
   }
@@ -229,7 +229,7 @@ sample "release_ce_linux_arm64_zip" {
       arch            = ["arm64"]
       artifact_source = ["artifactory"]
       artifact_type   = ["bundle"]
-      distro          = ["amzn2", "ubuntu"]
+      distro          = ["amzn", "ubuntu"]
       edition         = ["ce"]
     }
   }
@@ -239,7 +239,7 @@ sample "release_ce_linux_arm64_zip" {
       arch            = ["arm64"]
       artifact_source = ["artifactory"]
       artifact_type   = ["bundle"]
-      distro          = ["amzn2", "ubuntu"]
+      distro          = ["amzn", "ubuntu"]
       edition         = ["ce"]
     }
   }
@@ -249,7 +249,7 @@ sample "release_ce_linux_arm64_zip" {
       arch            = ["arm64"]
       artifact_source = ["artifactory"]
       artifact_type   = ["bundle"]
-      distro          = ["amzn2", "ubuntu"]
+      distro          = ["amzn", "ubuntu"]
       edition         = ["ce"]
     }
   }
@@ -259,7 +259,7 @@ sample "release_ce_linux_arm64_zip" {
       arch            = ["arm64"]
       artifact_source = ["artifactory"]
       artifact_type   = ["bundle"]
-      distro          = ["amzn2", "ubuntu"]
+      distro          = ["amzn", "ubuntu"]
       edition         = ["ce"]
     }
   }

--- a/enos/enos-scenario-agent.hcl
+++ b/enos/enos-scenario-agent.hcl
@@ -43,17 +43,10 @@ scenario "agent" {
       edition = [for e in matrix.edition : e if !strcontains(e, "hsm")]
     }
 
-    // arm64 AMIs are not offered for Leap
-    exclude {
-      distro = ["leap"]
-      arch   = ["arm64"]
-    }
-
-    // softhsm packages not available for leap/sles. Enos support for softhsm on amzn2 is
-    // not implemented yet.
+    // softhsm packages not available for leap/sles.
     exclude {
       seal   = ["pkcs11"]
-      distro = ["amzn2", "leap", "sles"]
+      distro = ["leap", "sles"]
     }
 
     // Testing in IPV6 mode is currently implemented for integrated Raft storage only
@@ -74,7 +67,7 @@ scenario "agent" {
   locals {
     artifact_path = matrix.artifact_source != "artifactory" ? abspath(var.vault_artifact_path) : null
     enos_provider = {
-      amzn2  = provider.enos.ec2_user
+      amzn   = provider.enos.ec2_user
       leap   = provider.enos.ec2_user
       rhel   = provider.enos.ec2_user
       sles   = provider.enos.ec2_user
@@ -185,7 +178,7 @@ scenario "agent" {
     }
 
     variables {
-      ami_id          = step.ec2_info.ami_ids["arm64"]["ubuntu"]["22.04"]
+      ami_id          = step.ec2_info.ami_ids["arm64"]["ubuntu"][global.distro_version["ubuntu"]]
       cluster_tag_key = global.backend_tag_key
       common_tags     = global.tags
       seal_key_names  = step.create_seal_key.resource_names
@@ -299,7 +292,7 @@ scenario "agent" {
       license              = matrix.edition != "ce" ? step.read_vault_license.license : null
       local_artifact_path  = local.artifact_path
       manage_service       = local.manage_service
-      packages             = concat(global.packages, global.distro_packages[matrix.distro])
+      packages             = concat(global.packages, global.distro_packages[matrix.distro][global.distro_version[matrix.distro]])
       seal_attributes      = step.create_seal_key.attributes
       seal_type            = matrix.seal
       storage_backend      = matrix.backend

--- a/enos/enos-scenario-autopilot.hcl
+++ b/enos/enos-scenario-autopilot.hcl
@@ -55,17 +55,10 @@ scenario "autopilot" {
       edition = [for e in matrix.edition : e if !strcontains(e, "hsm")]
     }
 
-    // arm64 AMIs are not offered for Leap
-    exclude {
-      distro = ["leap"]
-      arch   = ["arm64"]
-    }
-
-    // softhsm packages not available for leap/sles. Enos support for softhsm on amzn2 is
-    // not implemented yet.
+    // softhsm packages not available for leap/sles.
     exclude {
       seal   = ["pkcs11"]
-      distro = ["amzn2", "leap", "sles"]
+      distro = ["leap", "sles"]
     }
 
     // Testing in IPV6 mode is currently implemented for integrated Raft storage only
@@ -86,7 +79,7 @@ scenario "autopilot" {
   locals {
     artifact_path = matrix.artifact_source != "artifactory" ? abspath(var.vault_artifact_path) : null
     enos_provider = {
-      amzn2  = provider.enos.ec2_user
+      amzn   = provider.enos.ec2_user
       leap   = provider.enos.ec2_user
       rhel   = provider.enos.ec2_user
       sles   = provider.enos.ec2_user
@@ -255,7 +248,7 @@ scenario "autopilot" {
       install_dir          = global.vault_install_dir[matrix.artifact_type]
       ip_version           = matrix.ip_version
       license              = matrix.edition != "ce" ? step.read_license.license : null
-      packages             = concat(global.packages, global.distro_packages[matrix.distro])
+      packages             = concat(global.packages, global.distro_packages[matrix.distro][global.distro_version[matrix.distro]])
       release = {
         edition = matrix.edition
         version = matrix.initial_version
@@ -394,7 +387,7 @@ scenario "autopilot" {
       local_artifact_path         = local.artifact_path
       log_level                   = var.vault_log_level
       manage_service              = local.manage_service
-      packages                    = concat(global.packages, global.distro_packages[matrix.distro])
+      packages                    = concat(global.packages, global.distro_packages[matrix.distro][global.distro_version[matrix.distro]])
       root_token                  = step.create_vault_cluster.root_token
       seal_attributes             = step.create_seal_key.attributes
       seal_type                   = matrix.seal

--- a/enos/enos-scenario-proxy.hcl
+++ b/enos/enos-scenario-proxy.hcl
@@ -43,17 +43,10 @@ scenario "proxy" {
       edition = [for e in matrix.edition : e if !strcontains(e, "hsm")]
     }
 
-    // arm64 AMIs are not offered for Leap
-    exclude {
-      distro = ["leap"]
-      arch   = ["arm64"]
-    }
-
-    // softhsm packages not available for leap/sles. Enos support for softhsm on amzn2 is
-    // not implemented yet.
+    // softhsm packages not available for leap/sles.
     exclude {
       seal   = ["pkcs11"]
-      distro = ["amzn2", "leap", "sles"]
+      distro = ["leap", "sles"]
     }
 
     // Testing in IPV6 mode is currently implemented for integrated Raft storage only
@@ -74,7 +67,7 @@ scenario "proxy" {
   locals {
     artifact_path = matrix.artifact_source != "artifactory" ? abspath(var.vault_artifact_path) : null
     enos_provider = {
-      amzn2  = provider.enos.ec2_user
+      amzn   = provider.enos.ec2_user
       leap   = provider.enos.ec2_user
       rhel   = provider.enos.ec2_user
       sles   = provider.enos.ec2_user
@@ -192,7 +185,7 @@ scenario "proxy" {
     }
 
     variables {
-      ami_id          = step.ec2_info.ami_ids["arm64"]["ubuntu"]["22.04"]
+      ami_id          = step.ec2_info.ami_ids["arm64"]["ubuntu"][global.distro_version["ubuntu"]]
       cluster_tag_key = global.backend_tag_key
       common_tags     = global.tags
       seal_key_names  = step.create_seal_key.resource_names
@@ -306,7 +299,7 @@ scenario "proxy" {
       license              = matrix.edition != "ce" ? step.read_vault_license.license : null
       local_artifact_path  = local.artifact_path
       manage_service       = local.manage_service
-      packages             = concat(global.packages, global.distro_packages[matrix.distro])
+      packages             = concat(global.packages, global.distro_packages[matrix.distro][global.distro_version[matrix.distro]])
       seal_attributes      = step.create_seal_key.attributes
       seal_type            = matrix.seal
       storage_backend      = matrix.backend

--- a/enos/enos-scenario-replication.hcl
+++ b/enos/enos-scenario-replication.hcl
@@ -55,22 +55,15 @@ scenario "replication" {
       edition        = [for e in matrix.edition : e if !strcontains(e, "hsm")]
     }
 
-    // arm64 AMIs are not offered for Leap
-    exclude {
-      distro = ["leap"]
-      arch   = ["arm64"]
-    }
-
-    // softhsm packages not available for leap/sles. Enos support for softhsm on amzn2 is
-    // not implemented yet.
+    // softhsm packages not available for leap/sles.
     exclude {
       primary_seal = ["pkcs11"]
-      distro       = ["amzn2", "leap", "sles"]
+      distro       = ["leap", "sles"]
     }
 
     exclude {
       secondary_seal = ["pkcs11"]
-      distro         = ["amzn2", "leap", "sles"]
+      distro         = ["leap", "sles"]
     }
 
     // Testing in IPV6 mode is currently implemented for integrated Raft storage only
@@ -96,7 +89,7 @@ scenario "replication" {
   locals {
     artifact_path = matrix.artifact_source != "artifactory" ? abspath(var.vault_artifact_path) : null
     enos_provider = {
-      amzn2  = provider.enos.ec2_user
+      amzn   = provider.enos.ec2_user
       leap   = provider.enos.ec2_user
       rhel   = provider.enos.ec2_user
       sles   = provider.enos.ec2_user
@@ -230,7 +223,7 @@ scenario "replication" {
     }
 
     variables {
-      ami_id          = step.ec2_info.ami_ids["arm64"]["ubuntu"]["22.04"]
+      ami_id          = step.ec2_info.ami_ids["arm64"]["ubuntu"][global.distro_version["ubuntu"]]
       cluster_tag_key = global.backend_tag_key
       common_tags     = global.tags
       seal_key_names  = step.create_primary_seal_key.resource_names
@@ -288,7 +281,7 @@ scenario "replication" {
     }
 
     variables {
-      ami_id          = step.ec2_info.ami_ids["arm64"]["ubuntu"]["22.04"]
+      ami_id          = step.ec2_info.ami_ids["arm64"]["ubuntu"][global.distro_version["ubuntu"]]
       cluster_tag_key = global.backend_tag_key
       common_tags     = global.tags
       seal_key_names  = step.create_secondary_seal_key.resource_names
@@ -402,7 +395,7 @@ scenario "replication" {
       license              = matrix.edition != "ce" ? step.read_vault_license.license : null
       local_artifact_path  = local.artifact_path
       manage_service       = local.manage_service
-      packages             = concat(global.packages, global.distro_packages[matrix.distro])
+      packages             = concat(global.packages, global.distro_packages[matrix.distro][global.distro_version[matrix.distro]])
       seal_attributes      = step.create_primary_seal_key.attributes
       seal_type            = matrix.primary_seal
       storage_backend      = matrix.primary_backend
@@ -507,7 +500,7 @@ scenario "replication" {
       license              = matrix.edition != "ce" ? step.read_vault_license.license : null
       local_artifact_path  = local.artifact_path
       manage_service       = local.manage_service
-      packages             = concat(global.packages, global.distro_packages[matrix.distro])
+      packages             = concat(global.packages, global.distro_packages[matrix.distro][global.distro_version[matrix.distro]])
       seal_attributes      = step.create_secondary_seal_key.attributes
       seal_type            = matrix.secondary_seal
       storage_backend      = matrix.secondary_backend
@@ -973,7 +966,7 @@ scenario "replication" {
       license             = matrix.edition != "ce" ? step.read_vault_license.license : null
       local_artifact_path = local.artifact_path
       manage_service      = local.manage_service
-      packages            = concat(global.packages, global.distro_packages[matrix.distro])
+      packages            = concat(global.packages, global.distro_packages[matrix.distro][global.distro_version[matrix.distro]])
       root_token          = step.create_primary_cluster.root_token
       seal_attributes     = step.create_primary_seal_key.attributes
       seal_type           = matrix.primary_seal

--- a/enos/enos-scenario-seal-ha.hcl
+++ b/enos/enos-scenario-seal-ha.hcl
@@ -53,22 +53,15 @@ scenario "seal_ha" {
       edition        = [for e in matrix.edition : e if !strcontains(e, "hsm")]
     }
 
-    // arm64 AMIs are not offered for Leap
-    exclude {
-      distro = ["leap"]
-      arch   = ["arm64"]
-    }
-
-    // softhsm packages not available for leap/sles. Enos support for softhsm on amzn2 is
-    // not implemented yet.
+    // softhsm packages not available for leap/sles.
     exclude {
       primary_seal = ["pkcs11"]
-      distro       = ["amzn2", "leap", "sles"]
+      distro       = ["leap", "sles"]
     }
 
     exclude {
       secondary_seal = ["pkcs11"]
-      distro         = ["amzn2", "leap", "sles"]
+      distro         = ["leap", "sles"]
     }
 
     // Testing in IPV6 mode is currently implemented for integrated Raft storage only
@@ -89,7 +82,7 @@ scenario "seal_ha" {
   locals {
     artifact_path = matrix.artifact_source != "artifactory" ? abspath(var.vault_artifact_path) : null
     enos_provider = {
-      amzn2  = provider.enos.ec2_user
+      amzn   = provider.enos.ec2_user
       leap   = provider.enos.ec2_user
       rhel   = provider.enos.ec2_user
       sles   = provider.enos.ec2_user
@@ -224,7 +217,7 @@ scenario "seal_ha" {
     }
 
     variables {
-      ami_id          = step.ec2_info.ami_ids["arm64"]["ubuntu"]["22.04"]
+      ami_id          = step.ec2_info.ami_ids["arm64"]["ubuntu"][global.distro_version["ubuntu"]]
       cluster_tag_key = global.backend_tag_key
       common_tags     = global.tags
       seal_key_names  = step.create_secondary_seal_key.resource_names
@@ -337,7 +330,7 @@ scenario "seal_ha" {
       license              = matrix.edition != "ce" ? step.read_vault_license.license : null
       local_artifact_path  = local.artifact_path
       manage_service       = local.manage_service
-      packages             = concat(global.packages, global.distro_packages[matrix.distro])
+      packages             = concat(global.packages, global.distro_packages[matrix.distro][global.distro_version[matrix.distro]])
       // Only configure our primary seal during our initial cluster setup
       seal_attributes = step.create_primary_seal_key.attributes
       seal_type       = matrix.primary_seal

--- a/enos/enos-scenario-smoke.hcl
+++ b/enos/enos-scenario-smoke.hcl
@@ -42,17 +42,10 @@ scenario "smoke" {
       edition = [for e in matrix.edition : e if !strcontains(e, "hsm")]
     }
 
-    // arm64 AMIs are not offered for Leap
-    exclude {
-      distro = ["leap"]
-      arch   = ["arm64"]
-    }
-
-    // softhsm packages not available for leap/sles. Enos support for softhsm on amzn2 is
-    // not implemented yet.
+    // softhsm packages not available for leap/sles.
     exclude {
       seal   = ["pkcs11"]
-      distro = ["amzn2", "leap", "sles"]
+      distro = ["leap", "sles"]
     }
 
     // Testing in IPV6 mode is currently implemented for integrated Raft storage only
@@ -73,7 +66,7 @@ scenario "smoke" {
   locals {
     artifact_path = matrix.artifact_source != "artifactory" ? abspath(var.vault_artifact_path) : null
     enos_provider = {
-      amzn2  = provider.enos.ec2_user
+      amzn   = provider.enos.ec2_user
       leap   = provider.enos.ec2_user
       rhel   = provider.enos.ec2_user
       sles   = provider.enos.ec2_user
@@ -182,7 +175,7 @@ scenario "smoke" {
     }
 
     variables {
-      ami_id          = step.ec2_info.ami_ids["arm64"]["ubuntu"]["22.04"]
+      ami_id          = step.ec2_info.ami_ids["arm64"]["ubuntu"][global.distro_version["ubuntu"]]
       cluster_tag_key = global.backend_tag_key
       common_tags     = global.tags
       seal_key_names  = step.create_seal_key.resource_names
@@ -296,7 +289,7 @@ scenario "smoke" {
       license              = matrix.edition != "ce" ? step.read_vault_license.license : null
       local_artifact_path  = local.artifact_path
       manage_service       = local.manage_service
-      packages             = concat(global.packages, global.distro_packages[matrix.distro])
+      packages             = concat(global.packages, global.distro_packages[matrix.distro][global.distro_version[matrix.distro]])
       seal_attributes      = step.create_seal_key.attributes
       seal_type            = matrix.seal
       storage_backend      = matrix.backend

--- a/enos/enos-scenario-ui.hcl
+++ b/enos/enos-scenario-ui.hcl
@@ -122,7 +122,7 @@ scenario "ui" {
     }
 
     variables {
-      ami_id          = step.ec2_info.ami_ids[local.arch][local.distro][var.distro_version_ubuntu]
+      ami_id          = step.ec2_info.ami_ids["arm64"]["ubuntu"][global.distro_version["ubuntu"]]
       cluster_tag_key = local.vault_tag_key
       common_tags     = local.tags
       seal_key_names  = step.create_seal_key.resource_names
@@ -140,7 +140,7 @@ scenario "ui" {
     }
 
     variables {
-      ami_id          = step.ec2_info.ami_ids["arm64"]["ubuntu"]["22.04"]
+      ami_id          = step.ec2_info.ami_ids["arm64"]["ubuntu"][global.distro_version["ubuntu"]]
       cluster_tag_key = local.backend_tag_key
       common_tags     = local.tags
       seal_key_names  = step.create_seal_key.resource_names
@@ -252,7 +252,7 @@ scenario "ui" {
       ip_version           = local.ip_version
       license              = matrix.edition != "ce" ? step.read_vault_license.license : null
       local_artifact_path  = local.artifact_path
-      packages             = global.distro_packages["ubuntu"]
+      packages             = concat(global.packages, global.distro_packages["ubuntu"][global.distro_version["ubuntu"]])
       seal_attributes      = step.create_seal_key.attributes
       seal_type            = local.seal
       storage_backend      = matrix.backend

--- a/enos/enos-scenario-upgrade.hcl
+++ b/enos/enos-scenario-upgrade.hcl
@@ -65,17 +65,10 @@ scenario "upgrade" {
       edition = [for e in matrix.edition : e if !strcontains(e, "hsm")]
     }
 
-    // arm64 AMIs are not offered for Leap
-    exclude {
-      distro = ["leap"]
-      arch   = ["arm64"]
-    }
-
-    // softhsm packages not available for leap/sles. Enos support for softhsm on amzn2 is
-    // not implemented yet.
+    // softhsm packages not available for leap/sles.
     exclude {
       seal   = ["pkcs11"]
-      distro = ["amzn2", "leap", "sles"]
+      distro = ["leap", "sles"]
     }
 
     // Testing in IPV6 mode is currently implemented for integrated Raft storage only
@@ -96,7 +89,7 @@ scenario "upgrade" {
   locals {
     artifact_path = matrix.artifact_source != "artifactory" ? abspath(var.vault_artifact_path) : null
     enos_provider = {
-      amzn2  = provider.enos.ec2_user
+      amzn   = provider.enos.ec2_user
       leap   = provider.enos.ec2_user
       rhel   = provider.enos.ec2_user
       sles   = provider.enos.ec2_user
@@ -207,7 +200,7 @@ scenario "upgrade" {
     }
 
     variables {
-      ami_id          = step.ec2_info.ami_ids["arm64"]["ubuntu"]["22.04"]
+      ami_id          = step.ec2_info.ami_ids["arm64"]["ubuntu"][global.distro_version["ubuntu"]]
       cluster_tag_key = global.backend_tag_key
       common_tags     = global.tags
       seal_key_names  = step.create_seal_key.resource_names
@@ -318,7 +311,7 @@ scenario "upgrade" {
       ip_version           = matrix.ip_version
       license              = matrix.edition != "ce" ? step.read_vault_license.license : null
       manage_service       = true # always handle systemd for released bundles
-      packages             = concat(global.packages, global.distro_packages[matrix.distro])
+      packages             = concat(global.packages, global.distro_packages[matrix.distro][global.distro_version[matrix.distro]])
       release = {
         edition = matrix.edition
         version = matrix.initial_version

--- a/enos/enos-variables.hcl
+++ b/enos/enos-variables.hcl
@@ -75,34 +75,34 @@ variable "project_name" {
   default     = "vault-enos-integration"
 }
 
-variable "distro_version_amzn2" {
+variable "distro_version_amzn" {
   description = "The version of Amazon Linux 2 to use"
   type        = string
-  default     = "2"
+  default     = "2023" // or "2", though pkcs11 has not been tested with 2
 }
 
 variable "distro_version_leap" {
   description = "The version of openSUSE leap to use"
   type        = string
-  default     = "15.5"
+  default     = "15.6"
 }
 
 variable "distro_version_rhel" {
   description = "The version of RHEL to use"
   type        = string
-  default     = "9.3" // or "8.9"
+  default     = "9.4" // or "8.10"
 }
 
 variable "distro_version_sles" {
   description = "The version of SUSE SLES to use"
   type        = string
-  default     = "v15_sp5_standard"
+  default     = "15.6"
 }
 
 variable "distro_version_ubuntu" {
   description = "The version of ubuntu to use"
   type        = string
-  default     = "22.04" // or "20.04"
+  default     = "24.04" // or "20.04", "22.04"
 }
 
 variable "tags" {

--- a/enos/enos.vars.hcl
+++ b/enos/enos.vars.hcl
@@ -37,8 +37,8 @@
 // resources.
 // project_name = "vault-enos-integration"
 
-// distro_version_amzn2 is the version of Amazon Linux 2 to use for "distro:amzn2" variants
-// distro_version_amzn2 = "2"
+// distro_version_amzn is the version of Amazon Linux 2 to use for "distro:amzn" variants
+// distro_version_amzn = "2"
 
 // distro_version_leap is the version of openSUSE Leap to use for "distro:leap" variants
 // distro_version_leap = "15.5"

--- a/enos/modules/build_artifactory_artifact/locals.tf
+++ b/enos/modules/build_artifactory_artifact/locals.tf
@@ -6,14 +6,14 @@ locals {
   // file name extensions for the install packages of vault for the various architectures, distributions and editions
   package_extensions = {
     amd64 = {
-      amzn2  = "-1.x86_64.rpm"
+      amzn   = "-1.x86_64.rpm"
       leap   = "-1.x86_64.rpm"
       rhel   = "-1.x86_64.rpm"
       sles   = "-1.x86_64.rpm"
       ubuntu = "-1_amd64.deb"
     }
     arm64 = {
-      amzn2  = "-1.aarch64.rpm"
+      amzn   = "-1.aarch64.rpm"
       leap   = "-1.aarch64.rpm"
       rhel   = "-1.aarch64.rpm"
       sles   = "-1.aarch64.rpm"
@@ -26,7 +26,7 @@ locals {
 
   // file name prefixes for the install packages of vault for the various distributions and artifact types (package or bundle)
   artifact_package_release_names = {
-    amzn2 = {
+    amzn = {
       "ce"               = "vault-"
       "ent"              = "vault-enterprise-",
       "ent.fips1402"     = "vault-enterprise-fips1402-",
@@ -65,7 +65,7 @@ locals {
 
   # Prefix for the artifact name. Ex: vault_, vault-, vault-enterprise_, vault-enterprise-hsm-fips1402-, etc
   artifact_name_prefix = var.artifact_type == "package" ? local.artifact_package_release_names[var.distro][var.edition] : "vault_"
-  # Suffix and extension for the artifact name. Ex: _linux_<arch>.zip, 
+  # Suffix and extension for the artifact name. Ex: _linux_<arch>.zip,
   artifact_name_extension = var.artifact_type == "package" ? local.package_extensions[var.arch][var.distro] : "_linux_${var.arch}.zip"
   # Combine prefix/suffix/extension together to form the artifact name
   artifact_name = var.artifact_type == "package" ? "${local.artifact_name_prefix}${replace(local.artifact_version, "-", "~")}${local.artifact_name_extension}" : "${local.artifact_name_prefix}${var.product_version}${local.artifact_name_extension}"

--- a/enos/modules/ec2_info/main.tf
+++ b/enos/modules/ec2_info/main.tf
@@ -5,52 +5,175 @@
 # and accept SUSE's terms of use. You can do this at the links below. If the AWS account
 # you are using is already subscribed, this confirmation will be displayed on each page.
 # openSUSE Leap arm64 subscription: https://aws.amazon.com/marketplace/server/procurement?productId=a516e959-df54-4035-bb1a-63599b7a6df9
-# openSUSE leap amd64 subscription: https://aws.amazon.com/marketplace/server/procurement?productId=5535c495-72d4-4355-b169-54ffa874f849
+# openSUSE Leap amd64 subscription: https://aws.amazon.com/marketplace/server/procurement?productId=5535c495-72d4-4355-b169-54ffa874f849
 
 locals {
   architectures      = toset(["arm64", "x86_64"])
-  amzn2_owner_id     = "591542846629"
+  amazon_owner_id    = "591542846629"
   canonical_owner_id = "099720109477"
-  sles_owner_id      = "013907871322"
-  suse_owner_id      = "679593333241"
-  rhel_owner_id      = "309956199498"
+  suse_owner_id      = "013907871322"
+  opensuse_owner_id  = "679593333241"
+  redhat_owner_id    = "309956199498"
   ids = {
+    // NOTE: If you modify these versions you'll probably also need to update the `softhsm_install`
+    // module to match.
     "arm64" = {
-      "amzn2" = {
-        "2" = data.aws_ami.amzn2["arm64"].id
+      "amzn" = {
+        "2"    = data.aws_ami.amzn_2["arm64"].id
+        "2023" = data.aws_ami.amzn_2023["arm64"].id
+      }
+      "leap" = {
+        "15.6" = data.aws_ami.leap_15["arm64"].id
       }
       "rhel" = {
-        "8.9" = data.aws_ami.rhel_89["arm64"].id
-        "9.3" = data.aws_ami.rhel_93["arm64"].id
+        "8.10" = data.aws_ami.rhel_8["arm64"].id
+        "9.4"  = data.aws_ami.rhel_9["arm64"].id
       }
       "sles" = {
-        "v15_sp5_standard" = data.aws_ami.sles_15_sp5_standard["arm64"].id
+        "15.6" = data.aws_ami.sles_15["arm64"].id
       }
       "ubuntu" = {
         "20.04" = data.aws_ami.ubuntu_2004["arm64"].id
         "22.04" = data.aws_ami.ubuntu_2204["arm64"].id
+        "24.04" = data.aws_ami.ubuntu_2404["arm64"].id
       }
     }
     "amd64" = {
-      "amzn2" = {
-        "2" = data.aws_ami.amzn2["x86_64"].id
+      "amzn" = {
+        "2"    = data.aws_ami.amzn_2["x86_64"].id
+        "2023" = data.aws_ami.amzn_2023["x86_64"].id
       }
       "leap" = {
-        "15.5" = data.aws_ami.leap_155.id
+        "15.6" = data.aws_ami.leap_15["x86_64"].id
       }
       "rhel" = {
-        "8.9" = data.aws_ami.rhel_89["x86_64"].id
-        "9.3" = data.aws_ami.rhel_93["x86_64"].id
+        "8.10" = data.aws_ami.rhel_8["x86_64"].id
+        "9.4"  = data.aws_ami.rhel_9["x86_64"].id
       }
       "sles" = {
-        "v15_sp5_standard" = data.aws_ami.sles_15_sp5_standard["x86_64"].id
+        "15.6" = data.aws_ami.sles_15["x86_64"].id
       }
       "ubuntu" = {
         "20.04" = data.aws_ami.ubuntu_2004["x86_64"].id
         "22.04" = data.aws_ami.ubuntu_2204["x86_64"].id
+        "24.04" = data.aws_ami.ubuntu_2404["x86_64"].id
       }
     }
   }
+}
+
+data "aws_ami" "amzn_2" {
+  most_recent = true
+  for_each    = local.architectures
+
+  filter {
+    name   = "name"
+    values = ["amzn2-ami-ecs-hvm-2.0*"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = [each.value]
+  }
+
+  owners = [local.amazon_owner_id]
+}
+
+data "aws_ami" "amzn_2023" {
+  most_recent = true
+  for_each    = local.architectures
+
+  filter {
+    name   = "name"
+    values = ["al2023-ami-ecs-hvm*"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = [each.value]
+  }
+
+  owners = [local.amazon_owner_id]
+}
+
+data "aws_ami" "leap_15" {
+  most_recent = true
+  for_each    = local.architectures
+
+  filter {
+    name   = "name"
+    values = ["openSUSE-Leap-15-6*"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = [each.value]
+  }
+
+  owners = [local.opensuse_owner_id]
+}
+
+data "aws_ami" "rhel_8" {
+  most_recent = true
+  for_each    = local.architectures
+
+  # Currently latest latest point release-1
+  filter {
+    name   = "name"
+    values = ["RHEL-8.10*HVM-20*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = [each.value]
+  }
+
+  owners = [local.redhat_owner_id]
+}
+
+data "aws_ami" "rhel_9" {
+  most_recent = true
+  for_each    = local.architectures
+
+  # Currently latest latest point release-1
+  filter {
+    name   = "name"
+    values = ["RHEL-9.4*HVM-20*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = [each.value]
+  }
+
+  owners = [local.redhat_owner_id]
+}
+
+data "aws_ami" "sles_15" {
+  most_recent = true
+  for_each    = local.architectures
+
+  filter {
+    name   = "name"
+    values = ["suse-sles-15-sp6-v*-hvm-*"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = [each.value]
+  }
+
+  owners = [local.suse_owner_id]
 }
 
 data "aws_ami" "ubuntu_2004" {
@@ -97,14 +220,13 @@ data "aws_ami" "ubuntu_2204" {
   owners = [local.canonical_owner_id]
 }
 
-data "aws_ami" "rhel_89" {
+data "aws_ami" "ubuntu_2404" {
   most_recent = true
   for_each    = local.architectures
 
-  # Currently latest latest point release-1
   filter {
     name   = "name"
-    values = ["RHEL-8.9*HVM-20*"]
+    values = ["ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-*-server-*"]
   }
 
   filter {
@@ -117,81 +239,7 @@ data "aws_ami" "rhel_89" {
     values = [each.value]
   }
 
-  owners = [local.rhel_owner_id]
-}
-
-data "aws_ami" "rhel_93" {
-  most_recent = true
-  for_each    = local.architectures
-
-  # Currently latest latest point release-1
-  filter {
-    name   = "name"
-    values = ["RHEL-9.3*HVM-20*"]
-  }
-
-  filter {
-    name   = "virtualization-type"
-    values = ["hvm"]
-  }
-
-  filter {
-    name   = "architecture"
-    values = [each.value]
-  }
-
-  owners = [local.rhel_owner_id]
-}
-
-data "aws_ami" "amzn2" {
-  most_recent = true
-  for_each    = local.architectures
-
-  filter {
-    name   = "name"
-    values = ["amzn2-ami-ecs-hvm-2.0*"]
-  }
-
-  filter {
-    name   = "architecture"
-    values = [each.value]
-  }
-
-  owners = [local.amzn2_owner_id]
-}
-
-data "aws_ami" "sles_15_sp5_standard" {
-  most_recent = true
-  for_each    = local.architectures
-
-  filter {
-    name   = "name"
-    values = ["suse-sles-15-sp5-v*-hvm-*"]
-  }
-
-  filter {
-    name   = "architecture"
-    values = [each.value]
-  }
-
-  owners = [local.sles_owner_id]
-}
-
-data "aws_ami" "leap_155" {
-  most_recent = true
-
-  filter {
-    name   = "name"
-    values = ["openSUSE-Leap-15.5*"]
-  }
-
-  filter {
-    name = "architecture"
-    # Note: arm64 AMIs are not offered for Leap.
-    values = ["x86_64"]
-  }
-
-  owners = [local.suse_owner_id]
+  owners = [local.canonical_owner_id]
 }
 
 data "aws_region" "current" {}

--- a/enos/modules/install_packages/main.tf
+++ b/enos/modules/install_packages/main.tf
@@ -15,8 +15,6 @@ locals {
     "arm64" = "aarch64"
   }
   package_manager = {
-    # Note: though we generally use "amzn2" as our distro name for Amazon Linux 2,
-    # enos_host_info.hosts[each.key].distro returns "amzn", so that is what we reference here.
     "amzn"          = "yum"
     "opensuse-leap" = "zypper"
     "rhel"          = "dnf"
@@ -25,11 +23,11 @@ locals {
   }
   distro_repos = {
     "sles" = {
-      "15.5" = "https://download.opensuse.org/repositories/network:utilities/SLE_15_SP5/network:utilities.repo"
+      "15.6" = "https://download.opensuse.org/repositories/network:utilities/SLE_15_SP6/network:utilities.repo"
     }
     "rhel" = {
-      "8.9" = "https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm"
-      "9.3" = "https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm"
+      "8.10" = "https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm"
+      "9.4"  = "https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm"
     }
   }
 }

--- a/enos/modules/softhsm_create_vault_keys/main.tf
+++ b/enos/modules/softhsm_create_vault_keys/main.tf
@@ -27,7 +27,7 @@ locals {
   aes_label       = "vault_hsm_aes_${local.pin}"
   hmac_label      = "vault_hsm_hmac_${local.pin}"
   seal_attributes = jsondecode(resource.enos_remote_exec.create_keys.stdout)
-  target          = tomap({ "1" = var.hosts[0] })
+  target          = tomap({ "0" = var.hosts[0] })
   token           = "${var.cluster_id}_${local.pin}"
 }
 

--- a/enos/modules/softhsm_distribute_vault_keys/main.tf
+++ b/enos/modules/softhsm_distribute_vault_keys/main.tf
@@ -27,6 +27,7 @@ variable "token_base64" {
 locals {
   // The user/group name for softhsm
   softhsm_groups = {
+    "amzn"   = "ods"
     "rhel"   = "ods"
     "ubuntu" = "softhsm"
   }

--- a/enos/modules/softhsm_init/main.tf
+++ b/enos/modules/softhsm_init/main.tf
@@ -31,6 +31,7 @@ locals {
 
   // Where the default configuration is
   config_paths = {
+    "amzn"   = "/etc/softhsm2.conf"
     "rhel"   = "/etc/softhsm2.conf"
     "ubuntu" = "/etc/softhsm/softhsm2.conf"
   }

--- a/enos/modules/softhsm_install/main.tf
+++ b/enos/modules/softhsm_install/main.tf
@@ -37,14 +37,51 @@ variable "timeout" {
 }
 
 locals {
-  packages = var.include_tools ? ["softhsm", "opensc"] : ["softhsm"]
+  packages = var.include_tools ? {
+    // These packages match the distros that are currently defined in the `ec2_info` module.
+    amzn = {
+      "2023" = ["softhsm", "opensc"]
+    }
+    rhel = {
+      "8.10" = ["softhsm", "opensc"]
+      "9.4"  = ["softhsm", "opensc"]
+    }
+    ubuntu = {
+      "20.04" = ["softhsm", "opensc"]
+      "22.04" = ["softhsm", "opensc"]
+      "24.04" = ["softhsm2", "opensc"]
+    }
+    } : {
+    amzn = {
+      "2023" = ["softhsm"]
+    }
+    rhel = {
+      "8.10" = ["softhsm"]
+      "9.4"  = ["softhsm"]
+    }
+    ubuntu = {
+      "20.04" = ["softhsm"]
+      "22.04" = ["softhsm"]
+      "24.04" = ["softhsm2"]
+    }
+  }
+}
+
+// Get the host information so we can ensure that we install the correct packages depending on the
+// distro and distro version
+resource "enos_host_info" "target" {
+  transport = {
+    ssh = {
+      host = var.hosts["0"].public_ip
+    }
+  }
 }
 
 module "install_softhsm" {
   source = "../install_packages"
 
   hosts    = var.hosts
-  packages = local.packages
+  packages = local.packages[enos_host_info.target.distro][enos_host_info.target.distro_version]
 }
 
 resource "enos_remote_exec" "find_shared_object" {

--- a/enos/modules/vault_cluster/main.tf
+++ b/enos/modules/vault_cluster/main.tf
@@ -119,7 +119,7 @@ resource "enos_consul_start" "consul" {
   config = {
     # GetPrivateInterfaces is a go-sockaddr template that helps Consul get the correct
     # addr in all of our default cases. This is required in the case of Amazon Linux,
-    # because amzn2 has a default docker listener that will make Consul try to use the
+    # because amzn has a default docker listener that will make Consul try to use the
     # incorrect addr.
     bind_addr        = "{{ GetPrivateInterfaces | include \"type\" \"IP\" | sort \"default\" |  limit 1 | attr \"address\"}}"
     data_dir         = var.consul_data_dir

--- a/enos/modules/vault_upgrade/scripts/maybe-remove-old-unit-file.sh
+++ b/enos/modules/vault_upgrade/scripts/maybe-remove-old-unit-file.sh
@@ -19,7 +19,7 @@ fi
 # Get the unit file for the vault.service that is running. If it's not in /etc/systemd then it
 # should be a package provided unit file so we don't need to delete anything.
 #
-# Note that we use -p instead of -P so that we support ancient amzn2 systemctl.
+# Note that we use -p instead of -P so that we support ancient amzn 2 systemctl.
 if ! unit_path=$(systemctl show -p FragmentPath vault | cut -d = -f2 2>&1); then
   echo "Skipped removing unit file because and existing path could not be found: $unit_path"
   exit 0

--- a/enos/modules/vault_verify_version/scripts/verify-cluster-version.sh
+++ b/enos/modules/vault_verify_version/scripts/verify-cluster-version.sh
@@ -31,7 +31,7 @@ if ! out=$(jq -eMc --arg version "$version" '.keys | contains([$version])' <<< "
 fi
 
 if ! out=$(jq -eMc --arg version "$version" --arg bd "$VAULT_BUILD_DATE" '.key_info[$version].build_date == $bd' <<< "$vh"); then
-  fail "cluster version history build date is not the expected date: expected: $VAULT_BUILD_DATE, output: $out"
+  fail "cluster version history build date is not the expected date: expected: true, expected date: $VAULT_BUILD_DATE, key_info: $(jq -eMc '.key_info' <<< "$vh"), output: $out"
 fi
 
 printf "Cluster version information is valid!: %s\n" "$vh"


### PR DESCRIPTION
### Description

Our scenarios have been running the last gen of distributions in CI. This updates our default distributions as follows:
  - Amazon: 2023
  - Leap:   15.6
  - RHEL:   8.10, 9.4
  - SLES:   15.6
  - Ubuntu: 20.04, 24.04

With these changes we also unlock a few new variants combinations:
  - `distro:amzn seal:pkcs11`
  - `arch:arm64 distro:leap`

We also normalize our distro key for Amazon Linux to `amzn`, which matches the uname output on both versions that we've supported.

### TODO only if you're a HashiCorp employee
- [x] **Labels:** If this PR is the CE portion of an ENT change, and that ENT change is
  getting backported to N-2, use the new style `backport/ent/x.x.x+ent` labels
  instead of the old style `backport/x.x.x` labels.
- [x] **Labels:** If this PR is a CE only change, it can only be backported to N, so use
  the normal `backport/x.x.x` label (there should be only 1).
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
