### PR TITLE
UI (sidebranch) WIF Issuer field

### DIFF
--- a/ui/app/components/secret-engine/configure-aws.hbs
+++ b/ui/app/components/secret-engine/configure-aws.hbs
@@ -55,6 +55,17 @@
       </fieldset>
     {{/if}}
     {{#if (eq this.accessType "wif")}}
+      <FormField
+        @model={{this.issuerConfig}}
+        @attr={{hash
+          name="issuer"
+          type="string"
+          options=(hash
+            placeholder="https://vault.prod/v1/identity/oidc"
+            subText="The Issuer URL to be used in configuring Vault as an identity provider in AWS. If not set, Vault's default issuer will be used."
+          )
+        }}
+      />
       <FormFieldGroups
         @model={{@rootConfig}}
         @mode={{if @rootConfig.isNew "create" "edit"}}

--- a/ui/app/components/secret-engine/configure-aws.hbs
+++ b/ui/app/components/secret-engine/configure-aws.hbs
@@ -3,7 +3,7 @@
   SPDX-License-Identifier: BUSL-1.1
 ~}}
 
-<form {{on "submit" (perform this.save)}} aria-label="save aws creds" data-test-root-form>
+<form {{on "submit" (perform this.submitForm)}} aria-label="save aws creds" data-test-root-form>
   <div class="box is-fullwidth is-shadowless is-marginless">
     <NamespaceReminder @mode="save" @noun="configuration" />
     <MessageError @errorMessage={{this.errorMessageRoot}} />
@@ -63,6 +63,7 @@
           options=(hash
             placeholder="https://vault.prod/v1/identity/oidc"
             subText="The Issuer URL to be used in configuring Vault as an identity provider in AWS. If not set, Vault's default issuer will be used."
+            docLink="/vault/api-docs/secret/identity/tokens#configure-the-identity-tokens-backend"
           )
         }}
       />
