### PR TITLE
Add missing revocation storage lock on RevokeCert refactoring

### DIFF
--- a/builtin/logical/pki/backend.go
+++ b/builtin/logical/pki/backend.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/armon/go-metrics"
 	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-secure-stdlib/parseutil"
 	"github.com/hashicorp/vault/builtin/logical/pki/issuing"
 	"github.com/hashicorp/vault/builtin/logical/pki/managed_key"
 	"github.com/hashicorp/vault/builtin/logical/pki/pki_backend"
@@ -817,21 +818,68 @@ type revoker struct {
 	crlConfig      *pki_backend.CrlConfig
 }
 
-func (r *revoker) RevokeCert(cert *x509.Certificate) (*logical.Response, error) {
+func (r *revoker) RevokeCert(cert *x509.Certificate) (revocation.RevokeCertInfo, error) {
 	r.backend.GetRevokeStorageLock().Lock()
 	defer r.backend.GetRevokeStorageLock().Unlock()
-	return revokeCert(r.storageContext, r.crlConfig, cert)
+	resp, err := revokeCert(r.storageContext, r.crlConfig, cert)
+	return parseRevokeCertOutput(resp, err)
 }
 
-func (r *revoker) RevokeCertBySerial(serial string) (*logical.Response, error) {
-	return tryRevokeCertBySerial(r.storageContext, r.crlConfig, serial)
+func (r *revoker) RevokeCertBySerial(serial string) (revocation.RevokeCertInfo, error) {
+	// NOTE: tryRevokeCertBySerial grabs the revoke storage lock for us
+	resp, err := tryRevokeCertBySerial(r.storageContext, r.crlConfig, serial)
+	return parseRevokeCertOutput(resp, err)
 }
 
-func (b *backend) GetRevoker(ctx context.Context, s logical.Storage) revocation.Revoker {
+// There are a bunch of reasons that a certificate will/won't be revoked. Sadly we will need a further
+// refactoring but for now handle the basics of the reasons/response objects back to a usable object
+// that doesn't directly reply to the API request
+func parseRevokeCertOutput(resp *logical.Response, err error) (revocation.RevokeCertInfo, error) {
+	if err != nil {
+		return revocation.RevokeCertInfo{}, err
+	}
+
+	if resp == nil {
+		// nil, nil response, most likely means the certificate was missing,
+		// but *might* be other things such as a tainted mount
+		return revocation.RevokeCertInfo{}, nil
+	}
+
+	if resp.IsError() {
+		// There are a few reasons we return a response error but not an error,
+		// such as UserError's or they tried to revoke the CA
+		return revocation.RevokeCertInfo{}, resp.Error()
+	}
+
+	// It is possible we don't return the field for various reasons if just a bunch of warnings are set.
+	if revTimeRaw, ok := resp.Data["revocation_time"]; ok {
+		revTimeInt, err := parseutil.ParseInt(revTimeRaw)
+		if err != nil {
+			// Lets me lenient for now
+			revTimeInt = 0
+		}
+		revTime := time.Unix(revTimeInt, 0)
+		return revocation.RevokeCertInfo{
+			RevocationTime: revTime,
+		}, nil
+	}
+
+	// Since we don't really know what went wrong if anything, for example the certificate might
+	// have been expired or close to expiry, lets punt on it for now
+	return revocation.RevokeCertInfo{
+		Warnings: resp.Warnings,
+	}, nil
+}
+
+func (b *backend) GetRevoker(ctx context.Context, s logical.Storage) (revocation.Revoker, error) {
 	sc := b.makeStorageContext(ctx, s)
+	crlConfig, err := b.CrlBuilder().GetConfigWithUpdate(sc)
+	if err != nil {
+		return nil, err
+	}
 	return &revoker{
 		backend:        b,
-		crlConfig:      &b.CrlBuilder().config,
+		crlConfig:      crlConfig,
 		storageContext: sc,
-	}
+	}, nil
 }

--- a/builtin/logical/pki/backend.go
+++ b/builtin/logical/pki/backend.go
@@ -818,6 +818,8 @@ type revoker struct {
 }
 
 func (r *revoker) RevokeCert(cert *x509.Certificate) (*logical.Response, error) {
+	r.backend.GetRevokeStorageLock().Lock()
+	defer r.backend.GetRevokeStorageLock().Unlock()
 	return revokeCert(r.storageContext, r.crlConfig, cert)
 }
 

--- a/builtin/logical/pki/revocation/revoke.go
+++ b/builtin/logical/pki/revocation/revoke.go
@@ -21,12 +21,17 @@ const (
 )
 
 type RevokerFactory interface {
-	GetRevoker(context.Context, logical.Storage) Revoker
+	GetRevoker(context.Context, logical.Storage) (Revoker, error)
+}
+
+type RevokeCertInfo struct {
+	RevocationTime time.Time
+	Warnings       []string
 }
 
 type Revoker interface {
-	RevokeCert(cert *x509.Certificate) (*logical.Response, error)
-	RevokeCertBySerial(serial string) (*logical.Response, error)
+	RevokeCert(cert *x509.Certificate) (RevokeCertInfo, error)
+	RevokeCertBySerial(serial string) (RevokeCertInfo, error)
 }
 
 type RevocationInfo struct {


### PR DESCRIPTION
### Description

When we factored out the revocation API, I missed the fact that the `RevokeCert` implementation failed to grab the revocation storage lock prior to calling `revokeCert` method.

 - Leverage the GetConfigWithUpdate to fetch the current CRL config, otherwise we can use older or nil configs.
 - Change the API to process a little bit the logical.Response/error returns to a "normal" Go API to be used internally. This will require additional refactoring in the future to expose more specific ideas of what went wrong to the callers


### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [ ] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [X] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [X] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
