### PR TITLE
UI: Move Client Count Export button

### DIFF
--- a/ui/app/components/clients/attribution.hbs
+++ b/ui/app/components/clients/attribution.hbs
@@ -63,7 +63,6 @@
         <Clients::HorizontalBarChart
           @dataset={{this.barChartNewClients}}
           @chartLegend={{this.attributionLegend}}
-          @totalCounts={{@newUsageCounts}}
           @noDataMessage="There are no new clients for this namespace during this time period."
         />
       </div>

--- a/ui/app/components/clients/attribution.hbs
+++ b/ui/app/components/clients/attribution.hbs
@@ -8,52 +8,9 @@
   class={{concat "chart-wrapper" (if @isHistoricalMonth " dual-chart-grid" " single-chart-grid")}}
   data-test-clients-attribution
 >
-  <div class="chart-header has-header-link has-bottom-margin-m">
-    <div class="header-left">
-      <h2 class="chart-title">Attribution</h2>
-      <p class="chart-description" data-test-attribution-description>{{this.chartText.description}}</p>
-    </div>
-    <div class="header-right">
-      {{#if this.showExportButton}}
-        <Clients::ExportButton
-          @startTimestamp={{@startTimestamp}}
-          @endTimestamp={{@endTimestamp}}
-          @selectedNamespace={{@selectedNamespace}}
-        >
-          <:alert>
-            {{#if @upgradesDuringActivity}}
-              <Hds::Alert class="has-top-padding-m" @type="compact" @color="warning" as |A|>
-                <A.Description>
-                  <strong>Data contains {{pluralize @upgradesDuringActivity.length "upgrade"}}:</strong>
-                </A.Description>
-                <A.Description>
-                  <ul class="bullet">
-                    {{#each @upgradesDuringActivity as |upgrade|}}
-                      <li>
-                        {{upgrade.version}}
-                        {{this.parseAPITimestamp upgrade.timestampInstalled "(MMM d, yyyy)"}}
-                      </li>
-                    {{/each}}
-                  </ul>
-                </A.Description>
-                <A.Description>
-                  Visit our
-                  <Hds::Link::Inline
-                    @isHrefExternal={{true}}
-                    @href={{doc-link
-                      "/vault/docs/concepts/client-count/faq#q-which-vault-version-reflects-the-most-accurate-client-counts"
-                    }}
-                  >
-                    Client count FAQ
-                  </Hds::Link::Inline>
-                  for more information.
-                </A.Description>
-              </Hds::Alert>
-            {{/if}}
-          </:alert>
-        </Clients::ExportButton>
-      {{/if}}
-    </div>
+  <div class="chart-header has-bottom-margin-m">
+    <h2 class="chart-title">Attribution</h2>
+    <p class="chart-description" data-test-attribution-description>{{this.chartText.description}}</p>
   </div>
   {{#if this.barChartTotalClients}}
     {{#if @isHistoricalMonth}}

--- a/ui/app/components/clients/attribution.js
+++ b/ui/app/components/clients/attribution.js
@@ -18,7 +18,6 @@ import { waitFor } from '@ember/test-waiters';
  *
  * @example
  *  <Clients::Attribution
- *    @newUsageCounts={{this.newUsageCounts}}
  *    @totalClientAttribution={{this.totalClientAttribution}}
  *    @newClientAttribution={{this.newClientAttribution}}
  *    @selectedNamespace={{this.selectedNamespace}}
@@ -29,7 +28,6 @@ import { waitFor } from '@ember/test-waiters';
  *    @upgradesDuringActivity={{array (hash version="1.10.1" previousVersion="1.9.1" timestampInstalled= "2021-11-18T10:23:16Z") }}
  *  />
  *
- * @param {object} newUsageCounts - object with new client counts for chart tooltip text
  * @param {array} totalClientAttribution - array of objects containing a label and breakdown of client counts for total clients
  * @param {array} newClientAttribution - array of objects containing a label and breakdown of client counts for new clients
  * @param {string} selectedNamespace - namespace selected from filter bar

--- a/ui/app/components/clients/attribution.js
+++ b/ui/app/components/clients/attribution.js
@@ -54,11 +54,6 @@ export default class Attribution extends Component {
     return isSameMonth(startDateObject, endDateObject);
   }
 
-  get showExportButton() {
-    const hasData = this.args.totalClientAttribution ? this.args.totalClientAttribution.length > 0 : false;
-    return hasData && this.canDownload;
-  }
-
   get isSingleNamespace() {
     // if a namespace is selected, then we're viewing top 10 auth methods (mounts)
     return !!this.args.selectedNamespace;

--- a/ui/app/components/clients/attribution.js
+++ b/ui/app/components/clients/attribution.js
@@ -4,12 +4,8 @@
  */
 
 import Component from '@glimmer/component';
-import { tracked } from '@glimmer/tracking';
-import { service } from '@ember/service';
 import { parseAPITimestamp } from 'core/utils/date-formatters';
 import { isSameMonth } from 'date-fns';
-import { sanitizePath } from 'core/utils/sanitize-path';
-import { waitFor } from '@ember/test-waiters';
 
 /**
  * @module Attribution
@@ -25,7 +21,6 @@ import { waitFor } from '@ember/test-waiters';
  *    @endTimestamp={{this.endTime}}
  *    @isHistoricalMonth={{false}}
  *    @responseTimestamp={{this.responseTimestamp}}
- *    @upgradesDuringActivity={{array (hash version="1.10.1" previousVersion="1.9.1" timestampInstalled= "2021-11-18T10:23:16Z") }}
  *  />
  *
  * @param {array} totalClientAttribution - array of objects containing a label and breakdown of client counts for total clients
@@ -35,40 +30,10 @@ import { waitFor } from '@ember/test-waiters';
  * @param {string} endTimestamp - timestamp string from activity response to render end date for CSV modal and whether copy reads 'month' or 'date range'
  * @param {string} responseTimestamp -  ISO timestamp created in serializer to timestamp the response, renders in bottom left corner below attribution chart
  * @param {boolean} isHistoricalMonth - when true data is from a single, historical month so side-by-side charts should display for attribution data
- * @param {array} upgradesDuringActivity - array of objects containing version history upgrade data
  * @param {boolean} isSecretsSyncActivated - boolean to determine if secrets sync is activated
  */
 
 export default class Attribution extends Component {
-  @service download;
-  @service store;
-  @service namespace;
-
-  @tracked canDownload = false;
-  @tracked showExportModal = false;
-  @tracked exportFormat = 'csv';
-  @tracked downloadError = '';
-
-  constructor() {
-    super(...arguments);
-    this.getExportCapabilities(this.args.selectedNamespace);
-  }
-
-  @waitFor
-  async getExportCapabilities(ns = '') {
-    try {
-      // selected namespace usually ends in /
-      const url = ns
-        ? `${sanitizePath(ns)}/sys/internal/counters/activity/export`
-        : 'sys/internal/counters/activity/export';
-      const cap = await this.store.findRecord('capabilities', url);
-      this.canDownload = cap.canSudo;
-    } catch (e) {
-      // if we can't read capabilities, default to show
-      this.canDownload = true;
-    }
-  }
-
   get attributionLegend() {
     const attributionLegend = [
       { key: 'entity_clients', label: 'entity clients' },

--- a/ui/app/components/clients/page-header.hbs
+++ b/ui/app/components/clients/page-header.hbs
@@ -3,14 +3,26 @@
   SPDX-License-Identifier: BUSL-1.1
 ~}}
 
-<Hds::Button
-  data-test-attribution-export-button
-  @text="Export activity data"
-  @color="secondary"
-  {{on "click" (fn (mut this.showExportModal) true)}}
-/>
+<Hds::PageHeader class="has-top-padding-l has-bottom-padding-m" as |PH|>
+  <PH.Title>Vault Usage Metrics</PH.Title>
+  <PH.Description>
+    This dashboard surfaces Vault client usage over time.
+    <Hds::Link::Inline @href={{doc-link "/vault/docs/concepts/client-count"}}>Documentation is available here</Hds::Link::Inline>.
+    Date queries are sent in UTC.
+  </PH.Description>
+  <PH.Actions>
+    {{#if this.canDownload}}
+      <Hds::Button
+        data-test-export-button
+        @text="Export activity data"
+        @color="secondary"
+        @icon="download"
+        {{on "click" (fn (mut this.showExportModal) true)}}
+      />
+    {{/if}}
+  </PH.Actions>
+</Hds::PageHeader>
 
-{{! MODAL FOR CSV DOWNLOAD }}
 {{#if this.showExportModal}}
   <Hds::Modal id="attribution-csv-download-modal" class="has-text-left" @onClose={{this.resetModal}} as |M|>
     <M.Header @icon="info" data-test-export-modal-title>
@@ -66,7 +78,35 @@
         />
         <Hds::Button @text="Cancel" @color="secondary" {{on "click" F.close}} />
       </Hds::ButtonSet>
-      {{yield to="alert"}}
+      {{#if @upgradesDuringActivity}}
+        <Hds::Alert class="has-top-padding-m" @type="compact" @color="warning" data-test-export-upgrade-warning as |A|>
+          <A.Description>
+            <strong>Data contains {{pluralize @upgradesDuringActivity.length "upgrade"}}:</strong>
+          </A.Description>
+          <A.Description>
+            <ul class="bullet">
+              {{#each @upgradesDuringActivity as |upgrade|}}
+                <li>
+                  {{upgrade.version}}
+                  {{this.parseAPITimestamp upgrade.timestampInstalled "(MMM d, yyyy)"}}
+                </li>
+              {{/each}}
+            </ul>
+          </A.Description>
+          <A.Description>
+            Visit our
+            <Hds::Link::Inline
+              @isHrefExternal={{true}}
+              @href={{doc-link
+                "/vault/docs/concepts/client-count/faq#q-which-vault-version-reflects-the-most-accurate-client-counts"
+              }}
+            >
+              Client count FAQ
+            </Hds::Link::Inline>
+            for more information.
+          </A.Description>
+        </Hds::Alert>
+      {{/if}}
     </M.Footer>
   </Hds::Modal>
 {{/if}}

--- a/ui/app/components/clients/page-header.js
+++ b/ui/app/components/clients/page-header.js
@@ -5,6 +5,7 @@
 
 import { action } from '@ember/object';
 import { service } from '@ember/service';
+import { waitFor } from '@ember/test-waiters';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { parseAPITimestamp } from 'core/utils/date-formatters';
@@ -13,25 +14,47 @@ import { format, isSameMonth } from 'date-fns';
 import { task } from 'ember-concurrency';
 
 /**
- * @module ClientsExportButtonComponent
- * ClientsExportButton components are used to display the export button, manage the modal, and download the file from the clients export API
+ * @module ClientsPageHeader
+ * ClientsPageHeader components are used to render a header and check for export capabilities before rendering an export button.
  *
  * @example
  * ```js
- * <Clients::ExportButton @startTimestamp="2022-06-01T23:00:11.050Z" @endTimestamp="2022-12-01T23:00:11.050Z" @selectedNamespace="foo" />
+ * <Clients::PageHeader @startTimestamp="2022-06-01T23:00:11.050Z" @endTimestamp="2022-12-01T23:00:11.050Z" @namespace="foo" @upgradesDuringActivity={{array (hash version="1.10.1" previousVersion="1.9.1" timestampInstalled= "2021-11-18T10:23:16Z") }} />
  * ```
  * @param {string} [startTimestamp] - ISO timestamp of start time, to be passed to export request
  * @param {string} [endTimestamp] - ISO timestamp of end time, to be passed to export request
  * @param {string} [namespace] - namespace filter. Will be appended to the current namespace in the export request.
+ * @param {string} [upgradesDuringActivity] - array of objects containing version history upgrade data
  */
-export default class ClientsExportButtonComponent extends Component {
+export default class ClientsPageHeaderComponent extends Component {
   @service download;
   @service namespace;
   @service store;
 
+  @tracked canDownload = false;
   @tracked showExportModal = false;
   @tracked exportFormat = 'csv';
   @tracked downloadError = '';
+
+  constructor() {
+    super(...arguments);
+    this.getExportCapabilities(this.args.namespace);
+  }
+
+  @waitFor
+  async getExportCapabilities(ns = '') {
+    try {
+      // selected namespace usually ends in /
+      const url = ns
+        ? `${sanitizePath(ns)}/sys/internal/counters/activity/export`
+        : 'sys/internal/counters/activity/export';
+      const cap = await this.store.findRecord('capabilities', url);
+      this.canDownload = cap.canSudo;
+    } catch (e) {
+      // if we can't read capabilities, default to show
+      this.canDownload = true;
+    }
+  }
 
   get formattedStartDate() {
     if (!this.args.startTimestamp) return null;
@@ -55,8 +78,8 @@ export default class ClientsExportButtonComponent extends Component {
 
   get namespaceFilter() {
     const currentNs = this.namespace.path;
-    const { selectedNamespace } = this.args;
-    return selectedNamespace ? sanitizePath(`${currentNs}/${selectedNamespace}`) : sanitizePath(currentNs);
+    const { namespace } = this.args;
+    return namespace ? sanitizePath(`${currentNs}/${namespace}`) : sanitizePath(currentNs);
   }
 
   async getExportData() {
@@ -70,6 +93,10 @@ export default class ClientsExportButtonComponent extends Component {
       namespace: this.namespaceFilter,
     });
   }
+
+  parseAPITimestamp = (timestamp, format) => {
+    return parseAPITimestamp(timestamp, format);
+  };
 
   exportChartData = task({ drop: true }, async (filename) => {
     try {

--- a/ui/app/components/clients/page/counts.hbs
+++ b/ui/app/components/clients/page/counts.hbs
@@ -3,21 +3,14 @@
   SPDX-License-Identifier: BUSL-1.1
 ~}}
 
-<PageHeader as |p|>
-  <p.levelLeft>
-    <h1 class="title is-3">
-      Vault Usage Metrics
-    </h1>
-  </p.levelLeft>
-</PageHeader>
+<Clients::PageHeader
+  @startTimestamp={{@startTimestamp}}
+  @endTimestamp={{@endTimestamp}}
+  @namespace={{@namespace}}
+  @upgradesDuringActivity={{this.upgradesDuringActivity}}
+/>
 
 <div class="box is-sideless is-fullwidth is-marginless is-bottomless">
-  <p class="has-bottom-margin-xl">
-    This dashboard surfaces Vault client usage over time.
-    <Hds::Link::Inline @href={{doc-link "/vault/docs/concepts/client-count"}}>Documentation is available here</Hds::Link::Inline>.
-    Date queries are sent in UTC.
-  </p>
-
   <Clients::DateRange
     @startTime={{@startTimestamp}}
     @endTime={{@endTimestamp}}

--- a/ui/app/components/clients/page/counts.ts
+++ b/ui/app/components/clients/page/counts.ts
@@ -82,6 +82,12 @@ export default class ClientsCountsPageComponent extends Component<Args> {
     return null;
   }
 
+  // passed into page-header for the export modal alert
+  get upgradesDuringActivity() {
+    const { versionHistory, activity } = this.args;
+    return filterVersionHistory(versionHistory, activity.startTime, activity.endTime);
+  }
+
   get versionText() {
     return this.version.isEnterprise
       ? {

--- a/ui/app/components/clients/page/counts.ts
+++ b/ui/app/components/clients/page/counts.ts
@@ -53,11 +53,15 @@ export default class ClientsCountsPageComponent extends Component<Args> {
     return null;
   }
 
-  get upgradeExplanations() {
+  // passed into page-header for the export modal alert
+  get upgradesDuringActivity() {
     const { versionHistory, activity } = this.args;
-    const upgradesDuringActivity = filterVersionHistory(versionHistory, activity.startTime, activity.endTime);
-    if (upgradesDuringActivity.length) {
-      return upgradesDuringActivity.map((upgrade: ClientsVersionHistoryModel) => {
+    return filterVersionHistory(versionHistory, activity.startTime, activity.endTime);
+  }
+
+  get upgradeExplanations() {
+    if (this.upgradesDuringActivity.length) {
+      return this.upgradesDuringActivity.map((upgrade: ClientsVersionHistoryModel) => {
         let explanation;
         const date = parseAPITimestamp(upgrade.timestampInstalled, 'MMM d, yyyy');
         const version = upgrade.version || '';
@@ -80,12 +84,6 @@ export default class ClientsCountsPageComponent extends Component<Args> {
       });
     }
     return null;
-  }
-
-  // passed into page-header for the export modal alert
-  get upgradesDuringActivity() {
-    const { versionHistory, activity } = this.args;
-    return filterVersionHistory(versionHistory, activity.startTime, activity.endTime);
   }
 
   get versionText() {

--- a/ui/app/components/clients/page/overview.hbs
+++ b/ui/app/components/clients/page/overview.hbs
@@ -23,6 +23,5 @@
     @endTimestamp={{@endTimestamp}}
     @responseTimestamp={{@activity.responseTimestamp}}
     @isHistoricalMonth={{and (not this.isCurrentMonth) (not this.isDateRange)}}
-    @upgradesDuringActivity={{this.upgradesDuringActivity}}
   />
 {{/if}}

--- a/ui/app/components/clients/page/overview.hbs
+++ b/ui/app/components/clients/page/overview.hbs
@@ -16,7 +16,6 @@
 {{#if this.hasAttributionData}}
   <Clients::Attribution
     @isSecretsSyncActivated={{this.flags.secretsSyncIsActivated}}
-    @newUsageCounts={{this.newClientCounts}}
     @totalClientAttribution={{this.totalClientAttribution}}
     @newClientAttribution={{this.newClientAttribution}}
     @selectedNamespace={{@namespace}}

--- a/ui/mirage/handlers/clients.js
+++ b/ui/mirage/handlers/clients.js
@@ -253,12 +253,13 @@ function filterMonths(months, namespacePath) {
 /**
  * Util to mock filter namespace data from the activity response, matching what the API does
  */
-export function filterActivityResponse(data, namespacePath) {
+export function filterActivityResponse(originalData, namespacePath) {
+  // make a deep copy of the object so we don't mutate the original
+  const data = JSON.parse(JSON.stringify(originalData));
   if (!namespacePath) return data;
-  const { by_namespace, months } = data;
 
-  const filteredMonths = filterMonths(months, namespacePath);
-  const filteredNs = filterByNamespace(by_namespace, namespacePath);
+  const filteredMonths = filterMonths(data.months, namespacePath);
+  const filteredNs = filterByNamespace(data.by_namespace, namespacePath);
   const filteredTotals = calcCounts(filteredNs);
   return {
     ...data,

--- a/ui/tests/helpers/clients/client-count-selectors.ts
+++ b/ui/tests/helpers/clients/client-count-selectors.ts
@@ -32,7 +32,7 @@ export const CLIENT_COUNT = {
   selectedAuthMount: 'div#mounts-search-select [data-test-selected-option] div',
   selectedNs: 'div#namespace-search-select [data-test-selected-option] div',
   upgradeWarning: '[data-test-clients-upgrade-warning]',
-  exportButton: '[data-test-attribution-export-button]',
+  exportButton: '[data-test-export-button]',
 };
 
 export const CHARTS = {

--- a/ui/tests/integration/components/clients/attribution-test.js
+++ b/ui/tests/integration/components/clients/attribution-test.js
@@ -13,7 +13,6 @@ import subMonths from 'date-fns/subMonths';
 import timestamp from 'core/utils/timestamp';
 import { SERIALIZED_ACTIVITY_RESPONSE } from 'vault/tests/helpers/clients/client-count-helpers';
 import { setupMirage } from 'ember-cli-mirage/test-support';
-import { capabilitiesStub, overrideResponse } from 'vault/tests/helpers/stubs';
 
 module('Integration | Component | clients/attribution', function (hooks) {
   setupRenderingTest(hooks);
@@ -43,7 +42,6 @@ module('Integration | Component | clients/attribution', function (hooks) {
     assert.dom('[data-test-component="empty-state"]').exists();
     assert.dom('[data-test-empty-state-title]').hasText('No data found');
     assert.dom('[data-test-attribution-description]').hasText('There is a problem gathering data');
-    assert.dom('[data-test-attribution-export-button]').doesNotExist();
     assert.dom('[data-test-attribution-timestamp]').doesNotHaveTextContaining('Updated');
   });
 
@@ -62,7 +60,6 @@ module('Integration | Component | clients/attribution', function (hooks) {
 
     assert.dom('[data-test-component="empty-state"]').doesNotExist();
     assert.dom('[data-test-horizontal-bar-chart]').exists('chart displays');
-    assert.dom('[data-test-attribution-export-button]').exists();
     assert
       .dom('[data-test-attribution-description]')
       .hasText(
@@ -188,7 +185,6 @@ module('Integration | Component | clients/attribution', function (hooks) {
 
     assert.dom('[data-test-component="empty-state"]').doesNotExist();
     assert.dom('[data-test-horizontal-bar-chart]').exists('chart displays');
-    assert.dom('[data-test-attribution-export-button]').exists();
     assert
       .dom('[data-test-attribution-description]')
       .hasText(
@@ -201,45 +197,5 @@ module('Integration | Component | clients/attribution', function (hooks) {
       );
     assert.dom('[data-test-top-attribution]').includesText('auth method').includesText('auth/authid/0');
     assert.dom('[data-test-attribution-clients]').includesText('auth method').includesText('8,394');
-  });
-
-  test('it shows the export button if user does has SUDO capabilities', async function (assert) {
-    this.server.post('/sys/capabilities-self', () =>
-      capabilitiesStub('sys/internal/counters/activity/export', ['sudo'])
-    );
-
-    await render(hbs`
-      <Clients::Attribution
-        @totalClientAttribution={{this.totalClientAttribution}}
-        @responseTimestamp={{this.timestamp}}
-        />
-    `);
-    assert.dom('[data-test-attribution-export-button]').exists();
-  });
-
-  test('it hides the export button if user does not have SUDO capabilities', async function (assert) {
-    this.server.post('/sys/capabilities-self', () =>
-      capabilitiesStub('sys/internal/counters/activity/export', ['read'])
-    );
-
-    await render(hbs`
-      <Clients::Attribution
-        @totalClientAttribution={{this.totalClientAttribution}}
-        @responseTimestamp={{this.timestamp}}
-        />
-    `);
-    assert.dom('[data-test-attribution-export-button]').doesNotExist();
-  });
-
-  test('defaults to show the export button if capabilities cannot be read', async function (assert) {
-    this.server.post('/sys/capabilities-self', () => overrideResponse(403));
-
-    await render(hbs`
-      <Clients::ExportButton
-        @totalClientAttribution={{this.totalClientAttribution}}
-        @responseTimestamp={{this.timestamp}}
-        />
-    `);
-    assert.dom('[data-test-attribution-export-button]').exists();
   });
 });

--- a/ui/tests/integration/components/clients/page-header-test.js
+++ b/ui/tests/integration/components/clients/page-header-test.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'vault/tests/helpers';
 import { click, fillIn, render } from '@ember/test-helpers';

--- a/ui/tests/integration/components/clients/page-header-test.js
+++ b/ui/tests/integration/components/clients/page-header-test.js
@@ -25,7 +25,7 @@ module('Integration | Component | clients/page-header', function (hooks) {
     this.startTimestamp = '2022-06-01T23:00:11.050Z';
     this.endTimestamp = '2022-12-01T23:00:11.050Z';
     this.selectedNamespace = undefined;
-    this.upgradesDuringActivity = undefined;
+    this.upgradesDuringActivity = [];
     this.server.post('/sys/capabilities-self', () =>
       capabilitiesStub('sys/internal/counters/activity/export', ['sudo'])
     );

--- a/ui/tests/integration/components/clients/page-header-test.js
+++ b/ui/tests/integration/components/clients/page-header-test.js
@@ -1,20 +1,17 @@
-/**
- * Copyright (c) HashiCorp, Inc.
- * SPDX-License-Identifier: BUSL-1.1
- */
-
 import { module, test } from 'qunit';
-import Sinon from 'sinon';
-import { Response } from 'miragejs';
+import { setupRenderingTest } from 'vault/tests/helpers';
 import { click, fillIn, render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
-
-import { setupRenderingTest } from 'vault/tests/helpers';
+import { Response } from 'miragejs';
+import Sinon from 'sinon';
 import { GENERAL } from 'vault/tests/helpers/general-selectors';
-import { overrideResponse } from 'vault/tests/helpers/stubs';
+import { capabilitiesStub, overrideResponse } from 'vault/tests/helpers/stubs';
+import { CLIENT_COUNT } from 'vault/tests/helpers/clients/client-count-selectors';
 
-module('Integration | Component | clients/export-button', function (hooks) {
+// this test coverage mostly is around the export button functionality
+// since everything else is static
+module('Integration | Component | clients/page-header', function (hooks) {
   setupRenderingTest(hooks);
   setupMirage(hooks);
 
@@ -23,52 +20,56 @@ module('Integration | Component | clients/export-button', function (hooks) {
     this.startTimestamp = '2022-06-01T23:00:11.050Z';
     this.endTimestamp = '2022-12-01T23:00:11.050Z';
     this.selectedNamespace = undefined;
+    this.upgradesDuringActivity = undefined;
+    this.server.post('/sys/capabilities-self', () =>
+      capabilitiesStub('sys/internal/counters/activity/export', ['sudo'])
+    );
 
     this.renderComponent = async () => {
       return render(hbs`
-        <Clients::ExportButton
+        <Clients::PageHeader
           @startTimestamp={{this.startTimestamp}}
           @endTimestamp={{this.endTimestamp}}
-          @selectedNamespace={{this.selectedNamespace}}
+          @namespace={{this.selectedNamespace}}
+          @upgradesDuringActivity={{this.upgradesDuringActivity}}
         />`);
     };
   });
 
-  test('it renders modal with yielded alert', async function (assert) {
-    await render(hbs`
-      <Clients::ExportButton
-        @startTimestamp={{this.startTimestamp}}
-        @endTimestamp={{this.endTimestamp}}
-      >
-        <:alert>
-          <Hds::Alert class="has-top-padding-m" @type="compact" @color="warning" as |A|>
-            <A.Description data-test-custom-alert>Yielded alert!</A.Description>
-          </Hds::Alert>
-        </:alert>
-      </Clients::ExportButton>
-    `);
-
-    await click('[data-test-attribution-export-button]');
-    assert.dom('[data-test-custom-alert]').hasText('Yielded alert!');
+  test('it shows the export button if user does has SUDO capabilities', async function (assert) {
+    await this.renderComponent();
+    assert.dom(CLIENT_COUNT.exportButton).exists();
   });
 
-  test('shows the API error on the modal', async function (assert) {
+  test('it hides the export button if user does not have SUDO capabilities', async function (assert) {
+    this.server.post('/sys/capabilities-self', () =>
+      capabilitiesStub('sys/internal/counters/activity/export', ['read'])
+    );
+
+    await this.renderComponent();
+    assert.dom(CLIENT_COUNT.exportButton).doesNotExist();
+  });
+
+  test('defaults to show the export button if capabilities cannot be read', async function (assert) {
+    this.server.post('/sys/capabilities-self', () => overrideResponse(403));
+
+    await this.renderComponent();
+    assert.dom(CLIENT_COUNT.exportButton).exists();
+  });
+
+  test('it shows the export API error on the modal', async function (assert) {
     this.server.get('/sys/internal/counters/activity/export', function () {
-      return new Response(
-        403,
-        { 'Content-Type': 'application/json' },
-        { errors: ['this is an error from the API'] }
-      );
+      return overrideResponse(403);
     });
 
     await this.renderComponent();
 
-    await click('[data-test-attribution-export-button]');
+    await click(CLIENT_COUNT.exportButton);
     await click(GENERAL.confirmButton);
-    assert.dom('[data-test-export-error]').hasText('this is an error from the API');
+    assert.dom('[data-test-export-error]').hasText('permission denied');
   });
 
-  test('it works for json format', async function (assert) {
+  test('it exports when json format', async function (assert) {
     assert.expect(2);
     this.server.get('/sys/internal/counters/activity/export', function (_, req) {
       assert.deepEqual(req.queryParams, {
@@ -81,14 +82,14 @@ module('Integration | Component | clients/export-button', function (hooks) {
 
     await this.renderComponent();
 
-    await click('[data-test-attribution-export-button]');
+    await click(CLIENT_COUNT.exportButton);
     await fillIn('[data-test-download-format]', 'jsonl');
     await click(GENERAL.confirmButton);
     const extension = this.downloadStub.lastCall.args[2];
     assert.strictEqual(extension, 'jsonl');
   });
 
-  test('it works for csv format', async function (assert) {
+  test('it exports when csv format', async function (assert) {
     assert.expect(2);
 
     this.server.get('/sys/internal/counters/activity/export', function (_, req) {
@@ -102,7 +103,7 @@ module('Integration | Component | clients/export-button', function (hooks) {
 
     await this.renderComponent();
 
-    await click('[data-test-attribution-export-button]');
+    await click(CLIENT_COUNT.exportButton);
     await fillIn('[data-test-download-format]', 'csv');
     await click(GENERAL.confirmButton);
     const extension = this.downloadStub.lastCall.args[2];
@@ -118,14 +119,10 @@ module('Integration | Component | clients/export-button', function (hooks) {
       return new Response(200, { 'Content-Type': 'text/csv' }, '');
     });
 
-    await render(hbs`
-      <Clients::ExportButton
-        @totalClientAttribution={{this.totalClientAttribution}}
-        @responseTimestamp={{this.timestamp}}
-        />
-    `);
-    assert.dom('[data-test-attribution-export-button]').exists();
-    await click('[data-test-attribution-export-button]');
+    await this.renderComponent();
+
+    assert.dom(CLIENT_COUNT.exportButton).exists();
+    await click(CLIENT_COUNT.exportButton);
     await click(GENERAL.confirmButton);
   });
   test('it sends the selected namespace in export request', async function (assert) {
@@ -136,15 +133,9 @@ module('Integration | Component | clients/export-button', function (hooks) {
     });
     this.selectedNamespace = 'foobar/';
 
-    await render(hbs`
-      <Clients::ExportButton
-        @totalClientAttribution={{this.totalClientAttribution}}
-        @responseTimestamp={{this.timestamp}}
-        @selectedNamespace={{this.selectedNamespace}}
-        />
-    `);
-    assert.dom('[data-test-attribution-export-button]').exists();
-    await click('[data-test-attribution-export-button]');
+    await this.renderComponent();
+    assert.dom(CLIENT_COUNT.exportButton).exists();
+    await click(CLIENT_COUNT.exportButton);
     await click(GENERAL.confirmButton);
   });
 
@@ -158,30 +149,29 @@ module('Integration | Component | clients/export-button', function (hooks) {
     });
     this.selectedNamespace = 'bar/';
 
-    await render(hbs`
-      <Clients::ExportButton
-        @totalClientAttribution={{this.totalClientAttribution}}
-        @responseTimestamp={{this.timestamp}}
-        @selectedNamespace={{this.selectedNamespace}}
-        />
-    `);
-    assert.dom('[data-test-attribution-export-button]').exists();
-    await click('[data-test-attribution-export-button]');
+    await this.renderComponent();
+
+    assert.dom(CLIENT_COUNT.exportButton).exists();
+    await click(CLIENT_COUNT.exportButton);
     await click(GENERAL.confirmButton);
   });
 
-  test('it shows a no data message if endpoint returns 204', async function (assert) {
+  test('it shows a no data message if export returns 204', async function (assert) {
     this.server.get('/sys/internal/counters/activity/export', () => overrideResponse(204));
+    await this.renderComponent();
 
-    await render(hbs`
-      <Clients::ExportButton
-        @totalClientAttribution={{this.totalClientAttribution}}
-        @responseTimestamp={{this.timestamp}}
-        />
-    `);
-    await click('[data-test-attribution-export-button]');
+    await click(CLIENT_COUNT.exportButton);
     await click(GENERAL.confirmButton);
     assert.dom('[data-test-export-error]').hasText('no data to export in provided time range.');
+  });
+
+  test('it shows upgrade data in export modal', async function (assert) {
+    this.upgradesDuringActivity = [
+      { version: '1.10.1', previousVersion: '1.9.9', timestampInstalled: '2021-11-18T10:23:16Z' },
+    ];
+    await this.renderComponent();
+    await click(CLIENT_COUNT.exportButton);
+    assert.dom('[data-test-export-upgrade-warning]').includesText('1.10.1 (Nov 18, 2021)');
   });
 
   module('download naming', function () {
@@ -197,7 +187,7 @@ module('Integration | Component | clients/export-button', function (hooks) {
       });
 
       await this.renderComponent();
-      await click('[data-test-attribution-export-button]');
+      await click(CLIENT_COUNT.exportButton);
       await click(GENERAL.confirmButton);
       const args = this.downloadStub.lastCall.args;
       const [filename] = args;
@@ -217,7 +207,7 @@ module('Integration | Component | clients/export-button', function (hooks) {
       });
       await this.renderComponent();
 
-      await click('[data-test-attribution-export-button]');
+      await click(CLIENT_COUNT.exportButton);
       await click(GENERAL.confirmButton);
       const [filename] = this.downloadStub.lastCall.args;
       assert.strictEqual(filename, 'clients_export_June 2022', 'csv has single month in filename');
@@ -236,7 +226,7 @@ module('Integration | Component | clients/export-button', function (hooks) {
 
       await this.renderComponent();
 
-      await click('[data-test-attribution-export-button]');
+      await click(CLIENT_COUNT.exportButton);
       await click(GENERAL.confirmButton);
       const [filename] = this.downloadStub.lastCall.args;
       assert.strictEqual(filename, 'clients_export');
@@ -258,7 +248,7 @@ module('Integration | Component | clients/export-button', function (hooks) {
 
       await this.renderComponent();
 
-      await click('[data-test-attribution-export-button]');
+      await click(CLIENT_COUNT.exportButton);
       await click(GENERAL.confirmButton);
       const [filename] = this.downloadStub.lastCall.args;
       assert.strictEqual(filename, 'clients_export_bar');
@@ -279,7 +269,7 @@ module('Integration | Component | clients/export-button', function (hooks) {
 
       await this.renderComponent();
 
-      await click('[data-test-attribution-export-button]');
+      await click(CLIENT_COUNT.exportButton);
       await click(GENERAL.confirmButton);
       const [filename] = this.downloadStub.lastCall.args;
       assert.strictEqual(filename, 'clients_export_foo');


### PR DESCRIPTION
### Description
This PR moves the export button from the attribution block to the page header. It also fixes an issue with the filter data test helper which was mutating the original data (thanks @hellobontempo for tracking that down with me!)

**New page header:**
![image](https://github.com/user-attachments/assets/90e6ae80-702a-4556-80c5-ce87fb7dc689)

**Attribution block (will change again soon):** 
![image](https://github.com/user-attachments/assets/001d16a6-239f-47bc-b8ec-f864acce2c15)
