### PR TITLE
UI: pin chrome to same version as is on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,7 +164,7 @@ jobs:
           node-version-file: './ui/package.json'
           cache: yarn
           cache-dependency-path: ui/yarn.lock
-      - uses: browser-actions/setup-chrome@db1b524c26f20a8d1a10f7fc385c92387e2d0477 # v1.7.1
+      - uses: browser-actions/setup-chrome@facf10a55b9caf92e0cc749b4f82bf8220989148 # v1.7.2
         with:
           # Temporarily pin our Chrome version while we sort out a broken test on latest
           chrome-version: 1314712


### PR DESCRIPTION
### Description
Pins chrome in CI to the same version that is on `main`. An attempt to fix the flakiness we're seeing recently on the release branch runs. 