### PR TITLE
add documentation for external_id bug

### DIFF
--- a/website/content/docs/release-notes/1.17.0.mdx
+++ b/website/content/docs/release-notes/1.17.0.mdx
@@ -23,7 +23,7 @@ description: |-
 | Known issue (1.15.8+)          | [Autopilot upgrade for Vault Enterprise fails](/vault/docs/upgrading/upgrade-to-1.15.x#autopilot)                                                                   |
 | Known issue (1.17.1)           | [Listener stops listening on untrusted upstream connection with particular config settings](/vault/docs/upgrading/upgrade-to-1.17.x#listener-proxy-protocol-config) |
 | Known issue (1.17.0 - 1.17.2)  | [Vault standby nodes not deleting removed entity-aliases from in-memory database](/vault/docs/upgrading/upgrade-to-1.17.x#dangling-entity-alias-in-memory)          |
-| Known issue (1.17.0 - 1.17.3)  | [AWS Auth AssumeRole requires an external ID even if none is set](/vault//docs/upgrading/upgrade-to-1.17.x#aws-auth-external-id)                                         |
+| Known issue (1.17.0 - 1.17.3)  | [AWS Auth AssumeRole requires an external ID even if none is set](/vault/docs/upgrading/upgrade-to-1.17.x#aws-auth-role-configuration-requires-an-external_id)                                      |
 | Known Issue (0.7.0+)           | [Duplicate identity groups created](/vault/docs/upgrading/upgrade-to-1.17.x#duplicate-identity-groups-created-when-concurrent-requests-sent-to-the-primary-and-pr-secondary-cluster)
 | Known Issue (0.7.0+)           | [Manual entity merges fail](/vault/docs/upgrading/upgrade-to-1.17.x#manual-entity-merges-sent-to-a-pr-secondary-cluster-are-not-persisted-to-storage)
 

--- a/website/content/docs/release-notes/1.17.0.mdx
+++ b/website/content/docs/release-notes/1.17.0.mdx
@@ -23,6 +23,7 @@ description: |-
 | Known issue (1.15.8+)          | [Autopilot upgrade for Vault Enterprise fails](/vault/docs/upgrading/upgrade-to-1.15.x#autopilot)                                                                   |
 | Known issue (1.17.1)           | [Listener stops listening on untrusted upstream connection with particular config settings](/vault/docs/upgrading/upgrade-to-1.17.x#listener-proxy-protocol-config) |
 | Known issue (1.17.0 - 1.17.2)  | [Vault standby nodes not deleting removed entity-aliases from in-memory database](/vault/docs/upgrading/upgrade-to-1.17.x#dangling-entity-alias-in-memory)          |
+| Known issue (1.17.0 - 1.17.3)  | [AWS Auth AssumeRole requires an external ID even if none is set](/vault//docs/upgrading/upgrade-to-1.17.x#aws-auth-external-id)                                         |
 | Known Issue (0.7.0+)           | [Duplicate identity groups created](/vault/docs/upgrading/upgrade-to-1.17.x#duplicate-identity-groups-created-when-concurrent-requests-sent-to-the-primary-and-pr-secondary-cluster)
 | Known Issue (0.7.0+)           | [Manual entity merges fail](/vault/docs/upgrading/upgrade-to-1.17.x#manual-entity-merges-sent-to-a-pr-secondary-cluster-are-not-persisted-to-storage)
 

--- a/website/content/docs/upgrading/upgrade-to-1.17.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.17.x.mdx
@@ -83,7 +83,7 @@ incorrectly. For additional details, refer to the
 
 ### Auto-rolled billing start date
 
-As of 1.17.3 and later, the billing start date (license start date if not configured) rolls over to the latest billing year at the end of the last cycle. 
+As of 1.17.3 and later, the billing start date (license start date if not configured) rolls over to the latest billing year at the end of the last cycle.
 
 @include 'auto-roll-billing-start.mdx'
 
@@ -110,3 +110,5 @@ install it using `apk`, e.g.: `docker exec <CONTAINER-ID> apk add curl` or `kube
 @include 'known-issues/duplicate-identity-groups.mdx'
 
 @include 'known-issues/manual-entity-merge-does-not-persist.mdx'
+
+@include 'known-issues/aws-auth-external-id.mdx'

--- a/website/content/partials/known-issues/aws-auth-external-id.mdx
+++ b/website/content/partials/known-issues/aws-auth-external-id.mdx
@@ -1,0 +1,15 @@
+<a id="#aws-auth-external-id" />
+### AWS Auth Role configuration requires an external_id
+
+#### Affected Versions
+
+- 1.17.0 - 1.17.3
+
+#### Issue
+
+The Vault AWS Auth backend requires an external_id to be set during role configuration, or it will return a validation error.
+
+#### Workaround
+
+Configure the backend with an external_id set (if external ids are not being used, supplying any string longer than two
+characters will work). Then, configure any desired roles. After this is done, the external id can be removed.

--- a/website/content/partials/known-issues/aws-auth-external-id.mdx
+++ b/website/content/partials/known-issues/aws-auth-external-id.mdx
@@ -1,4 +1,3 @@
-<a id="#aws-auth-external-id" />
 ### AWS Auth Role configuration requires an external_id
 
 #### Affected Versions


### PR DESCRIPTION
Add some documentation for the external-id known issue.

This is theoretically fixed for 1.18, so i figured this should be done to the 1.17n release branch directly.

Should it?