### PR TITLE
UI: Split client count attribution

### DIFF
--- a/ui/app/components/clients/activity.ts
+++ b/ui/app/components/clients/activity.ts
@@ -10,7 +10,7 @@ import Component from '@glimmer/component';
 import { isSameMonth } from 'date-fns';
 import { parseAPITimestamp } from 'core/utils/date-formatters';
 import { calculateAverage } from 'vault/utils/chart-helpers';
-import { filterVersionHistory, hasMountsKey, hasNamespacesKey } from 'core/utils/client-count-utils';
+import { filterVersionHistory } from 'core/utils/client-count-utils';
 
 import type ClientsActivityModel from 'vault/models/clients/activity';
 import type ClientsVersionHistoryModel from 'vault/models/clients/version-history';
@@ -107,54 +107,5 @@ export default class ClientsActivityComponent extends Component<Args> {
   get upgradesDuringActivity() {
     const { versionHistory, activity } = this.args;
     return filterVersionHistory(versionHistory, activity.startTime, activity.endTime);
-  }
-
-  // (object) single month new client data with total counts and array of
-  // either namespaces or mounts
-  get newClientCounts() {
-    if (this.isDateRange || this.byMonthActivityData.length === 0) {
-      return null;
-    }
-
-    return this.byMonthActivityData[0]?.new_clients;
-  }
-
-  // total client data for horizontal bar chart in attribution component
-  get totalClientAttribution() {
-    const { namespace, activity } = this.args;
-    if (namespace) {
-      return this.filteredActivityByNamespace?.mounts || null;
-    } else {
-      return activity.byNamespace || null;
-    }
-  }
-
-  // new client data for horizontal bar chart
-  get newClientAttribution() {
-    // new client attribution only available in a single, historical month (not a date range or current month)
-    if (this.isDateRange || this.isCurrentMonth || !this.newClientCounts) return null;
-
-    const newCounts = this.newClientCounts;
-    if (this.args.namespace && hasMountsKey(newCounts)) return newCounts?.mounts;
-
-    if (hasNamespacesKey(newCounts)) return newCounts?.namespaces;
-
-    return null;
-  }
-
-  get hasAttributionData() {
-    const { mountPath, namespace } = this.args;
-    if (!mountPath) {
-      if (namespace) {
-        const mounts = this.filteredActivityByNamespace?.mounts?.map((mount) => ({
-          id: mount.label,
-          name: mount.label,
-        }));
-        return mounts && mounts.length > 0;
-      }
-      return !!this.totalClientAttribution && this.totalUsageCounts && this.totalUsageCounts.clients !== 0;
-    }
-
-    return false;
   }
 }

--- a/ui/app/components/clients/attribution.hbs
+++ b/ui/app/components/clients/attribution.hbs
@@ -9,10 +9,7 @@
     <p class="chart-description" data-test-attribution-description>{{this.chartText.description}}</p>
   </div>
   {{#if @attribution}}
-    <div
-      class={{concat (unless @attribution "chart-empty-state ") "chart-container-wide"}}
-      data-test-chart-container={{this.noun}}
-    >
+    <div class="chart-container-wide" data-test-chart-container={{this.noun}}>
       <Clients::HorizontalBarChart @dataset={{this.topTenAttribution}} @chartLegend={{this.attributionLegend}} />
     </div>
     <div class="chart-subTitle">

--- a/ui/app/components/clients/attribution.hbs
+++ b/ui/app/components/clients/attribution.hbs
@@ -3,7 +3,7 @@
   SPDX-License-Identifier: BUSL-1.1
 ~}}
 
-<div class="chart-wrapper single-chart-grid" data-test-clients-attribution>
+<div class="chart-wrapper single-chart-grid" data-test-clients-attribution={{this.noun}}>
   <div class="chart-header has-bottom-margin-m">
     <h2 class="chart-title" data-test-attribution-title>{{capitalize this.noun}} attribution</h2>
     <p class="chart-description" data-test-attribution-description>{{this.chartText.description}}</p>
@@ -11,7 +11,7 @@
   {{#if @attribution}}
     <div
       class={{concat (unless @attribution "chart-empty-state ") "chart-container-wide"}}
-      data-test-chart-container="single-chart"
+      data-test-chart-container={{this.noun}}
     >
       <Clients::HorizontalBarChart @dataset={{this.topTenAttribution}} @chartLegend={{this.attributionLegend}} />
     </div>

--- a/ui/app/components/clients/attribution.hbs
+++ b/ui/app/components/clients/attribution.hbs
@@ -3,53 +3,32 @@
   SPDX-License-Identifier: BUSL-1.1
 ~}}
 
-{{! only show side-by-side horizontal bar charts if data is from a single, historical month }}
-<div
-  class={{concat "chart-wrapper" (if @isHistoricalMonth " dual-chart-grid" " single-chart-grid")}}
-  data-test-clients-attribution
->
+<div class="chart-wrapper single-chart-grid" data-test-clients-attribution>
   <div class="chart-header has-bottom-margin-m">
-    <h2 class="chart-title">Attribution</h2>
+    <h2 class="chart-title" data-test-attribution-title>{{capitalize this.noun}} attribution</h2>
     <p class="chart-description" data-test-attribution-description>{{this.chartText.description}}</p>
   </div>
