### PR TITLE
enos(replication): wait for both clusters to be healthy before enabling replication

### DIFF
--- a/enos/enos-scenario-replication.hcl
+++ b/enos/enos-scenario-replication.hcl
@@ -710,8 +710,11 @@ scenario "replication" {
     EOF
     module      = module.vault_setup_perf_primary
     depends_on = [
+      // Wait for both clusters to be up and healthy...
+      step.get_primary_cluster_ips,
+      step.get_secondary_cluster_ips,
       step.write_test_data_on_primary,
-      // Do base verification before continuing on to our performance replication verification.
+      // Wait base verification to complete...
       step.verify_vault_version,
       step.verify_ui,
     ]


### PR DESCRIPTION
### Description
Fix a race where we might configure replication before getting secondary cluster IP addresses when using shamir seals.

### TODO only if you're a HashiCorp employee
- [x] **Labels:** If this PR is the CE portion of an ENT change, and that ENT change is
  getting backported to N-2, use the new style `backport/ent/x.x.x+ent` labels
  instead of the old style `backport/x.x.x` labels.
- [x] **Labels:** If this PR is a CE only change, it can only be backported to N, so use
  the normal `backport/x.x.x` label (there should be only 1).
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
