### PR TITLE
UI: Fix client counts hiding new monthly based on average

### DIFF
--- a/ui/app/components/clients/page/token.hbs
+++ b/ui/app/components/clients/page/token.hbs
@@ -36,8 +36,8 @@
     @description="Entity or non-entity clients which interacted with Vault for the first time during this date range. Each bar represents the total new clients for that month."
     @timestamp={{@activity.responseTimestamp}}
     @legend={{this.legend}}
-    @hasChartData={{this.averageNewClients}}
-    class={{unless this.averageNewClients "no-legend"}}
+    @hasChartData={{this.hasNewClients}}
+    class={{unless this.hasNewClients "no-legend"}}
   >
     <:stats>
       <StatText

--- a/ui/app/components/clients/page/token.ts
+++ b/ui/app/components/clients/page/token.ts
@@ -29,8 +29,8 @@ export default class ClientsTokenPageComponent extends ActivityComponent {
     }, 0);
   }
 
-  get averageNewClients() {
-    return this.calculateClientAverages(this.byMonthNewClients);
+  get hasNewClients() {
+    return this.byMonthNewClients.find((m) => m.entity_clients || m.non_entity_clients);
   }
 
   get tokenStats() {


### PR DESCRIPTION
### Description
Follow-on to #28036. This PR fixes a bug where the new monthly chart in client counts entity/non-entity dashboard is hidden if there are very few new tokens. This is because it was being shown depending on an average instead of whether there is data to show. 

**Before Left // After Right**
<img width="1911" alt="before and after" src="https://github.com/user-attachments/assets/d785d300-b5b7-49dd-a036-b47306e0f73f">

- [x] Ent tests pass