### PR TITLE
UI: add `isPatchAllowed` to jsdoc component notes

### DIFF
--- a/ui/lib/kv/addon/components/kv-subkeys-card.js
+++ b/ui/lib/kv/addon/components/kv-subkeys-card.js
@@ -32,9 +32,11 @@ sample subkeys:
 ```
  * 
  * @example
- * <KvSubkeysCard @subkeys={{this.subkeys}} />
+ * <KvSubkeysCard @subkeys={{this.subkeys}} @isPatchAllowed={{true}} />
  *
  * @param {object} subkeys - leaf keys of a kv v2 secret, all values (unless a nested object with more keys) return null
+ * @param {boolean} isPatchAllowed - true if the version is enterprise AND a user has "patch" secret + "read" subkeys capabilities, if true renders the "Patch secret" action
+
  */
 
 export default class KvSubkeysCard extends Component {

--- a/ui/lib/kv/addon/components/page/secret/details.js
+++ b/ui/lib/kv/addon/components/page/secret/details.js
@@ -33,7 +33,7 @@ import { isAdvancedSecret } from 'core/utils/advanced-secret';
  * @param {boolean} canReadData - if true and the secret is not destroyed/deleted the copy secret dropdown renders
  * @param {boolean} canReadMetadata - if true it renders the kv select version dropdown in the toolbar and "Version History" tab
  * @param {boolean} canUpdateData - if true it renders "Create new version" toolbar action
- * @param {boolean} isPatchAllowed - if true it renders "Patch latest version" toolbar action
+ * @param {boolean} isPatchAllowed - isPatchAllowed is true if the version is enterprise AND a user has "patch" secret + "read" subkeys capabilities, if true it renders "Patch latest version" toolbar action
  * @param {model} metadata - Ember data model: 'kv/metadata'
  * @param {string} path - path of kv secret 'my/secret' used as the title for the KV page header
  * @param {model} secret - Ember data model: 'kv/data'

--- a/ui/lib/kv/addon/components/page/secret/overview.js
+++ b/ui/lib/kv/addon/components/page/secret/overview.js
@@ -14,6 +14,7 @@ import { isDeleted } from 'kv/utils/kv-deleted';
  * @breadcrumbs={{this.breadcrumbs}}
  * @canReadMetadata={{true}}
  * @canUpdateData={{true}}
+ * @isPatchAllowed={{true}}
  * @metadata={{this.model.metadata}}
  * @path={{this.model.path}}
  * @subkeys={{this.model.subkeys}}
@@ -23,6 +24,7 @@ import { isDeleted } from 'kv/utils/kv-deleted';
  * @param {array} breadcrumbs - Array to generate breadcrumbs, passed to the page header component
  * @param {boolean} canReadMetadata - permissions to read metadata
  * @param {boolean} canUpdateData - permissions to create a new version of a secret
+ * @param {boolean} isPatchAllowed - isPatchAllowed is true if the version is enterprise AND a user has "patch" secret + "read" subkeys capabilities, passed to KvSubkeysCard
  * @param {model} metadata - Ember data model: 'kv/metadata'
  * @param {string} path - path to request secret data for selected version
  * @param {object} subkeys - API response from subkeys endpoint, object with "subkeys" and "metadata" keys. This arg is null for community edition


### PR DESCRIPTION
### Description
Adds `isPatchAllowed` to jsdoc component notes. Follow-on to https://github.com/hashicorp/vault/pull/28212

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [ ] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
