### PR TITLE
UI: improve control group UX

### DIFF
--- a/ui/app/adapters/kv/data.js
+++ b/ui/app/adapters/kv/data.js
@@ -129,6 +129,14 @@ export default class KvDataAdapter extends ApplicationAdapter {
   parseErrorOrResponse(errorOrResponse, secretDataBaseResponse, isSubkeys = false) {
     // if it's a legitimate error - throw it!
     if (errorOrResponse instanceof ControlGroupError) {
+      if (!isSubkeys) {
+        // note this will redirect any control group error for secret /data/ to the details route
+        const { backend, path } = secretDataBaseResponse;
+        errorOrResponse.uiParams = {
+          redirect_route: 'vault.cluster.secrets.backend.kv.secret.details.index',
+          params: [backend, path],
+        };
+      }
       throw errorOrResponse;
     }
 

--- a/ui/app/adapters/kv/data.js
+++ b/ui/app/adapters/kv/data.js
@@ -129,14 +129,6 @@ export default class KvDataAdapter extends ApplicationAdapter {
   parseErrorOrResponse(errorOrResponse, secretDataBaseResponse, isSubkeys = false) {
     // if it's a legitimate error - throw it!
     if (errorOrResponse instanceof ControlGroupError) {
-      if (!isSubkeys) {
-        // note this will redirect any control group error for secret /data/ to the details route
-        const { backend, path } = secretDataBaseResponse;
-        errorOrResponse.uiParams = {
-          redirect_route: 'vault.cluster.secrets.backend.kv.secret.details.index',
-          params: [backend, path],
-        };
-      }
       throw errorOrResponse;
     }
 

--- a/ui/app/components/control-group-success.js
+++ b/ui/app/components/control-group-success.js
@@ -34,10 +34,6 @@ export default Component.extend({
 
   markAndNavigate: task(function* () {
     this.controlGroup.markTokenForUnwrap(this.model.id);
-    if (this.controlGroupResponse.uiParams?.redirect_route) {
-      const { redirect_route, params = [] } = this.controlGroupResponse.uiParams;
-      yield this.router.transitionTo(redirect_route, ...params);
-    }
     const { url } = this.controlGroupResponse.uiParams;
     yield this.router.transitionTo(url);
   }).drop(),

--- a/ui/app/components/control-group-success.js
+++ b/ui/app/components/control-group-success.js
@@ -34,6 +34,10 @@ export default Component.extend({
 
   markAndNavigate: task(function* () {
     this.controlGroup.markTokenForUnwrap(this.model.id);
+    if (this.controlGroupResponse.uiParams?.redirect_route) {
+      const { redirect_route, params = [] } = this.controlGroupResponse.uiParams;
+      yield this.router.transitionTo(redirect_route, ...params);
+    }
     const { url } = this.controlGroupResponse.uiParams;
     yield this.router.transitionTo(url);
   }).drop(),

--- a/ui/app/models/kv/metadata.js
+++ b/ui/app/models/kv/metadata.js
@@ -49,6 +49,8 @@ export default class KvSecretMetadataModel extends Model {
   })
   deleteVersionAfter;
 
+  // the API returns custom_metadata: null if empty but because the attr is an 'object' ember data transforms it to an empty object.
+  // this is important because we rely on the empty object as a truthy value in template conditionals
   @attr('object', {
     editType: 'kv',
     isSectionHeader: true,

--- a/ui/app/services/control-group.js
+++ b/ui/app/services/control-group.js
@@ -135,6 +135,10 @@ export default Service.extend({
     return {
       type: 'error-with-html',
       content: lines.join('\n'),
+      href,
+      token,
+      accessor,
+      creation_path,
     };
   },
 });

--- a/ui/app/services/control-group.js
+++ b/ui/app/services/control-group.js
@@ -102,9 +102,9 @@ export default Service.extend({
   },
 
   handleError(error) {
-    const { accessor, token, creation_path, creation_time, ttl, uiParams } = error;
-    const data = { accessor, token, creation_path, creation_time, ttl, uiParams };
-    data.uiParams = { ...uiParams, url: this.router.currentURL };
+    const { accessor, token, creation_path, creation_time, ttl } = error;
+    const data = { accessor, token, creation_path, creation_time, ttl };
+    data.uiParams = { url: this.router.currentURL };
     this.storeControlGroupToken(data);
     return this.router.transitionTo('vault.cluster.access.control-group-accessor', accessor);
   },

--- a/ui/app/services/control-group.js
+++ b/ui/app/services/control-group.js
@@ -102,9 +102,9 @@ export default Service.extend({
   },
 
   handleError(error) {
-    const { accessor, token, creation_path, creation_time, ttl } = error;
-    const data = { accessor, token, creation_path, creation_time, ttl };
-    data.uiParams = { url: this.router.currentURL };
+    const { accessor, token, creation_path, creation_time, ttl, uiParams } = error;
+    const data = { accessor, token, creation_path, creation_time, ttl, uiParams };
+    data.uiParams = { ...uiParams, url: this.router.currentURL };
     this.storeControlGroupToken(data);
     return this.router.transitionTo('vault.cluster.access.control-group-accessor', accessor);
   },

--- a/ui/lib/core/addon/components/control-group-inline-error.hbs
+++ b/ui/lib/core/addon/components/control-group-inline-error.hbs
@@ -13,6 +13,11 @@
     <code>{{@error.token}}</code>. The Accessor is
     <code>{{@error.accessor}}</code>.
   </A.Description>
+  {{#if (has-block "customMessage")}}
+    <A.Description>
+      {{yield to="customMessage"}}
+    </A.Description>
+  {{/if}}
   <A.Description>
     Visit
     <Hds::Link::Inline

--- a/ui/lib/core/addon/components/control-group-inline-error.hbs
+++ b/ui/lib/core/addon/components/control-group-inline-error.hbs
@@ -1,0 +1,21 @@
+{{!
+  Copyright (c) HashiCorp, Inc.
+  SPDX-License-Identifier: BUSL-1.1
+~}}
+
+{{! This display only template is for rendering control group errors when the error is thrown from a component }}
+
+<Hds::Alert data-test-message-error @type="inline" @color="warning" ...attributes as |A|>
+  <A.Title>Control Group Error</A.Title>
+  <A.Description>
+    A Control Group was encountered at
+    <code>{{@error.creation_path}}</code>. The Control Group Token is
+    <code>{{@error.token}}</code>. The Accessor is
+    <code>{{@error.accessor}}</code>.
+  </A.Description>
+  <A.Description>
+    Visit
+    <Hds::Link::Inline @color="primary" @href={{@error.href}}>{{@error.href}}</Hds::Link::Inline>
+    for more details.
+  </A.Description>
+</Hds::Alert>

--- a/ui/lib/core/addon/components/control-group-inline-error.hbs
+++ b/ui/lib/core/addon/components/control-group-inline-error.hbs
@@ -15,7 +15,12 @@
   </A.Description>
   <A.Description>
     Visit
-    <Hds::Link::Inline @color="primary" @href={{@error.href}}>{{@error.href}}</Hds::Link::Inline>
+    <Hds::Link::Inline
+      @color="primary"
+      @href={{@error.href}}
+      data-test-control-error="href"
+      @isHrefExternal={{false}}
+    >{{@error.href}}</Hds::Link::Inline>
     for more details.
   </A.Description>
 </Hds::Alert>

--- a/ui/lib/core/addon/components/control-group-inline-error.hbs
+++ b/ui/lib/core/addon/components/control-group-inline-error.hbs
@@ -7,25 +7,29 @@
 
 <Hds::Alert data-test-message-error @type="inline" @color="warning" ...attributes as |A|>
   <A.Title>Control Group Error</A.Title>
-  <A.Description>
-    A Control Group was encountered at
-    <code>{{@error.creation_path}}</code>. The Control Group Token is
-    <code>{{@error.token}}</code>. The Accessor is
-    <code>{{@error.accessor}}</code>.
-  </A.Description>
+  {{#if (and @error.creation_path @error.token @error.accessor)}}
+    <A.Description>
+      A Control Group was encountered at
+      <code>{{@error.creation_path}}</code>. The Control Group Token is
+      <code>{{@error.token}}</code>. The Accessor is
+      <code>{{@error.accessor}}</code>.
+    </A.Description>
+  {{/if}}
   {{#if (has-block "customMessage")}}
     <A.Description>
       {{yield to="customMessage"}}
     </A.Description>
   {{/if}}
-  <A.Description>
-    Visit
-    <Hds::Link::Inline
-      @color="primary"
-      @href={{@error.href}}
-      data-test-control-error="href"
-      @isHrefExternal={{false}}
-    >{{@error.href}}</Hds::Link::Inline>
-    for more details.
-  </A.Description>
+  {{#if @error.href}}
+    <A.Description>
+      Visit
+      <Hds::Link::Inline
+        @color="primary"
+        @href={{@error.href}}
+        @isHrefExternal={{false}}
+        data-test-control-error="href"
+      >{{@error.href}}</Hds::Link::Inline>
+      for more details.
+    </A.Description>
+  {{/if}}
 </Hds::Alert>

--- a/ui/lib/core/app/components/control-group-inline-error.js
+++ b/ui/lib/core/app/components/control-group-inline-error.js
@@ -1,0 +1,6 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+export { default } from 'core/components/control-group-inline-error';

--- a/ui/lib/kv/addon/components/page/secret/details.hbs
+++ b/ui/lib/kv/addon/components/page/secret/details.hbs
@@ -104,10 +104,10 @@
     {{#if this.showDestroy}}
       <KvDeleteModal @mode="destroy" @secret={{@secret}} @onDelete={{this.handleDestruction}} @version={{this.version}} />
     {{/if}}
-    {{#if (or @secret.canReadData @secret.canReadMetadata @secret.canEditData)}}
+    {{#if (or @canReadData @canReadMetadata @canUpdateData)}}
       <div class="toolbar-separator"></div>
     {{/if}}
-    {{#if (and @secret.canReadData (eq @secret.state "created"))}}
+    {{#if (and @canReadData (eq @secret.state "created"))}}
       <CopySecretDropdown
         @clipboardText={{stringify @secret.secretData}}
         @onWrap={{perform this.wrapSecret}}
@@ -116,7 +116,7 @@
         @onClose={{this.clearWrappedData}}
       />
     {{/if}}
-    {{#if @secret.canReadMetadata}}
+    {{#if @canReadMetadata}}
       <KvVersionDropdown @displayVersion={{this.version}} @metadata={{@metadata}} @onClose={{this.closeVersionMenu}} />
     {{/if}}
     {{! @isPatchAllowed is true if the version is enterprise AND a user has "patch" secret + "read" subkeys capabilities }}
@@ -125,7 +125,7 @@
         Patch latest version
       </ToolbarLink>
     {{/if}}
-    {{#if @secret.canEditData}}
+    {{#if @canUpdateData}}
       <ToolbarLink
         data-test-create-new-version
         @route="secret.details.edit"

--- a/ui/lib/kv/addon/components/page/secret/details.hbs
+++ b/ui/lib/kv/addon/components/page/secret/details.hbs
@@ -64,11 +64,11 @@
     <li>
       <LinkTo @route="secret.paths" @models={{array @secret.backend @path}} data-test-secrets-tab="Paths">Paths</LinkTo>
     </li>
-    {{#if @secret.canReadMetadata}}
+    {{#if @canReadMetadata}}
       <li>
         <LinkTo
           @route="secret.metadata.versions"
-          @models={{array @secret.backend @path}}
+          @models={{array @backend @path}}
           data-test-secrets-tab="Version History"
         >Version History</LinkTo>
       </li>

--- a/ui/lib/kv/addon/components/page/secret/details.js
+++ b/ui/lib/kv/addon/components/page/secret/details.js
@@ -17,16 +17,26 @@ import { isAdvancedSecret } from 'core/utils/advanced-secret';
  * @module KvSecretDetails renders the key/value data of a KV secret.
  * It also renders a dropdown to display different versions of the secret.
  * <Page::Secret::Details
- *  @path={{this.model.path}}
- *  @secret={{this.model.secret}}
- *  @metadata={{this.model.metadata}}
- *  @breadcrumbs={{this.breadcrumbs}}
-  />
+ * @backend={{this.model.backend}}
+ * @breadcrumbs={{this.breadcrumbs}}
+ * @canReadData={{this.model.canReadData}}
+ * @canReadMetadata={{this.model.canReadMetadata}}
+ * @canUpdateData={{this.model.canUpdateData}}
+ * @isPatchAllowed={{this.model.isPatchAllowed}}
+ * @metadata={{this.model.metadata}}
+ * @path={{this.model.path}}
+ * @secret={{this.model.secret}}
+ * />
  *
+ * @param {string} backend - path where kv engine is mounted
+ * @param {array} breadcrumbs - Array to generate breadcrumbs, passed to the page header component
+ * @param {boolean} canReadData - if true and the secret is not destroyed/deleted the copy secret dropdown renders
+ * @param {boolean} canReadMetadata - if true it renders the kv select version dropdown in the toolbar and "Version History" tab
+ * @param {boolean} canUpdateData - if true it renders "Create new version" toolbar action
+ * @param {boolean} isPatchAllowed - if true it renders "Patch latest version" toolbar action
+ * @param {model} metadata - Ember data model: 'kv/metadata'
  * @param {string} path - path of kv secret 'my/secret' used as the title for the KV page header
  * @param {model} secret - Ember data model: 'kv/data'
- * @param {model} metadata - Ember data model: 'kv/metadata'
- * @param {array} breadcrumbs - Array to generate breadcrumbs, passed to the page header component
  */
 
 export default class KvSecretDetails extends Component {
@@ -188,7 +198,7 @@ export default class KvSecretDetails extends Component {
   }
 
   get emptyState() {
-    if (!this.args.secret.canReadData) {
+    if (!this.args.canReadData) {
       return {
         title: 'You do not have permission to read this secret',
         message:
@@ -201,7 +211,7 @@ export default class KvSecretDetails extends Component {
       return {
         title: `Version ${version} of this secret has been permanently destroyed`,
         message: `A version that has been permanently deleted cannot be restored. ${
-          this.args.secret.canReadMetadata
+          this.args.canReadMetadata
             ? ' You can view other versions of this secret in the Version History tab above.'
             : ''
         }`,
@@ -212,7 +222,7 @@ export default class KvSecretDetails extends Component {
       return {
         title: `Version ${version} of this secret has been deleted`,
         message: `This version has been deleted but can be undeleted. ${
-          this.args.secret.canReadMetadata
+          this.args.canReadMetadata
             ? 'View other versions of this secret by clicking the Version History tab above.'
             : ''
         }`,

--- a/ui/lib/kv/addon/components/page/secret/metadata/details.hbs
+++ b/ui/lib/kv/addon/components/page/secret/metadata/details.hbs
@@ -70,23 +70,12 @@
       </EmptyState>
     {{/each-in}}
   {{else if @canReadData}}
-    {{#if this.controlGroupError}}
-      <Hds::Alert
-        data-test-message-error
-        @type="inline"
-        @color="warning"
-        class="has-top-margin-s has-bottom-margin-s"
-        as |A|
-      >
-        <A.Title>Control Group Error</A.Title>
-        <A.Generic>
-          {{! template-lint-disable }}
-          {{{this.controlGroupError}}}
-        </A.Generic>
-      </Hds::Alert>
-    {{/if}}
-    {{#if this.errorMessage}}
-      <MessageError @errorMessage={{this.errorMessage}} />
+    {{#if this.error}}
+      {{#if this.error.isControlGroup}}
+        <ControlGroupInlineError @error={{this.error}} />
+      {{else}}
+        <MessageError @errorMessage={{this.error}} />
+      {{/if}}
     {{/if}}
     {{#if this.customMetadataFromData}}
       {{#each-in this.customMetadataFromData as |key value|}}

--- a/ui/lib/kv/addon/components/page/secret/metadata/details.hbs
+++ b/ui/lib/kv/addon/components/page/secret/metadata/details.hbs
@@ -93,6 +93,7 @@
           @icon="reload"
           @iconPosition="trailing"
           @isFullWidth={{true}}
+          data-test-request-data
           {{on "click" this.requestData}}
         />
       </div>

--- a/ui/lib/kv/addon/components/page/secret/metadata/details.hbs
+++ b/ui/lib/kv/addon/components/page/secret/metadata/details.hbs
@@ -48,9 +48,9 @@
   Custom metadata
 </h2>
 <div class="box is-fullwidth is-sideless is-paddingless is-marginless" data-test-kv-custom-metadata-section>
-  {{! if the user had read permissions and there is no custom_metadata this is an empty object, without read capabilities it's undefined }}
-  {{#if @metadata.customMetadata}}
-    {{#each-in @metadata.customMetadata as |key value|}}
+  {{! if the user had read permissions and there is no custom_metadata this is an empty object, without read capabilities it's falsy }}
+  {{#if this.customMetadata}}
+    {{#each-in this.customMetadata as |key value|}}
       <InfoTableRow @alwaysRender={{false}} @label={{key}} @value={{value}} />
     {{else}}
       <EmptyState
@@ -70,56 +70,33 @@
       </EmptyState>
     {{/each-in}}
   {{else if @canReadData}}
-    {{#if this.error}}
-      {{#if this.error.isControlGroup}}
-        <ControlGroupInlineError @error={{this.error}} />
-      {{else}}
-        <MessageError @errorMessage={{this.error}} />
-      {{/if}}
+    {{! Offer opportunity to manually request /data/ for custom_metadata }}
+    {{#if this.error.isControlGroup}}
+      <ControlGroupInlineError @error={{this.error}} class="has-top-margin-s has-bottom-margin-s" />
+    {{else if this.error}}
+      <MessageError @errorMessage={{this.error}} />
     {{/if}}
-    {{#if this.customMetadataFromData}}
-      {{#each-in this.customMetadataFromData as |key value|}}
-        <InfoTableRow @alwaysRender={{false}} @label={{key}} @value={{value}} />
-      {{else}}
-        <EmptyState
-          @title="No custom metadata"
-          @bottomBorder={{true}}
-          @message="This data is version-agnostic and is usually used to describe the secret being stored."
-        >
-          {{#if @canUpdateMetadata}}
-            <Hds::Link::Standalone
-              @icon="plus"
-              @text="Add metadata"
-              @route="secret.metadata.edit"
-              @models={{array @backend @path}}
-              data-test-add-custom-metadata
-            />
-          {{/if}}
-        </EmptyState>
-      {{/each-in}}
-    {{else}}
-      <EmptyState
-        @title="Request custom metadata?"
-        @bottomBorder={{true}}
-        @message="You do not have access to the metadata endpoint but you can retrieve custom metadata from the secret data endpoint."
-      >
-        <div class="is-block">
-          <Hds::Alert @type="compact" @color="critical" class="has-top-margin-xs" as |A|>
-            <A.Description>
-              Sensitive secret data will be retrieved.
-            </A.Description>
-          </Hds::Alert>
-          <Hds::Button
-            class="has-top-margin-xs"
-            @text="Request data"
-            @icon="reload"
-            @iconPosition="trailing"
-            @isFullWidth={{true}}
-            {{on "click" this.requestData}}
-          />
-        </div>
-      </EmptyState>
-    {{/if}}
+    <EmptyState
+      @title="Request custom metadata?"
+      @bottomBorder={{true}}
+      @message="You do not have access to the metadata endpoint but you can retrieve custom metadata from the secret data endpoint."
+    >
+      <div class="is-block">
+        <Hds::Alert @type="compact" @color="critical" class="has-top-margin-xs" as |A|>
+          <A.Description>
+            Sensitive secret data will be retrieved.
+          </A.Description>
+        </Hds::Alert>
+        <Hds::Button
+          class="has-top-margin-xs"
+          @text="Request data"
+          @icon="reload"
+          @iconPosition="trailing"
+          @isFullWidth={{true}}
+          {{on "click" this.requestData}}
+        />
+      </div>
+    </EmptyState>
   {{else}}
     <EmptyState
       @title="You do not have access to read custom metadata"

--- a/ui/lib/kv/addon/components/page/secret/metadata/details.hbs
+++ b/ui/lib/kv/addon/components/page/secret/metadata/details.hbs
@@ -109,7 +109,7 @@
   <h2 class="title is-5 has-bottom-padding-s has-top-margin-l">
     Secret metadata
   </h2>
-  {{#if @canReadMetadata}}
+  {{#if @metadata}}
     <div class="box is-fullwidth is-sideless is-paddingless is-marginless" data-test-kv-metadata-section>
       <InfoTableRow @alwaysRender={{true}} @label="Last updated">
         <KvTooltipTimestamp @timestamp={{@metadata.updatedTime}} />

--- a/ui/lib/kv/addon/components/page/secret/metadata/details.hbs
+++ b/ui/lib/kv/addon/components/page/secret/metadata/details.hbs
@@ -48,9 +48,9 @@
   Custom metadata
 </h2>
 <div class="box is-fullwidth is-sideless is-paddingless is-marginless" data-test-kv-custom-metadata-section>
-  {{! if the user had read permissions and there is no custom_metadata @customMetadata is an empty object, without read capabilities it's undefined }}
-  {{#if @customMetadata}}
-    {{#each-in @customMetadata as |key value|}}
+  {{! if the user had read permissions and there is no custom_metadata this is an empty object, without read capabilities it's undefined }}
+  {{#if @metadata.customMetadata}}
+    {{#each-in @metadata.customMetadata as |key value|}}
       <InfoTableRow @alwaysRender={{false}} @label={{key}} @value={{value}} />
     {{else}}
       <EmptyState
@@ -69,6 +69,68 @@
         {{/if}}
       </EmptyState>
     {{/each-in}}
+  {{else if @canReadData}}
+    {{#if this.controlGroupError}}
+      <Hds::Alert
+        data-test-message-error
+        @type="inline"
+        @color="warning"
+        class="has-top-margin-s has-bottom-margin-s"
+        as |A|
+      >
+        <A.Title>Control Group Error</A.Title>
+        <A.Generic>
+          {{! template-lint-disable }}
+          {{{this.controlGroupError}}}
+        </A.Generic>
+      </Hds::Alert>
+    {{/if}}
+    {{#if this.errorMessage}}
+      <MessageError @errorMessage={{this.errorMessage}} />
+    {{/if}}
+    {{#if this.customMetadataFromData}}
+      {{#each-in this.customMetadataFromData as |key value|}}
+        <InfoTableRow @alwaysRender={{false}} @label={{key}} @value={{value}} />
+      {{else}}
+        <EmptyState
+          @title="No custom metadata"
+          @bottomBorder={{true}}
+          @message="This data is version-agnostic and is usually used to describe the secret being stored."
+        >
+          {{#if @canUpdateMetadata}}
+            <Hds::Link::Standalone
+              @icon="plus"
+              @text="Add metadata"
+              @route="secret.metadata.edit"
+              @models={{array @backend @path}}
+              data-test-add-custom-metadata
+            />
+          {{/if}}
+        </EmptyState>
+      {{/each-in}}
+    {{else}}
+      <EmptyState
+        @title="Request custom metadata?"
+        @bottomBorder={{true}}
+        @message="You do not have access to the metadata endpoint but you can retrieve custom metadata from the secret data endpoint."
+      >
+        <div class="is-block">
+          <Hds::Alert @type="compact" @color="critical" class="has-top-margin-xs" as |A|>
+            <A.Description>
+              Sensitive secret data will be retrieved.
+            </A.Description>
+          </Hds::Alert>
+          <Hds::Button
+            class="has-top-margin-xs"
+            @text="Request data"
+            @icon="reload"
+            @iconPosition="trailing"
+            @isFullWidth={{true}}
+            {{on "click" this.requestData}}
+          />
+        </div>
+      </EmptyState>
+    {{/if}}
   {{else}}
     <EmptyState
       @title="You do not have access to read custom metadata"

--- a/ui/lib/kv/addon/components/page/secret/metadata/details.js
+++ b/ui/lib/kv/addon/components/page/secret/metadata/details.js
@@ -14,10 +14,10 @@ import errorMessage from 'vault/utils/error-message';
  * <Page::Secret::Metadata::Details
  * @backend={{this.model.backend}}
  * @breadcrumbs={{this.breadcrumbs}}
- * @canDeleteMetadata={{this.model.permissions.metadata.canDelete}}
- * @canReadMetadata={{this.model.permissions.metadata.canRead}}
- * @canUpdateMetadata={{this.model.permissions.metadata.canUpdate}}
- * @customMetadata={{or this.model.metadata.customMetadata this.model.secret.customMetadata}}
+ * @canDeleteMetadata={{this.model.canDeleteMetadata}}
+ * @canReadData={{this.model.canReadData}}
+ * @canReadMetadata={{this.model.canReadMetadata}}
+ * @canUpdateMetadata={{this.model.canUpdateMetadata}}
  * @metadata={{this.model.metadata}}
  * @path={{this.model.path}}
  * />
@@ -25,9 +25,9 @@ import errorMessage from 'vault/utils/error-message';
  * @param {string} backend - The name of the kv secret engine.
  * @param {array} breadcrumbs - Array to generate breadcrumbs, passed to the page header component
  * @param {boolean} canDeleteMetadata - if true, "Permanently delete" action renders in the toolbar
+ * @param {boolean} canReadData - if true, user can make a request for custom_metadata if they don't have "read" permissions for metadata
  * @param {boolean} canReadMetadata - if true, secret metadata renders below custom_metadata
  * @param {boolean} canUpdateMetadata - if true, "Edit" action renders in the toolbar
- * @param {object} customMetadata - comes from secret metadata or data endpoint. if undefined, user does not have "read" access, if an empty object then there is none
  * @param {model} metadata - Ember data model: 'kv/metadata'
  * @param {string} path - path of kv secret 'my/secret' used as the title for the KV page header
  *
@@ -42,6 +42,10 @@ export default class KvSecretMetadataDetails extends Component {
 
   @tracked error = null;
   @tracked customMetadataFromData = null;
+
+  get customMetadata() {
+    return this.args.metadata?.customMetadata || this.customMetadataFromData;
+  }
 
   @action
   async onDelete() {

--- a/ui/lib/kv/addon/components/page/secret/metadata/details.js
+++ b/ui/lib/kv/addon/components/page/secret/metadata/details.js
@@ -40,8 +40,7 @@ export default class KvSecretMetadataDetails extends Component {
   @service router;
   @service store;
 
-  @tracked controlGroupError = null;
-  @tracked errorMessage = null;
+  @tracked error = null;
   @tracked customMetadataFromData = null;
 
   @action
@@ -70,11 +69,12 @@ export default class KvSecretMetadataDetails extends Component {
     } catch (error) {
       if (error.message === 'Control Group encountered') {
         this.controlGroup.saveTokenFromError(error);
-        const err = this.controlGroup.logFromError(error);
-        this.controlGroupError = err.content;
+        this.error = this.controlGroup.logFromError(error);
+        this.error.isControlGroup = true;
         return;
       }
-      this.errorMessage = 'There was a problem requesting secret data.';
+      this.error.isControlGroup = false;
+      this.error = errorMessage(error);
     }
   }
 }

--- a/ui/lib/kv/addon/components/page/secret/overview.hbs
+++ b/ui/lib/kv/addon/components/page/secret/overview.hbs
@@ -52,7 +52,7 @@
         </Hds::Text::Display>
       </:customTitle>
       <:action>
-        {{#if @canUpdateSecret}}
+        {{#if @canUpdateData}}
           <Hds::Link::Standalone
             @text="Create new"
             @route="secret.details.edit"

--- a/ui/lib/kv/addon/components/page/secret/overview.js
+++ b/ui/lib/kv/addon/components/page/secret/overview.js
@@ -13,7 +13,7 @@ import { isDeleted } from 'kv/utils/kv-deleted';
  * @backend={{this.model.backend}}
  * @breadcrumbs={{this.breadcrumbs}}
  * @canReadMetadata={{true}}
- * @canUpdateSecret={{true}}
+ * @canUpdateData={{true}}
  * @metadata={{this.model.metadata}}
  * @path={{this.model.path}}
  * @subkeys={{this.model.subkeys}}
@@ -22,7 +22,7 @@ import { isDeleted } from 'kv/utils/kv-deleted';
  * @param {string} backend - kv secret mount to make network request
  * @param {array} breadcrumbs - Array to generate breadcrumbs, passed to the page header component
  * @param {boolean} canReadMetadata - permissions to read metadata
- * @param {boolean} canUpdateSecret - permissions to create a new version of a secret
+ * @param {boolean} canUpdateData - permissions to create a new version of a secret
  * @param {model} metadata - Ember data model: 'kv/metadata'
  * @param {string} path - path to request secret data for selected version
  * @param {object} subkeys - API response from subkeys endpoint, object with "subkeys" and "metadata" keys. This arg is null for community edition

--- a/ui/lib/kv/addon/components/page/secret/patch.hbs
+++ b/ui/lib/kv/addon/components/page/secret/patch.hbs
@@ -4,7 +4,15 @@
 ~}}
 
 <KvPageHeader @breadcrumbs={{@breadcrumbs}} @pageTitle="Patch Secret to New Version" />
-
+{{#if this.controlGroupError}}
+  <ControlGroupInlineError @error={{this.controlGroupError}} class="has-top-margin-s has-bottom-margin-s">
+    <:customMessage>
+      <strong>
+        You can re-submit the form once access is granted. Ask your authorizer when to attempt saving again.
+      </strong>
+    </:customMessage>
+  </ControlGroupInlineError>
+{{/if}}
 <MessageError @errorMessage={{this.errorMessage}} />
 
 <div class="box is-sideless is-fullwidth is-bottomless">

--- a/ui/lib/kv/addon/routes/secret.js
+++ b/ui/lib/kv/addon/routes/secret.js
@@ -62,7 +62,7 @@ export default class KvSecretRoute extends Route {
       subkeys: this.fetchSubkeys(backend, path),
       metadata: this.fetchSecretMetadata(backend, path),
       isPatchAllowed: this.isPatchAllowed(capabilities),
-      canUpdateSecret: capabilities.data.canUpdate,
+      canUpdateData: capabilities.data.canUpdate,
       canReadData: capabilities.data.canRead,
       canReadMetadata: capabilities.metadata.canRead,
       canDeleteMetadata: capabilities.metadata.canDelete,

--- a/ui/lib/kv/addon/routes/secret.js
+++ b/ui/lib/kv/addon/routes/secret.js
@@ -62,6 +62,7 @@ export default class KvSecretRoute extends Route {
       isPatchAllowed: this.isPatchAllowed(backend, path),
       // for creating a new secret version
       canUpdateSecret: this.capabilities.canUpdate(`${backend}/data/${path}`),
+      canReadMetadata: this.capabilities.canRead(`${backend}/metadata/${path}`),
     });
   }
 

--- a/ui/lib/kv/addon/routes/secret.js
+++ b/ui/lib/kv/addon/routes/secret.js
@@ -35,34 +35,38 @@ export default class KvSecretRoute extends Route {
     return null;
   }
 
-  isPatchAllowed(backend, path) {
+  isPatchAllowed({ subkeys, data }) {
     if (!this.version.isEnterprise) return false;
-    const capabilities = {
-      canPatch: this.capabilities.canPatch(`${backend}/data/${path}`),
-      canReadSubkeys: this.capabilities.canRead(`${backend}/subkeys/${path}`),
-    };
-    return hash(capabilities).then(
-      ({ canPatch, canReadSubkeys }) => canPatch && canReadSubkeys,
-      // this callback fires if either promise is rejected
-      // since this feature is only client-side gated we return false (instead of default to true)
-      // for debugging you can pass an arg to log the failure reason
-      () => false
-    );
+    return subkeys.canRead && data.canPatch;
   }
 
-  model() {
+  async fetchCapabilities(backend, path) {
+    const metadataPath = `${backend}/metadata/${path}`;
+    const dataPath = `${backend}/data/${path}`;
+    const subkeysPath = `${backend}/subkeys/${path}`;
+    const perms = await this.capabilities.fetchMultiplePaths([metadataPath, dataPath, subkeysPath]);
+    return {
+      metadata: perms[metadataPath],
+      data: perms[dataPath],
+      subkeys: perms[subkeysPath],
+    };
+  }
+
+  async model() {
     const backend = this.secretMountPath.currentPath;
     const { name: path } = this.paramsFor('secret');
-
+    const capabilities = await this.fetchCapabilities(backend, path);
     return hash({
       path,
       backend,
       subkeys: this.fetchSubkeys(backend, path),
       metadata: this.fetchSecretMetadata(backend, path),
-      isPatchAllowed: this.isPatchAllowed(backend, path),
-      // for creating a new secret version
-      canUpdateSecret: this.capabilities.canUpdate(`${backend}/data/${path}`),
-      canReadMetadata: this.capabilities.canRead(`${backend}/metadata/${path}`),
+      isPatchAllowed: this.isPatchAllowed(capabilities),
+      canUpdateSecret: capabilities.data.canUpdate,
+      canReadData: capabilities.data.canRead,
+      canReadMetadata: capabilities.metadata.canRead,
+      canDeleteMetadata: capabilities.metadata.canDelete,
+      canUpdateMetadata: capabilities.metadata.canUpdateMetadata,
     });
   }
 

--- a/ui/lib/kv/addon/routes/secret.js
+++ b/ui/lib/kv/addon/routes/secret.js
@@ -66,7 +66,7 @@ export default class KvSecretRoute extends Route {
       canReadData: capabilities.data.canRead,
       canReadMetadata: capabilities.metadata.canRead,
       canDeleteMetadata: capabilities.metadata.canDelete,
-      canUpdateMetadata: capabilities.metadata.canUpdateMetadata,
+      canUpdateMetadata: capabilities.metadata.canUpdate,
     });
   }
 

--- a/ui/lib/kv/addon/templates/secret/details/index.hbs
+++ b/ui/lib/kv/addon/templates/secret/details/index.hbs
@@ -4,9 +4,11 @@
 ~}}
 
 <Page::Secret::Details
+  @backend={{this.model.backend}}
   @breadcrumbs={{this.breadcrumbs}}
   @isPatchAllowed={{this.model.isPatchAllowed}}
   @path={{this.model.path}}
   @secret={{this.model.secret}}
   @metadata={{this.model.metadata}}
+  @canReadMetadata={{this.model.canReadMetadata}}
 />

--- a/ui/lib/kv/addon/templates/secret/details/index.hbs
+++ b/ui/lib/kv/addon/templates/secret/details/index.hbs
@@ -6,9 +6,11 @@
 <Page::Secret::Details
   @backend={{this.model.backend}}
   @breadcrumbs={{this.breadcrumbs}}
+  @canReadData={{this.model.canReadData}}
+  @canReadMetadata={{this.model.canReadMetadata}}
+  @canUpdateData={{this.model.canUpdateData}}
   @isPatchAllowed={{this.model.isPatchAllowed}}
+  @metadata={{this.model.metadata}}
   @path={{this.model.path}}
   @secret={{this.model.secret}}
-  @metadata={{this.model.metadata}}
-  @canReadMetadata={{this.model.canReadMetadata}}
 />

--- a/ui/lib/kv/addon/templates/secret/index.hbs
+++ b/ui/lib/kv/addon/templates/secret/index.hbs
@@ -7,8 +7,8 @@
   @backend={{this.model.backend}}
   @breadcrumbs={{this.breadcrumbs}}
   @canReadMetadata={{this.model.metadata.canReadMetadata}}
-  @isPatchAllowed={{this.model.isPatchAllowed}}
   @canUpdateData={{this.model.canUpdateData}}
+  @isPatchAllowed={{this.model.isPatchAllowed}}
   @metadata={{this.model.metadata}}
   @path={{this.model.path}}
   @subkeys={{this.model.subkeys}}

--- a/ui/lib/kv/addon/templates/secret/index.hbs
+++ b/ui/lib/kv/addon/templates/secret/index.hbs
@@ -8,7 +8,7 @@
   @breadcrumbs={{this.breadcrumbs}}
   @canReadMetadata={{this.model.metadata.canReadMetadata}}
   @isPatchAllowed={{this.model.isPatchAllowed}}
-  @canUpdateSecret={{this.model.canUpdateSecret}}
+  @canUpdateData={{this.model.canUpdateData}}
   @metadata={{this.model.metadata}}
   @path={{this.model.path}}
   @subkeys={{this.model.subkeys}}

--- a/ui/lib/kv/addon/templates/secret/metadata/index.hbs
+++ b/ui/lib/kv/addon/templates/secret/metadata/index.hbs
@@ -6,10 +6,10 @@
 <Page::Secret::Metadata::Details
   @backend={{this.model.backend}}
   @breadcrumbs={{this.breadcrumbs}}
-  @canDeleteMetadata={{this.model.permissions.metadata.canDelete}}
-  @canReadMetadata={{this.model.permissions.metadata.canRead}}
-  @canUpdateMetadata={{this.model.permissions.metadata.canUpdate}}
-  @customMetadata={{or this.model.metadata.customMetadata this.model.secret.customMetadata}}
+  @canDeleteMetadata={{this.model.canDeleteMetadata}}
+  @canReadData={{this.model.canReadData}}
+  @canReadMetadata={{this.model.canReadMetadata}}
+  @canUpdateMetadata={{this.model.canUpdateMetadata}}
   @metadata={{this.model.metadata}}
   @path={{this.model.path}}
 />

--- a/ui/mirage/factories/kv-metadatum.js
+++ b/ui/mirage/factories/kv-metadatum.js
@@ -59,11 +59,8 @@ export default Factory.extend({
   }),
 
   withCustomPath: trait({
-    data: {
-      ...data,
-      path(i) {
-        return `my-secret-${i}`;
-      },
+    path(i) {
+      return `my-secret-${i}`;
     },
   }),
 });

--- a/ui/mirage/factories/kv-metadatum.js
+++ b/ui/mirage/factories/kv-metadatum.js
@@ -17,6 +17,9 @@ const data = {
   max_versions: 15,
   oldest_version: 0,
   updated_time: '2023-07-21T03:11:58.095971Z',
+  // the API returns custom_metadata: null if empty but because the attr is an 'object' ember data transforms it to an empty object.
+  // this is important because we rely on the empty object as a truthy value in template conditionals
+  custom_metadata: null,
   versions: {
     1: {
       created_time: '2018-03-22T02:24:06.945319214Z',
@@ -45,16 +48,22 @@ export default Factory.extend({
   data,
 
   withCustomMetadata: trait({
-    custom_metadata: {
-      foo: 'abc',
-      bar: '123',
-      baz: '5c07d823-3810-48f6-a147-4c06b5219e84',
+    data: {
+      ...data,
+      custom_metadata: {
+        foo: 'abc',
+        bar: '123',
+        baz: '5c07d823-3810-48f6-a147-4c06b5219e84',
+      },
     },
   }),
 
   withCustomPath: trait({
-    path(i) {
-      return `my-secret-${i}`;
+    data: {
+      ...data,
+      path(i) {
+        return `my-secret-${i}`;
+      },
     },
   }),
 });

--- a/ui/tests/acceptance/secrets/backend/kv/kv-v2-workflow-create-test.js
+++ b/ui/tests/acceptance/secrets/backend/kv/kv-v2-workflow-create-test.js
@@ -405,6 +405,10 @@ module('Acceptance | kv-v2 workflow | secret and version create', function (hook
       await click(PAGE.secretTab('Metadata'));
       assert
         .dom(`${PAGE.metadata.customMetadataSection} ${PAGE.emptyStateTitle}`)
+        .hasText('Request custom metadata?');
+      await click(PAGE.metadata.requestData);
+      assert
+        .dom(`${PAGE.metadata.customMetadataSection} ${PAGE.emptyStateTitle}`)
         .hasText('No custom metadata', 'No custom metadata empty state');
       assert
         .dom(`${PAGE.metadata.secretMetadataSection} ${PAGE.emptyStateTitle}`)
@@ -548,6 +552,10 @@ module('Acceptance | kv-v2 workflow | secret and version create', function (hook
 
       // Metadata page
       await click(PAGE.secretTab('Metadata'));
+      assert
+        .dom(`${PAGE.metadata.customMetadataSection} ${PAGE.emptyStateTitle}`)
+        .hasText('Request custom metadata?');
+      await click(PAGE.metadata.requestData);
       assert
         .dom(`${PAGE.metadata.customMetadataSection} ${PAGE.emptyStateTitle}`)
         .hasText('No custom metadata', 'No custom metadata empty state');

--- a/ui/tests/acceptance/secrets/backend/kv/kv-v2-workflow-edge-cases-test.js
+++ b/ui/tests/acceptance/secrets/backend/kv/kv-v2-workflow-edge-cases-test.js
@@ -122,7 +122,7 @@ module('Acceptance | kv-v2 workflow | edge cases', function (hooks) {
       await click(PAGE.list.item(secret));
       assert
         .dom(GENERAL.overviewCard.container('Current version'))
-        .hasText(`Current version Create new The current version of this secret. 1`);
+        .hasText(`Current version The current version of this secret. 1`);
       // Secret details visible
       await click(PAGE.secretTab('Secret'));
       assert.dom(PAGE.title).hasText(this.fullSecretPath);

--- a/ui/tests/acceptance/secrets/backend/kv/kv-v2-workflow-navigation-test.js
+++ b/ui/tests/acceptance/secrets/backend/kv/kv-v2-workflow-navigation-test.js
@@ -571,7 +571,7 @@ module('Acceptance | kv-v2 workflow | navigation', function (hooks) {
       assert.true(currentURL().startsWith(`/vault/secrets/${backend}/kv/list`), 'links back to list root');
     });
     test('versioned secret nav, tabs, breadcrumbs (dr)', async function (assert) {
-      assert.expect(31);
+      assert.expect(32);
       const backend = this.backend;
       await navToBackend(backend);
 
@@ -614,6 +614,10 @@ module('Acceptance | kv-v2 workflow | navigation', function (hooks) {
       assertCorrectBreadcrumbs(assert, ['Secrets', backend, secretPath, 'Metadata']);
       assert.dom(PAGE.title).hasText(secretPath);
       assert.dom(PAGE.toolbarAction).doesNotExist('no toolbar actions available on metadata');
+      assert
+        .dom(`${PAGE.metadata.customMetadataSection} ${PAGE.emptyStateTitle}`)
+        .hasText('Request custom metadata?');
+      await click(PAGE.metadata.requestData);
       assert
         .dom(`${PAGE.metadata.customMetadataSection} ${PAGE.emptyStateTitle}`)
         .hasText('No custom metadata');
@@ -764,7 +768,7 @@ module('Acceptance | kv-v2 workflow | navigation', function (hooks) {
       assert.true(currentURL().startsWith(`/vault/secrets/${backend}/kv/list`), 'links back to list root');
     });
     test('versioned secret nav, tabs, breadcrumbs (dlr)', async function (assert) {
-      assert.expect(31);
+      assert.expect(32);
       const backend = this.backend;
       await navToBackend(backend);
       await click(PAGE.list.item(secretPath));
@@ -804,6 +808,10 @@ module('Acceptance | kv-v2 workflow | navigation', function (hooks) {
       );
       assertCorrectBreadcrumbs(assert, ['Secrets', backend, secretPath, 'Metadata']);
       assert.dom(PAGE.title).hasText(secretPath);
+      assert
+        .dom(`${PAGE.metadata.customMetadataSection} ${PAGE.emptyStateTitle}`)
+        .hasText('Request custom metadata?');
+      await click(PAGE.metadata.requestData);
       assert
         .dom(`${PAGE.metadata.customMetadataSection} ${PAGE.emptyStateTitle}`)
         .hasText('No custom metadata');

--- a/ui/tests/helpers/kv/kv-selectors.js
+++ b/ui/tests/helpers/kv/kv-selectors.js
@@ -29,6 +29,7 @@ export const PAGE = {
     link: (backend) => `[data-test-secrets-backend-link="${backend}"]`,
   },
   metadata: {
+    requestData: '[data-test-request-data]',
     editBtn: '[data-test-edit-metadata]',
     addCustomMetadataBtn: '[data-test-add-custom-metadata]',
     customMetadataSection: '[data-test-kv-custom-metadata-section]',

--- a/ui/tests/integration/components/edit-form-kmip-role-test.js
+++ b/ui/tests/integration/components/edit-form-kmip-role-test.js
@@ -221,7 +221,7 @@ module('Integration | Component | edit form kmip role', function (hooks) {
         );
       }
 
-      click('[data-test-edit-form-submit]');
+      await click('[data-test-edit-form-submit]');
 
       later(() => cancelTimers(), 50);
       await settled();

--- a/ui/tests/integration/components/kv/page/kv-page-overview-test.js
+++ b/ui/tests/integration/components/kv/page/kv-page-overview-test.js
@@ -47,7 +47,7 @@ module('Integration | Component | kv-v2 | Page::Secret::Overview', function (hoo
       },
     };
     this.canReadMetadata = true;
-    this.canUpdateSecret = true;
+    this.canUpdateData = true;
 
     this.format = (time) => dateFormat([time, 'MMM d yyyy, h:mm:ss aa'], {});
     this.renderComponent = async () => {
@@ -57,7 +57,7 @@ module('Integration | Component | kv-v2 | Page::Secret::Overview', function (hoo
           @backend={{this.backend}}
           @breadcrumbs={{this.breadcrumbs}}
           @canReadMetadata={{this.canReadMetadata}}
-          @canUpdateSecret={{this.canUpdateSecret}}
+          @canUpdateData={{this.canUpdateData}}
           @metadata={{this.metadata}}
           @path={{this.path}}
           @subkeys={{this.subkeys}}
@@ -116,7 +116,7 @@ module('Integration | Component | kv-v2 | Page::Secret::Overview', function (hoo
       // creating a new version of a secret is updating a secret
       // the overview only exists after an initial version is created
       // which is why we just check for update and not also create
-      this.canUpdateSecret = false;
+      this.canUpdateData = false;
       await this.renderComponent();
       assert
         .dom(`${overviewCard.container('Current version')} a`)


### PR DESCRIPTION
### Description
Small follow-on to https://github.com/hashicorp/vault/pull/28212

This addresses a case where a user has control group access to `/data/` but does not have "read" access to `/metadata/`. Adds a manual request for the `Metadata` tab to request `custom_metadata` via `/data/` if a user has read access via control groups. 

Sample policy 
```
path "secret/data/*" {
  capabilities = ["create", "read", "update", "delete", "list"]
  control_group = {
    max_ttl = "24h"
    factor "approver" {
      controlled_capabilities = ["read"]
      identity {
          group_names = ["managers"]
          approvals = 1
      }
    }
  }
}

```
#### empty state if user does not have `READ /metadata/` permissions
<img width="978" alt="Screenshot 2024-08-30 at 11 32 09 AM" src="https://github.com/user-attachments/assets/39a0a930-881a-4f93-b1ed-6ba8aa7ad3e5">

<hr>

#### after user clicks "request" if the`/data/` is only accessible via control group approval
<img width="968" alt="Screenshot 2024-08-30 at 11 35 03 AM" src="https://github.com/user-attachments/assets/7a1b2ede-96d9-4ef2-8308-007dbcb4f53f">

<hr>

#### after the user clicks "request" if `/data/` is not gated by control groups
<img width="1001" alt="Screenshot 2024-08-30 at 11 39 25 AM" src="https://github.com/user-attachments/assets/93f99a6a-750a-4569-a6bc-d21716efdc3c">


### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [ ] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
