### PR TITLE
lint: fix misspel linter install

### DIFF
--- a/.github/actions/set-up-misspell/action.yml
+++ b/.github/actions/set-up-misspell/action.yml
@@ -59,5 +59,5 @@ runs:
         mkdir -p tmp
         gh release download "$VERSION" -p "misspell_*_${OS}_${ARCH}.tar.gz" -O tmp/misspell.tgz -R golangci/misspell
         pushd tmp && tar -xvf misspell.tgz && popd
-        mv tmp/misspell "$DESTINATION"
+        mv tmp/misspell_"$(echo "$VERSION" | tr -d v)"_${OS}_${ARCH}/misspell "$DESTINATION"
         rm -rf tmp


### PR DESCRIPTION
It appears that starting with v0.5.2 the misspell linter embeds the version directory into the release archive.