### PR TITLE
Fix static secret caching race condition

### DIFF
--- a/changelog/28494.txt
+++ b/changelog/28494.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+proxy/cache (enterprise): Fixed a data race that could occur while tracking capabilities in Proxy's static secret cache.
+```

--- a/command/agentproxyshared/cache/lease_cache.go
+++ b/command/agentproxyshared/cache/lease_cache.go
@@ -789,8 +789,6 @@ func (c *LeaseCache) storeStaticSecretIndex(ctx context.Context, req *SendReques
 		return err
 	}
 
-	// TODO Violet: Lock here, unlock before set
-
 	path := getStaticSecretPathFromRequest(req)
 
 	capabilitiesIndex.IndexLock.Lock()

--- a/command/agentproxyshared/cache/lease_cache.go
+++ b/command/agentproxyshared/cache/lease_cache.go
@@ -789,8 +789,11 @@ func (c *LeaseCache) storeStaticSecretIndex(ctx context.Context, req *SendReques
 		return err
 	}
 
+	// TODO Violet: Lock here, unlock before set
+
 	path := getStaticSecretPathFromRequest(req)
 
+	capabilitiesIndex.IndexLock.Lock()
 	// Extra caution -- avoid potential nil
 	if capabilitiesIndex.ReadablePaths == nil {
 		capabilitiesIndex.ReadablePaths = make(map[string]struct{})
@@ -798,6 +801,7 @@ func (c *LeaseCache) storeStaticSecretIndex(ctx context.Context, req *SendReques
 
 	// update the index with the new capability:
 	capabilitiesIndex.ReadablePaths[path] = struct{}{}
+	capabilitiesIndex.IndexLock.Unlock()
 
 	err = c.SetCapabilitiesIndex(ctx, capabilitiesIndex)
 	if err != nil {


### PR DESCRIPTION
### Description

See: https://github.com/hashicorp/vault-enterprise/pull/6725

Fixes this data race that I spotted as part of an unrelated test run.

Will be backported.

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [x] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
