### PR TITLE
Improve Error Handling for Missing Credentials in AppRole and UserPass

### DIFF
--- a/builtin/credential/approle/path_login.go
+++ b/builtin/credential/approle/path_login.go
@@ -125,7 +125,7 @@ func (b *backend) pathLoginUpdate(ctx context.Context, req *logical.Request, dat
 	// RoleID must be supplied during every login
 	roleID := strings.TrimSpace(data.Get("role_id").(string))
 	if roleID == "" {
-		return logical.ErrorResponse("missing role_id"), nil
+		return nil, logical.ErrInvalidCredentials
 	}
 
 	// Look for the storage entry that maps the roleID to role

--- a/builtin/credential/userpass/path_login.go
+++ b/builtin/credential/userpass/path_login.go
@@ -67,7 +67,7 @@ func (b *backend) pathLogin(ctx context.Context, req *logical.Request, d *framew
 
 	password := d.Get("password").(string)
 	if password == "" {
-		return nil, fmt.Errorf("missing password")
+		return nil, logical.ErrInvalidCredentials
 	}
 
 	// Get the user and validate auth

--- a/changelog/28441.txt
+++ b/changelog/28441.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+auth: Updated error handling for missing login credentials in AppRole and UserPass auth methods to return a 400 error instead of a 500 error.
+```

--- a/vault/external_tests/delegated_auth/delegated_auth_test.go
+++ b/vault/external_tests/delegated_auth/delegated_auth_test.go
@@ -327,7 +327,7 @@ func TestDelegatedAuth(t *testing.T) {
 			path:          "login",
 			username:      "allowed-est",
 			password:      "",
-			errorContains: "missing password",
+			errorContains: "invalid credentials",
 		},
 		{
 			name:          "bad-path-within-delegated-auth-error",


### PR DESCRIPTION
### Description
This PR updates the error handling for AppRole and UserPass when login credentials are missing. Currently, a `500` error is returned, but a `400` error is more accurate and aligns with the behavior of other auth engines (e.g., LDAP).

Original output:
```sh
> curl --request POST -v \
       http://127.0.0.1:8200/v1/auth/userpass/login/mitchellh | jq -r ".auth"
...
< HTTP/1.1 500 Internal Server Error
...
```

New output:
```sh
> curl --request POST -v \
       http://127.0.0.1:8200/v1/auth/userpass/login/mitchellh | jq -r ".auth"
...
< HTTP/1.1 400 Bad Request
...
```

### TODO only if you're a HashiCorp employee
- [X] **Jira:** https://hashicorp.atlassian.net/browse/VAULT-31002