### PR TITLE
Update ssh docs to add missing conditional for valid_principals

### DIFF
--- a/website/content/api-docs/secret/ssh.mdx
+++ b/website/content/api-docs/secret/ssh.mdx
@@ -752,8 +752,9 @@ parameters of the issued certificate can be further customized in this API call.
   set.
 
 - `valid_principals` `(string: "")` – Specifies valid principals, either
-  usernames or hostnames, that the certificate should be signed for.  Required
-  unless the role has specified allow_empty_principals.
+  usernames or hostnames, that the certificate should be signed for. Required
+  unless the role has specified allow_empty_principals or a value has been set for
+  either the default_user or default_user_template role parameters.
 
 - `cert_type` `(string: "user")` – Specifies the type of certificate to be
   created; either "user" or "host".


### PR DESCRIPTION
### Description

When we introduced the new field `allow_empty_principals` within the ssh plugin docs, we missed an update to the `valid_principals` saying if the role had a default_user set it would be used and not that valid_principals is now always needed.

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [ ] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
