### PR TITLE
UI: address body-parser security vulnerability 

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -104,7 +104,7 @@
     "deepmerge": "^4.0.0",
     "doctoc": "^2.2.0",
     "dompurify": "^3.0.2",
-    "ember-a11y-testing": "^6.1.1",
+    "ember-a11y-testing": "^7.0.1",
     "ember-basic-dropdown": "^8.0.4",
     "ember-cli": "~5.4.2",
     "ember-cli-babel": "^8.2.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -190,7 +190,6 @@
   "resolutions": {
     "ansi-html": "^0.0.8",
     "async": "^2.6.4",
-    "body-parser": "1.20.3",
     "braces": "^3.0.3",
     "eslint-utils": "^1.4.1",
     "highlight.js": "^10.4.1",

--- a/ui/package.json
+++ b/ui/package.json
@@ -190,6 +190,7 @@
   "resolutions": {
     "ansi-html": "^0.0.8",
     "async": "^2.6.4",
+    "body-parser": "^1.20.3",
     "braces": "^3.0.3",
     "eslint-utils": "^1.4.1",
     "highlight.js": "^10.4.1",

--- a/ui/package.json
+++ b/ui/package.json
@@ -190,6 +190,7 @@
   "resolutions": {
     "ansi-html": "^0.0.8",
     "async": "^2.6.4",
+    "body-parser": "1.20.3",
     "braces": "^3.0.3",
     "eslint-utils": "^1.4.1",
     "highlight.js": "^10.4.1",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -4778,27 +4778,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"body-parser@npm:1.20.2":
-  version: 1.20.2
-  resolution: "body-parser@npm:1.20.2"
-  dependencies:
-    bytes: 3.1.2
-    content-type: ~1.0.5
-    debug: 2.6.9
-    depd: 2.0.0
-    destroy: 1.2.0
-    http-errors: 2.0.0
-    iconv-lite: 0.4.24
-    on-finished: 2.4.1
-    qs: 6.11.0
-    raw-body: 2.5.2
-    type-is: ~1.6.18
-    unpipe: 1.0.0
-  checksum: 14d37ec638ab5c93f6099ecaed7f28f890d222c650c69306872e00b9efa081ff6c596cd9afb9930656aae4d6c4e1c17537bea12bb73c87a217cb3cfea8896737
-  languageName: node
-  linkType: hard
-
-"body-parser@npm:^1.17.0, body-parser@npm:^1.19.0, body-parser@npm:^1.19.1":
+"body-parser@npm:^1.20.3":
   version: 1.20.3
   resolution: "body-parser@npm:1.20.3"
   dependencies:

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -4778,9 +4778,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"body-parser@npm:1.20.2, body-parser@npm:^1.17.0, body-parser@npm:^1.19.0, body-parser@npm:^1.19.1":
-  version: 1.20.2
-  resolution: "body-parser@npm:1.20.2"
+"body-parser@npm:1.20.3":
+  version: 1.20.3
+  resolution: "body-parser@npm:1.20.3"
   dependencies:
     bytes: 3.1.2
     content-type: ~1.0.5
@@ -4790,11 +4790,11 @@ __metadata:
     http-errors: 2.0.0
     iconv-lite: 0.4.24
     on-finished: 2.4.1
-    qs: 6.11.0
+    qs: 6.13.0
     raw-body: 2.5.2
     type-is: ~1.6.18
     unpipe: 1.0.0
-  checksum: 14d37ec638ab5c93f6099ecaed7f28f890d222c650c69306872e00b9efa081ff6c596cd9afb9930656aae4d6c4e1c17537bea12bb73c87a217cb3cfea8896737
+  checksum: 1a35c59a6be8d852b00946330141c4f142c6af0f970faa87f10ad74f1ee7118078056706a05ae3093c54dabca9cd3770fa62a170a85801da1a4324f04381167d
   languageName: node
   linkType: hard
 
@@ -15750,6 +15750,15 @@ __metadata:
   dependencies:
     side-channel: ^1.0.4
   checksum: 6e1f29dd5385f7488ec74ac7b6c92f4d09a90408882d0c208414a34dd33badc1a621019d4c799a3df15ab9b1d0292f97c1dd71dc7c045e69f81a8064e5af7297
+  languageName: node
+  linkType: hard
+
+"qs@npm:6.13.0":
+  version: 6.13.0
+  resolution: "qs@npm:6.13.0"
+  dependencies:
+    side-channel: ^1.0.6
+  checksum: e9404dc0fc2849245107108ce9ec2766cde3be1b271de0bf1021d049dc5b98d1a2901e67b431ac5509f865420a7ed80b7acb3980099fe1c118a1c5d2e1432ad8
   languageName: node
   linkType: hard
 

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -4778,7 +4778,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"body-parser@npm:1.20.3":
+"body-parser@npm:1.20.2":
+  version: 1.20.2
+  resolution: "body-parser@npm:1.20.2"
+  dependencies:
+    bytes: 3.1.2
+    content-type: ~1.0.5
+    debug: 2.6.9
+    depd: 2.0.0
+    destroy: 1.2.0
+    http-errors: 2.0.0
+    iconv-lite: 0.4.24
+    on-finished: 2.4.1
+    qs: 6.11.0
+    raw-body: 2.5.2
+    type-is: ~1.6.18
+    unpipe: 1.0.0
+  checksum: 14d37ec638ab5c93f6099ecaed7f28f890d222c650c69306872e00b9efa081ff6c596cd9afb9930656aae4d6c4e1c17537bea12bb73c87a217cb3cfea8896737
+  languageName: node
+  linkType: hard
+
+"body-parser@npm:^1.17.0, body-parser@npm:^1.19.0, body-parser@npm:^1.19.1":
   version: 1.20.3
   resolution: "body-parser@npm:1.20.3"
   dependencies:

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -7569,9 +7569,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ember-a11y-testing@npm:^6.1.1":
-  version: 6.1.1
-  resolution: "ember-a11y-testing@npm:6.1.1"
+"ember-a11y-testing@npm:^7.0.1":
+  version: 7.0.1
+  resolution: "ember-a11y-testing@npm:7.0.1"
   dependencies:
     "@ember/test-waiters": ^2.4.3 || ^3.0.0
     "@scalvert/ember-setup-middleware-reporter": ^0.1.1
@@ -7583,15 +7583,15 @@ __metadata:
     ember-cli-typescript: ^4.2.1
     ember-cli-version-checker: ^5.1.2
     ember-destroyable-polyfill: ^2.0.1
-    fs-extra: ^10.0.0
+    fs-extra: ^11.2.0
     validate-peer-dependencies: ^2.0.0
   peerDependencies:
-    "@ember/test-helpers": ^3.0.3
+    "@ember/test-helpers": ^3.0.3 || ^4.0.2
     qunit: ">= 2"
   peerDependenciesMeta:
     qunit:
       optional: true
-  checksum: cbb69a7e043adb1eee73d8f46c11a9d7c393e30069ff4b0c20e3fb1d76accf460968d3d9876189a0cd1d95cfcaecc8731343cbd072171464ea35fa957cbb5ccc
+  checksum: d546eecd628c34161b435a7fe877a5c5e15b98d2635d4b5215510832d687e41a3bdcfdd0e56ff9dd54f574d0a679431a45b29004482a4f9dbbac1c22f715aba0
   languageName: node
   linkType: hard
 
@@ -19082,7 +19082,7 @@ __metadata:
     deepmerge: ^4.0.0
     doctoc: ^2.2.0
     dompurify: ^3.0.2
-    ember-a11y-testing: ^6.1.1
+    ember-a11y-testing: ^7.0.1
     ember-auto-import: ^2.7.2
     ember-basic-dropdown: ^8.0.4
     ember-cli: ~5.4.2


### PR DESCRIPTION
### Description
Resolves security vulnerability in `body-parser < 1.20.3` https://github.com/hashicorp/vault-enterprise/security/code-scanning/2022

After upgrading `ember-a11y-testing` package there was still one dependency relying on a vulnerable version (`ember-cli` -> `express` -> `body-parser 1.20.2`)


### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [ ] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
