### PR TITLE
enos: poweroff and terminate instances when shutting them down

### DIFF
--- a/enos/modules/shutdown_multiple_nodes/main.tf
+++ b/enos/modules/shutdown_multiple_nodes/main.tf
@@ -19,7 +19,7 @@ variable "old_hosts" {
 
 resource "enos_remote_exec" "shutdown_multiple_nodes" {
   for_each = var.old_hosts
-  inline   = ["sudo shutdown -H --no-wall; exit 0"]
+  inline   = ["sudo shutdown -P --no-wall; exit 0"]
 
   transport = {
     ssh = {

--- a/enos/modules/shutdown_node/main.tf
+++ b/enos/modules/shutdown_node/main.tf
@@ -19,7 +19,7 @@ variable "host" {
 }
 
 resource "enos_remote_exec" "shutdown_node" {
-  inline = ["sudo shutdown -H --no-wall; exit 0"]
+  inline = ["sudo shutdown -P --no-wall; exit 0"]
 
   transport = {
     ssh = {


### PR DESCRIPTION
### Description
Previously our `shutdown_nodes` modules would halt the machine. While this is useful for simulating a failure, cleaning up the halted machines is very slow in AWS for some reason.

Instead, we now poweroff the machines and utilize EC2's instance poweroff handling to immediately terminate the instances.

I've tested both scenarios that use these modules locally and they still work as expected. I also timed before and after and this change saves 5 MINUTES in total runtime (~40%) for the PR replication scenario. I assume it yields similar results for autopilot.

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [x] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.