### PR TITLE
1.17 Manual backport: Current month inconsistencies

### DIFF
--- a/changelog/27547.txt
+++ b/changelog/27547.txt
@@ -1,0 +1,4 @@
+```release-note:improvement
+activity log: Changes how new client counts in the current month are estimated, in order to return more
+visibly sensible totals.
+```

--- a/changelog/28042.txt
+++ b/changelog/28042.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+activity: The sys/internal/counters/activity endpoint will return current month data when the end_date parameter is set to a future date.
+```

--- a/changelog/28062.txt
+++ b/changelog/28062.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+core/activity: Ensure client count queries that include the current month return consistent results by sorting the clients before performing estimation 
+```

--- a/vault/activity_log.go
+++ b/vault/activity_log.go
@@ -1769,12 +1769,20 @@ func (a *ActivityLog) handleQuery(ctx context.Context, startTime, endTime time.T
 	startTime = timeutil.StartOfMonth(startTime)
 	endTime = timeutil.EndOfMonth(endTime)
 
+	// At the max, we only want to return data up until the end of the current month.
+	// Adjust the end time be the current month if a future date has been provided.
+	endOfCurrentMonth := timeutil.EndOfMonth(a.clock.Now().UTC())
+	adjustedEndTime := endTime
+	if endTime.After(endOfCurrentMonth) {
+		adjustedEndTime = endOfCurrentMonth
+	}
+
 	// If the endTime of the query is the current month, request data from the queryStore
 	// with the endTime equal to the end of the last month, and add in the current month
 	// data.
-	precomputedQueryEndTime := endTime
-	if timeutil.IsCurrentMonth(endTime, a.clock.Now().UTC()) {
-		precomputedQueryEndTime = timeutil.EndOfMonth(timeutil.MonthsPreviousTo(1, timeutil.StartOfMonth(endTime)))
+	precomputedQueryEndTime := adjustedEndTime
+	if timeutil.IsCurrentMonth(adjustedEndTime, a.clock.Now().UTC()) {
+		precomputedQueryEndTime = timeutil.EndOfMonth(timeutil.MonthsPreviousTo(1, timeutil.StartOfMonth(adjustedEndTime)))
 		computePartial = true
 	}
 
@@ -1817,7 +1825,7 @@ func (a *ActivityLog) handleQuery(ctx context.Context, startTime, endTime time.T
 
 		// Estimate the current month totals. These record contains is complete with all the
 		// current month data, grouped by namespace and mounts
-		currentMonth, err := a.computeCurrentMonthForBillingPeriod(ctx, partialByMonth, startTime, endTime)
+		currentMonth, err := a.computeCurrentMonthForBillingPeriod(ctx, partialByMonth, startTime, adjustedEndTime)
 		if err != nil {
 			return nil, err
 		}
@@ -1867,7 +1875,7 @@ func (a *ActivityLog) handleQuery(ctx context.Context, startTime, endTime time.T
 	a.sortActivityLogMonthsResponse(months)
 
 	// Modify the final month output to make response more consumable based on API request
-	months = a.modifyResponseMonths(months, startTime, endTime)
+	months = a.modifyResponseMonths(months, startTime, adjustedEndTime)
 	responseData["months"] = months
 
 	return responseData, nil

--- a/vault/activity_log.go
+++ b/vault/activity_log.go
@@ -1715,30 +1715,6 @@ type ResponseNamespace struct {
 	Mounts        []*ResponseMount `json:"mounts"`
 }
 
-// Add adds the namespace counts to the existing record, then either adds the
-// mount counts to the existing mount (if it exists) or appends the mount to the
-// list of mounts
-func (r *ResponseNamespace) Add(newRecord *ResponseNamespace) {
-	// Create a map of the existing mounts, so we don't duplicate them
-	mountMap := make(map[string]*ResponseCounts)
-	for _, erm := range r.Mounts {
-		mountMap[erm.MountPath] = erm.Counts
-	}
-
-	r.Counts.Add(&newRecord.Counts)
-
-	// Check the current month mounts against the existing mounts and if there are matches, update counts
-	// accordingly. If there is no match, append the new mount to the existing mounts, so it will be counted
-	// later.
-	for _, newRecordMount := range newRecord.Mounts {
-		if existingRecordMountCounts, ok := mountMap[newRecordMount.MountPath]; ok {
-			existingRecordMountCounts.Add(newRecordMount.Counts)
-		} else {
-			r.Mounts = append(r.Mounts, newRecordMount)
-		}
-	}
-}
-
 type ResponseMonth struct {
 	Timestamp  string               `json:"timestamp"`
 	Counts     *ResponseCounts      `json:"counts"`

--- a/vault/activity_log.go
+++ b/vault/activity_log.go
@@ -1831,54 +1831,29 @@ func (a *ActivityLog) handleQuery(ctx context.Context, startTime, endTime time.T
 		pq = storedQuery
 	}
 
-	// Calculate the namespace response breakdowns and totals for entities and tokens from the initial
-	// namespace data.
-	totalCounts, byNamespaceResponse, err := a.calculateByNamespaceResponseForQuery(ctx, pq.Namespaces)
-	if err != nil {
-		return nil, err
-	}
-
-	// If we need to add the current month's client counts into the total, compute the namespace
-	// breakdown for the current month as well.
 	var partialByMonth map[int64]*processMonth
-	var partialByNamespace map[string]*processByNamespace
-	var byNamespaceResponseCurrent []*ResponseNamespace
-	var totalCurrentCounts *ResponseCounts
 	if computePartial {
 		// Traverse through current month's activitylog data and group clients
 		// into months and namespaces
 		a.fragmentLock.RLock()
-		partialByMonth, partialByNamespace = a.populateNamespaceAndMonthlyBreakdowns()
+		partialByMonth, _ = a.populateNamespaceAndMonthlyBreakdowns()
 		a.fragmentLock.RUnlock()
 
-		// Convert the byNamespace breakdowns into structs that are
-		// consumable by the /activity endpoint, so as to reuse code between these two
-		// endpoints.
-		byNamespaceComputation := a.transformALNamespaceBreakdowns(partialByNamespace)
-
-		// Calculate the namespace response breakdowns and totals for entities
-		// and tokens from current month namespace data.
-		totalCurrentCounts, byNamespaceResponseCurrent, err = a.calculateByNamespaceResponseForQuery(ctx, byNamespaceComputation)
+		// Estimate the current month totals. These record contains is complete with all the
+		// current month data, grouped by namespace and mounts
+		currentMonth, err := a.computeCurrentMonthForBillingPeriod(ctx, partialByMonth, startTime, endTime)
 		if err != nil {
 			return nil, err
 		}
 
-		// Create a mapping of namespace id to slice index, so that we can efficiently update our results without
-		// having to traverse the entire namespace response slice every time.
-		nsrMap := make(map[string]int)
-		for i, nr := range byNamespaceResponse {
-			nsrMap[nr.NamespaceID] = i
-		}
+		// Combine the existing months precomputed query with the current month data
+		pq.CombineWithCurrentMonth(currentMonth)
+	}
 
-		// Rather than blindly appending, which will create duplicates, check our existing counts against the current
-		// month counts, and append or update as necessary. We also want to account for mounts and their counts.
-		for _, nrc := range byNamespaceResponseCurrent {
-			if ndx, ok := nsrMap[nrc.NamespaceID]; ok {
-				byNamespaceResponse[ndx].Add(nrc)
-			} else {
-				byNamespaceResponse = append(byNamespaceResponse, nrc)
-			}
-		}
+	// Convert the namespace data into a protobuf format that can be returned in the response
+	totalCounts, byNamespaceResponse, err := a.calculateByNamespaceResponseForQuery(ctx, pq.Namespaces)
+	if err != nil {
+		return nil, err
 	}
 
 	// Sort clients within each namespace
@@ -1886,34 +1861,6 @@ func (a *ActivityLog) handleQuery(ctx context.Context, startTime, endTime time.T
 
 	if limitNamespaces > 0 {
 		totalCounts, byNamespaceResponse = a.limitNamespacesInALResponse(byNamespaceResponse, limitNamespaces)
-	}
-
-	distinctEntitiesResponse := totalCounts.EntityClients
-	if computePartial {
-		currentMonth, err := a.computeCurrentMonthForBillingPeriod(ctx, partialByMonth, startTime, endTime)
-		if err != nil {
-			return nil, err
-		}
-
-		// Add the namespace attribution for the current month to the newly computed current month value. Note
-		// that transformMonthBreakdowns calculates a superstruct of the required namespace struct due to its
-		// primary use-case being for precomputedQueryWorker, but we will reuse this code for brevity and extract
-		// the namespaces from it.
-		currentMonthNamespaceAttribution := a.transformMonthBreakdowns(partialByMonth)
-
-		// Ensure that there is only one element in this list -- if not, warn.
-		if len(currentMonthNamespaceAttribution) > 1 {
-			a.logger.Warn("more than one month worth of namespace and mount attribution calculated for "+
-				"current month values", "number of months", len(currentMonthNamespaceAttribution))
-		}
-		if len(currentMonthNamespaceAttribution) == 0 {
-			a.logger.Warn("no month data found, returning query with no namespace attribution for current month")
-		} else {
-			currentMonth.Namespaces = currentMonthNamespaceAttribution[0].Namespaces
-			currentMonth.NewClients.Namespaces = currentMonthNamespaceAttribution[0].NewClients.Namespaces
-		}
-		pq.Months = append(pq.Months, currentMonth)
-		distinctEntitiesResponse += pq.Months[len(pq.Months)-1].NewClients.Counts.EntityClients
 	}
 
 	// Now populate the response based on breakdowns.
@@ -1932,8 +1879,6 @@ func (a *ActivityLog) handleQuery(ctx context.Context, startTime, endTime time.T
 	}
 
 	responseData["by_namespace"] = byNamespaceResponse
-	totalCounts.Add(totalCurrentCounts)
-	totalCounts.DistinctEntities = distinctEntitiesResponse
 	responseData["total"] = totalCounts
 
 	// Create and populate the month response structs based on the monthly breakdown.

--- a/vault/activity_log_util_common.go
+++ b/vault/activity_log_util_common.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -156,20 +157,30 @@ func (a *ActivityLog) computeCurrentMonthForBillingPeriodInternal(ctx context.Co
 		return nil, errors.New("malformed current month used to calculate current month's activity")
 	}
 
-	for nsID, namespace := range month.Namespaces {
+	namespaces := month.Namespaces.sort()
+	for _, n := range namespaces {
+		nsID := n.id
+		namespace := n.processByNamespace
 		namespaceActivity := &activity.MonthlyNamespaceRecord{NamespaceID: nsID, Counts: &activity.CountsRecord{}}
 		newNamespaceActivity := &activity.MonthlyNamespaceRecord{NamespaceID: nsID, Counts: &activity.CountsRecord{}}
 		mountsActivity := make([]*activity.MountRecord, 0)
 		newMountsActivity := make([]*activity.MountRecord, 0)
 
-		for mountAccessor, mount := range namespace.Mounts {
+		mounts := namespace.Mounts.sort()
+		for _, m := range mounts {
+			mountAccessor := m.accessor
+			mount := m.processMount
 			mountPath := a.mountAccessorToMountPath(mountAccessor)
 
 			mountCounts := &activity.CountsRecord{}
 			newMountCounts := &activity.CountsRecord{}
 
 			for _, typ := range ActivityClientTypes {
-				for clientID := range mount.Counts.clientsByType(typ) {
+				clients := mount.Counts.clientsByType(typ)
+				clientIDs := clients.sort()
+			
+				// sort the client IDs before inserting
+				for _, clientID := range clientIDs {
 					hllByType[typ].Insert([]byte(clientID))
 
 					// increment the per mount, per namespace, and total counts
@@ -239,6 +250,47 @@ func (a *ActivityLog) incrementCount(c *activity.CountsRecord, num int, typ stri
 	case ACMEActivityType:
 		c.ACMEClients += num
 	}
+}
+
+type processByNamespaceID struct {
+	id string
+	*processByNamespace
+}
+
+func (s summaryByNamespace) sort() []*processByNamespaceID {
+	namespaces := make([]*processByNamespaceID, 0, len(s))
+	for nsID, namespace := range s {
+		namespaces = append(namespaces, &processByNamespaceID{id: nsID, processByNamespace: namespace})
+	}
+	slices.SortStableFunc(namespaces, func(a, b *processByNamespaceID) int {
+		return strings.Compare(a.id, b.id)
+	})
+	return namespaces
+}
+
+type processMountAccessor struct {
+	accessor string
+	*processMount
+}
+
+func (s summaryByMount) sort() []*processMountAccessor {
+	mounts := make([]*processMountAccessor, 0, len(s))
+	for mountAccessor, mount := range s {
+		mounts = append(mounts, &processMountAccessor{accessor: mountAccessor, processMount: mount})
+	}
+	slices.SortStableFunc(mounts, func(a, b *processMountAccessor) int {
+		return strings.Compare(a.accessor, b.accessor)
+	})
+	return mounts
+}
+
+func (c clientIDSet) sort() []string {
+	clientIDs := make([]string, 0, len(c))
+	for clientID := range c {
+		clientIDs = append(clientIDs, clientID)
+	}
+	sort.Strings(clientIDs)
+	return clientIDs
 }
 
 // sortALResponseNamespaces sorts the namespaces for activity log responses.

--- a/vault/external_tests/activity_testonly/activity_testonly_test.go
+++ b/vault/external_tests/activity_testonly/activity_testonly_test.go
@@ -8,10 +8,13 @@ package activity_testonly
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"math"
 	"testing"
 	"time"
 
 	"github.com/hashicorp/vault/api"
+	"github.com/hashicorp/vault/helper/namespace"
 	"github.com/hashicorp/vault/helper/testhelpers"
 	"github.com/hashicorp/vault/helper/testhelpers/minimal"
 	"github.com/hashicorp/vault/helper/timeutil"
@@ -446,4 +449,173 @@ func Test_ActivityLog_MountDeduplication(t *testing.T) {
 		"cubbyhole/": 2,
 		"secret/":    1,
 	}, mountSet)
+}
+
+// TestHandleQuery_MultipleMounts creates a cluster with
+// two userpass mounts. It then tests verifies that
+// the total new counts are calculated within a reasonably level of accuracy for
+// various numbers of clients in each mount.
+func TestHandleQuery_MultipleMounts(t *testing.T) {
+	tests := map[string]struct {
+		twoMonthsAgo          [][]int
+		oneMonthAgo           [][]int
+		currentMonth          [][]int
+		expectedNewClients    int
+		expectedTotalAccuracy float64
+	}{
+		"low volume, all mounts": {
+			twoMonthsAgo: [][]int{
+				{20, 20},
+			},
+			oneMonthAgo: [][]int{
+				{30, 30},
+			},
+			currentMonth: [][]int{
+				{40, 40},
+			},
+			expectedNewClients:    80,
+			expectedTotalAccuracy: 1,
+		},
+		"medium volume, all mounts": {
+			twoMonthsAgo: [][]int{
+				{200, 200},
+			},
+			oneMonthAgo: [][]int{
+				{300, 300},
+			},
+			currentMonth: [][]int{
+				{400, 400},
+			},
+			expectedNewClients:    800,
+			expectedTotalAccuracy: 0.98,
+		},
+		"higher volume, all mounts": {
+			twoMonthsAgo: [][]int{
+				{200, 200},
+			},
+			oneMonthAgo: [][]int{
+				{300, 300},
+			},
+			currentMonth: [][]int{
+				{2000, 5000},
+			},
+			expectedNewClients:    7000,
+			expectedTotalAccuracy: 0.95,
+		},
+		"higher volume, no repeats": {
+			twoMonthsAgo: [][]int{
+				{200, 200},
+			},
+			oneMonthAgo: [][]int{
+				{300, 300},
+			},
+			currentMonth: [][]int{
+				{4000, 6000},
+			},
+			expectedNewClients:    10000,
+			expectedTotalAccuracy: 0.98,
+		},
+	}
+
+	for i, tt := range tests {
+		testname := fmt.Sprintf("%s", i)
+		t.Run(testname, func(t *testing.T) {
+			var err error
+			cluster := minimal.NewTestSoloCluster(t, nil)
+			client := cluster.Cores[0].Client
+			_, err = client.Logical().Write("sys/internal/counters/config", map[string]interface{}{
+				"enabled": "enable",
+			})
+			require.NoError(t, err)
+
+			// Create two namespaces
+			namespaces := []string{namespace.RootNamespaceID}
+			mounts := make(map[string][]string)
+
+			// Add two userpass mounts to each namespace
+			for _, ns := range namespaces {
+				err = client.WithNamespace(ns).Sys().EnableAuthWithOptions("userpass1", &api.EnableAuthOptions{
+					Type: "userpass",
+				})
+				require.NoError(t, err)
+				err = client.WithNamespace(ns).Sys().EnableAuthWithOptions("userpass2", &api.EnableAuthOptions{
+					Type: "userpass",
+				})
+				require.NoError(t, err)
+				mounts[ns] = []string{"auth/userpass1", "auth/userpass2"}
+			}
+
+			activityLogGenerator := clientcountutil.NewActivityLogData(client)
+
+			// Write two months ago data
+			activityLogGenerator = activityLogGenerator.NewPreviousMonthData(2)
+			for nsIndex, nsId := range namespaces {
+				for mountIndex, mount := range mounts[nsId] {
+					activityLogGenerator = activityLogGenerator.
+						NewClientsSeen(tt.twoMonthsAgo[nsIndex][mountIndex], clientcountutil.WithClientNamespace(nsId), clientcountutil.WithClientMount(mount))
+				}
+			}
+
+			// Write previous months data
+			activityLogGenerator = activityLogGenerator.NewPreviousMonthData(1)
+			for nsIndex, nsId := range namespaces {
+				for mountIndex, mount := range mounts[nsId] {
+					activityLogGenerator = activityLogGenerator.
+						NewClientsSeen(tt.oneMonthAgo[nsIndex][mountIndex], clientcountutil.WithClientNamespace(nsId), clientcountutil.WithClientMount(mount))
+				}
+			}
+
+			// Write current month data
+			activityLogGenerator = activityLogGenerator.NewCurrentMonthData()
+			for nsIndex, nsPath := range namespaces {
+				for mountIndex, mount := range mounts[nsPath] {
+					activityLogGenerator = activityLogGenerator.
+						RepeatedClientSeen(clientcountutil.WithClientNamespace(nsPath), clientcountutil.WithClientMount(mount)).
+						NewClientsSeen(tt.currentMonth[nsIndex][mountIndex], clientcountutil.WithClientNamespace(nsPath), clientcountutil.WithClientMount(mount))
+				}
+			}
+
+			// Write all the client count data
+			_, err = activityLogGenerator.Write(context.Background(), generation.WriteOptions_WRITE_PRECOMPUTED_QUERIES, generation.WriteOptions_WRITE_ENTITIES)
+			require.NoError(t, err)
+
+			endOfCurrentMonth := timeutil.EndOfMonth(time.Now().UTC())
+
+			// query activity log
+			resp, err := client.Logical().ReadWithData("sys/internal/counters/activity", map[string][]string{
+				"end_time":   {endOfCurrentMonth.Format(time.RFC3339)},
+				"start_time": {timeutil.StartOfMonth(timeutil.MonthsPreviousTo(2, time.Now().UTC())).Format(time.RFC3339)},
+			})
+			require.NoError(t, err)
+
+			// Ensure that the month response is the same as the totals, because all clients
+			// are new clients and there will be no approximation in the single month partial
+			// case
+			monthsRaw, ok := resp.Data["months"]
+			if !ok {
+				t.Fatalf("malformed results. got %v", resp.Data)
+			}
+			monthsResponse := make([]*vault.ResponseMonth, 0)
+			err = mapstructure.Decode(monthsRaw, &monthsResponse)
+
+			currentMonthClients := monthsResponse[len(monthsResponse)-1]
+
+			// Now verify that the new client totals for ALL namespaces are approximately accurate (there are no namespaces in CE)
+			newClientsError := math.Abs((float64)(currentMonthClients.NewClients.Counts.Clients - tt.expectedNewClients))
+			newClientsErrorMargin := newClientsError / (float64)(tt.expectedNewClients)
+			expectedAccuracyCalc := (1 - tt.expectedTotalAccuracy) * 100 / 100
+			if newClientsErrorMargin > expectedAccuracyCalc {
+				t.Fatalf("bad accuracy: expected %+v, found %+v", expectedAccuracyCalc, newClientsErrorMargin)
+			}
+
+			// Verify that the totals for the clients are visibly sensible (that is the total of all the individual new clients per namespace)
+			total := 0
+			for _, newClientCounts := range currentMonthClients.NewClients.Namespaces {
+				total += newClientCounts.Counts.Clients
+			}
+			if diff := math.Abs(float64(currentMonthClients.NewClients.Counts.Clients - total)); diff >= 1 {
+				t.Fatalf("total expected was %d but got %d", currentMonthClients.NewClients.Counts.Clients, total)
+			}
+		})
+	}
 }

--- a/vault/external_tests/activity_testonly/activity_testonly_test.go
+++ b/vault/external_tests/activity_testonly/activity_testonly_test.go
@@ -227,6 +227,45 @@ func Test_ActivityLog_EmptyDataMonths(t *testing.T) {
 	}
 }
 
+// Test_ActivityLog_FutureEndDate queries a start time from the past
+// and an end date in the future. The test
+// verifies that the current month is returned in the response.
+func Test_ActivityLog_FutureEndDate(t *testing.T) {
+	t.Parallel()
+	cluster := minimal.NewTestSoloCluster(t, nil)
+	client := cluster.Cores[0].Client
+	_, err := client.Logical().Write("sys/internal/counters/config", map[string]interface{}{
+		"enabled": "enable",
+	})
+	require.NoError(t, err)
+	_, err = clientcountutil.NewActivityLogData(client).
+		NewPreviousMonthData(1).
+		NewClientsSeen(10).
+		NewCurrentMonthData().
+		NewClientsSeen(10).
+		Write(context.Background(), generation.WriteOptions_WRITE_PRECOMPUTED_QUERIES, generation.WriteOptions_WRITE_ENTITIES)
+	require.NoError(t, err)
+
+	now := time.Now().UTC()
+	// query from the beginning of 3 months ago to beginning of next month
+	resp, err := client.Logical().ReadWithData("sys/internal/counters/activity", map[string][]string{
+		"end_time":   {timeutil.StartOfNextMonth(now).Format(time.RFC3339)},
+		"start_time": {timeutil.StartOfMonth(timeutil.MonthsPreviousTo(3, now)).Format(time.RFC3339)},
+	})
+	require.NoError(t, err)
+	monthsResponse := getMonthsData(t, resp)
+
+	require.Len(t, monthsResponse, 4)
+
+	// Get the last month of data in the slice
+	expectedCurrentMonthData := monthsResponse[3]
+	expectedTime, err := time.Parse(time.RFC3339, expectedCurrentMonthData.Timestamp)
+	require.NoError(t, err)
+	if !timeutil.IsCurrentMonth(expectedTime, now) {
+		t.Fatalf("final month data is not current month")
+	}
+}
+
 func getMonthsData(t *testing.T, resp *api.Secret) []vault.ResponseMonth {
 	t.Helper()
 	monthsRaw, ok := resp.Data["months"]

--- a/website/content/api-docs/system/internal-counters.mdx
+++ b/website/content/api-docs/system/internal-counters.mdx
@@ -90,22 +90,6 @@ $ curl \
 This endpoint returns client activity information for a given billing
 period, which is represented by the `start_time` and `end_time` parameters.
 
-There are a few things to keep in mind while using this API.
-
-- For Vault versions before 1.11, the activity information only accounts for
-the activity of the latest contiguous months in the billing period.
-For example, if the billing period is from Jan 2022 to June 2022, and the
-activity subsystem in Vault was not capturing data for the months Jan to March,
-the response will only include information for May and June. Note that if no
-`start_time` and `end_time` parameters are specified, the billing period defaults
-to 12 months, so the endpoint will return activity information from the end of the
-previous month to the start of 12 months prior to that date.
-
-- As of 1.11, this behavior has been modified to return all available data within
-the specified billing period.
-
-- As of 1.12, the `end_time` can be the current month.
-
 - The response contains the total activity for the billing period and the
 attributions of the total activity against specific components in Vault. This
 helps in understanding the total activity better by knowing which components in
@@ -247,21 +231,19 @@ returned by the API for backward compatibility and it may be removed in the futu
 `non_entity_clients` field instead. The `non_entity_tokens` field is currently
 returned by the API for backward compatibility, and it may be removed in the future.
 
-- If the `end_date` supplied to the API is for the current month, the activity
-information returned by this API will only be till the previous month. The
-activity system is designed to process the accumulated activity only at the end
-of the month. Since the system does not fully process the current month's
-information, it will not be added to the API response.
+- The response includes month data for the entire queried period, but may
+not exactly match the `start_time` and `end_time` returned in the response.
+The `start_time` in the response is the earliest time there is activity data
+in the queried period. The `end_time` is the end of the final month of the queried
+period.
 
-- The response includes the actual time period covered, which may not exactly
-match the query parameters due to the month granularity of data or missing
-months in the requested time range.
+- If the `end_date` supplied to the API is the current month, exact activity
+information will be returned for all months in the queried period, except for the
+current month. The last element in the `months` response stanza will signify the current month. Furthermore, the
+`new_clients` counts returned for the current month will be an estimate.
 
-- Note that if the `end_date` specified is the current month,
-the last element in the `months` response stanza, signifying the current month, will
-not have namespace attribution for the `new_clients` stanza. Furthermore, the
-`new_clients` counts returned for the current month will be an approximation.
-That is to say, the response will appear as follows.
+The following is an example of the `months` breakdown with just the current month information.
+
 
   @include 'auto-roll-billing-start-example.mdx'
 
@@ -318,7 +300,35 @@ That is to say, the response will appear as follows.
                "acme_clients":"approx int value",
                "clients":"approx int value"
             },
-            "namespaces":[]
+            "namespaces":[
+               {
+                  "namespace_id":"root",
+                  "namespace_path":"",
+                  "counts":{},
+                  "mounts":[
+                     {
+                        "path":"auth/up2/",
+                        "counts":{
+                          "entity_clients":"approx int value",
+                          "non_entity_clients":"approx int value",
+                          "secret_syncs":"approx int value",
+                          "acme_clients":"approx int value",
+                          "clients":"approx int value"
+                         },
+                     },
+                     {
+                        "path":"auth/up1/",
+                        "counts":{
+                          "entity_clients":"approx int value",
+                          "non_entity_clients":"approx int value",
+                          "secret_syncs":"approx int value",
+                          "acme_clients":"approx int value",
+                          "clients":"approx int value"
+                        }
+                     }
+                  ]
+               }
+            ]
          }
       }
    ],
@@ -337,7 +347,6 @@ be listed as "deleted namespace :ID:." Deleted namespaces are reported only for
 queries in the root namespace because the information about the namespace path
 is unknown.
 
-This endpoint was added in Vault 1.6.
 
 @include 'alerts/restricted-root.mdx'
 
@@ -937,8 +946,6 @@ Note: the client count may be inaccurate in the moments following a Vault
 reboot, or leadership change. The estimate will stabilize when background
 loading of client data has completed.
 
-This endpoint was added in Vault 1.7.
-
 @include 'alerts/restricted-root.mdx'
 
 | Method | Path                                      |
@@ -1169,10 +1176,10 @@ $ curl \
 ```
 
 <Note title="Important change to supported versions">
-   As of 1.16.7, 1.17.3 and later, 
-   the <a href="/vault/docs/concepts/billing-start-date">billing start date</a> automatically 
+   As of 1.16.7, 1.17.3 and later,
+   the <a href="/vault/docs/concepts/billing-start-date">billing start date</a> automatically
    rolls over to the latest billing year at the end of the last cycle.
-        
+
    For more information, refer to the upgrade guide for your Vault version:
 
    [Vault v1.16.x](/vault/docs/upgrading/upgrade-to-1.16.x#auto-rolled-billing-start-date),
@@ -1199,7 +1206,6 @@ months in the requested time range.
 information returned by this API will include activity for this month, however
 it may be up to 20 minutes delayed.
 
-This endpoint was added in Vault 1.11.
 
 @include 'alerts/restricted-root.mdx'
 


### PR DESCRIPTION
### Description
This PR is a manual backport to 1.17 of all of the CE PRs for fixing current month inconsistencies. 

### TODO only if you're a HashiCorp employee
- [ ] **Labels:** If this PR is the CE portion of an ENT change, and that ENT change is
  getting backported to N-2, use the new style `backport/ent/x.x.x+ent` labels
  instead of the old style `backport/x.x.x` labels.
- [ ] **Labels:** If this PR is a CE only change, it can only be backported to N, so use
  the normal `backport/x.x.x` label (there should be only 1).
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
