### PR TITLE
UI: Spike/Discovery to support mfa for SSO methods (OIDC, SAML & JWT)

### DIFF
--- a/ui/app/components/auth-form.js
+++ b/ui/app/components/auth-form.js
@@ -257,6 +257,7 @@ export default Component.extend(DEFAULTS, {
           data.path = 'okta';
         }
       }
+      // calls performAuth in login-form.js which initiates the @task authenticate
       return this.performAuth(backend.type, data);
     },
     handleError(e) {

--- a/ui/app/components/auth-jwt.js
+++ b/ui/app/components/auth-jwt.js
@@ -161,7 +161,9 @@ export default Component.extend({
       // and show the error on the login screen
       return this.cancelLogin(oidcWindow, e);
     }
-    yield this.onSubmit(null, null, resp.auth.client_token);
+    const { mfa_requirement } = resp.auth;
+    // this.onSubmit calls doSubmit in auth-form.js
+    yield this.onSubmit({ mfa_requirement }, null, resp.auth.client_token);
   }),
 
   async startOIDCAuth() {

--- a/ui/app/components/auth-saml.js
+++ b/ui/app/components/auth-saml.js
@@ -98,7 +98,10 @@ export default class AuthSaml extends Component {
           continue;
         }
         // We've obtained the Vault token for the authentication flow, now log in.
-        yield this.args.onSubmit(null, null, resp.auth.client_token);
+        const { mfa_requirement, client_token } = resp.auth;
+
+        // onSubmit calls doSubmit in auth-form.js
+        yield this.args.onSubmit({ mfa_requirement }, null, client_token);
         this.closeWindow(samlWindow);
         return;
       } catch (e) {

--- a/ui/app/components/auth/login-form.js
+++ b/ui/app/components/auth/login-form.js
@@ -60,6 +60,15 @@ export default class AuthLoginFormComponent extends Component {
       } else {
         this.delayAuthMessageReminder.perform();
       }
+
+      if (data?.mfa_requirement) {
+        const mfa_requirement = this.auth._parseMfaResponse(data.mfa_requirement);
+        // calls onAuthResponse in auth/page.js
+        this.args.onSuccess(mfa_requirement, backendType, data);
+        // return here because mfa-form.js will finish login flow after mfa validation
+        return;
+      }
+
       const authResponse = yield this.auth.authenticate({
         clusterId,
         backend: backendType,
@@ -67,6 +76,7 @@ export default class AuthLoginFormComponent extends Component {
         selectedAuth,
       });
 
+      // calls onAuthResponse in auth/page.js
       this.args.onSuccess(authResponse, backendType, data);
     } catch (e) {
       if (!this.auth.mfaError) {

--- a/ui/app/components/auth/page.js
+++ b/ui/app/components/auth/page.js
@@ -55,12 +55,14 @@ export default class AuthPage extends Component {
     if (mfa_requirement) {
       this.mfaAuthData = { mfa_requirement, backend, data };
     } else {
+      // calls authSuccess in auth.js controller
       this.args.onAuthSuccess(authResponse);
     }
   }
 
   @action
   onMfaSuccess(authResponse) {
+    // calls authSuccess in auth.js controller
     this.args.onAuthSuccess(authResponse);
   }
 

--- a/ui/app/components/mfa/mfa-form.js
+++ b/ui/app/components/mfa/mfa-form.js
@@ -83,6 +83,7 @@ export default class MfaForm extends Component {
         clusterId: this.args.clusterId,
         ...this.args.authData,
       });
+      // calls onMfaSuccess in auth/page.js
       this.args.onSuccess(response);
     } catch (error) {
       const errors = error.errors || [];

--- a/ui/app/services/auth.js
+++ b/ui/app/services/auth.js
@@ -276,6 +276,7 @@ export default Service.extend({
       mountPath,
       ...BACKENDS.find((b) => b.type === backend),
     };
+    // TODO: displayName is not populated correctly with OIDC + totp (likely all MFA methods)
     let displayName;
     if (isArray(currentBackend.displayNamePath)) {
       displayName = currentBackend.displayNamePath.map((name) => get(resp, name)).join('/');


### PR DESCRIPTION
### Description
Spike/Discovery to support mfa for SSO methods (OIDC, SAML & JWT)

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [ ] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
