### PR TITLE
Add docs for github sync environment secrets

### DIFF
--- a/website/content/api-docs/system/secrets-sync.mdx
+++ b/website/content/api-docs/system/secrets-sync.mdx
@@ -856,7 +856,7 @@ custom GitHub application for syncing secrets with GitHub repositories.
 ### Parameters
 
 - `name` `(string: <required>)` - Specifies a custom name for the GitHub
-  application when configuring the sync destination. We recommend using the same 
+  application used when configuring a sync destination. We recommend using the same 
   app name configured in GitHub.
 
 - `app_id` `(string: <required>)` - Specifies the GitHub application ID, provided by GitHub.

--- a/website/content/api-docs/system/secrets-sync.mdx
+++ b/website/content/api-docs/system/secrets-sync.mdx
@@ -428,8 +428,9 @@ This endpoint creates a destination to synchronize action secrets with a GitHub 
   Use `access_token` as an alternative to authenticating with a GitHub app.
 
 - `app_name` `(string: <optional>)` - The name of a GitHub App configured in Vault to use for
-  authentication. Use `app_name` and `installation_id` as an alternative to
-  authenticating with an access token.
+  authentication. Use `app_name` and `installation_id` as an alternative to authenticating with
+  an access token. Refer to [this section](/vault/api-docs/system/secrets-sync#configure-a-custom-github-app)
+  for details on setting up a GitHub app in Vault.
 
   - `installation_id` `(string: <optional>)` - The installation ID of the GitHub
   app to use for authentication. Required when using `app_name` for
@@ -438,6 +439,9 @@ This endpoint creates a destination to synchronize action secrets with a GitHub 
 - `repository_owner` `(string: <required>)` - GitHub organization or username that owns the repository. For example, if a repository is located at https://github.com/hashicorp/vault.git the owner is hashicorp.
 
 - `repository_name` `(string: <required>)` - Name of the repository. For example, if a repository is located at https://github.com/hashicorp/vault.git the name is vault.
+
+  - `environment_name` `(string: <optional>)` - The name of a repository environment within the specified `repository_name`.
+  Defaults to no environment, meaning that a secret will be a repository secret if `environment_name` is not set. 
 
 - `secret_name_template` `(string: "")` - Template to use when generating the secret names on the external system.
 The default template yields names like `VAULT_KV_1234_MY_SECRET`. See [this documentation](/vault/docs/sync#name-template) for more details.
@@ -849,8 +853,8 @@ custom GitHub application for syncing secrets with GitHub repositories.
 
 ### Parameters
 
-- `name` `(string: <required>)` - Specifies a custom name for the GitHub
-application that is used when configuring the destination. Although this can be any name, we recommend using the same app name configured in GitHub.
+- `name` `(string: <required>)` - Specifies a custom name for the GitHub application that is used when configuring
+the destination. Although this can be any name, we recommend using the same app name configured in GitHub.
 
 - `app_id` `(string: <required>)` - Specifies the GitHub application ID, provided by GitHub.
 

--- a/website/content/api-docs/system/secrets-sync.mdx
+++ b/website/content/api-docs/system/secrets-sync.mdx
@@ -441,8 +441,9 @@ This endpoint creates a destination to synchronize action secrets with a GitHub 
 
 - `repository_name` `(string: <required>)` - Name of the repository. For example, if a repository is located at https://github.com/hashicorp/vault.git the name is vault.
 
-  - `environment_name` `(string: <optional>)` - The name of a repository environment within the specified `repository_name`.
-  Defaults to no environment, meaning that a secret will be a repository secret if `environment_name` is not set. 
+  - `environment_name` `(string: '')` - The name of a GitHub environment
+    within the repo specified by `repository_name`. By default, secrets are
+    global to the targeted repository. 
 
 - `secret_name_template` `(string: "")` - Template to use when generating the secret names on the external system.
 The default template yields names like `VAULT_KV_1234_MY_SECRET`. See [this documentation](/vault/docs/sync#name-template) for more details.

--- a/website/content/api-docs/system/secrets-sync.mdx
+++ b/website/content/api-docs/system/secrets-sync.mdx
@@ -428,9 +428,10 @@ This endpoint creates a destination to synchronize action secrets with a GitHub 
   Use `access_token` as an alternative to authenticating with a GitHub app.
 
 - `app_name` `(string: <optional>)` - The name of a GitHub App configured in Vault to use for
-  authentication. Use `app_name` and `installation_id` as an alternative to authenticating with
-  an access token. Refer to [this section](/vault/api-docs/system/secrets-sync#configure-a-custom-github-app)
-  for details on setting up a GitHub app in Vault.
+  authentication. You can use `app_name` with `installation_id` 
+  as authentication instead of an access token. Refer to the
+  [Configure a custom GitHub app section](/vault/api-docs/system/secrets-sync#configure-a-custom-github-app)
+  of the Secrets sync API docs for more information.
 
   - `installation_id` `(string: <optional>)` - The installation ID of the GitHub
   app to use for authentication. Required when using `app_name` for

--- a/website/content/api-docs/system/secrets-sync.mdx
+++ b/website/content/api-docs/system/secrets-sync.mdx
@@ -854,8 +854,9 @@ custom GitHub application for syncing secrets with GitHub repositories.
 
 ### Parameters
 
-- `name` `(string: <required>)` - Specifies a custom name for the GitHub application that is used when configuring
-the destination. Although this can be any name, we recommend using the same app name configured in GitHub.
+- `name` `(string: <required>)` - Specifies a custom name for the GitHub
+  application when configuring the sync destination. We recommend using the same 
+  app name configured in GitHub.
 
 - `app_id` `(string: <required>)` - Specifies the GitHub application ID, provided by GitHub.
 

--- a/website/content/docs/deprecation/index.mdx
+++ b/website/content/docs/deprecation/index.mdx
@@ -43,14 +43,14 @@ or raise a ticket with your support team.
 
 @include 'deprecation/vault-agent-api-proxy.mdx'
 
+@include 'deprecation/aws-field-change.mdx'
+
 @include 'deprecation/centrify-auth-method.mdx'
 
 </Tab>
 <Tab heading="REMOVED">
 
 @include 'deprecation/duplicative-docker-images.mdx'
-
-@include 'deprecation/aws-field-change.mdx'
 
 @include 'deprecation/azure-password-policy.mdx'
 

--- a/website/content/docs/sync/github.mdx
+++ b/website/content/docs/sync/github.mdx
@@ -4,9 +4,9 @@ page_title: GitHub - Secrets Sync Destination
 description: The GitHub destination syncs secrets from Vault to GitHub.
 ---
 
-# GitHub repository secrets
+# GitHub actions secrets
 
-The GitHub repository sync destination allows Vault to safely synchronize secrets as GitHub repository action secrets.
+The GitHub actions sync destination allows Vault to safely synchronize secrets as GitHub repository or environment secrets.
 This is a low footprint option that enables your applications to benefit from Vault-managed secrets without requiring them
 to connect directly with Vault. This guide walks you through the configuration process.
 
@@ -177,11 +177,11 @@ Then add your GitHub application to your Vault instance.
 
 To use your GitHub application with Vault:
 
-- the application must have permission to read and write secrets.
-- you must generate a private key for the application on GitHub.
-- the application must be installed on the repository you want to sync secrets with.
-- you must know the application ID assigned by GitHub.
-- you must know the installation ID assigned by GitHub.
+- The application must have permission to read and write secrets.
+- You must generate a private key for the application on GitHub.
+- The application must be installed on the repository you want to sync secrets with.
+- You must know the application ID assigned by GitHub.
+- You must know the installation ID assigned by GitHub.
 
 Callback, redirect URLs, and webhooks are not required at this time.
 
@@ -194,7 +194,7 @@ information:
 ```shell-session
 $ vault write sys/sync/github-apps/<APP_NAME> \
   app_id=<APP_ID> \
-  private_key=<PATH_TO_PRIVATE_KEY>
+  private_key=@/path/to/private/key
 
 Key            Value
 ---            -----

--- a/website/content/docs/sync/github.mdx
+++ b/website/content/docs/sync/github.mdx
@@ -158,13 +158,15 @@ or the association in Vault will delete the secret in GitHub as well.
 
 <Note>
 
-GitHub only supports single-value secrets. By default, GitHub destinations use a
-[granularity level](/vault/docs/sync#granularity) of `secret-key` so that KVv2 secrets from Vault will be split
-where key-value pairs are stored as distinct entries in GitHub secrets. If a granularity level of `secret-path` is
-chosen insteaad, the secret will be stored as a JSON string with each key-value pair contained within.
+GitHub only supports single-value secrets and stores secrets differently,
+depending on whether you have configured
+`secret-key` or `secret-path` [granularity](/vault/docs/sync#granularity):
 
-In the example above, the value for secret "my-secret" will be synced to GitHub as the JSON string
-`{"foo":"bar", "baz":"quux"}` if the destination is configured to use the `secret-path` granularity level.
+- `secret-key` granularity splits KVv2 secrets from Vault into key-value pairs
+  and stores the pairs as distinct entries in GitHub secrets. For example,
+  `secrets.foo="bar"` and `secrets.baz="quux"`.
+- `secret-path` granularity stores secrets as a single JSON string that contains
+  all of the associated key-value pairs. For example, `{"foo":"bar", "baz":"quux"}`.
 
 </Note>
 

--- a/website/content/docs/sync/github.mdx
+++ b/website/content/docs/sync/github.mdx
@@ -28,7 +28,7 @@ Prerequisites:
 </Warning>
 
 
-If you decide to go with an access token, here's how you can configure a sync destination:
+Using an access token to configure a repository sync destination:
 
   ```shell-session
   $ vault write sys/sync/destinations/gh/my-dest \
@@ -45,6 +45,30 @@ If you decide to go with an access token, here's how you can configure a sync de
   Key                   Value
   ---                   -----
   connection_details    map[access_token:***** repository_owner:<owner> repository_name:<name>]
+  name                  my-dest
+  type                  gh
+  ```
+
+  </CodeBlockConfig>
+
+  Configure an environment sync destination:
+
+  ```shell-session
+  $ vault write sys/sync/destinations/gh/my-dest \
+      access_token="$ACCESS_TOKEN" \
+      repository_owner="$OWNER" \
+      repository_name="$NAME"
+      environment_name="$ENVIRONMENT"
+  ```
+
+  **Output:**
+
+  <CodeBlockConfig hideClipboard>
+
+  ```plaintext
+  Key                   Value
+  ---                   -----
+  connection_details    map[access_token:***** environment_name:<environment> repository_owner:<owner> repository_name:<name>]
   name                  my-dest
   type                  gh
   ```
@@ -72,7 +96,7 @@ If you decide to go with an access token, here's how you can configure a sync de
 1. Create secrets you wish to sync with a target GitHub repository for Actions.
 
   ```shell-session
-  $ vault kv put -mount='my-kv' my-secret foo='bar'
+  $ vault kv put -mount='my-kv' my-secret foo='bar' baz='quux'
   ```
 
   **Output:**
@@ -99,8 +123,8 @@ If you decide to go with an access token, here's how you can configure a sync de
 
   ```shell-session
   $ vault write sys/sync/destinations/gh/my-dest/associations/set \
-      mount=my-kv \
-      secret_name=my-secret
+      mount='my-kv' \
+      secret_name='my-secret'
   ```
 
   **Output:**
@@ -127,9 +151,13 @@ or the association in Vault will delete the secret in GitHub as well.
 
 <Note>
 
-GitHub only supports single value secrets, so KVv2 secrets from Vault will be stored as a JSON string.
-In the example above, the value for secret "my-secret" will be synced to GitHub as the JSON string `{"foo":"bar"}` if the
-destination is configured to use the `secret-path` [granularity level](/vault/docs/sync#granularity).
+GitHub only supports single-value secrets. By default, GitHub destinations use a
+[granularity level](/vault/docs/sync#granularity) of `secret-key` so that KVv2 secrets from Vault will be split
+where key-value pairs are stored as distinct entries in GitHub secrets. If a granularity level of `secret-path` is
+chosen insteaad, the secret will be stored as a JSON string with each key-value pair contained within.
+
+In the example above, the value for secret "my-secret" will be synced to GitHub as the JSON string
+`{"foo":"bar", "baz":"quux"}` if the destination is configured to use the `secret-path` granularity level.
 
 </Note>
 

--- a/website/content/docs/sync/github.mdx
+++ b/website/content/docs/sync/github.mdx
@@ -51,29 +51,36 @@ Using an access token to configure a repository sync destination:
 
   </CodeBlockConfig>
 
-  Configure an environment sync destination:
+  Use `vault write` to configure an environment sync destination:
 
   ```shell-session
-  $ vault write sys/sync/destinations/gh/my-dest \
-      access_token="$ACCESS_TOKEN" \
-      repository_owner="$OWNER" \
-      repository_name="$NAME"
-      environment_name="$ENVIRONMENT"
+  $ vault write sys/sync/destinations/gh/DESTINATION_NAME \
+      access_token="GITHUB_ACCESS_TOKEN"                  \
+      repository_owner="GITHUB_OWNER_NAME"                \
+      repository_name="GITHUB_REPO_NAME"                  \
+      environment_name="GITHUB_ENVIRONMENT_NAME"
   ```
-
-  **Output:**
+  
+  For example:
 
   <CodeBlockConfig hideClipboard>
+  
+  ```
+  $ vault write sys/sync/destinations/gh/hcrepo-sandbox       \
+      access_token="0000000000000000000000000000000000000000" \
+      repository_owner="hashicorp"                            \
+      repository_name="hcrepo"                                \
+      environment_name="sandbox"
 
-  ```plaintext
   Key                   Value
   ---                   -----
-  connection_details    map[access_token:***** environment_name:<environment> repository_owner:<owner> repository_name:<name>]
-  name                  my-dest
+  connection_details    map[access_token:***** environment_name:sandbox repository_owner:hashicorp repository_name:hcrepo]
+  name                  hcrepo-sandbox
   type                  gh
   ```
 
   </CodeBlockConfig>
+
 
 ## Usage
 

--- a/website/content/docs/sync/github.mdx
+++ b/website/content/docs/sync/github.mdx
@@ -17,7 +17,7 @@ Prerequisites:
 
 ## Setup
 
-1. To get started with syncing Vault secrets to your GitHub repository, you will need a configured [GitHub application](#github-application) or an
+1. To get started with syncing Vault secrets to your GitHub, you will need a configured [GitHub application](#github-application) or an
   [access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens)
   which has access to the repository you want to manage secrets for and write permissions on the repository's actions secrets.
   In the list of GitHub permissions, this is simply called "Secrets". Choosing this will automatically include read-only Metadata.
@@ -27,25 +27,29 @@ Prerequisites:
   GitHub applications are long-lived and do not expire. Using a GitHub application for authentication is preferred over using a personal access token.
 </Warning>
 
-
-Using an access token to configure a repository sync destination:
+Use `vault write` to configure a repository sync destination with an access token:
 
   ```shell-session
-  $ vault write sys/sync/destinations/gh/my-dest \
-      access_token="$ACCESS_TOKEN" \
-      repository_owner="$OWNER" \
-      repository_name="$NAME"
+  $ vault write sys/sync/destinations/gh/DESTINATION_NAME \
+      access_token="GITHUB_ACCESS_TOKEN"                  \
+      repository_owner="GITHUB_OWNER_NAME"                \
+      repository_name="GITHUB_REPO_NAME"
   ```
-
-  **Output:**
+  
+  For example:
 
   <CodeBlockConfig hideClipboard>
+  
+  ```
+  $ vault write sys/sync/destinations/gh/hcrepo-sandbox       \
+      access_token="github_pat_11ABC000000000000000000000DEF" \
+      repository_owner="hashicorp"                            \
+      repository_name="hcrepo"
 
-  ```plaintext
   Key                   Value
   ---                   -----
-  connection_details    map[access_token:***** repository_owner:<owner> repository_name:<name>]
-  name                  my-dest
+  connection_details    map[access_token:***** repository_owner:hashicorp repository_name:hcrepo]
+  name                  hcrepo-sandbox
   type                  gh
   ```
 
@@ -67,7 +71,7 @@ Using an access token to configure a repository sync destination:
   
   ```
   $ vault write sys/sync/destinations/gh/hcrepo-sandbox       \
-      access_token="0000000000000000000000000000000000000000" \
+      access_token="github_pat_11ABC000000000000000000000DEF" \
       repository_owner="hashicorp"                            \
       repository_name="hcrepo"                                \
       environment_name="sandbox"
@@ -103,7 +107,7 @@ Using an access token to configure a repository sync destination:
 1. Create secrets you wish to sync with a target GitHub repository for Actions.
 
   ```shell-session
-  $ vault kv put -mount='my-kv' my-secret foo='bar' baz='quux'
+  $ vault kv put -mount='my-kv' my-secret key1='val1' key2='val2'
   ```
 
   **Output:**
@@ -150,7 +154,7 @@ Using an access token to configure a repository sync destination:
 
 1. Navigate to your GitHub repository settings to confirm your secret was successfully created.
 
-Moving forward, any modification on the Vault secret will be propagated in near real time to its GitHub repository secrets
+Moving forward, any modification on the Vault secret will be propagated in near-real time to its GitHub secrets
 counterpart. Creating a new secret version in Vault will create a new version in GitHub. Deleting the secret
 or the association in Vault will delete the secret in GitHub as well.
 
@@ -158,15 +162,15 @@ or the association in Vault will delete the secret in GitHub as well.
 
 <Note>
 
-GitHub only supports single-value secrets and stores secrets differently,
+GitHub only supports single-value secrets, and Vault syncs secrets differently
 depending on whether you have configured
 `secret-key` or `secret-path` [granularity](/vault/docs/sync#granularity):
 
 - `secret-key` granularity splits KVv2 secrets from Vault into key-value pairs
   and stores the pairs as distinct entries in GitHub secrets. For example,
-  `secrets.foo="bar"` and `secrets.baz="quux"`.
+  `secrets.key1="val1"` and `secrets.key2="val2"`.
 - `secret-path` granularity stores secrets as a single JSON string that contains
-  all of the associated key-value pairs. For example, `{"foo":"bar", "baz":"quux"}`.
+  all of the associated key-value pairs. For example, `{"key1":"val1", "key2":"val2"}`.
 
 </Note>
 


### PR DESCRIPTION
### Description
Add docs for github sync environment secrets

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [ ] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
