### PR TITLE
Sort namespaces, mounts, and clients before adding them to HLL

### DIFF
--- a/changelog/28062.txt
+++ b/changelog/28062.txt
@@ -1,0 +1,3 @@
+```release-note:change
+core/activity: Ensure client count queries that include the current month return consistent results by sorting the clients before performing estimation 
+```

--- a/changelog/28062.txt
+++ b/changelog/28062.txt
@@ -1,3 +1,3 @@
-```release-note:change
+```release-note:improvement
 core/activity: Ensure client count queries that include the current month return consistent results by sorting the clients before performing estimation 
 ```

--- a/vault/activity_log_util_common.go
+++ b/vault/activity_log_util_common.go
@@ -199,7 +199,13 @@ func (a *ActivityLog) computeCurrentMonthForBillingPeriodInternal(ctx context.Co
 			newMountCounts := &activity.CountsRecord{}
 
 			for _, typ := range ActivityClientTypes {
-				for clientID := range mount.Counts.clientsByType(typ) {
+				clients := mount.Counts.clientsByType(typ)
+				clientIDs := make([]string, 0, len(clients))
+				for clientID := range clients {
+					clientIDs = append(clientIDs, clientID)
+				}
+				sort.Strings(clientIDs)
+				for _, clientID := range clientIDs {
 					hllByType[typ].Insert([]byte(clientID))
 
 					// increment the per mount, per namespace, and total counts


### PR DESCRIPTION
### Description
Sort the activity log clients before adding them to the hyperloglog to ensure consistent results.

Performance:

```
$ VAULT_TEST_LOG_DIR=$(mktemp -d) go test -bench=^BenchmarkLargeClientCount$  -tags="ent enterprise testonly" $(pwd)/vault/external_tests/activity_testonly -run "^$" -benchmem 
goos: darwin
goarch: arm64
pkg: github.com/hashicorp/vault/vault/external_tests/activity_testonly
BenchmarkLargeClientCount/10000_per_mount-10                  18          56399891 ns/op        32806902 B/op      50671 allocs/op
BenchmarkLargeClientCount/100000_per_mount-10                  2         762893583 ns/op        207117244 B/op    465944 allocs/op
BenchmarkLargeClientCount/500000_per_mount-10                  1        5710724250 ns/op        1496278752 B/op  2420449 allocs/op
BenchmarkLargeClientCount/1000000_per_mount-10                 1        17837094792 ns/op       2983561024 B/op  4837697 allocs/op
BenchmarkLargeClientCount/2000000_per_mount-10                 1        38098365375 ns/op       5959903936 B/op  9690766 allocs/op
PASS
ok      github.com/hashicorp/vault/vault/external_tests/activity_testonly       145.191s
```

what's currently on `main`:

```
$ VAULT_TEST_LOG_DIR=$(mktemp -d) go test -bench=^BenchmarkLargeClientCount$  -tags="ent enterprise testonly" $(pwd)/vault/external_tests/activity_testonly -run "^$" -benchmem 
goos: darwin
goarch: arm64
pkg: github.com/hashicorp/vault/vault/external_tests/activity_testonly
BenchmarkLargeClientCount/10000_per_mount-10                  22          55692903 ns/op        32134565 B/op      50655 allocs/op
BenchmarkLargeClientCount/100000_per_mount-10                  2         781777021 ns/op        201372028 B/op    466613 allocs/op
BenchmarkLargeClientCount/500000_per_mount-10                  1        5563718292 ns/op        1467175480 B/op  2418694 allocs/op
BenchmarkLargeClientCount/1000000_per_mount-10                 1        11221255292 ns/op       2925794392 B/op  4835923 allocs/op
BenchmarkLargeClientCount/2000000_per_mount-10                 1        23813339459 ns/op       5842432544 B/op  9666556 allocs/op
PASS
ok      github.com/hashicorp/vault/vault/external_tests/activity_testonly       125.793s

```
Ent PR: https://github.com/hashicorp/vault-enterprise/pull/6369

### TODO only if you're a HashiCorp employee
- [x] **Labels:** If this PR is the CE portion of an ENT change, and that ENT change is
  getting backported to N-2, use the new style `backport/ent/x.x.x+ent` labels
  instead of the old style `backport/x.x.x` labels.
- [ ] **Labels:** If this PR is a CE only change, it can only be backported to N, so use
  the normal `backport/x.x.x` label (there should be only 1).
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
