### PR TITLE
UI: remove renew self call after login

### DIFF
--- a/changelog/28204.txt
+++ b/changelog/28204.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: fixes renew-self being called right after login for non-renewable tokens
+```

--- a/ui/app/components/auth-jwt.js
+++ b/ui/app/components/auth-jwt.js
@@ -87,6 +87,8 @@ export default Component.extend({
     this.onError(err);
   },
 
+  // NOTE TO DEVS: Be careful when updating the OIDC flow and ensure the updates
+  // work with implicit flow. See issue https://github.com/hashicorp/vault-plugin-auth-jwt/pull/192
   prepareForOIDC: task(function* (oidcWindow) {
     const thisWindow = this.getWindow();
     // show the loading animation in the parent

--- a/ui/app/services/auth.js
+++ b/ui/app/services/auth.js
@@ -390,7 +390,7 @@ export default Service.extend({
     const now = this.now();
     this.set('lastFetch', timestamp);
     // if expiration was allowed and we're over half the ttl we want to go ahead and renew here
-    if (this.allowExpiration && now >= this.renewAfterEpoch) {
+    if (this.allowExpiration && this.renewAfterEpoch && now >= this.renewAfterEpoch) {
       this.renew();
     }
     this.set('allowExpiration', false);

--- a/ui/tests/acceptance/auth-test.js
+++ b/ui/tests/acceptance/auth-test.js
@@ -6,8 +6,9 @@
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { click, currentURL, visit, waitUntil, find, fillIn } from '@ember/test-helpers';
-import { allSupportedAuthBackends, supportedAuthBackends } from 'vault/helpers/supported-auth-backends';
 import { setupMirage } from 'ember-cli-mirage/test-support';
+import { allSupportedAuthBackends, supportedAuthBackends } from 'vault/helpers/supported-auth-backends';
+import VAULT_KEYS from 'vault/tests/helpers/vault-keys';
 
 const AUTH_FORM = {
   method: '[data-test-select=auth-method]',
@@ -15,6 +16,7 @@ const AUTH_FORM = {
   login: '[data-test-auth-submit]',
 };
 const ENT_AUTH_METHODS = ['saml'];
+const { rootToken } = VAULT_KEYS;
 
 module('Acceptance | auth', function (hooks) {
   setupApplicationTest(hooks);
@@ -192,5 +194,19 @@ module('Acceptance | auth', function (hooks) {
     await visit('/vault/auth');
     await fillIn(AUTH_FORM.method, 'token');
     await click('[data-test-auth-submit]');
+  });
+
+  test('it does not call renew-self after successful login with non-renewable token', async function (assert) {
+    assert.expect(1);
+
+    this.server.post('/auth/token/renew-self', function () {
+      assert.notOk(true, 'should not call renew-self directly after logging in');
+    });
+
+    await visit('/vault/auth');
+    await fillIn(AUTH_FORM.method, 'token');
+    await fillIn(AUTH_FORM.token, rootToken);
+    await click('[data-test-auth-submit]');
+    assert.strictEqual(currentURL(), '/vault/dashboard');
   });
 });

--- a/ui/tests/acceptance/auth-test.js
+++ b/ui/tests/acceptance/auth-test.js
@@ -197,11 +197,10 @@ module('Acceptance | auth', function (hooks) {
   });
 
   test('it does not call renew-self after successful login with non-renewable token', async function (assert) {
-    assert.expect(1);
-
-    this.server.post('/auth/token/renew-self', function () {
-      assert.notOk(true, 'should not call renew-self directly after logging in');
-    });
+    this.server.post(
+      '/auth/token/renew-self',
+      () => new Error('should not call renew-self directly after logging in')
+    );
 
     await visit('/vault/auth');
     await fillIn(AUTH_FORM.method, 'token');


### PR DESCRIPTION
### Description
When logging in with a non-renewable token (such as root or batch), I was seeing that upon login the UI immediately triggered a `renew-self` call. I traced it back to [this PR](https://github.com/hashicorp/vault/pull/27479) where we updated the batch token to also updates expirationTime even though it's not renewable. This caused `setLastFetch` to try to compare now to null, which caused it to always renew. 

Batch token after login before
<img width="1703" alt="Screenshot 2024-08-27 at 16 36 01" src="https://github.com/user-attachments/assets/c68488d2-f9d6-4985-972d-b63190e633cb">
