### PR TITLE
Backport 1.17.x: add allow_empty_principals to ssh engine (fixes failing test)

### DIFF
--- a/ui/app/models/role-ssh.js
+++ b/ui/app/models/role-ssh.js
@@ -40,6 +40,7 @@ const CA_FIELDS = [
   'defaultExtensions',
   'allowBareDomains',
   'allowSubdomains',
+  'allowEmptyPrincipals',
   'allowUserKeyIds',
   'keyIdFormat',
   'notBeforeDuration',
@@ -121,6 +122,10 @@ export default Model.extend({
   allowSubdomains: attr('boolean', {
     helpText:
       'Specifies if host certificates that are requested are allowed to be subdomains of those listed in Allowed Domains',
+  }),
+  allowEmptyPrincipals: attr('boolean', {
+    helpText:
+      'Allow signing certificates with no valid principals (e.g. any valid principal). For backwards compatibility only. The default of false is highly recommended.',
   }),
   allowUserKeyIds: attr('boolean', {
     helpText: 'Specifies if users can override the key ID for a signed certificate with the "key_id" field',

--- a/ui/app/models/ssh-sign.js
+++ b/ui/app/models/ssh-sign.js
@@ -13,7 +13,6 @@ const CREATE_FIELDS = [
   'certType',
   'criticalOptions',
   'extensions',
-  'allowEmptyPrincipals',
   'ttl',
 ];
 
@@ -30,10 +29,6 @@ export default Model.extend({
   ttl: attr({
     label: 'TTL',
     editType: 'ttl',
-  }),
-  allowEmptyPrincipals: attr('boolean', {
-    helpText:
-      'Allow signing certificates with no valid principals (e.g. any valid principal). For backwards compatibility only. The default of false is highly recommended.',
   }),
   validPrincipals: attr('string', {
     helpText:

--- a/ui/app/models/ssh-sign.js
+++ b/ui/app/models/ssh-sign.js
@@ -13,6 +13,7 @@ const CREATE_FIELDS = [
   'certType',
   'criticalOptions',
   'extensions',
+  'allowEmptyPrincipals',
   'ttl',
 ];
 
@@ -30,7 +31,14 @@ export default Model.extend({
     label: 'TTL',
     editType: 'ttl',
   }),
-  validPrincipals: attr('string'),
+  allowEmptyPrincipals: attr('boolean', {
+    helpText:
+      'Allow signing certificates with no valid principals (e.g. any valid principal). For backwards compatibility only. The default of false is highly recommended.',
+  }),
+  validPrincipals: attr('string', {
+    helpText:
+      'Specifies valid principals, either usernames or hostnames, that the certificate should be signed for. Required unless the role has specified allow_empty_principals.',
+  }),
   certType: attr('string', {
     defaultValue: 'user',
     label: 'Certificate Type',

--- a/ui/app/templates/vault/cluster/secrets/backend/sign.hbs
+++ b/ui/app/templates/vault/cluster/secrets/backend/sign.hbs
@@ -81,48 +81,47 @@
       <MessageError @model={{this.model}} />
       <NamespaceReminder @mode="sign" @noun="SSH key" />
       {{#if this.model.attrs}}
-        {{#each (take 1 this.model.attrs) as |attr|}}
-          <FormFieldFromModel
-            @attr={{attr}}
-            @model={{this.model}}
-            @updateTtl={{action "updateTtl" attr.name}}
-            @emptyData={{this.emptyData}}
-            @codemirrorUpdated={{action "codemirrorUpdated" attr.name}}
-          />
-        {{/each}}
+        {{#let (find-by "name" "publicKey" this.model.attrs) as |attr|}}
+          <FormFieldFromModel @attr={{attr}} @model={{this.model}} />
+        {{/let}}
+        {{! valid_principals is required unless allow_empty_principals is true (not recommended) }}
+        {{#let (find-by "name" "validPrincipals" this.model.attrs) as |attr|}}
+          <FormFieldFromModel @attr={{attr}} @model={{this.model}} />
+        {{/let}}
         <ToggleButton @isOpen={{this.showOptions}} @onClick={{fn (mut this.showOptions)}} data-test-toggle-button />
         {{#if this.showOptions}}
           <div class="box is-marginless">
-            {{#each (drop 1 this.model.attrs) as |attr|}}
-              <FormFieldFromModel
-                @attr={{attr}}
-                @model={{this.model}}
-                @updateTtl={{action "updateTtl" attr.name}}
-                @emptyData={{this.emptyData}}
-                @codemirrorUpdated={{action "codemirrorUpdated" attr.name}}
-              />
+            {{#each this.model.attrs as |attr|}}
+              {{! These attrs render above, outside of the "More options" toggle }}
+              {{#if (not (includes attr.name (array "publicKey" "validPrincipals")))}}
+                <FormFieldFromModel
+                  @attr={{attr}}
+                  @model={{this.model}}
+                  @updateTtl={{action "updateTtl" attr.name}}
+                  @emptyData={{this.emptyData}}
+                  @codemirrorUpdated={{action "codemirrorUpdated" attr.name}}
+                />
+              {{/if}}
             {{/each}}
           </div>
         {{/if}}
       {{/if}}
     </div>
-    <div class="field is-grouped box is-fullwidth is-bottomless">
-      <Hds::ButtonSet>
-        <Hds::Button
-          @text="Sign"
-          @icon={{if this.loading "loading"}}
-          type="submit"
-          disabled={{this.loading}}
-          data-test-secret-generate
-        />
-        <Hds::Button
-          @text="Cancel"
-          @color="secondary"
-          @route="vault.cluster.secrets.backend.list-root"
-          @model={{this.backend.id}}
-          data-test-secret-generate-cancel
-        />
-      </Hds::ButtonSet>
-    </div>
+    <Hds::ButtonSet class="has-top-bottom-margin">
+      <Hds::Button
+        @text="Sign"
+        @icon={{if this.loading "loading"}}
+        type="submit"
+        disabled={{this.loading}}
+        data-test-secret-generate
+      />
+      <Hds::Button
+        @text="Cancel"
+        @color="secondary"
+        @route="vault.cluster.secrets.backend.list-root"
+        @model={{this.backend.id}}
+        data-test-secret-generate-cancel
+      />
+    </Hds::ButtonSet>
   </form>
 {{/if}}

--- a/ui/tests/acceptance/ssh-test.js
+++ b/ui/tests/acceptance/ssh-test.js
@@ -8,6 +8,7 @@ import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { v4 as uuidv4 } from 'uuid';
 
+import { GENERAL } from 'vault/tests/helpers/general-selectors';
 import authPage from 'vault/tests/pages/auth';
 import enablePage from 'vault/tests/pages/settings/mount-secret-backend';
 import { setRunOptions } from 'ember-a11y-testing/test-support';
@@ -28,6 +29,9 @@ module('Acceptance | ssh secret backend', function (hooks) {
       name: 'carole',
       async fillInCreate() {
         await click('[data-test-input="allowUserCertificates"]');
+        await click('[data-test-toggle-group="Options"]');
+        // it's recommended to keep allow_empty_principals false, check for testing so we don't have to input an extra field when signing a key
+        await click(GENERAL.inputByAttr('allowEmptyPrincipals'));
       },
       async fillInGenerate() {
         await fillIn('[data-test-input="publicKey"]', PUB_KEY);

--- a/ui/tests/helpers/openapi/expected-secret-attrs.js
+++ b/ui/tests/helpers/openapi/expected-secret-attrs.js
@@ -34,6 +34,13 @@ const ssh = {
       fieldGroup: 'default',
       type: 'boolean',
     },
+    allowEmptyPrincipals: {
+      editType: 'boolean',
+      fieldGroup: 'default',
+      helpText:
+        'Whether to allow issuing certificates with no valid principals (meaning any valid principal). Exists for backwards compatibility only, the default of false is highly recommended.',
+      type: 'boolean',
+    },
     allowHostCertificates: {
       editType: 'boolean',
       helpText:


### PR DESCRIPTION
### Description
Manual backport of #28484 

<hr>
#28466 Added allow_empty_principals to the ssh engine. Though it's recommended to keep this value false we've added for parity with the backend. Also, an acceptance test was failing because a valid_principals was not provided and is now required.

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [ ] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
