### PR TITLE
Audit: add auth and secret block to response test for hmac

### DIFF
--- a/audit/hashstructure_test.go
+++ b/audit/hashstructure_test.go
@@ -269,6 +269,24 @@ func TestHashResponse(t *testing.T) {
 			CreationTime:    now,
 			WrappedAccessor: "bar",
 		},
+		Auth: &logical.Auth{
+			ClientToken: "hvs.QWERTY-T1q5lEjIWux1Tjx-VGqAYJdd4FZtbp1wpD5Ym9pGh4KHGh2cy5TSjRndGoxaU44NzNscm5MSlRLQXZ0ZGg",
+			Accessor:    "ABClk9ZNLGOCuTrOEIAooJG3",
+			TokenType:   logical.TokenTypeService,
+		},
+		Secret: &logical.Secret{
+			LeaseOptions: logical.LeaseOptions{
+				TTL:       3,
+				MaxTTL:    5,
+				Renewable: false,
+				Increment: 1,
+				IssueTime: now,
+			},
+			InternalData: map[string]any{
+				"foo": "bar",
+			},
+			LeaseID: "abc",
+		},
 	}
 
 	req := &logical.Request{MountPoint: "/foo/bar"}
@@ -280,6 +298,11 @@ func TestHashResponse(t *testing.T) {
 	nonHMACDataKeys := []string{"baz"}
 
 	expected := &response{
+		Auth: &auth{
+			Accessor:    "hmac-sha256:253184715b2d5a6c3a2fc7afe0d2294085f5e886a1275ca735646a6f23be2587",
+			ClientToken: "hmac-sha256:2ce541100a8bcd687e8ec7712c8bb4c975a8d8599c02d98945e63ecd413bf0f3",
+			TokenType:   "service",
+		},
 		Data: map[string]interface{}{
 			"foo": "hmac-sha256:f9320baf0249169e73850cd6156ded0106e2bb6ad8cab01b7bbbebe6d1065317",
 			"baz": "foobar",
@@ -298,6 +321,9 @@ func TestHashResponse(t *testing.T) {
 		MountPoint:            "/foo/bar",
 		MountRunningVersion:   "123",
 		MountRunningSha256:    "256-256!",
+		Secret: &secret{
+			LeaseID: "abc",
+		},
 	}
 
 	inmemStorage := &logical.InmemStorage{}


### PR DESCRIPTION
### Description

Add test to prevent regression of HMAC for `auth` within a `response` for audit.

### TODO only if you're a HashiCorp employee

- [ ] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [ ] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
