### PR TITLE
database/postgres: add inline certificate authentication fields

### DIFF
--- a/builtin/logical/database/backend_test.go
+++ b/builtin/logical/database/backend_test.go
@@ -345,6 +345,8 @@ func TestBackend_config_connection(t *testing.T) {
 	assert.Equal(t, "plugin-test", eventSender.Events[2].Event.Metadata.AsMap()["name"])
 }
 
+// TestBackend_BadConnectionString tests that an error response resulting from
+// a failed connection does not expose the URL. The middleware should sanitize it.
 func TestBackend_BadConnectionString(t *testing.T) {
 	cluster, sys := getClusterPostgresDB(t)
 	defer cluster.Cleanup()

--- a/changelog/28024.txt
+++ b/changelog/28024.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+database/postgres: Add new fields to the plugin's config endpoint for client certificate authentication.
+```

--- a/plugins/database/mysql/connection_producer.go
+++ b/plugins/database/mysql/connection_producer.go
@@ -123,11 +123,8 @@ func (c *mySQLConnectionProducer) Init(ctx context.Context, conf map[string]inte
 	}
 
 	// validate auth_type if provided
-	authType := c.AuthType
-	if authType != "" {
-		if ok := connutil.ValidateAuthType(authType); !ok {
-			return nil, fmt.Errorf("invalid auth_type %s provided", authType)
-		}
+	if ok := connutil.ValidateAuthType(c.AuthType); !ok {
+		return nil, fmt.Errorf("invalid auth_type: %s", c.AuthType)
 	}
 
 	if c.AuthType == connutil.AuthTypeGCPIAM {

--- a/plugins/database/postgresql/postgresql.go
+++ b/plugins/database/postgresql/postgresql.go
@@ -116,6 +116,7 @@ func (p *PostgreSQL) Initialize(ctx context.Context, req dbplugin.InitializeRequ
 
 		tlsConfig.RootCAs = caCertPool
 		tlsConfig.ClientCAs = caCertPool
+		p.TLSConfig = tlsConfig
 	}
 
 	if (sslcert != "" && sslkey == "") || (sslcert == "" && sslkey != "") {
@@ -130,9 +131,11 @@ func (p *PostgreSQL) Initialize(ctx context.Context, req dbplugin.InitializeRequ
 			return dbplugin.InitializeResponse{}, fmt.Errorf("unable to load cert: %w", err)
 		}
 		tlsConfig.Certificates = []tls.Certificate{cert}
+		p.TLSConfig = tlsConfig
+	} else {
+		// set to nil to flag that this connection does not use a custom TLS config
+		p.TLSConfig = nil
 	}
-
-	p.TLSConfig = tlsConfig
 
 	newConf, err := p.SQLConnectionProducer.Init(ctx, req.Config, req.VerifyConnection)
 	if err != nil {

--- a/plugins/database/postgresql/postgresql.go
+++ b/plugins/database/postgresql/postgresql.go
@@ -107,6 +107,7 @@ func (p *PostgreSQL) Initialize(ctx context.Context, req dbplugin.InitializeRequ
 		return dbplugin.InitializeResponse{}, fmt.Errorf("failed to retrieve tls_ca: %w", err)
 	}
 
+	useTLS := false
 	tlsConfig := &tls.Config{}
 	if sslrootcert != "" {
 		caCertPool := x509.NewCertPool()
@@ -117,6 +118,7 @@ func (p *PostgreSQL) Initialize(ctx context.Context, req dbplugin.InitializeRequ
 		tlsConfig.RootCAs = caCertPool
 		tlsConfig.ClientCAs = caCertPool
 		p.TLSConfig = tlsConfig
+		useTLS = true
 	}
 
 	if (sslcert != "" && sslkey == "") || (sslcert == "" && sslkey != "") {
@@ -132,7 +134,10 @@ func (p *PostgreSQL) Initialize(ctx context.Context, req dbplugin.InitializeRequ
 		}
 		tlsConfig.Certificates = []tls.Certificate{cert}
 		p.TLSConfig = tlsConfig
-	} else {
+		useTLS = true
+	}
+
+	if !useTLS {
 		// set to nil to flag that this connection does not use a custom TLS config
 		p.TLSConfig = nil
 	}

--- a/sdk/database/helper/connutil/cloudsql.go
+++ b/sdk/database/helper/connutil/cloudsql.go
@@ -10,10 +10,6 @@ import (
 	"cloud.google.com/go/cloudsqlconn/postgres/pgxv4"
 )
 
-var configurableAuthTypes = []string{
-	AuthTypeGCPIAM,
-}
-
 func (c *SQLConnectionProducer) getCloudSQLDriverType() (string, error) {
 	var driverType string
 	// using switch case for future extensibility
@@ -61,16 +57,4 @@ func GetCloudSQLAuthOptions(credentials string, usePrivateIP bool) ([]cloudsqlco
 	}
 
 	return opts, nil
-}
-
-func ValidateAuthType(authType string) bool {
-	var valid bool
-	for _, typ := range configurableAuthTypes {
-		if authType == typ {
-			valid = true
-			break
-		}
-	}
-
-	return valid
 }

--- a/sdk/database/helper/connutil/postgres.go
+++ b/sdk/database/helper/connutil/postgres.go
@@ -46,7 +46,7 @@ import (
 	"github.com/jackc/pgx/v4/stdlib"
 )
 
-// OpenPostgres parses the connection string and opens a connection to the database.
+// openPostgres parses the connection string and opens a connection to the database.
 //
 // If sslinline is set, strips the connection string of all ssl settings and
 // creates a TLS config based on the settings provided, then uses the
@@ -54,8 +54,8 @@ import (
 // because the pgx driver does not support the sslinline parameter and instead
 // expects to source ssl material from the file system.
 //
-// Deprecated: OpenPostgres will be removed in a future version of the Vault SDK.
-func OpenPostgres(driverName, connString string) (*sql.DB, error) {
+// Deprecated: openPostgres will be removed in a future version of the Vault SDK.
+func openPostgres(driverName, connString string) (*sql.DB, error) {
 	if ok, _ := strconv.ParseBool(os.Getenv(pluginutil.PluginUsePostgresSSLInline)); !ok {
 		return nil, fmt.Errorf("failed to open postgres connection with deprecated funtion, set feature flag to enable")
 	}

--- a/sdk/database/helper/connutil/sql.go
+++ b/sdk/database/helper/connutil/sql.go
@@ -165,11 +165,11 @@ func (c *SQLConnectionProducer) Init(ctx context.Context, conf map[string]interf
 
 	if verifyConnection {
 		if _, err := c.Connection(ctx); err != nil {
-			return nil, fmt.Errorf("error verifying connection: %w", err)
+			return nil, errwrap.Wrapf("error verifying connection: {{err}}", err)
 		}
 
 		if err := c.db.PingContext(ctx); err != nil {
-			return nil, fmt.Errorf("error verifying connection: ping failed: %s", err)
+			return nil, errwrap.Wrapf("error verifying connection: ping failed: {{err}}", err)
 		}
 	}
 

--- a/sdk/database/helper/connutil/sql.go
+++ b/sdk/database/helper/connutil/sql.go
@@ -232,6 +232,10 @@ func (c *SQLConnectionProducer) Connection(ctx context.Context) (interface{}, er
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse config: %w", err)
 		}
+		if config.TLSConfig == nil {
+			// handle sslmode=disable
+			config.TLSConfig = &tls.Config{}
+		}
 
 		config.TLSConfig.RootCAs = c.TLSConfig.RootCAs
 		config.TLSConfig.ClientCAs = c.TLSConfig.ClientCAs
@@ -249,7 +253,7 @@ func (c *SQLConnectionProducer) Connection(ctx context.Context) (interface{}, er
 	} else if driverName == dbTypePostgres && os.Getenv(pluginutil.PluginUsePostgresSSLInline) != "" {
 		var err error
 		// TODO: remove this deprecated function call in a future SDK version
-		c.db, err = OpenPostgres(driverName, conn)
+		c.db, err = openPostgres(driverName, conn)
 		if err != nil {
 			return nil, fmt.Errorf("failed to open connection: %w", err)
 		}

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -84,7 +84,7 @@ require (
 	github.com/jackc/pgproto3/v2 v2.3.3 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a // indirect
 	github.com/jackc/pgtype v1.14.0 // indirect
-	github.com/jackc/pgx/v4 v4.18.3 // indirect
+	github.com/jackc/pgx/v4 v4.18.3
 	github.com/joshlf/go-acl v0.0.0-20200411065538-eae00ae38531 // indirect
 	github.com/klauspost/compress v1.16.5 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect


### PR DESCRIPTION
This PR adds support for inline TLS configuration. 

We add new fields to the plugin's config endpoint: `tls_certificate`, `tls_private_key` and `tls_ca`. These fields will take certificate data as a string. This allows Vault Operators and/or development teams to configure TLS when they do not have access to the Vault Server.

Here is an example of configuring TLS inline via the new fields on the plugin’s config endpoint:

```
CONN_URL="user='{{username}}' database='postgres' \
  host='localhost' port='5432' sslmode='verify-full'"

vault write database/config/postgres-db \
  plugin_name=postgresql-database-plugin \
  allowed_roles="*" \
  connection_url="$CONN_URL" \
  username=client \
  tls_certificate="@/path/to/client.crt" \
  tls_private_key="@/path/to/client.key" \
  tls_ca="@/path/to/ca.crt"
```

The `@` in the CLI argument indicates a path to a file on disk to be read.