### PR TITLE
Ferry ocsp_ca_certificates over the OCSP ValidationConf

### DIFF
--- a/builtin/credential/cert/path_login.go
+++ b/builtin/credential/cert/path_login.go
@@ -693,6 +693,15 @@ func (b *backend) loadTrustedCerts(ctx context.Context, storage logical.Storage,
 			conf.QueryAllServers = conf.QueryAllServers || entry.OcspQueryAllServers
 			conf.OcspThisUpdateMaxAge = entry.OcspThisUpdateMaxAge
 			conf.OcspMaxRetries = entry.OcspMaxRetries
+
+			if len(entry.OcspCaCertificates) > 0 {
+				certs, err := certutil.ParseCertsPEM([]byte(entry.OcspCaCertificates))
+				if err != nil {
+					b.Logger().Error("failed to parse ocsp_ca_certificates", "name", name, "error", err)
+					continue
+				}
+				conf.ExtraCas = certs
+			}
 		}
 	}
 

--- a/builtin/credential/cert/path_login_test.go
+++ b/builtin/credential/cert/path_login_test.go
@@ -5,6 +5,7 @@ package cert
 
 import (
 	"context"
+	"crypto"
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
@@ -281,19 +282,6 @@ func TestCert_RoleResolve_RoleDoesNotExist(t *testing.T) {
 }
 
 func TestCert_RoleResolveOCSP(t *testing.T) {
-	cases := []struct {
-		name        string
-		failOpen    bool
-		certStatus  int
-		errExpected bool
-	}{
-		{"failFalseGoodCert", false, ocsp.Good, false},
-		{"failFalseRevokedCert", false, ocsp.Revoked, true},
-		{"failFalseUnknownCert", false, ocsp.Unknown, true},
-		{"failTrueGoodCert", true, ocsp.Good, false},
-		{"failTrueRevokedCert", true, ocsp.Revoked, true},
-		{"failTrueUnknownCert", true, ocsp.Unknown, false},
-	}
 	certTemplate := &x509.Certificate{
 		Subject: pkix.Name{
 			CommonName: "example.com",
@@ -332,15 +320,76 @@ func TestCert_RoleResolveOCSP(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
+	tempDir, connState2, err := generateTestCertAndConnState(t, certTemplate)
+	if err != nil {
+		t.Fatalf("error testing connection state: %v", err)
+	}
+	ca2, err := ioutil.ReadFile(filepath.Join(tempDir, "ca_cert.pem"))
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	issuer2 := parsePEM(ca2)
+	pkf2, err := ioutil.ReadFile(filepath.Join(tempDir, "ca_key.pem"))
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	pk2, err := certutil.ParsePEMBundle(string(pkf2))
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	type caData struct {
+		privateKey crypto.Signer
+		caBytes    []byte
+		caChain    []*x509.Certificate
+		connState  tls.ConnectionState
+	}
+
+	ca1Data := caData{
+		pk.PrivateKey,
+		ca,
+		issuer,
+		connState,
+	}
+	ca2Data := caData{
+		pk2.PrivateKey,
+		ca2,
+		issuer2,
+		connState2,
+	}
+
+	cases := []struct {
+		name        string
+		failOpen    bool
+		certStatus  int
+		errExpected bool
+		caData      caData
+		ocspCaCerts string
+	}{
+		{name: "failFalseGoodCert", certStatus: ocsp.Good, caData: ca1Data},
+		{name: "failFalseRevokedCert", certStatus: ocsp.Revoked, errExpected: true, caData: ca1Data},
+		{name: "failFalseUnknownCert", certStatus: ocsp.Unknown, errExpected: true, caData: ca1Data},
+		{name: "failTrueGoodCert", failOpen: true, certStatus: ocsp.Good, caData: ca1Data},
+		{name: "failTrueRevokedCert", failOpen: true, certStatus: ocsp.Revoked, errExpected: true, caData: ca1Data},
+		{name: "failTrueUnknownCert", failOpen: true, certStatus: ocsp.Unknown, caData: ca1Data},
+		{name: "failFalseGoodCertExtraCas", certStatus: ocsp.Good, caData: ca2Data, ocspCaCerts: string(pkf2)},
+		{name: "failFalseRevokedCertExtraCas", certStatus: ocsp.Revoked, errExpected: true, caData: ca2Data, ocspCaCerts: string(pkf2)},
+		{name: "failFalseUnknownCertExtraCas", certStatus: ocsp.Unknown, errExpected: true, caData: ca2Data, ocspCaCerts: string(pkf2)},
+		{name: "failTrueGoodCertExtraCas", failOpen: true, certStatus: ocsp.Good, caData: ca2Data, ocspCaCerts: string(pkf2)},
+		{name: "failTrueRevokedCertExtraCas", failOpen: true, certStatus: ocsp.Revoked, errExpected: true, caData: ca2Data, ocspCaCerts: string(pkf2)},
+		{name: "failTrueUnknownCertExtraCas", failOpen: true, certStatus: ocsp.Unknown, caData: ca2Data, ocspCaCerts: string(pkf2)},
+	}
+
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			resp, err := ocsp.CreateResponse(issuer[0], issuer[0], ocsp.Response{
+			resp, err := ocsp.CreateResponse(c.caData.caChain[0], c.caData.caChain[0], ocsp.Response{
 				Status:       c.certStatus,
 				SerialNumber: certTemplate.SerialNumber,
 				ProducedAt:   time.Now(),
 				ThisUpdate:   time.Now(),
 				NextUpdate:   time.Now().Add(time.Hour),
-			}, pk.PrivateKey)
+			}, c.caData.privateKey)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -351,18 +400,18 @@ func TestCert_RoleResolveOCSP(t *testing.T) {
 			var resolveStep logicaltest.TestStep
 			var loginStep logicaltest.TestStep
 			if c.errExpected {
-				loginStep = testAccStepLoginWithNameInvalid(t, connState, "web")
-				resolveStep = testAccStepResolveRoleOCSPFail(t, connState, "web")
+				loginStep = testAccStepLoginWithNameInvalid(t, c.caData.connState, "web")
+				resolveStep = testAccStepResolveRoleOCSPFail(t, c.caData.connState, "web")
 			} else {
-				loginStep = testAccStepLoginWithName(t, connState, "web")
-				resolveStep = testAccStepResolveRoleWithName(t, connState, "web")
+				loginStep = testAccStepLoginWithName(t, c.caData.connState, "web")
+				resolveStep = testAccStepResolveRoleWithName(t, c.caData.connState, "web")
 			}
 			logicaltest.Test(t, logicaltest.TestCase{
 				CredentialBackend: b,
 				Steps: []logicaltest.TestStep{
-					testAccStepCertWithExtraParams(t, "web", ca, "foo", allowed{dns: "example.com"}, false,
-						map[string]interface{}{"ocsp_enabled": true, "ocsp_fail_open": c.failOpen}),
-					testAccStepReadCertPolicy(t, "web", false, map[string]interface{}{"ocsp_enabled": true, "ocsp_fail_open": c.failOpen}),
+					testAccStepCertWithExtraParams(t, "web", c.caData.caBytes, "foo", allowed{dns: "example.com"}, false,
+						map[string]interface{}{"ocsp_enabled": true, "ocsp_fail_open": c.failOpen, "ocsp_ca_certificates": c.ocspCaCerts}),
+					testAccStepReadCertPolicy(t, "web", false, map[string]interface{}{"ocsp_enabled": true, "ocsp_fail_open": c.failOpen, "ocsp_ca_certificates": c.ocspCaCerts}),
 					loginStep,
 					resolveStep,
 				},

--- a/changelog/28309.txt
+++ b/changelog/28309.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+auth/cert: ocsp_ca_certificates field was not honored when validating OCSP responses signed by a CA that did not issue the certificate.
+```

--- a/sdk/helper/ocsp/client.go
+++ b/sdk/helper/ocsp/client.go
@@ -494,7 +494,7 @@ func validateOCSPParsedResponse(ocspRes *ocsp.Response, subject, issuer *x509.Ce
 					}
 				}
 			} else {
-				matchedCA = issuer
+				matchedCA = ocspRes.Certificate
 			}
 
 			if overallErr != nil {

--- a/sdk/helper/ocsp/client.go
+++ b/sdk/helper/ocsp/client.go
@@ -538,16 +538,12 @@ func verifySignature(res *ocsp.Response, extraCas []*x509.Certificate) (*x509.Ce
 	var overallErr error
 	var matchedCA *x509.Certificate
 	for _, ca := range extraCas {
-		if ca.IsCA {
-			if err := res.CheckSignatureFrom(ca); err != nil {
-				overallErr = multierror.Append(overallErr, err)
-			} else {
-				matchedCA = ca
-				overallErr = nil
-				break
-			}
+		if err := res.CheckSignatureFrom(ca); err != nil {
+			overallErr = multierror.Append(overallErr, err)
 		} else {
-			overallErr = multierror.Append(overallErr, fmt.Errorf("certificate with subject %s is not a CA certificate", ca.Subject.String()))
+			matchedCA = ca
+			overallErr = nil
+			break
 		}
 	}
 	return matchedCA, overallErr

--- a/sdk/helper/ocsp/ocsp_test.go
+++ b/sdk/helper/ocsp/ocsp_test.go
@@ -677,7 +677,7 @@ func TestOCSPRetry(t *testing.T) {
 		context.TODO(),
 		client, fakeRequestFunc,
 		dummyOCSPHost,
-		make(map[string]string), []byte{0}, certs[0], certs[len(certs)-1])
+		make(map[string]string), []byte{0}, certs[0], certs[len(certs)-1], nil)
 	if err == nil {
 		fmt.Printf("should fail: %v, %v, %v\n", res, b, st)
 	}
@@ -692,7 +692,7 @@ func TestOCSPRetry(t *testing.T) {
 		context.TODO(),
 		client, fakeRequestFunc,
 		dummyOCSPHost,
-		make(map[string]string), []byte{0}, certs[0], certs[len(certs)-1])
+		make(map[string]string), []byte{0}, certs[0], certs[len(certs)-1], nil)
 	if err == nil {
 		fmt.Printf("should fail: %v, %v, %v\n", res, b, st)
 	}


### PR DESCRIPTION
Fixes VAULT-30379.  

### Description
What does this PR do?

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [ ] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.