### PR TITLE
enos: add shfmt formatting to enos module scripts

### DIFF
--- a/.github/actions/install-external-tools/action.yml
+++ b/.github/actions/install-external-tools/action.yml
@@ -18,6 +18,7 @@ runs:
     - uses: ./.github/actions/set-up-gosimports
     - uses: ./.github/actions/set-up-gotestsum
     - uses: ./.github/actions/set-up-misspell
+    - uses: ./.github/actions/set-up-shfmt
     - uses: ./.github/actions/set-up-staticcheck
       # We assume that the Go toolchain will be managed by the caller workflow so we don't set one
       # up here.

--- a/.github/actions/set-up-shfmt/action.yml
+++ b/.github/actions/set-up-shfmt/action.yml
@@ -1,0 +1,61 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+---
+name: Set up shfmt from Github releases
+description: Set up shfmt from Github releases
+
+inputs:
+  destination:
+    description: "Where to install the shfmt binary (default: $HOME/bin/shfmt)"
+    type: boolean
+    default: "$HOME/bin/shfmt"
+  version:
+    description: "The version to install (default: latest)"
+    type: string
+    default: Latest
+
+outputs:
+  destination:
+    description: Where the installed shfmt binary is
+    value: ${{ steps.install.outputs.destination }}
+  destination-dir:
+    description: The directory where the installed shfmt binary is
+    value: ${{ steps.install.outputs.destination-dir }}
+  version:
+    description: The installed version of shfmt
+    value: ${{ steps.install.outputs.version }}
+
+runs:
+  using: composite
+  steps:
+    - id: install
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        VERSION=$(./.github/scripts/retry-command.sh gh release list -R mvdan/sh --exclude-drafts --exclude-pre-releases | grep ${{ inputs.version }} | cut -f1)
+
+        mkdir -p $(dirname ${{ inputs.destination }})
+        DESTINATION="$(readlink -f "${{ inputs.destination }}")"
+        DESTINATION_DIR="$(dirname "$DESTINATION")"
+        echo "$DESTINATION_DIR" >> "$GITHUB_PATH"
+
+        {
+          echo "destination=$DESTINATION"
+          echo "destination-dir=$DESTINATION_DIR"
+          echo "version=$VERSION"
+        } | tee -a "$GITHUB_OUTPUT"
+
+        ARCH="$(echo "$RUNNER_ARCH" | tr '[:upper:]' '[:lower:]')"
+        OS="$(echo "$RUNNER_OS" | tr '[:upper:]' '[:lower:]')"
+        if [ "$ARCH" = "x64" ]; then
+          export ARCH="amd64"
+        fi
+        if [ "$OS" = "macos" ]; then
+          export OS="darwin"
+        fi
+
+        ./.github/scripts/retry-command.sh gh release download "$VERSION" --clobber -p "shfmt_*_${OS}_${ARCH}" -O shfmt -R mvdan/sh
+        chmod +x shfmt
+        mv shfmt "$DESTINATION"

--- a/.github/workflows/enos-lint.yml
+++ b/.github/workflows/enos-lint.yml
@@ -38,6 +38,7 @@ jobs:
       ENOS_VAR_tfc_api_token: ${{ secrets.TF_API_TOKEN }}
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - uses: ./.github/actions/install-external-tools
       - uses: hashicorp/setup-terraform@v3
         with:
           terraform_wrapper: false

--- a/enos/Makefile
+++ b/enos/Makefile
@@ -28,8 +28,16 @@ validate-enos:
 	enos scenario validate --timeout 30m0s
 
 .PHONY: lint
-lint: check-fmt shellcheck validate-enos
+lint: check-fmt check-fmt-modules check-shfmt shellcheck validate-enos
 
 .PHONY: shellcheck
 shellcheck:
 	find ./modules/ -type f -name '*.sh' | xargs shellcheck
