### PR TITLE
Do not acquire a read lock twice on tidyStatusLock during tidy-status

### DIFF
--- a/builtin/logical/pki/backend.go
+++ b/builtin/logical/pki/backend.go
@@ -297,7 +297,9 @@ func Backend(conf *logical.BackendConfig) *backend {
 
 	// Delay the first tidy until after we've started up, this will be reset within the initialize function
 	now := time.Now()
+	b.tidyStatusLock.Lock()
 	b.lastAutoTidy = now
+	b.tidyStatusLock.Unlock()
 
 	// Keep track of when this mount was started up.
 	b.mountStartup = now

--- a/builtin/logical/pki/path_tidy.go
+++ b/builtin/logical/pki/path_tidy.go
@@ -1724,7 +1724,7 @@ func (b *backend) pathTidyStatusRead(_ context.Context, _ *logical.Request, _ *f
 			"acme_account_safety_buffer":            nil,
 			"cert_metadata_deleted_count":           nil,
 			"cmpv2_nonce_deleted_count":             nil,
-			"last_auto_tidy_finished":               b.getLastAutoTidyTime(),
+			"last_auto_tidy_finished":               b.getLastAutoTidyTimeWithoutLock(), // we acquired the tidyStatusLock above.
 		},
 	}
 
@@ -2126,6 +2126,12 @@ func (b *backend) updateLastAutoTidyTime(sc *storageContext, lastRunTime time.Ti
 func (b *backend) getLastAutoTidyTime() time.Time {
 	b.tidyStatusLock.RLock()
 	defer b.tidyStatusLock.RUnlock()
+	return b.getLastAutoTidyTimeWithoutLock()
+}
+
+// getLastAutoTidyTimeWithoutLock should be used to read from b.lastAutoTidy with the
+// b.tidyStatusLock being acquired, normally use getLastAutoTidyTime
+func (b *backend) getLastAutoTidyTimeWithoutLock() time.Time {
 	return b.lastAutoTidy
 }
 


### PR DESCRIPTION
### Description

A deadlock can occur when we are reading the PKI tidy-status endpoint. This was introduced within [PR28488](https://github.com/hashicorp/vault/pull/28488) so no version of Vault that was released contains this issue.

The deadlock occurs when

1. The tidy-status api is called and acquires the read lock on `tidyStatusLock` at the top of pathTidyStatusRead [line 1689](https://github.com/hashicorp/vault/blob/main/builtin/logical/pki/path_tidy.go#L1689)
2. A blocking Lock call is performed against `tidyStatusLock` say within startTidyOperation [line 999](https://github.com/hashicorp/vault/blob/main/builtin/logical/pki/path_tidy.go#L999) 
3. The call to b.getLastAutoTidyTime() on [line 1727](https://github.com/hashicorp/vault/blob/main/builtin/logical/pki/path_tidy.go#L1727) attempts to re-acquire the read lock on `tidyStatusLock`. Normally this works as both calls are requesting read locks so it goes through but once a Write lock request is pending we will deadlock.

### TODO only if you're a HashiCorp employee
- [X] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [ ] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [X] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
