### PR TITLE
Add a core test logger to help capture the MSSQL container output

### DIFF
--- a/helper/testhelpers/mssql/mssqlhelper.go
+++ b/helper/testhelpers/mssql/mssqlhelper.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/vault/helper/testhelpers/corehelpers"
 	"github.com/hashicorp/vault/sdk/helper/docker"
 )
 
@@ -32,6 +33,8 @@ func PrepareMSSQLTestContainer(t *testing.T) (cleanup func(), retURL string) {
 		return func() {}, os.Getenv("MSSQL_URL")
 	}
 
+	logger := corehelpers.NewTestLogger(t)
+
 	var err error
 	for i := 0; i < numRetries; i++ {
 		var svc *docker.Service
@@ -43,13 +46,11 @@ func PrepareMSSQLTestContainer(t *testing.T) (cleanup func(), retURL string) {
 			Env:           []string{"ACCEPT_EULA=Y", "SA_PASSWORD=" + mssqlPassword},
 			Ports:         []string{"1433/tcp"},
 			LogConsumer: func(s string) {
-				if t.Failed() {
-					t.Logf("container logs: %s", s)
-				}
+				logger.Info(s)
 			},
 		})
 		if err != nil {
-			t.Logf("Could not start docker MSSQL: %v", err)
+			logger.Error("failed creating new service runner", "error", err.Error())
 			continue
 		}
 
@@ -57,9 +58,11 @@ func PrepareMSSQLTestContainer(t *testing.T) (cleanup func(), retURL string) {
 		if err == nil {
 			return svc.Cleanup, svc.Config.URL().String()
 		}
+
+		logger.Error("failed starting service", "error", err.Error())
 	}
 
-	t.Fatalf("Could not start docker MSSQL: %v", err)
+	t.Fatalf("Could not start docker MSSQL last error: %v", err)
 	return nil, ""
 }
 

--- a/helper/testhelpers/mssql/mssqlhelper.go
+++ b/helper/testhelpers/mssql/mssqlhelper.go
@@ -42,7 +42,7 @@ func PrepareMSSQLTestContainer(t *testing.T) (cleanup func(), retURL string) {
 		runner, err = docker.NewServiceRunner(docker.RunOptions{
 			ContainerName: "sqlserver",
 			ImageRepo:     "mcr.microsoft.com/mssql/server",
-			ImageTag:      "2017-latest-ubuntu",
+			ImageTag:      "2022-latest",
 			Env:           []string{"ACCEPT_EULA=Y", "SA_PASSWORD=" + mssqlPassword},
 			Ports:         []string{"1433/tcp"},
 			LogConsumer: func(s string) {


### PR DESCRIPTION
### Description

 - I believe the `if t.Failed` prevents the logging of the container logging as when executed the test isn't considered failed yet.
 - Use a test core logger so that we can capture the container output all the time and get it from the captured log files when the test fails

### TODO only if you're a HashiCorp employee
- [X] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [ ] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
