### PR TITLE
-agent-address flag should have higher precedence than the env var

### DIFF
--- a/changelog/28574.txt
+++ b/changelog/28574.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cli: Fixed a CLI precedence issue where -agent-address didn't override VAULT_AGENT_ADDR as it should
+```

--- a/command/base.go
+++ b/command/base.go
@@ -106,7 +106,7 @@ func (c *BaseCommand) Client() (*api.Client, error) {
 		config.Address = c.flagAddress
 	}
 	if c.flagAgentProxyAddress != "" {
-		config.Address = c.flagAgentProxyAddress
+		config.AgentAddress = c.flagAgentProxyAddress
 	}
 
 	if c.flagOutputCurlString {


### PR DESCRIPTION
### Description
Resolves https://github.com/hashicorp/vault/issues/27404

The issue here, as I understand it, is that the `VAULT_AGENT_ADDR` environment variable takes higher precedence than the `-agent-address` CLI flag, in violation of what our docs say about how CLI flags should take precedence. The people reporting and commenting on the issue provided a wonderful reproduction shell script that makes this problem easy to see.

From what I can tell, [NewClient](https://github.com/hashicorp/vault/blob/main/api/client.go#L639-L642) is doing the right thing, by prioritizing the agent address over the regular address. The main problem is that the API client doesn't have access to CLI flags - it can only work from the config it's given.

I _think_ the fix I've done here is correct, in that 1) the repro shell script now does the right thing in all cases, including the last one and also 2) nothing about the way the CLI parses its config has changed, so all the other callers of `api.NewClient()` will still get the same behavior they've always gotten.

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [ ] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