+
+.PHONY: shfmt
+shfmt:
+	find ./modules/ -type f -name '*.sh' | xargs shfmt -l -w -i 2 -bn -ci -kp -sr
+
+.PHONY: check-shfmt
+check-shfmt:
+	find ./modules/ -type f -name '*.sh' | xargs shfmt -l -d -i 2 -bn -ci -kp -sr

--- a/enos/modules/get_local_metadata/scripts/version.sh
+++ b/enos/modules/get_local_metadata/scripts/version.sh
@@ -75,22 +75,22 @@ function repo_root() {
 # Run Enos local
 function main() {
   case $1 in
-  version)
-    version
-  ;;
-  version-base)
-    version_base
-  ;;
-  version-pre)
-    version_pre
-  ;;
-  version-meta)
-    version_metadata
-  ;;
-  *)
-    echo "unknown sub-command" >&2
-    exit 1
-  ;;
+    version)
+      version
+      ;;
+    version-base)
+      version_base
+      ;;
+    version-pre)
+      version_pre
+      ;;
+    version-meta)
+      version_metadata
+      ;;
+    *)
+      echo "unknown sub-command" >&2
+      exit 1
+      ;;
   esac
 }
 

--- a/enos/modules/install_packages/scripts/add-repos.sh
+++ b/enos/modules/install_packages/scripts/add-repos.sh
@@ -31,7 +31,7 @@ add_repos() {
         fi
         sudo add-apt-repository "${repo}"
       done
-    ;;
+      ;;
     dnf)
       for repo in ${DISTRO_REPOS}; do
         if [ "$repo" == "__none" ]; then
@@ -40,7 +40,7 @@ add_repos() {
         sudo dnf install -y "${repo}"
         sudo dnf makecache -y
       done
-    ;;
+      ;;
     yum)
       for repo in ${DISTRO_REPOS}; do
         if [ "$repo" == "__none" ]; then
@@ -49,7 +49,7 @@ add_repos() {
         sudo yum install -y "${repo}"
         sudo yum makecache -y
       done
-    ;;
+      ;;
     zypper)
       # Add each repo
       for repo in ${DISTRO_REPOS}; do
@@ -64,9 +64,10 @@ add_repos() {
       done
       sudo zypper --gpg-auto-import-keys ref
       sudo zypper --gpg-auto-import-keys refs
-    ;;
+      ;;
     *)
       fail "Unsupported package manager: ${PACKAGE_MANAGER}"
+      ;;
   esac
 }
 

--- a/enos/modules/install_packages/scripts/install-packages.sh
+++ b/enos/modules/install_packages/scripts/install-packages.sh
@@ -40,7 +40,7 @@ install_packages() {
           fi
         fi
       done
-    ;;
+      ;;
     dnf)
       for package in ${PACKAGES}; do
         if rpm -q "${package}"; then
@@ -55,7 +55,7 @@ install_packages() {
           fi
         fi
       done
-    ;;
+      ;;
     yum)
       for package in ${PACKAGES}; do
         if rpm -q "${package}"; then
@@ -70,7 +70,7 @@ install_packages() {
           fi
         fi
       done
-    ;;
+      ;;
     zypper)
       for package in ${PACKAGES}; do
         if rpm -q "${package}"; then
@@ -85,10 +85,10 @@ install_packages() {
           fi
         fi
       done
-    ;;
+      ;;
     *)
       fail "No matching package manager provided."
-    ;;
+      ;;
   esac
 }
 

--- a/enos/modules/install_packages/scripts/synchronize-repos.sh
+++ b/enos/modules/install_packages/scripts/synchronize-repos.sh
@@ -35,11 +35,11 @@ sles_check_guestregister_service_and_restart_if_failed() {
   set -e
 
   case "$active_state" in
-    active|activating|deactivating)
+    active | activating | deactivating)
       # It's running so we'll return 1 and get retried by the caller
       echo "the guestregister.service is still in the ${active_state} state" 1>&2
       return 1
-    ;;
+      ;;
     *)
       if [ "$active_state" == "inactive" ] && [ "$failed_state" == "inactive" ]; then
         # The oneshot has completed and hasn't "failed"
