### PR TITLE
Remove beta tags from CMPv2 docs

### DIFF
--- a/website/content/api-docs/secret/pki/issuance.mdx
+++ b/website/content/api-docs/secret/pki/issuance.mdx
@@ -369,8 +369,6 @@ $ curl \
 
 ## EST Certificate issuance <EnterpriseAlert inline="true" />
 
-@include 'alerts/beta.mdx'
-
 Within Vault Enterprise, support can be enabled for the
 [EST (Enrollment over Secure Transport) protocol](https://datatracker.ietf.org/doc/html/rfc7030)
 for issuing and renewing leaf certificates.
@@ -383,8 +381,6 @@ point of view. Note that the `cacerts` endpoint is unauthenticated.
 @include 'pki-est-default-policy.mdx'
 
 ### Read EST Configuration <EnterpriseAlert inline="true" />
-
-@include 'alerts/beta.mdx'
 
 This endpoint fetches the current EST configuration.
 
@@ -428,8 +424,6 @@ $ curl \
 ```
 
 ### Set EST Configuration <EnterpriseAlert inline="true" />
-
-@include 'alerts/beta.mdx'
 
 This endpoint will update EST related configuration, returning the
 updated values as a response along with an updated `last_updated` field.
@@ -529,8 +523,6 @@ $ curl \
 
 ## CMPv2 Certificate issuance <EnterpriseAlert inline="true" />
 
-@include 'alerts/beta.mdx'
-
 Within Vault Enterprise, support can be enabled for the
 [CMPv2 (Certificate Management Protocol) protocol](https://datatracker.ietf.org/doc/html/rfc4210)
 for issuing and renewing leaf certificates.
@@ -542,8 +534,6 @@ point of view.
 
 
 ### Read CMPv2 Configuration <EnterpriseAlert inline="true" />
-
-@include 'alerts/beta.mdx'
 
 This endpoint fetches the current CMPv2 configuration.
 
@@ -580,8 +570,6 @@ $ curl \
 ```
 
 ### Set CMPv2 Configuration <EnterpriseAlert inline="true" />
-
-@include 'alerts/beta.mdx'
 
 This endpoint will update CMPv2 related configuration, returning the
 updated values as a response along with an updated `last_updated` field.

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -1618,9 +1618,9 @@
           {
             "title": "Certificate Management Protocol (CMPv2)",
             "badge": {
-              "text": "BETA",
+              "text": "ENTERPRISE",
               "type": "outlined",
-              "color": "highlight"
+              "color": "neutral"
             },
             "path": "secrets/pki/cmpv2"
           },


### PR DESCRIPTION
### Description

Documentation updates to remove the beta flag on CMPv2 api and navbar.

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [ ] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
