### PR TITLE
Update link to support and eol policy

### DIFF
--- a/website/content/docs/enterprise/lts.mdx
+++ b/website/content/docs/enterprise/lts.mdx
@@ -104,7 +104,7 @@ consider moving to a Vault Enterprise version with long-term support.
 Long-term support offers extended maintenance through minor releases for select,
 major Vault Enterprise versions.
 
-The standard [support period and end of life policy](https://go.hashi.co/vault-support-policy)
+The standard [support period and end of life policy](https://support.hashicorp.com/hc/en-us/articles/360021185113-Support-Period-and-End-of-Life-EOL-Policy)
 covers "N&minus;2" versions, which means, at any given time, HashiCorp maintains
 the current version ("N") and the two previous versions ("N&minus;2").
 


### PR DESCRIPTION
The existing link in the doc uses hashilinks and requires employee access, but then just redirects to a public facing page. This PR updates the link to go directly to the public facing page.

### Description
What does this PR do?

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [ ] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