@@ -49,7 +49,7 @@ sles_check_guestregister_service_and_restart_if_failed() {
 
       # Our service is stopped and failed, restart it and hope it works the next time
       sudo systemctl restart --wait guestregister.service
-    ;;
+      ;;
   esac
 }
 
@@ -77,13 +77,13 @@ synchronize_repos() {
   case $PACKAGE_MANAGER in
     apt)
       sudo apt update
-    ;;
+      ;;
     dnf)
       sudo dnf makecache
-    ;;
+      ;;
     yum)
       sudo yum makecache
-    ;;
+      ;;
     zypper)
       if [ "$DISTRO" == "sles" ]; then
         if ! sles_ensure_suseconnect; then
@@ -95,7 +95,7 @@ synchronize_repos() {
       ;;
     *)
       return 0
-    ;;
+      ;;
   esac
 }
 

--- a/enos/modules/k8s_vault_verify_replication/scripts/smoke-verify-replication.sh
+++ b/enos/modules/k8s_vault_verify_replication/scripts/smoke-verify-replication.sh
@@ -2,7 +2,6 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-
 # The Vault replication smoke test, documented in
 # https://docs.google.com/document/d/16sjIk3hzFDPyY5A9ncxTZV_9gnpYSF1_Vx6UA1iiwgI/edit#heading=h.kgrxf0f1et25
 

--- a/enos/modules/k8s_vault_verify_ui/scripts/smoke-verify-ui.sh
+++ b/enos/modules/k8s_vault_verify_ui/scripts/smoke-verify-ui.sh
@@ -2,7 +2,6 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-
 set -e
 
 fail() {

--- a/enos/modules/k8s_vault_verify_version/scripts/get-status.sh
+++ b/enos/modules/k8s_vault_verify_version/scripts/get-status.sh
@@ -2,7 +2,6 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-
 set -e
 
 status=$(${VAULT_BIN_PATH} status -format=json)

--- a/enos/modules/k8s_vault_verify_version/scripts/smoke-verify-version.sh
+++ b/enos/modules/k8s_vault_verify_version/scripts/smoke-verify-version.sh
@@ -2,7 +2,6 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-
 # The Vault smoke test to verify the Vault version installed
 
 set -e
@@ -25,12 +24,12 @@ fi
 vault_expected_version="Vault v${EXPECTED_VERSION} (${VAULT_REVISION})"
 
 case "${VAULT_EDITION}" in
-  ce) version_expected="${vault_expected_version}${expected_build_date}";;
-  ent) version_expected="${vault_expected_version}${expected_build_date}";;
-  ent.hsm) version_expected="${vault_expected_version}${expected_build_date} (cgo)";;
+  ce) version_expected="${vault_expected_version}${expected_build_date}" ;;
+  ent) version_expected="${vault_expected_version}${expected_build_date}" ;;
+  ent.hsm) version_expected="${vault_expected_version}${expected_build_date} (cgo)" ;;
   ent.fips1402) version_expected="${vault_expected_version}${expected_build_date} (cgo)" ;;
   ent.hsm.fips1402) version_expected="${vault_expected_version}${expected_build_date} (cgo)" ;;
-  *) fail "(${VAULT_EDITION}) does not match any known Vault editions"
+  *) fail "(${VAULT_EDITION}) does not match any known Vault editions" ;;
 esac
 
 version_expected_nosha=$(echo "$version_expected" | awk '!($3="")' | sed 's/  / /' | sed -e 's/[[:space:]]*$//')

