### PR TITLE
Split the Key_Usage Field into separate fields

### DIFF
--- a/builtin/logical/pki/fields.go
+++ b/builtin/logical/pki/fields.go
@@ -275,20 +275,6 @@ this value.`,
 		},
 	}
 
-	fields["key_usage"] = &framework.FieldSchema{ // Same Name as Leaf-Cert Field, but Description and Default Differ
-		Type:    framework.TypeCommaStringSlice,
-		Default: []string{"CertSign", "CRLSign"},
-		Description: `A comma-separated string or list of key usages (not extended
-key usages). Valid values can be found at
-https://golang.org/pkg/crypto/x509/#KeyUsage
--- simply drop the "KeyUsage" part of the name.
-To remove all key usages from being set, set
-this value to an empty list.  This defaults to 
-CertSign, CRLSign for CAs.  If neither of those
-two set, a warning will be thrown.  To use the
-issuer for CMPv2, DigitalSignature must be set.`,
-	} // TODO: Fix Description Here
-
 	fields["serial_number"] = &framework.FieldSchema{
 		Type: framework.TypeString,
 		Description: `The Subject's requested serial number, if any.
@@ -671,6 +657,36 @@ SHA-2-512. Defaults to 0 to automatically detect based on key length
 		Default: issuing.DefaultRoleUsePss,
 		Description: `Whether or not to use PSS signatures when using a
 RSA key-type issuer. Defaults to false.`,
+	}
+
+	return fields
+}
+
+func addCACertKeyUsage(fields map[string]*framework.FieldSchema) map[string]*framework.FieldSchema {
+	fields["key_usage"] = &framework.FieldSchema{ // Same Name as Leaf-Cert Field, and CA CSR Field, but Description and Default Differ
+		Type:    framework.TypeCommaStringSlice,
+		Default: []string{"CertSign", "CRLSign"},
+		Description: `This list of key usages (not extended key usages) will be 
+added to the existing set of key usages, CRL,CertSign, on 
+the generated certificate.  Valid values can be found at 
+https://golang.org/pkg/crypto/x509/#KeyUsage -- simply drop 
+the "KeyUsage" part of the name.  To use the issuer for 
+CMPv2, DigitalSignature must be set.`,
+	}
+
+	return fields
+}
+
+func addCaCsrKeyUsage(fields map[string]*framework.FieldSchema) map[string]*framework.FieldSchema {
+	fields["key_usage"] = &framework.FieldSchema{ // Same Name as Leaf-Cert, CA-Cert Field, but Description and Default Differ
+		Type:    framework.TypeCommaStringSlice,
+		Default: []string{},
+		Description: `Specifies key_usage to encode in the certificate signing
+request.  This is a comma-separated string or list of key
+usages (not extended key usages). Valid values can be found
+at https://golang.org/pkg/crypto/x509/#KeyUsage -- simply 
+drop the "KeyUsage" part of the name.  If not set, key 
+usage will not appear on the CSR.`,
 	}
 
 	return fields

--- a/builtin/logical/pki/path_manage_issuers.go
+++ b/builtin/logical/pki/path_manage_issuers.go
@@ -117,6 +117,7 @@ func buildPathGenerateRoot(b *backend, pattern string, displayAttrs *framework.D
 	ret.Fields = addCACommonFields(map[string]*framework.FieldSchema{})
 	ret.Fields = addCAKeyGenerationFields(ret.Fields)
 	ret.Fields = addCAIssueFields(ret.Fields)
+	ret.Fields = addCACertKeyUsage(ret.Fields)
 	return ret
 }
 
@@ -197,6 +198,7 @@ extension with CA: true. Only needed as a
 workaround in some compatibility scenarios
 with Active Directory Certificate Services.`,
 	}
+	ret.Fields = addCaCsrKeyUsage(ret.Fields)
 
 	// At this time Go does not support signing CSRs using PSS signatures, see
 	// https://github.com/golang/go/issues/45990

--- a/builtin/logical/pki/path_sign_issuers.go
+++ b/builtin/logical/pki/path_sign_issuers.go
@@ -149,6 +149,8 @@ in the above RFC section.`,
 RSA key-type issuer. Defaults to false.`,
 	}
 
+	fields = addCACertKeyUsage(fields)
+
 	return path
 }
 

--- a/builtin/logical/pki/storage_test.go
+++ b/builtin/logical/pki/storage_test.go
@@ -242,6 +242,7 @@ func genCertBundle(t *testing.T, b *backend, s logical.Storage) *certutil.CertBu
 	fields := addCACommonFields(map[string]*framework.FieldSchema{})
 	fields = addCAKeyGenerationFields(fields)
 	fields = addCAIssueFields(fields)
+	fields = addCACertKeyUsage(fields)
 	apiData := &framework.FieldData{
 		Schema: fields,
 		Raw: map[string]interface{}{


### PR DESCRIPTION
This should be two fields: one field for the Cert Endpoints (Sign-intermediate/Generate Root) the other for the CSR Endpoint (intermediate generate).  These have different defaults, and descriptions.

### Description
This fixes the help text and open-api text of the key_usage parameter on 

### TODO only if you're a HashiCorp employee
- [*] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
- [*] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.


