### PR TITLE
Update LTS language to not contradict

### DIFF
--- a/website/content/docs/enterprise/lts.mdx
+++ b/website/content/docs/enterprise/lts.mdx
@@ -91,7 +91,7 @@ upgrade frequently, quickly, or easily.
 Vault upgrades are challenging, especially for sensitive or critical workflows,
 extensive integrations, and large-scale deployments. Strict upgrade policies
 also require significant planning, testing, and employee hours to execute
-successfully. 
+successfully.
 
 Customers who need assurances that their current installation will receive
 critical bug fixes and security patches with minimal service disruptions should
@@ -111,8 +111,8 @@ the current version ("N") and the two previous versions ("N&minus;2").
 Vault versions typically update 3 times per calendar year (CY), which means that
 **standard maintenance** for a given Vault version lasts approximately 1 year.
 After the first year, LTS Vault versions move from standard maintenance to
-**extended maintenance** for an additional year with patches for bugs that
-may cause outages and critical vulnerabilities and exposures (CVEs).
+**extended maintenance** for three additional major version releases (approximately one additional year)
+with patches for bugs that may cause outages and critical vulnerabilities and exposures (CVEs).
 
 Maintenance updates               | Standard maintenance | Extended maintenance
 --------------------------------- | -------------------- | --------------------
@@ -152,10 +152,10 @@ The goal is to establish a predictable upgrade path with a longer timeline
 rather than extending the lifetime for every Vault version.
 
 Long-term support ensures your Vault Enterprise version continues to receive
-critical patches for an additional year. If you upgrade to a non-LTS version,
-you are moving your Vault instance to a version that lacks extended support.
-Non-LTS versions stop receiving updates once they leave the standard maintenance
-window.
+critical patches for an additional three major version releases (approximately one additional year).
+If you upgrade to a non-LTS version,you are moving your Vault instance to a version
+that lacks extended support. Non-LTS versions stop receiving updates once they leave
+the standard maintenance window.
 
 @include 'assets/lts-upgrade-path.mdx'
 
@@ -164,7 +164,7 @@ Version | Expected release | Standard maintenance ends  | Extended maintenance e
 1.19    | CY25 Q1          | CY26 Q1 (1.22 release)     | CY27 Q1 (1.25 release)
 1.18    | CY24 Q3          | CY25 Q3 (1.21 release)     | Not provided
 1.17    | CY24 Q2          | CY25 Q2 (1.20 release)     | Not provided
-1.16    | CY24 Q1          | CY25 Q1 (1.19 release)     | CY26 Q1 (1.22 release) 
+1.16    | CY24 Q1          | CY25 Q1 (1.19 release)     | CY26 Q1 (1.22 release)
 
 If a newer version of Vault Enterprise includes features you want to take
 advantage of, you have two options:


### PR DESCRIPTION
### Description

Unlike where we say that:
> **standard maintenance** for a given Vault version lasts approximately 1 year

We said that extended maintenance lasts for one year, but in a later section said that it's three major releases. As a result, it's unclear which is right. The correct answer is three major releases, which is approximately (not exactly) a year.

Closes https://github.com/hashicorp/vault/issues/28135

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [x] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
