### PR TITLE
AWS refactor, move to one form

### DIFF
--- a/ui/app/adapters/aws/lease-config.js
+++ b/ui/app/adapters/aws/lease-config.js
@@ -12,9 +12,11 @@ export default class AwsLeaseConfig extends ApplicationAdapter {
   queryRecord(store, type, query) {
     const { backend } = query;
     return this.ajax(`${this.buildURL()}/${encodePath(backend)}/config/lease`, 'GET').then((resp) => {
-      resp.id = backend;
-      resp.backend = backend;
-      return resp;
+      return {
+        ...resp,
+        id: backend,
+        backend,
+      };
     });
   }
 

--- a/ui/app/adapters/aws/lease-config.js
+++ b/ui/app/adapters/aws/lease-config.js
@@ -6,15 +6,36 @@
 import ApplicationAdapter from '../application';
 import { encodePath } from 'vault/utils/path-encoding-helpers';
 
-export default class AwsRootConfig extends ApplicationAdapter {
+export default class AwsLeaseConfig extends ApplicationAdapter {
   namespace = 'v1';
-  // For now this is only being used on the vault.cluster.secrets.backend.configuration route. This is a read-only route.
-  // Eventually, this will be used to create the lease config for the AWS secret backend, replacing the requests located on the secret-engine adapter.
+
   queryRecord(store, type, query) {
     const { backend } = query;
     return this.ajax(`${this.buildURL()}/${encodePath(backend)}/config/lease`, 'GET').then((resp) => {
       resp.id = backend;
+      resp.backend = backend;
       return resp;
     });
+  }
+
+  createOrUpdate(store, type, snapshot) {
+    const serializer = store.serializerFor(type.modelName);
+    const data = serializer.serialize(snapshot);
+    const backend = snapshot.record.backend;
+    return this.ajax(`${this.buildURL()}/${backend}/config/lease`, 'POST', { data }).then((resp) => {
+      // ember data requires an id on the response
+      return {
+        ...resp,
+        id: backend,
+      };
+    });
+  }
+
+  createRecord() {
+    return this.createOrUpdate(...arguments);
+  }
+
+  updateRecord() {
+    return this.createOrUpdate(...arguments);
   }
 }

--- a/ui/app/adapters/aws/root-config.js
+++ b/ui/app/adapters/aws/root-config.js
@@ -8,13 +8,34 @@ import { encodePath } from 'vault/utils/path-encoding-helpers';
 
 export default class AwsRootConfig extends ApplicationAdapter {
   namespace = 'v1';
-  // For now this is only being used on the vault.cluster.secrets.backend.configuration route. This is a read-only route.
-  // Eventually, this will be used to create the root config for the AWS secret backend, replacing the requests located on the secret-engine adapter.
+
   queryRecord(store, type, query) {
     const { backend } = query;
     return this.ajax(`${this.buildURL()}/${encodePath(backend)}/config/root`, 'GET').then((resp) => {
       resp.id = backend;
+      resp.backend = backend;
       return resp;
     });
+  }
+
+  createOrUpdate(store, type, snapshot) {
+    const serializer = store.serializerFor(type.modelName);
+    const data = serializer.serialize(snapshot);
+    const backend = snapshot.record.backend;
+    return this.ajax(`${this.buildURL()}/${backend}/config/root`, 'POST', { data }).then((resp) => {
+      // ember data requires an id on the response
+      return {
+        ...resp,
+        id: backend,
+      };
+    });
+  }
+
+  createRecord() {
+    return this.createOrUpdate(...arguments);
+  }
+
+  updateRecord() {
+    return this.createOrUpdate(...arguments);
   }
 }

--- a/ui/app/adapters/aws/root-config.js
+++ b/ui/app/adapters/aws/root-config.js
@@ -12,9 +12,11 @@ export default class AwsRootConfig extends ApplicationAdapter {
   queryRecord(store, type, query) {
     const { backend } = query;
     return this.ajax(`${this.buildURL()}/${encodePath(backend)}/config/root`, 'GET').then((resp) => {
-      resp.id = backend;
-      resp.backend = backend;
-      return resp;
+      return {
+        ...resp,
+        id: backend,
+        backend,
+      };
     });
   }
 

--- a/ui/app/adapters/secret-engine.js
+++ b/ui/app/adapters/secret-engine.js
@@ -87,16 +87,6 @@ export default ApplicationAdapter.extend({
     }
   },
 
-  queryRecord(store, type, query) {
-    if (query.type === 'aws') {
-      return this.ajax(`/v1/${encodePath(query.backend)}/config/lease`, 'GET').then((resp) => {
-        resp.path = query.backend + '/';
-        return resp;
-      });
-    }
-    return;
-  },
-
   updateRecord(store, type, snapshot) {
     const { apiPath, options, adapterMethod } = snapshot.adapterOptions;
     if (adapterMethod) {
@@ -108,18 +98,6 @@ export default ApplicationAdapter.extend({
       const path = encodePath(snapshot.id);
       return this.ajax(`/v1/${path}/${apiPath}`, options.isDelete ? 'DELETE' : 'POST', { data });
     }
-  },
-
-  saveAWSRoot(store, type, snapshot) {
-    const { data } = snapshot.adapterOptions;
-    const path = encodePath(snapshot.id);
-    return this.ajax(`/v1/${path}/config/root`, 'POST', { data });
-  },
-
-  saveAWSLease(store, type, snapshot) {
-    const { data } = snapshot.adapterOptions;
-    const path = encodePath(snapshot.id);
-    return this.ajax(`/v1/${path}/config/lease`, 'POST', { data });
   },
 
   saveZeroAddressConfig(store, type, snapshot) {

--- a/ui/app/components/secret-engine/configure-aws.hbs
+++ b/ui/app/components/secret-engine/configure-aws.hbs
@@ -3,7 +3,7 @@
   SPDX-License-Identifier: BUSL-1.1
 ~}}
 
-<form {{on "submit" (perform this.save)}} aria-label="save aws creds" data-test-root-config-form>
+<form {{on "submit" (perform this.save)}} aria-label="save aws creds" data-test-root-form>
   <div class="box is-fullwidth is-shadowless is-marginless">
     <NamespaceReminder @mode="save" @noun="configuration" />
     <MessageError @errorMessage={{this.errorMessageRoot}} />

--- a/ui/app/components/secret-engine/configure-aws.hbs
+++ b/ui/app/components/secret-engine/configure-aws.hbs
@@ -3,143 +3,63 @@
   SPDX-License-Identifier: BUSL-1.1
 ~}}
 
-<Hds::Tabs class="has-top-margin-l" as |T|>
-  <T.Tab data-test-tab="access-to-aws">
-    Dynamic IAM root credentials
-  </T.Tab>
-  <T.Tab data-test-tab="lease">
+<form {{on "submit" (perform this.save)}} aria-label="save aws creds" data-test-root-config-form>
+  <div class="box is-fullwidth is-shadowless is-marginless">
+    <NamespaceReminder @mode="save" @noun="configuration" />
+    <MessageError @errorMessage={{this.errorMessageRoot}} />
+    <p class="has-text-grey-dark">
+      Note: the client uses the official AWS SDK and will use the specified credentials, environment credentials, shared file
+      credentials, or IAM role/ECS task credentials in that order.
+    </p>
+  </div>
+  {{! Root configuration details }}
+  <h2 class="title is-5 has-bottom-padding-s has-top-margin-l" data-test-access-title>
+    Access to AWS
+  </h2>
+  <div class="box is-fullwidth is-sideless">
+    <FormFieldGroups
+      @model={{@rootConfig}}
+      @mode={{if @rootConfig.isNew "create" "edit"}}
+      @modelValidations={{this.modelValidationsRoot}}
+      @useEnableInput={{true}}
+    />
+  </div>
+
+  {{! Lease configuration details }}
+  <h2 class="title is-5 has-bottom-padding-s has-top-margin-l" data-test-lease-title>
     Leases
-  </T.Tab>
-  <T.Panel>
-    <form
-      onsubmit={{action
-        "saveRootCreds"
-        (hash access_key=@accessKey iam_endpoint=@iamEndpoint sts_endpoint=@stsEndpoint secret_key=@secretKey region=@region)
-      }}
-      data-test-root-form
-      aria-label="save root creds form"
-    >
-      <div class="box is-fullwidth is-shadowless is-marginless">
-        <NamespaceReminder @mode="save" @noun="configuration" />
-        <p class="has-text-grey-dark">
-          Note: the client uses the official AWS SDK and will use the specified credentials, environment credentials, shared
-          file credentials, or IAM role/ECS task credentials in that order.
-        </p>
-      </div>
+  </h2>
+  <div class="box is-fullwidth is-sideless is-bottomless">
+    {{#each @leaseConfig.attrs as |attr|}}
+      <FormField @attr={{attr}} @model={{@leaseConfig}} @modelValidations={{this.modelValidationsLease}} />
+    {{/each}}
+  </div>
 
-      <div class="field">
-        <label for="access" class="is-label">
-          Access key
-        </label>
-        <div class="control">
-          <Input
-            @type="text"
-            id="access"
-            name="access"
-            class="input"
-            autocomplete="off"
-            spellcheck="false"
-            @value={{@accessKey}}
-            data-test-input="accessKey"
-          />
-        </div>
-      </div>
-
-      <div class="field">
-        <label for="secret" class="is-label">
-          Secret key
-        </label>
-        <div class="control">
-          <Input
-            @type="password"
-            id="secret"
-            name="secret"
-            class="input"
-            @value={{@secretKey}}
-            data-test-input="secretKey"
-          />
-        </div>
-      </div>
-
-      <ToggleButton
-        @isOpen={{this.showOptions}}
-        @onClick={{fn (mut this.showOptions)}}
-        data-test-toggle-group="Root config options"
+  <div class="box is-fullwidth is-bottomless">
+    <div class="control">
+      <Hds::Button
+        @text="Save"
+        @icon={{if this.save.isRunning "loading"}}
+        type="submit"
+        disabled={{this.save.isRunning}}
+        data-test-save
       />
-      {{#if this.showOptions}}
-        <div class="box is-marginless">
-          <div class="field">
-            <label for="region" class="is-label">
-              Region
-            </label>
-            <div class="control is-expanded">
-              <div class="select is-fullwidth">
-                <select
-                  name="region"
-                  id="region"
-                  onchange={{action (mut @region) value="target.value"}}
-                  data-test-select="region"
-                >
-                  <option value=""></option>
-                  {{#each (aws-regions) as |val|}}
-                    <option>{{val}}</option>
-                  {{/each}}
-                </select>
-              </div>
-            </div>
-          </div>
-          <div class="field">
-            <label for="iam" class="is-label">
-              IAM endpoint
-            </label>
-            <div class="control">
-              <Input @type="text" id="iam" name="iam" class="input" @value={{@iamEndpoint}} />
-            </div>
-          </div>
-          <div class="field">
-            <label for="sts" class="is-label">
-              STS endpoint
-            </label>
-            <div class="control">
-              <Input @type="text" id="sts" name="sts" class="input" @value={{@stsEndpoint}} />
-            </div>
-          </div>
-        </div>
-      {{/if}}
-
-      <div class="box is-bottomless is-fullwidth">
-        <Hds::Button @text="Save" data-test-save-root-config type="submit" />
-      </div>
-    </form>
-  </T.Panel>
-  <T.Panel>
-    <form
-      onsubmit={{action "saveLease" (hash lease=@model.lease lease_max=@model.leaseMax)}}
-      aria-label="save lease form"
-      data-test-lease-form
-    >
-      <div class="box is-fullwidth is-shadowless is-marginless">
-        <NamespaceReminder @mode="saved" @noun="configuration" />
-        <MessageError @model={{@model}} />
-        <p class="has-text-grey-dark">
-          If you do not supply lease settings, we will use the default values in AWS.
-        </p>
-      </div>
-      <TtlPicker
-        @label="Lease"
-        @initialValue={{@model.lease}}
-        @initialEnabled={{@model.lease}}
-        @onChange={{fn this.handleTtlChange "lease"}}
+      <Hds::Button
+        @text="Cancel"
+        @color="secondary"
+        class="has-left-margin-s"
+        disabled={{this.save.isRunning}}
+        {{on "click" this.onCancel}}
+        data-test-cancel
       />
-      <TtlPicker
-        @label="Maximum Lease"
-        @initialValue={{@model.leaseMax}}
-        @initialEnabled={{@model.leaseMax}}
-        @onChange={{fn this.handleTtlChange "leaseMax"}}
+    </div>
+    {{#if this.invalidFormAlert}}
+      <AlertInline
+        data-test-invalid-form-alert
+        class="has-top-padding-s"
+        @type="danger"
+        @message={{this.invalidFormAlert}}
       />
-      <div class="box is-bottomless is-fullwidth">
-        <Hds::Button @text="Save" data-test-save-lease-config type="submit" />
-      </div>
-    </form>
-  </T.Panel>
-</Hds::Tabs>
+    {{/if}}
+  </div>
+</form>

--- a/ui/app/components/secret-engine/configure-aws.ts
+++ b/ui/app/components/secret-engine/configure-aws.ts
@@ -58,7 +58,7 @@ export default class ConfigureAwsComponent extends Component<Args> {
   *save(event: Event) {
     event.preventDefault();
     this.resetErrors();
-    const { leaseConfig, rootConfig, backendPath } = this.args;
+    const { leaseConfig, rootConfig } = this.args;
     // Note: aws/root-config model does not have any validations
     const isValid = this.validate(leaseConfig);
     if (!isValid) return;

--- a/ui/app/components/secret-engine/configure-aws.ts
+++ b/ui/app/components/secret-engine/configure-aws.ts
@@ -5,78 +5,145 @@
 
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
+import { task } from 'ember-concurrency';
+import { service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+import { ValidationMap } from 'vault/vault/app-types';
+import errorMessage from 'vault/utils/error-message';
 
-import type SecretEngineModel from 'vault/models/secret-engine';
-import type { TtlEvent } from 'vault/app-types';
+import type LeaseConfigModel from 'vault/models/aws/lease-config';
+import type RootConfigModel from 'vault/models/aws/root-config';
+import type Router from '@ember/routing/router';
+import type Store from '@ember-data/store';
+import type FlashMessageService from 'vault/services/flash-messages';
 
 /**
- * @module ConfigureAwsComponent
+ * @module ConfigureAwsComponent is used to configure the AWS secret engine
+ * A user can configure the endpoint root/config and/or lease/config. 
+ * The fields for these endpoints are on one form.
  *
  * @example
  * ```js
  * <SecretEngine::ConfigureAws
-    @model={{model}}
-    @tab={{tab}}
-    @accessKey={{accessKey}}
-    @secretKey={{secretKey}}
-    @region={{region}}
-    @iamEndpoint={{iamEndpoint}}
-    @stsEndpoint={{stsEndpoint}}
-    @saveAWSRoot={{action "save" "saveAWSRoot"}}
-    @saveAWSLease={{action "save" "saveAWSLease"}} />
+    @rootConfig={{this.model.aws-root-config}}
+    @leaseConfig={{this.model.aws-lease-config}} 
+    @id={{this.model.id}} 
+    />
  * ```
  *
- * @param {object} model - aws secret engine model
- * @param {string} tab - current tab selection
- * @param {string} accessKey - AWS access key
- * @param {string} secretKey - AWS secret key
- * @param {string} region - AWS region
- * @param {string} iamEndpoint - IAM endpoint
- * @param {string} stsEndpoint - Sts endpoint
- * @param {Function} saveAWSRoot - parent action which saves AWS root credentials
- * @param {Function} saveAWSLease - parent action which updates AWS lease information
- *
+ * @param {object} rootConfig - AWS secret engine config/root model
+ * @param {object} leaseConfig - AWS secret engine config/lease model
+ * @param {string} id - name of the AWS secret engine, ex: 'aws-123'
  */
 
-type AWSRootCredsFields = {
-  access_key: string | null;
-  iam_endpoint: string | null;
-  sts_endpoint: string | null;
-  secret_key: string | null;
-  region: string | null;
-};
-
-type LeaseFields = { lease: string; lease_max: string };
-
 interface Args {
-  model: SecretEngineModel;
-  tab?: string;
-  accessKey: string;
-  secretKey: string;
-  region: string;
-  iamEndpoint: string;
-  stsEndpoint: string;
-  saveAWSRoot: (data: AWSRootCredsFields) => void;
-  saveAWSLease: (data: LeaseFields) => void;
+  leaseConfig: LeaseConfigModel;
+  rootConfig: RootConfigModel;
+  id: string;
 }
 
 export default class ConfigureAwsComponent extends Component<Args> {
-  @action
-  saveRootCreds(data: AWSRootCredsFields, event: Event) {
+  @service declare readonly router: Router;
+  @service declare readonly store: Store;
+  @service declare readonly flashMessages: FlashMessageService;
+
+  @tracked errorMessageRoot: string | null = null;
+  @tracked invalidFormAlert: string | null = null;
+  @tracked modelValidationsLease: ValidationMap | null = null;
+  @tracked modelValidationsRoot: ValidationMap | null = null;
+
+  @task
+  *save(event: Event) {
     event.preventDefault();
-    this.args.saveAWSRoot(data);
+    this.resetErrors();
+    const { id, leaseConfig, rootConfig } = this.args;
+    // root does not have any validations, yet, but it could in the future so designing flow to accommodate to model validations.
+    const isValidLease = this.validate(leaseConfig, 'leaseConfig');
+
+    if (!isValidLease) {
+      this.flashMessages.danger('Please correct the errors in the form before submitting.');
+      return;
+    }
+    // Check if any of the models attributes have changed.
+    // (note: "backend" dirties model state so explicity ignore it here.)
+    // If no changes to either model, transition and notify user.
+    // If changes to one model, save the model that changed and notify user.
+    // Otherwise save both models.
+    const leaseAttrChanged =
+      Object.keys(leaseConfig.changedAttributes()).filter((item) => item !== 'backend').length > 0;
+    const rootAttrChanged =
+      Object.keys(rootConfig.changedAttributes()).filter((item) => item !== 'backend').length > 0;
+
+    if (!leaseAttrChanged && !rootAttrChanged) {
+      this.flashMessages.danger('No changes detected.');
+      this.transition(id);
+    }
+    if (rootAttrChanged) {
+      try {
+        yield rootConfig.save();
+        this.flashMessages.success(`Successfully saved ${id}'s root configuration.`);
+      } catch (error) {
+        this.errorMessageRoot = errorMessage(error);
+      }
+    }
+    if (leaseAttrChanged) {
+      try {
+        yield leaseConfig.save();
+        this.flashMessages.success(`Successfully saved ${id}'s lease configuration.`);
+      } catch (error) {
+        // if lease config fails, notify with a flash message but still allow users to save the root config.
+        if (!this.errorMessageRoot) {
+          this.flashMessages.danger(`Lease configuration was not saved: ${errorMessage(error)}`, {
+            sticky: true,
+          });
+        } else {
+          this.flashMessages.danger(
+            `Configuration not saved: ${errorMessage(error)}. ${this.errorMessageRoot}`,
+            {
+              sticky: true,
+            }
+          );
+        }
+      }
+    }
+    this.transition(id);
+  }
+
+  transition(id: string) {
+    // prevent transition if there are errors with root configuration
+    if (this.errorMessageRoot) {
+      this.invalidFormAlert = 'There was an error submitting this form.';
+    } else {
+      this.unloadModels();
+      this.router.transitionTo('vault.cluster.secrets.backend.configuration', id);
+    }
+  }
+
+  resetErrors() {
+    this.flashMessages.clearMessages();
+    this.errorMessageRoot = null;
+    this.invalidFormAlert = null;
+  }
+
+  validate(model: LeaseConfigModel, modelName: string) {
+    const { isValid, state, invalidFormMessage } = model.validate();
+    // cannot use a tracked object for modelValidations because it will not update the form.
+    if (modelName === 'leaseConfig') {
+      this.modelValidationsLease = isValid ? null : state;
+    }
+    this.invalidFormAlert = isValid ? '' : invalidFormMessage;
+    return isValid;
+  }
+
+  unloadModels() {
+    this.args.rootConfig.unloadRecord();
+    this.args.leaseConfig.unloadRecord();
   }
 
   @action
-  saveLease(data: LeaseFields, event: Event) {
-    event.preventDefault();
-    this.args.saveAWSLease(data);
-  }
-
-  @action
-  handleTtlChange(name: string, ttlObj: TtlEvent) {
-    // lease values cannot be undefined, set to 0 to use default
-    const valueToSet = ttlObj.enabled ? ttlObj.goSafeTimeString : 0;
-    this.args.model.set(name, valueToSet);
+  onCancel() {
+    // clear errors because they're canceling out of the workflow.
+    this.resetErrors();
+    this.transition(this.args.id);
   }
 }

--- a/ui/app/components/secret-engine/configure-aws.ts
+++ b/ui/app/components/secret-engine/configure-aws.ts
@@ -6,6 +6,7 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { task } from 'ember-concurrency';
+import { waitFor } from '@ember/test-waiters';
 import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { ValidationMap } from 'vault/vault/app-types';
@@ -31,8 +32,8 @@ import type FlashMessageService from 'vault/services/flash-messages';
     />
  * ```
  *
- * @param {object} rootConfig - AWS secret engine config/root model
- * @param {object} leaseConfig - AWS secret engine config/lease model
+ * @param {object} rootConfig - AWS config/root model
+ * @param {object} leaseConfig - AWS config/lease model
  * @param {string} id - name of the AWS secret engine, ex: 'aws-123'
  */
 
@@ -48,55 +49,57 @@ export default class ConfigureAwsComponent extends Component<Args> {
   @service declare readonly flashMessages: FlashMessageService;
 
   @tracked errorMessageRoot: string | null = null;
+  @tracked errorMessageLease: string | null = null;
   @tracked invalidFormAlert: string | null = null;
   @tracked modelValidationsLease: ValidationMap | null = null;
-  @tracked modelValidationsRoot: ValidationMap | null = null;
 
   @task
+  @waitFor
   *save(event: Event) {
     event.preventDefault();
     this.resetErrors();
     const { id, leaseConfig, rootConfig } = this.args;
-    // root does not have any validations, yet, but it could in the future so designing flow to accommodate to model validations.
-    const isValidLease = this.validate(leaseConfig, 'leaseConfig');
-
-    if (!isValidLease) {
-      this.flashMessages.danger('Please correct the errors in the form before submitting.');
-      return;
-    }
-    // Check if any of the models attributes have changed.
-    // (note: "backend" dirties model state so explicity ignore it here.)
+    // Note: aws/root-config model does not have any validations
+    const isValid = this.validate(leaseConfig);
+    if (!isValid) return;
+    // Check if any of the models' attributes have changed.
     // If no changes to either model, transition and notify user.
     // If changes to one model, save the model that changed and notify user.
     // Otherwise save both models.
+    // Note: "backend" dirties model state so explicity ignore it here.
     const leaseAttrChanged =
       Object.keys(leaseConfig.changedAttributes()).filter((item) => item !== 'backend').length > 0;
     const rootAttrChanged =
       Object.keys(rootConfig.changedAttributes()).filter((item) => item !== 'backend').length > 0;
 
     if (!leaseAttrChanged && !rootAttrChanged) {
-      this.flashMessages.danger('No changes detected.');
+      this.flashMessages.info('No changes detected.');
       this.transition(id);
     }
     if (rootAttrChanged) {
       try {
         yield rootConfig.save();
+        this.transition();
         this.flashMessages.success(`Successfully saved ${id}'s root configuration.`);
       } catch (error) {
         this.errorMessageRoot = errorMessage(error);
+        this.invalidFormAlert = 'There was an error submitting this form.';
       }
     }
     if (leaseAttrChanged) {
       try {
         yield leaseConfig.save();
         this.flashMessages.success(`Successfully saved ${id}'s lease configuration.`);
+        this.transition();
       } catch (error) {
-        // if lease config fails, notify with a flash message but still allow users to save the root config.
+        // if lease config fails, but there was no error saving rootConfig: notify user of the lease failure with a flash message and allow users to save the root config and transition.
         if (!this.errorMessageRoot) {
           this.flashMessages.danger(`Lease configuration was not saved: ${errorMessage(error)}`, {
             sticky: true,
           });
+          this.transition();
         } else {
+          this.errorMessageLease = errorMessage(error);
           this.flashMessages.danger(
             `Configuration not saved: ${errorMessage(error)}. ${this.errorMessageRoot}`,
             {
@@ -106,17 +109,6 @@ export default class ConfigureAwsComponent extends Component<Args> {
         }
       }
     }
-    this.transition(id);
-  }
-
-  transition(id: string) {
-    // prevent transition if there are errors with root configuration
-    if (this.errorMessageRoot) {
-      this.invalidFormAlert = 'There was an error submitting this form.';
-    } else {
-      this.unloadModels();
-      this.router.transitionTo('vault.cluster.secrets.backend.configuration', id);
-    }
   }
 
   resetErrors() {
@@ -125,25 +117,21 @@ export default class ConfigureAwsComponent extends Component<Args> {
     this.invalidFormAlert = null;
   }
 
-  validate(model: LeaseConfigModel, modelName: string) {
-    const { isValid, state, invalidFormMessage } = model.validate();
-    // cannot use a tracked object for modelValidations because it will not update the form.
-    if (modelName === 'leaseConfig') {
-      this.modelValidationsLease = isValid ? null : state;
-    }
-    this.invalidFormAlert = isValid ? '' : invalidFormMessage;
-    return isValid;
+  transition() {
+    this.router.transitionTo('vault.cluster.secrets.backend.configuration', this.args.id);
   }
 
-  unloadModels() {
-    this.args.rootConfig.unloadRecord();
-    this.args.leaseConfig.unloadRecord();
+  validate(model: LeaseConfigModel) {
+    const { isValid, state, invalidFormMessage } = model.validate();
+    this.modelValidationsLease = isValid ? null : state;
+    this.invalidFormAlert = isValid ? '' : invalidFormMessage;
+    return isValid;
   }
 
   @action
   onCancel() {
     // clear errors because they're canceling out of the workflow.
     this.resetErrors();
-    this.transition(this.args.id);
+    this.transition();
   }
 }

--- a/ui/app/components/secret-engine/configure-aws.ts
+++ b/ui/app/components/secret-engine/configure-aws.ts
@@ -66,6 +66,7 @@ export default class ConfigureAwsComponent extends Component<Args> {
     // If no changes to either model, transition and notify user.
     // If changes to either model, save the model(s) that changed and notify user.
     // Note: "backend" dirties model state so explicity ignore it here.
+
     const leaseAttrChanged =
       Object.keys(leaseConfig.changedAttributes()).filter((item) => item !== 'backend').length > 0;
     const rootAttrChanged =
@@ -90,11 +91,11 @@ export default class ConfigureAwsComponent extends Component<Args> {
   async saveRoot() {
     const { backendPath, rootConfig } = this.args;
     try {
-      rootConfig.save();
+      await rootConfig.save();
       this.flashMessages.success(`Successfully saved ${backendPath}'s root configuration.`);
       return true;
     } catch (error) {
-      this.errorMessageRoot = errorMessage('error');
+      this.errorMessageRoot = errorMessage(error);
       this.invalidFormAlert = 'There was an error submitting this form.';
       return false;
     }
@@ -103,7 +104,7 @@ export default class ConfigureAwsComponent extends Component<Args> {
   async saveLease() {
     const { backendPath, leaseConfig } = this.args;
     try {
-      leaseConfig.save();
+      await leaseConfig.save();
       this.flashMessages.success(`Successfully saved ${backendPath}'s lease configuration.`);
       return true;
     } catch (error) {

--- a/ui/app/components/secret-engine/configure-aws.ts
+++ b/ui/app/components/secret-engine/configure-aws.ts
@@ -74,13 +74,13 @@ export default class ConfigureAwsComponent extends Component<Args> {
 
     if (!leaseAttrChanged && !rootAttrChanged) {
       this.flashMessages.info('No changes detected.');
-      this.transition(id);
+      this.transition();
     }
     if (rootAttrChanged) {
       try {
         yield rootConfig.save();
-        this.transition();
         this.flashMessages.success(`Successfully saved ${id}'s root configuration.`);
+        this.transition();
       } catch (error) {
         this.errorMessageRoot = errorMessage(error);
         this.invalidFormAlert = 'There was an error submitting this form.';
@@ -92,7 +92,7 @@ export default class ConfigureAwsComponent extends Component<Args> {
         this.flashMessages.success(`Successfully saved ${id}'s lease configuration.`);
         this.transition();
       } catch (error) {
-        // if lease config fails, but there was no error saving rootConfig: notify user of the lease failure with a flash message and allow users to save the root config and transition.
+        // if lease config fails, but there was no error saving rootConfig: notify user of the lease failure with a flash message, save the root config, and transition.
         if (!this.errorMessageRoot) {
           this.flashMessages.danger(`Lease configuration was not saved: ${errorMessage(error)}`, {
             sticky: true,
@@ -101,10 +101,7 @@ export default class ConfigureAwsComponent extends Component<Args> {
         } else {
           this.errorMessageLease = errorMessage(error);
           this.flashMessages.danger(
-            `Configuration not saved: ${errorMessage(error)}. ${this.errorMessageRoot}`,
-            {
-              sticky: true,
-            }
+            `Configuration not saved: ${errorMessage(error)}. ${this.errorMessageRoot}`
           );
         }
       }

--- a/ui/app/components/secret-engine/configure-ssh.ts
+++ b/ui/app/components/secret-engine/configure-ssh.ts
@@ -24,17 +24,17 @@ import type FlashMessageService from 'vault/services/flash-messages';
  * ```js
  * <SecretEngine::ConfigureSsh
  *    @model={{this.model.ssh-ca-config}}
- *    @backendPath={{this.model.id}}
+ *    @id={{this.model.id}}
  *  />
  * ```
  *
  * @param {string} model - SSH ca-config model
- * @param {string} backendPath - name of the SSH secret engine, ex: 'ssh-123'
+ * @param {string} id - name of the SSH secret engine, ex: 'ssh-123'
  */
 
 interface Args {
   model: CaConfigModel;
-  backendPath: string;
+  id: string;
 }
 
 export default class ConfigureSshComponent extends Component<Args> {
@@ -51,7 +51,7 @@ export default class ConfigureSshComponent extends Component<Args> {
   *save(event: Event) {
     event.preventDefault();
     this.resetErrors();
-    const { backendPath, model } = this.args;
+    const { id, model } = this.args;
     const isValid = this.validate(model);
 
     if (!isValid) return;
@@ -67,7 +67,7 @@ export default class ConfigureSshComponent extends Component<Args> {
     try {
       yield model.save();
       this.transition();
-      this.flashMessages.success(`Successfully saved ${backendPath}'s root configuration.`);
+      this.flashMessages.success(`Successfully saved ${id}'s root configuration.`);
     } catch (error) {
       this.errorMessage = errorMessage(error);
       this.invalidFormAlert = 'There was an error submitting this form.';
@@ -82,11 +82,11 @@ export default class ConfigureSshComponent extends Component<Args> {
 
   transition(isDelete = false) {
     // deleting a key is the only case in which we want to stay on the create/edit page.
-    const { backendPath } = this.args;
+    const { id } = this.args;
     if (isDelete) {
-      this.router.transitionTo('vault.cluster.secrets.backend.configuration.edit', backendPath);
+      this.router.transitionTo('vault.cluster.secrets.backend.configuration.edit', id);
     } else {
-      this.router.transitionTo('vault.cluster.secrets.backend.configuration', backendPath);
+      this.router.transitionTo('vault.cluster.secrets.backend.configuration', id);
     }
   }
 

--- a/ui/app/components/secret-engine/configure-ssh.ts
+++ b/ui/app/components/secret-engine/configure-ssh.ts
@@ -74,13 +74,6 @@ export default class ConfigureSshComponent extends Component<Args> {
     }
   }
 
-  validate(model: CaConfigModel) {
-    const { isValid, state, invalidFormMessage } = model.validate();
-    this.modelValidations = isValid ? null : state;
-    this.invalidFormAlert = isValid ? '' : invalidFormMessage;
-    return isValid;
-  }
-
   resetErrors() {
     this.flashMessages.clearMessages();
     this.errorMessage = null;
@@ -94,6 +87,13 @@ export default class ConfigureSshComponent extends Component<Args> {
     } else {
       this.router.transitionTo('vault.cluster.secrets.backend.configuration', this.args.id);
     }
+  }
+
+  validate(model: CaConfigModel) {
+    const { isValid, state, invalidFormMessage } = model.validate();
+    this.modelValidations = isValid ? null : state;
+    this.invalidFormAlert = isValid ? '' : invalidFormMessage;
+    return isValid;
   }
 
   @action

--- a/ui/app/components/secret-engine/configure-ssh.ts
+++ b/ui/app/components/secret-engine/configure-ssh.ts
@@ -24,17 +24,17 @@ import type FlashMessageService from 'vault/services/flash-messages';
  * ```js
  * <SecretEngine::ConfigureSsh
  *    @model={{this.model.ssh-ca-config}}
- *    @id={{this.model.id}}
+ *    @backendPath={{this.model.id}}
  *  />
  * ```
  *
  * @param {string} model - SSH ca-config model
- * @param {string} id - name of the SSH secret engine, ex: 'ssh-123'
+ * @param {string} backendPath - name of the SSH secret engine, ex: 'ssh-123'
  */
 
 interface Args {
   model: CaConfigModel;
-  id: string;
+  backendPath: string;
 }
 
 export default class ConfigureSshComponent extends Component<Args> {
@@ -51,7 +51,7 @@ export default class ConfigureSshComponent extends Component<Args> {
   *save(event: Event) {
     event.preventDefault();
     this.resetErrors();
-    const { id, model } = this.args;
+    const { backendPath, model } = this.args;
     const isValid = this.validate(model);
 
     if (!isValid) return;
@@ -67,7 +67,7 @@ export default class ConfigureSshComponent extends Component<Args> {
     try {
       yield model.save();
       this.transition();
-      this.flashMessages.success(`Successfully saved ${id}'s root configuration.`);
+      this.flashMessages.success(`Successfully saved ${backendPath}'s root configuration.`);
     } catch (error) {
       this.errorMessage = errorMessage(error);
       this.invalidFormAlert = 'There was an error submitting this form.';
@@ -82,10 +82,11 @@ export default class ConfigureSshComponent extends Component<Args> {
 
   transition(isDelete = false) {
     // deleting a key is the only case in which we want to stay on the create/edit page.
+    const { backendPath } = this.args;
     if (isDelete) {
-      this.router.transitionTo('vault.cluster.secrets.backend.configuration.edit', this.args.id);
+      this.router.transitionTo('vault.cluster.secrets.backend.configuration.edit', backendPath);
     } else {
-      this.router.transitionTo('vault.cluster.secrets.backend.configuration', this.args.id);
+      this.router.transitionTo('vault.cluster.secrets.backend.configuration', backendPath);
     }
   }
 

--- a/ui/app/helpers/aws-regions.js
+++ b/ui/app/helpers/aws-regions.js
@@ -7,6 +7,7 @@ import { helper as buildHelper } from '@ember/component/helper';
 
 //list from http://docs.aws.amazon.com/general/latest/gr/rande.html#sts_region
 const REGIONS = [
+  '', // initial region blank
   'us-east-1',
   'us-east-2',
   'us-west-1',

--- a/ui/app/models/aws/lease-config.js
+++ b/ui/app/models/aws/lease-config.js
@@ -5,7 +5,20 @@
 
 import Model, { attr } from '@ember-data/model';
 import { expandAttributeMeta } from 'vault/utils/field-to-attrs';
+import { withModelValidations } from 'vault/decorators/model-validations';
 
+const validations = {
+  lease: [
+    {
+      validator(model) {
+        const { lease, leaseMax } = model;
+        return (lease && leaseMax) || (!lease && !leaseMax) ? true : false;
+      },
+      message: 'Lease TTL and Max Lease TTL are both required if one of them is set.',
+    },
+  ],
+};
+@withModelValidations(validations)
 export default class AwsLeaseConfig extends Model {
   @attr('string') backend; // dynamic path of secret -- set on response from value passed to queryRecord
   @attr({

--- a/ui/app/models/aws/root-config.js
+++ b/ui/app/models/aws/root-config.js
@@ -4,20 +4,22 @@
  */
 
 import Model, { attr } from '@ember-data/model';
-import { expandAttributeMeta } from 'vault/utils/field-to-attrs';
+import fieldToAttrs, { expandAttributeMeta } from 'vault/utils/field-to-attrs';
+import { regions } from 'vault/helpers/aws-regions';
 
 export default class AwsRootConfig extends Model {
   @attr('string') backend; // dynamic path of secret -- set on response from value passed to queryRecord
   @attr('string') accessKey;
-  @attr('string') region;
+  @attr('string', { sensitive: true }) secretKey; // obfuscated, never returned by API
   @attr('string', {
-    label: 'IAM endpoint',
+    possibleValues: regions(),
+    subText:
+      'Specifies the AWS region. If not set it will use the AWS_REGION env var, AWS_DEFAULT_REGION env var, or us-east-1 in that order.',
   })
+  region;
+  @attr('string', { label: 'IAM endpoint' })
   iamEndpoint;
-  @attr('string', {
-    label: 'STS endpoint',
-  })
-  stsEndpoint;
+  @attr('string', { label: 'STS endpoint' }) stsEndpoint;
   @attr('number', {
     defaultValue: -1,
     label: 'Maximum retries',
@@ -28,5 +30,18 @@ export default class AwsRootConfig extends Model {
   get attrs() {
     const keys = ['accessKey', 'region', 'iamEndpoint', 'stsEndpoint', 'maxRetries'];
     return expandAttributeMeta(this, keys);
+  }
+  // used for the configure-aws-secret component
+  get formFieldGroups() {
+    return [
+      { default: ['accessKey', 'secretKey'] },
+      {
+        'Root config options': ['region', 'iamEndpoint', 'stsEndpoint', 'maxRetries'],
+      },
+    ];
+  }
+
+  get fieldGroups() {
+    return fieldToAttrs(this, this.formFieldGroups);
   }
 }

--- a/ui/app/models/aws/root-config.js
+++ b/ui/app/models/aws/root-config.js
@@ -31,7 +31,7 @@ export default class AwsRootConfig extends Model {
     const keys = ['accessKey', 'region', 'iamEndpoint', 'stsEndpoint', 'maxRetries'];
     return expandAttributeMeta(this, keys);
   }
-  // used for the configure-aws-secret component
+
   get formFieldGroups() {
     return [
       { default: ['accessKey', 'secretKey'] },

--- a/ui/app/routes/vault/cluster/secrets/backend/configuration/edit.ts
+++ b/ui/app/routes/vault/cluster/secrets/backend/configuration/edit.ts
@@ -19,7 +19,7 @@ import type SecretEngineModel from 'vault/models/secret-engine';
 // Saving and updating of those models are done within the engine specific components.
 
 const CONFIG_ADAPTERS_PATHS: Record<string, string[]> = {
-  // aws: ['aws/lease-config', 'aws/root-config'], TODO will be uncommented when AWS refactor occurs
+  aws: ['aws/lease-config', 'aws/root-config'],
   ssh: ['ssh/ca-config'],
 };
 
@@ -37,68 +37,36 @@ export default class SecretsBackendConfigurationEdit extends Route {
       set(error, 'httpStatus', 404);
       throw error;
     }
-    // TODO this conditional will be removed when we handle AWS
-    if (type !== 'aws') {
-      // generate the model based on the engine type.
-      // and pre-set with the type and backend (e.g. type: ssh, id: ssh-123)
-      const model: Record<string, unknown> = { type, id: backend };
-      for (const adapterPath of CONFIG_ADAPTERS_PATHS[type] as string[]) {
-        // convert the adapterPath with a name that can be passed to the components
-        // ex: adapterPath = ssh/ca-config, convert to: ssh-ca-config so that you can pass to component @model={{this.model.ssh-ca-config}}
-        const standardizedKey = adapterPath.replace(/\//g, '-');
-        try {
-          model[standardizedKey] = await this.store.queryRecord(adapterPath, {
+    // generate the model based on the engine type.
+    // and pre-set with the type and backend (e.g. type: ssh, id: ssh-123)
+    const model: Record<string, unknown> = { type, id: backend };
+    for (const adapterPath of CONFIG_ADAPTERS_PATHS[type] as string[]) {
+      // convert the adapterPath with a name that can be passed to the components
+      // ex: adapterPath = ssh/ca-config, convert to: ssh-ca-config so that you can pass to component @model={{this.model.ssh-ca-config}}
+      const standardizedKey = adapterPath.replace(/\//g, '-');
+      try {
+        model[standardizedKey] = await this.store.queryRecord(adapterPath, {
+          backend,
+          type,
+        });
+      } catch (e: AdapterError) {
+        // For most models if the adapter returns a 404, we want to create a new record.
+        // The ssh secret engine however returns a 400 if the CA is not configured.
+        // For ssh's 400 error, we want to create the CA config model.
+        if (
+          e.httpStatus === 404 ||
+          (type === 'ssh' && e.httpStatus === 400 && errorMessage(e) === `keys haven't been configured yet`)
+        ) {
+          model[standardizedKey] = await this.store.createRecord(adapterPath, {
             backend,
             type,
           });
-        } catch (e: AdapterError) {
-          // For most models if the adapter returns a 404, we want to create a new record.
-          // The ssh secret engine however returns a 400 if the CA is not configured.
-          // For ssh's 400 error, we want to create the CA config model.
-          if (
-            e.httpStatus === 404 ||
-            (type === 'ssh' && e.httpStatus === 400 && errorMessage(e) === `keys haven't been configured yet`)
-          ) {
-            model[standardizedKey] = await this.store.createRecord(adapterPath, {
-              backend,
-              type,
-            });
-          } else {
-            throw e;
-          }
+        } else {
+          throw e;
         }
       }
-      return model;
-    } else {
-      // TODO for now AWS configs rely on the secret-engine model and adapter. This will be refactored.
-      return await this.store.findRecord('secret-engine', backend);
-    }
-  }
-
-  // TODO everything below line will be removed once we handle AWS. This is the old code wrapped in AWS conditionals when appropriate.
-  afterModel(model: Record<string, unknown>) {
-    const type = model.type;
-
-    if (type === 'aws') {
-      return this.store
-        .queryRecord('secret-engine', {
-          backend: model.id,
-          type,
-        })
-        .then(
-          () => model,
-          () => model
-        );
     }
     return model;
-  }
-
-  resetController(controller, isExiting) {
-    if (controller.model.type === 'aws') {
-      if (isExiting) {
-        controller.reset();
-      }
-    }
   }
 
   @action

--- a/ui/app/routes/vault/cluster/secrets/backend/configuration/edit.ts
+++ b/ui/app/routes/vault/cluster/secrets/backend/configuration/edit.ts
@@ -38,7 +38,7 @@ export default class SecretsBackendConfigurationEdit extends Route {
       throw error;
     }
     // generate the model based on the engine type.
-    // and pre-set with the type and backend (e.g. type: ssh, id: ssh-123)
+    // and pre-set model with type and backend e.g. {type: ssh, id: ssh-123}
     const model: Record<string, unknown> = { type, id: backend };
     for (const adapterPath of CONFIG_ADAPTERS_PATHS[type] as string[]) {
       // convert the adapterPath with a name that can be passed to the components

--- a/ui/app/templates/vault/cluster/secrets/backend/configuration/edit.hbs
+++ b/ui/app/templates/vault/cluster/secrets/backend/configuration/edit.hbs
@@ -35,5 +35,5 @@
     @backendPath={{this.model.id}}
   />
 {{else if (eq this.model.type "ssh")}}
-  <SecretEngine::ConfigureSsh @model={{this.model.ssh-ca-config}} @backendPath={{this.model.id}} />
+  <SecretEngine::ConfigureSsh @model={{this.model.ssh-ca-config}} @id={{this.model.id}} />
 {{/if}}

--- a/ui/app/templates/vault/cluster/secrets/backend/configuration/edit.hbs
+++ b/ui/app/templates/vault/cluster/secrets/backend/configuration/edit.hbs
@@ -30,15 +30,9 @@
 
 {{#if (eq this.model.type "aws")}}
   <SecretEngine::ConfigureAws
-    @model={{this.model}}
-    @tab={{this.tab}}
-    @accessKey={{this.accessKey}}
-    @secretKey={{this.secretKey}}
-    @region={{this.region}}
-    @iamEndpoint={{this.iamEndpoint}}
-    @stsEndpoint={{this.stsEndpoint}}
-    @saveAWSRoot={{action "save" "saveAWSRoot"}}
-    @saveAWSLease={{action "save" "saveAWSLease"}}
+    @leaseConfig={{this.model.aws-lease-config}}
+    @rootConfig={{this.model.aws-root-config}}
+    @id={{this.model.id}}
   />
 {{else if (eq this.model.type "ssh")}}
   <SecretEngine::ConfigureSsh @model={{this.model.ssh-ca-config}} @id={{this.model.id}} />

--- a/ui/app/templates/vault/cluster/secrets/backend/configuration/edit.hbs
+++ b/ui/app/templates/vault/cluster/secrets/backend/configuration/edit.hbs
@@ -32,8 +32,8 @@
   <SecretEngine::ConfigureAws
     @leaseConfig={{this.model.aws-lease-config}}
     @rootConfig={{this.model.aws-root-config}}
-    @id={{this.model.id}}
+    @backendPath={{this.model.id}}
   />
 {{else if (eq this.model.type "ssh")}}
-  <SecretEngine::ConfigureSsh @model={{this.model.ssh-ca-config}} @id={{this.model.id}} />
+  <SecretEngine::ConfigureSsh @model={{this.model.ssh-ca-config}} @backendPath={{this.model.id}} />
 {{/if}}

--- a/ui/lib/core/addon/components/form-field-groups.hbs
+++ b/ui/lib/core/addon/components/form-field-groups.hbs
@@ -24,6 +24,10 @@
             {{! OTHERWISE WE'RE EDITING }}
             {{#if (or (eq attr.name "name") (attr.options.editDisabled))}}
               <ReadonlyFormField @attr={{attr}} @value={{get @model attr.name}} />
+            {{else if (and @useEnableInput attr.options.sensitive)}}
+              <EnableInput data-test-enable-field={{attr.name}} class="field" @attr={{attr}}>
+                <FormField @attr={{attr}} @model={{@model}} @modelValidations={{@modelValidations}} @onKeyUp={{@onKeyUp}} />
+              </EnableInput>
             {{else}}
               <FormField
                 data-test-field

--- a/ui/lib/core/addon/components/form-field-groups.ts
+++ b/ui/lib/core/addon/components/form-field-groups.ts
@@ -21,6 +21,7 @@ import type { ValidationMap } from 'vault/vault/app-types';
  * @param {function} [onKeyUp] - Handler that will set the value and trigger validation on input changes
  * @param {object} [modelValidations] - Object containing validation message for each property
  * @param {string} [groupName=fieldGroups] - attribute name where the field groups are
+ * @param {boolean} [useEnableInput=false] - if you want to wrap your sensitive fields with the EnableInput component while editing. Defaults to false.
  */
 
 interface Args {

--- a/ui/lib/core/addon/components/form-field-groups.ts
+++ b/ui/lib/core/addon/components/form-field-groups.ts
@@ -21,7 +21,7 @@ import type { ValidationMap } from 'vault/vault/app-types';
  * @param {function} [onKeyUp] - Handler that will set the value and trigger validation on input changes
  * @param {object} [modelValidations] - Object containing validation message for each property
  * @param {string} [groupName=fieldGroups] - attribute name where the field groups are
- * @param {boolean} [useEnableInput=false] - if you want to wrap your sensitive fields with the EnableInput component while editing. Defaults to false.
+ * @param {boolean} [useEnableInput=false] - if you want to wrap your sensitive fields with the EnableInput component while editing.
  */
 
 interface Args {

--- a/ui/tests/acceptance/secrets/backend/aws/aws-configuration-test.js
+++ b/ui/tests/acceptance/secrets/backend/aws/aws-configuration-test.js
@@ -32,7 +32,7 @@ module('Acceptance | aws | configuration', function (hooks) {
     const flash = this.owner.lookup('service:flash-messages');
     this.store = this.owner.lookup('service:store');
     this.flashSuccessSpy = spy(flash, 'success');
-    this.flashDangerSpy = spy(flash, 'danger');
+    this.flashInfoSpy = spy(flash, 'info');
 
     this.uid = uuidv4();
     return authPage.login();
@@ -213,7 +213,7 @@ module('Acceptance | aws | configuration', function (hooks) {
     await click(SES.configure);
     await click(SES.aws.save);
     assert.true(
-      this.flashDangerSpy.calledWith('No changes detected.'),
+      this.flashInfoSpy.calledWith('No changes detected.'),
       'Flash message shows no changes detected.'
     );
     assert.strictEqual(

--- a/ui/tests/acceptance/secrets/backend/aws/aws-configuration-test.js
+++ b/ui/tests/acceptance/secrets/backend/aws/aws-configuration-test.js
@@ -60,8 +60,6 @@ module('Acceptance | aws | configuration', function (hooks) {
     assert.strictEqual(currentURL(), `/vault/secrets/${path}/configuration/edit`);
     assert.dom(SES.configureTitle('aws')).hasText('Configure AWS');
     assert.dom(SES.aws.rootForm).exists('it lands on the root configuration form.');
-    assert.dom(GENERAL.tab('access-to-aws')).exists('renders the root creds tab');
-    assert.dom(GENERAL.tab('lease')).exists('renders the leases config tab');
     // cleanup
     await runCmd(`delete sys/mounts/${path}`);
   });
@@ -78,40 +76,47 @@ module('Acceptance | aws | configuration', function (hooks) {
   });
 
   test('it should save root AWS configuration', async function (assert) {
+    assert.expect(3);
     const path = `aws-${this.uid}`;
     await enablePage.enable('aws', path);
+
+    this.server.post(configUrl('aws-lease', path), () => {
+      assert.false(true, 'post request was made to config/lease when no data was changed. test should fail.');
+    });
+
     await click(SES.configTab);
     await click(SES.configure);
     await fillInAwsConfig();
-    await click(SES.aws.saveRootConfig);
+    await click(SES.aws.save);
     assert.true(
-      this.flashSuccessSpy.calledWith('The backend configuration saved successfully!'),
-      'Success flash message is rendered'
+      this.flashSuccessSpy.calledWith(`Successfully saved ${path}'s root configuration.`),
+      'Success flash message is rendered showing the root configuration was saved.'
     );
-
-    await visit(`/vault/secrets/${path}/configuration`);
-    assert.dom(GENERAL.infoRowValue('Access key')).hasText('foo', `Access Key has been set.`);
+    assert.dom(GENERAL.infoRowValue('Access key')).hasText('foo', 'Access Key has been set.');
     assert
       .dom(GENERAL.infoRowValue('Secret key'))
-      .doesNotExist(`Secret key is not shown because it does not get returned by the api.`);
+      .doesNotExist('Secret key is not shown because it does not get returned by the api.');
     // cleanup
     await runCmd(`delete sys/mounts/${path}`);
   });
 
   test('it should save lease AWS configuration', async function (assert) {
+    assert.expect(3);
     const path = `aws-${this.uid}`;
     await enablePage.enable('aws', path);
+
+    this.server.post(configUrl('aws', path), () => {
+      assert.false(true, 'post request was made to config/root when no data was changed. test should fail.');
+    });
     await click(SES.configTab);
     await click(SES.configure);
-    await click(GENERAL.hdsTab('lease'));
     await fillInAwsConfig(false, false, true); // only fills in lease config with defaults
-    await click(SES.aws.saveLeaseConfig);
+    await click(SES.aws.save);
     assert.true(
-      this.flashSuccessSpy.calledWith('The backend configuration saved successfully!'),
-      'Success flash message is rendered'
+      this.flashSuccessSpy.calledWith(`Successfully saved ${path}'s lease configuration.`),
+      'Success flash message is rendered showing the lease configuration was saved.'
     );
 
-    await visit(`/vault/secrets/${path}/configuration`);
     assert.dom(GENERAL.infoRowValue('Default Lease TTL')).hasText('33s', `Default TTL has been set.`);
     assert.dom(GENERAL.infoRowValue('Max Lease TTL')).hasText('44s', `Max lease TTL has been set.`);
     // cleanup
@@ -153,26 +158,24 @@ module('Acceptance | aws | configuration', function (hooks) {
     // create accessKey with value foo and confirm it shows up in the details page.
     await click(SES.configTab);
     await click(SES.configure);
-    await fillIn(GENERAL.inputByAttr('accessKey'), 'foo');
-    await click(SES.aws.saveRootConfig);
-    await click(SES.viewBackend);
-    await click(SES.configTab);
+    await fillInAwsConfig();
+    await click(SES.aws.save);
     assert.dom(GENERAL.infoRowValue('Access key')).hasText('foo', 'Access key is foo');
     assert
       .dom(GENERAL.infoRowValue('Region'))
       .doesNotExist('Region has not been added therefor it does not show up on the details view.');
     // edit root config details and lease config details and confirm the configuration.index page is updated.
     await click(SES.configure);
-    await fillIn(GENERAL.inputByAttr('accessKey'), 'hello');
+    // edit root config details
+    await fillIn(GENERAL.inputByAttr('accessKey'), 'not-foo');
     await click(GENERAL.toggleGroup('Root config options'));
-    await fillIn(GENERAL.selectByAttr('region'), 'ap-southeast-2');
-    await click(SES.aws.saveRootConfig);
+    await fillIn(GENERAL.inputByAttr('region'), 'ap-southeast-2');
     // add lease config details
     await fillInAwsConfig(false, false, true); // only fills in lease config with defaults
-    await click(SES.aws.saveLeaseConfig);
-    await click(SES.viewBackend);
-    await click(SES.configTab);
-    assert.dom(GENERAL.infoRowValue('Access key')).hasText('hello', 'Access key has been updated to hello');
+    await click(SES.aws.save);
+    assert
+      .dom(GENERAL.infoRowValue('Access key'))
+      .hasText('not-foo', 'Access key has been updated to not-foo');
     assert.dom(GENERAL.infoRowValue('Region')).hasText('ap-southeast-2', 'Region has been added');
     assert.dom(GENERAL.infoRowValue('Default Lease TTL')).hasText('33s', 'Default Lease TTL has been added');
     assert.dom(GENERAL.infoRowValue('Max Lease TTL')).hasText('44s', 'Max Lease TTL has been added');
@@ -191,5 +194,57 @@ module('Acceptance | aws | configuration', function (hooks) {
     });
     await click(SES.configTab);
     assert.dom(SES.error.title).hasText('Error', 'shows the secrets backend error route');
+  });
+
+  test('it should not make a post request if lease or root data was unchanged', async function (assert) {
+    assert.expect(3);
+    const path = `aws-${this.uid}`;
+    const type = 'aws';
+    await enablePage.enable(type, path);
+
+    this.server.post(configUrl(type, path), () => {
+      assert.false(true, 'post request was made to config/root when no data was changed. test should fail.');
+    });
+    this.server.post(configUrl('aws-lease', path), () => {
+      assert.false(true, 'post request was made to config/lease when no data was changed. test should fail.');
+    });
+
+    await click(SES.configTab);
+    await click(SES.configure);
+    await click(SES.aws.save);
+    assert.true(
+      this.flashDangerSpy.calledWith('No changes detected.'),
+      'Flash message shows no changes detected.'
+    );
+    assert.strictEqual(
+      currentURL(),
+      `/vault/secrets/${path}/configuration`,
+      'navigates back to the configuration index view'
+    );
+    assert.dom(GENERAL.emptyStateTitle).hasText('AWS not configured');
+    // cleanup
+    await runCmd(`delete sys/mounts/${path}`);
+  });
+
+  test('it should reset models after saving', async function (assert) {
+    const path = `aws-${this.uid}`;
+    const type = 'aws';
+    await enablePage.enable(type, path);
+    await click(SES.configTab);
+    await click(SES.configure);
+    await fillInAwsConfig(true);
+    //  the way to tell if a record has been unloaded is if the private key is not saved in the store (the API does not return it, but if the record was not unloaded it would have stayed.)
+    await click(SES.aws.save); // save the configuration
+    await click(SES.configure);
+    const privateKeyExists = this.store.peekRecord('aws/root-config', path).privateKey ? true : false;
+    assert.false(
+      privateKeyExists,
+      'private key is not on the store record, meaning it was unloaded after save. This new record without the key comes from the API.'
+    );
+    assert
+      .dom(GENERAL.enableField('secretKey'))
+      .exists('secret key field is wrapped inside an enableInput component');
+    // cleanup
+    await runCmd(`delete sys/mounts/${path}`);
   });
 });

--- a/ui/tests/helpers/general-selectors.ts
+++ b/ui/tests/helpers/general-selectors.ts
@@ -92,7 +92,6 @@ export const GENERAL = {
   navLink: (label: string) => `[data-test-sidebar-nav-link="${label}"]`,
   cancelButton: '[data-test-cancel]',
   saveButton: '[data-test-save]',
-  saveButtonId: (id: string) => `[data-test-save="${id}"]`, // there are many uses of save button, but very few with an id. Instead of making all instances of saveButton a function with an empty string, we can just use this selector. TODO: should be removed after refactor of AWS.
   maskedInput: (name: string) => `[data-test-textarea="${name}"]`,
   codemirror: `[data-test-component="code-mirror-modifier"]`,
   codemirrorTextarea: `[data-test-component="code-mirror-modifier"] textarea`,

--- a/ui/tests/helpers/secret-engine/secret-engine-helpers.js
+++ b/ui/tests/helpers/secret-engine/secret-engine-helpers.js
@@ -41,7 +41,7 @@ const createAwsLeaseConfig = (store, backend) => {
     data: {
       backend: backend,
       lease: '50s',
-      leaseMax: '55s',
+      lease_max: '55s',
     },
   });
   return store.peekRecord('aws/lease-config', backend);

--- a/ui/tests/helpers/secret-engine/secret-engine-helpers.js
+++ b/ui/tests/helpers/secret-engine/secret-engine-helpers.js
@@ -24,7 +24,7 @@ const createAwsRootConfig = (store, backend) => {
     id: backend,
     modelName: 'aws/root-config',
     data: {
-      backend,
+      backend: backend,
       region: 'us-west-2',
       access_key: '123-key',
       iam_endpoint: 'iam-endpoint',
@@ -48,13 +48,12 @@ const createAwsLeaseConfig = (store, backend) => {
 };
 
 const createSshCaConfig = (store, backend) => {
-  // consider this model a placeholder for the actual ssh/ca-config model that has been generated with data. isNew is false.
   store.pushPayload('ssh/ca-config', {
     id: backend,
     modelName: 'ssh/ca-config',
     data: {
-      backend,
-      public_key: '123456',
+      backend: backend,
+      public_key: 'public-key',
       generate_signing_key: true,
     },
   });
@@ -89,6 +88,10 @@ export const expectedConfigKeys = (type) => {
   switch (type) {
     case 'aws':
       return ['Access key', 'Region', 'IAM endpoint', 'STS endpoint', 'Maximum retries'];
+    case 'aws-lease':
+      return ['Default Lease TTL', 'Max Lease TTL'];
+    case 'aws-root-create':
+      return ['accessKey', 'secretKey', 'region', 'iamEndpoint', 'stsEndpoint', 'maxRetries'];
     case 'ssh':
       return ['Public key', 'Generate signing key'];
   }
@@ -130,20 +133,19 @@ export const expectedValueOfConfigKeys = (type, string) => {
 export const fillInAwsConfig = async (withAccess = true, withAccessOptions = false, withLease = false) => {
   if (withAccess) {
     await fillIn(GENERAL.inputByAttr('accessKey'), 'foo');
-    await fillIn(GENERAL.inputByAttr('secretKey'), 'bar');
+    await fillIn(GENERAL.maskedInput('secretKey'), 'bar');
   }
   if (withAccessOptions) {
     await click(GENERAL.toggleGroup('Root config options'));
-    await fillIn(GENERAL.selectByAttr('region'), 'ca-central-1');
+    await fillIn(GENERAL.inputByAttr('region'), 'ca-central-1');
     await fillIn(GENERAL.inputByAttr('iamEndpoint'), 'iam-endpoint');
     await fillIn(GENERAL.inputByAttr('stsEndpoint'), 'sts-endpoint');
     await fillIn(GENERAL.inputByAttr('maxRetries'), '3');
   }
-  await click(GENERAL.hdsTab('lease'));
   if (withLease) {
-    await click(GENERAL.ttl.toggle('Lease'));
-    await fillIn(GENERAL.ttl.input('Lease'), '33');
-    await click(GENERAL.ttl.toggle('Maximum Lease'));
-    await fillIn(GENERAL.ttl.input('Maximum Lease'), '44');
+    await click(GENERAL.ttl.toggle('Default Lease TTL'));
+    await fillIn(GENERAL.ttl.input('Default Lease TTL'), '33');
+    await click(GENERAL.ttl.toggle('Max Lease TTL'));
+    await fillIn(GENERAL.ttl.input('Max Lease TTL'), '44');
   }
 };

--- a/ui/tests/helpers/secret-engine/secret-engine-helpers.js
+++ b/ui/tests/helpers/secret-engine/secret-engine-helpers.js
@@ -24,7 +24,7 @@ const createAwsRootConfig = (store, backend) => {
     id: backend,
     modelName: 'aws/root-config',
     data: {
-      backend: backend,
+      backend,
       region: 'us-west-2',
       access_key: '123-key',
       iam_endpoint: 'iam-endpoint',
@@ -39,7 +39,7 @@ const createAwsLeaseConfig = (store, backend) => {
     id: backend,
     modelName: 'aws/lease-config',
     data: {
-      backend: backend,
+      backend,
       lease: '50s',
       lease_max: '55s',
     },
@@ -52,7 +52,7 @@ const createSshCaConfig = (store, backend) => {
     id: backend,
     modelName: 'ssh/ca-config',
     data: {
-      backend: backend,
+      backend,
       public_key: 'public-key',
       generate_signing_key: true,
     },

--- a/ui/tests/helpers/secret-engine/secret-engine-selectors.ts
+++ b/ui/tests/helpers/secret-engine/secret-engine-selectors.ts
@@ -23,10 +23,10 @@ export const SECRET_ENGINE_SELECTORS = {
   warning: '[data-test-warning]',
   aws: {
     rootForm: '[data-test-root-form]',
-    leaseForm: '[data-test-lease-form]',
-    saveRootConfig: '[data-test-save-root-config]',
-    saveLeaseConfig: '[data-test-save-lease-config]',
-    cancelConfig: '[data-test-cancel-config]',
+    accessTitle: '[data-test-access-title]',
+    leaseTitle: '[data-test-lease-title]',
+    save: '[data-test-save]',
+    cancel: '[data-test-cancel]',
     deleteRole: (role: string) => `[data-test-aws-role-delete="${role}"]`,
   },
   ssh: {

--- a/ui/tests/helpers/sync/sync-selectors.js
+++ b/ui/tests/helpers/sync/sync-selectors.js
@@ -85,7 +85,7 @@ export const PAGE = {
   saveButton: '[data-test-save]',
   toolbar: (btnText) => `[data-test-toolbar="${btnText}"]`,
   form: {
-    enableInput: (attr) => `[data-test-enable-field="${attr}"] [data-test-icon="edit"]`,
+    enableInput: (attr) => `[data-test-enable-field="${attr}"] [data-test-icon="edit"]`, // TODO duplicated in general-selectors as this component became more widely used
     fieldGroupHeader: (group) => `[data-test-destination-header="${group}"]`,
     fieldGroupSubtext: (group) => `[data-test-destination-subText="${group}"]`,
     fillInByAttr: async (attr, value) => {

--- a/ui/tests/integration/components/secret-engine/configure-aws-test.js
+++ b/ui/tests/integration/components/secret-engine/configure-aws-test.js
@@ -12,7 +12,13 @@ import { render, click, fillIn } from '@ember/test-helpers';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { hbs } from 'ember-cli-htmlbars';
 import { v4 as uuidv4 } from 'uuid';
-import { createConfig } from 'vault/tests/helpers/secret-engine/secret-engine-helpers';
+import { overrideResponse } from 'vault/tests/helpers/stubs';
+import {
+  expectedConfigKeys,
+  createConfig,
+  configUrl,
+  fillInAwsConfig,
+} from 'vault/tests/helpers/secret-engine/secret-engine-helpers';
 
 module('Integration | Component | SecretEngine/configure-aws', function (hooks) {
   setupRenderingTest(hooks);
@@ -20,45 +26,142 @@ module('Integration | Component | SecretEngine/configure-aws', function (hooks) 
 
   hooks.beforeEach(function () {
     this.store = this.owner.lookup('service:store');
+    this.flashMessages = this.owner.lookup('service:flash-messages');
+    this.flashMessages.registerTypes(['success', 'danger']);
+    this.flashSuccessSpy = sinon.spy(this.flashMessages, 'success');
+    this.flashDangerSpy = sinon.spy(this.flashMessages, 'danger');
+    this.transitionStub = sinon.stub(this.owner.lookup('service:router'), 'transitionTo');
 
     this.uid = uuidv4();
     this.id = `aws-${this.uid}`;
-    this.model = createConfig(this.store, this.id, 'aws-lease'); // currently when you queryRecord for secret-engine type aws it returns the lease/config. This is going to change in the refactor.
-    this.saveAWSLease = sinon.stub();
-    this.saveAWSRoot = sinon.stub();
+    this.model = createConfig(this.store, this.id, 'aws-lease');
+    this.rootConfig = this.store.createRecord('aws/root-config');
+    this.leaseConfig = this.store.createRecord('aws/lease-config');
+    // Add backend to the configs because it's not on the testing snapshot (would come from url)
+    this.rootConfig.backend = this.leaseConfig.backend = this.id;
 
     this.renderComponent = () => {
       return render(hbs`
-        <SecretEngine::ConfigureAws @model={{this.model}} @saveAWSLease={{this.saveAWSLease}} @saveAWSRoot={{this.saveAWSRoot}} @tab="root" @region="" />
+        <SecretEngine::ConfigureAws @rootConfig={{this.rootConfig}} @leaseConfig={{this.leaseConfig}} @id={{this.id}} />
         `);
     };
   });
+  module('Create view', function () {
+    test('it renders fields', async function (assert) {
+      assert.expect(11);
+      await this.renderComponent();
+      assert.dom(SES.aws.rootForm).exists('it lands on the aws root configuration form.');
+      assert.dom(SES.aws.accessTitle).exists('Access section is rendered');
+      assert.dom(SES.aws.leaseTitle).exists('Lease section is rendered');
+      // check all the form fields are present
+      await click(GENERAL.toggleGroup('Root config options'));
+      for (const key of expectedConfigKeys('aws-root-create')) {
+        if (key === 'secretKey') {
+          assert.dom(GENERAL.maskedInput(key)).exists(`${key} shows for root section.`);
+        } else {
+          assert.dom(GENERAL.inputByAttr(key)).exists(`${key} shows for root section.`);
+        }
+      }
+      for (const key of expectedConfigKeys('aws-lease')) {
+        assert.dom(`[data-test-ttl-form-label="${key}"]`).exists(`${key} shows for Lease section.`);
+      }
+    });
 
-  test('it renders fields', async function (assert) {
-    await this.renderComponent();
-    assert.dom(SES.aws.rootForm).exists('it lands on the aws root configuration form.');
-    assert.dom(GENERAL.inputByAttr('accessKey')).exists(`accessKey shows for Access section.`);
-    assert.dom(GENERAL.inputByAttr('secretKey')).exists(`secretKey shows for Access section.`);
+    test('it shows validation error if default lease is entered but max lease is not', async function (assert) {
+      assert.expect(2);
+      await this.renderComponent();
+      this.server.post(configUrl('aws-lease', this.id), () => {
+        assert.false(
+          true,
+          'post request was made to config/lease when no data was changed. test should fail.'
+        );
+      });
+      this.server.post(configUrl('aws', this.id), () => {
+        assert.false(
+          true,
+          'post request was made to config/root when no data was changed. test should fail.'
+        );
+      });
+      await click(GENERAL.ttl.toggle('Default Lease TTL'));
+      await fillIn(GENERAL.ttl.input('Default Lease TTL'), '33');
+      await click(SES.aws.save);
+      assert
+        .dom(GENERAL.inlineError)
+        .hasText('Lease TTL and Max Lease TTL are both required if one of them is set.');
+      assert.dom(SES.aws.rootForm).exists('remains on the configuration form');
+    });
 
-    await click(GENERAL.hdsTab('lease'));
-    assert.dom('[data-test-ttl-form-label="Lease"]').exists('Lease TTL is rendered');
-    assert.dom('[data-test-ttl-form-label="Maximum Lease"]').exists('Maximum Lease TTL is rendered');
+    test('it surfaces the API error if one occurs on root/config, preventing user from transitioning', async function (assert) {
+      assert.expect(3);
+      await this.renderComponent();
+      this.server.post(configUrl('aws', this.id), () => {
+        return overrideResponse(400, { errors: ['bad request'] });
+      });
+      this.server.post(configUrl('aws-lease', this.id), () => {
+        assert.true(true, 'post request was made to config/lease when config/root failed. test should pass.');
+      });
+      // fill in both lease and root endpoints to ensure that both payloads are attempted to be sent
+      await fillInAwsConfig(true, false, true);
+      await click(SES.aws.save);
+      assert.dom(GENERAL.messageError).exists('API error surfaced to user');
+      assert.dom(GENERAL.inlineError).exists('User shown inline error message');
+    });
+
+    test('it allows user to submit root config even if API error occurs on config/lease config', async function (assert) {
+      assert.expect(3);
+      await this.renderComponent();
+      this.server.post(configUrl('aws', this.id), () => {
+        assert.true(true, 'post request was made to config/root when config/lease failed. test should pass.');
+      });
+      this.server.post(configUrl('aws-lease', this.id), () => {
+        return overrideResponse(400, { errors: ['bad request'] });
+      });
+      // fill in both lease and root endpoints to ensure that both payloads are attempted to be sent
+      await fillInAwsConfig(true, false, true);
+      await click(SES.aws.save);
+
+      assert.true(
+        this.flashDangerSpy.calledWith('Lease configuration was not saved: bad request'),
+        'Flash message shows that lease was not saved.'
+      );
+      assert.ok(
+        this.transitionStub.calledWith('vault.cluster.secrets.backend.configuration', this.id),
+        'Transitioned to the configuration index route.'
+      );
+    });
+
+    test('it transitions without sending a lease or root payload on cancel', async function (assert) {
+      assert.expect(3);
+      await this.renderComponent();
+      this.server.post(configUrl('aws', this.id), () => {
+        assert.true(
+          false,
+          'post request was made to config/root when user canceled out of flow. test should fail.'
+        );
+      });
+      this.server.post(configUrl('aws-lease', this.id), () => {
+        assert.true(
+          false,
+          'post request was made to config/lease when user canceled out of flow. test should fail.'
+        );
+      });
+      // fill in both lease and root endpoints to ensure that both payloads are attempted to be sent
+      await fillInAwsConfig(true, false, true);
+      await click(SES.aws.cancel);
+
+      assert.true(this.flashDangerSpy.notCalled, 'No danger flash messages called.');
+      assert.true(this.flashSuccessSpy.notCalled, 'No success flash messages called.');
+      assert.ok(
+        this.transitionStub.calledWith('vault.cluster.secrets.backend.configuration', this.id),
+        'Transitioned to the configuration index route.'
+      );
+    });
   });
-
-  test('it calls saveAWSRoot on save root config', async function (assert) {
-    await this.renderComponent();
-    await fillIn(GENERAL.inputByAttr('accessKey'), 'foo');
-    await fillIn(GENERAL.inputByAttr('secretKey'), 'bar');
-    await click(SES.aws.saveRootConfig);
-    assert.ok(this.saveAWSRoot.calledOnce, 'saveAWSRoot was called once');
-    assert.ok(this.saveAWSLease.notCalled, 'saveAWSLease was not called');
-  });
-
-  test('it calls saveAWSLease on save lease config', async function (assert) {
-    await this.renderComponent();
-    // createLease config already has ttls set so just save the values
-    await click(SES.aws.saveLeaseConfig);
-    assert.ok(this.saveAWSLease.calledOnce, 'saveAWSLease was called once');
-    assert.ok(this.saveAWSRoot.notCalled, 'saveAWSRoot was not called');
+  module('Edit view', function () {
+    // TODO: module edit
+    // ('it shows previously saved lease information and allows you to edit', async function (assert) {});
+    // ('it requires a double click to change the secret key', async function (assert) {});
+    // ('it transitions without sending a payload on cancel', async function (assert) {});
+    // FOR EACH: check transition, payload, and flashMessages.
   });
 });

--- a/ui/tests/integration/components/secret-engine/configure-aws-test.js
+++ b/ui/tests/integration/components/secret-engine/configure-aws-test.js
@@ -41,7 +41,7 @@ module('Integration | Component | SecretEngine/configure-aws', function (hooks) 
 
     this.renderComponent = () => {
       return render(hbs`
-        <SecretEngine::ConfigureAws @rootConfig={{this.rootConfig}} @leaseConfig={{this.leaseConfig}} @id={{this.id}} />
+        <SecretEngine::ConfigureAws @rootConfig={{this.rootConfig}} @leaseConfig={{this.leaseConfig}} @backendPath={{this.id}} />
         `);
     };
   });

--- a/ui/tests/integration/components/secret-engine/configure-ssh-test.js
+++ b/ui/tests/integration/components/secret-engine/configure-ssh-test.js
@@ -21,7 +21,7 @@ module('Integration | Component | SecretEngine/configure-ssh', function (hooks) 
     this.store = this.owner.lookup('service:store');
     const router = this.owner.lookup('service:router');
     this.id = 'ssh-test';
-    this.model = this.store.createRecord('ssh/ca-config', { backend: this.id, id: this.id });
+    this.model = this.store.createRecord('ssh/ca-config', { backend: this.id });
     this.transitionStub = sinon.stub(router, 'transitionTo');
     this.refreshStub = sinon.stub(router, 'refresh');
   });
@@ -51,7 +51,7 @@ module('Integration | Component | SecretEngine/configure-ssh', function (hooks) 
     await click(SES.ssh.cancel);
 
     assert.true(
-      this.transitionStub.calledWith('vault.cluster.secrets.backend.configuration', this.id),
+      this.transitionStub.calledWith('vault.cluster.secrets.backend.configuration', 'ssh-test'),
       'On cancel the router transitions to the parent configuration index route.'
     );
   });

--- a/ui/tests/integration/components/secret-engine/configure-ssh-test.js
+++ b/ui/tests/integration/components/secret-engine/configure-ssh-test.js
@@ -30,7 +30,7 @@ module('Integration | Component | SecretEngine/configure-ssh', function (hooks) 
     await render(hbs`
       <SecretEngine::ConfigureSsh
     @model={{this.model}}
-    @id={{this.id}}
+    @backendPath={{this.id}}
   />
     `);
     assert.dom(GENERAL.maskedInput('privateKey')).hasNoText('Private key is empty and reset');
@@ -44,7 +44,7 @@ module('Integration | Component | SecretEngine/configure-ssh', function (hooks) 
     await render(hbs`
       <SecretEngine::ConfigureSsh
     @model={{this.model}}
-    @id={{this.id}}
+    @backendPath={{this.id}}
   />
     `);
 
@@ -60,7 +60,7 @@ module('Integration | Component | SecretEngine/configure-ssh', function (hooks) 
     await render(hbs`
       <SecretEngine::ConfigureSsh
     @model={{this.model}}
-    @id={{this.id}}
+    @backendPath={{this.id}}
   />
     `);
     await fillIn(GENERAL.inputByAttr('publicKey'), 'hello');
@@ -95,7 +95,7 @@ module('Integration | Component | SecretEngine/configure-ssh', function (hooks) 
     await render(hbs`
       <SecretEngine::ConfigureSsh
     @model={{this.model}}
-    @id={{this.id}}
+    @backendPath={{this.id}}
   />
     `);
 

--- a/ui/tests/integration/components/secret-engine/configure-ssh-test.js
+++ b/ui/tests/integration/components/secret-engine/configure-ssh-test.js
@@ -21,7 +21,7 @@ module('Integration | Component | SecretEngine/configure-ssh', function (hooks) 
     this.store = this.owner.lookup('service:store');
     const router = this.owner.lookup('service:router');
     this.id = 'ssh-test';
-    this.model = this.store.createRecord('ssh/ca-config', { backend: this.id });
+    this.model = this.store.createRecord('ssh/ca-config', { backend: this.id, id: this.id });
     this.transitionStub = sinon.stub(router, 'transitionTo');
     this.refreshStub = sinon.stub(router, 'refresh');
   });
@@ -30,7 +30,7 @@ module('Integration | Component | SecretEngine/configure-ssh', function (hooks) 
     await render(hbs`
       <SecretEngine::ConfigureSsh
     @model={{this.model}}
-    @backendPath={{this.id}}
+    @id={{this.id}}
   />
     `);
     assert.dom(GENERAL.maskedInput('privateKey')).hasNoText('Private key is empty and reset');
@@ -44,14 +44,14 @@ module('Integration | Component | SecretEngine/configure-ssh', function (hooks) 
     await render(hbs`
       <SecretEngine::ConfigureSsh
     @model={{this.model}}
-    @backendPath={{this.id}}
+    @id={{this.id}}
   />
     `);
 
     await click(SES.ssh.cancel);
 
     assert.true(
-      this.transitionStub.calledWith('vault.cluster.secrets.backend.configuration', 'ssh-test'),
+      this.transitionStub.calledWith('vault.cluster.secrets.backend.configuration', this.id),
       'On cancel the router transitions to the parent configuration index route.'
     );
   });
@@ -60,7 +60,7 @@ module('Integration | Component | SecretEngine/configure-ssh', function (hooks) 
     await render(hbs`
       <SecretEngine::ConfigureSsh
     @model={{this.model}}
-    @backendPath={{this.id}}
+    @id={{this.id}}
   />
     `);
     await fillIn(GENERAL.inputByAttr('publicKey'), 'hello');
@@ -95,7 +95,7 @@ module('Integration | Component | SecretEngine/configure-ssh', function (hooks) 
     await render(hbs`
       <SecretEngine::ConfigureSsh
     @model={{this.model}}
-    @backendPath={{this.id}}
+    @id={{this.id}}
   />
     `);
 

--- a/ui/types/vault/models/secret-engine.d.ts
+++ b/ui/types/vault/models/secret-engine.d.ts
@@ -40,7 +40,6 @@ export default class SecretEngineModel extends Model {
   get localDisplay(): string;
   get formFields(): Array<FormField>;
   get formFieldGroups(): FormFieldGroups;
-  saveCA(options: object): Promise;
   saveZeroAddressConfig(): Promise;
   validate(): ModelValidations;
   // need to override isNew which is a computed prop and ts will complain since it sees it as a function


### PR DESCRIPTION
- [x] Enterprise test pass locally.

### Description
* Removes tabs on AWS config form and puts Lease and Root configuration on one edit/create view (per designs).
* Adds form validations to root and lease models.
* Removes old methods under the secret-engine model and adapter that handled aws configuration saving.

#### What this PR does not do:
* Add any new fields, specifically AWS WIF fields. This will be done in a PR targeted at the sidebranch.

### Updated views
**Create View**
![image](https://github.com/user-attachments/assets/03eab762-8698-4f10-beb3-50da28c1c110)
**Edit View**
![image](https://github.com/user-attachments/assets/3e2c1e5f-2e76-44d4-9575-947ce721a00d)
**Lease Validations**
![image](https://github.com/user-attachments/assets/dae6217e-67a3-4c66-ac98-90dce3442fa9)

