### PR TITLE
VAULT-29658: Docs update for AOP

### DIFF
--- a/website/content/docs/concepts/adaptive-overload-protection/index.mdx
+++ b/website/content/docs/concepts/adaptive-overload-protection/index.mdx
@@ -10,8 +10,6 @@ description: >-
 
 @include 'alerts/enterprise-only.mdx'
 
-@include 'alerts/beta.mdx'
-
 Adaptive overload protection refers to a set of features in Vault Enterprise
 that prevent client requests from overwhelming different server resources
 leading to poor availability.
@@ -25,15 +23,15 @@ These protection measures are "Adaptive" in the sense that they automatically
 and continuously adjust to maintain optimal performance for the current workload
 and hardware resources available without any user tuning.
 
-Load testing and tuning of appropriate limits is time consuming for users during
+Load testing and tuning of appropriate limits is time-consuming for users during
 initial setup. Even when clusters are carefully tuned during installation,
 real-world workloads and hardware performance both change over time. A static
-tuning will soon be sub-optimal or even completely ineffective at preventing
+tuning will soon be suboptimal or even completely ineffective at preventing
 overloads.
 
 For example, an increase in disk latency caused by failing hardware might reduce
 the server's available throughput. A static limit configured while disks were
-performing a their peak would not protect the degraded system from overload. By
+performing at their peak would not protect the degraded system from overload. By
 adaptively responding to current load and performance characteristics, Vault
 Enterprise is able to provide long-term protection against overloads.
 
@@ -60,8 +58,9 @@ In some cases, a sudden influx of write requests that exceeds Vault's hardware
 capacity can result in the writes queueing for so long that every request times
 out before the write can make it through the queue. This makes Vault effectively
 unavailable to clients even though it is still processing requests and storing
-data as fast as it can. This is illustrated in the test results shown below for
-a workload of 100% logins.
+data as fast as it can. This can also result in Replication lagging behind causing
+data discrepancies between replicated clusters. This is illustrated in the test
+results shown below for a workload of 100% logins.
 
 ![Login workload telemetry graphs showing difference with and without adaptive overload protection for writes](/img/adaptive-overload-protection-writes.png)
 
@@ -69,12 +68,14 @@ Adaptive Write Overload Protection prevents this scenario. It constantly
 monitors the current state of the write queue and uses a carefully tuned
 algorithm to allow just enough queueing to maximize throughput on the available
 hardware while keeping latencies under control and unnecessary rejections to a
-minimum.
+minimum. Writes related to replication are always handled, avoiding a sudden
+increase of write requests causing replication lag.
 
 Write overload protection was added in Vault Enterprise 1.17 as a beta feature
-which is disabled by default.
+which is now enabled by default for Raft Integrated Storage. Adaptive overload
+protection is disabled by default for Consul storage.
 
-To enable the feature use the [`adaptive_overload_protection` configuration
+To disable the feature use the [`adaptive_overload_protection` configuration
 stanza](/vault/docs/configuration/adaptive-overload-protection).
 
 ### Metrics

--- a/website/content/docs/concepts/adaptive-overload-protection/vault-server-temporarily-overloaded.mdx
+++ b/website/content/docs/concepts/adaptive-overload-protection/vault-server-temporarily-overloaded.mdx
@@ -17,13 +17,12 @@ Vault returns a `503 - Service Unavailable` response to indicate that a request
 was rejected because there was not enough capacity to service it in a timely way:
 
 ```
-Error making API request.
+Error authenticating: Error making API request.
 
-URL: PUT https://127.0.0.1:61555/v1/auth/userpass/login/foo
+URL: PUT http://127.0.0.1:8200/v1/auth/userpass/login/foo
 Code: 503. Errors:
 
-* 1 error occurred:
-	* Vault server temporarily overloaded
+* failed to create token: failed to persist accessor index entry: overloaded, try again later: internal error
 ```
 
 `503 - Service Unavailable` is a retryable HTTP error.

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -326,19 +326,14 @@
       {
         "title": "Adaptive overload protection",
         "badge": {
-          "text": "ENTERPRISE | BETA",
+          "text": "ENTERPRISE",
           "type": "outlined",
           "color": "neutral"
         },
         "routes": [
           {
             "title": "Overview",
-            "path": "concepts/adaptive-overload-protection",
-            "badge": {
-              "text": "BETA",
-              "type": "outlined",
-              "color": "highlight"
-            }
+            "path": "concepts/adaptive-overload-protection"
           },
           {
             "title": "Vault server temporarily overloaded",


### PR DESCRIPTION
### Description
Update docs for Adaptive Overload Protection

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [ ] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
