### PR TITLE
Update vso namespace paramater

### DIFF
--- a/website/content/docs/platform/k8s/vso/api-reference.mdx
+++ b/website/content/docs/platform/k8s/vso/api-reference.mdx
@@ -949,8 +949,8 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `vaultAuthRef` _string_ | VaultAuthRef to the VaultAuth resource, can be prefixed with a namespace,<br />eg: `namespaceA/vaultAuthRefB`. If no namespace prefix is provided it will default to<br />namespace of the VaultAuth CR. If no value is specified for VaultAuthRef the Operator will<br />default to the `default` VaultAuth, configured in the operator's namespace. |  |  |
-| `namespace` _string_ | Namespace where the secrets engine is mounted in Vault. |  |  |
+| `vaultAuthRef` _string_ | VaultAuthRef to the VaultAuth resource, can be prefixed with a namespace,<br />eg: `namespaceA/vaultAuthRefB`. If no value is specified for VaultAuthRef the Operator will<br />default to the `default` VaultAuth, configured in the operator's namespace. |  |  |
+| `namespace` _string_ | Namespace where the secrets engine is mounted in Vault. In case this parameter is not provided, the namespace will be inferred from the `namespace` parameter of the utilized VaultAuth resource.|  |  |
 | `mount` _string_ | Mount path of the secret's engine in Vault. |  |  |
 | `requestHTTPMethod` _string_ | RequestHTTPMethod to use when syncing Secrets from Vault.<br />Setting a value here is not typically required.<br />If left unset the Operator will make requests using the GET method.<br />In the case where Params are specified the Operator will use the PUT method.<br />Please consult [secrets](/vault/docs/secrets) if you are<br />uncertain about what method to use.<br />Of note, the Vault client treats PUT and POST as being equivalent.<br />The underlying Vault client implementation will always use the PUT method. |  | Enum: [GET POST PUT] <br /> |
 | `path` _string_ | Path in Vault to get the credentials for, and is relative to Mount.<br />Please consult [secrets](/vault/docs/secrets) if you are<br />uncertain about what 'path' should be set to. |  |  |
@@ -1015,8 +1015,8 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `vaultAuthRef` _string_ | VaultAuthRef to the VaultAuth resource, can be prefixed with a namespace,<br />eg: `namespaceA/vaultAuthRefB`. If no namespace prefix is provided it will default to<br />namespace of the VaultAuth CR. If no value is specified for VaultAuthRef the Operator will<br />default to the `default` VaultAuth, configured in the operator's namespace. |  |  |
-| `namespace` _string_ | Namespace to get the secret from in Vault |  |  |
+| `vaultAuthRef` _string_ | VaultAuthRef to the VaultAuth resource, can be prefixed with a namespace,<br />eg: ``. If no value is specified for VaultAuthRef the Operator will<br />default to the `default` VaultAuth, configured in the operator's namespace. |  |  |
+| `namespace` _string_ | Namespace to get the secret from in Vault.In case this parameter is not provided, the namespace will be inferred from the `namespace` parameter of the utilized VaultAuth resource |  |  |
 | `mount` _string_ | Mount for the secret in Vault |  |  |
 | `role` _string_ | Role in Vault to use when issuing TLS certificates. |  |  |
 | `revoke` _boolean_ | Revoke the certificate when the resource is deleted. |  |  |
