### PR TITLE
SDK: fix docker helper (explicitly add `iptables`)

### DIFF
--- a/sdk/helper/testcluster/docker/environment.go
+++ b/sdk/helper/testcluster/docker/environment.go
@@ -1008,6 +1008,7 @@ func (n *DockerClusterNode) PartitionFromCluster(ctx context.Context) error {
 		"-xec", strings.Join([]string{
 			fmt.Sprintf("echo partitioning container from network"),
 			"apk add iproute2",
+			"apk add iptables",
 			// Get the gateway address for the bridge so we can allow host to
 			// container traffic still.
 			"GW=$(ip r | grep default | grep eth0 | cut -f 3 -d' ')",


### PR DESCRIPTION
### Description

The most recent version of `Alpine` doesn't appear to automatically add `iptables` like it used to, which caused some Enterprise (external) tests to fail.

The reason we are seeing this now is that we made a change to stay up to date with latest: https://github.com/hashicorp/vault/pull/27971 and we've gone from Alpine 3.18 to 3.19.

ENT PR: https://github.com/hashicorp/vault-enterprise/pull/6420

### HashiCorp Checklist

- [x] **Labels:** If this PR is the CE portion of an ENT change, and that ENT change is
  getting backported to N-2, use the new style `backport/ent/x.x.x+ent` labels
  instead of the old style `backport/x.x.x` labels.
- [x] **Labels:** If this PR is a CE only change, it can only be backported to N, so use
  the normal `backport/x.x.x` label (there should be only 1).
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
