### PR TITLE
UI: Fix enabling replication capabilities bug

### DIFF
--- a/changelog/28371.txt
+++ b/changelog/28371.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fix UI improperly checking capabilities for enabling performance and dr replication
+```

--- a/ui/app/app.js
+++ b/ui/app/app.js
@@ -27,6 +27,7 @@ export default class App extends Application {
       dependencies: {
         services: [
           'auth',
+          'capabilities',
           'flash-messages',
           'namespace',
           'replication-mode',

--- a/ui/lib/replication/addon/components/enable-replication-form.js
+++ b/ui/lib/replication/addon/components/enable-replication-form.js
@@ -19,16 +19,15 @@ import { waitFor } from '@ember/test-waiters';
  * but otherwise it handles the rest of the form inputs. On success it will clear the form and call the onSuccess callback.
  *
  * @example
- * ```js
  * <EnableReplicationForm @replicationMode="dr" @canEnablePrimary={{true}} @canEnableSecondary={{false}} @performanceReplicationDisabled={{false}} @onSuccess={{this.reloadCluster}} />
- *    @param {string} replicationMode - should be one of "dr" or "performance"
- *    @param {boolean} canEnablePrimary - if the capabilities allow the user to enable a primary cluster
- *    @param {boolean} canEnableSecondary - if the capabilities allow the user to enable a secondary cluster
- *    @param {boolean} performanceMode - should be "primary", "secondary", or "disabled". If enabled, form will show a warning when attempting to enable DR secondary
- *    @param {Promise} onSuccess - (optional) callback called after successful replication enablement. Must be a promise.
- *    @param {boolean} doTransition - (optional) if provided, passed to onSuccess callback to determine if a transition should be done
- *  />
- * ```
+ *
+ * @param {string} replicationMode - should be one of "dr" or "performance"
+ * @param {boolean} canEnablePrimary - if the capabilities allow the user to enable a primary cluster, parent getter returns capabilities based on type (i.e. "dr" or "performance")
+ * @param {boolean} canEnableSecondary - if the capabilities allow the user to enable a secondary cluster, parent getter returns capabilities based on type (i.e. "dr" or "performance")
+ * @param {boolean} performanceMode - should be "primary", "secondary", or "disabled". If enabled, form will show a warning when attempting to enable DR secondary
+ * @param {Promise} onSuccess - (optional) callback called after successful replication enablement. Must be a promise.
+ * @param {boolean} doTransition - (optional) if provided, passed to onSuccess callback to determine if a transition should be done
+ *
  */
 export default class EnableReplicationFormComponent extends Component {
   @service version;

--- a/ui/lib/replication/addon/components/page/mode-index.hbs
+++ b/ui/lib/replication/addon/components/page/mode-index.hbs
@@ -45,8 +45,8 @@
   </div>
   <EnableReplicationForm
     @replicationMode={{@replicationMode}}
-    @canEnablePrimary={{this.canEnablePrimary}}
-    @canEnableSecondary={{this.canEnableSecondary}}
+    @canEnablePrimary={{this.canEnable "Primary"}}
+    @canEnableSecondary={{this.canEnable "Secondary"}}
     @performanceReplicationDisabled={{@cluster.performance.replicationDisabled}}
     @performanceMode={{if @cluster.performance.replicationDisabled "disabled" @cluster.performance.modeForUrl}}
     @onSuccess={{@onEnableSuccess}}

--- a/ui/lib/replication/addon/components/page/mode-index.hbs
+++ b/ui/lib/replication/addon/components/page/mode-index.hbs
@@ -45,8 +45,8 @@
   </div>
   <EnableReplicationForm
     @replicationMode={{@replicationMode}}
-    @canEnablePrimary={{@cluster.canEnablePrimary}}
-    @canEnableSecondary={{@cluster.canEnableSecondary}}
+    @canEnablePrimary={{this.canEnablePrimary}}
+    @canEnableSecondary={{this.canEnableSecondary}}
     @performanceReplicationDisabled={{@cluster.performance.replicationDisabled}}
     @performanceMode={{if @cluster.performance.replicationDisabled "disabled" @cluster.performance.modeForUrl}}
     @onSuccess={{@onEnableSuccess}}

--- a/ui/lib/replication/addon/components/page/mode-index.js
+++ b/ui/lib/replication/addon/components/page/mode-index.js
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import Component from '@glimmer/component';
+
+/**
+ * @module PageModeIndex
+ *
+ * @example
+ * <Page::ModeIndex
+ *  @cluster={{this.model}}
+ *  @onEnableSuccess={{this.onEnableSuccess}}
+ *  @replicationDisabled={{this.replicationForMode.replicationDisabled}
+ *  @replicationMode={{this.replicationMode}}
+ * />
+ *
+ * @param {model} cluster - cluster route model
+ * @param {function} onEnableSuccess - callback after enabling is successful, handles transition if enabled from the top-level index route
+ * @param {boolean} replicationDisabled - whether or not replication is enabled
+ * @param {string} replicationMode - should be "dr" or "performance"
+ */
+export default class PageModeIndex extends Component {
+  get canEnablePrimary() {
+    const { cluster } = this.args;
+    switch (this.args.replicationMode) {
+      case 'dr':
+        return cluster.canEnablePrimaryDr;
+      case 'performance':
+        return cluster.canEnablePrimaryPerformance;
+      default:
+        // if there's a problem checking capabilities, default to true
+        // since the backend will gate as a fallback
+        return true;
+    }
+  }
+  get canEnableSecondary() {
+    const { cluster } = this.args;
+    switch (this.args.replicationMode) {
+      case 'dr':
+        return cluster.canEnableSecondaryDr;
+      case 'performance':
+        return cluster.canEnableSecondaryPerformance;
+      default:
+        // if there's a problem checking capabilities, default to true
+        // since the backend will gate as a fallback
+        return true;
+    }
+  }
+}

--- a/ui/lib/replication/addon/components/page/mode-index.js
+++ b/ui/lib/replication/addon/components/page/mode-index.js
@@ -22,30 +22,19 @@ import Component from '@glimmer/component';
  * @param {string} replicationMode - should be "dr" or "performance"
  */
 export default class PageModeIndex extends Component {
-  get canEnablePrimary() {
-    const { cluster } = this.args;
-    switch (this.args.replicationMode) {
-      case 'dr':
-        return cluster.canEnablePrimaryDr;
-      case 'performance':
-        return cluster.canEnablePrimaryPerformance;
-      default:
-        // if there's a problem checking capabilities, default to true
-        // since the backend will gate as a fallback
-        return true;
+  canEnable = (type) => {
+    const { cluster, replicationMode } = this.args;
+    let perm;
+    if (replicationMode === 'dr') {
+      // returns canEnablePrimaryDr or canEnableSecondaryDr
+      perm = `canEnable${type}Dr`;
     }
-  }
-  get canEnableSecondary() {
-    const { cluster } = this.args;
-    switch (this.args.replicationMode) {
-      case 'dr':
-        return cluster.canEnableSecondaryDr;
-      case 'performance':
-        return cluster.canEnableSecondaryPerformance;
-      default:
-        // if there's a problem checking capabilities, default to true
-        // since the backend will gate as a fallback
-        return true;
+    if (replicationMode === 'performance') {
+      // returns canEnablePrimaryPerformance or canEnableSecondaryPerformance
+      perm = `canEnable${type}Performance`;
     }
-  }
+    // if there's a problem checking capabilities, default to true
+    // since the backend can gate as a fallback
+    return cluster[perm] ?? true;
+  };
 }

--- a/ui/lib/replication/addon/controllers/index.js
+++ b/ui/lib/replication/addon/controllers/index.js
@@ -8,4 +8,29 @@ import { tracked } from '@glimmer/tracking';
 
 export default class ReplicationIndexController extends ReplicationModeBaseController {
   @tracked modeSelection = 'dr';
+
+  get canEnablePrimary() {
+    switch (this.modeSelection) {
+      case 'dr':
+        return this.model.canEnablePrimaryDr;
+      case 'performance':
+        return this.model.canEnablePrimaryPerformance;
+      default:
+        // if there's a problem checking capabilities, default to true
+        // since the backend will gate as a fallback
+        return true;
+    }
+  }
+  get canEnableSecondary() {
+    switch (this.modeSelection) {
+      case 'dr':
+        return this.model.canEnableSecondaryDr;
+      case 'performance':
+        return this.model.canEnableSecondaryPerformance;
+      default:
+        // if there's a problem checking capabilities, default to true
+        // since the backend will gate as a fallback
+        return true;
+    }
+  }
 }

--- a/ui/lib/replication/addon/controllers/index.js
+++ b/ui/lib/replication/addon/controllers/index.js
@@ -9,28 +9,23 @@ import { tracked } from '@glimmer/tracking';
 export default class ReplicationIndexController extends ReplicationModeBaseController {
   @tracked modeSelection = 'dr';
 
-  get canEnablePrimary() {
-    switch (this.modeSelection) {
-      case 'dr':
-        return this.model.canEnablePrimaryDr;
-      case 'performance':
-        return this.model.canEnablePrimaryPerformance;
-      default:
-        // if there's a problem checking capabilities, default to true
-        // since the backend will gate as a fallback
-        return true;
+  getPerm(type) {
+    if (this.modeSelection === 'dr') {
+      // returns canEnablePrimaryDr or canEnableSecondaryDr
+      return `canEnable${type}Dr`;
+    }
+    if (this.modeSelection === 'performance') {
+      // returns canEnablePrimaryPerformance or canEnableSecondaryPerformance
+      return `canEnable${type}Performance`;
     }
   }
+
+  // if there's a problem checking capabilities, default to true
+  // since the backend will gate as a fallback
+  get canEnablePrimary() {
+    return this.model[this.getPerm('Primary')] ?? true;
+  }
   get canEnableSecondary() {
-    switch (this.modeSelection) {
-      case 'dr':
-        return this.model.canEnableSecondaryDr;
-      case 'performance':
-        return this.model.canEnableSecondaryPerformance;
-      default:
-        // if there's a problem checking capabilities, default to true
-        // since the backend will gate as a fallback
-        return true;
-    }
+    return this.model[this.getPerm('Secondary')] ?? true;
   }
 }

--- a/ui/lib/replication/addon/engine.js
+++ b/ui/lib/replication/addon/engine.js
@@ -16,6 +16,7 @@ const Eng = Engine.extend({
   dependencies: {
     services: [
       'auth',
+      'capabilities',
       'flash-messages',
       'namespace',
       'replication-mode',

--- a/ui/lib/replication/addon/routes/application.js
+++ b/ui/lib/replication/addon/routes/application.js
@@ -5,7 +5,6 @@
 
 import { service } from '@ember/service';
 import { setProperties } from '@ember/object';
-import { hash } from 'rsvp';
 import Route from '@ember/routing/route';
 import ClusterRoute from 'vault/mixins/cluster-route';
 
@@ -14,6 +13,23 @@ export default Route.extend(ClusterRoute, {
   store: service(),
   auth: service(),
   router: service(),
+  capabilities: service(),
+
+  async fetchCapabilities() {
+    const enablePath = (type, cluster) => `sys/replication/${type}/${cluster}/enable`;
+    const perms = await this.capabilities.fetchMultiplePaths([
+      enablePath('dr', 'primary'),
+      enablePath('dr', 'primary'),
+      enablePath('performance', 'secondary'),
+      enablePath('performance', 'secondary'),
+    ]);
+    return {
+      canEnablePrimaryDr: perms[enablePath('dr', 'primary')].canUpdate,
+      canEnableSecondaryDr: perms[enablePath('dr', 'primary')].canUpdate,
+      canEnablePrimaryPerformance: perms[enablePath('performance', 'secondary')].canUpdate,
+      canEnableSecondaryPerformance: perms[enablePath('performance', 'secondary')].canUpdate,
+    };
+  },
 
   beforeModel() {
     if (this.auth.activeCluster.replicationRedacted) {
@@ -29,21 +45,21 @@ export default Route.extend(ClusterRoute, {
     return this.auth.activeCluster;
   },
 
-  afterModel(model) {
-    return hash({
-      canEnablePrimary: this.store
-        .findRecord('capabilities', 'sys/replication/primary/enable')
-        .then((c) => c.canUpdate),
-      canEnableSecondary: this.store
-        .findRecord('capabilities', 'sys/replication/secondary/enable')
-        .then((c) => c.canUpdate),
-    }).then(({ canEnablePrimary, canEnableSecondary }) => {
-      setProperties(model, {
-        canEnablePrimary,
-        canEnableSecondary,
-      });
-      return model;
+  async afterModel(model) {
+    const {
+      canEnablePrimaryDr,
+      canEnableSecondaryDr,
+      canEnablePrimaryPerformance,
+      canEnableSecondaryPerformance,
+    } = await this.fetchCapabilities();
+
+    setProperties(model, {
+      canEnablePrimaryDr,
+      canEnableSecondaryDr,
+      canEnablePrimaryPerformance,
+      canEnableSecondaryPerformance,
     });
+    return model;
   },
   actions: {
     refresh() {

--- a/ui/lib/replication/addon/templates/index.hbs
+++ b/ui/lib/replication/addon/templates/index.hbs
@@ -92,8 +92,8 @@
       </div>
       <EnableReplicationForm
         @replicationMode={{this.modeSelection}}
-        @canEnablePrimary={{this.model.canEnablePrimary}}
-        @canEnableSecondary={{this.model.canEnableSecondary}}
+        @canEnablePrimary={{this.canEnablePrimary}}
+        @canEnableSecondary={{this.canEnableSecondary}}
         @performanceReplicationDisabled={{this.model.performance.replicationDisabled}}
         @performanceMode={{if this.model.performance.replicationDisabled "disabled" this.model.performance.modeForUrl}}
         @onSuccess={{this.onEnableSuccess}}

--- a/ui/tests/integration/components/page/mode-index-test.js
+++ b/ui/tests/integration/components/page/mode-index-test.js
@@ -13,7 +13,9 @@ const S = {
   title: 'h1',
   subtitle: 'h2',
   enableForm: '[data-test-replication-enable-form]',
+  enableBtn: '[data-test-replication-enable]',
   summary: '[data-test-replication-summary]',
+  notAllowed: '[data-test-not-allowed]',
 };
 module('Integration | Component | replication page/mode-index', function (hooks) {
   setupRenderingTest(hooks);
@@ -43,6 +45,8 @@ module('Integration | Component | replication page/mode-index', function (hooks)
 
       assert.dom(S.title).hasText('Enable Disaster Recovery Replication');
       assert.dom(S.enableForm).exists();
+      assert.dom(S.notAllowed).doesNotExist();
+      assert.dom(S.enableBtn).exists('Enable button shows by default if no permissions available');
     });
     test('it renders correctly when replication enabled', async function (assert) {
       this.replicationDisabled = false;
@@ -50,6 +54,24 @@ module('Integration | Component | replication page/mode-index', function (hooks)
 
       assert.dom(S.enableForm).doesNotExist();
       assert.dom(S.summary).exists();
+    });
+
+    test('it hides enable button if no permissions', async function (assert) {
+      this.clusterModel.canEnablePrimaryDr = false;
+      await this.renderComponent();
+
+      assert.dom(S.enableForm).exists();
+      assert.dom(S.notAllowed).exists();
+      assert.dom(S.enableBtn).doesNotExist();
+    });
+
+    test('it shows enable button if has permissions', async function (assert) {
+      this.clusterModel.canEnablePrimaryDr = true;
+      await this.renderComponent();
+
+      assert.dom(S.enableForm).exists();
+      assert.dom(S.notAllowed).doesNotExist();
+      assert.dom(S.enableBtn).exists();
     });
   });
 
@@ -62,6 +84,8 @@ module('Integration | Component | replication page/mode-index', function (hooks)
 
       assert.dom(S.title).hasText('Enable Performance Replication');
       assert.dom(S.enableForm).exists();
+      assert.dom(S.notAllowed).doesNotExist();
+      assert.dom(S.enableBtn).exists('Enable button shows by default if no permissions available');
     });
     test('it renders correctly when replication enabled', async function (assert) {
       this.replicationDisabled = false;
@@ -69,6 +93,24 @@ module('Integration | Component | replication page/mode-index', function (hooks)
 
       assert.dom(S.enableForm).doesNotExist();
       assert.dom(S.summary).exists();
+    });
+
+    test('it hides enable button if no permissions', async function (assert) {
+      this.clusterModel.canEnablePrimaryPerformance = false;
+      await this.renderComponent();
+
+      assert.dom(S.enableForm).exists();
+      assert.dom(S.notAllowed).exists();
+      assert.dom(S.enableBtn).doesNotExist();
+    });
+
+    test('it shows enable button if has permissions', async function (assert) {
+      this.clusterModel.canEnablePrimaryPerformance = true;
+      await this.renderComponent();
+
+      assert.dom(S.enableForm).exists();
+      assert.dom(S.notAllowed).doesNotExist();
+      assert.dom(S.enableBtn).exists();
     });
   });
 });


### PR DESCRIPTION
### Description
A user with the policy below (which is used in this [tutorial](https://developer.hashicorp.com/vault/tutorials/enterprise/disaster-recovery#policy-requirements)) was unable to enable replication in the GUI because the UI wasn't checking specifically for `/dr/` or `/performance/` in the original capabilities check. 

```js
// original check, path didn't include type
canEnablePrimary: this.store
        .findRecord('capabilities', 'sys/replication/primary/enable')
        .then((c) => c.canUpdate),
      canEnableSecondary: this.store
        .findRecord('capabilities', 'sys/replication/secondary/enable')
        .then((c) => c.canUpdate),
