### PR TITLE
UI: only render date range reset button in enterprise

### DIFF
--- a/ui/app/components/clients/date-range.hbs
+++ b/ui/app/components/clients/date-range.hbs
@@ -78,13 +78,15 @@
               <F.Label>End</F.Label>
             </Hds::Form::TextInput::Field>
           </div>
-          <Hds::Button
-            @text="Reset"
-            @color="tertiary"
-            @icon="reload"
-            {{on "click" this.resetDates}}
-            data-test-date-edit="reset"
-          />
+          {{#if this.version.isEnterprise}}
+            <Hds::Button
+              @text="Reset"
+              @color="tertiary"
+              @icon="reload"
+              {{on "click" this.resetDates}}
+              data-test-date-edit="reset"
+            />
+          {{/if}}
         </div>
         {{#if this.validationError}}
           <Hds::Form::Error

--- a/ui/tests/integration/components/clients/date-range-test.js
+++ b/ui/tests/integration/components/clients/date-range-test.js
@@ -84,13 +84,12 @@ module('Integration | Component | clients/date-range', function (hooks) {
 
     await click(DATE_RANGE.edit);
     assert.dom(DATE_RANGE.editModal).exists();
+    assert.dom(DATE_RANGE.editDate('reset')).doesNotExist();
     assert.dom(DATE_RANGE.editDate('start')).hasValue('2018-01');
     assert.dom(DATE_RANGE.editDate('end')).hasValue('2019-01');
     assert.dom(DATE_RANGE.defaultRangeAlert).doesNotExist();
 
-    await click(DATE_RANGE.editDate('reset'));
-    assert.dom(DATE_RANGE.editDate('start')).hasValue('');
-    assert.dom(DATE_RANGE.editDate('end')).hasValue('');
+    await fillIn(DATE_RANGE.editDate('start'), '');
     assert.dom(DATE_RANGE.validation).hasText('You must supply both start and end dates.');
     await click(GENERAL.saveButton);
     assert.false(this.onChange.called);
@@ -117,25 +116,12 @@ module('Integration | Component | clients/date-range', function (hooks) {
     assert.dom(DATE_RANGE.editModal).doesNotExist();
   });
 
-  test('it does not trigger onChange when reset and CE', async function (assert) {
-    this.owner.lookup('service:version').type = 'community';
-    await this.renderComponent();
-
-    await click(DATE_RANGE.edit);
-
-    await click(DATE_RANGE.reset);
-    assert.dom(DATE_RANGE.validation).hasText('You must supply both start and end dates.');
-    await click(GENERAL.saveButton);
-    assert.false(this.onChange.called);
-  });
-
   test('it resets the tracked values on close', async function (assert) {
     await this.renderComponent();
 
     await click(DATE_RANGE.edit);
-    await click(DATE_RANGE.editDate('reset'));
-    assert.dom(DATE_RANGE.editDate('start')).hasValue('');
-    assert.dom(DATE_RANGE.editDate('end')).hasValue('');
+    await fillIn(DATE_RANGE.editDate('start'), '2017-04');
+    await fillIn(DATE_RANGE.editDate('end'), '2018-05');
     await click(GENERAL.cancelButton);
 
     await click(DATE_RANGE.edit);


### PR DESCRIPTION
### Description
Follow-on to #28036. Only shows reset button in enterprise. Still includes validation for Community version when start/end dates are not filled in: 
<img width="1066" alt="CE date picker" src="https://github.com/user-attachments/assets/d49aac3c-6ef7-4aea-95df-116cb109f3b5">
