### PR TITLE
VAULT-28477 Bootstrap and persist autopilot versions

### DIFF
--- a/changelog/28186.txt
+++ b/changelog/28186.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+raft/autopilot: Persist Raft server versions so autopilot always knows the versions of all servers in the cluster. Include server versions in the Raft bootstrap challenge answer so autopilot immediately knows the versions of new nodes.
+```

--- a/physical/raft/raft.go
+++ b/physical/raft/raft.go
@@ -690,6 +690,12 @@ func (b *RaftBackend) UpgradeVersion() string {
 	return b.effectiveSDKVersion
 }
 
+func (b *RaftBackend) SDKVersion() string {
+	b.l.RLock()
+	defer b.l.RUnlock()
+	return b.effectiveSDKVersion
+}
+
 func (b *RaftBackend) verificationInterval() time.Duration {
 	b.l.RLock()
 	defer b.l.RUnlock()

--- a/physical/raft/raft_autopilot.go
+++ b/physical/raft/raft_autopilot.go
@@ -433,21 +433,6 @@ func (d *Delegate) KnownServers() map[raft.ServerID]*autopilot.Server {
 		// be the SDK version, not the upgrade version.
 		currentServerID := raft.ServerID(id)
 		followerVersion := state.Version
-		leaderVersion := d.effectiveSDKVersion
-		d.dl.Lock()
-		if followerVersion == "" {
-			if _, ok := d.emptyVersionLogs[currentServerID]; !ok {
-				d.logger.Trace("received empty Vault version in heartbeat state. faking it with the leader version for now", "id", id, "leader version", leaderVersion)
-				d.emptyVersionLogs[currentServerID] = struct{}{}
-			}
-			followerVersion = leaderVersion
-		} else {
-			if _, ok := d.emptyVersionLogs[currentServerID]; ok {
-				d.logger.Trace("received non-empty version in heartbeat state. no longer need to fake it", "id", id, "update_version", followerVersion)
-				delete(d.emptyVersionLogs, currentServerID)
-			}
-		}
-		d.dl.Unlock()
 
 		server := &autopilot.Server{
 			ID:          currentServerID,

--- a/vault/external_tests/raft/raft_test.go
+++ b/vault/external_tests/raft/raft_test.go
@@ -64,6 +64,7 @@ func raftClusterBuilder(t testing.TB, ropts *RaftClusterOpts) (*vault.CoreConfig
 		DisableAutopilot:               !ropts.EnableAutopilot,
 		EnableResponseHeaderRaftNodeID: ropts.EnableResponseHeaderRaftNodeID,
 		Seal:                           ropts.Seal,
+		EnableRaw:                      true,
 	}
 
 	opts := vault.TestClusterOptions{

--- a/vault/logical_system_raft.go
+++ b/vault/logical_system_raft.go
@@ -50,6 +50,12 @@ func (b *SystemBackend) raftStoragePaths() []*framework.Path {
 				"non_voter": {
 					Type: framework.TypeBool,
 				},
+				"upgrade_version": {
+					Type: framework.TypeString,
+				},
+				"sdk_version": {
+					Type: framework.TypeString,
+				},
 			},
 
 			Operations: map[logical.Operation]framework.OperationHandler{
@@ -370,6 +376,8 @@ func (b *SystemBackend) handleRaftBootstrapAnswerWrite() framework.OperationFunc
 		added := b.Core.raftFollowerStates.Update(&raft.EchoRequestUpdate{
 			NodeID:          serverID,
 			DesiredSuffrage: desiredSuffrage,
+			SDKVersion:      d.Get("sdk_version").(string),
+			UpgradeVersion:  d.Get("upgrade_version").(string),
 		})
 
 		switch nonVoter {

--- a/vault/raft.go
+++ b/vault/raft.go
@@ -1321,10 +1321,12 @@ func (c *Core) joinRaftSendAnswer(ctx context.Context, sealAccess seal.Access, r
 
 	answerReq := raftInfo.leaderClient.NewRequest("PUT", "/v1/sys/storage/raft/bootstrap/answer")
 	if err := answerReq.SetJSONBody(map[string]interface{}{
-		"answer":       base64.StdEncoding.EncodeToString(plaintext),
-		"cluster_addr": clusterAddr,
-		"server_id":    raftBackend.NodeID(),
-		"non_voter":    raftInfo.nonVoter,
+		"answer":          base64.StdEncoding.EncodeToString(plaintext),
+		"cluster_addr":    clusterAddr,
+		"server_id":       raftBackend.NodeID(),
+		"non_voter":       raftInfo.nonVoter,
+		"sdk_version":     raftBackend.SDKVersion(),
+		"upgrade_version": raftBackend.UpgradeVersion(),
 	}); err != nil {
 		return err
 	}

--- a/vault/raft.go
+++ b/vault/raft.go
@@ -26,6 +26,7 @@ import (
 	"github.com/hashicorp/go-uuid"
 	goversion "github.com/hashicorp/go-version"
 	"github.com/hashicorp/vault/api"
+	httpPriority "github.com/hashicorp/vault/http/priority"
 	"github.com/hashicorp/vault/physical/raft"
 	"github.com/hashicorp/vault/sdk/helper/jsonutil"
 	"github.com/hashicorp/vault/sdk/logical"
@@ -373,7 +374,7 @@ func (c *Core) saveAutopilotPersistedState(states map[string]raft.PersistedFollo
 	if err != nil {
 		return err
 	}
-	return c.barrier.Put(c.activeContext, entry)
+	return c.barrier.Put(httpPriority.ContextWithRequestPriority(c.activeContext, httpPriority.NeverDrop), entry)
 }
 
 func (c *Core) stopRaftActiveNode() {


### PR DESCRIPTION
### Description
When setting up Raft and autopilot, the leader node will read a storage entry (`core/raft/autopilot/states`), which has a map of server IDs to upgrade and sdk versions. Autopilot will store this map in memory in a structure called `persistedStates`. If the storage entry does not exist, an error is logged but operation continues.

Whenever the autopilot library calls `NotifyStates` to inform the vault delegate that a state has changed, the leader will check to see if the cluster membership differs from what is in the `persistedStates` map, or if the upgrade version or sdk version differs from the `persistedStates` map. If either of these conditions is true, `persistedStates` is updated and written to storage at the path `core/raft/autopilot/states`.

`core/raft/autopilot/states` is not replicated to performance or DR secondaries.

New nodes joining a cluster will include their sdk version and upgrade version when they answer the Raft bootstrap challenge. When the active node receives this answer, the versions will be stored (along with the other server state) in the follower states map.

When autopilot routinely calls `KnownServers` to get information about the nodes in the cluster, the leader will:
* Check for follower versions in the follower states map. Use these versions if they exist. Otherwise,
* Check for versions in the persisted states map. Use these versions if they exist. Otherwise,
* Check if the persisted states map is empty, indicating a new upgrade to 1.18. Use the leader versions if this is true. Otherwise,
* Return empty versions for these servers.

The persisted states need to exist in order to ensure that a new leader doesn’t demote existing voters if their heartbeat is late. If the persisted states weren’t available, a new leader wouldn’t have any knowledge of the other node’s versions until the heartbeats happened.

Ent PR: https://github.com/hashicorp/vault-enterprise/pull/6351
Doc: https://docs.google.com/document/d/10MY9U-r8dH46-ICIdrObEjVfHKwQxLzqzh33YWWnYrQ/edit

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [ ] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
