### PR TITLE
docs: update Docker `curl` upgrade guide

### DIFF
--- a/website/content/docs/upgrading/upgrade-to-1.15.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.15.x.mdx
@@ -47,9 +47,43 @@ option.
 
 ### Docker image no longer contains `curl`
 
-As of 1.15.13 and later, the `curl` binary is no longer included in the published Docker container images
-for Vault and Vault Enterprise. If your workflow depends on `curl` in the image you can dynamically
-install it using `apk`, e.g.: `docker exec <CONTAINER-ID> apk add curl` or `kubectl exec -ti <NAME> -- apk add curl`.
+As of 1.15.13 and later, the `curl` binary is no longer included in the published Docker container
+images for Vault and Vault Enterprise. If your workflow depends on `curl` being available in the
+container, consider one of the following strategies:
+
+#### Create a wrapper container image
+
+Use the HashiCorp image as a base image to create a new container image with `curl` installed.
+
+```Dockerfile
+FROM hashicorp/vault-enterprise
+RUN apk add curl
+```
+
+**NOTE:** While this is the preferred option it will require managing your own registry and rebuilding new images.
+
+#### Install it at runtime dynamically
+
+When running the image as root (not recommended), you can install it at runtime dynamically by using the `apk` package manager:
+
+```shell-session
+docker exec <CONTAINER-ID> apk add curl
+```
+```shell-session
+kubectl exec -ti <NAME> -- apk add curl
+```
+
+When running the image as non-root without privilege escalation (recommended) you can use existing
+tools to install a static binary of `curl` into the `vault` users home directory:
+
+```shell-session
+docker exec <CONTAINER-ID> wget https://github.com/moparisthebest/static-curl/releases/latest/download/curl-amd64 -O /home/vault/curl && chmod +x /home/vault/curl
+```
+```shell-session
+kubectl exec -ti <NAME> -- wget https://github.com/moparisthebest/static-curl/releases/latest/download/curl-amd64 -O /home/vault/curl && chmod +x /home/vault/curl
+```
+
+**NOTE:** When using this option you'll want to verify that the static binary comes from a trusted source.
 
 ## Known issues and workarounds
 

