### PR TITLE
Have go-test timeout before the GH step timeout to gather information

### DIFF
--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -49,6 +49,11 @@ on:
         required: false
         default: 20
         type: number
+      go-test-timeout:
+        description: The timeout parameter for Go tests
+        required: false
+        default: 50m
+        type: string
       timeout-minutes:
         description: The maximum number of minutes that this workflow should run
         required: false
@@ -443,7 +448,7 @@ jobs:
               -- \
               $package_parallelism \
               -tags "${{ inputs.go-tags }}" \
-              -timeout=${{ env.TIMEOUT_IN_MINUTES }}m \
+              -timeout=${{ inputs.go-test-timeout }} \
               -parallel=${{ inputs.go-test-parallelism }} \
               ${{ inputs.extra-flags }} \
       - name: Prepare datadog-ci


### PR DESCRIPTION
### Description

 - If we encounter a deadlock/long running test it is better to have go test timeout. As we've noticed if we hit the GitHub step timeout, we lose all information about what was running at the time of the timeout making things harder to diagnose.
 - Having the timeout through go test itself on a long running test it outputs what test was running along with a full panic output within the logs which is quite useful to diagnose

### TODO only if you're a HashiCorp employee
- [X] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [ ] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [X] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
