### PR TITLE
Revert "backport of commit e7e16fd1756afa5921f402ee9bff0bd58b422023 (#28554)"

### DIFF
--- a/vault/init.go
+++ b/vault/init.go
@@ -319,6 +319,32 @@ func (c *Core) Initialize(ctx context.Context, initParams *InitParams) (*InitRes
 		SecretShares: [][]byte{},
 	}
 
+	// If we are storing shares, pop them out of the returned results and push
+	// them through the seal
+	switch c.seal.StoredKeysSupported() {
+	case seal.StoredKeysSupportedShamirRoot:
+		keysToStore := [][]byte{barrierKey}
+		if err := c.seal.GetAccess().SetShamirSealKey(sealKey); err != nil {
+			c.logger.Error("failed to set seal key", "error", err)
+			return nil, fmt.Errorf("failed to set seal key: %w", err)
+		}
+		if err := c.seal.SetStoredKeys(ctx, keysToStore); err != nil {
+			c.logger.Error("failed to store keys", "error", err)
+			return nil, fmt.Errorf("failed to store keys: %w", err)
+		}
+		results.SecretShares = sealKeyShares
+	case seal.StoredKeysSupportedGeneric:
+		keysToStore := [][]byte{barrierKey}
+		if err := c.seal.SetStoredKeys(ctx, keysToStore); err != nil {
+			c.logger.Error("failed to store keys", "error", err)
+			return nil, fmt.Errorf("failed to store keys: %w", err)
+		}
+	default:
+		// We don't support initializing an old-style Shamir seal anymore, so
+		// this case is only reachable by tests.
+		results.SecretShares = barrierKeyShares
+	}
+
 	// Perform initial setup
 	if err := c.setupCluster(ctx); err != nil {
 		c.logger.Error("cluster setup failed during init", "error", err)
@@ -329,12 +355,6 @@ func (c *Core) Initialize(ctx context.Context, initParams *InitParams) (*InitRes
 	if initPTCleanup != nil {
 		initPTCleanup()
 	}
-
-	// Save in a variable whether stored keys are supported before calling postUnsea(), as postUnseal()
-	// clears the barrier config. For a defaultSeal with a "legacy seal" (i.e. barrier config has StoredShares == 0),
-	// this will cause StoredKeysSupported() to go from StoredKeysNotSupported to StoredKeysSupportedShamirRoot.
-	// This would be a problem below when we determine whether to call SetStoredKeys.
-	storedKeysSupported := c.seal.StoredKeysSupported()
 
 	activeCtx, ctxCancel := context.WithCancel(namespace.RootContext(nil))
 	if err := c.postUnseal(activeCtx, ctxCancel, standardUnsealStrategy{}); err != nil {
@@ -391,32 +411,6 @@ func (c *Core) Initialize(ctx context.Context, initParams *InitParams) (*InitRes
 			c.logger.Error("failed to create raft TLS keyring", "error", err)
 			return nil, err
 		}
-	}
-
-	// If we are storing shares, pop them out of the returned results and push
-	// them through the seal
-	switch storedKeysSupported {
-	case seal.StoredKeysSupportedShamirRoot:
-		keysToStore := [][]byte{barrierKey}
-		if err := c.seal.GetAccess().SetShamirSealKey(sealKey); err != nil {
-			c.logger.Error("failed to set seal key", "error", err)
-			return nil, fmt.Errorf("failed to set seal key: %w", err)
-		}
-		if err := c.seal.SetStoredKeys(ctx, keysToStore); err != nil {
-			c.logger.Error("failed to store keys", "error", err)
-			return nil, fmt.Errorf("failed to store keys: %w", err)
-		}
-		results.SecretShares = sealKeyShares
-	case seal.StoredKeysSupportedGeneric:
-		keysToStore := [][]byte{barrierKey}
-		if err := c.seal.SetStoredKeys(ctx, keysToStore); err != nil {
-			c.logger.Error("failed to store keys", "error", err)
-			return nil, fmt.Errorf("failed to store keys: %w", err)
-		}
-	default:
-		// We don't support initializing an old-style Shamir seal anymore, so
-		// this case is only reachable by tests.
-		results.SecretShares = barrierKeyShares
 	}
 
 	// Prepare to re-seal


### PR DESCRIPTION
### Description

This reverts commit c77aa48e72ee923d45a66db839f0cf4f51aa8a1a.

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [ ] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
