### PR TITLE
Remove early-static config check

### DIFF
--- a/ui/config/deprecation-workflow.js
+++ b/ui/config/deprecation-workflow.js
@@ -14,7 +14,6 @@ self.deprecationWorkflow.config = {
   workflow: [
     { handler: 'silence', matchId: 'ember-engines.deprecation-router-service-from-host' },
     // ember-data
-    { handler: 'silence', matchId: 'ember-data:deprecate-early-static' }, // decorator tests
     { handler: 'silence', matchId: 'ember-data:deprecate-promise-proxies' }, // Transform secrets
     { handler: 'silence', matchId: 'ember-data:no-a-with-array-like' }, // MFA
     { handler: 'silence', matchId: 'ember-data:deprecate-promise-many-array-behaviors' }, // MFA


### PR DESCRIPTION
### Description
Early-static deprecation was handled in [this](https://github.com/hashicorp/vault/pull/28444/commits/38ccb9ee78541673568ef7bc3a2dfd3fe06cc071) commit. I confirmed it was all handled and this PR removes the check from the config blob.

- [x] Enterprise test pass.