### PR TITLE
CI: add back chrome version pin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,6 +165,9 @@ jobs:
           cache: yarn
           cache-dependency-path: ui/yarn.lock
       - uses: browser-actions/setup-chrome@facf10a55b9caf92e0cc749b4f82bf8220989148 # v1.7.2
+        with:
+          # Temporarily pin our Chrome version while we sort out a broken test on latest
+          chrome-version: 1314712
       - name: ui-dependencies
         working-directory: ./ui
         run: |


### PR DESCRIPTION
### Description
Reverts #28159 and adds back the pinned chrome version. Without it we are seeing a lot of failed tests (specifically on enterprise, like [this](https://github.com/hashicorp/vault-enterprise/actions/runs/10531689862)). Also, Ryan has [resolved](https://github.com/hashicorp/vault/pull/28177) 🤞🏻 the wrapped_token flakiness that we were seeing in CE