```

Now type is included in the path passed to the capabilities endpoint which hides or shows "Enable" accordingly. If there's a problem reading capabilities, then the default is `true` because the backend can be used as a fallback to gate a user who does not have the correct permissions.

I will open a manual backport to address this fix in 1.16 and 1.17 because the capabilities service is new and was added in 1.18
<hr>

### 📸 The left is before the fix, and on the right is after. 
_Both browsers the user is logged in with the policy below._
<img width="1685" alt="Screenshot 2024-09-11 at 5 52 56 PM" src="https://github.com/user-attachments/assets/11db862a-f6d2-4591-b4e9-772163372404">

```
# To enable DR primary
path "sys/replication/dr/primary/enable" {
  capabilities = ["create", "update"]
}

# To generate a secondary token required to add a DR secondary
path "sys/replication/dr/primary/secondary-token" {
  capabilities = ["create", "update", "sudo"]
}

# To create ACL policies
path "sys/policies/acl/*" {
  capabilities = ["create", "update", "list"]
}

# Create a token role for batch DR operation token
path "auth/token/roles/*" {
  capabilities = ["create", "update"]
}

# Create a token
path "auth/token/create" {
  capabilities = ["create", "update"]
}

# To demote the primary to secondary
path "sys/replication/dr/primary/demote" {
  capabilities = ["create", "update"]
}

# To enable DR secondary
path "sys/replication/dr/secondary/enable" {
  capabilities = ["create", "update"]
}

# To generate an operation token
path "sys/replication/dr/secondary/generate-operation-token/*" {
  capabilities = ["create", "update"]
}

# To promote the secondary cluster to be primary
path "sys/replication/dr/secondary/promote" {
  capabilities = ["create", "update"]
}

# To update the assigned primary cluster
path "sys/replication/dr/secondary/update-primary" {
  capabilities = ["create", "update"]
}

# If you choose to disable the original primary cluster post-recovery
path "sys/replication/dr/primary/disable" {
  capabilities = ["create", "update"]
}

```

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [ ] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
