### PR TITLE
UI: Show filters and hide mount attribution when child clients only

### DIFF
--- a/ui/app/components/clients/page/counts.hbs
+++ b/ui/app/components/clients/page/counts.hbs
@@ -36,7 +36,7 @@
       </Hds::Alert>
     {{/if}}
 
-    {{#if (or @mountPath this.mountPaths)}}
+    {{#if (or @namespace this.namespaces @mountPath this.mountPaths)}}
       <Hds::Text::Display @tag="p">
         Filters
       </Hds::Text::Display>

--- a/ui/app/components/clients/page/counts.ts
+++ b/ui/app/components/clients/page/counts.ts
@@ -131,7 +131,7 @@ export default class ClientsCountsPageComponent extends Component<Args> {
 
   // namespace list for the search-select filter
   get namespaces() {
-    return this.args.activity.byNamespace
+    return this.args.activity?.byNamespace
       ? this.args.activity.byNamespace
           .map((namespace) => ({
             name: namespace.label,

--- a/ui/app/components/clients/page/overview.hbs
+++ b/ui/app/components/clients/page/overview.hbs
@@ -21,10 +21,12 @@
     @responseTimestamp={{@activity.responseTimestamp}}
     @isSecretsSyncActivated={{this.flags.secretsSyncIsActivated}}
   />
-  <Clients::Attribution
-    @noun="mount"
-    @attribution={{this.namespaceMountAttribution}}
-    @responseTimestamp={{@activity.responseTimestamp}}
-    @isSecretsSyncActivated={{this.flags.secretsSyncIsActivated}}
-  />
+  {{#if this.namespaceMountAttribution}}
+    <Clients::Attribution
+      @noun="mount"
+      @attribution={{this.namespaceMountAttribution}}
+      @responseTimestamp={{@activity.responseTimestamp}}
+      @isSecretsSyncActivated={{this.flags.secretsSyncIsActivated}}
+    />
+  {{/if}}
 {{/if}}


### PR DESCRIPTION
### Description
Follow-on to #28036. This PR fixes a bug where if there are only client counts in the child namespaces (not root/current), the filter bar is incorrectly hidden. It also would show "No data found" for mount attribution which is correct (because there are no mounts with clients in the current namespace) but misleading because there are mounts with attribution in other namespaces. 

Before/After
<img width="1906" alt="Screenshot 2024-09-11 at 12 03 58" src="https://github.com/user-attachments/assets/9b5df8b3-1928-4514-867d-3493daf279bc">

