### PR TITLE
UI: address flaky auth-jwt and control group tests

### DIFF
--- a/ui/tests/helpers/auth/auth-form-selectors.ts
+++ b/ui/tests/helpers/auth/auth-form-selectors.ts
@@ -9,7 +9,7 @@ export const AUTH_FORM = {
   tabs: (method: string) => (method ? `[data-test-auth-method="${method}"]` : '[data-test-auth-method]'),
   description: '[data-test-description]',
   roleInput: '[data-test-role]',
-  input: (item: string) => `[data-test-${item}]`, // i.e. role, token, password or username
+  input: (item: string) => `[data-test-${item}]`, // i.e. jwt, role, token, password or username
   mountPathInput: '[data-test-auth-form-mount-path]',
   moreOptions: '[data-test-auth-form-options-toggle]',
 };

--- a/ui/tests/integration/components/control-group-success-test.js
+++ b/ui/tests/integration/components/control-group-success-test.js
@@ -3,97 +3,95 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { later, run, _cancelTimers as cancelTimers } from '@ember/runloop';
 import { resolve } from 'rsvp';
 import Service from '@ember/service';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, settled } from '@ember/test-helpers';
+import { click, fillIn, find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import sinon from 'sinon';
-import { create } from 'ember-cli-page-object';
-import controlGroupSuccess from '../../pages/components/control-group-success';
 import { setRunOptions } from 'ember-a11y-testing/test-support';
 
-const component = create(controlGroupSuccess);
-
-const controlGroupService = Service.extend({
-  deleteControlGroupToken: sinon.stub(),
-  markTokenForUnwrap: sinon.stub(),
-});
-
-const storeService = Service.extend({
-  adapterFor() {
-    return {
-      toolAction() {
-        return resolve({ data: { foo: 'bar' } });
-      },
-    };
-  },
-});
+const SELECTORS = {
+  jsonViewer: '[data-test-json-viewer]',
+  navigate: '[data-test-navigate-button]',
+  navMessage: '[data-test-navigate-message]',
+  tokenInput: '[data-test-token-input]',
+  unwrap: '[data-test-unwrap-button]',
+  unwrapForm: '[data-test-unwrap-form]',
+};
 
 module('Integration | Component | control group success', function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function () {
-    run(() => {
-      this.owner.unregister('service:store');
-      this.owner.register('service:control-group', controlGroupService);
-      this.controlGroup = this.owner.lookup('service:control-group');
-      this.owner.register('service:store', storeService);
-      this.router = this.owner.lookup('service:router');
-      this.router.reopen({
-        transitionTo: sinon.stub().returns(resolve()),
-      });
-      setRunOptions({
-        rules: {
-          // TODO: swap out JsonEditor with Hds::CodeBlock for display
-          'color-contrast': { enabled: false },
-          label: { enabled: false },
-        },
-      });
+    this.store = this.owner.lookup('service:store');
+    this.transitionStub = sinon.stub(this.owner.lookup('service:router'), 'transitionTo');
+    this.controlGroup = this.owner.lookup('service:control-group');
+    this.markTokenForUnwrapStub = sinon.stub(this.controlGroup, 'markTokenForUnwrap');
+    this.model = {
+      approved: false,
+      requestPath: 'foo/bar',
+      id: 'accessor',
+      requestEntity: { id: 'requestor', name: 'entity8509' },
+      reload: sinon.stub(),
+    };
+    setRunOptions({
+      rules: {
+        // TODO: swap out JsonEditor with Hds::CodeBlock for display
+        'color-contrast': { enabled: false },
+        label: { enabled: false },
+      },
     });
   });
 
-  const MODEL = {
-    approved: false,
-    requestPath: 'foo/bar',
-    id: 'accessor',
-    requestEntity: { id: 'requestor', name: 'entity8509' },
-    reload: sinon.stub(),
-  };
   test('render with saved token', async function (assert) {
     assert.expect(3);
     const response = {
       uiParams: { url: '/foo' },
       token: 'token',
     };
-    this.set('model', MODEL);
     this.set('response', response);
     await render(hbs`<ControlGroupSuccess @model={{this.model}} @controlGroupResponse={{this.response}} />`);
+    assert
+      .dom(SELECTORS.navMessage)
+      .hasText(
+        'You have been granted access to foo/bar. Be careful, you can only access this data once. If you need access again in the future you will need to get authorized again. Visit'
+      );
 
-    assert.true(component.showsNavigateMessage, 'shows unwrap message');
-
-    await component.navigate();
-    later(() => cancelTimers(), 50);
-    await settled();
-
-    assert.true(this.controlGroup.markTokenForUnwrap.calledOnce, 'marks token for unwrap');
-    assert.true(this.router.transitionTo.calledOnce, 'calls router transition');
+    await click(SELECTORS.navigate);
+    const [transition] = this.transitionStub.lastCall.args;
+    const [accessor] = this.markTokenForUnwrapStub.lastCall.args;
+    assert.strictEqual(accessor, 'accessor', 'marks token for unwrap');
+    assert.strictEqual(transition, '/foo', 'calls router transition');
   });
 
   test('render without token', async function (assert) {
     assert.expect(2);
-    this.set('model', MODEL);
     await render(hbs`<ControlGroupSuccess @model={{this.model}} />`);
+    assert.dom(SELECTORS.unwrapForm).exists();
+    assert.dom(SELECTORS.tokenInput).hasValue('');
+  });
 
-    assert.true(component.showsUnwrapForm, 'shows unwrap form');
-
-    await component.token('token');
-    component.unwrap();
-    later(() => cancelTimers(), 50);
-    await settled();
-
-    assert.true(component.showsJsonViewer, 'shows unwrapped data');
+  test('it unwraps data on submit', async function (assert) {
+    assert.expect(2);
+    const storeService = Service.extend({
+      adapterFor() {
+        return {
+          toolAction() {
+            return resolve({ data: { foo: 'bar' } });
+          },
+        };
+      },
+    });
+    this.owner.unregister('service:store');
+    this.owner.register('service:store', storeService);
+    await render(hbs`<ControlGroupSuccess @model={{this.model}} />`);
+    assert.dom(SELECTORS.tokenInput).hasValue('');
+    await fillIn(SELECTORS.tokenInput, 'token');
+    await click(SELECTORS.unwrap);
+    const actual = find(SELECTORS.jsonViewer).innerText;
+    const expected = JSON.stringify({ foo: 'bar' }, null, 2);
+    assert.strictEqual(actual, expected, `it renders unwrapped data: ${actual}`);
   });
 });


### PR DESCRIPTION
### Description
After merging https://github.com/hashicorp/vault/pull/28262 these tests started failing consistently.  
```
Integration | Component | auth jwt: oidc: test role: it renders: Chrome 128.0
fetches the auth_url when the path changes
Expected:
3

Result:
4
```
```
  Integration | Component | control group success: render without token: Chrome 128.0
shows unwrapped data
Expected:
    true
Result:
false
```

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [ ] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
