### PR TITLE
add model to linkto

### DIFF
--- a/ui/app/templates/vault/cluster/access/mfa/enforcements/enforcement/index.hbs
+++ b/ui/app/templates/vault/cluster/access/mfa/enforcements/enforcement/index.hbs
@@ -24,6 +24,7 @@
         @route="vault.cluster.access.mfa.enforcements.enforcement"
         @query={{hash tab="targets"}}
         data-test-tab="targets"
+        @model={{this.model}}
       >
         Targets
       </LinkTo>
@@ -31,6 +32,7 @@
         @route="vault.cluster.access.mfa.enforcements.enforcement"
         @query={{hash tab="methods"}}
         data-test-tab="methods"
+        @model={{this.model}}
       >
         Methods
       </LinkTo>


### PR DESCRIPTION
### Description
Fixes transition when navigating away from mfa enforcements back to dashboard
```
Preparing to transition from 'vault.cluster.access.mfa.enforcements.enforcement.index' to 'vault.cluster.index'
runtime.js:4142 

Error occurred:

- While rendering:
  -top-level
    application
      sidebar/frame
        hds/app-frame
          hds/app-frame/parts/main
            vault
              vault.cluster
                token-expire-warning
                  vault.cluster.access
                    vault.cluster.access.mfa
                      vault.cluster.access.mfa.enforcements
                        vault.cluster.access.mfa.enforcements.enforcement
                          vault.cluster.access.mfa.enforcements.enforcement.index
                            link-to



router_js.js:1010 Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'shouldSupersede')
    at NamedTransitionIntent.applyToHandlers (router_js.js:1010:1)
    at NamedTransitionIntent.applyToState (router_js.js:959:1)
    at PrivateRouter.applyIntent (router_js.js:1823:1)
    at calculatePostTransitionState (router.js:1228:1)
    at Router._prepareQueryParams (router.js:795:1)
    at RouterState.isActiveIntent (router_state.js:21:1)
    at RoutingService.isActiveForRoute (routing-service.js:87:1)
    at _LinkTo.isActiveForState (index.js:1032:1)
    at get isActive (index.js:960:1)
    at get class (index.js:837:1)
applyToHandlers @ router_js.js:1010
applyToState @ router_js.js:959
router.js:508 Intermediate-transitioned into 'vault.cluster.loading'
router.js:21 Transitioned into 'vault.cluster.dashboard'
```
<img width="911" alt="Screenshot 2024-10-02 at 1 29 33 PM" src="https://github.com/user-attachments/assets/68ee73fe-2f94-497f-89b9-4386568f33b7">

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [ ] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
