### PR TITLE
UI: CC Filter bar update

### DIFF
--- a/ui/app/components/clients/activity.ts
+++ b/ui/app/components/clients/activity.ts
@@ -22,7 +22,6 @@ import type ClientsActivityModel from 'vault/models/clients/activity';
 import type ClientsVersionHistoryModel from 'vault/models/clients/version-history';
 import type {
   ByMonthNewClients,
-  MountClients,
   MountNewClients,
   NamespaceByKey,
   NamespaceNewClients,

--- a/ui/app/components/clients/page/counts.hbs
+++ b/ui/app/components/clients/page/counts.hbs
@@ -60,6 +60,7 @@
               class="is-marginless"
               data-test-counts-namespaces
             />
+            <div class="has-left-margin-xs"></div>
           {{/if}}
           {{#if (or @mountPath this.mountPaths)}}
             <SearchSelect
@@ -79,7 +80,7 @@
       </Toolbar>
     {{/if}}
 
-    {{#if this.filteredActivity}}
+    {{#if this.totalUsageCounts}}
       {{#if this.upgradeExplanations}}
         <Hds::Alert data-test-clients-upgrade-warning @type="inline" @color="warning" class="has-bottom-margin-m" as |A|>
           <A.Title>

--- a/ui/app/components/clients/page/counts.hbs
+++ b/ui/app/components/clients/page/counts.hbs
@@ -123,7 +123,7 @@
       {{yield}}
 
     {{else if (and this.version.isCommunity (not @startTimestamp))}}
-      {{! Empty state for community without start QP }}
+      {{! Empty state for community without start query param }}
       <EmptyState
         @title="No start date found"
         @message="In order to get the most from this data, please enter a start month above. Vault will calculate new clients starting from that month."

--- a/ui/app/components/clients/page/counts.hbs
+++ b/ui/app/components/clients/page/counts.hbs
@@ -122,9 +122,12 @@
       {{! CLIENT COUNT PAGE COMPONENTS RENDER HERE }}
       {{yield}}
 
-    {{else if (and (not @config.billingStartTimestamp) (not @startTimestamp))}}
-      {{! Empty state for no billing/license start date }}
-      <EmptyState @title={{this.versionText.title}} @message={{this.versionText.message}} />
+    {{else if (and this.version.isCommunity (not @startTimestamp))}}
+      {{! Empty state for community without start QP }}
+      <EmptyState
+        @title="No start date found"
+        @message="In order to get the most from this data, please enter a start month above. Vault will calculate new clients starting from that month."
+      />
     {{else}}
       <EmptyState
         @title="No data received {{if this.dateRangeMessage this.dateRangeMessage}}"

--- a/ui/app/components/clients/page/counts.hbs
+++ b/ui/app/components/clients/page/counts.hbs
@@ -35,7 +35,7 @@
       </Hds::Alert>
     {{/if}}
 
-    {{#if @startTimestamp}}
+    {{#if (or @mountPath this.mountPaths)}}
       <Hds::Text::Display @tag="p">
         Filters
       </Hds::Text::Display>

--- a/ui/app/components/clients/page/counts.hbs
+++ b/ui/app/components/clients/page/counts.hbs
@@ -55,7 +55,7 @@
               @disallowNewItems={{true}}
               @fallbackComponent="input-search"
               @onChange={{fn this.setFilterValue "ns"}}
-              @placeholder="Filter by namespace"
+              @placeholder="Namespace within {{this.namespacePathForFilter}}"
               @displayInherit={{true}}
               class="is-marginless"
               data-test-counts-namespaces
@@ -71,7 +71,7 @@
               @disallowNewItems={{true}}
               @fallbackComponent="input-search"
               @onChange={{fn this.setFilterValue "mountPath"}}
-              @placeholder="Filter by mount path"
+              @placeholder="Mount path within {{this.namespacePathForFilter}}"
               @displayInherit={{true}}
               data-test-counts-auth-mounts
             />

--- a/ui/app/components/clients/page/counts.ts
+++ b/ui/app/components/clients/page/counts.ts
@@ -115,7 +115,7 @@ export default class ClientsCountsPageComponent extends Component<Args> {
     const { activity } = this.args;
     const nsPath = this.namespacePathForFilter;
     // we always return activity for namespace, either the selected filter or the current
-    return activity.byNamespace.find((ns) => sanitizePath(ns.label) === nsPath);
+    return activity?.byNamespace?.find((ns) => sanitizePath(ns.label) === nsPath);
   }
 
   // duplicate of the method found in the activity component, so that we render the child only when there is activity to view

--- a/ui/app/components/clients/page/counts.ts
+++ b/ui/app/components/clients/page/counts.ts
@@ -174,8 +174,7 @@ export default class ClientsCountsPageComponent extends Component<Args> {
 
   // the dashboard should show sync tab if the flag is on or there's data
   get hasSecretsSyncClients(): boolean {
-    const { activity } = this.args;
-    return activity && activity?.total?.secret_syncs > 0;
+    return this.args.activity?.total?.secret_syncs > 0;
   }
 
   @action

--- a/ui/app/components/clients/page/counts.ts
+++ b/ui/app/components/clients/page/counts.ts
@@ -9,6 +9,7 @@ import { action } from '@ember/object';
 import { isSameMonth, isAfter } from 'date-fns';
 import { parseAPITimestamp } from 'core/utils/date-formatters';
 import { filteredTotalForMount, filterVersionHistory, TotalClients } from 'core/utils/client-count-utils';
+import { sanitizePath } from 'core/utils/sanitize-path';
 
 import type AdapterError from '@ember-data/adapter';
 import type FlagsService from 'vault/services/flags';
@@ -17,6 +18,7 @@ import type VersionService from 'vault/services/version';
 import type ClientsActivityModel from 'vault/models/clients/activity';
 import type ClientsConfigModel from 'vault/models/clients/config';
 import type ClientsVersionHistoryModel from 'vault/models/clients/version-history';
+import type NamespaceService from 'vault/services/namespace';
 interface Args {
   activity: ClientsActivityModel;
   activityError?: AdapterError;
@@ -32,6 +34,7 @@ interface Args {
 export default class ClientsCountsPageComponent extends Component<Args> {
   @service declare readonly flags: FlagsService;
   @service declare readonly version: VersionService;
+  @service declare readonly namespace: NamespaceService;
   @service declare readonly store: StoreService;
 
   get formattedStartDate() {
@@ -100,27 +103,56 @@ export default class ClientsCountsPageComponent extends Component<Args> {
         };
   }
 
+  // path of the filtered namespace OR current one, for filtering relevant data
+  get namespacePathForFilter() {
+    const { namespace } = this.args;
+    const currentNs = this.namespace.currentNamespace;
+    return sanitizePath(namespace || currentNs || 'root');
+  }
+
+  // activityForNamespace gets the byNamespace data for the selected or current namespace so we can get the list of mounts from that namespace for attribution
+  get activityForNamespace() {
+    const { activity } = this.args;
+    const nsPath = this.namespacePathForFilter;
+    // we always return activity for namespace, either the selected filter or the current
+    return activity.byNamespace.find((ns) => sanitizePath(ns.label) === nsPath);
+  }
+
+  // duplicate of the method found in the activity component, so that we render the child only when there is activity to view
+  get totalUsageCounts(): TotalClients {
+    const { namespace, mountPath, activity } = this.args;
+    if (mountPath) {
+      // only do this if we have a mountPath filter.
+      // namespace is filtered on API layer
+      return filteredTotalForMount(activity.byNamespace, namespace, mountPath);
+    }
+    return activity?.total;
+  }
+
+  // namespace list for the search-select filter
   get namespaces() {
     return this.args.activity.byNamespace
-      ? this.args.activity.byNamespace.map((namespace) => ({
-          name: namespace.label,
-          id: namespace.label,
-        }))
+      ? this.args.activity.byNamespace
+          .map((namespace) => ({
+            name: namespace.label,
+            id: namespace.label,
+          }))
+          .filter((ns) => sanitizePath(ns.name) !== this.namespacePathForFilter)
       : [];
   }
 
+  // mounts within the current/filtered namespace for the sesarch-select filter
   get mountPaths() {
-    if (this.namespaces.length) {
-      return this.activityForNamespace?.mounts.map((mount) => ({
+    return (
+      this.activityForNamespace?.mounts.map((mount) => ({
         id: mount.label,
         name: mount.label,
-      }));
-    }
-    return [];
+      })) || []
+    );
   }
 
+  // banner contents shown if startTime returned from activity API (which matches the first month with data) is after the queried startTime
   get startTimeDiscrepancy() {
-    // show banner if startTime returned from activity log (response) is after the queried startTime
     const { activity, config } = this.args;
     const activityStartDateObject = parseAPITimestamp(activity.startTime) as Date;
     const queryStartDateObject = parseAPITimestamp(this.args.startTimestamp) as Date;
@@ -140,25 +172,9 @@ export default class ClientsCountsPageComponent extends Component<Args> {
     }
   }
 
-  get activityForNamespace() {
-    // TODO: always return activity for namespace. If no namespace selected, use the current
-    const { activity, namespace } = this.args;
-    return namespace ? activity.byNamespace.find((ns) => ns.label === namespace) : null;
-  }
-
-  get filteredActivity(): TotalClients {
-    const { namespace, mountPath, activity } = this.args;
-    if (mountPath) {
-      // only do this if we have a mountPath filter.
-      // namespace is filtered on API layer
-      return filteredTotalForMount(activity.byNamespace, namespace, mountPath);
-    }
-    return activity?.total;
-  }
-
+  // the dashboard should show sync tab if the flag is on or there's data
   get hasSecretsSyncClients(): boolean {
     const { activity } = this.args;
-    // if there is any sync client data, show it
     return activity && activity?.total?.secret_syncs > 0;
   }
 
@@ -170,9 +186,12 @@ export default class ClientsCountsPageComponent extends Component<Args> {
   @action
   setFilterValue(type: 'ns' | 'mountPath', [value]: [string | undefined]) {
     const params = { [type]: value };
-    // unset mountPath value when namespace is cleared
     if (type === 'ns' && !value) {
+      // unset mountPath value when namespace is cleared
       params['mountPath'] = undefined;
+    } else if (type === 'mountPath' && !this.args.namespace) {
+      // set namespace when mountPath set without namespace already set
+      params['ns'] = this.namespacePathForFilter;
     }
     this.args.onFilterChange(params);
   }

--- a/ui/app/components/clients/page/overview.ts
+++ b/ui/app/components/clients/page/overview.ts
@@ -12,13 +12,16 @@ export default class ClientsOverviewPageComponent extends ActivityComponent {
   @service declare readonly flags: FlagsService;
 
   get hasAttributionData() {
-    // we only hide attribution data when we filter on mountPath
-    return !this.args.mountPath;
+    // we hide attribution data when mountPath filter present
+    // or if there's no data
+    if (this.args.mountPath || !this.totalUsageCounts.clients) return false;
+    return true;
   }
 
+  // mounts attribution
   get namespaceMountAttribution() {
     const { activity } = this.args;
     const nsLabel = this.namespacePathForFilter;
-    return activity.byNamespace?.find((ns) => sanitizePath(ns.label) === nsLabel)?.mounts;
+    return activity?.byNamespace?.find((ns) => sanitizePath(ns.label) === nsLabel)?.mounts || [];
   }
 }

--- a/ui/tests/acceptance/clients/counts-test.js
+++ b/ui/tests/acceptance/clients/counts-test.js
@@ -30,9 +30,12 @@ module('Acceptance | clients | counts', function (hooks) {
     assert.expect(2);
     this.owner.lookup('service:version').type = 'community';
     await visit('/vault/clients/counts/overview');
-
-    assert.dom(GENERAL.emptyStateTitle).hasText('No data received');
-    assert.dom(GENERAL.emptyStateMessage).hasText('Select a start date above to query client count data.');
+    assert.dom(GENERAL.emptyStateTitle).hasText('No start date found');
+    assert
+      .dom(GENERAL.emptyStateMessage)
+      .hasText(
+        'In order to get the most from this data, please enter a start month above. Vault will calculate new clients starting from that month.'
+      );
   });
 
   test('it should redirect to counts overview route for transitions to parent', async function (assert) {

--- a/ui/tests/integration/components/clients/page/counts-test.js
+++ b/ui/tests/integration/components/clients/page/counts-test.js
@@ -265,9 +265,9 @@ module('Integration | Component | clients | Page::Counts', function (hooks) {
       );
   });
 
-  test('it should render empty state for no start or license start time', async function (assert) {
+  test('it should render empty state for no start when CE', async function (assert) {
+    this.owner.lookup('service:version').type = 'community';
     this.startTimestamp = null;
-    this.config.billingStartTimestamp = null;
     this.activity = {};
 
     await this.renderComponent();

--- a/ui/tests/integration/components/clients/page/overview-test.js
+++ b/ui/tests/integration/components/clients/page/overview-test.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'vault/tests/helpers';
 import { render } from '@ember/test-helpers';

--- a/ui/tests/integration/components/clients/page/overview-test.js
+++ b/ui/tests/integration/components/clients/page/overview-test.js
@@ -1,0 +1,105 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'vault/tests/helpers';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { ACTIVITY_RESPONSE_STUB } from 'vault/tests/helpers/clients/client-count-helpers';
+import { filterActivityResponse } from 'vault/mirage/handlers/clients';
+import { CHARTS, CLIENT_COUNT } from 'vault/tests/helpers/clients/client-count-selectors';
+
+module('Integration | Component | clients/page/overview', function (hooks) {
+  setupRenderingTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(async function () {
+    this.server.get('sys/internal/counters/activity', (_, req) => {
+      const namespace = req.requestHeaders['X-Vault-Namespace'];
+      if (namespace === 'no-data') {
+        return {
+          request_id: 'some-activity-id',
+          data: {
+            by_namespace: [],
+            end_time: '2024-08-31T23:59:59Z',
+            months: [],
+            start_time: '2024-01-01T00:00:00Z',
+            total: {
+              distinct_entities: 0,
+              entity_clients: 0,
+              non_entity_tokens: 0,
+              non_entity_clients: 0,
+              clients: 0,
+              secret_syncs: 0,
+            },
+          },
+        };
+      }
+      return {
+        request_id: 'some-activity-id',
+        data: filterActivityResponse(ACTIVITY_RESPONSE_STUB, namespace),
+      };
+    });
+    this.store = this.owner.lookup('service:store');
+    this.mountPath = '';
+    this.namespace = '';
+    this.versionHistory = '';
+  });
+
+  test('it hides attribution data when mount filter applied', async function (assert) {
+    this.mountPath = '';
+    this.activity = await this.store.queryRecord('clients/activity', {
+      namespace: 'ns1',
+    });
+    await render(
+      hbs`<Clients::Page::Overview @activity={{this.activity}} @namespace="ns1" @mountPath={{this.mountPath}} />`
+    );
+
+    assert.dom(CHARTS.container('Vault client counts')).exists('shows running totals');
+    assert.dom(CLIENT_COUNT.attributionBlock('namespace')).exists();
+    assert.dom(CLIENT_COUNT.attributionBlock('mount')).exists();
+
+    this.set('mountPath', 'auth/authid/0');
+    assert.dom(CHARTS.container('Vault client counts')).exists('shows running totals');
+    assert.dom(CLIENT_COUNT.attributionBlock('namespace')).doesNotExist();
+    assert.dom(CLIENT_COUNT.attributionBlock('mount')).doesNotExist();
+  });
+
+  test('it hides attribution data when no data returned', async function (assert) {
+    this.mountPath = '';
+    this.activity = await this.store.queryRecord('clients/activity', {
+      namespace: 'no-data',
+    });
+    await render(hbs`<Clients::Page::Overview @activity={{this.activity}} />`);
+    assert.dom(CLIENT_COUNT.usageStats('Total usage')).exists();
+    assert.dom(CHARTS.container('Vault client counts')).doesNotExist('usage stats instead of running totals');
+    assert.dom(CLIENT_COUNT.attributionBlock('namespace')).doesNotExist();
+    assert.dom(CLIENT_COUNT.attributionBlock('mount')).doesNotExist();
+  });
+
+  test('it shows the correct mount attributions', async function (assert) {
+    this.nsService = this.owner.lookup('service:namespace');
+    const rootActivity = await this.store.queryRecord('clients/activity', {});
+    this.activity = rootActivity;
+    await render(hbs`<Clients::Page::Overview @activity={{this.activity}} />`);
+    // start at "root" namespace
+    let expectedMounts = rootActivity.byNamespace.find((ns) => ns.label === 'root').mounts;
+    assert
+      .dom(`${CLIENT_COUNT.attributionBlock('mount')} [data-test-group="y-labels"] text`)
+      .exists({ count: expectedMounts.length });
+    assert
+      .dom(`${CLIENT_COUNT.attributionBlock('mount')} [data-test-group="y-labels"]`)
+      .includesText(expectedMounts[0].label);
+
+    // now pretend we're querying within a child namespace
+    this.nsService.path = 'ns1';
+    this.activity = await this.store.queryRecord('clients/activity', {
+      namespace: 'ns1',
+    });
+    expectedMounts = rootActivity.byNamespace.find((ns) => ns.label === 'ns1').mounts;
+    assert
+      .dom(`${CLIENT_COUNT.attributionBlock('mount')} [data-test-group="y-labels"] text`)
+      .exists({ count: expectedMounts.length });
+    assert
+      .dom(`${CLIENT_COUNT.attributionBlock('mount')} [data-test-group="y-labels"]`)
+      .includesText(expectedMounts[0].label);
+  });
+});


### PR DESCRIPTION
### Description
Updates the client count filter behavior. Before, the namespace and mount path filters were mutually exclusive, and you could filter on the current namespace that you are logged into. 

With these changes: 
* the user can no longer see the current namespace as a filter option (because it doesn't do anything to filter on the current namespace)
* the mount filter is always available, listing the namespaces within the current OR chosen filtered namespace
* the namespace filter is hidden if there are no child namespaces available to filter on

#### Screenshots
When no counts are within child namespaces - namespace filter is hidden:
![image](https://github.com/user-attachments/assets/a52e7a3a-c8f3-49f3-adf4-a51ae8e5994f)

When namespace counts available - current namespace is not shown in options
![image](https://github.com/user-attachments/assets/8fca646f-6961-41f3-a34b-f955fb073c61)

When both namespace & mount are filtered - hides attribution blocks
![image](https://github.com/user-attachments/assets/c8072b75-b063-4aef-a0bd-d484a54eef26)

Nested namespaces with clients - shows all levels of namespace in filter dropdown
<img width="555" alt="Screenshot 2024-08-20 at 10 13 51" src="https://github.com/user-attachments/assets/9276ca29-3d45-4501-8707-2713433afd35">