### PR TITLE
enos: don't exit in verify-billing-start retry loop

### DIFF
--- a/enos/enos-scenario-upgrade.hcl
+++ b/enos/enos-scenario-upgrade.hcl
@@ -710,8 +710,9 @@ scenario "upgrade" {
     ]
 
     variables {
-      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
       hosts             = step.create_vault_cluster_targets.hosts
+      vault_addr        = step.create_vault_cluster.api_addr_localhost
+      vault_install_dir = global.vault_install_dir[matrix.artifact_type]
       vault_root_token  = step.create_vault_cluster.root_token
     }
   }

--- a/enos/modules/vault_verify_billing_start_date/main.tf
+++ b/enos/modules/vault_verify_billing_start_date/main.tf
@@ -9,6 +9,11 @@ terraform {
   }
 }
 
+variable "vault_addr" {
+  type        = string
+  description = "The local vault API listen address"
+}
+
 variable "vault_cluster_addr_port" {
   description = "The Raft cluster address port"
   type        = string
@@ -42,6 +47,7 @@ resource "enos_remote_exec" "vault_verify_billing_start_date" {
   for_each = var.hosts
 
   environment = {
+    VAULT_ADDR              = var.vault_addr
     VAULT_CLUSTER_ADDR      = "${each.value.private_ip}:${var.vault_cluster_addr_port}"
     VAULT_INSTALL_DIR       = var.vault_install_dir
     VAULT_LOCAL_BINARY_PATH = "${var.vault_install_dir}/vault"


### PR DESCRIPTION
### Description

Previously we'd fail in the verify-billing-start.sh retry loop instead of returning a 1. This fixes that and normalizes the script.

Fixes errors as seen here: https://github.com/hashicorp/vault/actions/runs/10478967676

We'll want to backport this to https://github.com/hashicorp/vault/pull/28130 and include both changes in the 1.15.x+ent and 1.16.x+ent changes.

### TODO only if you're a HashiCorp employee
- [] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [ ] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
