### PR TITLE
Audit: always use derived context for audit logging, increase timeout to 10s

### DIFF
--- a/audit/broker.go
+++ b/audit/broker.go
@@ -22,7 +22,7 @@ import (
 
 const (
 	// timeout is the duration which should be used for context related timeouts.
-	timeout = 5 * time.Second
+	timeout = 10 * time.Second
 )
 
 var (
@@ -277,29 +277,12 @@ func (b *Broker) LogRequest(ctx context.Context, in *logical.LogInput) (retErr e
 
 	e.Data = in
 
-	// Evaluate whether we need a new context for auditing.
-	var auditContext context.Context
-	if isContextViable(ctx) {
-		auditContext = ctx
-	} else {
-		// In cases where we are trying to audit the request, and the existing
-		// context is not viable due to a short deadline, we detach ourselves from
-		// the original context (keeping only the namespace).
-		// This is so that we get a fair run at writing audit entries if Vault
-		// has taken up a lot of time handling the request before audit (request)
-		// is triggered. Pipeline nodes and the eventlogger.Broker may check for a
-		// cancelled context and refuse to process the nodes further.
-		ns, err := nshelper.FromContext(ctx)
-		if err != nil {
-			return fmt.Errorf("namespace missing from context: %w", err)
-		}
-
-		tempContext, auditCancel := context.WithTimeout(context.Background(), timeout)
-		defer auditCancel()
-		auditContext = nshelper.ContextWithNamespace(tempContext, ns)
-
-		b.logger.Trace("log request requires a derived context (original context was not viable)", "namespace ID", ns.ID, "namespace path", ns.Path, "timeout", timeout)
+	// Get a context to use for auditing.
+	auditContext, auditCancel, err := getAuditContext(ctx)
+	if err != nil {
+		return err
 	}
+	defer auditCancel()
 
 	var status eventlogger.Status
 	if hasAuditPipelines(b.broker) {
@@ -361,29 +344,12 @@ func (b *Broker) LogResponse(ctx context.Context, in *logical.LogInput) (retErr 
 
 	e.Data = in
 
-	// Evaluate whether we need a new context for auditing.
-	var auditContext context.Context
-	if isContextViable(ctx) {
-		auditContext = ctx
-	} else {
-		// In cases where we are trying to audit the response, and the existing
-		// context is not viable due to a short deadline, we detach ourselves from
-		// the original context (keeping only the namespace).
-		// This is so that we get a fair run at writing audit entries if Vault
-		// has taken up a lot of time handling the request before audit (response)
-		// is triggered. Pipeline nodes and the eventlogger.Broker may check for a
-		// cancelled context and refuse to process the nodes further.
-		ns, err := nshelper.FromContext(ctx)
-		if err != nil {
-			return fmt.Errorf("namespace missing from context: %w", err)
-		}
-
-		tempContext, auditCancel := context.WithTimeout(context.Background(), timeout)
-		defer auditCancel()
-		auditContext = nshelper.ContextWithNamespace(tempContext, ns)
-
-		b.logger.Trace("log response requires a derived context (original context was not viable)", "namespace ID", ns.ID, "namespace path", ns.Path, "timeout", timeout)
+	// Get a context to use for auditing.
+	auditContext, auditCancel, err := getAuditContext(ctx)
+	if err != nil {
+		return err
 	}
+	defer auditCancel()
 
 	var status eventlogger.Status
 	if hasAuditPipelines(b.broker) {
@@ -463,33 +429,19 @@ func (b *Broker) IsRegistered(name string) bool {
 	return b.isRegisteredByName(name)
 }
 
-// isContextViable examines the supplied context to see if its own deadline would
-// occur later than a newly created context with a specific timeout.
-// Additionally, whether the supplied context is already cancelled, thus making it
-// unviable.
-// If the existing context is viable it can be used 'as-is', if not, the caller
-// should consider creating a new context with the relevant deadline and associated
-// context values (e.g. namespace) in order to reduce the likelihood that the
-// audit system believes there is a failure in audit (and updating its metrics)
-// when the root cause is elsewhere.
-func isContextViable(ctx context.Context) bool {
-	if ctx == nil {
-		return false
+// getAuditContext extracts the namespace from the specified context and returns
+// a new context and cancelation function, completely detached from the original
+// with a timeout.
+// NOTE: The context.CancelFunc returned from this function should be deferred
+// immediately by the caller to prevent resource leaks.
+func getAuditContext(ctx context.Context) (context.Context, context.CancelFunc, error) {
+	ns, err := nshelper.FromContext(ctx)
+	if err != nil {
+		return nil, nil, fmt.Errorf("namespace missing from context: %w", err)
 	}
 
-	select {
-	case <-ctx.Done():
-		return false
-	default:
-	}
+	tempContext := nshelper.ContextWithNamespace(context.Background(), ns)
+	auditContext, auditCancel := context.WithTimeout(tempContext, timeout)
 
-	deadline, hasDeadline := ctx.Deadline()
-
-	// If there's no deadline on the context then we don't need to worry about
-	// it being cancelled due to a timeout.
-	if !hasDeadline {
-		return true
-	}
-
-	return deadline.After(time.Now().Add(timeout))
+	return auditContext, auditCancel, nil
 }

--- a/audit/broker.go
+++ b/audit/broker.go
@@ -432,8 +432,8 @@ func (b *Broker) IsRegistered(name string) bool {
 // getAuditContext extracts the namespace from the specified context and returns
 // a new context and cancelation function, completely detached from the original
 // with a timeout.
-// NOTE: The context.CancelFunc returned from this function should be deferred
-// immediately by the caller to prevent resource leaks.
+// NOTE: When error is nil, the context.CancelFunc returned from this function
+// should be deferred immediately by the caller to prevent resource leaks.
 func getAuditContext(ctx context.Context) (context.Context, context.CancelFunc, error) {
 	ns, err := nshelper.FromContext(ctx)
 	if err != nil {

--- a/changelog/28286.txt
+++ b/changelog/28286.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+audit: Internal implementation changes to the audit subsystem which improve relability.
+```


### PR DESCRIPTION
### Description

This PR makes the following changes to the Audit system:

* Always use a newly derived context so that we cannot be cancelled by the HTTP request etc.
* Increase new context timeout to 10 secs
* Remove non-required code and tests (`isContextViable`)

No ENT PR required.

**NOTE:** 

The reason we are not currently looking into making the timeout tuneable/configurable is that it's an easy/surefire way to brick your Vault cluster if you turn this up too high. 

Each attempt to log a request or response means the eventlogger could spin up multiple goroutines for Vault's audit devices, if we're dealing with clusters experiencing 10s of thousands of requests per second, this could mean there's a lot 'in flight', and giving audit longer and longer likely won't resolve an issue if a file/socket/syslog cannot write within ~10secs. 

It just means we would be making the eventlogger wait longer and longer before deciding if we wrote to enough audit sinks. With Vault sat waiting in the meantime.

###  HashiCorp employee checklist

- [x] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [x] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
