### PR TITLE
LDAP Secrets Engine documentation: URL to external link is broken, this PR corrects the URL.

### DIFF
--- a/website/content/docs/secrets/ldap.mdx
+++ b/website/content/docs/secrets/ldap.mdx
@@ -206,7 +206,7 @@ Some important things to remember when crafting your LDIF entries:
   authenticate with old passwords for a specified amount of time.
 
   For more information, refer to the
- [NTLM network authentication behavior](https://learn.microsoft.com/en-us/troubleshoot/windows-server/windows-security new-setting-modifies-ntlm-network-authentication)
+ [NTLM network authentication behavior](https://learn.microsoft.com/en-us/troubleshoot/windows-server/windows-security/new-setting-modifies-ntlm-network-authentication)
   guide by Microsoft.
 
 </Note>


### PR DESCRIPTION
### Description
What does this PR do?

old:
<img width="918" alt="Screenshot 2024-10-03 at 11 37 01" src="https://github.com/user-attachments/assets/a74b0ccc-0f36-42c7-b487-be73f3c2603a">

new:
<img width="1011" alt="Screenshot 2024-10-03 at 11 37 41" src="https://github.com/user-attachments/assets/8291b118-a915-400b-99ee-7b77447d5d6c">


### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [ ] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