@@ -123,7 +124,7 @@
 </form>
 
 {{#if this.saveIssuerWarning}}
-  <Hds::Modal @color="warning" @onClose={{this.cancelSave}} data-test-issuer-warning as |M|>
+  <Hds::Modal @color="warning" @onClose={{action (mut this.saveIssuerWarning) ""}} data-test-issuer-warning as |M|>
     <M.Header @icon="alert-circle">
       Are you sure?
     </M.Header>
@@ -134,8 +135,13 @@
     </M.Body>
     <M.Footer>
       <Hds::ButtonSet>
-        <Hds::Button @text="Continue" {{on "click" (action (mut this.saveIssuerWarning) "")}} data-test-issuer-save />
-        <Hds::Button @text="Cancel" @color="secondary" {{on "click" this.cancelSave}} data-test-issuer-cancel />
+        <Hds::Button @text="Continue" {{on "click" (perform this.save)}} data-test-issuer-save />
+        <Hds::Button
+          @text="Cancel"
+          @color="secondary"
+          {{on "click" (action (mut this.saveIssuerWarning) "")}}
+          data-test-issuer-cancel
+        />
       </Hds::ButtonSet>
     </M.Footer>
   </Hds::Modal>

--- a/ui/app/components/secret-engine/configure-aws.hbs
+++ b/ui/app/components/secret-engine/configure-aws.hbs
@@ -121,3 +121,22 @@
     {{/if}}
   </div>
 </form>
+
+{{#if this.saveIssuerWarning}}
+  <Hds::Modal id="rotate-credentials-modal" @onClose={{this.cancelSave}} data-test-issuer-warning as |M|>
+    <M.Header @icon="info">
+      Save global issuer?
+    </M.Header>
+    <M.Body>
+      <p class="has-bottom-margin-s">
+        {{this.saveIssuerWarning}}
+      </p>
+    </M.Body>
+    <M.Footer>
+      <Hds::ButtonSet>
+        <Hds::Button @text="Continue" {{on "click" (action (mut this.saveIssuerWarning) false)}} data-test-save-issuer />
+        <Hds::Button @text="Cancel" @color="secondary" {{on "click" this.cancelSave}} data-test-cancel />
+      </Hds::ButtonSet>
+    </M.Footer>
+  </Hds::Modal>
+{{/if}}

--- a/ui/app/components/secret-engine/configure-aws.hbs
+++ b/ui/app/components/secret-engine/configure-aws.hbs
@@ -135,10 +135,11 @@
     </M.Body>
     <M.Footer>
       <Hds::ButtonSet>
-        <Hds::Button @text="Continue" {{on "click" (perform this.save)}} data-test-issuer-save />
+        <Hds::Button @text="Continue" {{on "click" this.continueSubmitForm}} data-test-issuer-save />
         <Hds::Button
           @text="Cancel"
           @color="secondary"
+          {{! clear the warning and return to form }}
           {{on "click" (action (mut this.saveIssuerWarning) "")}}
           data-test-issuer-cancel
         />

--- a/ui/app/components/secret-engine/configure-aws.hbs
+++ b/ui/app/components/secret-engine/configure-aws.hbs
@@ -133,16 +133,10 @@
         {{this.saveIssuerWarning}}
       </p>
     </M.Body>
-    <M.Footer>
+    <M.Footer as |F|>
       <Hds::ButtonSet>
         <Hds::Button @text="Continue" {{on "click" this.continueSubmitForm}} data-test-issuer-save />
-        <Hds::Button
-          @text="Cancel"
-          @color="secondary"
-          {{! clear the warning and return to form }}
-          {{on "click" (action (mut this.saveIssuerWarning) "")}}
-          data-test-issuer-cancel
-        />
+        <Hds::Button @text="Cancel" @color="secondary" {{on "click" F.close}} data-test-issuer-cancel />
       </Hds::ButtonSet>
     </M.Footer>
   </Hds::Modal>

--- a/ui/app/components/secret-engine/configure-aws.hbs
+++ b/ui/app/components/secret-engine/configure-aws.hbs
@@ -134,8 +134,8 @@
     </M.Body>
     <M.Footer>
       <Hds::ButtonSet>
-        <Hds::Button @text="Continue" {{on "click" (action (mut this.saveIssuerWarning) false)}} data-test-save-issuer />
-        <Hds::Button @text="Cancel" @color="secondary" {{on "click" this.cancelSave}} data-test-cancel />
+        <Hds::Button @text="Continue" {{on "click" (action (mut this.saveIssuerWarning) "")}} data-test-issuer-save />
+        <Hds::Button @text="Cancel" @color="secondary" {{on "click" this.cancelSave}} data-test-issuer-cancel />
       </Hds::ButtonSet>
     </M.Footer>
   </Hds::Modal>

--- a/ui/app/components/secret-engine/configure-aws.hbs
+++ b/ui/app/components/secret-engine/configure-aws.hbs
@@ -123,9 +123,9 @@
 </form>
 
 {{#if this.saveIssuerWarning}}
-  <Hds::Modal id="rotate-credentials-modal" @onClose={{this.cancelSave}} data-test-issuer-warning as |M|>
-    <M.Header @icon="info">
-      Save global issuer?
+  <Hds::Modal @color="warning" @onClose={{this.cancelSave}} data-test-issuer-warning as |M|>
+    <M.Header @icon="alert-circle">
+      Are you sure?
     </M.Header>
     <M.Body>
       <p class="has-bottom-margin-s">

--- a/ui/app/components/secret-engine/configure-aws.ts
+++ b/ui/app/components/secret-engine/configure-aws.ts
@@ -114,7 +114,7 @@ export default class ConfigureAwsComponent extends Component<Args> {
         // show modal with warning that the config will change
         // if the modal is shown, the user has to click confirm to continue save
         this.saveIssuerWarning = `You are updating the global issuer config. This will overwrite Vault's current issuer ${
-          this.issuerConfig.noRead && 'if it exists '
+          this.issuerConfig.noRead ? 'if it exists ' : ''
         }and may affect other configurations using this value. Continue?`;
         return;
       }

--- a/ui/app/routes/vault/cluster/secrets/backend/configuration/edit.ts
+++ b/ui/app/routes/vault/cluster/secrets/backend/configuration/edit.ts
@@ -74,7 +74,7 @@ export default class SecretsBackendConfigurationEdit extends Route {
       try {
         const adapter = this.store.adapterFor('application');
         const response = await adapter.ajax('/v1/identity/oidc/config', 'GET');
-        model['issuer'] = response.issuer;
+        model['issuer'] = response.data.issuer;
       } catch (e) {
         model['issuer'] = 'no-read';
       }

--- a/ui/app/routes/vault/cluster/secrets/backend/configuration/edit.ts
+++ b/ui/app/routes/vault/cluster/secrets/backend/configuration/edit.ts
@@ -69,6 +69,7 @@ export default class SecretsBackendConfigurationEdit extends Route {
       }
     }
     // if the type is AWS and it's enterprise, we also fetch the issuer
+    // from a global endpoint which has no associated model/adapter
     if (type === 'aws' && this.version.isEnterprise) {
       try {
         const adapter = this.store.adapterFor('application');

--- a/ui/app/routes/vault/cluster/secrets/backend/configuration/edit.ts
+++ b/ui/app/routes/vault/cluster/secrets/backend/configuration/edit.ts
@@ -73,7 +73,7 @@ export default class SecretsBackendConfigurationEdit extends Route {
       try {
         const adapter = this.store.adapterFor('application');
         const response = await adapter.ajax('/v1/identity/oidc/config', 'GET');
-        model['issuer'] = response.issuer || 'foo-bar';
+        model['issuer'] = response.issuer;
       } catch (e) {
         model['issuer'] = 'no-read';
       }

--- a/ui/app/routes/vault/cluster/secrets/backend/configuration/edit.ts
+++ b/ui/app/routes/vault/cluster/secrets/backend/configuration/edit.ts
@@ -28,8 +28,8 @@ export default class SecretsBackendConfigurationEdit extends Route {
 
   async model() {
     const { backend } = this.paramsFor('vault.cluster.secrets.backend');
-    const secretEngineRecord = this.modelFor('vault.cluster.secrets.backend') as { type: SecretEngineModel };
-    const type = secretEngineRecord.type as string;
+    const secretEngineRecord = this.modelFor('vault.cluster.secrets.backend') as SecretEngineModel;
+    const type = secretEngineRecord.type;
 
     // if the engine type is not configurable, return a 404.
     if (!secretEngineRecord || !CONFIGURABLE_SECRET_ENGINES.includes(type)) {

--- a/ui/app/templates/vault/cluster/secrets/backend/configuration/edit.hbs
+++ b/ui/app/templates/vault/cluster/secrets/backend/configuration/edit.hbs
@@ -33,6 +33,7 @@
     @leaseConfig={{this.model.aws-lease-config}}
     @rootConfig={{this.model.aws-root-config}}
     @backendPath={{this.model.id}}
+    @issuer={{this.model.issuer}}
   />
 {{else if (eq this.model.type "ssh")}}
   <SecretEngine::ConfigureSsh @model={{this.model.ssh-ca-config}} @id={{this.model.id}} />

--- a/ui/lib/core/addon/components/form-field.hbs
+++ b/ui/lib/core/addon/components/form-field.hbs
@@ -322,6 +322,7 @@
           disabled={{and @attr.options.editDisabled (not @model.isNew)}}
           autocomplete="off"
           spellcheck="false"
+          placeholder={{@attr.options.placeholder}}
           value={{get @model this.valuePath}}
           {{on "change" this.onChangeWithEvent}}
           {{on "input" this.onChangeWithEvent}}

--- a/ui/tests/helpers/secret-engine/secret-engine-selectors.ts
+++ b/ui/tests/helpers/secret-engine/secret-engine-selectors.ts
@@ -31,6 +31,9 @@ export const SECRET_ENGINE_SELECTORS = {
     accessTypeSection: '[data-test-access-type-section]',
     accessTypeSubtext: '[data-test-access-type-subtext]',
     accessType: (type: string) => `[data-test-access-type="${type}"]`,
+    issuerWarningModal: '[data-test-issuer-warning]',
+    issuerWarningSave: '[data-test-save-issuer]',
+    issuerWarningCancel: '[data-test-cancel-issuer]',
   },
   ssh: {
     configureForm: '[data-test-configure-form]',

--- a/ui/tests/helpers/secret-engine/secret-engine-selectors.ts
+++ b/ui/tests/helpers/secret-engine/secret-engine-selectors.ts
@@ -32,8 +32,8 @@ export const SECRET_ENGINE_SELECTORS = {
     accessTypeSubtext: '[data-test-access-type-subtext]',
     accessType: (type: string) => `[data-test-access-type="${type}"]`,
     issuerWarningModal: '[data-test-issuer-warning]',
-    issuerWarningSave: '[data-test-save-issuer]',
-    issuerWarningCancel: '[data-test-cancel-issuer]',
+    issuerWarningSave: '[data-test-issuer-save]',
+    issuerWarningCancel: '[data-test-issuer-cancel]',
   },
   ssh: {
     configureForm: '[data-test-configure-form]',

--- a/ui/tests/integration/components/form-field-test.js
+++ b/ui/tests/integration/components/form-field-test.js
@@ -250,10 +250,14 @@ module('Integration | Component | form field', function (hooks) {
     assert.strictEqual(component.fields.objectAt(0).labelValue, 'Not Foo', 'renders the label from options');
   });
 
-  test('it renders a help tooltip', async function (assert) {
-    await setup.call(this, createAttr('foo', 'string', { helpText: 'Here is some help text' }));
+  test('it renders a help tooltip and placeholder', async function (assert) {
+    await setup.call(
+      this,
+      createAttr('foo', 'string', { helpText: 'Here is some help text', placeholder: 'example::value' })
+    );
     await component.tooltipTrigger();
     assert.ok(component.hasTooltip, 'renders the tooltip component');
+    assert.dom('[data-test-input="foo"]').hasAttribute('placeholder', 'example::value');
   });
 
   test('it should not expand and toggle ttl when default 0s value is present', async function (assert) {

--- a/ui/tests/integration/components/secret-engine/configure-aws-test.js
+++ b/ui/tests/integration/components/secret-engine/configure-aws-test.js
@@ -251,7 +251,7 @@ module('Integration | Component | SecretEngine/ConfigureAws', function (hooks) {
         assert.dom(SES.aws.issuerWarningModal).doesNotExist();
         assert.true(this.flashDangerSpy.notCalled, 'No danger flash messages called.');
         assert.true(this.flashSuccessSpy.notCalled, 'No success flash messages called.');
-        assert.true(this.transitionStub.notCalled(), 'Does not redirect');
+        assert.true(this.transitionStub.notCalled, 'Does not redirect');
       });
 
       test('it shows modal when updating issuer from no read and calls correct APIs on save', async function (assert) {
@@ -275,6 +275,8 @@ module('Integration | Component | SecretEngine/ConfigureAws', function (hooks) {
         await click(GENERAL.saveButton);
         assert.dom(SES.aws.issuerWarningModal).exists();
         await click(SES.aws.issuerWarningSave);
+
+        // TODO: these aren't working correctly
         assert.true(this.flashDangerSpy.notCalled, 'No danger flash messages called.');
         assert.true(
           this.flashSuccessSpy.calledWith('Issuer was saved'),
@@ -302,8 +304,9 @@ module('Integration | Component | SecretEngine/ConfigureAws', function (hooks) {
         await click(GENERAL.saveButton);
         assert.dom(SES.aws.issuerWarningModal).exists();
         await click(SES.aws.issuerWarningSave);
+        // TODO: these aren't working correctly
         assert.true(
-          this.flashDangerSpy.calledWith('Issuer was not saved'),
+          this.flashDangerSpy.calledWith('Issuer was not saved: permission denied'),
           'shows danger flash for issuer save'
         );
         assert.true(this.flashSuccessSpy.notCalled, 'No success flash messages called.');

--- a/ui/types/vault/models/aws/lease-config.d.ts
+++ b/ui/types/vault/models/aws/lease-config.d.ts
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import Model from '@ember-data/model';
+import type { ModelValidations } from 'vault/vault/app-types';
+
+export default class AwsLeaseConfig extends Model {
+  backend: any;
+  leaseMax: any;
+  lease: any;
+  get attrs(): string[];
+  // for some reason the following Model attrs don't exist on the Model definition
+  changedAttributes(): {
+    [key: string]: unknown[];
+  };
+  isNew: boolean;
+  save(): void;
+  unloadRecord(): void;
+  validate(): ModelValidations;
+}

--- a/ui/types/vault/models/aws/root-config.d.ts
+++ b/ui/types/vault/models/aws/root-config.d.ts
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import type Model from '@ember-data/model';
+
+export default class AwsRootConfig extends Model {
+  backend: any;
+  accessKey: any;
+  secretKey: any;
+  roleArn: any;
+  identityTokenAudience: any;
+  identityTokenTtl: any;
+  region: any;
+  iamEndpoint: any;
+  stsEndpoint: any;
+  maxRetries: any;
+  get attrs(): any;
+  get fieldGroupsWif(): any;
+  get fieldGroupsIam(): any;
+  formFieldGroups(accessType?: string): {
+    [key: string]: string[];
+  }[];
+  // for some reason the following Model attrs don't exist on the Model definition
+  changedAttributes(): {
+    [key: string]: unknown[];
+  };
+  isNew: boolean;
+  save(): void;
+  unloadRecord(): void;
+}


### PR DESCRIPTION
### Description
This PR adds a WIF-only field `issuer` to the AWS configure form. This value is read and written to a [global endpoint](https://developer.hashicorp.com/vault/api-docs/secret/identity/tokens#read-configurations-for-the-identity-tokens-backend), not part of the AWS configuration models. On the configuration edit route we attempt to read this value if it's enterprise + AWS, and pass the currently configured value to the form component so a user can choose to update it. 

The field has a placeholder when issuer is not set or can't be read: 
![image](https://github.com/user-attachments/assets/b60e2387-39e7-45ed-bead-48e89049559c)

When the issuer could not be read, but the user updates it the modal says:
![image](https://github.com/user-attachments/assets/ff01c222-b7fe-416c-9e6c-1792cb5a71b1)

Otherwise when the value is changed, the modal says: 
![image](https://github.com/user-attachments/assets/0580f691-3b0f-4823-b394-20e00ee1b98a)

- [x] Ent tests passed