-  {{#if this.barChartTotalClients}}
-    {{#if @isHistoricalMonth}}
-      <div class="chart-container-left" data-test-chart-container="new-clients">
-        <h2 class="chart-title">New clients</h2>
-        <p class="chart-description">{{this.chartText.newCopy}}</p>
-        <Clients::HorizontalBarChart
-          @dataset={{this.barChartNewClients}}
-          @chartLegend={{this.attributionLegend}}
-          @noDataMessage="There are no new clients for this namespace during this time period."
-        />
-      </div>
+  {{#if @attribution}}
+    <div
+      class={{concat (unless @attribution "chart-empty-state ") "chart-container-wide"}}
+      data-test-chart-container="single-chart"
+    >
+      <Clients::HorizontalBarChart @dataset={{this.topTenAttribution}} @chartLegend={{this.attributionLegend}} />
+    </div>
+    <div class="chart-subTitle">
+      <p class="chart-subtext" data-test-attribution-subtext>{{this.chartText.subtext}}</p>
+    </div>
 
-      <div class="chart-container-right" data-test-chart-container="total-clients">
-        <h2 class="chart-title">Total clients</h2>
-        <p class="chart-description">{{this.chartText.totalCopy}}</p>
-        <Clients::HorizontalBarChart @dataset={{this.barChartTotalClients}} @chartLegend={{this.attributionLegend}} />
-      </div>
-    {{else}}
-      <div
-        class={{concat (unless this.barChartTotalClients "chart-empty-state ") "chart-container-wide"}}
-        data-test-chart-container="single-chart"
-      >
-        <Clients::HorizontalBarChart @dataset={{this.barChartTotalClients}} @chartLegend={{this.attributionLegend}} />
-      </div>
-      <div class="chart-subTitle">
-        <p class="chart-subtext" data-test-attribution-subtext>{{this.chartText.totalCopy}}</p>
-      </div>
+    <div class="data-details-top" data-test-top-attribution>
+      <h3 class="data-details">Top {{this.noun}}</h3>
+      <p class="data-details is-word-break">{{this.topAttribution.label}}</p>
+    </div>
 
-      <div class="data-details-top" data-test-top-attribution>
-        <h3 class="data-details">Top {{this.attributionBreakdown}}</h3>
-        <p class="data-details is-word-break">{{this.topClientCounts.label}}</p>
-      </div>
+    <div class="data-details-bottom" data-test-attribution-clients>
+      <h3 class="data-details">Clients in {{this.noun}}</h3>
+      <p class="data-details">{{format-number this.topAttribution.clients}}</p>
+    </div>
 
-      <div class="data-details-bottom" data-test-attribution-clients>
-        <h3 class="data-details">Clients in {{this.attributionBreakdown}}</h3>
-        <p class="data-details">{{format-number this.topClientCounts.clients}}</p>
-      </div>
-    {{/if}}
     <div class="legend">
       {{#each this.attributionLegend as |legend idx|}}
         <span class="legend-colors dot-{{idx}}"></span><span class="legend-label">{{capitalize legend.label}}</span>

--- a/ui/app/components/clients/attribution.js
+++ b/ui/app/components/clients/attribution.js
@@ -43,17 +43,21 @@ export default class Attribution extends Component {
   }
 
   get sortedAttribution() {
-    return this.args.attribution?.sort((a, b) => b.clients - a.clients);
+    if (this.args.attribution) {
+      // shallow copy so it doesn't mutate the data during tests
+      return this.args.attribution?.slice().sort((a, b) => b.clients - a.clients);
+    }
+    return [];
   }
 
   // truncate data before sending to chart component
   get topTenAttribution() {
-    return this.sortedAttribution?.slice(0, 10);
+    return this.sortedAttribution.slice(0, 10);
   }
 
   get topAttribution() {
     // get top namespace or mount
-    return this.sortedAttribution ? this.sortedAttribution[0] : null;
+    return this.sortedAttribution[0] ?? null;
   }
 
   get chartText() {

--- a/ui/app/components/clients/attribution.js
+++ b/ui/app/components/clients/attribution.js
@@ -4,36 +4,31 @@
  */
 
 import Component from '@glimmer/component';
-import { parseAPITimestamp } from 'core/utils/date-formatters';
-import { isSameMonth } from 'date-fns';
 
 /**
  * @module Attribution
- * Attribution components display the top 10 total client counts for namespaces or auth methods (mounts) during a billing period.
+ * Attribution components display the top 10 total client counts for namespaces or mounts during a billing period.
  * A horizontal bar chart shows on the right, with the top namespace/auth method and respective client totals on the left.
  *
  * @example
  *  <Clients::Attribution
- *    @totalClientAttribution={{this.totalClientAttribution}}
- *    @newClientAttribution={{this.newClientAttribution}}
- *    @selectedNamespace={{this.selectedNamespace}}
- *    @startTimestamp={{this.startTime}}
- *    @endTimestamp={{this.endTime}}
- *    @isHistoricalMonth={{false}}
- *    @responseTimestamp={{this.responseTimestamp}}
+ *    @noun="auth mount"
+ *    @attribution={{array (hash label="ns1" clients=100)}}
+ *    @responseTimestamp="2018-04-03T14:15:30"
+ *    @isSecretsSyncActivated={{true}}
  *  />
  *
- * @param {array} totalClientAttribution - array of objects containing a label and breakdown of client counts for total clients
- * @param {array} newClientAttribution - array of objects containing a label and breakdown of client counts for new clients
- * @param {string} selectedNamespace - namespace selected from filter bar
- * @param {string} startTimestamp - timestamp string from activity response to render start date for CSV modal and whether copy reads 'month' or 'date range'
- * @param {string} endTimestamp - timestamp string from activity response to render end date for CSV modal and whether copy reads 'month' or 'date range'
+ * @param {string} noun - noun which reflects the type of data and used in title. Should be "namespace" (default) or "auth mount"
+ * @param {array} attribution - array of objects containing a label and breakdown of client counts for total clients
  * @param {string} responseTimestamp -  ISO timestamp created in serializer to timestamp the response, renders in bottom left corner below attribution chart
- * @param {boolean} isHistoricalMonth - when true data is from a single, historical month so side-by-side charts should display for attribution data
- * @param {boolean} isSecretsSyncActivated - boolean to determine if secrets sync is activated
+ * @param {boolean} isSecretsSyncActivated - boolean reflecting if secrets sync is activated. Determines the labels and data shown
  */
 
 export default class Attribution extends Component {
+  get noun() {
+    return this.args.noun || 'namespace';
+  }
+
   get attributionLegend() {
     const attributionLegend = [
       { key: 'entity_clients', label: 'entity clients' },
@@ -47,64 +42,34 @@ export default class Attribution extends Component {
     return attributionLegend;
   }
 
-  get isSingleMonth() {
-    if (!this.args.startTimestamp && !this.args.endTimestamp) return false;
-    const startDateObject = parseAPITimestamp(this.args.startTimestamp);
-    const endDateObject = parseAPITimestamp(this.args.endTimestamp);
-    return isSameMonth(startDateObject, endDateObject);
-  }
-
-  get isSingleNamespace() {
-    // if a namespace is selected, then we're viewing top 10 auth methods (mounts)
-    return !!this.args.selectedNamespace;
+  get sortedAttribution() {
+    return this.args.attribution?.sort((a, b) => b.clients - a.clients);
   }
 
   // truncate data before sending to chart component
-  get barChartTotalClients() {
-    return this.args.totalClientAttribution?.slice(0, 10);
+  get topTenAttribution() {
+    return this.sortedAttribution?.slice(0, 10);
   }
 
-  get barChartNewClients() {
-    return this.args.newClientAttribution?.slice(0, 10);
-  }
-
-  get topClientCounts() {
+  get topAttribution() {
     // get top namespace or auth method
-    return this.args.totalClientAttribution ? this.args.totalClientAttribution[0] : null;
-  }
-
-  get attributionBreakdown() {
-    // display text for hbs
-    return this.isSingleNamespace ? 'auth method' : 'namespace';
+    return this.sortedAttribution ? this.sortedAttribution[0] : null;
   }
 
   get chartText() {
-    if (!this.args.totalClientAttribution) {
-      return { description: 'There is a problem gathering data' };
-    }
-    const dateText = this.isSingleMonth ? 'month' : 'date range';
-    switch (this.isSingleNamespace) {
-      case true:
-        return {
-          description:
-            'This data shows the top ten authentication methods by client count within this namespace, and can be used to understand where clients are originating. Authentication methods are organized by path.',
-          newCopy: `The new clients used by the auth method for this ${dateText}. This aids in understanding which auth methods create and use new clients${
-            dateText === 'date range' ? ' over time.' : '.'
-          }`,
-          totalCopy: `The total clients used by the auth method for this ${dateText}. This number is useful for identifying overall usage volume. `,
-        };
-      case false:
-        return {
-          description:
-            'This data shows the top ten namespaces by client count and can be used to understand where clients are originating. Namespaces are identified by path. To see all namespaces, export this data.',
-          newCopy: `The new clients in the namespace for this ${dateText}.
-          This aids in understanding which namespaces create and use new clients${
-            dateText === 'date range' ? ' over time.' : '.'
-          }`,
-          totalCopy: `The total clients in the namespace for this ${dateText}. This number is useful for identifying overall usage volume.`,
-        };
-      default:
-        return '';
+    if (this.noun === 'namespace') {
+      return {
+        subtext: 'This data shows the top ten namespaces by total clients for the date range selected.',
+        description:
+          'This data shows the top ten namespaces by total clients and can be used to understand where clients are originating. Namespaces are identified by path. To see all namespaces, click export data on top of the page.',
+      };
+    } else {
+      return {
+        subtext:
+          'The total clients used by the auth method for this date range. This number is useful for identifying overall usage volume.',
+        description:
+          'This data shows the top ten authentication methods by client count within this namespace, and can be used to understand where clients are originating. Auth methods are organized by path. To see all auth methods, click export data on top of the page.',
+      };
     }
   }
 }

--- a/ui/app/components/clients/attribution.js
+++ b/ui/app/components/clients/attribution.js
@@ -8,17 +8,17 @@ import Component from '@glimmer/component';
 /**
  * @module Attribution
  * Attribution components display the top 10 total client counts for namespaces or mounts during a billing period.
- * A horizontal bar chart shows on the right, with the top namespace/auth method and respective client totals on the left.
+ * A horizontal bar chart shows on the right, with the top namespace/mount and respective client totals on the left.
  *
  * @example
  *  <Clients::Attribution
- *    @noun="auth mount"
- *    @attribution={{array (hash label="ns1" clients=100)}}
+ *    @noun="mount"
+ *    @attribution={{array (hash label="my-kv" clients=100)}}
  *    @responseTimestamp="2018-04-03T14:15:30"
  *    @isSecretsSyncActivated={{true}}
  *  />
  *
- * @param {string} noun - noun which reflects the type of data and used in title. Should be "namespace" (default) or "auth mount"
+ * @param {string} noun - noun which reflects the type of data and used in title. Should be "namespace" (default) or "mount"
  * @param {array} attribution - array of objects containing a label and breakdown of client counts for total clients
  * @param {string} responseTimestamp -  ISO timestamp created in serializer to timestamp the response, renders in bottom left corner below attribution chart
  * @param {boolean} isSecretsSyncActivated - boolean reflecting if secrets sync is activated. Determines the labels and data shown
@@ -52,7 +52,7 @@ export default class Attribution extends Component {
   }
 
   get topAttribution() {
-    // get top namespace or auth method
+    // get top namespace or mount
     return this.sortedAttribution ? this.sortedAttribution[0] : null;
   }
 
@@ -61,14 +61,14 @@ export default class Attribution extends Component {
       return {
         subtext: 'This data shows the top ten namespaces by total clients for the date range selected.',
         description:
-          'This data shows the top ten namespaces by total clients and can be used to understand where clients are originating. Namespaces are identified by path. To see all namespaces, click export data on top of the page.',
+          'This data shows the top ten namespaces by total clients and can be used to understand where clients are originating. Namespaces are identified by path.',
       };
     } else {
       return {
         subtext:
-          'The total clients used by the auth method for this date range. This number is useful for identifying overall usage volume.',
+          'The total clients used by the mounts for this date range. This number is useful for identifying overall usage volume.',
         description:
-          'This data shows the top ten authentication methods by client count within this namespace, and can be used to understand where clients are originating. Auth methods are organized by path. To see all auth methods, click export data on top of the page.',
+          'This data shows the top ten mounts by client count within this namespace, and can be used to understand where clients are originating. Mounts are organized by path.',
       };
     }
   }

--- a/ui/app/components/clients/date-range.hbs
+++ b/ui/app/components/clients/date-range.hbs
@@ -5,8 +5,11 @@
 
 <div ...attributes>
   <Hds::Text::Display @tag="p" class="has-bottom-margin-xs">
-    Date range
+    Client counting period
   </Hds::Text::Display>
+  <Hds::Text::Body @tag="p" @color="faint" @size="300">
+    The dashboard displays client count activity during the specified date range below. Click edit to update the date range.
+  </Hds::Text::Body>
 
   <div class="is-flex-align-baseline">
     {{#if (and @startTime @endTime)}}

--- a/ui/app/components/clients/page/counts.hbs
+++ b/ui/app/components/clients/page/counts.hbs
@@ -10,7 +10,7 @@
   @upgradesDuringActivity={{this.upgradesDuringActivity}}
 />
 
-<div class="box is-sideless is-fullwidth is-marginless is-bottomless">
+<div class="box is-sideless is-fullwidth is-marginless is-bottomless is-shadowless">
   <Clients::DateRange
     @startTime={{@startTimestamp}}
     @endTime={{@endTimestamp}}

--- a/ui/app/components/clients/page/overview.hbs
+++ b/ui/app/components/clients/page/overview.hbs
@@ -13,15 +13,18 @@
   @responseTimestamp={{@activity.responseTimestamp}}
   @mountPath={{@mountPath}}
 />
+
 {{#if this.hasAttributionData}}
   <Clients::Attribution
-    @isSecretsSyncActivated={{this.flags.secretsSyncIsActivated}}
-    @totalClientAttribution={{this.totalClientAttribution}}
-    @newClientAttribution={{this.newClientAttribution}}
-    @selectedNamespace={{@namespace}}
-    @startTimestamp={{@startTimestamp}}
-    @endTimestamp={{@endTimestamp}}
+    @noun="namespace"
+    @attribution={{@activity.byNamespace}}
     @responseTimestamp={{@activity.responseTimestamp}}
-    @isHistoricalMonth={{and (not this.isCurrentMonth) (not this.isDateRange)}}
+    @isSecretsSyncActivated={{this.flags.secretsSyncIsActivated}}
+  />
+  <Clients::Attribution
+    @noun="auth mount"
+    @attribution={{this.namespaceMountAttribution}}
+    @responseTimestamp={{@activity.responseTimestamp}}
+    @isSecretsSyncActivated={{this.flags.secretsSyncIsActivated}}
   />
 {{/if}}

--- a/ui/app/components/clients/page/overview.hbs
+++ b/ui/app/components/clients/page/overview.hbs
@@ -22,7 +22,7 @@
     @isSecretsSyncActivated={{this.flags.secretsSyncIsActivated}}
   />
   <Clients::Attribution
-    @noun="auth mount"
+    @noun="mount"
     @attribution={{this.namespaceMountAttribution}}
     @responseTimestamp={{@activity.responseTimestamp}}
     @isSecretsSyncActivated={{this.flags.secretsSyncIsActivated}}

--- a/ui/app/components/clients/page/overview.ts
+++ b/ui/app/components/clients/page/overview.ts
@@ -5,8 +5,58 @@
 
 import ActivityComponent from '../activity';
 import { service } from '@ember/service';
+import { hasMountsKey, hasNamespacesKey } from 'core/utils/client-count-utils';
 import type FlagsService from 'vault/services/flags';
 
 export default class ClientsOverviewPageComponent extends ActivityComponent {
   @service declare readonly flags: FlagsService;
+
+  // (object) single month new client data with total counts and array of
+  // either namespaces or mounts
+  get newClientCounts() {
+    if (this.isDateRange || this.byMonthActivityData.length === 0) {
+      return null;
+    }
+
+    return this.byMonthActivityData[0]?.new_clients;
+  }
+
+  // total client data for horizontal bar chart in attribution component
+  get totalClientAttribution() {
+    const { namespace, activity } = this.args;
+    if (namespace) {
+      return this.filteredActivityByNamespace?.mounts || null;
+    } else {
+      return activity.byNamespace || null;
+    }
+  }
+
+  // new client data for horizontal bar chart
+  get newClientAttribution() {
+    // new client attribution only available in a single, historical month (not a date range or current month)
+    if (this.isDateRange || this.isCurrentMonth || !this.newClientCounts) return null;
+
+    const newCounts = this.newClientCounts;
+    if (this.args.namespace && hasMountsKey(newCounts)) return newCounts?.mounts;
+
+    if (hasNamespacesKey(newCounts)) return newCounts?.namespaces;
+
+    return null;
+  }
+
+  get hasAttributionData() {
+    const { mountPath, namespace } = this.args;
+    if (!mountPath) {
+      if (namespace) {
+        const mounts = this.filteredActivityByNamespace?.mounts?.map((mount) => ({
+          id: mount.label,
+          name: mount.label,
+        }));
+        return mounts && mounts.length > 0;
+      }
+      return !!this.totalClientAttribution && this.totalUsageCounts && this.totalUsageCounts.clients !== 0;
+    }
+
+    return false;
+  }
 }

--- a/ui/app/components/clients/page/overview.ts
+++ b/ui/app/components/clients/page/overview.ts
@@ -38,22 +38,8 @@ export default class ClientsOverviewPageComponent extends ActivityComponent {
   }
 
   get hasAttributionData() {
-    // TODO: update this logic. when do we hide attribution?
-    if (this.args.mountPath) return false;
-    return true;
-    // const { mountPath, namespace } = this.args;
-    // if (!mountPath) {
-    //   if (namespace) {
-    //     const mounts = this.filteredActivityByNamespace?.mounts?.map((mount) => ({
-    //       id: mount.label,
-    //       name: mount.label,
-    //     }));
-    //     return mounts && mounts.length > 0;
-    //   }
-    //   return !!this.totalClientAttribution && this.totalUsageCounts && this.totalUsageCounts.clients !== 0;
-    // }
-
-    // return false;
+    // we only hide attribution data when we filter on mountPath
+    return !this.args.mountPath;
   }
 
   get namespaceMountAttribution() {

--- a/ui/app/components/clients/page/overview.ts
+++ b/ui/app/components/clients/page/overview.ts
@@ -14,29 +14,6 @@ export default class ClientsOverviewPageComponent extends ActivityComponent {
   @service declare readonly flags: FlagsService;
   @service declare readonly namespace: NamespaceService;
 
-  get showNewClientAttribution(): boolean {
-    return this.args.activity.byMonth.length === 1;
-  }
-
-  get newClientNamespaceAttribution(): ByNamespaceClients[] | undefined {
-    if (this.showNewClientAttribution) {
-      return this.args.activity.byMonth[0]?.namespaces;
-    }
-    return;
-  }
-
-  get newClientMountAttribution(): MountClients[] | undefined {
-    if (this.showNewClientAttribution) {
-      const currentNs = this.namespace.currentNamespace;
-      const nsLabel = sanitizePath(this.args.namespace || currentNs || 'root');
-      const singleNamespace = this.newClientNamespaceAttribution?.find(
-        (namespace) => sanitizePath(namespace.label) === nsLabel
-      );
-      return singleNamespace?.mounts;
-    }
-    return;
-  }
-
   get hasAttributionData() {
     // we only hide attribution data when we filter on mountPath
     return !this.args.mountPath;

--- a/ui/app/components/clients/page/overview.ts
+++ b/ui/app/components/clients/page/overview.ts
@@ -5,58 +5,61 @@
 
 import ActivityComponent from '../activity';
 import { service } from '@ember/service';
-import { hasMountsKey, hasNamespacesKey } from 'core/utils/client-count-utils';
+import { ByNamespaceClients, MountClients } from 'core/utils/client-count-utils';
+import { sanitizePath } from 'core/utils/sanitize-path';
 import type FlagsService from 'vault/services/flags';
+import type NamespaceService from 'vault/services/namespace';
 
 export default class ClientsOverviewPageComponent extends ActivityComponent {
   @service declare readonly flags: FlagsService;
+  @service declare readonly namespace: NamespaceService;
 
-  // (object) single month new client data with total counts and array of
-  // either namespaces or mounts
-  get newClientCounts() {
-    if (this.isDateRange || this.byMonthActivityData.length === 0) {
-      return null;
-    }
-
-    return this.byMonthActivityData[0]?.new_clients;
+  get showNewClientAttribution(): boolean {
+    return this.args.activity.byMonth.length === 1;
   }
 
-  // total client data for horizontal bar chart in attribution component
-  get totalClientAttribution() {
-    const { namespace, activity } = this.args;
-    if (namespace) {
-      return this.filteredActivityByNamespace?.mounts || null;
-    } else {
-      return activity.byNamespace || null;
+  get newClientNamespaceAttribution(): ByNamespaceClients[] | undefined {
+    if (this.showNewClientAttribution) {
+      return this.args.activity.byMonth[0]?.namespaces;
     }
+    return;
   }
 
-  // new client data for horizontal bar chart
-  get newClientAttribution() {
-    // new client attribution only available in a single, historical month (not a date range or current month)
-    if (this.isDateRange || this.isCurrentMonth || !this.newClientCounts) return null;
-
-    const newCounts = this.newClientCounts;
-    if (this.args.namespace && hasMountsKey(newCounts)) return newCounts?.mounts;
-
-    if (hasNamespacesKey(newCounts)) return newCounts?.namespaces;
-
-    return null;
+  get newClientMountAttribution(): MountClients[] | undefined {
+    if (this.showNewClientAttribution) {
+      const currentNs = this.namespace.currentNamespace;
+      const nsLabel = sanitizePath(this.args.namespace || currentNs || 'root');
+      const singleNamespace = this.newClientNamespaceAttribution?.find(
+        (namespace) => sanitizePath(namespace.label) === nsLabel
+      );
+      return singleNamespace?.mounts;
+    }
+    return;
   }
 
   get hasAttributionData() {
-    const { mountPath, namespace } = this.args;
-    if (!mountPath) {
-      if (namespace) {
-        const mounts = this.filteredActivityByNamespace?.mounts?.map((mount) => ({
-          id: mount.label,
-          name: mount.label,
-        }));
-        return mounts && mounts.length > 0;
-      }
-      return !!this.totalClientAttribution && this.totalUsageCounts && this.totalUsageCounts.clients !== 0;
-    }
+    // TODO: update this logic. when do we hide attribution?
+    if (this.args.mountPath) return false;
+    return true;
+    // const { mountPath, namespace } = this.args;
+    // if (!mountPath) {
+    //   if (namespace) {
+    //     const mounts = this.filteredActivityByNamespace?.mounts?.map((mount) => ({
+    //       id: mount.label,
+    //       name: mount.label,
+    //     }));
+    //     return mounts && mounts.length > 0;
+    //   }
+    //   return !!this.totalClientAttribution && this.totalUsageCounts && this.totalUsageCounts.clients !== 0;
+    // }
 
-    return false;
+    // return false;
+  }
+
+  get namespaceMountAttribution() {
+    const { activity, namespace } = this.args;
+    const currentNs = this.namespace.currentNamespace;
+    const nsLabel = sanitizePath(namespace || currentNs || 'root');
+    return activity.byNamespace?.find((ns) => sanitizePath(ns.label) === nsLabel)?.mounts;
   }
 }

--- a/ui/app/styles/components/chart-container.scss
+++ b/ui/app/styles/components/chart-container.scss
@@ -21,13 +21,6 @@
   }
 }
 
-.dual-chart-grid {
-  display: grid;
-  grid-template-columns: repeat(6, 1fr);
-  grid-template-rows: 0.7fr 1fr 1fr 1fr 0.3fr;
-  width: 100%;
-}
-
 .chart-header {
   grid-column-start: 1;
   grid-column-end: span col4-end;

--- a/ui/app/styles/core/charts.scss
+++ b/ui/app/styles/core/charts.scss
@@ -83,13 +83,6 @@
 // RESPONSIVE STYLING //
 
 @media only screen and (max-width: 950px) {
-  .dual-chart-grid {
-    display: grid;
-    grid-template-columns: repeat(2, 1fr);
-    grid-template-rows: 0.2fr 0.75fr 0.75fr 0.2fr;
-    width: 100%;
-  }
-
   .chart-container-left {
     grid-column-start: 1;
     grid-column-end: 4;

--- a/ui/lib/core/addon/utils/client-count-utils.ts
+++ b/ui/lib/core/addon/utils/client-count-utils.ts
@@ -6,7 +6,6 @@
 import { parseAPITimestamp } from 'core/utils/date-formatters';
 import { compareAsc, getUnixTime, isWithinInterval } from 'date-fns';
 
-import type ClientsConfigModel from 'vault/models/clients/config';
 import type ClientsVersionHistoryModel from 'vault/vault/models/clients/version-history';
 
 /*

--- a/ui/tests/acceptance/clients/counts/overview-test.js
+++ b/ui/tests/acceptance/clients/counts/overview-test.js
@@ -68,14 +68,9 @@ module('Acceptance | clients | overview', function (hooks) {
     assert
       .dom(CHARTS.container('Vault client counts'))
       .doesNotExist('running total month over month charts do not show');
-    assert.dom(CLIENT_COUNT.attributionBlock).exists('attribution area shows');
-    assert
-      .dom(`${CHARTS.container('new-clients')} ${GENERAL.emptyStateTitle}`)
-      .exists('new client attribution has empty state');
-    assert
-      .dom(GENERAL.emptyStateSubtitle)
-      .hasText('There are no new clients for this namespace during this time period.');
-    assert.dom(CHARTS.container('total-clients')).exists('total client attribution chart shows');
+    assert.dom(CLIENT_COUNT.attributionBlock).exists({ count: 2 });
+    assert.dom(CHARTS.container('namespace')).exists('namespace attribution chart shows');
+    assert.dom(CHARTS.container('auth mount')).exists('mount attribution chart shows');
 
     // reset to billing period
     await click(CLIENT_COUNT.dateRange.edit);
@@ -109,8 +104,8 @@ module('Acceptance | clients | overview', function (hooks) {
       .dom(CHARTS.container('Vault client counts'))
       .doesNotExist('running total month over month charts do not show');
     assert.dom(CLIENT_COUNT.attributionBlock).exists('attribution area shows');
-    assert.dom(CHARTS.container('new-clients')).exists('new client attribution chart shows');
-    assert.dom(CHARTS.container('total-clients')).exists('total client attribution chart shows');
+    assert.dom(CHARTS.container('namespace')).exists('namespace attribution chart shows');
+    assert.dom(CHARTS.container('auth mount')).exists('mount attribution chart shows');
 
     // query historical date range (from September 2023 to December 2023)
     await click(CLIENT_COUNT.dateRange.edit);
@@ -171,9 +166,11 @@ module('Acceptance | clients | overview', function (hooks) {
     const topMount = topNamespace.mounts[0];
 
     assert.dom(CLIENT_COUNT.selectedNs).hasText(topNamespace.label, 'selects top namespace');
-    assert.dom('[data-test-top-attribution]').includesText('Top auth method');
     assert
-      .dom('[data-test-attribution-clients] p')
+      .dom('[data-test-clients-attribution="auth mount"] [data-test-top-attribution]')
+      .includesText('Top auth mount');
+    assert
+      .dom('[data-test-clients-attribution="auth mount"] [data-test-attribution-clients] p')
       .includesText(`${formatNumber([topMount.clients])}`, 'top attribution clients accurate');
 
     let expectedStats = {

--- a/ui/tests/acceptance/clients/counts/overview-test.js
+++ b/ui/tests/acceptance/clients/counts/overview-test.js
@@ -70,7 +70,7 @@ module('Acceptance | clients | overview', function (hooks) {
       .doesNotExist('running total month over month charts do not show');
     assert.dom(CLIENT_COUNT.attributionBlock).exists({ count: 2 });
     assert.dom(CHARTS.container('namespace')).exists('namespace attribution chart shows');
-    assert.dom(CHARTS.container('auth mount')).exists('mount attribution chart shows');
+    assert.dom(CHARTS.container('mount')).exists('mount attribution chart shows');
 
     // reset to billing period
     await click(CLIENT_COUNT.dateRange.edit);
@@ -105,7 +105,7 @@ module('Acceptance | clients | overview', function (hooks) {
       .doesNotExist('running total month over month charts do not show');
     assert.dom(CLIENT_COUNT.attributionBlock).exists('attribution area shows');
     assert.dom(CHARTS.container('namespace')).exists('namespace attribution chart shows');
-    assert.dom(CHARTS.container('auth mount')).exists('mount attribution chart shows');
+    assert.dom(CHARTS.container('mount')).exists('mount attribution chart shows');
 
     // query historical date range (from September 2023 to December 2023)
     await click(CLIENT_COUNT.dateRange.edit);
@@ -167,10 +167,10 @@ module('Acceptance | clients | overview', function (hooks) {
 
     assert.dom(CLIENT_COUNT.selectedNs).hasText(topNamespace.label, 'selects top namespace');
     assert
-      .dom('[data-test-clients-attribution="auth mount"] [data-test-top-attribution]')
-      .includesText('Top auth mount');
+      .dom('[data-test-clients-attribution="mount"] [data-test-top-attribution]')
+      .includesText('Top mount');
     assert
-      .dom('[data-test-clients-attribution="auth mount"] [data-test-attribution-clients] p')
+      .dom('[data-test-clients-attribution="mount"] [data-test-attribution-clients] p')
       .includesText(`${formatNumber([topMount.clients])}`, 'top attribution clients accurate');
 
     let expectedStats = {

--- a/ui/tests/helpers/clients/client-count-helpers.js
+++ b/ui/tests/helpers/clients/client-count-helpers.js
@@ -131,7 +131,7 @@ export const ACTIVITY_RESPONSE_STUB = {
       timestamp: '2023-07-01T00:00:00Z',
       counts: {
         acme_clients: 100,
-        clients: 100,
+        clients: 400,
         entity_clients: 100,
         non_entity_clients: 100,
         secret_syncs: 100,
@@ -142,7 +142,7 @@ export const ACTIVITY_RESPONSE_STUB = {
           namespace_path: '',
           counts: {
             acme_clients: 100,
-            clients: 100,
+            clients: 400,
             entity_clients: 100,
             non_entity_clients: 100,
             secret_syncs: 100,
@@ -162,7 +162,7 @@ export const ACTIVITY_RESPONSE_STUB = {
               mount_path: 'auth/authid/0',
               counts: {
                 acme_clients: 0,
-                clients: 100,
+                clients: 200,
                 entity_clients: 100,
                 non_entity_clients: 100,
                 secret_syncs: 0,
@@ -184,7 +184,7 @@ export const ACTIVITY_RESPONSE_STUB = {
       new_clients: {
         counts: {
           acme_clients: 100,
-          clients: 100,
+          clients: 400,
           entity_clients: 100,
           non_entity_clients: 100,
           secret_syncs: 100,
@@ -195,7 +195,7 @@ export const ACTIVITY_RESPONSE_STUB = {
             namespace_path: '',
             counts: {
               acme_clients: 100,
-              clients: 100,
+              clients: 400,
               entity_clients: 100,
               non_entity_clients: 100,
               secret_syncs: 100,
@@ -215,7 +215,7 @@ export const ACTIVITY_RESPONSE_STUB = {
                 mount_path: 'auth/authid/0',
                 counts: {
                   acme_clients: 0,
-                  clients: 100,
+                  clients: 200,
                   entity_clients: 100,
                   non_entity_clients: 100,
                   secret_syncs: 0,
@@ -240,7 +240,7 @@ export const ACTIVITY_RESPONSE_STUB = {
       timestamp: '2023-08-01T00:00:00Z',
       counts: {
         acme_clients: 100,
-        clients: 100,
+        clients: 400,
         entity_clients: 100,
         non_entity_clients: 100,
         secret_syncs: 100,
@@ -251,7 +251,7 @@ export const ACTIVITY_RESPONSE_STUB = {
           namespace_path: '',
           counts: {
             acme_clients: 100,
-            clients: 100,
+            clients: 400,
             entity_clients: 100,
             non_entity_clients: 100,
             secret_syncs: 100,
@@ -271,7 +271,7 @@ export const ACTIVITY_RESPONSE_STUB = {
               mount_path: 'auth/authid/0',
               counts: {
                 acme_clients: 0,
-                clients: 100,
+                clients: 200,
                 entity_clients: 100,
                 non_entity_clients: 100,
                 secret_syncs: 0,
@@ -740,7 +740,7 @@ export const SERIALIZED_ACTIVITY_RESPONSE = {
       month: '7/23',
       timestamp: '2023-07-01T00:00:00Z',
       acme_clients: 100,
-      clients: 100,
+      clients: 400,
       entity_clients: 100,
       non_entity_clients: 100,
       secret_syncs: 100,
@@ -748,7 +748,7 @@ export const SERIALIZED_ACTIVITY_RESPONSE = {
         {
           label: 'root',
           acme_clients: 100,
-          clients: 100,
+          clients: 400,
           entity_clients: 100,
           non_entity_clients: 100,
           secret_syncs: 100,
@@ -764,7 +764,7 @@ export const SERIALIZED_ACTIVITY_RESPONSE = {
             {
               label: 'auth/authid/0',
               acme_clients: 0,
-              clients: 100,
+              clients: 200,
               entity_clients: 100,
               non_entity_clients: 100,
               secret_syncs: 0,
@@ -783,7 +783,7 @@ export const SERIALIZED_ACTIVITY_RESPONSE = {
       namespaces_by_key: {
         root: {
           acme_clients: 100,
-          clients: 100,
+          clients: 400,
           entity_clients: 100,
           non_entity_clients: 100,
           secret_syncs: 100,
@@ -794,7 +794,7 @@ export const SERIALIZED_ACTIVITY_RESPONSE = {
             timestamp: '2023-07-01T00:00:00Z',
             label: 'root',
             acme_clients: 100,
-            clients: 100,
+            clients: 400,
             entity_clients: 100,
             non_entity_clients: 100,
             secret_syncs: 100,
@@ -810,7 +810,7 @@ export const SERIALIZED_ACTIVITY_RESPONSE = {
               {
                 label: 'auth/authid/0',
                 acme_clients: 0,
-                clients: 100,
+                clients: 200,
                 entity_clients: 100,
                 non_entity_clients: 100,
                 secret_syncs: 0,
@@ -849,7 +849,7 @@ export const SERIALIZED_ACTIVITY_RESPONSE = {
             'auth/authid/0': {
               label: 'auth/authid/0',
               acme_clients: 0,
-              clients: 100,
+              clients: 200,
               entity_clients: 100,
               non_entity_clients: 100,
               secret_syncs: 0,
@@ -860,7 +860,7 @@ export const SERIALIZED_ACTIVITY_RESPONSE = {
                 timestamp: '2023-07-01T00:00:00Z',
                 label: 'auth/authid/0',
                 acme_clients: 0,
-                clients: 100,
+                clients: 200,
                 entity_clients: 100,
                 non_entity_clients: 100,
                 secret_syncs: 0,
@@ -893,7 +893,7 @@ export const SERIALIZED_ACTIVITY_RESPONSE = {
         month: '7/23',
         timestamp: '2023-07-01T00:00:00Z',
         acme_clients: 100,
-        clients: 100,
+        clients: 400,
         entity_clients: 100,
         non_entity_clients: 100,
         secret_syncs: 100,
@@ -901,7 +901,7 @@ export const SERIALIZED_ACTIVITY_RESPONSE = {
           {
             label: 'root',
             acme_clients: 100,
-            clients: 100,
+            clients: 400,
             entity_clients: 100,
             non_entity_clients: 100,
             secret_syncs: 100,
@@ -917,7 +917,7 @@ export const SERIALIZED_ACTIVITY_RESPONSE = {
               {
                 label: 'auth/authid/0',
                 acme_clients: 0,
-                clients: 100,
+                clients: 200,
                 entity_clients: 100,
                 non_entity_clients: 100,
                 secret_syncs: 0,
@@ -939,7 +939,7 @@ export const SERIALIZED_ACTIVITY_RESPONSE = {
       month: '8/23',
       timestamp: '2023-08-01T00:00:00Z',
       acme_clients: 100,
-      clients: 100,
+      clients: 400,
       entity_clients: 100,
       non_entity_clients: 100,
       secret_syncs: 100,
@@ -947,7 +947,7 @@ export const SERIALIZED_ACTIVITY_RESPONSE = {
         {
           label: 'root',
           acme_clients: 100,
-          clients: 100,
+          clients: 400,
           entity_clients: 100,
           non_entity_clients: 100,
           secret_syncs: 100,
@@ -963,7 +963,7 @@ export const SERIALIZED_ACTIVITY_RESPONSE = {
             {
               label: 'auth/authid/0',
               acme_clients: 0,
-              clients: 100,
+              clients: 200,
               entity_clients: 100,
               non_entity_clients: 100,
               secret_syncs: 0,
@@ -982,7 +982,7 @@ export const SERIALIZED_ACTIVITY_RESPONSE = {
       namespaces_by_key: {
         root: {
           acme_clients: 100,
-          clients: 100,
+          clients: 400,
           entity_clients: 100,
           non_entity_clients: 100,
           secret_syncs: 100,
@@ -1013,7 +1013,7 @@ export const SERIALIZED_ACTIVITY_RESPONSE = {
             'auth/authid/0': {
               label: 'auth/authid/0',
               acme_clients: 0,
-              clients: 100,
+              clients: 200,
               entity_clients: 100,
               non_entity_clients: 100,
               secret_syncs: 0,

--- a/ui/tests/integration/components/clients/attribution-test.js
+++ b/ui/tests/integration/components/clients/attribution-test.js
@@ -79,9 +79,9 @@ module('Integration | Component | clients/attribution', function (hooks) {
       .dom(CLIENTS_ATTRIBUTION.subtext)
       .hasText('This data shows the top ten namespaces by total clients for the date range selected.');
 
-    // when noun is auth mount
-    this.set('noun', 'auth mount');
-    assert.dom(CLIENTS_ATTRIBUTION.title).hasText('Auth mount attribution');
+    // when noun is mount
+    this.set('noun', 'mount');
+    assert.dom(CLIENTS_ATTRIBUTION.title).hasText('Mount attribution');
     assert
       .dom(CLIENTS_ATTRIBUTION.description)
       .hasText(
@@ -124,18 +124,18 @@ module('Integration | Component | clients/attribution', function (hooks) {
     assert.dom(CLIENTS_ATTRIBUTION.yLabel).hasText('ns1root');
   });
 
-  test('it renders with data for auth mounts', async function (assert) {
+  test('it renders with data for mounts', async function (assert) {
     await render(hbs`
       <Clients::Attribution
-        @noun="auth mount"
+        @noun="mount"
         @attribution={{this.authMountAttribution}}
         />
     `);
 
     assert.dom(GENERAL.emptyStateTitle).doesNotExist();
     assert.dom(CLIENTS_ATTRIBUTION.chart).exists();
-    assert.dom(CLIENTS_ATTRIBUTION.topItem).includesText('auth mount').includesText('auth/authid/0');
-    assert.dom(CLIENTS_ATTRIBUTION.topItemCount).includesText('auth mount').includesText('8,394');
+    assert.dom(CLIENTS_ATTRIBUTION.topItem).includesText('mount').includesText('auth/authid/0');
+    assert.dom(CLIENTS_ATTRIBUTION.topItemCount).includesText('mount').includesText('8,394');
     assert
       .dom(CLIENTS_ATTRIBUTION.yLabels)
       .exists({ count: 3 }, 'bars reflect number of mounts in single month');

--- a/ui/tests/integration/components/clients/attribution-test.js
+++ b/ui/tests/integration/components/clients/attribution-test.js
@@ -73,7 +73,7 @@ module('Integration | Component | clients/attribution', function (hooks) {
     assert
       .dom(CLIENTS_ATTRIBUTION.description)
       .hasText(
-        'This data shows the top ten namespaces by total clients and can be used to understand where clients are originating. Namespaces are identified by path. To see all namespaces, click export data on top of the page.'
+        'This data shows the top ten namespaces by total clients and can be used to understand where clients are originating. Namespaces are identified by path.'
       );
     assert
       .dom(CLIENTS_ATTRIBUTION.subtext)
@@ -85,12 +85,12 @@ module('Integration | Component | clients/attribution', function (hooks) {
     assert
       .dom(CLIENTS_ATTRIBUTION.description)
       .hasText(
-        'This data shows the top ten authentication methods by client count within this namespace, and can be used to understand where clients are originating. Auth methods are organized by path. To see all auth methods, click export data on top of the page.'
+        'This data shows the top ten mounts by client count within this namespace, and can be used to understand where clients are originating. Mounts are organized by path.'
       );
     assert
       .dom(CLIENTS_ATTRIBUTION.subtext)
       .hasText(
-        'The total clients used by the auth method for this date range. This number is useful for identifying overall usage volume.'
+        'The total clients used by the mounts for this date range. This number is useful for identifying overall usage volume.'
       );
 
     // when noun is namespace
@@ -99,7 +99,7 @@ module('Integration | Component | clients/attribution', function (hooks) {
     assert
       .dom(CLIENTS_ATTRIBUTION.description)
       .hasText(
-        'This data shows the top ten namespaces by total clients and can be used to understand where clients are originating. Namespaces are identified by path. To see all namespaces, click export data on top of the page.'
+        'This data shows the top ten namespaces by total clients and can be used to understand where clients are originating. Namespaces are identified by path.'
       );
     assert
       .dom(CLIENTS_ATTRIBUTION.subtext)

--- a/ui/tests/integration/components/clients/attribution-test.js
+++ b/ui/tests/integration/components/clients/attribution-test.js
@@ -8,12 +8,25 @@ import sinon from 'sinon';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { endOfMonth, formatRFC3339 } from 'date-fns';
+import { formatRFC3339 } from 'date-fns';
 import subMonths from 'date-fns/subMonths';
 import timestamp from 'core/utils/timestamp';
 import { SERIALIZED_ACTIVITY_RESPONSE } from 'vault/tests/helpers/clients/client-count-helpers';
 import { setupMirage } from 'ember-cli-mirage/test-support';
+import { GENERAL } from 'vault/tests/helpers/general-selectors';
+import { CLIENT_TYPES } from 'core/utils/client-count-utils';
 
+const CLIENTS_ATTRIBUTION = {
+  title: '[data-test-attribution-title]',
+  description: '[data-test-attribution-description]',
+  subtext: '[data-test-attribution-subtext]',
+  timestamp: '[data-test-attribution-timestamp]',
+  chart: '[data-test-horizontal-bar-chart]',
+  topItem: '[data-test-top-attribution]',
+  topItemCount: '[data-test-attribution-clients]',
+  yLabel: '[data-test-group="y-labels"]',
+  yLabels: '[data-test-group="y-labels"] text',
+};
 module('Integration | Component | clients/attribution', function (hooks) {
   setupRenderingTest(hooks);
   setupMirage(hooks);
@@ -23,15 +36,15 @@ module('Integration | Component | clients/attribution', function (hooks) {
   });
 
   hooks.beforeEach(function () {
-    const { total, by_namespace } = SERIALIZED_ACTIVITY_RESPONSE;
     const mockNow = this.timestampStub();
     this.mockNow = mockNow;
     this.startTimestamp = formatRFC3339(subMonths(mockNow, 6));
     this.timestamp = formatRFC3339(mockNow);
     this.selectedNamespace = null;
-    this.totalUsageCounts = total;
-    this.totalClientAttribution = [...by_namespace];
-    this.namespaceMountsData = by_namespace.find((ns) => ns.label === 'ns1').mounts;
+    this.namespaceAttribution = SERIALIZED_ACTIVITY_RESPONSE.by_namespace;
+    this.authMountAttribution = SERIALIZED_ACTIVITY_RESPONSE.by_namespace.find(
+      (ns) => ns.label === 'ns1'
+    ).mounts;
   });
 
   test('it renders empty state with no data', async function (assert) {
@@ -39,163 +52,137 @@ module('Integration | Component | clients/attribution', function (hooks) {
       <Clients::Attribution />
     `);
 
-    assert.dom('[data-test-component="empty-state"]').exists();
-    assert.dom('[data-test-empty-state-title]').hasText('No data found');
-    assert.dom('[data-test-attribution-description]').hasText('There is a problem gathering data');
-    assert.dom('[data-test-attribution-timestamp]').doesNotHaveTextContaining('Updated');
+    assert.dom(GENERAL.emptyStateTitle).hasText('No data found');
+    assert.dom(CLIENTS_ATTRIBUTION.title).hasText('Namespace attribution', 'uses default noun');
+    assert.dom(CLIENTS_ATTRIBUTION.timestamp).hasNoText();
+  });
+
+  test('it updates language based on noun', async function (assert) {
+    this.noun = '';
+    await render(hbs`
+      <Clients::Attribution
+        @noun={{this.noun}}
+        @attribution={{this.namespaceAttribution}}
+        @responseTimestamp={{this.timestamp}}
+        />
+    `);
+    assert.dom(CLIENTS_ATTRIBUTION.timestamp).includesText('Updated Apr 3');
+
+    // when noun is blank, uses default
+    assert.dom(CLIENTS_ATTRIBUTION.title).hasText('Namespace attribution');
+    assert
+      .dom(CLIENTS_ATTRIBUTION.description)
+      .hasText(
+        'This data shows the top ten namespaces by total clients and can be used to understand where clients are originating. Namespaces are identified by path. To see all namespaces, click export data on top of the page.'
+      );
+    assert
+      .dom(CLIENTS_ATTRIBUTION.subtext)
+      .hasText('This data shows the top ten namespaces by total clients for the date range selected.');
+
+    // when noun is auth mount
+    this.set('noun', 'auth mount');
+    assert.dom(CLIENTS_ATTRIBUTION.title).hasText('Auth mount attribution');
+    assert
+      .dom(CLIENTS_ATTRIBUTION.description)
+      .hasText(
+        'This data shows the top ten authentication methods by client count within this namespace, and can be used to understand where clients are originating. Auth methods are organized by path. To see all auth methods, click export data on top of the page.'
+      );
+    assert
+      .dom(CLIENTS_ATTRIBUTION.subtext)
+      .hasText(
+        'The total clients used by the auth method for this date range. This number is useful for identifying overall usage volume.'
+      );
+
+    // when noun is namespace
+    this.set('noun', 'namespace');
+    assert.dom(CLIENTS_ATTRIBUTION.title).hasText('Namespace attribution');
+    assert
+      .dom(CLIENTS_ATTRIBUTION.description)
+      .hasText(
+        'This data shows the top ten namespaces by total clients and can be used to understand where clients are originating. Namespaces are identified by path. To see all namespaces, click export data on top of the page.'
+      );
+    assert
+      .dom(CLIENTS_ATTRIBUTION.subtext)
+      .hasText('This data shows the top ten namespaces by total clients for the date range selected.');
   });
 
   test('it renders with data for namespaces', async function (assert) {
     await render(hbs`
       <Clients::Attribution
-        @totalClientAttribution={{this.totalClientAttribution}}
-        @totalUsageCounts={{this.totalUsageCounts}}
+        @attribution={{this.namespaceAttribution}}
         @responseTimestamp={{this.timestamp}}
-        @startTimestamp={{this.startTimestamp}}
-        @endTimestamp={{this.timestamp}}
-        @selectedNamespace={{this.selectedNamespace}}
-        @isHistoricalMonth={{false}}
         />
     `);
 
-    assert.dom('[data-test-component="empty-state"]').doesNotExist();
-    assert.dom('[data-test-horizontal-bar-chart]').exists('chart displays');
+    assert.dom(GENERAL.emptyStateTitle).doesNotExist();
+    assert.dom(CLIENTS_ATTRIBUTION.chart).exists();
+    assert.dom(CLIENTS_ATTRIBUTION.topItem).includesText('namespace').includesText('ns1');
+    assert.dom(CLIENTS_ATTRIBUTION.topItemCount).includesText('namespace').includesText('18,903');
     assert
-      .dom('[data-test-attribution-description]')
-      .hasText(
-        'This data shows the top ten namespaces by client count and can be used to understand where clients are originating. Namespaces are identified by path. To see all namespaces, export this data.'
-      );
-    assert
-      .dom('[data-test-attribution-subtext]')
-      .hasText(
-        'The total clients in the namespace for this date range. This number is useful for identifying overall usage volume.'
-      );
-    assert.dom('[data-test-top-attribution]').includesText('namespace').includesText('ns1');
-    assert.dom('[data-test-attribution-clients]').includesText('namespace').includesText('18,903');
+      .dom(CLIENTS_ATTRIBUTION.yLabels)
+      .exists({ count: 2 }, 'bars reflect number of namespaces in single month');
+    assert.dom(CLIENTS_ATTRIBUTION.yLabel).hasText('ns1root');
   });
 
-  test('it renders two charts and correct text for single, historical month', async function (assert) {
-    this.start = formatRFC3339(subMonths(this.mockNow, 1));
-    this.end = formatRFC3339(subMonths(endOfMonth(this.mockNow), 1));
+  test('it renders with data for auth mounts', async function (assert) {
     await render(hbs`
       <Clients::Attribution
-        @totalClientAttribution={{this.totalClientAttribution}}
-        @totalUsageCounts={{this.totalUsageCounts}}
-        @responseTimestamp={{this.timestamp}}
-        @startTimestamp={{this.start}}
-        @endTimestamp={{this.end}}
-        @selectedNamespace={{this.selectedNamespace}}
-        @isHistoricalMonth={{true}}
+        @noun="auth mount"
+        @attribution={{this.authMountAttribution}}
         />
     `);
-    assert
-      .dom('[data-test-attribution-description]')
-      .includesText(
-        'This data shows the top ten namespaces by client count and can be used to understand where clients are originating. Namespaces are identified by path. To see all namespaces, export this data.',
-        'renders correct auth attribution description'
-      );
-    assert
-      .dom('[data-test-chart-container="total-clients"] .chart-description')
-      .includesText(
-        'The total clients in the namespace for this month. This number is useful for identifying overall usage volume.',
-        'renders total monthly namespace text'
-      );
-    assert
-      .dom('[data-test-chart-container="new-clients"] .chart-description')
-      .includesText(
-        'The new clients in the namespace for this month. This aids in understanding which namespaces create and use new clients.',
-        'renders new monthly namespace text'
-      );
-    this.set('selectedNamespace', 'ns1');
 
+    assert.dom(GENERAL.emptyStateTitle).doesNotExist();
+    assert.dom(CLIENTS_ATTRIBUTION.chart).exists();
+    assert.dom(CLIENTS_ATTRIBUTION.topItem).includesText('auth mount').includesText('auth/authid/0');
+    assert.dom(CLIENTS_ATTRIBUTION.topItemCount).includesText('auth mount').includesText('8,394');
     assert
-      .dom('[data-test-attribution-description]')
-      .includesText(
-        'This data shows the top ten authentication methods by client count within this namespace, and can be used to understand where clients are originating. Authentication methods are organized by path.',
-        'renders correct auth attribution description'
-      );
-    assert
-      .dom('[data-test-chart-container="total-clients"] .chart-description')
-      .includesText(
-        'The total clients used by the auth method for this month. This number is useful for identifying overall usage volume.',
-        'renders total monthly auth method text'
-      );
-    assert
-      .dom('[data-test-chart-container="new-clients"] .chart-description')
-      .includesText(
-        'The new clients used by the auth method for this month. This aids in understanding which auth methods create and use new clients.',
-        'renders new monthly auth method text'
-      );
+      .dom(CLIENTS_ATTRIBUTION.yLabels)
+      .exists({ count: 3 }, 'bars reflect number of mounts in single month');
+    assert.dom(CLIENTS_ATTRIBUTION.yLabel).hasText('auth/authid/0pki-engine-0kvv2-engine-0');
   });
 
-  test('it renders single chart for current month', async function (assert) {
+  test('it shows secret syncs when flag is on', async function (assert) {
+    this.isSecretsSyncActivated = true;
     await render(hbs`
       <Clients::Attribution
-        @totalClientAttribution={{this.totalClientAttribution}}
-        @totalUsageCounts={{this.totalUsageCounts}}
+        @attribution={{this.namespaceAttribution}}
         @responseTimestamp={{this.timestamp}}
-        @startTimestamp={{this.timestamp}}
-        @endTimestamp={{this.timestamp}}
-        @selectedNamespace={{this.selectedNamespace}}
-        @isHistoricalMonth={{false}}
+        @isSecretsSyncActivated={{true}}
         />
     `);
-    assert
-      .dom('[data-test-chart-container="single-chart"]')
-      .exists('renders single chart with total clients');
-    assert
-      .dom('[data-test-attribution-subtext]')
-      .hasTextContaining('this month', 'renders total monthly namespace text');
+
+    assert.dom('[data-test-group="secret_syncs"] rect').exists({ count: 2 });
   });
 
-  test('it renders single chart and correct text for for date range', async function (assert) {
+  test('it hids secret syncs when flag is off or missing', async function (assert) {
+    this.isSecretsSyncActivated = true;
     await render(hbs`
       <Clients::Attribution
-        @totalClientAttribution={{this.totalClientAttribution}}
-        @totalUsageCounts={{this.totalUsageCounts}}
+        @attribution={{this.namespaceAttribution}}
         @responseTimestamp={{this.timestamp}}
-        @startTimestamp={{this.startTimestamp}}
-        @endTimestamp={{this.timestamp}}
-        @selectedNamespace={{this.selectedNamespace}}
-        @isHistoricalMonth={{false}}
         />
     `);
 
-    assert
-      .dom('[data-test-chart-container="single-chart"]')
-      .exists('renders single chart with total clients');
-    assert
-      .dom('[data-test-attribution-subtext]')
-      .hasTextContaining('date range', 'renders total monthly namespace text');
+    assert.dom('[data-test-group="secret_syncs"]').doesNotExist();
   });
 
-  test('it renders with data for selected namespace auth methods for a date range', async function (assert) {
-    this.set('selectedNamespace', 'ns1');
+  test('it sorts and limits before rendering bars', async function (assert) {
+    this.tooManyAttributions = Array(15)
+      .fill(null)
+      .map((_, idx) => {
+        const attr = { label: `ns${idx}` };
+        CLIENT_TYPES.forEach((type) => {
+          attr[type] = 10 + idx;
+        });
+        return attr;
+      });
     await render(hbs`
       <Clients::Attribution
-        @totalClientAttribution={{this.namespaceMountsData}}
-        @totalUsageCounts={{this.totalUsageCounts}}
-        @responseTimestamp={{this.timestamp}}
-        @startTimestamp={{this.startTimestamp}}
-        @endTimestamp={{this.timestamp}}
-        @selectedNamespace={{this.selectedNamespace}}
-        @isHistoricalMonth={{this.isHistoricalMonth}}
+        @attribution={{this.tooManyAttributions}}
         />
     `);
-
-    assert.dom('[data-test-component="empty-state"]').doesNotExist();
-    assert.dom('[data-test-horizontal-bar-chart]').exists('chart displays');
-    assert
-      .dom('[data-test-attribution-description]')
-      .hasText(
-        'This data shows the top ten authentication methods by client count within this namespace, and can be used to understand where clients are originating. Authentication methods are organized by path.'
-      );
-    assert
-      .dom('[data-test-attribution-subtext]')
-      .hasText(
-        'The total clients used by the auth method for this date range. This number is useful for identifying overall usage volume.'
-      );
-    assert.dom('[data-test-top-attribution]').includesText('auth method').includesText('auth/authid/0');
-    assert.dom('[data-test-attribution-clients]').includesText('auth method').includesText('8,394');
+    assert.dom(CLIENTS_ATTRIBUTION.yLabels).exists({ count: 10 }, 'only 10 bars are shown');
+    assert.dom(CLIENTS_ATTRIBUTION.topItem).includesText('ns14');
   });
 });


### PR DESCRIPTION
### Description
This PR updates the client count dashboard overview so that attribution for both namespaces and mount paths are shown unless we are filtered on the mount path level. 

**Updated attribution:**
![image](https://github.com/user-attachments/assets/4f01eaee-297d-4e05-9501-3644db1c45ec)

**Not shown when filtered:**
![image](https://github.com/user-attachments/assets/26e14fc7-6b10-4f96-b95c-cdba398a1723)

