### PR TITLE
Field descriptions and basic "internal role" setting to add extended …

### DIFF
--- a/builtin/logical/pki/ca_util.go
+++ b/builtin/logical/pki/ca_util.go
@@ -73,6 +73,8 @@ func getGenerationParams(sc *storageContext, data *framework.FieldData) (exporte
 		NotBeforeDuration:         time.Duration(data.Get("not_before_duration").(int)) * time.Second,
 		CNValidations:             []string{"disabled"},
 		KeyUsage:                  data.Get("key_usage").([]string),
+		ExtKeyUsage:               data.Get("ext_key_usage").([]string),
+		ExtKeyUsageOIDs:           data.Get("ext_key_usage_oids").([]string),
 	}
 	*role.AllowWildcardCertificates = true
 

--- a/builtin/logical/pki/fields.go
+++ b/builtin/logical/pki/fields.go
@@ -673,7 +673,26 @@ https://golang.org/pkg/crypto/x509/#KeyUsage -- simply drop
 the "KeyUsage" part of the name.  To use the issuer for 
 CMPv2, DigitalSignature must be set.`,
 	}
-
+	fields["ext_key_usage"] = &framework.FieldSchema{ // Same Name as Leaf-Cert Field, and CA CSR Field, but Description and Default Differ
+		Type:    framework.TypeCommaStringSlice,
+		Default: []string{"OCSPSigning"},
+		Description: `Specifies ext_key_usage to encode in the certificate.
+This is a comma-separated string or list of extended key 
+usages (not key usages).  Valid values can be found at 
+https://golang.org/pkg/crypto/x509/#ExtKeyUsage -- simply 
+drop the "ExtKeyUsage" part of the name.  If this is set to 
+an empty list, and no OID is added to ext_key_usage_oids, 
+then extended key usage will not appear on the Certificate.
+This defaults to OCSPSigning.`,
+	}
+	fields["ext_key_usage_oids"] = &framework.FieldSchema{ // Same Name as Leaf-Cert Field, and CA CSR Field, but Description Differs
+		Type:    framework.TypeCommaStringSlice,
+		Default: []string{},
+		Description: `This is a comma-separated string or list of OIDs that
+refer to extended key usages.  If both this field and
+ext_key_usage are empty, extended key usage will not
+appear on the certificate.`,
+	}
 	return fields
 }
 
@@ -688,6 +707,24 @@ at https://golang.org/pkg/crypto/x509/#KeyUsage -- simply
 drop the "KeyUsage" part of the name.  If not set, key 
 usage will not appear on the CSR.`,
 	}
-
+	fields["ext_key_usage"] = &framework.FieldSchema{ // Same Name as Leaf-Cert, CA-Cert Field, but Description and Default Differ
+		Type:    framework.TypeCommaStringSlice,
+		Default: []string{},
+		Description: `Specifies ext_key_usage to encode in the certificate
+signing request.  This is a comma-separated string or list
+of extended key usages (not key usages).  Valid values can
+be found at https://golang.org/pkg/crypto/x509/#ExtKeyUsage
+-- simply drop the "ExtKeyUsage" part of the name.  If this 
+is not set, and no OID is added to ext_key_usage_oids, then
+extended key usage will not appear on the CSR.`,
+	}
+	fields["ext_key_usage_oids"] = &framework.FieldSchema{ // Same Name as Leaf-Cert, CA-Cert Field, but Description Differs
+		Type:    framework.TypeCommaStringSlice,
+		Default: []string{},
+		Description: `This is a comma-separated string or list of OIDs that
+refer to extended key usages.  If both this field and
+ext_key_usage are not set, extended key usage will not
+appear on the CSR.`,
+	}
 	return fields
 }

--- a/builtin/logical/pki/path_root.go
+++ b/builtin/logical/pki/path_root.go
@@ -357,6 +357,8 @@ func (b *backend) pathIssuerSignIntermediate(ctx context.Context, req *logical.R
 		NotBeforeDuration:         time.Duration(data.Get("not_before_duration").(int)) * time.Second,
 		CNValidations:             []string{"disabled"},
 		KeyUsage:                  data.Get("key_usage").([]string),
+		ExtKeyUsage:               data.Get("ext_key_usage").([]string),
+		ExtKeyUsageOIDs:           data.Get("ext_key_usage_oids").([]string),
 	}
 	*role.AllowWildcardCertificates = true
 


### PR DESCRIPTION
…key usage (and extended key usage oids) to issuers.

### Description
What does this PR do?

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [ ] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
