### PR TITLE
docs(lambda-extension): update distributed tracing headers warning;

### DIFF
--- a/website/content/docs/platform/aws/lambda-extension.mdx
+++ b/website/content/docs/platform/aws/lambda-extension.mdx
@@ -248,7 +248,7 @@ token.
   The Vault Lambda Extension cache key includes headers from proxy requests, but excludes
   standard distributed tracing headers `traceparent` and `tracestate`, since trace IDs are unique
   per request. However, certain distributed tracing tools may add nonstandard tracing headers. 
-  These nonstandard tracing headers headers can lead to individualized hashes, which render repeated 
+  These nonstandard tracing headers headers can lead to individualized hashes that make repeated 
   requests unique and cause cache misses.
 
 </Warning>

--- a/website/content/docs/platform/aws/lambda-extension.mdx
+++ b/website/content/docs/platform/aws/lambda-extension.mdx
@@ -243,12 +243,13 @@ request will be forwarded to Vault and the response returned and cached.
 Currently, the cache key is a hash of the request URL path, headers, body, and
 token.
 
-<Warning title="Distributed tracing headers may negate the cache">
+<Warning title="Nonstandard distributed tracing headers may negate the cache">
 
-  The Vault Lambda Extension cache key includes headers from proxy requests. As
-  a result, distributed tracing headers like `traceparent` can lead to
-  individualized hashes that make repeated requests appear unique and cause cache
-  misses.
+  The Vault Lambda Extension cache key includes headers from proxy requests, but excludes
+  standard distributed tracing headers `traceparent` and `tracestate`, since trace IDs are unique
+  per request. However, certain distributed tracing tools may add nonstandard tracing headers. 
+  These nonstandard tracing headers headers can lead to individualized hashes, which render repeated 
+  requests unique and cause cache misses.
 
 </Warning>
 

--- a/website/content/docs/platform/aws/lambda-extension.mdx
+++ b/website/content/docs/platform/aws/lambda-extension.mdx
@@ -245,11 +245,14 @@ token.
 
 <Warning title="Nonstandard distributed tracing headers may negate the cache">
 
-  The Vault Lambda Extension cache key includes headers from proxy requests, but excludes
-  standard distributed tracing headers `traceparent` and `tracestate`, since trace IDs are unique
-  per request. However, certain distributed tracing tools may add nonstandard tracing headers. 
-  These nonstandard tracing headers headers can lead to individualized hashes that make repeated 
-  requests unique and cause cache misses.
+  The Vault Lambda Extension cache key includes headers from proxy requests, but 
+  excludes the standard distributed tracing headers `traceparent` and
+  `tracestate` because trace IDs are unique per request and would lead to unique
+  hashes for repeated requests.
+  
+  Some distributed tracing tools may add nonstandard tracing headers, which can 
+  also lead to individualized hashes that make repeated requests unique and 
+  cause cache misses.
 
 </Warning>
 


### PR DESCRIPTION
### Description 
Standard distributed tracing headers are now excluded from the cache key since https://github.com/hashicorp/vault-lambda-extension/pull/145 was merged. 

So, I've updated the warning about distributed tracing headers to focus on nonstandard headers. Such headers may still cause issues without consumers being aware of them. I didn't call it out, but for example: New Relic adds a vendor-specific distributed tracing header for backwards compatibility that needs to be explicitly turned off.

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [ ] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
