### PR TITLE
UI: Remove parallel command for running tests on github

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -29,7 +29,7 @@
     "start:chroot": "ember server --proxy=http://127.0.0.1:8300 --port=4300",
     "test": "concurrently --kill-others-on-fail -P -c \"auto\" -n lint:js,lint:hbs,vault \"yarn:lint:js:quiet\" \"yarn:lint:hbs:quiet\" \"node scripts/start-vault.js {@}\" --",
     "test:enos": "concurrently --kill-others-on-fail -P -c \"auto\" -n lint:js,lint:hbs,enos \"yarn:lint:js:quiet\" \"yarn:lint:hbs:quiet\" \"node scripts/enos-test-ember.js {@}\" --",
-    "test:oss": "yarn run test -f='!enterprise' --split=8 --preserve-test-name --parallel",
+    "test:oss": "yarn run test -f='!enterprise'",
     "test:quick": "node scripts/start-vault.js --split=8 --preserve-test-name --parallel",
     "test:quick-oss": "node scripts/start-vault.js -f='!enterprise' --split=8 --preserve-test-name --parallel",
     "test:filter": "node scripts/start-vault.js --server -f='!enterprise'",


### PR DESCRIPTION
### Description
In 1.18 we removed running the tests in parallel to address test flakiness https://github.com/hashicorp/vault/pull/28262. We seem to be seeing similar flakiness in 1.17, hoping removing this command (even though it will make running test 1.5 times longer) reduces flakes.  

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [ ] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
