### PR TITLE
Update MongoDB Atlas Secrets Engine link

### DIFF
--- a/website/content/docs/secrets/databases/mongodbatlas.mdx
+++ b/website/content/docs/secrets/databases/mongodbatlas.mdx
@@ -19,7 +19,7 @@ more information about setting up the database secrets engine.
 
 <Note>
   The information below relates to the MongoDB Altas <b>database plugin</b> for the Vault database secrets engine.
-  Refer to the <a href="vault/docs/secrets/mongodbatlas">MongoDB Atlas secrets engine</a> 
+  Refer to the <a href="../mongodbatlas.mdx">MongoDB Atlas secrets engine</a> 
   for information about using the MongoDB Atlas secrets engine for the Vault.
 </Note>
 


### PR DESCRIPTION


### Description
Currently, there is a link on the MongoDB Atlas database secrets engine page (https://developer.hashicorp.com/vault/docs/secrets/databases/mongodbatlas) that links to the MongoDB Atlas secrets engine (non-db) but returns a "We couldn't find the page you're looking for." Seems like the path is broken and the link needs to be updated.

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [ ] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
