### PR TITLE
UI [to sidebranch]: Update CC mirage filtering

### DIFF
--- a/ui/mirage/handlers/clients.js
+++ b/ui/mirage/handlers/clients.js
@@ -214,6 +214,16 @@ function calcCounts(arr) {
 }
 
 /**
+ * Helper fn to filter namespaces to include the namespace itself, and any children
+ */
+function filterByNamespace(namespaces, namespacePath) {
+  // if we simply do a check for startsWith, filtering for `ns1` will include `ns11` as well as the desired `ns1/child`
+  return namespaces.filter(
+    (ns) => ns.namespace_path === namespacePath || ns.namespace_path.startsWith(`${namespacePath}/`)
+  );
+}
+
+/**
  * Helper fn to filter months data from activity response
  */
 function filterMonths(months, namespacePath) {
@@ -223,13 +233,11 @@ function filterMonths(months, namespacePath) {
     const newMonth = {
       ...month,
     };
-    const filteredNs = month.namespaces.filter((ns) => ns.namespace_path.startsWith(namespacePath));
+    const filteredNs = filterByNamespace(month.namespaces, namespacePath);
     const monthsCount = calcCounts(filteredNs);
 
     if (month.new_clients?.namespaces) {
-      const filteredNewNs = month.new_clients.namespaces.filter((ns) =>
-        ns.namespace_path.startsWith(namespacePath)
-      );
+      const filteredNewNs = filterByNamespace(month.new_clients.namespaces, namespacePath);
       const newCount = calcCounts(filteredNewNs);
 
       newMonth.new_clients.namespaces = filteredNewNs;
@@ -250,7 +258,7 @@ export function filterActivityResponse(data, namespacePath) {
   const { by_namespace, months } = data;
 
   const filteredMonths = filterMonths(months, namespacePath);
-  const filteredNs = by_namespace.filter((ns) => ns.namespace_path.startsWith(namespacePath));
+  const filteredNs = filterByNamespace(by_namespace, namespacePath);
   const filteredTotals = calcCounts(filteredNs);
   return {
     ...data,


### PR DESCRIPTION
### Description
This PR updates our Mirage scenario for client counts so that it filters based on the passed namespace header, similar to what the API does. Before, when using the clients mirage scenario, the activity response would stay the same when filtering by a namespace. Now, it filters the data consistently so we won't have weird unreliable numbers. 

To show what changed, in the GIF below I am logging the number `activity.total.clients` coming from the response, which should match the running total in the UI. Before this change the number would stay the same as when we are not filtering by a namespace. 

![Kapture 2024-08-08 at 16 06 43](https://github.com/user-attachments/assets/e46df902-231b-423d-b18b-738def17460f)

No user-facing changes, but this will be essential for updating the filter behavior without breaking a bunch of tests.

This doesn't *really* have to go into the sidebranch, other than I updated a test that only exists there. If the team's preference is to get this into main first I can update it. 

- [x] Ent tests pass
