### PR TITLE
Fix Vercel error caused by spaces before code snippet

### DIFF
--- a/website/content/docs/sync/github.mdx
+++ b/website/content/docs/sync/github.mdx
@@ -35,11 +35,11 @@ Use `vault write` to configure a repository sync destination with an access toke
       repository_owner="GITHUB_OWNER_NAME"                \
       repository_name="GITHUB_REPO_NAME"
   ```
-  
+
   For example:
 
   <CodeBlockConfig hideClipboard>
-  
+
   ```
   $ vault write sys/sync/destinations/gh/hcrepo-sandbox       \
       access_token="github_pat_11ABC000000000000000000000DEF" \
@@ -64,11 +64,11 @@ Use `vault write` to configure a repository sync destination with an access toke
       repository_name="GITHUB_REPO_NAME"                  \
       environment_name="GITHUB_ENVIRONMENT_NAME"
   ```
-  
+
   For example:
 
   <CodeBlockConfig hideClipboard>
-  
+
   ```
   $ vault write sys/sync/destinations/gh/hcrepo-sandbox       \
       access_token="github_pat_11ABC000000000000000000000DEF" \
@@ -177,7 +177,7 @@ depending on whether you have configured
 If using the secret-path granularity, it is strongly advised to mask individual values for each sub-key to prevent the
 unintended disclosure of secrets in any GitHub Action outputs. The following snippet illustrates how to mask each secret values:
 
-  ```yaml
+```yaml
   name: Mask synced secret values
 
   on:
@@ -192,7 +192,7 @@ unintended disclosure of secrets in any GitHub Action outputs. The following sni
             for v in $(echo '${{ secrets.VAULT_KV_1234_MY_SECRET }}' | jq -r '.[]'); do
               echo "::add-mask::$v"
             done
-  ```
+```
 
 If the GitHub destination uses the default `secret-key` granularity, the values are masked by GitHub automatically.
 


### PR DESCRIPTION
### Description

Fixes issue with build being broken due to spaces before code block, e.g.: 
https://vercel.com/hashicorp/vault/5JEnsMKDPQtFFpoMhJ9LpUGrXoCf?filter=errors

Unclear why this started happening now, as it's been like that for over a year, but hey.

Green build: https://vercel.com/hashicorp/vault/HPb2SM71PoBPtECabfMPkBH5Z8Uj


### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [x] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
