### PR TITLE
ubi: fix `HasLicense` Redhat requirement

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -104,6 +104,9 @@ ENV VERSION=$VERSION
 # Copy the license file as per Legal requirement
 COPY LICENSE /usr/share/doc/$NAME/LICENSE.txt
 
+# We must have a copy of the license in this directory to comply with the HasLicense Redhat requirement
+COPY LICENSE /licenses/LICENSE.txt
+
 # Set up certificates, our base tools, and Vault. Unlike the other version of
 # this (https://github.com/hashicorp/docker-vault/blob/master/ubi/Dockerfile),
 # we copy in the Vault binary from CRT.


### PR DESCRIPTION
### Description

When https://github.com/hashicorp/vault/pull/27154 and subsequently https://github.com/hashicorp/vault/pull/28141 were merged we stopped creating a top level `licenses` directory in the UBI container. That directory with our licenses and terms are required to pass [Redhat's container requirements](https://docs.redhat.com/en/documentation/red_hat_software_certification/2024/html-single/red_hat_openshift_software_certification_policy_guide/index#con-image-content-requirements_openshift-sw-cert-policy-container-images), which we [failed when trying to promote the latest containers](https://github.com/hashicorp/crt-workflows-common/actions/runs/10604245970/job/29392127321#step:12:115).

```json
           "failed": [
              {
                  "name": "HasLicense",
                  "elapsed_time": 0,
                  "description": "Checking if terms and conditions applicable to the software including open source licensing information are present. The license must be at /licenses",
                  "help": "Check HasLicense encountered an error. Please review the preflight.log file for more information.",
                  "suggestion": "Create a directory named /licenses and include all relevant licensing and/or terms and conditions as text file(s) in that directory.",
                  "knowledgebase_url": "https://access.redhat.com/documentation/en-us/red_hat_software_certification/2024/html-single/red_hat_openshift_software_certification_policy_guide/index#assembly-requirements-for-container-images_openshift-sw-cert-policy-introduction",
                  "check_url": "https://access.redhat.com/documentation/en-us/red_hat_software_certification/2024/html-single/red_hat_openshift_software_certification_policy_guide/index#assembly-requirements-for-container-images_openshift-sw-cert-policy-introduction"
              }
          ],
```

Since those other PR's were not backported to 1.15 and 1.16 they passed as expected with the old Dockerfile and subsequent container. Rather than backport this change to 1.15 and 1.16 I'll just synchronize our Dockerfiles with this as separate PRs afterwards.

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [x] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
