### PR TITLE
UI: Fix toast message text when deleting a kv v2 secret

### DIFF
--- a/changelog/28093.txt
+++ b/changelog/28093.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: fixes toast (flash) alert message saying "created" when deleting a kv v2 secret
+```

--- a/ui/lib/kv/addon/components/page/secret/details.js
+++ b/ui/lib/kv/addon/components/page/secret/details.js
@@ -108,7 +108,8 @@ export default class KvSecretDetails extends Component {
     const { secret } = this.args;
     try {
       await secret.destroyRecord({ adapterOptions: { deleteType: type, deleteVersions: this.version } });
-      this.flashMessages.success(`Successfully ${secret.state} Version ${this.version} of ${secret.path}.`);
+      const verb = type.includes('delete') ? 'deleted' : 'destroyed';
+      this.flashMessages.success(`Successfully ${verb} Version ${this.version} of ${secret.path}.`);
       this.refreshRoute();
     } catch (err) {
       const verb = type.includes('delete') ? 'deleting' : 'destroying';

--- a/ui/tests/acceptance/secrets/backend/kv/kv-v2-workflow-delete-test.js
+++ b/ui/tests/acceptance/secrets/backend/kv/kv-v2-workflow-delete-test.js
@@ -67,7 +67,7 @@ module('Acceptance | kv-v2 workflow | delete, undelete, destroy', function (hook
     });
     test('can delete and undelete the latest secret version (a)', async function (assert) {
       assert.expect(18);
-      this.flashSuccess = sinon.spy(this.owner.lookup('service:flash-messages'), 'success');
+      const flashSuccess = sinon.spy(this.owner.lookup('service:flash-messages'), 'success');
       // go to secret details
       await visit(`/vault/secrets/${this.backend}/kv/${this.secretPath}/details`);
       // correct toolbar options & details show
@@ -81,7 +81,7 @@ module('Acceptance | kv-v2 workflow | delete, undelete, destroy', function (hook
       await click(PAGE.detail.deleteOptionLatest);
       await click(PAGE.detail.deleteConfirm);
       const expected = `Successfully deleted Version 4 of ${this.secretPath}.`;
-      const [actual] = this.flashSuccess.lastCall.args;
+      const [actual] = flashSuccess.lastCall.args;
       assert.strictEqual(actual, expected, 'renders correct flash message');
 
       // details update accordingly
@@ -129,7 +129,8 @@ module('Acceptance | kv-v2 workflow | delete, undelete, destroy', function (hook
       assertDeleteActions(assert, ['delete', 'destroy']);
     });
     test('can destroy a secret version (a)', async function (assert) {
-      assert.expect(9);
+      assert.expect(10);
+      const flashSuccess = sinon.spy(this.owner.lookup('service:flash-messages'), 'success');
       // go to secret details
       await visit(`/vault/secrets/${this.backend}/kv/${this.secretPath}/details?version=3`);
       // correct toolbar options show
@@ -138,6 +139,9 @@ module('Acceptance | kv-v2 workflow | delete, undelete, destroy', function (hook
       await click(PAGE.detail.destroy);
       assert.dom(PAGE.detail.deleteModalTitle).includesText('Destroy version?', 'modal has correct title');
       await click(PAGE.detail.deleteConfirm);
+      const expected = `Successfully destroyed Version 3 of ${this.secretPath}.`;
+      const [actual] = flashSuccess.lastCall.args;
+      assert.strictEqual(actual, expected, 'renders correct flash message');
       // details update accordingly
       assert
         .dom(PAGE.emptyStateTitle)

--- a/ui/tests/acceptance/secrets/backend/kv/kv-v2-workflow-delete-test.js
+++ b/ui/tests/acceptance/secrets/backend/kv/kv-v2-workflow-delete-test.js
@@ -13,6 +13,7 @@ import { clearRecords, deleteLatestCmd, writeVersionedSecret } from 'vault/tests
 import { setupControlGroup } from 'vault/tests/helpers/control-groups';
 import { click, currentURL, visit } from '@ember/test-helpers';
 import { PAGE } from 'vault/tests/helpers/kv/kv-selectors';
+import sinon from 'sinon';
 
 const ALL_DELETE_ACTIONS = ['delete', 'destroy', 'undelete'];
 const assertDeleteActions = (assert, expected = ['delete', 'destroy']) => {
@@ -65,7 +66,8 @@ module('Acceptance | kv-v2 workflow | delete, undelete, destroy', function (hook
       return;
     });
     test('can delete and undelete the latest secret version (a)', async function (assert) {
-      assert.expect(17);
+      assert.expect(18);
+      this.flashSuccess = sinon.spy(this.owner.lookup('service:flash-messages'), 'success');
       // go to secret details
       await visit(`/vault/secrets/${this.backend}/kv/${this.secretPath}/details`);
       // correct toolbar options & details show
@@ -78,6 +80,10 @@ module('Acceptance | kv-v2 workflow | delete, undelete, destroy', function (hook
       assert.dom(PAGE.detail.deleteOptionLatest).isNotDisabled('delete latest option is selectable');
       await click(PAGE.detail.deleteOptionLatest);
       await click(PAGE.detail.deleteConfirm);
+      const expected = `Successfully deleted Version 4 of ${this.secretPath}.`;
+      const [actual] = this.flashSuccess.lastCall.args;
+      assert.strictEqual(actual, expected, 'renders correct flash message');
+
       // details update accordingly
       assert
         .dom(PAGE.emptyStateTitle)


### PR DESCRIPTION
### Description
Fixes an incorrect flash message when deleting a secret that says `Successfully created`:
![image](https://github.com/user-attachments/assets/c28e70a9-2097-48e3-9890-b38de1e5fb9d)


## after fix `Successfully deleted` or `Successfully destroyed`
<img width="377" alt="Screenshot 2024-08-15 at 10 25 05 AM" src="https://github.com/user-attachments/assets/506baba9-f147-4455-aed7-b943ae16c711">



### TODO only if you're a HashiCorp employee
- [ ] **Labels:** If this PR is the CE portion of an ENT change, and that ENT change is
  getting backported to N-2, use the new style `backport/ent/x.x.x+ent` labels
  instead of the old style `backport/x.x.x` labels.
- [ ] **Labels:** If this PR is a CE only change, it can only be backported to N, so use
  the normal `backport/x.x.x` label (there should be only 1).
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
