### PR TITLE
Verify Certificate before returning it does do name constraint-checks.

### DIFF
--- a/builtin/logical/pki/path_issue_sign.go
+++ b/builtin/logical/pki/path_issue_sign.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/rand"
+	"crypto/x509"
 	"encoding/base64"
 	"encoding/pem"
 	"fmt"
@@ -431,7 +432,23 @@ func (b *backend) pathIssueSignCert(ctx context.Context, req *logical.Request, d
 			return nil, fmt.Errorf("error signing/generating certificate: %w", err)
 		}
 	}
-
+	// Validation Code, assuming we need to validate the entire chain of constraints
+	certChainPool := x509.NewCertPool()
+	for _, certificate := range parsedBundle.CAChain {
+		certChainPool.AddCert(certificate.Certificate)
+	}
+	options := x509.VerifyOptions{
+		Intermediates:             nil, // We aren't verifying the chain here, this would do more work
+		Roots:                     certChainPool,
+		CurrentTime:               time.Time{},
+		KeyUsages:                 nil,
+		MaxConstraintComparisions: 0, // This means infinite
+		//
+	}
+	_, err = parsedBundle.Certificate.Verify(options) // By default this does name constraints
+	if err != nil {
+		return nil, err
+	}
 	generateLease := false
 	if role.GenerateLease != nil && *role.GenerateLease {
 		generateLease = true


### PR DESCRIPTION
### Description
What does this PR do?  Enforces chain-restraints.

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [ ] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
