### PR TITLE
UI: Hide patch for deleted or destroyed secrets

### DIFF
--- a/ui/lib/kv/addon/components/kv-subkeys-card.js
+++ b/ui/lib/kv/addon/components/kv-subkeys-card.js
@@ -35,8 +35,7 @@ sample subkeys:
  * <KvSubkeysCard @subkeys={{this.subkeys}} @isPatchAllowed={{true}} />
  *
  * @param {object} subkeys - leaf keys of a kv v2 secret, all values (unless a nested object with more keys) return null
- * @param {boolean} isPatchAllowed - true if the version is enterprise AND a user has "patch" secret + "read" subkeys capabilities, if true renders the "Patch secret" action
-
+ * @param {boolean} isPatchAllowed - if true, renders the "Patch secret" action. True when: (1) the version is enterprise, (2) a user has "patch" secret + "read" subkeys capabilities, (3) latest secret version is not deleted or destroyed
  */
 
 export default class KvSubkeysCard extends Component {

--- a/ui/lib/kv/addon/components/page/secret/details.js
+++ b/ui/lib/kv/addon/components/page/secret/details.js
@@ -33,7 +33,7 @@ import { isAdvancedSecret } from 'core/utils/advanced-secret';
  * @param {boolean} canReadData - if true and the secret is not destroyed/deleted the copy secret dropdown renders
  * @param {boolean} canReadMetadata - if true it renders the kv select version dropdown in the toolbar and "Version History" tab
  * @param {boolean} canUpdateData - if true it renders "Create new version" toolbar action
- * @param {boolean} isPatchAllowed - isPatchAllowed is true if the version is enterprise AND a user has "patch" secret + "read" subkeys capabilities, if true it renders "Patch latest version" toolbar action
+ * @param {boolean} isPatchAllowed - if true it renders "Patch latest version" toolbar action. True when: (1) the version is enterprise, (2) a user has "patch" secret + "read" subkeys capabilities, (3) latest secret version is not deleted or destroyed
  * @param {model} metadata - Ember data model: 'kv/metadata'
  * @param {string} path - path of kv secret 'my/secret' used as the title for the KV page header
  * @param {model} secret - Ember data model: 'kv/data'

--- a/ui/lib/kv/addon/components/page/secret/overview.js
+++ b/ui/lib/kv/addon/components/page/secret/overview.js
@@ -24,7 +24,7 @@ import { isDeleted } from 'kv/utils/kv-deleted';
  * @param {array} breadcrumbs - Array to generate breadcrumbs, passed to the page header component
  * @param {boolean} canReadMetadata - permissions to read metadata
  * @param {boolean} canUpdateData - permissions to create a new version of a secret
- * @param {boolean} isPatchAllowed - isPatchAllowed is true if the version is enterprise AND a user has "patch" secret + "read" subkeys capabilities, passed to KvSubkeysCard
+ * @param {boolean} isPatchAllowed - passed to KvSubkeysCard for rendering patch action. True when: (1) the version is enterprise, (2) a user has "patch" secret + "read" subkeys capabilities, (3) latest secret version is not deleted or destroyed
  * @param {model} metadata - Ember data model: 'kv/metadata'
  * @param {string} path - path to request secret data for selected version
  * @param {object} subkeys - API response from subkeys endpoint, object with "subkeys" and "metadata" keys. This arg is null for community edition

--- a/ui/lib/kv/addon/routes/secret.js
+++ b/ui/lib/kv/addon/routes/secret.js
@@ -7,6 +7,7 @@ import Route from '@ember/routing/route';
 import { service } from '@ember/service';
 import { hash } from 'rsvp';
 import { action } from '@ember/object';
+import { isDeleted } from 'kv/utils/kv-deleted';
 
 export default class KvSecretRoute extends Route {
   @service secretMountPath;
@@ -25,6 +26,7 @@ export default class KvSecretRoute extends Route {
     });
   }
 
