### PR TITLE
add end-to-end test for audit HMACing

### DIFF
--- a/vault/external_tests/audit/audit_test.go
+++ b/vault/external_tests/audit/audit_test.go
@@ -22,7 +22,6 @@ import (
 // request and response entries are HMACed properly. The fields in question are:
 //   - request.headers.x-correlation-id
 //   - request.data: all sub-fields
-//   - all sub-fields
 //   - respnse.auth.client_token
 //   - response.auth.accessor
 //   - response.data: all sub-fields
@@ -55,7 +54,7 @@ func TestAudit_HMACFields(t *testing.T) {
 	require.NoError(t, err)
 
 	// Request 2
-	// Ensure the device has not been created.
+	// Ensure the device has been created.
 	devices, err := client.Sys().ListAudit()
 	require.NoError(t, err)
 	require.Len(t, devices, 1)

--- a/vault/external_tests/audit/audit_test.go
+++ b/vault/external_tests/audit/audit_test.go
@@ -115,14 +115,28 @@ func TestAudit_HMACFields(t *testing.T) {
 	hashedBar, err := client.Sys().AuditHash(devicePath, "bar")
 	require.NoError(t, err)
 
+	// Request 11
 	hashedWrapAccessor, err := client.Sys().AuditHash(devicePath, wrapResp.WrapInfo.Accessor)
 	require.NoError(t, err)
 
+	// Request 12
 	hashedWrapToken, err := client.Sys().AuditHash(devicePath, wrapResp.WrapInfo.Token)
 	require.NoError(t, err)
 
+	// Request 13
 	hashedCorrelationID, err := client.Sys().AuditHash(devicePath, correlationID)
 	require.NoError(t, err)
+
+	// Request 14
+	// Disable the audit device. The request will be audited but not the response.
+	_, err = client.Logical().Delete("sys/audit/" + devicePath)
+	require.NoError(t, err)
+
+	// Request 15
+	// Ensure the device has been deleted. This will not be audited.
+	devices, err = client.Sys().ListAudit()
+	require.NoError(t, err)
+	require.Len(t, devices, 0)
 
 	entries := make([]map[string]interface{}, 0)
 	scanner := bufio.NewScanner(logFile)
@@ -137,7 +151,7 @@ func TestAudit_HMACFields(t *testing.T) {
 	}
 
 	// This count includes the initial test probe upon creation of the audit device
-	require.Equal(t, 26, len(entries))
+	require.Equal(t, 27, len(entries))
 
 	loginReqEntry := entries[8]
 	loginRespEntry := entries[9]

--- a/vault/external_tests/audit/audit_test.go
+++ b/vault/external_tests/audit/audit_test.go
@@ -50,6 +50,8 @@ func TestAudit_HMACFields(t *testing.T) {
 	require.NoError(t, err)
 
 	// Request 1
+	// Enable the audit device. A test probe request will audited along with the associated
+	// to the creation response
 	_, err = client.Logical().Write("sys/audit/"+devicePath, deviceData)
 	require.NoError(t, err)
 
@@ -60,6 +62,7 @@ func TestAudit_HMACFields(t *testing.T) {
 	require.Len(t, devices, 1)
 
 	// Request 3
+	// Enable the userpass auth method (this will be an audited action)
 	err = client.Sys().EnableAuthWithOptions("userpass", &api.EnableAuthOptions{
 		Type: "userpass",
 	})
@@ -69,6 +72,7 @@ func TestAudit_HMACFields(t *testing.T) {
 	password := "abc123"
 
 	// Request 4
+	// Create a user with a password (another audited action)
 	_, err = client.Logical().Write(fmt.Sprintf("auth/userpass/users/%s", username), map[string]interface{}{
 		"password": password,
 	})

--- a/vault/external_tests/audit/audit_test.go
+++ b/vault/external_tests/audit/audit_test.go
@@ -28,6 +28,8 @@ import (
 //   - response.wrap_info.token
 //   - response.wrap_info.accessor
 func TestAudit_HMACFields(t *testing.T) {
+	const hmacPrefix = "hmac-sha256:"
+
 	cluster := minimal.NewTestSoloCluster(t, nil)
 	client := cluster.Cores[0].Client
 
@@ -150,26 +152,26 @@ func TestAudit_HMACFields(t *testing.T) {
 
 	loginAuth := loginRespEntry["auth"].(map[string]interface{})
 
-	require.True(t, strings.HasPrefix(loginRequestDataFromReq["password"].(string), "hmac-sha256:"))
+	require.True(t, strings.HasPrefix(loginRequestDataFromReq["password"].(string), hmacPrefix))
 	require.Equal(t, loginRequestDataFromReq["password"].(string), hashedPassword)
 
-	require.True(t, strings.HasPrefix(loginRequestDataFromResp["password"].(string), "hmac-sha256:"))
+	require.True(t, strings.HasPrefix(loginRequestDataFromResp["password"].(string), hmacPrefix))
 	require.Equal(t, loginRequestDataFromResp["password"].(string), hashedPassword)
 
-	require.True(t, strings.HasPrefix(loginAuth["client_token"].(string), "hmac-sha256:"))
+	require.True(t, strings.HasPrefix(loginAuth["client_token"].(string), hmacPrefix))
 	require.Equal(t, loginAuth["client_token"].(string), hashedClientToken)
 
-	require.True(t, strings.HasPrefix(loginAuth["accessor"].(string), "hmac-sha256:"))
+	require.True(t, strings.HasPrefix(loginAuth["accessor"].(string), hmacPrefix))
 	require.Equal(t, loginAuth["accessor"].(string), hashedAccessor)
 
 	xCorrelationIDFromReq := loginHeadersFromReq["x-correlation-id"].([]interface{})
 	require.Equal(t, len(xCorrelationIDFromReq), 1)
-	require.True(t, strings.HasPrefix(xCorrelationIDFromReq[0].(string), "hmac-sha256:"))
+	require.True(t, strings.HasPrefix(xCorrelationIDFromReq[0].(string), hmacPrefix))
 	require.Equal(t, xCorrelationIDFromReq[0].(string), hashedCorrelationID)
 
 	xCorrelationIDFromResp := loginHeadersFromResp["x-correlation-id"].([]interface{})
 	require.Equal(t, len(xCorrelationIDFromResp), 1)
-	require.True(t, strings.HasPrefix(xCorrelationIDFromReq[0].(string), "hmac-sha256:"))
+	require.True(t, strings.HasPrefix(xCorrelationIDFromReq[0].(string), hmacPrefix))
 	require.Equal(t, xCorrelationIDFromResp[0].(string), hashedCorrelationID)
 
 	wrapReqEntry := entries[16]
@@ -181,18 +183,18 @@ func TestAudit_HMACFields(t *testing.T) {
 	wrapRequestFromResp := wrapRespEntry["request"].(map[string]interface{})
 	wrapRequestDataFromResp := wrapRequestFromResp["data"].(map[string]interface{})
 
-	require.True(t, strings.HasPrefix(wrapRequestDataFromReq["foo"].(string), "hmac-sha256:"))
+	require.True(t, strings.HasPrefix(wrapRequestDataFromReq["foo"].(string), hmacPrefix))
 	require.Equal(t, wrapRequestDataFromReq["foo"].(string), hashedBar)
 
-	require.True(t, strings.HasPrefix(wrapRequestDataFromResp["foo"].(string), "hmac-sha256:"))
+	require.True(t, strings.HasPrefix(wrapRequestDataFromResp["foo"].(string), hmacPrefix))
 	require.Equal(t, wrapRequestDataFromResp["foo"].(string), hashedBar)
 
 	wrapResponseData := wrapRespEntry["response"].(map[string]interface{})
 	wrapInfo := wrapResponseData["wrap_info"].(map[string]interface{})
 
-	require.True(t, strings.HasPrefix(wrapInfo["accessor"].(string), "hmac-sha256:"))
+	require.True(t, strings.HasPrefix(wrapInfo["accessor"].(string), hmacPrefix))
 	require.Equal(t, wrapInfo["accessor"].(string), hashedWrapAccessor)
 
-	require.True(t, strings.HasPrefix(wrapInfo["token"].(string), "hmac-sha256:"))
+	require.True(t, strings.HasPrefix(wrapInfo["token"].(string), hmacPrefix))
 	require.Equal(t, wrapInfo["token"].(string), hashedWrapToken)
 }

--- a/vault/external_tests/audit/audit_test.go
+++ b/vault/external_tests/audit/audit_test.go
@@ -130,6 +130,7 @@ func TestAudit_HMACFields(t *testing.T) {
 		entries = append(entries, entry)
 	}
 
+	// This count includes the initial test probe upon creation of the audit device
 	require.Equal(t, 26, len(entries))
 
 	loginReqEntry := entries[8]


### PR DESCRIPTION
### Description
This PR adds a new end to end test `TestAudit_HMACFields` which verifies that the proper fields are HMACed in audit request and response entries.

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [ ] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