@@ -1128,8 +1128,8 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `vaultAuthRef` _string_ | VaultAuthRef to the VaultAuth resource, can be prefixed with a namespace,<br />eg: `namespaceA/vaultAuthRefB`. If no namespace prefix is provided it will default to<br />namespace of the VaultAuth CR. If no value is specified for VaultAuthRef the Operator will<br />default to the `default` VaultAuth, configured in the operator's namespace. |  |  |
-| `namespace` _string_ | Namespace to get the secret from in Vault |  |  |
+| `vaultAuthRef` _string_ | VaultAuthRef to the VaultAuth resource, can be prefixed with a namespace,<br />eg: ``. If no value is specified for VaultAuthRef the Operator will<br />default to the `default` VaultAuth, configured in the operator's namespace. |  |  |
+| `namespace` _string_ | Namespace to get the secret from in Vault. In case this parameter is not provided, the namespace will be inferred from the `namespace` parameter of the utilized VaultAuth resource |  |  |
 | `mount` _string_ | Mount for the secret in Vault |  |  |
 | `path` _string_ | Path of the secret in Vault, corresponds to the `path` parameter for,<br />[kv-v1](/vault/api-docs/secret/kv/kv-v1#read-secret) [kv-v2](/vault/api-docs/secret/kv/kv-v2#read-secret-version) |  |  |
 | `version` _integer_ | Version of the secret to fetch. Only valid for type kv-v2. Corresponds to version query parameter:<br />[version](/vault/api-docs/secret/kv/kv-v2#version) |  | Minimum: 0 <br /> |

--- a/website/content/docs/platform/k8s/vso/api-reference.mdx
+++ b/website/content/docs/platform/k8s/vso/api-reference.mdx
@@ -949,7 +949,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `vaultAuthRef` _string_ | VaultAuthRef to the VaultAuth resource, can be prefixed with a namespace,<br />eg: `namespaceA/vaultAuthRefB`. If no value is specified for VaultAuthRef the Operator will<br />default to the `default` VaultAuth, configured in the operator's namespace. |  |  |
+| `vaultAuthRef` _string_ | VaultAuthRef to the VaultAuth resource, can be prefixed with a namespace, eg: `namespaceA/vaultAuthRefB`.<br /> If no value is specified for VaultAuthRef the Operator will default to the `default` VaultAuth, configured in the operator's namespace. |  |  |
 | `namespace` _string_ | Namespace where the secrets engine is mounted in Vault. In case this parameter is not provided, the namespace will be inferred from the `namespace` parameter of the utilized VaultAuth resource.|  |  |
 | `mount` _string_ | Mount path of the secret's engine in Vault. |  |  |
 | `requestHTTPMethod` _string_ | RequestHTTPMethod to use when syncing Secrets from Vault.<br />Setting a value here is not typically required.<br />If left unset the Operator will make requests using the GET method.<br />In the case where Params are specified the Operator will use the PUT method.<br />Please consult [secrets](/vault/docs/secrets) if you are<br />uncertain about what method to use.<br />Of note, the Vault client treats PUT and POST as being equivalent.<br />The underlying Vault client implementation will always use the PUT method. |  | Enum: [GET POST PUT] <br /> |
@@ -1015,7 +1015,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `vaultAuthRef` _string_ | VaultAuthRef to the VaultAuth resource, can be prefixed with a namespace,<br />eg: ``. If no value is specified for VaultAuthRef the Operator will<br />default to the `default` VaultAuth, configured in the operator's namespace. |  |  |
+| `vaultAuthRef` _string_ | VaultAuthRef to the VaultAuth resource, can be prefixed with a namespace, eg: `namespaceA/vaultAuthRefB`.<br /> If no value is specified for VaultAuthRef the Operator will default to the `default` VaultAuth, configured in the operator's namespace. |  |  |
 | `namespace` _string_ | Namespace to get the secret from in Vault.In case this parameter is not provided, the namespace will be inferred from the `namespace` parameter of the utilized VaultAuth resource |  |  |
 | `mount` _string_ | Mount for the secret in Vault |  |  |
 | `role` _string_ | Role in Vault to use when issuing TLS certificates. |  |  |
@@ -1128,7 +1128,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `vaultAuthRef` _string_ | VaultAuthRef to the VaultAuth resource, can be prefixed with a namespace,<br />eg: ``. If no value is specified for VaultAuthRef the Operator will<br />default to the `default` VaultAuth, configured in the operator's namespace. |  |  |
+| `vaultAuthRef` _string_ | VaultAuthRef to the VaultAuth resource, can be prefixed with a namespace, eg: `namespaceA/vaultAuthRefB`.<br /> If no value is specified for VaultAuthRef the Operator will default to the `default` VaultAuth, configured in the operator's namespace. |  |  |
 | `namespace` _string_ | Namespace to get the secret from in Vault. In case this parameter is not provided, the namespace will be inferred from the `namespace` parameter of the utilized VaultAuth resource |  |  |
 | `mount` _string_ | Mount for the secret in Vault |  |  |
 | `path` _string_ | Path of the secret in Vault, corresponds to the `path` parameter for,<br />[kv-v1](/vault/api-docs/secret/kv/kv-v1#read-secret) [kv-v2](/vault/api-docs/secret/kv/kv-v2#read-secret-version) |  |  |


### PR DESCRIPTION
### Description
What does this PR do?

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [ ] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
