### PR TITLE
UI: hide client count warning on dashboard

### DIFF
--- a/changelog/27559.txt
+++ b/changelog/27559.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: Remove deprecated `current_billing_period` from dashboard activity log request
+```

--- a/ui/app/adapters/application.js
+++ b/ui/app/adapters/application.js
@@ -92,7 +92,7 @@ export default RESTAdapter.extend({
         controlGroup.deleteControlGroupToken(controlGroupToken.accessor);
       }
       const [resp] = args;
-      if (resp && resp.warnings) {
+      if (resp && resp.warnings && !options.skipWarnings) {
         const flash = this.flashMessages;
         resp.warnings.forEach((message) => {
           flash.info(message);

--- a/ui/app/adapters/clients/activity.js
+++ b/ui/app/adapters/clients/activity.js
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { debug } from '@ember/debug';
 import ApplicationAdapter from '../application';
 import { formatDateObject } from 'core/utils/client-count-utils';
+import { debug } from '@ember/debug';
 
 export default class ActivityAdapter extends ApplicationAdapter {
   // javascript localizes new Date() objects but all activity log data is stored in UTC

--- a/ui/app/adapters/clients/activity.js
+++ b/ui/app/adapters/clients/activity.js
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
+import { debug } from '@ember/debug';
 import ApplicationAdapter from '../application';
 import { formatDateObject } from 'core/utils/client-count-utils';
 
@@ -32,5 +33,14 @@ export default class ActivityAdapter extends ApplicationAdapter {
         return response;
       });
     }
+  }
+
+  // Only dashboard uses findRecord, the client count dashboard uses queryRecord
+  findRecord(store, type, id) {
+    if (id !== 'clients/activity') {
+      debug(`findRecord('clients/activity') should pass 'clients/activity' as the id, you passed: '${id}'`);
+    }
+    const url = `${this.buildURL()}/internal/counters/activity`;
+    return this.ajax(url, 'GET', { skipWarnings: true });
   }
 }

--- a/ui/app/components/clients/no-data.hbs
+++ b/ui/app/components/clients/no-data.hbs
@@ -3,13 +3,13 @@
   SPDX-License-Identifier: BUSL-1.1
 ~}}
 
-{{#if (eq @config.enabled "On")}}
+{{#if (or @config.reportingEnabled (eq @config.enabled "On"))}}
   <EmptyState
     @title="No data received {{if @dateRangeMessage @dateRangeMessage}}"
     @message="Tracking is turned on and Vault is gathering data. It should appear here within 30 minutes."
     class="is-shadowless"
   />
-{{else}}
+{{else if @config}}
   <EmptyState
     @title="Data tracking is disabled"
     @message="Tracking is disabled, and no data is being collected. To turn it on, edit the configuration."
@@ -24,4 +24,10 @@
       />
     {{/if}}
   </EmptyState>
+{{else}}
+  <EmptyState
+    @title="Activity configuration data is unavailable"
+    @message="Reporting status is unknown and could be enabled or disabled. Check the Vault logs for more information."
+    class="is-shadowless"
+  />
 {{/if}}

--- a/ui/app/components/dashboard/client-count-card.hbs
+++ b/ui/app/components/dashboard/client-count-card.hbs
@@ -14,10 +14,10 @@
 
   <hr class="has-background-gray-100" />
 
-  {{#if this.hasActivity}}
-    {{#if this.fetchClientActivity.isRunning}}
-      <VaultLogoSpinner />
-    {{else}}
+  {{#if this.fetchClientActivity.isRunning}}
+    <VaultLogoSpinner />
+  {{else}}
+    {{#if this.activityData}}
       <div class="is-grid grid-2-columns grid-gap-2 has-top-margin-m grid-align-items-start is-flex-v-centered">
         <StatText @label="Total" @value={{this.activityData.total.clients}} @size="l" @subText={{this.statSubText.total}} />
         <StatText @label="New" @value={{this.currentMonthActivityTotalCount}} @size="l" @subText={{this.statSubText.new}} />
@@ -34,15 +34,13 @@
           {{on "click" (perform this.fetchClientActivity)}}
           data-test-refresh
         />
-        <small class="has-left-margin-xs has-text-grey">
+        <small class="has-left-margin-xs has-text-grey" data-test-updated-timestamp>
           Updated
           {{date-format this.updatedAt "MMM d yyyy, h:mm:ss aaa" withTimeZone=true}}
         </small>
       </div>
+    {{else}}
+      <Clients::NoData @config={{this.activityConfig}} />
     {{/if}}
-  {{else}}
-    {{! This will likely never show since the clients activity api has changed to always return data. In the past it
-  would return no activity data. Adding this empty state here to match the current client count behavior }}
-    <Clients::NoData @config={{hash enabled="On"}} />
   {{/if}}
 </Hds::Card::Container>

--- a/ui/app/components/dashboard/client-count-card.js
+++ b/ui/app/components/dashboard/client-count-card.js
@@ -23,7 +23,7 @@ export default class DashboardClientCountCard extends Component {
   @service store;
 
   @tracked activityData = null;
-  @tracked hasActivity = false;
+  @tracked activityConfig = null;
   @tracked updatedAt = null;
 
   constructor() {
@@ -54,8 +54,9 @@ export default class DashboardClientCountCard extends Component {
 
     try {
       this.activityData = yield this.store.findRecord('clients/activity', 'clients/activity');
-      this.hasActivity = this.activityData.id === 'no-data' ? false : true;
     } catch (error) {
+      // used for rendering the "No data" empty state, swallow any errors requesting config data
+      this.activityConfig = yield this.store.queryRecord('clients/config', {}).catch(() => null);
       this.error = error;
     }
   }

--- a/ui/app/components/dashboard/client-count-card.js
+++ b/ui/app/components/dashboard/client-count-card.js
@@ -53,9 +53,7 @@ export default class DashboardClientCountCard extends Component {
     this.updatedAt = timestamp.now().toISOString();
 
     try {
-      this.activityData = yield this.store.queryRecord('clients/activity', {
-        current_billing_period: true,
-      });
+      this.activityData = yield this.store.findRecord('clients/activity', 'clients/activity');
       this.hasActivity = this.activityData.id === 'no-data' ? false : true;
     } catch (error) {
       this.error = error;

--- a/ui/app/models/clients/config.js
+++ b/ui/app/models/clients/config.js
@@ -31,8 +31,10 @@ export default class ClientsConfigModel extends Model {
 
   @attr('number') minimumRetentionMonths;
 
+  // refers specifically to the activitylog and will always be on for enterprise
   @attr('string') enabled;
 
+  // reporting_enabled is for automated reporting and only true of the customer hasn’t opted-out of automated license reporting
   @attr('boolean') reportingEnabled;
 
   @attr('date') billingStartTimestamp;

--- a/ui/mirage/handlers/clients.js
+++ b/ui/mirage/handlers/clients.js
@@ -217,9 +217,9 @@ export default function (server) {
 
   server.get('/sys/internal/counters/activity', (schema, req) => {
     let { start_time, end_time } = req.queryParams;
-    if (req.queryParams.current_billing_period) {
-      // { current_billing_period: true } automatically queries the activity log
-      // from the builtin license start timestamp to the current month
+    if (!start_time && !end_time) {
+      // if there are no date query params, the activity log default behavior
+      // queries from the builtin license start timestamp to the current month
       start_time = LICENSE_START.toISOString();
       end_time = STATIC_NOW.toISOString();
     }

--- a/ui/tests/acceptance/chroot-namespace-test.js
+++ b/ui/tests/acceptance/chroot-namespace-test.js
@@ -6,7 +6,7 @@
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { currentRouteName } from '@ember/test-helpers';
-import authPage from 'vault/tests/pages/auth';
+import { login, loginNs } from 'vault/tests/helpers/auth/auth-helpers';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import chrootNamespaceHandlers from 'vault/mirage/handlers/chroot-namespace';
 import { createTokenCmd, runCmd, tokenWithPolicyCmd } from '../helpers/commands';
@@ -24,13 +24,13 @@ module('Acceptance | chroot-namespace enterprise ui', function (hooks) {
   });
 
   test('it should render normally when chroot namespace exists', async function (assert) {
-    await authPage.login();
+    await login();
     assert.strictEqual(currentRouteName(), 'vault.cluster.dashboard', 'goes to dashboard page');
     assert.dom('[data-test-badge-namespace]').includesText('root', 'Shows root namespace badge');
   });
 
   test('root-only nav items are unavailable', async function (assert) {
-    await authPage.login();
+    await login();
 
     ['Dashboard', 'Secrets Engines', 'Access', 'Tools', 'Policies', 'Client Count'].forEach((nav) => {
       assert.dom(navLink(nav)).exists(`Shows ${nav} nav item in chroot listener`);
@@ -40,19 +40,19 @@ module('Acceptance | chroot-namespace enterprise ui', function (hooks) {
     });
 
     // cleanup namespace
-    await authPage.login();
+    await login();
     await runCmd(`delete sys/namespaces/${namespace}`);
   });
 
   test('a user with default policy should see nav items', async function (assert) {
-    await authPage.login();
+    await login();
     // Create namespace
     await runCmd(`write sys/namespaces/${namespace} -f`, false);
     // Create user within the namespace
-    await authPage.loginNs(namespace);
+    await loginNs(namespace);
     const userDefault = await runCmd(createTokenCmd());
 
-    await authPage.loginNs(namespace, userDefault);
+    await loginNs(namespace, userDefault);
     ['Dashboard', 'Secrets Engines', 'Access', 'Tools'].forEach((nav) => {
       assert.dom(navLink(nav)).exists(`Shows ${nav} nav item for user with default policy`);
     });
@@ -61,16 +61,16 @@ module('Acceptance | chroot-namespace enterprise ui', function (hooks) {
     });
 
     // cleanup namespace
-    await authPage.login();
+    await login();
     await runCmd(`delete sys/namespaces/${namespace}`);
   });
 
   test('a user with read policy should see nav items', async function (assert) {
-    await authPage.login();
+    await login();
     // Create namespace
     await runCmd(`write sys/namespaces/${namespace} -f`, false);
     // Create user within the namespace
-    await authPage.loginNs(namespace);
+    await loginNs(namespace);
     const reader = await runCmd(
       tokenWithPolicyCmd(
         'read-all',
@@ -82,7 +82,7 @@ module('Acceptance | chroot-namespace enterprise ui', function (hooks) {
       )
     );
 
-    await authPage.loginNs(namespace, reader);
+    await loginNs(namespace, reader);
     ['Dashboard', 'Secrets Engines', 'Access', 'Policies', 'Tools', 'Client Count'].forEach((nav) => {
       assert.dom(navLink(nav)).exists(`Shows ${nav} nav item for user with read access policy`);
     });
@@ -91,16 +91,16 @@ module('Acceptance | chroot-namespace enterprise ui', function (hooks) {
     });
 
     // cleanup namespace
-    await authPage.login();
+    await login();
     await runCmd(`delete sys/namespaces/${namespace}`);
   });
 
   test('it works within a child namespace', async function (assert) {
-    await authPage.login();
+    await login();
     // Create namespace
     await runCmd(`write sys/namespaces/${namespace} -f`, false);
     // Create user within the namespace
-    await authPage.loginNs(namespace);
+    await loginNs(namespace);
     const childReader = await runCmd(
       tokenWithPolicyCmd(
         'read-child',
@@ -114,7 +114,7 @@ module('Acceptance | chroot-namespace enterprise ui', function (hooks) {
     // Create child namespace
     await runCmd(`write sys/namespaces/child -f`, false);
 
-    await authPage.loginNs(namespace, childReader);
+    await loginNs(namespace, childReader);
     ['Dashboard', 'Secrets Engines', 'Access', 'Tools'].forEach((nav) => {
       assert.dom(navLink(nav)).exists(`Shows ${nav} nav item`);
     });
@@ -122,7 +122,7 @@ module('Acceptance | chroot-namespace enterprise ui', function (hooks) {
       assert.dom(navLink(nav)).doesNotExist(`Does not show ${nav} nav item`);
     });
 
-    await authPage.loginNs(`${namespace}/child`, childReader);
+    await loginNs(`${namespace}/child`, childReader);
     ['Dashboard', 'Secrets Engines', 'Access', 'Policies', 'Tools', 'Client Count'].forEach((nav) => {
       assert.dom(navLink(nav)).exists(`Shows ${nav} nav item within child namespace`);
     });
@@ -131,9 +131,9 @@ module('Acceptance | chroot-namespace enterprise ui', function (hooks) {
     });
 
     // cleanup namespaces
-    await authPage.loginNs(namespace);
+    await loginNs(namespace);
     await runCmd(`delete sys/namespaces/child`);
-    await authPage.login();
+    await login();
     await runCmd(`delete sys/namespaces/${namespace}`);
   });
 });

--- a/ui/tests/acceptance/chroot-namespace-test.js
+++ b/ui/tests/acceptance/chroot-namespace-test.js
@@ -5,7 +5,7 @@
 
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
-import { currentRouteName } from '@ember/test-helpers';
+import { currentRouteName, waitFor } from '@ember/test-helpers';
 import { login, loginNs } from 'vault/tests/helpers/auth/auth-helpers';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import chrootNamespaceHandlers from 'vault/mirage/handlers/chroot-namespace';
@@ -83,6 +83,7 @@ module('Acceptance | chroot-namespace enterprise ui', function (hooks) {
     );
 
     await loginNs(namespace, reader);
+    await waitFor(navLink('Dashboard'));
     ['Dashboard', 'Secrets Engines', 'Access', 'Policies', 'Tools', 'Client Count'].forEach((nav) => {
       assert.dom(navLink(nav)).exists(`Shows ${nav} nav item for user with read access policy`);
     });

--- a/ui/tests/acceptance/dashboard-test.js
+++ b/ui/tests/acceptance/dashboard-test.js
@@ -402,7 +402,7 @@ module('Acceptance | landing page dashboard', function (hooks) {
       assert.true(version.isEnterprise, 'version is enterprise');
       assert.strictEqual(currentURL(), '/vault/dashboard');
       assert.dom(DASHBOARD.cardName('client-count')).exists();
-      const response = await this.store.peekRecord('clients/activity', 'clients/activity');
+      const response = await this.store.findRecord('clients/activity', 'clients/activity');
       assert.dom('[data-test-client-count-title]').hasText('Client count');
       assert.dom('[data-test-stat-text="Total"] .stat-label').hasText('Total');
       assert.dom('[data-test-stat-text="Total"] .stat-value').hasText(formatNumber([response.total.clients]));

--- a/ui/tests/acceptance/dashboard-test.js
+++ b/ui/tests/acceptance/dashboard-test.js
@@ -29,6 +29,7 @@ import { runCmd, deleteEngineCmd, createNS } from 'vault/tests/helpers/commands'
 
 import { DASHBOARD } from 'vault/tests/helpers/components/dashboard/dashboard-selectors';
 import { CUSTOM_MESSAGES } from 'vault/tests/helpers/config-ui/message-selectors';
+import { GENERAL } from 'vault/tests/helpers/general-selectors';
 
 const authenticatedMessageResponse = {
   request_id: '664fbad0-fcd8-9023-4c5b-81a7962e9f4b',
@@ -397,12 +398,11 @@ module('Acceptance | landing page dashboard', function (hooks) {
     });
 
     test('shows the client count card for enterprise', async function (assert) {
-      assert.expect(9);
       const version = this.owner.lookup('service:version');
       assert.true(version.isEnterprise, 'version is enterprise');
       assert.strictEqual(currentURL(), '/vault/dashboard');
       assert.dom(DASHBOARD.cardName('client-count')).exists();
-      const response = await this.store.peekRecord('clients/activity', 'some-activity-id');
+      const response = await this.store.peekRecord('clients/activity', 'clients/activity');
       assert.dom('[data-test-client-count-title]').hasText('Client count');
       assert.dom('[data-test-stat-text="Total"] .stat-label').hasText('Total');
       assert.dom('[data-test-stat-text="Total"] .stat-value').hasText(formatNumber([response.total.clients]));
@@ -413,6 +413,9 @@ module('Acceptance | landing page dashboard', function (hooks) {
       assert
         .dom('[data-test-stat-text="New"] .stat-value')
         .hasText(formatNumber([response.byMonth.lastObject.new_clients.clients]));
+      assert
+        .dom(`${GENERAL.flashMessage}.is-info`)
+        .doesNotExist('Does not show warning about client count estimations');
     });
   });
 

--- a/ui/tests/helpers/auth/auth-helpers.ts
+++ b/ui/tests/helpers/auth/auth-helpers.ts
@@ -17,6 +17,15 @@ export const login = async (token = rootToken) => {
   return await click(AUTH_FORM.login);
 };
 
+export const loginNs = async (ns: string, token = rootToken) => {
+  // make sure we're always logged out and logged back in
+  await logout();
+  await visit('/vault/auth?with=token');
+  await fillIn('[data-test-auth-form-ns-input]', ns);
+  await fillIn(AUTH_FORM.input('token'), token);
+  return await click(AUTH_FORM.login);
+};
+
 export const logout = async () => {
   // make sure we're always logged out and logged back in
   await visit('/vault/logout');

--- a/ui/tests/integration/components/clients/no-data-test.js
+++ b/ui/tests/integration/components/clients/no-data-test.js
@@ -1,0 +1,93 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'vault/tests/helpers';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { GENERAL } from 'vault/tests/helpers/general-selectors';
+import { allowAllCapabilitiesStub } from 'vault/tests/helpers/stubs';
+
+module('Integration | Component | clients/no-data', function (hooks) {
+  setupRenderingTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(async function () {
+    this.server.post('/sys/capabilities-self', allowAllCapabilitiesStub());
+    this.store = this.owner.lookup('service:store');
+    this.setConfig = async (data) => {
+      // the clients/config model does some funky serializing for the "enabled" param
+      // so stubbing the request here instead of just the model for additional coverage
+      this.server.get('sys/internal/counters/config', () => {
+        return {
+          request_id: '25a94b99-b49a-c4ac-cb7b-5ba0eb390a25',
+          data,
+        };
+      });
+      return this.store.queryRecord('clients/config', {});
+    };
+    this.renderComponent = async () => {
+      return render(hbs`<Clients::NoData @config={{this.config}} />`);
+    };
+  });
+
+  test('it renders empty state when enabled is "on"', async function (assert) {
+    assert.expect(2);
+    const data = {
+      enabled: 'default-enabled',
+      reporting_enabled: false,
+    };
+    ``;
+    this.config = await this.setConfig(data);
+    await this.renderComponent();
+    assert.dom(GENERAL.emptyStateTitle).hasText('No data received');
+    assert
+      .dom(GENERAL.emptyStateMessage)
+      .hasText('Tracking is turned on and Vault is gathering data. It should appear here within 30 minutes.');
+  });
+
+  test('it renders empty state when reporting_enabled is true', async function (assert) {
+    assert.expect(2);
+    const data = {
+      enabled: 'default-disabled',
+      reporting_enabled: true,
+    };
+    this.config = await this.setConfig(data);
+    await this.renderComponent();
+    assert.dom(GENERAL.emptyStateTitle).hasText('No data received');
+    assert
+      .dom(GENERAL.emptyStateMessage)
+      .hasText('Tracking is turned on and Vault is gathering data. It should appear here within 30 minutes.');
+  });
+
+  test('it renders empty state when reporting is fully disabled', async function (assert) {
+    assert.expect(2);
+    const data = {
+      enabled: 'default-disabled',
+      reporting_enabled: false,
+    };
+    this.config = await this.setConfig(data);
+    await this.renderComponent();
+    assert.dom(GENERAL.emptyStateTitle).hasText('Data tracking is disabled');
+    assert
+      .dom(GENERAL.emptyStateMessage)
+      .hasText(
+        'Tracking is disabled, and no data is being collected. To turn it on, edit the configuration.'
+      );
+  });
+
+  test('it renders empty state when config data is not available', async function (assert) {
+    assert.expect(2);
+    this.config = null;
+    await this.renderComponent();
+    assert.dom(GENERAL.emptyStateTitle).hasText('Activity configuration data is unavailable');
+    assert
+      .dom(GENERAL.emptyStateMessage)
+      .hasText(
+        'Reporting status is unknown and could be enabled or disabled. Check the Vault logs for more information.'
+      );
+  });
+});

--- a/ui/tests/integration/components/dashboard/client-count-card-test.js
+++ b/ui/tests/integration/components/dashboard/client-count-card-test.js
@@ -8,6 +8,7 @@ import { setupRenderingTest } from 'vault/tests/helpers';
 import { render, click } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
+import { Response } from 'miragejs';
 import sinon from 'sinon';
 import { STATIC_NOW } from 'vault/mirage/handlers/clients';
 import timestamp from 'core/utils/timestamp';
@@ -21,21 +22,14 @@ module('Integration | Component | dashboard/client-count-card', function (hooks)
   setupMirage(hooks);
 
   test('it should display client count information', async function (assert) {
-    sinon.replace(timestamp, 'now', sinon.fake.returns(STATIC_NOW));
-    assert.expect(5);
+    assert.expect(6);
+    sinon.replace(timestamp, 'now', sinon.fake.returns(STATIC_NOW)); // 1/25/24
     const { months, total } = ACTIVITY_RESPONSE_STUB;
     const [latestMonth] = months.slice(-1);
-    this.server.get('sys/internal/counters/activity', (schema, req) => {
+    this.server.get('sys/internal/counters/activity', () => {
       // this assertion should be hit twice, once initially and then again clicking 'refresh'
-      assert.propEqual(
-        req.queryParams,
-        { current_billing_period: 'true' },
-        'it makes request to sys/internal/counters/activity with builtin license start time'
-      );
-      return {
-        request_id: 'some-activity-id',
-        data: ACTIVITY_RESPONSE_STUB,
-      };
+      assert.true(true, 'makes request to sys/internal/counters/activity');
+      return { data: ACTIVITY_RESPONSE_STUB };
     });
 
     await render(hbs`<Dashboard::ClientCountCard />`);
@@ -54,6 +48,7 @@ module('Integration | Component | dashboard/client-count-card', function (hooks)
           latestMonth.new_clients.counts.clients,
         ])}`
       );
