### PR TITLE
Remove one more use of ScalarMult from CE

### DIFF
--- a/helper/dhutil/dhutil.go
+++ b/helper/dhutil/dhutil.go
@@ -30,14 +30,17 @@ type Envelope struct {
 // generatePublicPrivateKey uses curve25519 to generate a public and private key
 // pair.
 func GeneratePublicPrivateKey() ([]byte, []byte, error) {
-	var scalar, public [32]byte
+	scalar := make([]byte, 32)
 
-	if _, err := io.ReadFull(rand.Reader, scalar[:]); err != nil {
+	if _, err := io.ReadFull(rand.Reader, scalar); err != nil {
 		return nil, nil, err
 	}
 
-	curve25519.ScalarBaseMult(&public, &scalar)
-	return public[:], scalar[:], nil
+	public, err := curve25519.X25519(curve25519.Basepoint, scalar)
+	if err != nil {
+		return nil, nil, err
+	}
+	return public, scalar, nil
 }
 
 // GenerateSharedSecret uses the private key and the other party's public key to

--- a/helper/dhutil/dhutil.go
+++ b/helper/dhutil/dhutil.go
@@ -36,7 +36,7 @@ func GeneratePublicPrivateKey() ([]byte, []byte, error) {
 		return nil, nil, err
 	}
 
-	public, err := curve25519.X25519(curve25519.Basepoint, scalar)
+	public, err := curve25519.X25519(scalar, curve25519.Basepoint)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
dhutil uses ScalarMult for ed25519 math, which has been deprecated because it can be problematic copying
data into fixed size arrays. This PR switches to the X25519 function instead.

### Description
What does this PR do?

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [ ] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.