### PR TITLE
chore: fix some function names

### DIFF
--- a/helper/locking/core_locking.go
+++ b/helper/locking/core_locking.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 )
 
-// ParseDeadlockDetectionSetting takes the detectDeadlockConfigParameter string
+// ParseDetectDeadlockConfigParameter takes the detectDeadlockConfigParameter string
 // and transforms it to a lowercase version of the string, then splits it into
 // a slice of strings by interpreting commas as the element delimiters.
 func ParseDetectDeadlockConfigParameter(detectDeadlockConfigParameter string) []string {

--- a/internalshared/configutil/listener.go
+++ b/internalshared/configutil/listener.go
@@ -638,7 +638,7 @@ func (l *Listener) parseProfilingSettings() error {
 	return nil
 }
 
-// parseProfilingSettings attempts to parse the raw listener in-flight request logging settings.
+// parseInFlightRequestSettings attempts to parse the raw listener in-flight request logging settings.
 // The state of the listener will be modified, raw data will be cleared upon
 // successful parsing.
 func (l *Listener) parseInFlightRequestSettings() error {

--- a/vault/ha_test.go
+++ b/vault/ha_test.go
@@ -12,7 +12,7 @@ import (
 	"time"
 )
 
-// TestGrabLockOrStopped is a non-deterministic test to detect deadlocks in the
+// TestGrabLockOrStop is a non-deterministic test to detect deadlocks in the
 // grabLockOrStopped function. This test starts a bunch of workers which
 // continually lock/unlock and rlock/runlock the same RWMutex. Each worker also
 // starts a goroutine which closes the stop channel 1/2 the time, which races


### PR DESCRIPTION
### Description

fix some function names

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [ ] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
