### PR TITLE
Docs (lambda-extension): add warning about caching re. distributed tracing headers

### DIFF
--- a/website/content/docs/platform/aws/lambda-extension.mdx
+++ b/website/content/docs/platform/aws/lambda-extension.mdx
@@ -243,6 +243,10 @@ request will be forwarded to Vault and the response returned and cached.
 Currently, the cache key is a hash of the request URL path, headers, body, and
 token.
 
+~> **Warning!** Since the Vault Lambda Extension's cache key includes the headers of the request
+to the proxy, any usage of distributed tracing headers in such request, like `traceparent`, may render all requests
+unique and prevent cache hits.
+
 Caching may also be enabled for all requests by setting the environment variable
 `VAULT_DEFAULT_CACHE_ENABLED` to `true`. Then all requests will be fetched and/or
 cached as though the header `X-Vault-Cache-Control: cache` was present. Setting

--- a/website/content/docs/platform/aws/lambda-extension.mdx
+++ b/website/content/docs/platform/aws/lambda-extension.mdx
@@ -243,9 +243,14 @@ request will be forwarded to Vault and the response returned and cached.
 Currently, the cache key is a hash of the request URL path, headers, body, and
 token.
 
-~> **Warning!** Since the Vault Lambda Extension's cache key includes the headers of the request
-to the proxy, any usage of distributed tracing headers in such request, like `traceparent`, may render all requests
-unique and prevent cache hits.
+<Warning title="Distributed tracing headers may negate the cache">
+
+  The Vault Lambda Extension cache key includes headers from proxy requests. As
+  a result, distributed tracing headers like `traceparent` can lead to
+  individualized hashes that make repeated requests appear unique and cause cache
+  misses.
+
+</Warning>
 
 Caching may also be enabled for all requests by setting the environment variable
 `VAULT_DEFAULT_CACHE_ENABLED` to `true`. Then all requests will be fetched and/or


### PR DESCRIPTION
🔍 [Deploy preview](https://vault-git-fork-aztalbot-docs-lambdaextensionca-d0296c-hashicorp.vercel.app/vault/docs/platform/aws/lambda-extension#caching)

### Description
- adds warning in the caching section of the vault—lambda-extension docs
- explains how distributed tracing headers can produce unintended consequences on caching
- if this behavior changes in a future version of the vault-extension (see open [PR](https://github.com/hashicorp/vault-lambda-extension/pull/145) and [issue](https://github.com/hashicorp/vault-lambda-extension/issues/146)), a warning like this may still be useful for usage of older versions