### PR TITLE
CE: Added deleted namespace string

### DIFF
--- a/vault/activity_log.go
+++ b/vault/activity_log.go
@@ -2792,7 +2792,7 @@ func (a *ActivityLog) calculateByNamespaceResponseForQuery(ctx context.Context, 
 
 			var displayPath string
 			if ns == nil {
-				displayPath = fmt.Sprintf("deleted namespace %q", nsRecord.NamespaceID)
+				displayPath = fmt.Sprintf(DeletedNamespaceFmt, nsRecord.NamespaceID)
 			} else {
 				displayPath = ns.Path
 			}
@@ -2873,7 +2873,7 @@ func (a *ActivityLog) prepareNamespaceResponse(ctx context.Context, nsRecords []
 
 			var displayPath string
 			if ns == nil {
-				displayPath = fmt.Sprintf("deleted namespace %q", nsRecord.NamespaceID)
+				displayPath = fmt.Sprintf(DeletedNamespaceFmt, nsRecord.NamespaceID)
 			} else {
 				displayPath = ns.Path
 			}
@@ -3044,6 +3044,12 @@ func (a *ActivityLog) writeExport(ctx context.Context, rw http.ResponseWriter, f
 			if err != nil {
 				return err
 			}
+			var nsDisplayPath string
+			if ns == nil {
+				nsDisplayPath = fmt.Sprintf(DeletedNamespaceFmt, e.NamespaceID)
+			} else {
+				nsDisplayPath = ns.Path
+			}
 
 			if !a.includeInResponse(reqNS, ns) {
 				continue
@@ -3054,14 +3060,14 @@ func (a *ActivityLog) writeExport(ctx context.Context, rw http.ResponseWriter, f
 			record := &ActivityLogExportRecord{
 				ClientID:      e.ClientID,
 				ClientType:    e.ClientType,
-				NamespaceID:   ns.ID,
-				NamespacePath: ns.Path,
+				NamespaceID:   e.NamespaceID,
+				NamespacePath: nsDisplayPath,
 				Timestamp:     ts.UTC().Format(time.RFC3339),
 				MountAccessor: e.MountAccessor,
 			}
 
 			if e.MountAccessor != "" {
-				cacheKey := ns.Path + mountPathIdentity
+				cacheKey := e.NamespaceID + mountPathIdentity
 
 				var identityBackend logical.Backend
 

--- a/vault/activity_log_util_common.go
+++ b/vault/activity_log_util_common.go
@@ -391,8 +391,9 @@ func (a *ActivityLog) sortActivityLogMonthsResponse(months []*ResponseMonth) {
 }
 
 const (
-	noMountAccessor = "no mount accessor (pre-1.10 upgrade?)"
-	deletedMountFmt = "deleted mount; accessor %q"
+	noMountAccessor     = "no mount accessor (pre-1.10 upgrade?)"
+	deletedMountFmt     = "deleted mount; accessor %q"
+	DeletedNamespaceFmt = "deleted namespace %q"
 )
 
 // mountAccessorToMountPath transforms the mount accessor to the mount path

--- a/website/content/api-docs/system/internal-counters.mdx
+++ b/website/content/api-docs/system/internal-counters.mdx
@@ -1058,10 +1058,10 @@ $ curl \
 ```
 
 <Note title="Important change to supported versions">
-   As of 1.16.7, 1.17.3 and later, 
-   the <a href="/vault/docs/concepts/billing-start-date">billing start date</a> automatically 
+   As of 1.16.7, 1.17.3 and later,
+   the <a href="/vault/docs/concepts/billing-start-date">billing start date</a> automatically
    rolls over to the latest billing year at the end of the last cycle.
-        
+
    For more information, refer to the upgrade guide for your Vault version:
 
    [Vault v1.16.x](/vault/docs/upgrading/upgrade-to-1.16.x#auto-rolled-billing-start-date),
@@ -1104,6 +1104,10 @@ it may be up to 20 minutes delayed.
 - `format` `(string, optional)` - The desired format of the output file. Allowed
     values are `csv` and `json`. If no format is provided a default of `json`
     will be used.
+
+The response will include all child namespaces of the namespace in which the
+request was made. If some namespace has subsequently been deleted, its path will
+be listed as "deleted namespace :ID:."
 
 ### Sample request
 

--- a/website/content/api-docs/system/internal-counters.mdx
+++ b/website/content/api-docs/system/internal-counters.mdx
@@ -1107,7 +1107,7 @@ it may be up to 20 minutes delayed.
 
 The response will include all child namespaces of the namespace in which the
 request was made. If some namespace has subsequently been deleted, its path will
-be listed as "deleted namespace :ID:."
+be listed as "deleted namespace :ID:"
 
 ### Sample request
 


### PR DESCRIPTION
### Description
When a namespace is deleted, display "deleted namespace <ns_id>" as the namespace path.
ENT pr: https://github.com/hashicorp/vault-enterprise/pull/6448

### TODO only if you're a HashiCorp employee
- [ ] **Labels:** If this PR is the CE portion of an ENT change, and that ENT change is
  getting backported to N-2, use the new style `backport/ent/x.x.x+ent` labels
  instead of the old style `backport/x.x.x` labels.
- [ ] **Labels:** If this PR is a CE only change, it can only be backported to N, so use
  the normal `backport/x.x.x` label (there should be only 1).
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