+    assert.dom('[data-test-updated-timestamp]').hasTextContaining('Updated Jan 25 2024');
 
     // fires second request to /activity
     await click('[data-test-refresh]');
@@ -65,7 +60,6 @@ module('Integration | Component | dashboard/client-count-card', function (hooks)
     // stubbing this unrealistic response just to test component subtext logic
     this.server.get('sys/internal/counters/activity', () => {
       return {
-        request_id: 'some-activity-id',
         data: { by_namespace: [], months: [], total: {} },
       };
     });
@@ -75,19 +69,48 @@ module('Integration | Component | dashboard/client-count-card', function (hooks)
     assert.dom(CLIENT_COUNT.statText('New')).hasText('New No new client data available. -');
   });
 
-  test('it shows empty state if no activity data', async function (assert) {
+  test('it shows empty state if no activity data and reporting is enabled', async function (assert) {
     // the activity response has changed and now should ALWAYS return something
     // but adding this test until we update the adapter to reflect that
-    assert.expect(3);
+    assert.expect(4);
     this.server.get('sys/internal/counters/activity', () => {
       assert.true(true, 'makes request to sys/internal/counters/activity');
       return { data: {} };
     });
-
+    this.server.get('sys/internal/counters/config', () => {
+      assert.true(true, 'makes request to sys/internal/counters/config');
+      return {
+        request_id: '25a94b99-b49a-c4ac-cb7b-5ba0eb390a25',
+        data: { reporting_enabled: true },
+      };
+    });
     await render(hbs`<Dashboard::ClientCountCard />`);
     assert.dom(GENERAL.emptyStateTitle).hasText('No data received');
     assert
       .dom(GENERAL.emptyStateMessage)
       .hasText('Tracking is turned on and Vault is gathering data. It should appear here within 30 minutes.');
+  });
+
+  test('it shows empty state if no activity data and config data is unavailable', async function (assert) {
+    assert.expect(4);
+    this.server.get('sys/internal/counters/activity', () => {
+      assert.true(true, 'makes request to sys/internal/counters/activity');
+      return { data: {} };
+    });
+    this.server.get('sys/internal/counters/config', () => {
+      assert.true(true, 'makes request to sys/internal/counters/config');
+      return new Response(
+        403,
+        { 'Content-Type': 'application/json' },
+        JSON.stringify({ errors: ['permission denied'] })
+      );
+    });
+    await render(hbs`<Dashboard::ClientCountCard />`);
+    assert.dom(GENERAL.emptyStateTitle).hasText('Activity configuration data is unavailable');
+    assert
+      .dom(GENERAL.emptyStateMessage)
+      .hasText(
+        'Reporting status is unknown and could be enabled or disabled. Check the Vault logs for more information.'
+      );
   });
 });

