### PR TITLE
UI: Add enterprise checks

### DIFF
--- a/ui/lib/kv/addon/components/kv-subkeys-card.hbs
+++ b/ui/lib/kv/addon/components/kv-subkeys-card.hbs
@@ -3,7 +3,7 @@
   SPDX-License-Identifier: BUSL-1.1
 ~}}
 
-<OverviewCard @cardTitle="Subkeys" class="has-top-margin-l">
+<OverviewCard @cardTitle="Subkeys" class="has-top-margin-l" {{style max-height="325px" overflow-y="auto"}}>
   <:customSubtext>
     <Hds::Text::Body @tag="p" @color="faint" data-test-overview-card-subtitle="Subkeys">
       {{#if this.showJson}}

--- a/ui/lib/kv/addon/components/page/secret/overview.hbs
+++ b/ui/lib/kv/addon/components/page/secret/overview.hbs
@@ -101,6 +101,6 @@
   <KvPathsCard @backend={{@backend}} @path={{@path}} @isCondensed={{true}} />
 </Hds::Card::Container>
 
-{{#if @subkeys.subkeys}}
+{{#if (and @subkeys.subkeys this.version.isEnterprise)}}
   <KvSubkeysCard @subkeys={{@subkeys.subkeys}} @canPatchSecret={{@canPatchSecret}} @backend={{@backend}} @path={{@path}} />
 {{/if}}

--- a/ui/lib/kv/addon/components/page/secret/overview.hbs
+++ b/ui/lib/kv/addon/components/page/secret/overview.hbs
@@ -101,6 +101,6 @@
   <KvPathsCard @backend={{@backend}} @path={{@path}} @isCondensed={{true}} />
 </Hds::Card::Container>
 
-{{#if (and @subkeys.subkeys this.version.isEnterprise)}}
+{{#if @subkeys.subkeys}}
   <KvSubkeysCard @subkeys={{@subkeys.subkeys}} @canPatchSecret={{@canPatchSecret}} @backend={{@backend}} @path={{@path}} />
 {{/if}}

--- a/ui/lib/kv/addon/components/page/secret/overview.js
+++ b/ui/lib/kv/addon/components/page/secret/overview.js
@@ -6,7 +6,6 @@
 import Component from '@glimmer/component';
 import { dateFormat } from 'core/helpers/date-format';
 import { isDeleted } from 'kv/utils/kv-deleted';
-import { service } from '@ember/service';
 
 /**
  * @module KvSecretOverview
@@ -26,12 +25,10 @@ import { service } from '@ember/service';
  * @param {boolean} canUpdateSecret - permissions to create a new version of a secret
  * @param {model} metadata - Ember data model: 'kv/metadata'
  * @param {string} path - path to request secret data for selected version
- * @param {object} subkeys - API response from subkeys endpoint, object with "subkeys" and "metadata" keys
+ * @param {object} subkeys - API response from subkeys endpoint, object with "subkeys" and "metadata" keys. This arg is null for community edition
  */
 
 export default class KvSecretOverview extends Component {
-  @service version;
-
   get secretState() {
     if (this.args.metadata) {
       return this.args.metadata.currentSecret.state;

--- a/ui/lib/kv/addon/components/page/secret/overview.js
+++ b/ui/lib/kv/addon/components/page/secret/overview.js
@@ -6,6 +6,7 @@
 import Component from '@glimmer/component';
 import { dateFormat } from 'core/helpers/date-format';
 import { isDeleted } from 'kv/utils/kv-deleted';
+import { service } from '@ember/service';
 
 /**
  * @module KvSecretOverview
@@ -29,6 +30,8 @@ import { isDeleted } from 'kv/utils/kv-deleted';
  */
 
 export default class KvSecretOverview extends Component {
+  @service version;
+
   get secretState() {
     if (this.args.metadata) {
       return this.args.metadata.currentSecret.state;

--- a/ui/lib/kv/addon/routes/secret.js
+++ b/ui/lib/kv/addon/routes/secret.js
@@ -12,6 +12,7 @@ export default class KvSecretRoute extends Route {
   @service secretMountPath;
   @service store;
   @service capabilities;
+  @service version;
 
   fetchSecretMetadata(backend, path) {
     // catch error and only return 404 which indicates the secret truly does not exist.
@@ -25,10 +26,13 @@ export default class KvSecretRoute extends Route {
   }
 
   fetchSubkeys(backend, path) {
-    const adapter = this.store.adapterFor('kv/data');
-    // metadata will throw if the secret does not exist
-    // always return here so we get deletion state and relevant metadata
-    return adapter.fetchSubkeys(backend, path);
+    if (this.version.isEnterprise) {
+      const adapter = this.store.adapterFor('kv/data');
+      // metadata will throw if the secret does not exist
+      // always return here so we get deletion state and relevant metadata
+      return adapter.fetchSubkeys(backend, path);
+    }
+    return null;
   }
 
   model() {

--- a/ui/tests/acceptance/secrets/backend/kv/kv-v2-workflow-navigation-test.js
+++ b/ui/tests/acceptance/secrets/backend/kv/kv-v2-workflow-navigation-test.js
@@ -1494,6 +1494,13 @@ path "${this.backend}/*" {
       );
     });
 
+    test('overview subkeys card is hidden for community edition', async function (assert) {
+      this.version.type = 'community';
+      await navToBackend(this.backend);
+      await click(PAGE.list.item(secretPath));
+      assert.dom(GENERAL.overviewCard.container('Subkeys')).doesNotExist();
+    });
+
     test('it does not redirect for enterprise', async function (assert) {
       this.version.type = 'enterprise';
       await visit(`/vault/secrets/${this.backend}/kv/app%2Fnested%2Fsecret/patch`);

--- a/ui/tests/integration/components/kv/page/kv-page-overview-test.js
+++ b/ui/tests/integration/components/kv/page/kv-page-overview-test.js
@@ -17,7 +17,7 @@ import { baseSetup } from 'vault/tests/helpers/kv/kv-run-commands';
 
 const { overviewCard } = GENERAL;
 
-// subkey is enterprise only but we don't have any version testing here because the @subkey arg is null for non-enterprise versions
+// subkeys access is enterprise only (in the GUI) but we don't have any version testing here because the @subkeys arg is null for non-enterprise versions
 module('Integration | Component | kv-v2 | Page::Secret::Overview', function (hooks) {
   setupRenderingTest(hooks);
   setupEngine(hooks, 'kv');

--- a/ui/tests/integration/components/kv/page/kv-page-overview-test.js
+++ b/ui/tests/integration/components/kv/page/kv-page-overview-test.js
@@ -23,6 +23,9 @@ module('Integration | Component | kv-v2 | Page::Secret::Overview', function (hoo
 
   hooks.beforeEach(async function () {
     baseSetup(this);
+    // subkey/patch is enterprise only, stub service here so these tests can run on both repos
+    this.version = this.owner.lookup('service:version');
+    this.version.type = 'enterprise';
     this.breadcrumbs = [
       { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: this.backend, route: 'list' },
@@ -192,6 +195,29 @@ module('Integration | Component | kv-v2 | Page::Secret::Overview', function (hoo
           `Paths The paths to use when referring to this secret in API or CLI. API path /v1/${this.backend}/data/${this.path} CLI path -mount="${this.backend}" "${this.path}"`
         );
     });
+
+    test('on community edition', async function (assert) {
+      this.version.type = 'community';
+      await this.renderComponent();
+      const fromNow = dateFromNow([this.metadata.updatedTime]); // uses date-fns so can't stub timestamp util
+      const expectedTime = this.format(this.metadata.updatedTime);
+      assert
+        .dom(overviewCard.container('Current version'))
+        .hasText(
+          `Current version Create new The current version of this secret. ${this.metadata.currentVersion}`
+        );
+      assert
+        .dom(overviewCard.container('Secret age'))
+        .hasText(
+          `Secret age View metadata Current secret version age. Last updated on ${expectedTime}. ${fromNow}`
+        );
+      assert
+        .dom(overviewCard.container('Paths'))
+        .hasText(
+          `Paths The paths to use when referring to this secret in API or CLI. API path /v1/${this.backend}/data/${this.path} CLI path -mount="${this.backend}" "${this.path}"`
+        );
+      assert.dom(overviewCard.container('Subkeys')).doesNotExist();
+    });
   });
 
   module('deleted version', function (hooks) {
@@ -259,6 +285,7 @@ module('Integration | Component | kv-v2 | Page::Secret::Overview', function (hoo
         .hasText(
           `Current version Deleted Create new The current version of this secret was deleted ${expectedTime}. ${this.metadata.currentVersion}`
         );
+      assert.dom(overviewCard.container('Subkeys')).doesNotExist();
     });
 
     test('with no permissions', async function (assert) {
@@ -266,6 +293,18 @@ module('Integration | Component | kv-v2 | Page::Secret::Overview', function (hoo
       this.metadata = null;
       await this.renderComponent();
       assert.dom(overviewCard.container('Current version')).doesNotExist();
+    });
+
+    test('on community edition', async function (assert) {
+      this.version.type = 'community';
+      const expectedTime = this.format(this.metadata.versions[4].deletion_time);
+      await this.renderComponent();
+      assert
+        .dom(overviewCard.container('Current version'))
+        .hasText(
+          `Current version Deleted Create new The current version of this secret was deleted ${expectedTime}. ${this.metadata.currentVersion}`
+        );
+      assert.dom(overviewCard.container('Subkeys')).doesNotExist();
     });
   });
 
@@ -331,6 +370,7 @@ module('Integration | Component | kv-v2 | Page::Secret::Overview', function (hoo
         .hasText(
           `Current version Destroyed Create new The current version of this secret has been permanently deleted and cannot be restored. ${this.metadata.currentVersion}`
         );
+      assert.dom(overviewCard.container('Subkeys')).doesNotExist();
     });
 
     test('with no permissions', async function (assert) {
@@ -338,6 +378,17 @@ module('Integration | Component | kv-v2 | Page::Secret::Overview', function (hoo
       this.metadata = null;
       await this.renderComponent();
       assert.dom(overviewCard.container('Current version')).doesNotExist();
+    });
+
+    test('on community edition', async function (assert) {
+      this.version.type = 'community';
+      await this.renderComponent();
+      assert
+        .dom(overviewCard.container('Current version'))
+        .hasText(
+          `Current version Destroyed Create new The current version of this secret has been permanently deleted and cannot be restored. ${this.metadata.currentVersion}`
+        );
+      assert.dom(overviewCard.container('Subkeys')).doesNotExist();
     });
   });
 });


### PR DESCRIPTION

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [ ] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
