### PR TITLE
VAULT-30694 Adding a check for nil values returned by the queue

### DIFF
--- a/builtin/logical/aws/path_static_roles.go
+++ b/builtin/logical/aws/path_static_roles.go
@@ -217,7 +217,7 @@ func (b *backend) pathStaticRolesWrite(ctx context.Context, req *logical.Request
 		// what here stays the same and what changes? Can we change the name?
 		i, err := b.credRotationQueue.PopByKey(config.Name)
 		if err != nil {
-			return nil, fmt.Errorf("could not populate the queue with %q, due to an error: %w", config.Name, err)
+			return nil, fmt.Errorf("expected an item with name %q, but got an error: %w", config.Name, err)
 		}
 		// check if i is nil to prevent panic
 		if i == nil {

--- a/builtin/logical/aws/path_static_roles.go
+++ b/builtin/logical/aws/path_static_roles.go
@@ -220,11 +220,10 @@ func (b *backend) pathStaticRolesWrite(ctx context.Context, req *logical.Request
 			return nil, fmt.Errorf("expected an item with name %q, but got an error: %w", config.Name, err)
 		}
 		// check if i is nil to prevent panic
-		if i != nil {
-			i.Value = config
-		} else {
-			return nil, fmt.Errorf("expected an item with name %q, but no name exists", config.Name)
+		if i == nil {
+			return nil, fmt.Errorf("expected an item with name %q, but got nil", config.Name)
 		}
+		i.Value = config
 		// update the next rotation to occur at now + the new rotation period
 		i.Priority = time.Now().Add(config.RotationPeriod).Unix()
 		err = b.credRotationQueue.Push(i)

--- a/builtin/logical/aws/path_static_roles.go
+++ b/builtin/logical/aws/path_static_roles.go
@@ -217,7 +217,7 @@ func (b *backend) pathStaticRolesWrite(ctx context.Context, req *logical.Request
 		// what here stays the same and what changes? Can we change the name?
 		i, err := b.credRotationQueue.PopByKey(config.Name)
 		if err != nil {
-			return nil, fmt.Errorf("expected an item with name %q, but got an error: %w", config.Name, err)
+			return nil, fmt.Errorf("could not populate the queue with %q, due to an error: %w", config.Name, err)
 		}
 		// check if i is nil to prevent panic
 		if i == nil {

--- a/builtin/logical/aws/path_static_roles.go
+++ b/builtin/logical/aws/path_static_roles.go
@@ -219,7 +219,9 @@ func (b *backend) pathStaticRolesWrite(ctx context.Context, req *logical.Request
 		if err != nil {
 			return nil, fmt.Errorf("expected an item with name %q, but got an error: %w", config.Name, err)
 		}
-		// check if i is nil to prevent panic
+		// check if i is nil to prevent panic because
+		// 1. PopByKey returns nil if the key does not exist; and
+		// 2. the static cred queue is not repopulated on reload (see VAULT-30877)
 		if i == nil {
 			return nil, fmt.Errorf("expected an item with name %q, but got nil", config.Name)
 		}

--- a/builtin/logical/aws/path_static_roles.go
+++ b/builtin/logical/aws/path_static_roles.go
@@ -219,7 +219,12 @@ func (b *backend) pathStaticRolesWrite(ctx context.Context, req *logical.Request
 		if err != nil {
 			return nil, fmt.Errorf("expected an item with name %q, but got an error: %w", config.Name, err)
 		}
-		i.Value = config
+		// check if i is nil to prevent panic
+		if i != nil {
+			i.Value = config
+		} else {
+			return nil, fmt.Errorf("expected an item with name %q, but no name exists", config.Name)
+		}
 		// update the next rotation to occur at now + the new rotation period
 		i.Priority = time.Now().Add(config.RotationPeriod).Unix()
 		err = b.credRotationQueue.Push(i)

--- a/changelog/28330.txt
+++ b/changelog/28330.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+auth/aws: Fixed potential panic after step-down and the queue has not repopulated.
+```


### PR DESCRIPTION
### Description
What does this PR do?

### TODO only if you're a HashiCorp employee
- [x ] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [x ] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [x ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
