### PR TITLE
UI: hide client count nav link when chrooted listener

### DIFF
--- a/ui/app/components/sidebar/nav/cluster.hbs
+++ b/ui/app/components/sidebar/nav/cluster.hbs
@@ -53,7 +53,7 @@
   {{#if
     (or
       (and this.isRootNamespace (has-permission "status" routeParams=(array "replication" "raft" "license" "seal")))
-      (has-permission "clients" routeParams="activity")
+      (and (has-permission "clients" routeParams="activity") (not this.hasChrootNamespace))
     )
   }}
     <Nav.Title data-test-sidebar-nav-heading="Monitoring">Monitoring</Nav.Title>
@@ -81,7 +81,9 @@
       data-test-sidebar-nav-link="Raft Storage"
     />
   {{/if}}
-  {{#if (and (has-permission "clients" routeParams="activity") (not this.cluster.dr.isSecondary))}}
+  {{#if
+    (and (has-permission "clients" routeParams="activity") (not this.cluster.dr.isSecondary) (not this.hasChrootNamespace))
+  }}
     <Nav.Link
       @route="vault.cluster.clients"
       @text="Client Count"

--- a/ui/app/components/sidebar/nav/cluster.js
+++ b/ui/app/components/sidebar/nav/cluster.js
@@ -17,8 +17,12 @@ export default class SidebarNavClusterComponent extends Component {
     return this.currentCluster.cluster;
   }
 
+  get hasChrootNamespace() {
+    return this.cluster?.hasChrootNamespace;
+  }
+
   get isRootNamespace() {
     // should only return true if we're in the true root namespace
-    return this.namespace.inRootNamespace && !this.cluster?.hasChrootNamespace;
+    return this.namespace.inRootNamespace && !this.hasChrootNamespace;
   }
 }

--- a/ui/tests/integration/components/sidebar/nav/cluster-test.js
+++ b/ui/tests/integration/components/sidebar/nav/cluster-test.js
@@ -112,6 +112,32 @@ module('Integration | Component | sidebar-nav-cluster', function (hooks) {
     });
   });
 
+  test('it should hide client counts link in chroot namespace', async function (assert) {
+    this.owner.lookup('service:permissions').setPaths({
+      data: {
+        chroot_namespace: 'admin',
+        root: true,
+      },
+    });
+    this.owner.lookup('service:currentCluster').setCluster({
+      id: 'foo',
+      anyReplicationEnabled: true,
+      usingRaft: true,
+      hasChrootNamespace: true,
+    });
+    const links = ['Client Counts', 'Replication', 'Raft Storage', 'License', 'Seal Vault'];
+
+    await renderComponent();
+    assert
+      .dom('[data-test-sidebar-nav-heading="Monitoring"]')
+      .doesNotExist('Monitoring heading is hidden in chroot namespace');
+    links.forEach((link) => {
+      assert
+        .dom(`[data-test-sidebar-nav-link="${link}"]`)
+        .doesNotExist(`${link} is hidden in chroot namespace`);
+    });
+  });
+
   test('it should render badge for promotional links on managed clusters', async function (assert) {
     this.owner.lookup('service:flags').featureFlags = ['VAULT_CLOUD_ADMIN_NAMESPACE'];
     const promotionalLinks = ['Secrets Sync'];


### PR DESCRIPTION
### Description
Follow-on to #28036. There is undesirable behavior when accessing the client count dashboard within a chrooted listener, so this PR removes the nav item to client counts when the GUI is accessed on a chrooted listener. 

Here is the sidenav as a root user logged into a chrooted listener:
<img width="324" alt="Screenshot 2024-09-10 at 17 09 13" src="https://github.com/user-attachments/assets/ec087b37-074a-43cb-b872-775d5f250b5e">


- [x] Ent tests pass