--- a/website/content/docs/upgrading/upgrade-to-1.16.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.16.x.mdx
@@ -104,9 +104,43 @@ As of 1.16.7 and later, the billing start date (license start date if not config
 
 ### Docker image no longer contains `curl`
 
-As of 1.16.7 and later, the `curl` binary is no longer included in the published Docker container images
-for Vault and Vault Enterprise. If your workflow depends on `curl` in the image you can dynamically
-install it using `apk`, e.g.: `docker exec <CONTAINER-ID> apk add curl` or `kubectl exec -ti <NAME> -- apk add curl`.
+As of 1.16.7 and later, the `curl` binary is no longer included in the published Docker container
+images for Vault and Vault Enterprise. If your workflow depends on `curl` being available in the
+container, consider one of the following strategies:
+
+#### Create a wrapper container image
+
+Use the HashiCorp image as a base image to create a new container image with `curl` installed.
+
+```Dockerfile
+FROM hashicorp/vault-enterprise
+RUN apk add curl
+```
+
+**NOTE:** While this is the preferred option it will require managing your own registry and rebuilding new images.
+
+#### Install it at runtime dynamically
+
+When running the image as root (not recommended), you can install it at runtime dynamically by using the `apk` package manager:
+
+```shell-session
+docker exec <CONTAINER-ID> apk add curl
+```
+```shell-session
+kubectl exec -ti <NAME> -- apk add curl
+```
+
+When running the image as non-root without privilege escalation (recommended) you can use existing
+tools to install a static binary of `curl` into the `vault` users home directory:
+
+```shell-session
+docker exec <CONTAINER-ID> wget https://github.com/moparisthebest/static-curl/releases/latest/download/curl-amd64 -O /home/vault/curl && chmod +x /home/vault/curl
+```
+```shell-session
+kubectl exec -ti <NAME> -- wget https://github.com/moparisthebest/static-curl/releases/latest/download/curl-amd64 -O /home/vault/curl && chmod +x /home/vault/curl
+```
+
+**NOTE:** When using this option you'll want to verify that the static binary comes from a trusted source.
 
 ## Known issues and workarounds
 

--- a/website/content/docs/upgrading/upgrade-to-1.17.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.17.x.mdx
@@ -91,9 +91,43 @@ As of 1.17.3 and later, the billing start date (license start date if not config
 
 ### Docker image no longer contains `curl`
 
-As of 1.17.3 and later, the `curl` binary is no longer included in the published Docker container images
-for Vault and Vault Enterprise. If your workflow depends on `curl` in the image you can dynamically
-install it using `apk`, e.g.: `docker exec <CONTAINER-ID> apk add curl` or `kubectl exec -ti <NAME> -- apk add curl`.
+As of 1.17.3 and later, the `curl` binary is no longer included in the published Docker container
+images for Vault and Vault Enterprise. If your workflow depends on `curl` being available in the
+container, consider one of the following strategies:
+
+#### Create a wrapper container image
+
+Use the HashiCorp image as a base image to create a new container image with `curl` installed.
+
+```Dockerfile
+FROM hashicorp/vault-enterprise
+RUN apk add curl
+```
+
+**NOTE:** While this is the preferred option it will require managing your own registry and rebuilding new images.
+
+#### Install it at runtime dynamically
+
+When running the image as root (not recommended), you can install it at runtime dynamically by using the `apk` package manager:
+
+```shell-session
+docker exec <CONTAINER-ID> apk add curl
+```
+```shell-session
+kubectl exec -ti <NAME> -- apk add curl
+```
+
+When running the image as non-root without privilege escalation (recommended) you can use existing
+tools to install a static binary of `curl` into the `vault` users home directory:
+
+```shell-session
+docker exec <CONTAINER-ID> wget https://github.com/moparisthebest/static-curl/releases/latest/download/curl-amd64 -O /home/vault/curl && chmod +x /home/vault/curl
+```
+```shell-session
+kubectl exec -ti <NAME> -- wget https://github.com/moparisthebest/static-curl/releases/latest/download/curl-amd64 -O /home/vault/curl && chmod +x /home/vault/curl
+```
+
+**NOTE:** When using this option you'll want to verify that the static binary comes from a trusted source.
 
 ## Known issues and workarounds
 

--- a/website/content/docs/upgrading/upgrade-to-1.18.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.18.x.mdx
@@ -61,5 +61,39 @@ WARNING! The following warnings were returned from Vault:
 ### Docker image no longer contains `curl`
 
 The `curl` binary is no longer included in the published Docker container images for Vault and Vault
-Enterprise. If your workflow depends on `curl` in the image you can dynamically install it using
-`apk`, e.g.: `docker exec <CONTAINER-ID> apk add curl` or `kubectl exec -ti <NAME> -- apk add curl`.
+Enterprise. If your workflow depends on `curl` being available in the container, consider one of the
+following strategies:
+
+#### Create a wrapper container image
+
+Use the HashiCorp image as a base image to create a new container image with `curl` installed.
+
+```Dockerfile
+FROM hashicorp/vault-enterprise
+RUN apk add curl
+```
+
+**NOTE:** While this is the preferred option it will require managing your own registry and rebuilding new images.
+
+#### Install it at runtime dynamically
+
+When running the image as root (not recommended), you can install it at runtime dynamically by using the `apk` package manager:
+
+```shell-session
+docker exec <CONTAINER-ID> apk add curl
+```
+```shell-session
+kubectl exec -ti <NAME> -- apk add curl
+```
+
+When running the image as non-root without privilege escalation (recommended) you can use existing
+tools to install a static binary of `curl` into the `vault` users home directory:
+
+```shell-session
+docker exec <CONTAINER-ID> wget https://github.com/moparisthebest/static-curl/releases/latest/download/curl-amd64 -O /home/vault/curl && chmod +x /home/vault/curl
+```
+```shell-session
+kubectl exec -ti <NAME> -- wget https://github.com/moparisthebest/static-curl/releases/latest/download/curl-amd64 -O /home/vault/curl && chmod +x /home/vault/curl
+```
+
+**NOTE:** When using this option you'll want to verify that the static binary comes from a trusted source.


### PR DESCRIPTION
### Description
Update the upgrade guides for the removal of `curl` in the Docker containers. Specifically we handle the case where users are utilizing our security contexts and running the container as `vault` and without privilege escalation.