### PR TITLE
Rename activity export API identity fields

### DIFF
--- a/vault/activity_log.go
+++ b/vault/activity_log.go
@@ -241,14 +241,14 @@ type ActivityLogCoreConfig struct {
 // perform the logged activity. The omitempty JSON tag is not used to ensure
 // that the fields are consistent between CSV and JSON output.
 type ActivityLogExportRecord struct {
-	// IdentityName is the name of the entity
-	IdentityName string `json:"identity_name" mapstructure:"identity_name"`
+	// EntityName is the name of the entity
+	EntityName string `json:"entity_name" mapstructure:"entity_name"`
 
-	// AliasName is the entity alias name provided by the auth backend upon login
-	AliasName string `json:"alias_name" mapstructure:"alias_name"`
+	// EntityAliasName is the entity alias name provided by the auth backend upon login
+	EntityAliasName string `json:"entity_alias_name" mapstructure:"entity_alias_name"`
 
-	// LocalAlias indicates if the alias only belongs to the cluster where it was created.
-	LocalAlias bool `json:"local_alias" mapstructure:"local_alias"`
+	// LocalEntityAlias indicates if the entity alias only belongs to the cluster where it was created.
+	LocalEntityAlias bool `json:"local_entity_alias" mapstructure:"local_entity_alias"`
 
 	// ClientID is the unique identifier assigned to the entity that performed the activity
 	ClientID string `json:"client_id" mapstructure:"client_id"`
@@ -277,19 +277,19 @@ type ActivityLogExportRecord struct {
 	// Policies are the list of policy names attached to the token used
 	Policies []string `json:"policies" mapstructure:"policies"`
 
-	// IdentityMetadata represents explicit metadata set by clients. Multiple entities can have the
+	// EntityMetadata represents explicit metadata set by clients. Multiple entities can have the
 	// same metadata which enables virtual groupings of entities.
-	IdentityMetadata map[string]string `json:"identity_metadata" mapstructure:"identity_metadata"`
+	EntityMetadata map[string]string `json:"entity_metadata" mapstructure:"entity_metadata"`
 
-	// AliasMetadata represents the metadata associated with the identity alias. Multiple aliases can
+	// EntityAliasMetadata represents the metadata associated with the identity alias. Multiple aliases can
 	// have the same custom metadata which enables virtual grouping of aliases.
-	AliasMetadata map[string]string `json:"alias_metadata" mapstructure:"alias_metadata"`
+	EntityAliasMetadata map[string]string `json:"entity_alias_metadata" mapstructure:"entity_alias_metadata"`
 
-	// AliasCustomMetadata represents the custom metadata associated with the identity alias
-	AliasCustomMetadata map[string]string `json:"alias_custom_metadata" mapstructure:"alias_custom_metadata"`
+	// EntityAliasCustomMetadata represents the custom metadata associated with the identity alias
+	EntityAliasCustomMetadata map[string]string `json:"entity_alias_custom_metadata" mapstructure:"entity_alias_custom_metadata"`
 
-	// IdentityGroupIDs provides a list of all of the identity group IDs in which an entity belongs
-	IdentityGroupIDs []string `json:"identity_group_ids" mapstructure:"identity_group_ids"`
+	// EntityGroupIDs provides a list of all of the identity group IDs in which an entity belongs
+	EntityGroupIDs []string `json:"entity_group_ids" mapstructure:"entity_group_ids"`
 }
 
 // NewActivityLog creates an activity log.
@@ -3101,9 +3101,9 @@ func (a *ActivityLog) writeExport(ctx context.Context, rw http.ResponseWriter, f
 					}
 
 					if entityResp != nil {
-						record.IdentityName, ok = entityResp.Data["name"].(string)
+						record.EntityName, ok = entityResp.Data["name"].(string)
 						if !ok {
-							return fmt.Errorf("failed to process identity name")
+							return fmt.Errorf("failed to process entity name")
 						}
 
 						record.Policies, ok = entityResp.Data["policies"].([]string)
@@ -3113,17 +3113,17 @@ func (a *ActivityLog) writeExport(ctx context.Context, rw http.ResponseWriter, f
 
 						slices.Sort(record.Policies)
 
-						record.IdentityMetadata, ok = entityResp.Data["metadata"].(map[string]string)
+						record.EntityMetadata, ok = entityResp.Data["metadata"].(map[string]string)
 						if !ok {
-							return fmt.Errorf("failed to process identity metadata")
+							return fmt.Errorf("failed to process entity metadata")
 						}
 
-						record.IdentityGroupIDs, ok = entityResp.Data["group_ids"].([]string)
+						record.EntityGroupIDs, ok = entityResp.Data["group_ids"].([]string)
 						if !ok {
-							return fmt.Errorf("failed to process identity group IDs")
+							return fmt.Errorf("failed to process entity group IDs")
 						}
 
-						slices.Sort(record.IdentityGroupIDs)
+						slices.Sort(record.EntityGroupIDs)
 
 						aliases, ok := entityResp.Data["aliases"].([]interface{})
 						if !ok {
@@ -3145,14 +3145,14 @@ func (a *ActivityLog) writeExport(ctx context.Context, rw http.ResponseWriter, f
 								continue
 							}
 
-							record.AliasName, ok = alias["name"].(string)
+							record.EntityAliasName, ok = alias["name"].(string)
 							if !ok {
-								return fmt.Errorf("failed to process alias name")
+								return fmt.Errorf("failed to process entity alias name")
 							}
 
-							record.LocalAlias, ok = alias["local"].(bool)
+							record.LocalEntityAlias, ok = alias["local"].(bool)
 							if !ok {
-								return fmt.Errorf("failed to process local alias")
+								return fmt.Errorf("failed to process local entity alias")
 							}
 
 							record.MountType, ok = alias["mount_type"].(string)
@@ -3165,14 +3165,14 @@ func (a *ActivityLog) writeExport(ctx context.Context, rw http.ResponseWriter, f
 								return fmt.Errorf("failed to process mount path")
 							}
 
-							record.AliasMetadata, ok = alias["metadata"].(map[string]string)
+							record.EntityAliasMetadata, ok = alias["metadata"].(map[string]string)
 							if !ok {
-								return fmt.Errorf("failed to process alias metadata")
+								return fmt.Errorf("failed to process entity alias metadata")
 							}
 
-							record.AliasCustomMetadata, ok = alias["custom_metadata"].(map[string]string)
+							record.EntityAliasCustomMetadata, ok = alias["custom_metadata"].(map[string]string)
 							if !ok {
-								return fmt.Errorf("failed to process alias custom metadata")
+								return fmt.Errorf("failed to process entity alias custom metadata")
 							}
 						}
 					}
@@ -3300,11 +3300,11 @@ type csvEncoder struct {
 // be appended to the end.
 func baseActivityExportCSVHeader() []string {
 	return []string{
-		"identity_name",
-		"alias_name",
+		"entity_name",
+		"entity_alias_name",
 		"client_id",
 		"client_type",
-		"local_alias",
+		"local_entity_alias",
 		"namespace_id",
 		"namespace_path",
 		"mount_accessor",

--- a/vault/activity_log_test.go
+++ b/vault/activity_log_test.go
@@ -4916,14 +4916,14 @@ func TestActivityLog_Export_CSV_Header(t *testing.T) {
 		Policies: []string{
 			"foo",
 		},
-		IdentityMetadata: map[string]string{
+		EntityMetadata: map[string]string{
 			"email_address": "jdoe@abc.com",
 		},
 	})
 	require.NoError(t, err)
 
 	expectedColumnIndex["policies.0"] = exportCSVFlatteningInitIndex
-	expectedColumnIndex["identity_metadata.email_address"] = exportCSVFlatteningInitIndex
+	expectedColumnIndex["entity_metadata.email_address"] = exportCSVFlatteningInitIndex
 
 	require.Empty(t, deep.Equal(expectedColumnIndex, encoder.columnIndex))
 
@@ -4933,7 +4933,7 @@ func TestActivityLog_Export_CSV_Header(t *testing.T) {
 			"bar",
 			"baz",
 		},
-		AliasCustomMetadata: map[string]string{
+		EntityAliasCustomMetadata: map[string]string{
 			"region": "west",
 			"group":  "san_francisco",
 		},
@@ -4942,8 +4942,8 @@ func TestActivityLog_Export_CSV_Header(t *testing.T) {
 
 	expectedColumnIndex["policies.1"] = exportCSVFlatteningInitIndex
 	expectedColumnIndex["policies.2"] = exportCSVFlatteningInitIndex
-	expectedColumnIndex["alias_custom_metadata.group"] = exportCSVFlatteningInitIndex
-	expectedColumnIndex["alias_custom_metadata.region"] = exportCSVFlatteningInitIndex
+	expectedColumnIndex["entity_alias_custom_metadata.group"] = exportCSVFlatteningInitIndex
+	expectedColumnIndex["entity_alias_custom_metadata.region"] = exportCSVFlatteningInitIndex
 
 	require.Empty(t, deep.Equal(expectedColumnIndex, encoder.columnIndex))
 
@@ -4951,39 +4951,39 @@ func TestActivityLog_Export_CSV_Header(t *testing.T) {
 		Policies: []string{
 			"foo",
 		},
-		IdentityGroupIDs: []string{
+		EntityGroupIDs: []string{
 			"97798e02-51e5-4ef3-906e-82c76d1a396e",
 		},
-		IdentityMetadata: map[string]string{
+		EntityMetadata: map[string]string{
 			"first_name": "John",
 			"last_name":  "Doe",
 		},
-		AliasMetadata: map[string]string{
+		EntityAliasMetadata: map[string]string{
 			"contact_email": "foo@abc.com",
 		},
 	})
 	require.NoError(t, err)
 
-	expectedColumnIndex["identity_metadata.first_name"] = exportCSVFlatteningInitIndex
-	expectedColumnIndex["identity_metadata.last_name"] = exportCSVFlatteningInitIndex
-	expectedColumnIndex["alias_metadata.contact_email"] = exportCSVFlatteningInitIndex
-	expectedColumnIndex["identity_group_ids.0"] = exportCSVFlatteningInitIndex
+	expectedColumnIndex["entity_metadata.last_name"] = exportCSVFlatteningInitIndex
+	expectedColumnIndex["entity_metadata.first_name"] = exportCSVFlatteningInitIndex
+	expectedColumnIndex["entity_alias_metadata.contact_email"] = exportCSVFlatteningInitIndex
+	expectedColumnIndex["entity_group_ids.0"] = exportCSVFlatteningInitIndex
 
 	require.Empty(t, deep.Equal(expectedColumnIndex, encoder.columnIndex))
 
 	// no change because all the fields have seen before
 	err = encoder.accumulateHeaderFields(&ActivityLogExportRecord{
-		AliasCustomMetadata: map[string]string{
+		EntityAliasCustomMetadata: map[string]string{
 			"group":  "does-not-matter",
 			"region": "does-not-matter",
 		},
-		AliasMetadata: map[string]string{
+		EntityAliasMetadata: map[string]string{
 			"contact_email": "does-not-matter",
 		},
-		IdentityGroupIDs: []string{
+		EntityGroupIDs: []string{
 			"does-not-matter",
 		},
-		IdentityMetadata: map[string]string{
+		EntityMetadata: map[string]string{
 			"first_name": "does-not-matter",
 			"last_name":  "does-not-matter",
 		},
@@ -5002,13 +5002,13 @@ func TestActivityLog_Export_CSV_Header(t *testing.T) {
 	require.Empty(t, deep.Equal(expectedColumnIndex, encoder.columnIndex))
 
 	expectedHeader := append(baseActivityExportCSVHeader(),
-		"alias_custom_metadata.group",
-		"alias_custom_metadata.region",
-		"alias_metadata.contact_email",
-		"identity_group_ids.0",
-		"identity_metadata.email_address",
-		"identity_metadata.first_name",
-		"identity_metadata.last_name",
+		"entity_alias_custom_metadata.group",
+		"entity_alias_custom_metadata.region",
+		"entity_alias_metadata.contact_email",
+		"entity_group_ids.0",
+		"entity_metadata.email_address",
+		"entity_metadata.first_name",
+		"entity_metadata.last_name",
 		"policies.0",
 		"policies.1",
 		"policies.2")

--- a/vault/external_tests/activity_testonly/activity_testonly_test.go
+++ b/vault/external_tests/activity_testonly/activity_testonly_test.go
@@ -544,18 +544,18 @@ func getCSVExport(t *testing.T, client *api.Client, monthsPreviousTo int, now ti
 	t.Helper()
 
 	boolFields := map[string]struct{}{
-		"local_alias": {},
+		"local_entity_alias": {},
 	}
 
 	mapFields := map[string]struct{}{
-		"alias_custom_metadata": {},
-		"alias_metadata":        {},
-		"identity_metadata":     {},
+		"entity_alias_custom_metadata": {},
+		"entity_alias_metadata":        {},
+		"entity_metadata":              {},
 	}
 
 	sliceFields := map[string]struct{}{
-		"identity_group_ids": {},
-		"policies":           {},
+		"entity_group_ids": {},
+		"policies":         {},
 	}
 
 	resp, err := client.Logical().ReadRawWithData("sys/internal/counters/activity/export", map[string][]string{


### PR DESCRIPTION
### Description
This PR changes some field names in the activity export API to be more consistent with entity nomenclature.

- `identity_name` -> `entity_name`
- `alias_name` -> `entity_alias_name`
- `local_alias` -> `local_entity_alias`
- `identity_metadata` -> `entity_metadata`
- `alias_metadata` -> `entity_alias_metadata`
- `alias_custom_metadata` -> `entity_alias_custom_metadata`
- `identity_group_ids` -> `entity_group_ids`

RFC: https://docs.google.com/document/d/1L42mm7rSwJSwMN4h7TnJCwt2GJ_DjKnlJIW8LxJzRgU/edit
ENT PR: https://github.com/hashicorp/vault-enterprise/pull/6515

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [x] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
