### PR TITLE
UI: Move Client Count filtering

### DIFF
--- a/ui/app/components/clients/activity.ts
+++ b/ui/app/components/clients/activity.ts
@@ -10,15 +10,18 @@ import Component from '@glimmer/component';
 import { isSameMonth } from 'date-fns';
 import { parseAPITimestamp } from 'core/utils/date-formatters';
 import { calculateAverage } from 'vault/utils/chart-helpers';
-import { filterVersionHistory, hasMountsKey, hasNamespacesKey } from 'core/utils/client-count-utils';
+import { filterVersionHistory } from 'core/utils/client-count-utils';
 
 import type ClientsActivityModel from 'vault/models/clients/activity';
 import type ClientsVersionHistoryModel from 'vault/models/clients/version-history';
 import type {
+  ByMonthClients,
   ByMonthNewClients,
+  MountByKey,
   MountNewClients,
   NamespaceByKey,
   NamespaceNewClients,
+  TotalClients,
 } from 'core/utils/client-count-utils';
 
 interface Args {
@@ -28,8 +31,11 @@ interface Args {
   endTimestamp: string;
   namespace: string;
   mountPath: string;
+  filteredByMonth: ByMonthClients[] | MountByKey[];
+  filteredTotals: TotalClients | undefined;
 }
 
+// Component class extended by Clients::Page::* components
 export default class ClientsActivityComponent extends Component<Args> {
   average = (
     data:
@@ -41,45 +47,11 @@ export default class ClientsActivityComponent extends Component<Args> {
   };
 
   get byMonthActivityData() {
-    const { activity, namespace } = this.args;
-    return namespace ? this.filteredActivityByMonth : activity.byMonth;
+    return this.args.filteredByMonth;
   }
 
   get byMonthNewClients() {
     return this.byMonthActivityData ? this.byMonthActivityData?.map((m) => m?.new_clients) : [];
-  }
-
-  get filteredActivityByMonth() {
-    const { namespace, mountPath, activity } = this.args;
-    if (!namespace && !mountPath) {
-      return activity.byMonth;
-    }
-    const namespaceData = activity.byMonth
-      ?.map((m) => m.namespaces_by_key[namespace])
-      .filter((d) => d !== undefined);
-
-    if (!mountPath) {
-      return namespaceData || [];
-    }
-
-    const mountData = namespaceData
-      ?.map((namespace) => namespace?.mounts_by_key[mountPath])
-      .filter((d) => d !== undefined);
-
-    return mountData || [];
-  }
-
-  get filteredActivityByNamespace() {
-    const { namespace, activity } = this.args;
-    return activity.byNamespace.find((ns) => ns.label === namespace);
-  }
-
-  get filteredActivityByAuthMount() {
-    return this.filteredActivityByNamespace?.mounts?.find((mount) => mount.label === this.args.mountPath);
-  }
-
-  get filteredActivity() {
-    return this.args.mountPath ? this.filteredActivityByAuthMount : this.filteredActivityByNamespace;
   }
 
   get isCurrentMonth() {
@@ -98,10 +70,9 @@ export default class ClientsActivityComponent extends Component<Args> {
     );
   }
 
-  // (object) top level TOTAL client counts for given date range
+  // (object) TOTAL client counts for given date range (filtered)
   get totalUsageCounts() {
-    const { namespace, activity } = this.args;
-    return namespace ? this.filteredActivity : activity.total;
+    return this.args.filteredTotals;
   }
 
   get upgradesDuringActivity() {
@@ -117,44 +88,5 @@ export default class ClientsActivityComponent extends Component<Args> {
     }
 
     return this.byMonthActivityData[0]?.new_clients;
-  }
-
-  // total client data for horizontal bar chart in attribution component
-  get totalClientAttribution() {
-    const { namespace, activity } = this.args;
-    if (namespace) {
-      return this.filteredActivityByNamespace?.mounts || null;
-    } else {
-      return activity.byNamespace || null;
-    }
-  }
-
-  // new client data for horizontal bar chart
-  get newClientAttribution() {
-    // new client attribution only available in a single, historical month (not a date range or current month)
-    if (this.isDateRange || this.isCurrentMonth || !this.newClientCounts) return null;
-
-    const newCounts = this.newClientCounts;
-    if (this.args.namespace && hasMountsKey(newCounts)) return newCounts?.mounts;
-
-    if (hasNamespacesKey(newCounts)) return newCounts?.namespaces;
-
-    return null;
-  }
-
-  get hasAttributionData() {
-    const { mountPath, namespace } = this.args;
-    if (!mountPath) {
-      if (namespace) {
-        const mounts = this.filteredActivityByNamespace?.mounts?.map((mount) => ({
-          id: mount.label,
-          name: mount.label,
-        }));
-        return mounts && mounts.length > 0;
-      }
-      return !!this.totalClientAttribution && this.totalUsageCounts && this.totalUsageCounts.clients !== 0;
-    }
-
-    return false;
   }
 }

--- a/ui/app/components/clients/attribution.hbs
+++ b/ui/app/components/clients/attribution.hbs
@@ -63,7 +63,6 @@
         <Clients::HorizontalBarChart
           @dataset={{this.barChartNewClients}}
           @chartLegend={{this.attributionLegend}}
-          @totalCounts={{@newUsageCounts}}
           @noDataMessage="There are no new clients for this namespace during this time period."
         />
       </div>

--- a/ui/app/components/clients/attribution.js
+++ b/ui/app/components/clients/attribution.js
@@ -18,7 +18,6 @@ import { waitFor } from '@ember/test-waiters';
  *
  * @example
  *  <Clients::Attribution
- *    @newUsageCounts={{this.newUsageCounts}}
  *    @totalClientAttribution={{this.totalClientAttribution}}
  *    @newClientAttribution={{this.newClientAttribution}}
  *    @selectedNamespace={{this.selectedNamespace}}
@@ -29,7 +28,6 @@ import { waitFor } from '@ember/test-waiters';
  *    @upgradesDuringActivity={{array (hash version="1.10.1" previousVersion="1.9.1" timestampInstalled= "2021-11-18T10:23:16Z") }}
  *  />
  *
- * @param {object} newUsageCounts - object with new client counts for chart tooltip text
  * @param {array} totalClientAttribution - array of objects containing a label and breakdown of client counts for total clients
  * @param {array} newClientAttribution - array of objects containing a label and breakdown of client counts for new clients
  * @param {string} selectedNamespace - namespace selected from filter bar

--- a/ui/app/components/clients/page/counts.hbs
+++ b/ui/app/components/clients/page/counts.hbs
@@ -86,7 +86,7 @@
       </Toolbar>
     {{/if}}
 
-    {{#if this.filteredActivity}}
+    {{#if @filteredTotals}}
       {{#if this.upgradeExplanations}}
         <Hds::Alert data-test-clients-upgrade-warning @type="inline" @color="warning" class="has-bottom-margin-m" as |A|>
           <A.Title>

--- a/ui/app/components/clients/page/counts.ts
+++ b/ui/app/components/clients/page/counts.ts
@@ -29,6 +29,11 @@ interface Args {
   versionHistory: ClientsVersionHistoryModel[];
 }
 
+/**
+ * This component is the parent page for all the client count dashboard views.
+ * it is responsible for rendering the title, filters, warnings, and tabs that
+ * are shared across views.
+ */
 export default class ClientsCountsPageComponent extends Component<Args> {
   @service declare readonly flags: FlagsService;
   @service declare readonly version: VersionService;

--- a/ui/app/components/clients/page/counts.ts
+++ b/ui/app/components/clients/page/counts.ts
@@ -17,6 +17,8 @@ import type VersionService from 'vault/services/version';
 import type ClientsActivityModel from 'vault/models/clients/activity';
 import type ClientsConfigModel from 'vault/models/clients/config';
 import type ClientsVersionHistoryModel from 'vault/models/clients/version-history';
+import type { TotalClients } from 'core/utils/client-count-utils';
+
 interface Args {
   activity: ClientsActivityModel;
   activityError?: AdapterError;
@@ -27,6 +29,7 @@ interface Args {
   onFilterChange: CallableFunction;
   startTimestamp: string; // ISO format
   versionHistory: ClientsVersionHistoryModel[];
+  filteredTotals: TotalClients | undefined;
 }
 
 /**
@@ -144,17 +147,6 @@ export default class ClientsCountsPageComponent extends Component<Args> {
   get activityForNamespace() {
     const { activity, namespace } = this.args;
     return namespace ? activity.byNamespace.find((ns) => ns.label === namespace) : null;
-  }
-
-  get filteredActivity() {
-    // return activity counts based on selected namespace and auth mount values
-    const { namespace, mountPath, activity } = this.args;
-    if (namespace) {
-      return mountPath
-        ? this.activityForNamespace?.mounts.find((mount) => mount.label === mountPath)
-        : this.activityForNamespace;
-    }
-    return activity?.total;
   }
 
   get hasSecretsSyncClients(): boolean {

--- a/ui/app/components/clients/page/overview.hbs
+++ b/ui/app/components/clients/page/overview.hbs
@@ -16,7 +16,6 @@
 {{#if this.hasAttributionData}}
   <Clients::Attribution
     @isSecretsSyncActivated={{this.flags.secretsSyncIsActivated}}
-    @newUsageCounts={{this.newClientCounts}}
     @totalClientAttribution={{this.totalClientAttribution}}
     @newClientAttribution={{this.newClientAttribution}}
     @selectedNamespace={{@namespace}}

--- a/ui/app/components/clients/page/overview.hbs
+++ b/ui/app/components/clients/page/overview.hbs
@@ -5,10 +5,10 @@
 
 <Clients::RunningTotal
   @isSecretsSyncActivated={{this.flags.secretsSyncIsActivated}}
-  @byMonthActivityData={{this.byMonthActivityData}}
+  @byMonthActivityData={{@filteredByMonth}}
   @isHistoricalMonth={{and (not this.isCurrentMonth) (not this.isDateRange)}}
   @isCurrentMonth={{this.isCurrentMonth}}
-  @runningTotals={{this.totalUsageCounts}}
+  @runningTotals={{@filteredTotals}}
   @upgradeData={{this.upgradesDuringActivity}}
   @responseTimestamp={{@activity.responseTimestamp}}
   @mountPath={{@mountPath}}

--- a/ui/app/components/clients/page/overview.ts
+++ b/ui/app/components/clients/page/overview.ts
@@ -5,8 +5,60 @@
 
 import ActivityComponent from '../activity';
 import { service } from '@ember/service';
+import { hasMountsKey, hasNamespacesKey } from 'core/utils/client-count-utils';
+import { sanitizePath } from 'core/utils/sanitize-path';
 import type FlagsService from 'vault/services/flags';
+import type NamespaceService from 'vault/services/namespace';
 
 export default class ClientsOverviewPageComponent extends ActivityComponent {
   @service declare readonly flags: FlagsService;
+  @service declare readonly namespace: NamespaceService;
+
+  // new client data for horizontal bar chart @isHistoricalMonth only
+  get newClientAttribution() {
+    // new client attribution only available in a single, historical month (not a date range or current month)
+    if (this.isDateRange || this.isCurrentMonth || !this.newClientCounts) return null;
+
+    const newCounts = this.newClientCounts;
+    if (this.args.namespace && hasMountsKey(newCounts)) return newCounts?.mounts;
+
+    if (hasNamespacesKey(newCounts)) return newCounts?.namespaces;
+
+    return null;
+  }
+
+  get filteredActivityByNamespace() {
+    const { activity, namespace } = this.args;
+    const currentNs = this.namespace.currentNamespace;
+    const nsLabel = sanitizePath(namespace || currentNs || 'root');
+    return activity.byNamespace.find((namespace) => sanitizePath(namespace.label) === nsLabel);
+  }
+
+  // TODO: replace with constant namespace & mount attribution
+  // total client data for horizontal bar chart in attribution component
+  // array of labels + counts for namespace or mounts
+  get totalClientAttribution() {
+    const { namespace, activity } = this.args;
+    if (namespace) {
+      return this.filteredActivityByNamespace?.mounts || null;
+    } else {
+      return activity.byNamespace || null;
+    }
+  }
+
+  get hasAttributionData() {
+    const { mountPath, namespace } = this.args;
+    if (!mountPath) {
+      if (namespace) {
+        const mounts = this.filteredActivityByNamespace?.mounts?.map((mount) => ({
+          id: mount.label,
+          name: mount.label,
+        }));
+        return mounts && mounts.length > 0;
+      }
+      return !!this.totalClientAttribution && this.totalUsageCounts && this.totalUsageCounts.clients !== 0;
+    }
+
+    return false;
+  }
 }

--- a/ui/app/components/clients/page/token.hbs
+++ b/ui/app/components/clients/page/token.hbs
@@ -21,15 +21,6 @@
       />
     </:subTitle>
 
-    <:stats>
-      <StatText
-        @label="Average total clients per month"
-        @value={{this.averageTotalClients}}
-        @size="m"
-        class="data-details-top has-top-padding-l"
-      />
-    </:stats>
-
     <:chart>
       <Clients::Charts::VerticalBarStacked
         @chartTitle="Entity/Non-entity clients usage"
@@ -45,7 +36,7 @@
     @description="Entity or non-entity clients which interacted with Vault for the first time during this date range. Each bar represents the total new clients for that month."
     @timestamp={{@activity.responseTimestamp}}
     @legend={{this.legend}}
-    @hasChartData={{this.averageNewClients}}
+    @hasChartData={{this.hasNewClients}}
     class={{unless this.averageNewClients "no-legend"}}
   >
     <:stats>

--- a/ui/app/components/clients/page/token.ts
+++ b/ui/app/components/clients/page/token.ts
@@ -29,12 +29,15 @@ export default class ClientsTokenPageComponent extends ActivityComponent {
     }, 0);
   }
 
-  get averageTotalClients() {
-    return this.calculateClientAverages(this.byMonthActivityData);
-  }
-
   get averageNewClients() {
     return this.calculateClientAverages(this.byMonthNewClients);
+  }
+
+  get hasNewClients(): boolean {
+    return !!this.byMonthNewClients.find(
+      (m) =>
+        (m?.entity_clients && m.entity_clients > 0) || (m?.non_entity_clients && m.non_entity_clients > 0)
+    );
   }
 
   get tokenStats() {

--- a/ui/app/controllers/vault/cluster/clients/counts.ts
+++ b/ui/app/controllers/vault/cluster/clients/counts.ts
@@ -5,17 +5,25 @@
 
 import Controller from '@ember/controller';
 import { action, set } from '@ember/object';
+import { service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+import { MountClients } from 'core/utils/client-count-utils';
 
-import type { ClientsCountsRouteParams } from 'vault/routes/vault/cluster/clients/counts';
+import type {
+  ClientsCountsRouteModel,
+  ClientsCountsRouteParams,
+} from 'vault/routes/vault/cluster/clients/counts';
+import type NamespaceService from 'vault/services/namespace';
 
 const queryParamKeys = ['start_time', 'end_time', 'ns', 'mountPath'];
 export default class ClientsCountsController extends Controller {
   queryParams = queryParamKeys;
+  @service('namespace') declare readonly namespaceSvc: NamespaceService;
 
-  start_time: string | number | undefined = undefined;
-  end_time: string | number | undefined = undefined;
-  ns: string | undefined = undefined;
-  mountPath: string | undefined = undefined;
+  @tracked start_time: string | number | undefined = undefined;
+  @tracked end_time: string | number | undefined = undefined;
+  @tracked ns: string | undefined = undefined;
+  @tracked mountPath: string | undefined = undefined;
 
   // using router.transitionTo to update the query params results in the model hook firing each time
   // this happens when the queryParams object is not added to the route or refreshModel is explicitly set to false
@@ -32,5 +40,40 @@ export default class ClientsCountsController extends Controller {
         }
       });
     }
+  }
+
+  get filteredActivityTotals() {
+    const { activity } = this.model as ClientsCountsRouteModel;
+    const { ns, mountPath } = this;
+
+    // only do this if we have a mountPath filter.
+    // namespace is filtered on API layer
+    if (activity?.byMonth && ns && mountPath) {
+      const filtered = activity.byNamespace
+        .find((namespace) => namespace.label === ns)
+        ?.mounts.find((mount: MountClients) => mount.label === mountPath);
+      return filtered;
+    }
+    return activity?.total;
+  }
+
+  get filteredByMonthActivity() {
+    const { activity } = this.model as ClientsCountsRouteModel;
+    const { ns, mountPath } = this;
+
+    // only do this if we have a mountPath filter.
+    // namespace is filtered on API layer
+    if (activity?.byMonth && ns && mountPath) {
+      const namespaceData = activity.byMonth
+        ?.map((m) => m.namespaces_by_key[ns])
+        .filter((d) => d !== undefined);
+
+      const mountData = namespaceData
+        ?.map((namespace) => namespace?.mounts_by_key[mountPath])
+        .filter((d) => d !== undefined);
+
+      return mountData || [];
+    }
+    return activity?.byMonth;
   }
 }

--- a/ui/app/templates/vault/cluster/clients/counts.hbs
+++ b/ui/app/templates/vault/cluster/clients/counts.hbs
@@ -13,6 +13,7 @@
   @onFilterChange={{this.updateQueryParams}}
   @startTimestamp={{this.model.startTimestamp}}
   @versionHistory={{this.model.versionHistory}}
+  @filteredTotals={{this.filteredActivityTotals}}
 >
   {{outlet}}
 </Clients::Page::Counts>

--- a/ui/app/templates/vault/cluster/clients/counts/acme.hbs
+++ b/ui/app/templates/vault/cluster/clients/counts/acme.hbs
@@ -10,4 +10,6 @@
   @endTimestamp={{this.model.endTimestamp}}
   @namespace={{this.countsController.ns}}
   @mountPath={{this.countsController.mountPath}}
+  @filteredTotals={{this.countsController.filteredActivityTotals}}
+  @filteredByMonth={{this.countsController.filteredByMonthActivity}}
 />

--- a/ui/app/templates/vault/cluster/clients/counts/overview.hbs
+++ b/ui/app/templates/vault/cluster/clients/counts/overview.hbs
@@ -10,4 +10,6 @@
   @endTimestamp={{this.model.endTimestamp}}
   @namespace={{this.countsController.ns}}
   @mountPath={{this.countsController.mountPath}}
+  @filteredTotals={{this.countsController.filteredActivityTotals}}
+  @filteredByMonth={{this.countsController.filteredByMonthActivity}}
 />

--- a/ui/app/templates/vault/cluster/clients/counts/sync.hbs
+++ b/ui/app/templates/vault/cluster/clients/counts/sync.hbs
@@ -10,4 +10,6 @@
   @endTimestamp={{this.model.endTimestamp}}
   @namespace={{this.countsController.ns}}
   @mountPath={{this.countsController.mountPath}}
+  @filteredTotals={{this.countsController.filteredActivityTotals}}
+  @filteredByMonth={{this.countsController.filteredByMonthActivity}}
 />

--- a/ui/app/templates/vault/cluster/clients/counts/token.hbs
+++ b/ui/app/templates/vault/cluster/clients/counts/token.hbs
@@ -10,4 +10,6 @@
   @endTimestamp={{this.model.endTimestamp}}
   @namespace={{this.countsController.ns}}
   @mountPath={{this.countsController.mountPath}}
+  @filteredTotals={{this.countsController.filteredActivityTotals}}
+  @filteredByMonth={{this.countsController.filteredByMonthActivity}}
 />

--- a/ui/app/utils/chart-helpers.js
+++ b/ui/app/utils/chart-helpers.js
@@ -28,13 +28,13 @@ export function numericalAxisLabel(number) {
 }
 
 export function calculateAverage(dataset, objectKey) {
-  // before mapping for values, check that the objectKey exists at least once in the dataset because
-  // map returns 0 when dataset[objectKey] is undefined in order to calculate average
+  // before mapping for values, check that the objectKey exists at least once in the dataset
   if (!Array.isArray(dataset) || !objectKey || !dataset.some((d) => Object.keys(d).includes(objectKey))) {
     return null;
   }
 
-  const integers = dataset.map((d) => (d[objectKey] ? d[objectKey] : 0));
+  // averages should not include items that don't have the key because that means there's no data rather than 0
+  const integers = dataset.filter((d) => typeof d[objectKey] === 'number').map((d) => d[objectKey]);
   const checkIntegers = integers.every((n) => Number.isInteger(n)); // decimals will be false
   return checkIntegers ? Math.round(mean(integers)) : null;
 }

--- a/ui/lib/core/addon/utils/client-count-utils.ts
+++ b/ui/lib/core/addon/utils/client-count-utils.ts
@@ -27,6 +27,18 @@ export const CLIENT_TYPES = [
 
 export type ClientTypes = (typeof CLIENT_TYPES)[number];
 
+/**
+ * emptyCounts generates a block of total clients for use as defaults
+ * @returns TotalClients block with 0's filled in for all counts
+ */
+export function emptyCounts() {
+  return CLIENT_TYPES.reduce((prev, type) => {
+    const key = type;
+    prev[key as ClientTypes] = 0;
+    return prev;
+  }, {} as TotalClientsSometimes) as TotalClients;
+}
+
 // returns array of VersionHistoryModels for noteworthy upgrades: 1.9, 1.10
 // that occurred between timestamps (i.e. queried activity data)
 export const filterVersionHistory = (
@@ -163,6 +175,7 @@ export const sortMonthsByTimestamp = (
   );
 };
 
+// TODO: Deprecate this method now that we don't filter client-side
 export const namespaceArrayToObject = (
   monthTotals: ByNamespaceClients[],
   // technically this arg (monthNew) is the same type as above, just nested inside monthly new clients

--- a/ui/mirage/handlers/clients.js
+++ b/ui/mirage/handlers/clients.js
@@ -228,8 +228,7 @@ function filterByNamespace(namespaces, namespacePath) {
  */
 function filterMonths(months, namespacePath) {
   return months.map((month) => {
-    if (!month.namespaces) return month;
-
+    if (!month.namespaces || month.namespaces.length === 0) return month;
     const newMonth = {
       ...month,
     };

--- a/ui/tests/helpers/clients/client-count-helpers.js
+++ b/ui/tests/helpers/clients/client-count-helpers.js
@@ -14,7 +14,7 @@ export function assertBarChart(assert, chartName, byMonthData, isStacked = false
   );
   const xAxisLabels = findAll(`${chart} ${CHARTS.xAxisLabel}`);
 
-  let count = byMonthData.filter((m) => m.clients).length;
+  let count = byMonthData.filter((m) => m?.clients).length;
   if (isStacked) count = count * 2;
 
   assert.strictEqual(dataBars.length, count, `${chartName}: it renders bars for each non-zero month`);

--- a/ui/tests/integration/components/clients/horizontal-bar-chart-test.js
+++ b/ui/tests/integration/components/clients/horizontal-bar-chart-test.js
@@ -18,19 +18,16 @@ module('Integration | Component | clients/horizontal-bar-chart', function (hooks
   });
 
   test('it renders chart and tooltip', async function (assert) {
-    const totalObject = { clients: 5, entity_clients: 2, non_entity_clients: 3 };
     const dataArray = [
       { label: 'second', clients: 3, entity_clients: 1, non_entity_clients: 2 },
       { label: 'first', clients: 2, entity_clients: 1, non_entity_clients: 1 },
     ];
-    this.set('totalCounts', totalObject);
     this.set('totalClientAttribution', dataArray);
 
     await render(hbs`
     <Clients::HorizontalBarChart
       @dataset={{this.totalClientAttribution}}
       @chartLegend={{this.chartLegend}}
-      @totalCounts={{this.totalCounts}}
     />`);
 
     assert.dom('[data-test-horizontal-bar-chart]').exists();
@@ -59,19 +56,16 @@ module('Integration | Component | clients/horizontal-bar-chart', function (hooks
   });
 
   test('it renders data with a large range', async function (assert) {
-    const totalObject = { clients: 5929393, entity_clients: 1391997, non_entity_clients: 4537396 };
     const dataArray = [
       { label: 'second', clients: 5929093, entity_clients: 1391896, non_entity_clients: 4537100 },
       { label: 'first', clients: 300, entity_clients: 101, non_entity_clients: 296 },
     ];
-    this.set('totalCounts', totalObject);
     this.set('totalClientAttribution', dataArray);
 
     await render(hbs`
     <Clients::HorizontalBarChart
       @dataset={{this.totalClientAttribution}}
       @chartLegend={{this.chartLegend}}
-      @totalCounts={{this.totalCounts}}
     />`);
 
     assert.dom('[data-test-horizontal-bar-chart]').exists();

--- a/ui/tests/integration/components/clients/page/acme-test.js
+++ b/ui/tests/integration/components/clients/page/acme-test.js
@@ -47,6 +47,8 @@ module('Integration | Component | clients | Clients::Page::Acme', function (hook
         @endTimestamp={{this.endTimestamp}}
         @namespace={{this.countsController.ns}}
         @mountPath={{this.countsController.mountPath}}
+        @filteredTotals={{this.activity.total}}
+        @filteredByMonth={{this.activity.byMonth}}
       />
     `);
     // Fails on #ember-testing-container

--- a/ui/tests/integration/components/clients/page/counts-test.js
+++ b/ui/tests/integration/components/clients/page/counts-test.js
@@ -52,6 +52,7 @@ module('Integration | Component | clients | Page::Counts', function (hooks) {
         @namespace={{this.namespace}}
         @mountPath={{this.mountPath}}
         @onFilterChange={{this.onFilterChange}}
+        @filteredTotals={{this.activity.total}}
       >
         <div data-test-yield>Yield block</div>
       </Clients::Page::Counts>

--- a/ui/tests/integration/components/clients/page/sync-test.js
+++ b/ui/tests/integration/components/clients/page/sync-test.js
@@ -36,6 +36,8 @@ module('Integration | Component | clients | Clients::Page::Sync', function (hook
         @endTimestamp={{this.endTimestamp}}
         @namespace={{this.countsController.ns}}
         @mountPath={{this.countsController.mountPath}}
+        @filteredTotals={{this.activity.total}}
+        @filteredByMonth={{this.activity.byMonth}}
       />
     `);
   });

--- a/ui/tests/integration/components/clients/page/token-test.js
+++ b/ui/tests/integration/components/clients/page/token-test.js
@@ -57,6 +57,8 @@ module('Integration | Component | clients | Clients::Page::Token', function (hoo
           @endTimestamp={{this.endTimestamp}}
           @namespace={{this.ns}}
           @mountPath={{this.mountPath}}
+          @filteredTotals={{this.activity.total}}
+          @filteredByMonth={{this.activity.byMonth}}
         />
       `);
     // Fails on #ember-testing-container

--- a/ui/tests/unit/utils/chart-helpers-test.js
+++ b/ui/tests/unit/utils/chart-helpers-test.js
@@ -37,6 +37,7 @@ module('Unit | Utility | chart-helpers', function () {
     ];
     const testArray2 = [
       { label: 'foo', value: undefined },
+      { label: 'bar', value: 0 },
       { label: 'bar', value: 22 },
     ];
     const testArray3 = [{ label: 'foo' }, { label: 'bar' }];

--- a/ui/types/vault/services/namespace.d.ts
+++ b/ui/types/vault/services/namespace.d.ts
@@ -11,6 +11,7 @@ interface PathsResponse {
   };
 }
 export default class NamespaceService extends Service {
+  path: string;
   userRootNamespace: string;
   inRootNamespace: boolean;
   currentNamespace: string;


### PR DESCRIPTION
## ON HOLD ##
going to re-do these changes, half in one PR and half in another

### Description
This PR updates the Client Count dashboard to use API-level filtering (via namespace header) when the filter bar is used. Mount-based filtering is still done client-side, and the logic for that has been updated for consistency. 

Below is a GIF showing that the data is re-fetched when the namespace filter changes, but not when the mount filter changes. You may also notice that filtering on `root` does not change the top-level value. This is intentional; before, we were showing totals by filtering client-side. Now we are showing the totals from the API, which include the root namespace + all of its children. Same goes for all other stats, they are now rolled up instead of only the selected namespace. 

![Kapture 2024-08-09 at 14 28 22](https://github.com/user-attachments/assets/32360284-8d90-47e3-81cd-49cdf26248fb)

