### PR TITLE
UI: Fix no data read within namespaces

### DIFF
--- a/ui/app/serializers/capabilities.js
+++ b/ui/app/serializers/capabilities.js
@@ -15,7 +15,12 @@ export default ApplicationSerializer.extend({
 
     if (requestType === 'query') {
       // each key on the response is a path with an array of capabilities as its value
-      response = Object.keys(payload.data).map((path) => ({ capabilities: payload.data[path], path }));
+      response = Object.keys(payload.data).map((fullPath) => {
+        // we use pathMap to normalize a namespace-prefixed path back to the relative path
+        // this is okay because we clear capabilities when moving between namespaces
+        const path = payload.pathMap ? payload.pathMap[fullPath] : fullPath;
+        return { capabilities: payload.data[fullPath], path };
+      });
     } else {
       response = { ...payload.data, path: payload.path };
     }

--- a/ui/app/services/capabilities.ts
+++ b/ui/app/services/capabilities.ts
@@ -40,14 +40,13 @@ export default class CapabilitiesService extends Service {
     return assert('query object must contain "paths" or "path" key', false);
   }
 
-  async fetchMultiplePaths(paths: string[]): MultipleCapabilities | AdapterError {
+  async fetchMultiplePaths(paths: string[]): Promise<MultipleCapabilities> {
     // if the request to capabilities-self fails, silently catch
     // all of path capabilities default to "true"
-    const resp: Array<CapabilitiesModel> | [] = await this.request({ paths }).catch(() => []);
-
+    const resp: CapabilitiesModel[] = await this.request({ paths }).catch(() => []);
     return paths.reduce((obj: MultipleCapabilities, apiPath: string) => {
       // path is the model's primaryKey (id)
-      const model: CapabilitiesModel | undefined = resp.find((m) => m.path === apiPath);
+      const model = resp.find((m) => m.path === apiPath);
       if (model) {
         const { canCreate, canDelete, canList, canPatch, canRead, canSudo, canUpdate } = model;
         obj[apiPath] = { canCreate, canDelete, canList, canPatch, canRead, canSudo, canUpdate };


### PR DESCRIPTION
### Description
This bugfix is a follow-on to #28212 which added new capabilities features. Before this fix, accessing the KV secret data without access when within a namespace would incorrectly calculate that the user had read access, even though they didn't, resulting in a screen like: 

<img width="1065" alt="Screenshot 2024-09-06 at 12 22 30" src="https://github.com/user-attachments/assets/247e3968-d6c3-45a7-9b58-6fc79af2d175">

With this fix, the namespace secret tab correctly shows an empty state:
<img width="1100" alt="Screenshot 2024-09-06 at 12 23 48" src="https://github.com/user-attachments/assets/08af8601-fd7a-47f1-ad11-e755db01255c">
