### PR TITLE
Mention the cert forwarding header in cert auth docs

### DIFF
--- a/website/content/docs/auth/cert.mdx
+++ b/website/content/docs/auth/cert.mdx
@@ -24,10 +24,6 @@ lower-case.
 
 Please note that to use this auth method, `tls_disable` and `tls_disable_client_certs` must be false in the Vault
 configuration. This is because the certificates are sent through TLS communication itself. 
-If the Vault server is fronted by a reverse proxy or load balancer, TLS is
-terminated before Vault.  In that case the proxy must provide the validated
-client certificate via header, and [configured in the Vault configuration's
-listener stanza](vault/docs/configuration/listener/tcp#tcp-listener-parameters)
 
 ## Revocation checking
 
@@ -143,6 +139,18 @@ management tool.
    "web" and "prod" policies. The certificate (public key) used to verify
    clients is given by the "web-cert.pem" file. Lastly, an optional `ttl` value
    can be provided in seconds to limit the lease duration.
+
+### Load Balancing / Proxying Consideration
+
+If the Vault server is fronted by a reverse proxy or load balancer, TLS is
+terminated before Vault.  In that case the proxy must provide the validated
+client certificate via header, and [configured in the Vault configuration's
+listener stanza](/vault/docs/configuration/listener/tcp#tcp-listener-parameters).
+
+Configure the listener with the header name that your load balancer provides.  
+In this mode, the security of authentication depends on the load balancer performing 
+full TLS verification to the client, and that the connection between the load
+balancer and Vault is secured, ideally with Mutual TLS.
 
 ## API
 

--- a/website/content/docs/auth/cert.mdx
+++ b/website/content/docs/auth/cert.mdx
@@ -23,7 +23,11 @@ CA certificates are associated with a role; role names and CRL names are normali
 lower-case.
 
 Please note that to use this auth method, `tls_disable` and `tls_disable_client_certs` must be false in the Vault
-configuration. This is because the certificates are sent through TLS communication itself.
+configuration. This is because the certificates are sent through TLS communication itself. 
+If the Vault server is fronted by a reverse proxy or load balancer, TLS is
+terminated before Vault.  In that case the proxy must provide the validated
+client certificate via header, and [configured in the Vault configuration's
+listener stanza](vault/docs/configuration/listener/tcp#tcp-listener-parameters)
 
 ## Revocation checking
 


### PR DESCRIPTION
### Description
What does this PR do?

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [ ] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.