--- a/enos/modules/softhsm_create_vault_keys/scripts/create-keys.sh
+++ b/enos/modules/softhsm_create_vault_keys/scripts/create-keys.sh
@@ -66,7 +66,7 @@ main() {
   fi
 
   # Return our seal configuration attributes as JSON
-  cat <<EOF
+  cat << EOF
 {
   "lib": "${so}",
   "slot": "${slot}",

--- a/enos/modules/softhsm_init/scripts/init-softhsm.sh
+++ b/enos/modules/softhsm_init/scripts/init-softhsm.sh
@@ -17,7 +17,7 @@ if [ "$SKIP" == "true" ]; then
   exit 0
 fi
 
-cat <<EOF | sudo tee "$CONFIG_PATH"
+cat << EOF | sudo tee "$CONFIG_PATH"
 directories.tokendir = $TOKEN_DIR
 objectstore.backend = file
 log.level = DEBUG

--- a/enos/modules/vault_cluster/scripts/enable-audit-devices.sh
+++ b/enos/modules/vault_cluster/scripts/enable-audit-devices.sh
@@ -20,7 +20,7 @@ enable_file_audit_device() {
   $VAULT_BIN_PATH audit enable file file_path="$LOG_FILE_PATH"
 }
 
-enable_syslog_audit_device(){
+enable_syslog_audit_device() {
   $VAULT_BIN_PATH audit enable syslog tag="vault" facility="AUTH"
 }
 

--- a/enos/modules/vault_cluster/scripts/start-audit-socket-listener.sh
+++ b/enos/modules/vault_cluster/scripts/start-audit-socket-listener.sh
@@ -31,13 +31,13 @@ test_socket_listener() {
   case $IP_VERSION in
     4)
       "${NETCAT_COMMAND}" -zvw 2 "${SOCKET_ADDR}" "$SOCKET_PORT" < /dev/null
-    ;;
+      ;;
     6)
       "${NETCAT_COMMAND}" -6 -zvw 2 "${SOCKET_ADDR}" "$SOCKET_PORT" < /dev/null
-    ;;
+      ;;
     *)
       fail "unknown IP_VERSION: $IP_VERSION"
-    ;;
+      ;;
   esac
 }
 
@@ -53,13 +53,13 @@ start_socket_listener() {
   case $IP_VERSION in
     4)
       nohup nc -kl "$SOCKET_PORT" >> /tmp/vault-socket.log 2>&1 < /dev/null &
-    ;;
+      ;;
     6)
       nohup nc -6 -kl "$SOCKET_PORT" >> /tmp/vault-socket.log 2>&1 < /dev/null &
-    ;;
+      ;;
     *)
       fail "unknown IP_VERSION: $IP_VERSION"
-    ;;
+      ;;
   esac
 }
 

--- a/enos/modules/vault_get_cluster_ips/scripts/get-follower-ipv4s.sh
+++ b/enos/modules/vault_get_cluster_ips/scripts/get-follower-ipv4s.sh
@@ -2,7 +2,6 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-
 set -e
 
 function fail() {
@@ -66,14 +65,14 @@ while :; do
 
         return $?
       fi
-    ;;
+      ;;
     6)
       echo '[]'
       exit 0
-    ;;
+      ;;
     *)
       fail "unknown IP_VERSION: $IP_VERSION"
-    ;;
+      ;;
   esac
 
   wait=$((2 ** count))

--- a/enos/modules/vault_get_cluster_ips/scripts/get-follower-ipv6s.sh
+++ b/enos/modules/vault_get_cluster_ips/scripts/get-follower-ipv6s.sh
@@ -2,7 +2,6 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-
 set -e
 
 function fail() {
@@ -56,7 +55,7 @@ while :; do
     4)
       echo "[]"
       exit 0
-    ;;
+      ;;
     6)
       [[ -z "$VAULT_IPV6S" ]] && fail "VAULT_IPV6S env variable has not been set"
       [[ -z "$VAULT_LEADER_IPV6" ]] && fail "VAULT_LEADER_IPV6 env variable has not been set"
@@ -72,10 +71,10 @@ while :; do
         removeIP "$VAULT_LEADER_IPV6" "$VAULT_IPV6S"
         exit $?
       fi
-    ;;
+      ;;
     *)
       fail "unknown IP_VERSION: $IP_VERSION"
-    ;;
+      ;;
   esac
 
   wait=$((2 ** count))

