### PR TITLE
Hide Max retries

### DIFF
--- a/ui/app/routes/vault/cluster/secrets/backend/configuration/index.js
+++ b/ui/app/routes/vault/cluster/secrets/backend/configuration/index.js
@@ -77,6 +77,11 @@ export default class SecretsBackendConfigurationRoute extends Route {
     // AWS has two configuration endpoints root and lease, return an array of these responses.
     const configArray = [];
     const configRoot = await this.fetchAwsConfig(id, 'aws/root-config');
+    // maxRetries on configRoot has a default of -1, which would show on the configuration details page regardless of whether it's been set.
+    // check if it's been set and if it hasn't, set to null so it does not show.
+    if (configRoot?.maxRetries === -1) {
+      configRoot.maxRetries = null;
+    }
     const configLease = await this.fetchAwsConfig(id, 'aws/lease-config');
     configArray.push(configRoot, configLease);
     return configArray;

--- a/ui/tests/helpers/secret-engine/secret-engine-helpers.js
+++ b/ui/tests/helpers/secret-engine/secret-engine-helpers.js
@@ -67,7 +67,7 @@ export const createConfig = (store, backend, type) => {
 export const expectedConfigKeys = (type) => {
   switch (type) {
     case 'aws':
-      return ['Access key', 'Region', 'IAM endpoint', 'STS endpoint', 'Maximum retries'];
+      return ['Access key', 'Region', 'IAM endpoint', 'STS endpoint'];
     case 'ssh':
       return ['Public key', 'Generate signing key'];
   }
@@ -83,8 +83,6 @@ const valueOfAwsKeys = (string) => {
       return 'iam-endpoint';
     case 'STS endpoint':
       return 'sts-endpoint';
-    case 'Maximum retries':
-      return '-1';
   }
 };
 


### PR DESCRIPTION
### Description
WIP, can wait to merge after doing the aws merge. But this is a nice-to-have I grabbed while waiting for pr comments.

### TODO only if you're a HashiCorp employee
- [ ] **Labels:** If this PR is the CE portion of an ENT change, and that ENT change is
  getting backported to N-2, use the new style `backport/ent/x.x.x+ent` labels
  instead of the old style `backport/x.x.x` labels.
- [ ] **Labels:** If this PR is a CE only change, it can only be backported to N, so use
  the normal `backport/x.x.x` label (there should be only 1).
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
