### PR TITLE
Add retry logic to building zlint test container

### DIFF
--- a/builtin/logical/pkiext/zlint_test.go
+++ b/builtin/logical/pkiext/zlint_test.go
@@ -6,10 +6,13 @@ package pkiext
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/vault/builtin/logical/pki"
+	"github.com/hashicorp/vault/helper/testhelpers"
 	"github.com/hashicorp/vault/sdk/helper/docker"
 	"github.com/stretchr/testify/require"
 )
@@ -50,15 +53,21 @@ RUN go install github.com/zmap/zlint/v3/cmd/zlint@v3.6.2
 	}
 
 	ctx := context.Background()
-	output, err := zRunner.BuildImage(ctx, containerfile, bCtx,
-		docker.BuildRemove(true), docker.BuildForceRemove(true),
-		docker.BuildPullParent(true),
-		docker.BuildTags([]string{imageName + ":" + imageTag}))
-	if err != nil {
-		t.Fatalf("Could not build new image: %v", err)
-	}
 
-	t.Logf("Image build output: %v", string(output))
+	// Sometimes we see timeouts and issues pulling the zlint code from GitHub
+	testhelpers.RetryUntil(t, 30*time.Second, func() error {
+		output, err := zRunner.BuildImage(ctx, containerfile, bCtx,
+			docker.BuildRemove(true),
+			docker.BuildForceRemove(true),
+			docker.BuildPullParent(true),
+			docker.BuildTags([]string{imageName + ":" + imageTag}))
+		if err != nil {
+			return fmt.Errorf("could not build new image with zlint: %w", err)
+		}
+
+		t.Logf("Image build output: %v", string(output))
+		return nil
+	})
 }
 
 func RunZLintContainer(t *testing.T, certificate string) []byte {


### PR DESCRIPTION
### Description

Sometimes we are failing to pull the zlint tagged version from GitHub when building up the test containers. Add a simple retry around the container building step to see if this resolves the issue.

Sample run: https://github.com/hashicorp/vault/actions/runs/10515176400/job/29134760780

```
{"stream":" ---\u003e Running in 8cb432ed9fde\n"}
{"stream":"\u001b[91mgo: github.com/zmap/zlint/v3/cmd/zlint@v3.6.2: github.com/zmap/zlint/v3/cmd/zlint@v3.6.2: Get \"[https://proxy.golang.org/github.com/zmap/zlint/v3/cmd/zlint/@v/v3.6.2.info\](https://proxy.golang.org/github.com/zmap/zlint/v3/cmd/zlint/@v/v3.6.2.info/)": net/http: TLS handshake timeout\n\u001b[0m"}
{"stream":" ---\u003e Removed intermediate container 8cb432ed9fde\n"}
{"errorDetail":{"code":1,"message":"The command '/bin/sh -c go install github.com/zmap/zlint/v3/cmd/zlint@v3.6.2' returned a non-zero code: 1"},"error":"The command '/bin/sh -c go install github.com/zmap/zlint/v3/cmd/zlint@v3.6.2' returned a non-zero code: 1"}
```

### TODO only if you're a HashiCorp employee
- [X] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
- [ ] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
