### PR TITLE
add ce changes and documentation for tidying cmpv2 nonce store

### DIFF
--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -4114,6 +4114,7 @@ func TestBackend_RevokePlusTidy_Intermediate(t *testing.T) {
 			"tidy_revocation_queue":                 false,
 			"tidy_cross_cluster_revoked_certs":      false,
 			"tidy_cert_metadata":                    false,
+			"tidy_cmpv2_nonce_store":                false,
 			"pause_duration":                        "0s",
 			"state":                                 "Finished",
 			"error":                                 nil,
@@ -4136,6 +4137,7 @@ func TestBackend_RevokePlusTidy_Intermediate(t *testing.T) {
 			"acme_account_deleted_count":            json.Number("0"),
 			"total_acme_account_count":              json.Number("0"),
 			"cert_metadata_deleted_count":           json.Number("0"),
+			"cmpv2_nonce_deleted_count":             json.Number("0"),
 		}
 		// Let's copy the times from the response so that we can use deep.Equal()
 		timeStarted, ok := tidyStatus.Data["time_started"]

--- a/builtin/logical/pki/cmpv2_util_oss.go
+++ b/builtin/logical/pki/cmpv2_util_oss.go
@@ -1,6 +1,8 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: BUSL-1.1
 
+//go:build !enterprise
+
 package pki
 
 import (

--- a/builtin/logical/pki/cmpv2_util_oss.go
+++ b/builtin/logical/pki/cmpv2_util_oss.go
@@ -1,0 +1,14 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package pki
+
+import (
+	"context"
+
+	"github.com/hashicorp/vault/sdk/logical"
+)
+
+func (b *backend) doTidyCMPV2NonceStore(_ context.Context, _ logical.Storage) error {
+	return nil
+}

--- a/builtin/logical/pki/fields.go
+++ b/builtin/logical/pki/fields.go
@@ -598,6 +598,11 @@ primary node.`,
 		Description: `Set to true to enable tidying up certificate metadata`,
 	}
 
+	fields["tidy_cmpv2_nonce_store"] = &framework.FieldSchema{
+		Type:        framework.TypeBool,
+		Description: `Set to true to enable tidying up the CMPv2 nonce store`,
+	}
+
 	return fields
 }
 

--- a/website/content/api-docs/secret/pki/index.mdx
+++ b/website/content/api-docs/secret/pki/index.mdx
@@ -4415,6 +4415,9 @@ expiration time.
  - `tidy_cert_metadata` `(bool: false)` - Specifies whether to tidy metadata
   for expired certificates.
 
+ - `tidy_cmpv2_nonce_store` `(bool: false)` - Specifies whether to tidy expired
+nonces in the CMPv2 nonce store.
+
 #### Sample payload
 
 ```json
@@ -4476,7 +4479,8 @@ $ curl \
     "tidy_revocation_queue": false,
     "tidy_revoked_cert_issuer_associations": false,
     "tidy_revoked_certs": false,
-    "tidy_cert_metadata": false
+    "tidy_cert_metadata": false,
+    "tidy_cmpv2_nonce_store": false
   },
   "auth": null
 }
@@ -4572,6 +4576,7 @@ The result includes the following fields:
 * `last_auto_tidy_finished`: the time when the last auto-tidy operation finished; may be different than `time_finished` especially if the last operation was a manually executed tidy operation. Set to current time at mount time to delay the initial auto-tidy operation; not persisted.
 * `tidy_cert_metadata`: the value of this parameter when initiating the tidy operation
 * `cert_metadata_deleted_count`: the number of metadata entries deleted
+* `cmpv2_nonce_deleted_count`: the number of CMPv2 nonces deleted
 
 
 | Method | Path               |


### PR DESCRIPTION
### Description
What does this PR do?

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [ ] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
