### PR TITLE
[Docs] Add cross referencing link to AppRole usage best practices

### DIFF
--- a/website/content/docs/auth/approle.mdx
+++ b/website/content/docs/auth/approle.mdx
@@ -236,9 +236,15 @@ belonging to configured CIDR blocks on the AppRole.
 
 ## Tutorial
 
-Refer to the [AppRole Pull
-Authentication](/vault/tutorials/auth-methods/approle)
-tutorial to learn how to use the AppRole method to generate tokens for machines or apps.
+Refer to the following tutorials to learn more:
+
+- [AppRole Pull Authentication](/vault/tutorials/auth-methods/approle) tutorial
+to learn how to use the AppRole method to generate tokens for machines or apps.
+
+- [AppRole usage best
+  practices](/vault/tutorials/auth-methods/approle-best-practices) to understand
+  the best practices in securely distributing the AppRole credentials to the
+  target Vault clients.
 
 ## User lockout
 

--- a/website/content/docs/auth/approle.mdx
+++ b/website/content/docs/auth/approle.mdx
@@ -239,12 +239,13 @@ belonging to configured CIDR blocks on the AppRole.
 Refer to the following tutorials to learn more:
 
 - [AppRole Pull Authentication](/vault/tutorials/auth-methods/approle) tutorial
-to learn how to use the AppRole method to generate tokens for machines or apps.
+  to learn how to use the AppRole auth method to generate tokens for machines or
+  apps.
 
 - [AppRole usage best
   practices](/vault/tutorials/auth-methods/approle-best-practices) to understand
-  the best practices in securely distributing the AppRole credentials to the
-  target Vault clients.
+  the recommendation for distributing the AppRole credentials to the target
+  Vault clients.
 
 ## User lockout
 


### PR DESCRIPTION
### Description

This PR is related to a tutorial PR: https://github.com/hashicorp/tutorials/pull/2210 and its Jira ticket (https://hashicorp.atlassian.net/browse/VAULT-11085).

To make the best practices guide to be more discoverable, adding a link to the AppRole doc page.

🔍 [Deploy preview](https://vault-hqeodnfnp-hashicorp.vercel.app/vault/docs/auth/approle#tutorial)

----

### TODO only if you're a HashiCorp employee
- [ ] **Labels:** If this PR is the CE portion of an ENT change, and that ENT change is
  getting backported to N-2, use the new style `backport/ent/x.x.x+ent` labels
  instead of the old style `backport/x.x.x` labels.
- [x] **Labels:** If this PR is a CE only change, it can only be backported to N, so use
  the normal `backport/x.x.x` label (there should be only 1).
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
