### PR TITLE
Adding AD lifetime period of an old password  note to Vault LDAP secrets Engine Documentation.

### DIFF
--- a/website/content/docs/secrets/ldap.mdx
+++ b/website/content/docs/secrets/ldap.mdx
@@ -200,7 +200,7 @@ Some important things to remember when crafting your LDIF entries:
 ### Active directory (AD)
 
 -> Note: Active Directory might allow old passwords to be used for authentication during a certain amount of time.
-This is refered to as `lifetime period of an old password`, this setting is configurable on the Windows Servers hosting Active Directory.
+This is refered to as the `lifetime period of an old password`, this setting is configurable on the Windows Servers hosting Active Directory.
 For more information refer to the following Microsoft [guide](https://learn.microsoft.com/en-us/troubleshoot/windows-server/windows-security/new-setting-modifies-ntlm-network-authentication)
 
 For Active Directory, there are a few additional details that are important to remember:

--- a/website/content/docs/secrets/ldap.mdx
+++ b/website/content/docs/secrets/ldap.mdx
@@ -199,9 +199,17 @@ Some important things to remember when crafting your LDIF entries:
 
 ### Active directory (AD)
 
--> Note: Active Directory might allow old passwords to be used for authentication during a certain amount of time.
-This is refered to as the `lifetime period of an old password`, this setting is configurable on the Windows Servers hosting Active Directory.
-For more information refer to the following Microsoft [guide](https://learn.microsoft.com/en-us/troubleshoot/windows-server/windows-security/new-setting-modifies-ntlm-network-authentication)
+<Note> 
+
+  Windows Servers hosting Active Directory include a 
+  `lifetime period of an old password` configuration setting that lets clients
+  authenticate with old passwords for a specified amount of time.
+
+  For more information, refer to the
+ [NTLM network authentication behavior](https://learn.microsoft.com/en-us/troubleshoot/windows-server/windows-security new-setting-modifies-ntlm-network-authentication)
+  guide by Microsoft.
+
+</Note>
 
 For Active Directory, there are a few additional details that are important to remember:
 

--- a/website/content/docs/secrets/ldap.mdx
+++ b/website/content/docs/secrets/ldap.mdx
@@ -199,6 +199,10 @@ Some important things to remember when crafting your LDIF entries:
 
 ### Active directory (AD)
 
+-> Note: Active Directory might allow old passwords to be used for authentication during a certain amount of time.
+This is refered to as `lifetime period of an old password`, this setting is configurable on the Windows Servers hosting Active Directory.
+For more information refer to the following Microsoft [guide](https://learn.microsoft.com/en-us/troubleshoot/windows-server/windows-security/new-setting-modifies-ntlm-network-authentication)
+
 For Active Directory, there are a few additional details that are important to remember:
 
 To create a user programmatically in AD, you first `add` a user object and then `modify` that user to provide a


### PR DESCRIPTION
### Description
What does this PR do?
This PR adds an AD lifetime period of an old password  note to Vault LDAP secrets Engine Documentation. 


<img width="1124" alt="Screenshot 2024-09-18 at 17 27 53" src="https://github.com/user-attachments/assets/44632ebc-3c25-4698-bf56-7e08f0ba21b3">


### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [ ] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
  
  
  
