### PR TITLE
Add log message indicating expected goroutine dump behavior

### DIFF
--- a/command/server.go
+++ b/command/server.go
@@ -1721,6 +1721,7 @@ func (c *ServerCommand) Run(args []string) int {
 			// Notify systemd that the server has completed reloading config
 			c.notifySystemd(systemd.SdNotifyReady)
 		case <-c.SigUSR2Ch:
+			c.logger.Info("Received SIGUSR2, dumping goroutines. This is expected behavior. Vault continues to run normally.")
 			logWriter := c.logger.StandardWriter(&hclog.StandardLoggerOptions{})
 			pprof.Lookup("goroutine").WriteTo(logWriter, 2)
 


### PR DESCRIPTION
### Description
This PR adds an informational log message to clarify that the observed goroutine dumps are expected behavior and do not indicate a panic. The log message reassures that Vault is still running normally and can be unsealed. This should help reduce confusion when encountering goroutine dumps in the logs.