### PR TITLE
LDAP Secrets Engine api documentation: URL to external link is broken, this PR corrects the URL

### DIFF
--- a/website/content/api-docs/secret/ldap.mdx
+++ b/website/content/api-docs/secret/ldap.mdx
@@ -177,7 +177,7 @@ The `static-role` endpoint configures Vault to manage the passwords of existing 
   authenticate with old passwords for a specified amount of time.
 
   For more information, refer to the
- [NTLM network authentication behavior](https://learn.microsoft.com/en-us/troubleshoot/windows-server/windows-security new-setting-modifies-ntlm-network-authentication)
+ [NTLM network authentication behavior](https://learn.microsoft.com/en-us/troubleshoot/windows-server/windows-security/new-setting-modifies-ntlm-network-authentication)
   guide by Microsoft.
 
 </Note>


### PR DESCRIPTION
### Description
What does this PR do?

old:
<img width="769" alt="Screenshot 2024-10-03 at 11 58 59" src="https://github.com/user-attachments/assets/4a551432-3175-4cfa-bd4e-eb5778ad3e1c">

new:

<img width="708" alt="Screenshot 2024-10-03 at 11 59 26" src="https://github.com/user-attachments/assets/8ad6a3f5-790d-447f-b9bc-049b5807869a">

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [ ] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
