### PR TITLE
UI: update wrapped token test

### DIFF
--- a/ui/tests/acceptance/wrapped-token-test.js
+++ b/ui/tests/acceptance/wrapped-token-test.js
@@ -5,46 +5,25 @@
 
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
-import { settled, currentURL, visit } from '@ember/test-helpers';
-import { create } from 'ember-cli-page-object';
+import { currentURL, visit, currentRouteName } from '@ember/test-helpers';
 import { setupMirage } from 'ember-cli-mirage/test-support';
-import auth from 'vault/tests/pages/auth';
-import consoleClass from 'vault/tests/pages/components/console/ui-panel';
+import { login, logout } from 'vault/tests/helpers/auth/auth-helpers';
+import { runCmd } from 'vault/tests/helpers/commands';
 
-const consoleComponent = create(consoleClass);
-
-const wrappedAuth = async () => {
-  await consoleComponent.toggle();
-  await settled();
-  await consoleComponent.runCommands(
-    `write -field=token auth/token/create policies=default -wrap-ttl=3m`,
-    false
-  );
-  await settled();
-  return consoleComponent.lastLogOutput;
-};
-
-const setupWrapping = async () => {
-  await auth.logout();
-  await settled();
-  await auth.visit();
-  await settled();
-  await auth.authType('token');
-  await auth.tokenInput('root').submit();
-  await settled();
-  const token = await wrappedAuth();
-  await auth.logout();
-  await settled();
-  return token;
-};
-module('Acceptance | wrapped_token query param functionality', function (hooks) {
+module(`Acceptance | wrapped_token query param functionality`, function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
+  hooks.beforeEach(async function () {
+    await login();
+    // create wrapped token
+    const token = await runCmd(`write -field=token auth/token/create policies=default -wrap-ttl=3m`);
+    await logout();
+    this.token = token;
+  });
+
   test('it authenticates you if the query param is present', async function (assert) {
-    const token = await setupWrapping();
-    await auth.visit({ wrapped_token: token });
-    await settled();
+    await visit(`/vault/auth?wrapped_token=${this.token}`);
     assert.strictEqual(
       currentURL(),
       '/vault/dashboard',
@@ -53,9 +32,7 @@ module('Acceptance | wrapped_token query param functionality', function (hooks) 
   });
 
   test('it authenticates when used with the with=token query param', async function (assert) {
-    const token = await setupWrapping();
-    await auth.visit({ wrapped_token: token, with: 'token' });
-    await settled();
+    await visit(`/vault/auth?wrapped_token=${this.token}&with=token`);
     assert.strictEqual(
       currentURL(),
       '/vault/dashboard',
@@ -64,11 +41,9 @@ module('Acceptance | wrapped_token query param functionality', function (hooks) 
   });
 
   test('it should authenticate when hitting logout url with wrapped_token when logged out', async function (assert) {
-    this.server.post('/sys/wrapping/unwrap', () => {
-      return { auth: { client_token: 'root' } };
-    });
-
-    await visit(`/vault/logout?wrapped_token=1234`);
+    await login();
+    assert.strictEqual(currentRouteName(), 'vault.cluster.dashboard');
+    await visit(`/vault/logout?wrapped_token=${this.token}`);
     assert.strictEqual(
       currentURL(),
       '/vault/dashboard',

--- a/ui/tests/helpers/auth/auth-helpers.ts
+++ b/ui/tests/helpers/auth/auth-helpers.ts
@@ -11,10 +11,16 @@ const { rootToken } = VAULT_KEYS;
 
 export const login = async (token = rootToken) => {
   // make sure we're always logged out and logged back in
-  await visit('/vault/logout');
-  // clear session storage to ensure we have a clean state
-  window.localStorage.clear();
+  await logout();
   await visit('/vault/auth?with=token');
   await fillIn(AUTH_FORM.input('token'), token);
   return await click(AUTH_FORM.login);
+};
+
+export const logout = async () => {
+  // make sure we're always logged out and logged back in
+  await visit('/vault/logout');
+  // clear session storage to ensure we have a clean state
+  window.localStorage.clear();
+  return;
 };


### PR DESCRIPTION
### Description
Attempts to stabilize the wrapped_token tests, which have been particularly flaky in CI with the following: 

```
Error: Browser timeout exceeded: 10s
Error while executing test: Acceptance | wrapped_token query param functionality: it authenticates you if the query param is present
Stderr: 
 [0822/150758.502910:WARNING:sandbox_linux.cc(430)] InitializeSandbox() called with multiple threads in process gpu-process.

DevTools listening on ws://127.0.0.1:39411/devtools/browser/b2d2da15-9f0f-4565-b919-f198a86a795b
[0822/150800.909169:WARNING:bluez_dbus_manager.cc(248)] Floss manager not present, cannot set Floss enable/disable.
```

I'm not totally confident this will fix the flakiness because the error seems Chrome-related, but at least the test is using more modern patterns
