### PR TITLE
Adding AD lifetime period of an old password note to Vault LDAP secrets Engine API Documentation

### DIFF
--- a/website/content/api-docs/secret/ldap.mdx
+++ b/website/content/api-docs/secret/ldap.mdx
@@ -170,6 +170,10 @@ The `static-role` endpoint configures Vault to manage the passwords of existing 
 | `POST`   | `/ldap/static-role/:role_name` |
 | `DELETE` | `/ldap/static-role/:role_name` |
 
+-> Note: Active Directory might allow old passwords to be used for authentication during a certain amount of time.
+This is refered to as `lifetime period of an old password` this setting is configurable on the Windows Servers hosting Active Directory.
+For more information refer to the following Microsoft [guide](https://learn.microsoft.com/en-us/troubleshoot/windows-server/windows-security/new-setting-modifies-ntlm-network-authentication)
+
 ### Parameters
 
 - `role_name` `(string: <required>)` – URL parameter specifying the name of the

--- a/website/content/api-docs/secret/ldap.mdx
+++ b/website/content/api-docs/secret/ldap.mdx
@@ -171,7 +171,7 @@ The `static-role` endpoint configures Vault to manage the passwords of existing 
 | `DELETE` | `/ldap/static-role/:role_name` |
 
 -> Note: Active Directory might allow old passwords to be used for authentication during a certain amount of time.
-This is refered to as `lifetime period of an old password` this setting is configurable on the Windows Servers hosting Active Directory.
+This is refered to as the `lifetime period of an old password`, this setting is configurable on the Windows Servers hosting Active Directory.
 For more information refer to the following Microsoft [guide](https://learn.microsoft.com/en-us/troubleshoot/windows-server/windows-security/new-setting-modifies-ntlm-network-authentication)
 
 ### Parameters

--- a/website/content/api-docs/secret/ldap.mdx
+++ b/website/content/api-docs/secret/ldap.mdx
@@ -170,9 +170,17 @@ The `static-role` endpoint configures Vault to manage the passwords of existing 
 | `POST`   | `/ldap/static-role/:role_name` |
 | `DELETE` | `/ldap/static-role/:role_name` |
 
--> Note: Active Directory might allow old passwords to be used for authentication during a certain amount of time.
-This is refered to as the `lifetime period of an old password`, this setting is configurable on the Windows Servers hosting Active Directory.
-For more information refer to the following Microsoft [guide](https://learn.microsoft.com/en-us/troubleshoot/windows-server/windows-security/new-setting-modifies-ntlm-network-authentication)
+<Note> 
+
+  Windows Servers hosting Active Directory include a 
+  `lifetime period of an old password` configuration setting that lets clients
+  authenticate with old passwords for a specified amount of time.
+
+  For more information, refer to the
+ [NTLM network authentication behavior](https://learn.microsoft.com/en-us/troubleshoot/windows-server/windows-security new-setting-modifies-ntlm-network-authentication)
+  guide by Microsoft.
+
+</Note>
 
 ### Parameters
 


### PR DESCRIPTION
### Description
This PR adds an AD lifetime period of an old password note to Vault LDAP secrets Engine API Documentation.

<img width="1359" alt="Screenshot 2024-09-18 at 18 06 04" src="https://github.com/user-attachments/assets/fae5b95c-de45-476c-a25b-9e16e9cb81d3">


### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [ ] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
