### PR TITLE
VAULT-30640: support running test-go in parallel on multiple branches

### DIFF
--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -98,12 +98,6 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           ref: ${{ inputs.checkout-ref }}
-      - uses: ./.github/actions/set-up-go
-        with:
-          github-token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
-      - id: metadata
-        name: Set up metadata
-        run: echo "go-test-dir=test-results/go-test" | tee -a "$GITHUB_OUTPUT"
       - name: Authenticate to Vault
         id: vault-auth
         if: github.repository == 'hashicorp/vault-enterprise'
@@ -131,6 +125,12 @@ jobs:
         if: github.repository != 'hashicorp/vault-enterprise'
         run: |
           git config --global url."https://${{ secrets.ELEVATED_GITHUB_TOKEN}}@github.com".insteadOf https://github.com
+      - uses: ./.github/actions/set-up-go
+        with:
+          github-token: ${{ github.repository == 'hashicorp/vault-enterprise' && steps.secrets.outputs.github-token || secrets.ELEVATED_GITHUB_TOKEN }}
+      - id: metadata
+        name: Set up metadata
+        run: echo "go-test-dir=test-results/go-test" | tee -a "$GITHUB_OUTPUT"
       - uses: ./.github/actions/set-up-gotestsum
       - run: mkdir -p ${{ steps.metadata.outputs.go-test-dir }}
       - uses: actions/cache/restore@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
@@ -243,24 +243,26 @@ jobs:
           # Example comments assume:
           #   - needs.test-matrix.outputs.go-test-dir == test-results/go-test
           #   - inputs.name == testonly
+          #   - inputs.checkout-ref == main
           #   - matrix.id == 1
-          name='${{ inputs.name }}-${{ matrix.id }}'                                    # testonly-1
+          ref="$(tr / - <<< "${{ inputs.checkout-ref }}")"                              # main, but removes special characters from refs with /
+          name="${{ inputs.name }}-${ref}-${{ matrix.id }}"                             # testonly-main-1
           go_test_dir='${{ needs.test-matrix.outputs.go-test-dir }}'                    # test-results/go-test
           test_results_dir="$(dirname "$go_test_dir")"                                  # test-results
           go_test_dir_absolute="$(pwd)/${go_test_dir}"                                  # /home/runner/work/vault/vault/test-results/go-test
           go_test_log_dir="${go_test_dir}/logs"                                         # test-results/go-test/logs
           go_test_log_dir_absolute="${go_test_dir_absolute}/logs"                       # /home/runner/work/vault/vault/test-results/go-test/logs
-          go_test_log_archive_name="test-logs-${name}.tar"                              # test-logs-testonly-1.tar
-          go_test_results_upload_key="${test_results_dir}-${name}"                      # test-results/go-test-testonly-1
-          go_test_results_download_pattern="${test_results_dir}-${{ inputs.name }}-*"   # test-results/go-test-testonly-*
+          go_test_log_archive_name="test-logs-${name}.tar"                              # test-logs-testonly-main-1.tar
+          go_test_results_upload_key="${test_results_dir}-${name}"                      # test-results/go-test-testonly-main-1
+          go_test_results_download_pattern="${test_results_dir}-${{ inputs.name }}-*"   # test-results/go-test-testonly-main-*
           gotestsum_results_prefix="results"                                            # results
-          gotestsum_junitfile=${go_test_dir}/${gotestsum_results_prefix}-${name}.xml    # test-results/go-test/results-testonly-1.xml
-          gotestsum_jsonfile=${go_test_dir}/${gotestsum_results_prefix}-${name}.json    # test-results/go-test/results-testonly-1.json
-          gotestsum_timing_events=failure-summary-${name}.json                          # failure-summary-testonly-1.json
-          failure_summary_file_name="failure-summary-${name}.md"                        # failure-summary-testonly-1.md
+          gotestsum_junitfile=${go_test_dir}/${gotestsum_results_prefix}-${name}.xml    # test-results/go-test/results-testonly-main-1.xml
+          gotestsum_jsonfile=${go_test_dir}/${gotestsum_results_prefix}-${name}.json    # test-results/go-test/results-testonly-main-1.json
+          gotestsum_timing_events=failure-summary-${name}.json                          # failure-summary-testonly-main-1.json
+          failure_summary_file_name="failure-summary-${name}.md"                        # failure-summary-testonly-main-1.md
           data_race_log_file="data-race.log"                                            # data-race.log
-          data_race_log_download_pattern="data-race-${{ inputs.name }}*.log"            # data-race-testonly-*.log
-          data_race_log_upload_key="data-race-${name}.log"                              # data-race-testonly-1.log
+          data_race_log_download_pattern="data-race-${{ inputs.name }}*.log"            # data-race-testonly-main-*.log
+          data_race_log_upload_key="data-race-${name}.log"                              # data-race-testonly-main-1.log
           {
             echo "name=${name}"
             echo "failure-summary-file-name=${failure_summary_file_name}"


### PR DESCRIPTION
### Description

In order for our enterprise nightlies to run the same test-go job but across a matrix of different base references we need to consider the checkout ref in our failure and summary uploads in order to prevent an upload race.

We also configure Git with our token before setting up Go so that enterprise CI workflows can execute without downloading a module cache.

CE bits extracted from https://github.com/hashicorp/vault-enterprise/pull/6586

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [x] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
