### PR TITLE
Fix some broken links on the PKI EST docs page

### DIFF
--- a/website/content/docs/secrets/pki/est.mdx
+++ b/website/content/docs/secrets/pki/est.mdx
@@ -122,9 +122,9 @@ label.
 
 @include 'pki-est-default-policy.mdx'
 
-Within the Vault [EST configuration API](/vault/api-docs/secret/pki#set-est-configuration), a PKI
-mount can be specified as the default mount by enabling [default_mount](/vault/api-docs/secret/pki#default_mount)
-to true, or provide a mapping of a label within [label_to_path_policy](http://localhost:3000/vault/api-docs/secret/pki#label_to_path_policy)
+Within the Vault [EST configuration API](/vault/api-docs/secret/pki/issuance#set-est-configuration), a PKI
+mount can be specified as the default mount by enabling [default_mount](/vault/api-docs/secret/pki/issuance#default_mount)
+to true, or provide a mapping of a label within [label_to_path_policy](/vault/api-docs/secret/pki/issuance#label_to_path_policy)
 
 As an example of a complete EST configuration, that would enable the pki mount
 to register the .well-known/est default label, along with two additional labels


### PR DESCRIPTION
### Description

Fix some broken links on the PKI EST docs page when we moved the EST api-docs to a separate page.