+  // this request always returns subkeys for the latest version
   fetchSubkeys(backend, path) {
     if (this.version.isEnterprise) {
       const adapter = this.store.adapterFor('kv/data');
@@ -35,9 +37,17 @@ export default class KvSecretRoute extends Route {
     return null;
   }
 
-  isPatchAllowed({ subkeys, data }) {
+  isPatchAllowed({ capabilities, subkeysMeta }) {
     if (!this.version.isEnterprise) return false;
-    return subkeys.canRead && data.canPatch;
+    const canReadSubkeys = capabilities.subkeys.canRead;
+    const canPatchData = capabilities.data.canPatch;
+    if (canReadSubkeys && canPatchData) {
+      const { deletion_time, destroyed } = subkeysMeta;
+      const isLatestActive = isDeleted(deletion_time) || destroyed ? false : true;
+      // only the latest secret version can be patched, it cannot be deleted or destroyed
+      return isLatestActive;
+    }
+    return false;
   }
 
   async fetchCapabilities(backend, path) {
@@ -56,12 +66,13 @@ export default class KvSecretRoute extends Route {
     const backend = this.secretMountPath.currentPath;
     const { name: path } = this.paramsFor('secret');
     const capabilities = await this.fetchCapabilities(backend, path);
+    const subkeys = await this.fetchSubkeys(backend, path);
     return hash({
       path,
       backend,
-      subkeys: this.fetchSubkeys(backend, path),
+      subkeys,
       metadata: this.fetchSecretMetadata(backend, path),
-      isPatchAllowed: this.isPatchAllowed(capabilities),
+      isPatchAllowed: this.isPatchAllowed({ capabilities, subkeysMeta: subkeys.metadata }),
       canUpdateData: capabilities.data.canUpdate,
       canReadData: capabilities.data.canRead,
       canReadMetadata: capabilities.metadata.canRead,

--- a/ui/lib/kv/addon/routes/secret.js
+++ b/ui/lib/kv/addon/routes/secret.js
@@ -72,7 +72,7 @@ export default class KvSecretRoute extends Route {
       backend,
       subkeys,
       metadata: this.fetchSecretMetadata(backend, path),
-      isPatchAllowed: this.isPatchAllowed({ capabilities, subkeysMeta: subkeys.metadata }),
+      isPatchAllowed: this.isPatchAllowed({ capabilities, subkeysMeta: subkeys?.metadata }),
       canUpdateData: capabilities.data.canUpdate,
       canReadData: capabilities.data.canRead,
       canReadMetadata: capabilities.metadata.canRead,

--- a/ui/lib/kv/addon/routes/secret.js
+++ b/ui/lib/kv/addon/routes/secret.js
@@ -44,7 +44,7 @@ export default class KvSecretRoute extends Route {
     if (canReadSubkeys && canPatchData) {
       const { deletion_time, destroyed } = subkeysMeta;
       const isLatestActive = isDeleted(deletion_time) || destroyed ? false : true;
-      // only the latest secret version can be patched, it cannot be deleted or destroyed
+      // only the latest secret version can be patched and it must not be deleted or destroyed
       return isLatestActive;
     }
     return false;

--- a/ui/lib/kv/addon/routes/secret/patch.js
+++ b/ui/lib/kv/addon/routes/secret/patch.js
@@ -21,7 +21,7 @@ export default class SecretPatch extends Route {
     controller.breadcrumbs = breadcrumbsArray;
   }
 
-  // isPatchAllowed is true if the version is enterprise AND a user has "patch" secret + "read" subkeys capabilities
+  // isPatchAllowed is true if (1) the version is enterprise, (2) a user has "patch" secret + "read" subkeys capabilities, (3) latest secret version is not deleted or destroyed
   redirect(model) {
     if (!model.isPatchAllowed) {
       this.router.transitionTo('vault.cluster.secrets.backend.kv.secret.index', model.path);

--- a/ui/tests/acceptance/secrets/backend/kv/kv-v2-workflow-delete-test.js
+++ b/ui/tests/acceptance/secrets/backend/kv/kv-v2-workflow-delete-test.js
@@ -65,12 +65,13 @@ module('Acceptance | kv-v2 workflow | delete, undelete, destroy', function (hook
       return;
     });
     test('can delete and undelete the latest secret version (a)', async function (assert) {
-      assert.expect(18);
+      assert.expect(20);
       const flashSuccess = sinon.spy(this.owner.lookup('service:flash-messages'), 'success');
       // go to secret details
       await visit(`/vault/secrets/${this.backend}/kv/${this.secretPath}/details`);
       // correct toolbar options & details show
       assertDeleteActions(assert);
+      assert.dom(PAGE.detail.patchLatest).exists();
       assert.dom(PAGE.infoRow).exists('shows secret data on load');
       // delete flow
       await click(PAGE.detail.delete);
@@ -91,6 +92,7 @@ module('Acceptance | kv-v2 workflow | delete, undelete, destroy', function (hook
       assert.dom(PAGE.detail.versionTimestamp).includesText('Version 4 deleted');
       // updated toolbar options
       assertDeleteActions(assert, ['undelete', 'destroy']);
+      assert.dom(PAGE.detail.patchLatest).doesNotExist('patching a deleted secret is not allowed');
       // undelete flow
       await click(PAGE.detail.undelete);
       // details update accordingly
@@ -99,13 +101,15 @@ module('Acceptance | kv-v2 workflow | delete, undelete, destroy', function (hook
       assert.dom(PAGE.detail.versionTimestamp).includesText('Version 4 created');
       // correct toolbar options
       assertDeleteActions(assert, ['delete', 'destroy']);
+      assert.dom(PAGE.detail.patchLatest).exists('patch is allowed after undeleting');
     });
     test('can soft delete and undelete an older secret version (a)', async function (assert) {
-      assert.expect(17);
+      assert.expect(20);
       // go to secret details
       await visit(`/vault/secrets/${this.backend}/kv/${this.secretPath}/details?version=2`);
       // correct toolbar options & details show
       assertDeleteActions(assert);
+      assert.dom(PAGE.detail.patchLatest).exists();
       assert.dom(PAGE.infoRow).exists('shows secret data on load');
       // delete flow
       await click(PAGE.detail.delete);
@@ -122,6 +126,10 @@ module('Acceptance | kv-v2 workflow | delete, undelete, destroy', function (hook
       assert.dom(PAGE.detail.versionTimestamp).includesText('Version 2 deleted');
       // updated toolbar options
       assertDeleteActions(assert, ['undelete', 'destroy']);
+      assert
+        .dom(PAGE.detail.patchLatest)
+        .exists('patching the latest version is allowed after deleting an older version');
+
       // undelete flow
       await click(PAGE.detail.undelete);
       // details update accordingly
@@ -132,12 +140,13 @@ module('Acceptance | kv-v2 workflow | delete, undelete, destroy', function (hook
       assertDeleteActions(assert, ['delete', 'destroy']);
     });
     test('can destroy a secret version (a)', async function (assert) {
-      assert.expect(10);
+      assert.expect(12);
       const flashSuccess = sinon.spy(this.owner.lookup('service:flash-messages'), 'success');
       // go to secret details
       await visit(`/vault/secrets/${this.backend}/kv/${this.secretPath}/details?version=3`);
       // correct toolbar options show
       assertDeleteActions(assert);
+      assert.dom(PAGE.detail.patchLatest).exists();
       // delete flow
       await click(PAGE.detail.destroy);
       assert.dom(PAGE.detail.deleteModalTitle).includesText('Destroy version?', 'modal has correct title');
@@ -153,6 +162,9 @@ module('Acceptance | kv-v2 workflow | delete, undelete, destroy', function (hook
       assert.dom(PAGE.detail.versionTimestamp).doesNotExist('does not show version timestamp');
       // updated toolbar options
       assertDeleteActions(assert, []);
+      assert
+        .dom(PAGE.detail.patchLatest)
+        .exists('patching the latest version is allowed after destroying an older version');
     });
 
     test('can permanently delete all secret versions (a)', async function (assert) {

--- a/ui/tests/acceptance/secrets/backend/kv/kv-v2-workflow-delete-test.js
+++ b/ui/tests/acceptance/secrets/backend/kv/kv-v2-workflow-delete-test.js
@@ -59,13 +59,16 @@ module('Acceptance | kv-v2 workflow | delete, undelete, destroy', function (hook
 
   module('admin persona', function (hooks) {
     hooks.beforeEach(async function () {
+      // patch is an enterprise feature but stubbing the version so assertions that check
+      // patch actions exist before/after deletion can run on both CE and ent repos
+      this.version = this.owner.lookup('service:version').type = 'enterprise';
       const token = await runCmd(makeToken('admin', this.backend, personas.admin));
       await authPage.login(token);
       clearRecords(this.store);
       return;
     });
     test('can delete and undelete the latest secret version (a)', async function (assert) {
-      assert.expect(20);
+      assert.expect(21);
       const flashSuccess = sinon.spy(this.owner.lookup('service:flash-messages'), 'success');
       // go to secret details
       await visit(`/vault/secrets/${this.backend}/kv/${this.secretPath}/details`);
@@ -104,7 +107,7 @@ module('Acceptance | kv-v2 workflow | delete, undelete, destroy', function (hook
       assert.dom(PAGE.detail.patchLatest).exists('patch is allowed after undeleting');
     });
     test('can soft delete and undelete an older secret version (a)', async function (assert) {
-      assert.expect(20);
+      assert.expect(19);
       // go to secret details
       await visit(`/vault/secrets/${this.backend}/kv/${this.secretPath}/details?version=2`);
       // correct toolbar options & details show

--- a/ui/tests/acceptance/secrets/backend/kv/kv-v2-workflow-edge-cases-test.js
+++ b/ui/tests/acceptance/secrets/backend/kv/kv-v2-workflow-edge-cases-test.js
@@ -390,12 +390,11 @@ module('Acceptance | kv-v2 workflow | edge cases', function (hooks) {
     assert.dom(FORM.toggleJson).isNotChecked();
   });
 
-  // patch is technically enterprise only but stubbing the version so these run on both CE and enterprise
+  // patch is technically enterprise only but stubbing the version so these tests run on both CE and enterprise
   module('patch-persona', function (hooks) {
     hooks.beforeEach(async function () {
       this.patchSecret = 'patch-secret';
-      this.version = this.owner.lookup('service:version');
-      this.version.type = 'enterprise';
+      this.owner.lookup('service:version').type = 'enterprise';
       this.store = this.owner.lookup('service:store');
       await writeSecret(this.backend, this.patchSecret, 'foo', 'bar');
       await writeSecret(this.backend, 'my-destroyed-secret', 'foo', 'bar');

--- a/ui/tests/acceptance/secrets/backend/kv/kv-v2-workflow-navigation-test.js
+++ b/ui/tests/acceptance/secrets/backend/kv/kv-v2-workflow-navigation-test.js
@@ -1573,7 +1573,7 @@ path "${this.backend}/subkeys/*" {
     });
   });
 
-  // patch is technically enterprise only but stubbing the version so they can run on both CE and enterprise
+  // patch is technically enterprise only but stubbing the version so these tests can run on both CE and enterprise
   module('patch-persona', function (hooks) {
     hooks.beforeEach(async function () {
       const token = await runCmd([

--- a/ui/tests/helpers/kv/policy-generator.js
+++ b/ui/tests/helpers/kv/policy-generator.js
@@ -108,5 +108,8 @@ export const personas = {
   secretPatcher: (backend) =>
     dataPolicy({ backend, capabilities: ['patch'] }) +
     metadataPolicy({ backend, capabilities: ['list', 'read'] }) +
-    subkeysPolicy({ backend }),
+    subkeysPolicy({ backend }) +
+    // granting patcher persona delete/destroy capabilities because this matches policies from real customer use cases
+    deleteVersionsPolicy({ backend }) +
+    destroyVersionsPolicy({ backend }),
 };

--- a/ui/tests/helpers/kv/policy-generator.js
+++ b/ui/tests/helpers/kv/policy-generator.js
@@ -106,6 +106,7 @@ export const personas = {
     dataPolicy({ backend, capabilities: ['create', 'update'] }) +
     metadataPolicy({ backend, capabilities: ['delete'] }),
   secretPatcher: (backend) =>
+    // this persona should never have data "read"
     dataPolicy({ backend, capabilities: ['patch'] }) +
     metadataPolicy({ backend, capabilities: ['list', 'read'] }) +
     subkeysPolicy({ backend }) +


### PR DESCRIPTION
### Description
Follow-on to https://github.com/hashicorp/vault/pull/28212. I forgot to check for the secret state in the original implementation PR. This was caught from smoke testing (thanks, @Monkeychip!) Patching a secret is only available if the latest version has not been deleted or destroyed.
 

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [ ] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
