### PR TITLE
UI: Fix CC mount filter

### DIFF
--- a/ui/lib/core/addon/utils/client-count-utils.ts
+++ b/ui/lib/core/addon/utils/client-count-utils.ts
@@ -85,8 +85,9 @@ export const filteredTotalForMount = (
   if (!nsPath || !mountPath || isEmpty(byNamespace)) return emptyCounts();
   return (
     byNamespace
-      .find((namespace) => namespace.label === nsPath)
-      ?.mounts.find((mount: MountClients) => mount.label === mountPath) || emptyCounts()
+      .find((namespace) => sanitizePath(namespace.label) === sanitizePath(nsPath))
+      ?.mounts.find((mount: MountClients) => sanitizePath(mount.label) === sanitizePath(mountPath)) ||
+    emptyCounts()
   );
 };
 


### PR DESCRIPTION
### Description
Follow-on to #28036. This PR fixes an issue where filtering to a mount from within a namespace was not correctly returning the matching data. 

Before / After
<img width="1704" alt="Screenshot 2024-09-10 at 17 03 35" src="https://github.com/user-attachments/assets/0170d3b4-b5de-42ca-beaf-7a4873b9b4f2">

- [x] Ent tests pass