--- a/ui/tests/unit/adapters/application-test.js
+++ b/ui/tests/unit/adapters/application-test.js
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { module, test } from 'qunit';
+import Sinon from 'sinon';
+
+import { setupTest } from 'vault/tests/helpers';
+
+module('Unit | Adapter | application', function (hooks) {
+  setupTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(function () {
+    this.server.get('/some-url', function () {
+      return {
+        warnings: ['this is a warning'],
+      };
+    });
+    this.adapter = this.owner.lookup('adapter:application');
+  });
+
+  test('it triggers info flash message when warnings returned from API', async function (assert) {
+    const flashSuccessSpy = Sinon.spy(this.owner.lookup('service:flash-messages'), 'info');
+    await this.adapter.ajax('/v1/some-url', 'GET', { skipWarnings: true });
+    assert.true(flashSuccessSpy.notCalled, 'flash is not called when skipWarnings option passed');
+    await this.adapter.ajax('/v1/some-url', 'GET', {});
+    assert.true(flashSuccessSpy.calledOnce);
+    assert.true(flashSuccessSpy.calledWith('this is a warning'));
+  });
+});


### PR DESCRIPTION
### Description
This PR removes the info flash message from showing on the dashboard page when the client count card is shown. These changes were already incorporated into main/1.18 in [this PR](https://github.com/hashicorp/vault/pull/28036), but the backend backported the API changes that set the default date range and added the warning message so we must also backport this change.  

- [ ] Ent tests pass