--- a/enos/modules/vault_get_cluster_ips/scripts/get-leader-ipv4.sh
+++ b/enos/modules/vault_get_cluster_ips/scripts/get-leader-ipv4.sh
@@ -2,7 +2,6 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-
 set -e
 
 function fail() {
@@ -48,13 +47,13 @@ while :; do
         echo "$ip"
         exit 0
       fi
-    ;;
+      ;;
     6)
       exit 0
-    ;;
+      ;;
     *)
       fail "unknown IP_VERSION: $IP_VERSION"
-    ;;
+      ;;
   esac
 
   wait=$((2 ** count))

--- a/enos/modules/vault_get_cluster_ips/scripts/get-leader-ipv6.sh
+++ b/enos/modules/vault_get_cluster_ips/scripts/get-leader-ipv6.sh
@@ -2,7 +2,6 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-
 set -e
 
 function fail() {
@@ -45,16 +44,16 @@ while :; do
   case $IP_VERSION in
     4)
       exit 0
-    ;;
+      ;;
     6)
       if ip=$(findLeaderIPV6); then
         echo "$ip"
         exit 0
       fi
-    ;;
+      ;;
     *)
       fail "unknown IP_VERSION: $IP_VERSION"
-    ;;
+      ;;
   esac
 
   wait=$((2 ** count))

--- a/enos/modules/vault_proxy/scripts/set-up-approle-and-proxy.sh
+++ b/enos/modules/vault_proxy/scripts/set-up-approle-and-proxy.sh
@@ -2,7 +2,6 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-
 set -e
 
 binpath=${VAULT_INSTALL_DIR}/vault

--- a/enos/modules/vault_proxy/scripts/use-proxy.sh
+++ b/enos/modules/vault_proxy/scripts/use-proxy.sh
@@ -2,15 +2,12 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-
 set -e
-
 
 fail() {
   echo "$1" 1>&2
   return 1
 }
-
 
 [[ -z "$VAULT_PROXY_ADDRESS" ]] && fail "VAULT_ADDR env variable has not been set"
 [[ -z "$VAULT_PROXY_PIDFILE" ]] && fail "VAULT_ADDR env variable has not been set"

--- a/enos/modules/vault_raft_remove_peer/scripts/raft-remove-peer.sh
+++ b/enos/modules/vault_raft_remove_peer/scripts/raft-remove-peer.sh
@@ -2,7 +2,6 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-
 set -e
 
 binpath=${VAULT_INSTALL_DIR}/vault

--- a/enos/modules/vault_setup_perf_primary/scripts/configure-vault-pr-primary.sh
+++ b/enos/modules/vault_setup_perf_primary/scripts/configure-vault-pr-primary.sh
@@ -2,7 +2,6 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-
 set -e
 
 binpath=${VAULT_INSTALL_DIR}/vault
