### PR TITLE
Set broken `notify` systemd unit type back to `simple`.

### DIFF
--- a/.release/linux/package/usr/lib/systemd/system/vault.service
+++ b/.release/linux/package/usr/lib/systemd/system/vault.service
@@ -8,7 +8,7 @@ StartLimitIntervalSec=60
 StartLimitBurst=3
 
 [Service]
-Type=notify
+Type=simple
 EnvironmentFile=/etc/vault.d/vault.env
 User=vault
 Group=vault


### PR DESCRIPTION
This should never have been changed. The systemd unit in production is currently invalid using the vault binary in `ExecStart` instead of a proper dbus notify script.

Reversing https://github.com/hashicorp/vault/pull/14385

### Description
This PR fixes pull 14385 which never should have been merged and introduced a broken systemd unit into production customer environments of Vault and Vault Enterprise.  The fact an outsider whithout understanding of systemd got an invalid merge into production packaging is alarming.

Issue: https://github.com/hashicorp/vault/issues/27935