### PR TITLE
add aws and k8s auth examples to export

### DIFF
--- a/website/content/api-docs/system/internal-counters.mdx
+++ b/website/content/api-docs/system/internal-counters.mdx
@@ -1125,10 +1125,10 @@ $ curl \
 
 The entity alias names for userpass in the sample response records below are user-provided. They are
 system-provided for AWS and Kubernetes based on how the auth backend has been configured. In the case of
-AWS, an IAM role ID is used but this can be configured via the [iam_alias](vault/api-docs/auth/aws#iam_alias)
-or [ec2_alias](vault/api-docs/auth/aws#ec2_alias) configuration parameters. In the case of Kubernetes, the entity
+AWS, an IAM role ID is used but this can be configured via the [iam_alias](/vault/api-docs/auth/aws#iam_alias)
+or [ec2_alias](/vault/api-docs/auth/aws#ec2_alias) configuration parameters. In the case of Kubernetes, the entity
 alias name has been populated with the service account ID though this can be configured via the
-[alias_name_source](vault/api-docs/auth/kubernetes#alias_name_source) configuration parameter.
+[alias_name_source](/vault/api-docs/auth/kubernetes#alias_name_source) configuration parameter.
 
 ~> **NOTE**: The activity records below are pretty-printed to improve readability. The API returns
    JSON lines and will thus be compacted so that each record consumes a single line.

--- a/website/content/api-docs/system/internal-counters.mdx
+++ b/website/content/api-docs/system/internal-counters.mdx
@@ -1123,6 +1123,13 @@ $ curl \
 
 ### Sample JSON response
 
+The entity alias names for userpass in the sample response records below are user-provided. They are
+system-provided for AWS and Kubernetes based on how the auth backend has been configured. In the case of
+AWS, an IAM role ID is used but this can be configured via the [iam_alias](vault/api-docs/auth/aws#iam_alias)
+or [ec2_alias](vault/api-docs/auth/aws#ec2_alias) configuration parameters. In the case of Kubernetes, the entity
+alias name has been populated with the service account ID though this can be configured via the
+[alias_name_source](vault/api-docs/auth/kubernetes#alias_name_source) configuration parameter.
+
 ~> **NOTE**: The activity records below are pretty-printed to improve readability. The API returns
    JSON lines and will thus be compacted so that each record consumes a single line.
 
@@ -1232,7 +1239,7 @@ $ curl \
 }
 
 {
-  "entity_name": "",
+  "entity_name": "e91fa61e-d53e-4b0a-8fe2-ce813a064caa",
   "entity_alias_name": "bee2d6ea-b873-47bc-9bc3-6f5e16e5c1b3",
   "local_entity_alias": false,
   "client_id": "cc7c504f-8d10-4add-9951-f6a194f188ec",
@@ -1258,8 +1265,8 @@ $ curl \
 }
 
 {
-  "entity_name": "admin",
-  "entity_alias_name": "bee2d6ea-b873-47bc-9bc3-6f5e16e5c1b3",
+  "entity_name": "55ee5905-0314-485d-85ad-c29dc987a054",
+  "entity_alias_name": "admin",
   "local_entity_alias": false,
   "client_id": "cc7c504f-8d10-4add-9951-f6a194f188ec",
   "client_type": "entity",

--- a/website/content/api-docs/system/internal-counters.mdx
+++ b/website/content/api-docs/system/internal-counters.mdx
@@ -1230,6 +1230,53 @@ $ curl \
     "76a374a1-72fd-30ca-2455-f51dfeaa805e"
   ]
 }
+
+{
+  "entity_name": "",
+  "entity_alias_name": "bee2d6ea-b873-47bc-9bc3-6f5e16e5c1b3",
+  "local_entity_alias": false,
+  "client_id": "cc7c504f-8d10-4add-9951-f6a194f188ec",
+  "client_type": "entity",
+  "namespace_id": "root",
+  "namespace_path": "",
+  "mount_accessor": "auth_kubernetes_b596406f",
+  "mount_type": "kubernetes",
+  "mount_path": "auth/kubernetes/",
+  "timestamp": "2024-07-10T09:33:51Z",
+  "policies": [
+    "secret-read"
+  ],
+  "entity_metadata": {},
+  "entity_alias_metadata": {
+	  "service_account_uid": "bee2d6ea-b873-47bc-9bc3-6f5e16e5c1b3",
+	  "service_account_name": "vault-auth",
+	  "service_account_namespace": "default",
+	  "service_account_secret_name": "vault-auth-token"
+  },
+  "entity_alias_custom_metadata": {},
+  "entity_group_ids": []
+}
+
+{
+  "entity_name": "admin",
+  "entity_alias_name": "bee2d6ea-b873-47bc-9bc3-6f5e16e5c1b3",
+  "local_entity_alias": false,
+  "client_id": "cc7c504f-8d10-4add-9951-f6a194f188ec",
+  "client_type": "entity",
+  "namespace_id": "root",
+  "namespace_path": "",
+  "mount_accessor": "auth_aws_c223ff01",
+  "mount_type": "aws",
+  "mount_path": "auth/aws/",
+  "timestamp": "2024-07-10T09:33:51Z",
+  "policies": [
+    "secret-read"
+  ],
+  "entity_metadata": {},
+  "entity_alias_metadata": {},
+  "entity_alias_custom_metadata": {},
+  "entity_group_ids": []
+}
 ```
 
 ### Sample CSV response


### PR DESCRIPTION
### Description
Add a couple more examples to the activity export API response to outline what AWS and k8s entity records might look like.

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [ ] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
