### PR TITLE
Log when the seal is unavailable as error

### DIFF
--- a/changelog/28564.txt
+++ b/changelog/28564.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+core: log at level ERROR rather than WARN when all seals are unhealthy.
+```

--- a/changelog/28564.txt
+++ b/changelog/28564.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-core: log at level ERROR rather than WARN when all seals are unhealthy.
+core: log at level ERROR rather than INFO when all seals are unhealthy.
 ```

--- a/vault/seal_autoseal.go
+++ b/vault/seal_autoseal.go
@@ -517,7 +517,7 @@ error and restart Vault.`)
 				d.core.MetricSink().SetGauge(autoSealUnavailableDuration, 0)
 			} else {
 				if lastTestOk && allUnhealthy {
-					d.logger.Info("seal backend is completely unhealthy (all seal wrappers all unhealthy)", "downtime", now.Sub(lastSeenOk).String())
+					d.logger.Error("seal backend is completely unhealthy (all seal wrappers all unhealthy)", "downtime", now.Sub(lastSeenOk).String())
 				}
 				lastTestOk = false
 				healthCheck.Reset(seal.HealthTestIntervalUnhealthy)


### PR DESCRIPTION
### Description

Vault's seal health checking is advisory, meaning it doesn't affect the operation of Vault to detect an unhealthy seal.  As such we originally logged failures as Warn.  In particular, we only logged at Warn level the message indicating all seals are unhealthy, which is a bad situation for operators.  This quick PR changes that line to ERROR to make it easier for operators to spot.  Addresses SR-175.

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [ ] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
