### PR TITLE
Remove the BETA badge from EST in documentation (#28265)

### DIFF
--- a/website/content/docs/secrets/pki/est.mdx
+++ b/website/content/docs/secrets/pki/est.mdx
@@ -6,8 +6,6 @@ description: An overview of the Enrollment over Secure Transport protocol implem
 
 # PKI secrets engine - Enrollment over Secure Transport (EST) <EnterpriseAlert inline="true" />
 
-@include 'alerts/beta.mdx'
-
 This document covers configuration and limitations of Vault's PKI Secrets Engine
 implementation of the [EST protocol](https://datatracker.ietf.org/doc/html/rfc7030) <EnterpriseAlert inline="true" />.
 

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -1634,10 +1634,11 @@
           },
           {
             "title": "Enrollment over Secure Transport (EST)",
+            "path": "secrets/pki/est",
             "badge": {
-              "text": "BETA",
+              "text": "ENTERPRISE",
               "type": "outlined",
-              "color": "highlight"
+              "color": "neutral"
             },
             "path": "secrets/pki/est"
           }


### PR DESCRIPTION
## Cherry pick PR 28265 to release/1.17.x branch

Currently, the versioned [doc](https://developer.hashicorp.com/vault/docs/secrets/pki/est) still shows `BETA` tag since the changes were only applied to `main`.

🔍 [Deploy preview](https://vault-4gcmhz1pi-hashicorp.vercel.app/vault/docs/secrets/pki/est)

* Remove the BETA badge from EST

* Add ent badge

### Description
What does this PR do?

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [ ] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
