### PR TITLE
UI: Add patch latest version to toolbar

### DIFF
--- a/ui/app/models/kv/data.js
+++ b/ui/app/models/kv/data.js
@@ -105,6 +105,9 @@ export default class KvSecretDataModel extends Model {
   get canEditData() {
     return this.dataPath.get('canUpdate') !== false;
   }
+  get canPatchData() {
+    return this.dataPath.get('canPatch') !== false;
+  }
   get canReadData() {
     return this.dataPath.get('canRead') !== false;
   }

--- a/ui/app/models/kv/data.js
+++ b/ui/app/models/kv/data.js
@@ -105,9 +105,6 @@ export default class KvSecretDataModel extends Model {
   get canEditData() {
     return this.dataPath.get('canUpdate') !== false;
   }
-  get canPatchData() {
-    return this.dataPath.get('canPatch') !== false;
-  }
   get canReadData() {
     return this.dataPath.get('canRead') !== false;
   }

--- a/ui/lib/kv/addon/components/kv-subkeys-card.hbs
+++ b/ui/lib/kv/addon/components/kv-subkeys-card.hbs
@@ -33,7 +33,7 @@
           <F.Label>JSON</F.Label>
         </Hds::Form::Toggle::Field>
       </div>
-      {{#if @canPatchSecret}}
+      {{#if @isPatchAllowed}}
         <Hds::Link::Standalone
           @text="Patch secret"
           @route="secret.patch"

--- a/ui/lib/kv/addon/components/page/secret/details.hbs
+++ b/ui/lib/kv/addon/components/page/secret/details.hbs
@@ -120,6 +120,11 @@
     {{#if @secret.canReadMetadata}}
       <KvVersionDropdown @displayVersion={{this.version}} @metadata={{@metadata}} @onClose={{this.closeVersionMenu}} />
     {{/if}}
+    {{#if @secret.canPatchData}}
+      <ToolbarLink data-test-patch-latest-version @route="secret.patch" @models={{array @secret.backend @path}} @type="add">
+        Patch latest version
+      </ToolbarLink>
+    {{/if}}
     {{#if @secret.canEditData}}
       <ToolbarLink
         data-test-create-new-version

--- a/ui/lib/kv/addon/components/page/secret/details.hbs
+++ b/ui/lib/kv/addon/components/page/secret/details.hbs
@@ -120,7 +120,8 @@
     {{#if @secret.canReadMetadata}}
       <KvVersionDropdown @displayVersion={{this.version}} @metadata={{@metadata}} @onClose={{this.closeVersionMenu}} />
     {{/if}}
-    {{#if @secret.canPatchData}}
+    {{! @isPatchAllowed is true if the version is enterprise AND a user has "patch" secret + "read" subkeys capabilities }}
+    {{#if @isPatchAllowed}}
       <ToolbarLink data-test-patch-latest-version @route="secret.patch" @models={{array @secret.backend @path}} @type="add">
         Patch latest version
       </ToolbarLink>

--- a/ui/lib/kv/addon/components/page/secret/overview.hbs
+++ b/ui/lib/kv/addon/components/page/secret/overview.hbs
@@ -103,6 +103,7 @@
   <KvPathsCard @backend={{@backend}} @path={{@path}} @isCondensed={{true}} />
 </Hds::Card::Container>
 
+{{! @subkeys is null for community edition or if a user does not have read permissions }}
 {{#if @subkeys.subkeys}}
-  <KvSubkeysCard @subkeys={{@subkeys.subkeys}} @canPatchSecret={{@canPatchSecret}} @backend={{@backend}} @path={{@path}} />
+  <KvSubkeysCard @subkeys={{@subkeys.subkeys}} @isPatchAllowed={{@isPatchAllowed}} @backend={{@backend}} @path={{@path}} />
 {{/if}}

--- a/ui/lib/kv/addon/components/page/secret/overview.hbs
+++ b/ui/lib/kv/addon/components/page/secret/overview.hbs
@@ -31,6 +31,8 @@
       </li>
     {{/if}}
   </:tabLinks>
+  <:toolbarActions>
+  </:toolbarActions>
 </KvPageHeader>
 
 {{#if (or @metadata @subkeys.metadata)}}

--- a/ui/lib/kv/addon/routes/secret.js
+++ b/ui/lib/kv/addon/routes/secret.js
@@ -44,7 +44,7 @@ export default class KvSecretRoute extends Route {
     return hash(capabilities).then(
       ({ canPatch, canReadSubkeys }) => canPatch && canReadSubkeys,
       // this callback fires if either promise is rejected
-      // since this is GUI gated feature we return false (instead of default to true)
+      // since this feature is only client-side gated we return false (instead of default to true)
       // for debugging you can pass an arg to log the failure reason
       () => false
     );

--- a/ui/lib/kv/addon/routes/secret.js
+++ b/ui/lib/kv/addon/routes/secret.js
@@ -35,6 +35,13 @@ export default class KvSecretRoute extends Route {
     return null;
   }
 
+  async isPatchAllowed(backend, path) {
+    if (!this.version.isEnterprise) return false;
+    const canPatch = await this.capabilities.canPatch(`${backend}/data/${path}`);
+    const canReadSubkeys = await this.capabilities.canRead(`${backend}/subkeys/${path}`);
+    return canPatch && canReadSubkeys;
+  }
+
   model() {
     const backend = this.secretMountPath.currentPath;
     const { name: path } = this.paramsFor('secret');
@@ -44,7 +51,7 @@ export default class KvSecretRoute extends Route {
       backend,
       subkeys: this.fetchSubkeys(backend, path),
       metadata: this.fetchSecretMetadata(backend, path),
-      canPatchSecret: this.capabilities.canPatch(`${backend}/data/${path}`),
+      isPatchAllowed: this.isPatchAllowed(backend, path),
       // for creating a new secret version
       canUpdateSecret: this.capabilities.canUpdate(`${backend}/data/${path}`),
     });

--- a/ui/lib/kv/addon/routes/secret/patch.js
+++ b/ui/lib/kv/addon/routes/secret/patch.js
@@ -6,9 +6,9 @@
 import Route from '@ember/routing/route';
 import { breadcrumbsForSecret } from 'kv/utils/kv-breadcrumbs';
 import { service } from '@ember/service';
+
 export default class SecretPatch extends Route {
   @service router;
-  @service version;
 
   setupController(controller, resolvedModel) {
     super.setupController(controller, resolvedModel);
@@ -21,9 +21,9 @@ export default class SecretPatch extends Route {
     controller.breadcrumbs = breadcrumbsArray;
   }
 
-  // patch is enterprise only and users must permissions to "read" subkeys and "patch" a secret
+  // isPatchAllowed is true if the version is enterprise AND a user has "patch" secret + "read" subkeys capabilities
   redirect(model) {
-    if (!this.version.isEnterprise || !model.canPatchSecret || !model.subkeys.subkeys) {
+    if (!model.isPatchAllowed) {
       this.router.transitionTo('vault.cluster.secrets.backend.kv.secret.index', model.path);
     }
   }

--- a/ui/lib/kv/addon/templates/secret/details/index.hbs
+++ b/ui/lib/kv/addon/templates/secret/details/index.hbs
@@ -4,8 +4,9 @@
 ~}}
 
 <Page::Secret::Details
+  @breadcrumbs={{this.breadcrumbs}}
+  @isPatchAllowed={{this.model.isPatchAllowed}}
   @path={{this.model.path}}
   @secret={{this.model.secret}}
   @metadata={{this.model.metadata}}
-  @breadcrumbs={{this.breadcrumbs}}
 />

--- a/ui/lib/kv/addon/templates/secret/index.hbs
+++ b/ui/lib/kv/addon/templates/secret/index.hbs
@@ -7,7 +7,7 @@
   @backend={{this.model.backend}}
   @breadcrumbs={{this.breadcrumbs}}
   @canReadMetadata={{this.model.metadata.canReadMetadata}}
-  @canPatchSecret={{this.model.canPatchSecret}}
+  @isPatchAllowed={{this.model.isPatchAllowed}}
   @canUpdateSecret={{this.model.canUpdateSecret}}
   @metadata={{this.model.metadata}}
   @path={{this.model.path}}

--- a/ui/tests/helpers/kv/policy-generator.js
+++ b/ui/tests/helpers/kv/policy-generator.js
@@ -25,7 +25,7 @@ export const dataPolicy = ({ backend, secretPath = '*', capabilities = root }) =
   `;
 };
 
-export const subkeyPolicy = ({ backend, secretPath = '*' }) => {
+export const subkeysPolicy = ({ backend, secretPath = '*' }) => {
   return `
     path "${backend}/subkeys/${secretPath}" {
       capabilities = ["read"]
@@ -90,7 +90,7 @@ export const destroyVersionsPolicy = ({ backend, secretPath = '*' }) => {
 
 // Personas for reuse in workflow tests
 export const personas = {
-  admin: (backend) => adminPolicy(backend),
+  admin: (backend) => adminPolicy(backend) + subkeysPolicy({ backend }),
   dataReader: (backend) => dataPolicy({ backend, capabilities: ['read'] }),
   dataListReader: (backend) =>
     dataPolicy({ backend, capabilities: ['read', 'delete'] }) + metadataListPolicy(backend),
@@ -108,5 +108,5 @@ export const personas = {
   secretPatcher: (backend) =>
     dataPolicy({ backend, capabilities: ['patch'] }) +
     metadataPolicy({ backend, capabilities: ['list', 'read'] }) +
-    subkeyPolicy({ backend }),
+    subkeysPolicy({ backend }),
 };

--- a/ui/tests/integration/components/kv/kv-subkeys-card-test.js
+++ b/ui/tests/integration/components/kv/kv-subkeys-card-test.js
@@ -15,7 +15,7 @@ module('Integration | Component | kv | kv-subkeys-card', function (hooks) {
   setupRenderingTest(hooks);
   setupEngine(hooks, 'kv');
   hooks.beforeEach(function () {
-    this.canPatchSecret = true;
+    this.isPatchAllowed = true;
     this.subkeys = {
       foo: null,
       bar: {
@@ -24,7 +24,7 @@ module('Integration | Component | kv | kv-subkeys-card', function (hooks) {
     };
     this.renderComponent = async () => {
       return render(
-        hbs`<KvSubkeysCard @subkeys={{this.subkeys}} @canPatchSecret={{this.canPatchSecret}} />`,
+        hbs`<KvSubkeysCard @subkeys={{this.subkeys}} @isPatchAllowed={{this.isPatchAllowed}} />`,
         {
           owner: this.engine,
         }
@@ -46,8 +46,8 @@ module('Integration | Component | kv | kv-subkeys-card', function (hooks) {
     assert.dom(overviewCard.actionText('Patch secret')).exists();
   });
 
-  test('it hides patch action when canPatchSecret is false', async function (assert) {
-    this.canPatchSecret = false;
+  test('it hides patch action when isPatchAllowed is false', async function (assert) {
+    this.isPatchAllowed = false;
     await this.renderComponent();
     assert.dom(overviewCard.title('Subkeys')).exists();
     assert.dom(overviewCard.actionText('Patch secret')).doesNotExist();


### PR DESCRIPTION
### Description
The original designs placed `Create new version` and `Patch latest version` into a dropdown. However, with feature freeze tomorrow we don't have time to do this because updating the tests will take too long. As an interim solution, adding the action to the toolbar and then as a follow-on we can put it in a dropdown for enterprise users only, pending permissions of course.

## designs
<img width="1141" alt="Screenshot 2024-08-29 at 10 04 50 AM" src="https://github.com/user-attachments/assets/1fc44930-c291-48bc-9d2c-9078b32a6883">


## actual implementation
<img width="1141" alt="Screenshot 2024-08-29 at 10 04 10 AM" src="https://github.com/user-attachments/assets/5816e9d8-dcb7-4264-b382-2b9623eb996f">


### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [ ] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