@@ -15,7 +14,7 @@ fail() {
 test -x "$binpath" || fail "unable to locate vault binary at $binpath"
 
 # Create superuser policy
-$binpath policy write superuser -<<EOF
+$binpath policy write superuser - << EOF
 path "*" {
   capabilities = ["create", "read", "update", "delete", "list", "sudo"]
 }

--- a/enos/modules/vault_step_down/scripts/operator-step-down.sh
+++ b/enos/modules/vault_step_down/scripts/operator-step-down.sh
@@ -2,7 +2,6 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-
 set -eou pipefail
 
 fail() {

--- a/enos/modules/vault_test_ui/scripts/test_ui.sh
+++ b/enos/modules/vault_test_ui/scripts/test_ui.sh
@@ -2,7 +2,6 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-
 set -eux -o pipefail
 
 project_root=$(git rev-parse --show-toplevel)

--- a/enos/modules/vault_unseal_nodes/scripts/unseal-node.sh
+++ b/enos/modules/vault_unseal_nodes/scripts/unseal-node.sh
@@ -2,7 +2,6 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-
 binpath=${VAULT_INSTALL_DIR}/vault
 
 IFS="," read -r -a keys <<< "${UNSEAL_KEYS}"

--- a/enos/modules/vault_unseal_nodes/scripts/wait-until-sealed.sh
+++ b/enos/modules/vault_unseal_nodes/scripts/wait-until-sealed.sh
@@ -2,7 +2,6 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-
 binpath=${VAULT_INSTALL_DIR}/vault
 
 function fail() {

--- a/enos/modules/vault_upgrade/scripts/maybe-remove-old-unit-file.sh
+++ b/enos/modules/vault_upgrade/scripts/maybe-remove-old-unit-file.sh
@@ -11,7 +11,7 @@ fail() {
 
 [[ -z "$ARTIFACT_NAME" ]] && fail "ARTIFACT_NAME env variable has not been set"
 
-if [ "${ARTIFACT_NAME##*.}" == "zip" ];  then
+if [ "${ARTIFACT_NAME##*.}" == "zip" ]; then
   echo "Skipped removing unit file because new artifact is a zip bundle"
   exit 0
 fi

--- a/enos/modules/vault_verify_agent_output/scripts/verify-vault-agent-output.sh
+++ b/enos/modules/vault_verify_agent_output/scripts/verify-vault-agent-output.sh
@@ -2,7 +2,6 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-
 set -e
 
 fail() {

--- a/enos/modules/vault_verify_billing_start_date/scripts/verify-billing-start.sh
+++ b/enos/modules/vault_verify_billing_start_date/scripts/verify-billing-start.sh
@@ -57,14 +57,14 @@ verify_date_is_in_current_year() {
     Linux)
       billing_start_unix=$(TZ=UTC date -d "$1" +'%s')    # For "now", use $(date +'%s')
       one_year_ago_unix=$(TZ=UTC date -d "1 year ago" +'%s')
-    ;;
+      ;;
     Darwin)
       one_year_ago_unix=$(TZ=UTC date -v -1y +'%s')
-      billing_start_unix=$(TZ=UTC date -j -f "%Y-%m-%dT%H:%M:%SZ" "${1}" +'%s' )
-    ;;
+      billing_start_unix=$(TZ=UTC date -j -f "%Y-%m-%dT%H:%M:%SZ" "${1}" +'%s')
+      ;;
     *)
       fail "Unsupported target host operating system: $(get_target_platform)" 1>&2
-    ;;
+      ;;
   esac
 
   if [ "$billing_start_unix" -gt "$one_year_ago_unix" ]; then

--- a/enos/modules/vault_verify_performance_replication/scripts/verify-replication-status.sh
+++ b/enos/modules/vault_verify_performance_replication/scripts/verify-replication-status.sh
@@ -2,7 +2,6 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-
 # This script waits for the replication status to be established
 # then verifies the performance replication between primary and
 # secondary clusters
@@ -89,7 +88,6 @@ check_pr_status() {
   echo "$pr_status"
   return 0
 }
-
 
 if [ "$IP_VERSION" != 4 ] && [ "$IP_VERSION" != 6 ]; then
   fail "unsupported IP_VERSION: $IP_VERSION"

--- a/enos/modules/vault_verify_raft_auto_join_voter/scripts/verify-raft-auto-join-voter.sh
+++ b/enos/modules/vault_verify_raft_auto_join_voter/scripts/verify-raft-auto-join-voter.sh
@@ -2,7 +2,6 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-
 set -e
 
 binpath=${VAULT_INSTALL_DIR}/vault

--- a/enos/modules/vault_verify_read_data/scripts/verify-data.sh
+++ b/enos/modules/vault_verify_read_data/scripts/verify-data.sh
@@ -2,7 +2,6 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-
 set -e
 
 function retry {

--- a/enos/modules/vault_verify_ui/scripts/smoke-verify-ui.sh
+++ b/enos/modules/vault_verify_ui/scripts/smoke-verify-ui.sh
@@ -2,7 +2,6 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-
 set -e
 
 fail() {

--- a/enos/modules/vault_verify_unsealed/scripts/verify-vault-node-unsealed.sh
+++ b/enos/modules/vault_verify_unsealed/scripts/verify-vault-node-unsealed.sh
@@ -4,7 +4,6 @@
 
 set -e
 
-
 fail() {
   echo "$1" 1>&2
   exit 1
@@ -23,21 +22,21 @@ while :; do
     if unseal_status=$($binpath status -format json | jq -Mre --argjson expected "false" '.sealed == $expected'); then
       echo "$health_status"
       exit 0
-    fi
+  fi
 
     wait=$((2 ** count))
     count=$((count + 1))
     if [ "$count" -lt "$retries" ]; then
       sleep "$wait"
-    else
+  else
       if [ -n "$HOST_IPV6" ]; then
         fail "expected ${HOST_IPV6} to be unsealed, got unseal status: $unseal_status"
-      else
+    else
         if [ -n "$HOST_IPV4" ]; then
           fail "expected ${HOST_IPV4} to be unsealed, got unseal status: $unseal_status"
-        else
+      else
           fail "expected ${VAULT_ADDR} to be unsealed, got unseal status: $unseal_status"
-        fi
       fi
     fi
+  fi
 done

--- a/enos/modules/vault_verify_version/scripts/verify-cli-version.sh
+++ b/enos/modules/vault_verify_version/scripts/verify-cli-version.sh
@@ -31,7 +31,7 @@ version_expected="Vault v$version ($sha), built $build_date"
 case "$edition" in
   *ce) ;;
   *ent) ;;
-  *ent.hsm) version_expected="$version_expected (cgo)";;
+  *ent.hsm) version_expected="$version_expected (cgo)" ;;
   *ent.fips1402) version_expected="$version_expected (cgo)" ;;
   *ent.hsm.fips1402) version_expected="$version_expected (cgo)" ;;
   *) fail "Unknown Vault edition: ($edition)" ;;
@@ -46,7 +46,7 @@ else
   msg="$(printf "\nThe Vault cluster did not match the expected version, expected:\n%s\nor\n%s\ngot:\n%s" "$version_expected" "$version_expected_nosha" "$version_output")"
   if type diff &> /dev/null; then
     # Diff exits non-zero if we have a diff, which we want, so we'll guard against failing early.
-    if ! version_diff=$(diff  <(echo "$version_expected" ) <(echo "$version_output") -u -L expected -L got); then
+    if ! version_diff=$(diff  <(echo "$version_expected")  <(echo "$version_output") -u -L expected -L got); then
       msg="$(printf "\nThe Vault cluster did not match the expected version:\n%s" "$version_diff")"
     fi
   fi

--- a/enos/modules/vault_verify_write_data/scripts/smoke-enable-secrets-kv.sh
+++ b/enos/modules/vault_verify_write_data/scripts/smoke-enable-secrets-kv.sh
@@ -2,7 +2,6 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-
 set -e
 
 retry() {
@@ -40,7 +39,7 @@ test -x "$binpath" || fail "unable to locate vault binary at $binpath"
 retry 5 "$binpath" status > /dev/null 2>&1
 
 # Create user policy
-retry 5 "$binpath" policy write reguser -<<EOF
+retry 5 "$binpath" policy write reguser - << EOF
 path "*" {
   capabilities = ["read", "list"]
 }

--- a/enos/modules/vault_verify_write_data/scripts/smoke-write-test-data.sh
+++ b/enos/modules/vault_verify_write_data/scripts/smoke-write-test-data.sh
@@ -2,7 +2,6 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-
 set -e
 
 retry() {

--- a/enos/modules/vault_wait_for_leader/scripts/wait-for-leader.sh
+++ b/enos/modules/vault_wait_for_leader/scripts/wait-for-leader.sh
@@ -2,7 +2,6 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-
 set -e
 
 fail() {
@@ -22,7 +21,7 @@ test -x "$binpath" || fail "unable to locate vault binary at $binpath"
 findLeaderInPrivateIPs() {
   # Find the leader private IP address
   local leader_private_ip
-  if ! leader_private_ip=$($binpath read sys/leader -format=json | jq -er '.data.leader_address | scan("[0-9]+.[0-9]+.[0-9]+.[0-9]+")') ; then
+  if ! leader_private_ip=$($binpath read sys/leader -format=json | jq -er '.data.leader_address | scan("[0-9]+.[0-9]+.[0-9]+.[0-9]+")'); then
     # Some older versions of vault don't support reading sys/leader. Fallback to the cli status.
     if ! leader_private_ip=$($binpath status -format json | jq -er '.leader_address | scan("[0-9]+.[0-9]+.[0-9]+.[0-9]+")'); then
       return 1
@@ -42,7 +41,7 @@ findLeaderInPrivateIPs() {
 findLeaderInIPV6s() {
   # Find the leader private IP address
   local leader_ipv6
-  if ! leader_ipv6=$($binpath read sys/leader -format=json | jq -er '.data.leader_address | scan("\\[(.+)\\]") | .[0]') ; then
+  if ! leader_ipv6=$($binpath read sys/leader -format=json | jq -er '.data.leader_address | scan("\\[(.+)\\]") | .[0]'); then
     # Some older versions of vault don't support reading sys/leader. Fallback to the cli status.
     if ! leader_ipv6=$($binpath status -format json | jq -er '.leader_address | scan("\\[(.+)\\]") | .[0]'); then
       return 1
@@ -69,16 +68,16 @@ while [ "$(date +%s)" -lt "$end_time" ]; do
       if findLeaderInPrivateIPs; then
         exit 0
       fi
-    ;;
+      ;;
     6)
       [[ -z "$VAULT_INSTANCE_IPV6S" ]] && fail "VAULT_INSTANCE_IPV6S env variable has not been set"
       if findLeaderInIPV6s; then
         exit 0
       fi
-    ;;
+      ;;
     *)
       fail "No matching package manager provided."
-    ;;
+      ;;
   esac
 
   sleep "$RETRY_INTERVAL"
@@ -87,11 +86,11 @@ done
 case $IP_VERSION in
   4)
     fail "Timed out waiting for one of $VAULT_INSTANCE_PRIVATE_IPS to be leader."
-  ;;
+    ;;
   6)
     fail "Timed out waiting for one of $VAULT_INSTANCE_IPV6S to be leader."
-  ;;
+    ;;
   *)
     fail "Timed out waiting for leader"
-  ;;
+    ;;
 esac

--- a/enos/modules/vault_wait_for_seal_rewrap/scripts/wait-for-seal-rewrap.sh
+++ b/enos/modules/vault_wait_for_seal_rewrap/scripts/wait-for-seal-rewrap.sh
@@ -2,7 +2,6 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-
 set -e
 
 fail() {

--- a/tools/tools.sh
+++ b/tools/tools.sh
@@ -37,18 +37,19 @@ install_external() {
   # install action .github/actions/install-external-tools/action.yml
   #
   tools=(
+    honnef.co/go/tools/cmd/staticcheck@latest
     github.com/bufbuild/buf/cmd/buf@v1.25.0
     github.com/favadi/protoc-go-inject-tag@latest
     github.com/golangci/misspell/cmd/misspell@latest
     github.com/golangci/revgrep/cmd/revgrep@latest
+    github.com/loggerhead/enumer@latest
     github.com/rinchsan/gosimports/cmd/gosimports@latest
     golang.org/x/tools/cmd/goimports@latest
     google.golang.org/protobuf/cmd/protoc-gen-go@latest
     google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.4.0
     gotest.tools/gotestsum@latest
-    honnef.co/go/tools/cmd/staticcheck@latest
     mvdan.cc/gofumpt@latest
-    github.com/loggerhead/enumer@latest
+    mvdan.cc/sh/v3/cmd/shfmt@latest
   )
 
   echo "==> Installing external tools..."
@@ -76,6 +77,7 @@ check_external() {
     protoc-gen-go-grpc
     protoc-go-inject-tag
     revgrep
+    shfmt
     staticcheck
   )
 


### PR DESCRIPTION
### Description
Add `shfmt` to our external tools install and enable checking shell formatting for all enos module shell scripts. This helps us maintain an verify a consistent style across all the scripts.

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [x] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
