### PR TITLE
VAULT-30108: Include User-Agent header in audit requests by default

### DIFF
--- a/audit/headers.go
+++ b/audit/headers.go
@@ -175,6 +175,7 @@ func (a *HeadersConfig) DefaultHeaders() map[string]*headerSettings {
 	return map[string]*headerSettings{
 		correlationID:  {},
 		xCorrelationID: {},
+		"user-agent":   {},
 	}
 }
 

--- a/audit/headers_test.go
+++ b/audit/headers_test.go
@@ -245,7 +245,6 @@ func TestAuditedHeadersConfig_ApplyConfig(t *testing.T) {
 		"X-Test-Header":  {"foo"},
 		"X-Vault-Header": {"bar", "bar"},
 		"Content-Type":   {"json"},
-		"User-Agent":     {"foo-agent"},
 	}
 
 	salter := &testSalter{}
@@ -260,7 +259,6 @@ func TestAuditedHeadersConfig_ApplyConfig(t *testing.T) {
 	expected := map[string][]string{
 		"x-test-header":  {"foo"},
 		"x-vault-header": {hmacPrefix, hmacPrefix},
-		"user-agent":     {"foo-agent"},
 	}
 
 	if len(expected) != len(result) {

--- a/audit/headers_test.go
+++ b/audit/headers_test.go
@@ -245,6 +245,7 @@ func TestAuditedHeadersConfig_ApplyConfig(t *testing.T) {
 		"X-Test-Header":  {"foo"},
 		"X-Vault-Header": {"bar", "bar"},
 		"Content-Type":   {"json"},
+		"User-Agent":     {"foo-agent"},
 	}
 
 	salter := &testSalter{}
@@ -254,9 +255,12 @@ func TestAuditedHeadersConfig_ApplyConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	const hmacPrefix = "hmac-sha256:"
+
 	expected := map[string][]string{
 		"x-test-header":  {"foo"},
-		"x-vault-header": {"hmac-sha256:", "hmac-sha256:"},
+		"x-vault-header": {hmacPrefix, hmacPrefix},
+		"user-agent":     {"foo-agent"},
 	}
 
 	if len(expected) != len(result) {
@@ -271,7 +275,7 @@ func TestAuditedHeadersConfig_ApplyConfig(t *testing.T) {
 		}
 
 		for i, e := range expectedValues {
-			if e == "hmac-sha256:" {
+			if e == hmacPrefix {
 				if !strings.HasPrefix(resultValues[i], e) {
 					t.Fatalf("Expected headers did not match actual: Expected %#v...\n Got %#v\n", e, resultValues[i])
 				}
@@ -288,6 +292,7 @@ func TestAuditedHeadersConfig_ApplyConfig(t *testing.T) {
 		"X-Test-Header":  {"foo"},
 		"X-Vault-Header": {"bar", "bar"},
 		"Content-Type":   {"json"},
+		"User-Agent":     {"foo-agent"},
 	}
 
 	if !reflect.DeepEqual(reqHeaders, reqHeadersCopy) {
@@ -609,13 +614,28 @@ func TestAuditedHeaders_invalidate_defaults(t *testing.T) {
 	require.Equal(t, len(ahc.DefaultHeaders())+1, len(ahc.headerSettings)) // (defaults + 1 new header)
 	_, ok := ahc.headerSettings["x-magic-header"]
 	require.True(t, ok)
+
 	s, ok := ahc.headerSettings["x-correlation-id"]
 	require.True(t, ok)
 	require.False(t, s.HMAC)
 
-	// Add correlation ID specifically with HMAC and make sure it doesn't get blasted away.
-	fakeHeaders1 = map[string]*headerSettings{"x-magic-header": {}, "X-Correlation-ID": {HMAC: true}}
+	s, ok = ahc.headerSettings["user-agent"]
+	require.True(t, ok)
+	require.False(t, s.HMAC)
+
+	// Add correlation ID and user-agent specifically with HMAC and make sure it doesn't get blasted away.
+	fakeHeaders1 = map[string]*headerSettings{
+		"x-magic-header": {},
+		"X-Correlation-ID": {
+			HMAC: true,
+		},
+		"User-Agent": {
+			HMAC: true,
+		},
+	}
+
 	fakeBytes1, err = json.Marshal(fakeHeaders1)
+
 	require.NoError(t, err)
 	err = view.Put(context.Background(), &logical.StorageEntry{Key: auditedHeadersEntry, Value: fakeBytes1})
 	require.NoError(t, err)
@@ -626,7 +646,12 @@ func TestAuditedHeaders_invalidate_defaults(t *testing.T) {
 	require.Equal(t, len(ahc.DefaultHeaders())+1, len(ahc.headerSettings)) // (defaults + 1 new header, 1 is also a default)
 	_, ok = ahc.headerSettings["x-magic-header"]
 	require.True(t, ok)
+
 	s, ok = ahc.headerSettings["x-correlation-id"]
+	require.True(t, ok)
+	require.True(t, s.HMAC)
+
+	s, ok = ahc.headerSettings["user-agent"]
 	require.True(t, ok)
 	require.True(t, s.HMAC)
 }

--- a/audit/headers_test.go
+++ b/audit/headers_test.go
@@ -290,7 +290,6 @@ func TestAuditedHeadersConfig_ApplyConfig(t *testing.T) {
 		"X-Test-Header":  {"foo"},
 		"X-Vault-Header": {"bar", "bar"},
 		"Content-Type":   {"json"},
-		"User-Agent":     {"foo-agent"},
 	}
 
 	if !reflect.DeepEqual(reqHeaders, reqHeadersCopy) {

--- a/changelog/28596.txt
+++ b/changelog/28596.txt
@@ -1,0 +1,4 @@
+```release-note:improvement
+audit: Audit logs will contain User-Agent headers when they are present in the incoming request. They are not
+HMAC'ed by default but can be configured to be via the `/sys/config/auditing/request-headers/user-agent` endpoint.
+```

--- a/vault/external_tests/audit/audit_test.go
+++ b/vault/external_tests/audit/audit_test.go
@@ -212,3 +212,81 @@ func TestAudit_HMACFields(t *testing.T) {
 	require.True(t, strings.HasPrefix(wrapInfo["token"].(string), hmacPrefix))
 	require.Equal(t, wrapInfo["token"].(string), hashedWrapToken)
 }
+
+func TestAudit_Headers(t *testing.T) {
+	cluster := minimal.NewTestSoloCluster(t, nil)
+	client := cluster.Cores[0].Client
+
+	tempDir := t.TempDir()
+	logFile, err := os.CreateTemp(tempDir, "")
+	require.NoError(t, err)
+	devicePath := "file"
+	deviceData := map[string]any{
+		"type":        "file",
+		"description": "",
+		"local":       false,
+		"options": map[string]any{
+			"file_path": logFile.Name(),
+		},
+	}
+
+	_, err = client.Logical().Write("sys/config/auditing/request-headers/x-some-header", map[string]interface{}{
+		"hmac": false,
+	})
+	require.NoError(t, err)
+
+	// User-Agent header is audited by default
+	client.AddHeader("User-Agent", "foo-agent")
+
+	// X-Some-Header has been added to audited headers manually
+	client.AddHeader("X-Some-Header", "some-value")
+
+	// X-Some-Other-Header will not be audited
+	client.AddHeader("X-Some-Other-Header", "some-other-value")
+
+	// Request 1
+	// Enable the audit device. A test probe request will audited along with the associated
+	// to the creation response
+	_, err = client.Logical().Write("sys/audit/"+devicePath, deviceData)
+	require.NoError(t, err)
+
+	// Request 2
+	// Ensure the device has been created.
+	devices, err := client.Sys().ListAudit()
+	require.NoError(t, err)
+	require.Len(t, devices, 1)
+
+	// Request 3
+	resp, err := client.Sys().SealStatus()
+	require.NoError(t, err)
+	require.NotEmpty(t, resp)
+
+	expectedHeaders := map[string]interface{}{
+		"user-agent":    []interface{}{"foo-agent"},
+		"x-some-header": []interface{}{"some-value"},
+	}
+
+	entries := make([]map[string]interface{}, 0)
+	scanner := bufio.NewScanner(logFile)
+
+	for scanner.Scan() {
+		entry := make(map[string]interface{})
+
+		err := json.Unmarshal(scanner.Bytes(), &entry)
+		require.NoError(t, err)
+
+		request := entry["request"].(map[string]interface{})
+
+		// test probe will not have headers set
+		if request["path"].(string) != "sys/audit/test" {
+			headers := request["headers"].(map[string]interface{})
+			require.Equal(t, expectedHeaders, headers)
+
+		}
+
+		entries = append(entries, entry)
+	}
+
+	// This count includes the initial test probe upon creation of the audit device
+	require.Equal(t, 4, len(entries))
+}

--- a/vault/external_tests/audit/audit_test.go
+++ b/vault/external_tests/audit/audit_test.go
@@ -278,7 +278,8 @@ func TestAudit_Headers(t *testing.T) {
 		err := json.Unmarshal(scanner.Bytes(), &entry)
 		require.NoError(t, err)
 
-		request := entry["request"].(map[string]interface{})
+		request, ok := entry["request"].(map[string]interface{})
+		require.True(t, ok)
 
 		// test probe will not have headers set
 		requestPath, ok := request["path"].(string)

--- a/vault/external_tests/audit/audit_test.go
+++ b/vault/external_tests/audit/audit_test.go
@@ -281,10 +281,14 @@ func TestAudit_Headers(t *testing.T) {
 		request := entry["request"].(map[string]interface{})
 
 		// test probe will not have headers set
-		if request["path"].(string) != "sys/audit/test" {
-			headers := request["headers"].(map[string]interface{})
-			require.Equal(t, expectedHeaders, headers)
+		requestPath, ok := request["path"].(string)
+		require.True(t, ok)
 
+		if requestPath != "sys/audit/test" {
+			headers, ok := request["headers"].(map[string]interface{})
+
+			require.True(t, ok)
+			require.Equal(t, expectedHeaders, headers)
 		}
 
 		entries = append(entries, entry)

--- a/vault/external_tests/audit/audit_test.go
+++ b/vault/external_tests/audit/audit_test.go
@@ -52,8 +52,8 @@ func TestAudit_HMACFields(t *testing.T) {
 	require.NoError(t, err)
 
 	// Request 1
-	// Enable the audit device. A test probe request will audited along with the associated
-	// to the creation response
+	// Enable the audit device. A test probe request will audited along
+	// with the associated creation response
 	_, err = client.Logical().Write("sys/audit/"+devicePath, deviceData)
 	require.NoError(t, err)
 
@@ -213,6 +213,9 @@ func TestAudit_HMACFields(t *testing.T) {
 	require.Equal(t, wrapInfo["token"].(string), hashedWrapToken)
 }
 
+// TestAudit_Headers validates that headers are audited correctly. This includes
+// the default headers (x-correlation-id and user-agent) along with user-specified
+// headers.
 func TestAudit_Headers(t *testing.T) {
 	cluster := minimal.NewTestSoloCluster(t, nil)
 	client := cluster.Cores[0].Client
@@ -245,8 +248,8 @@ func TestAudit_Headers(t *testing.T) {
 	client.AddHeader("X-Some-Other-Header", "some-other-value")
 
 	// Request 1
-	// Enable the audit device. A test probe request will audited along with the associated
-	// to the creation response
+	// Enable the audit device. A test probe request will audited along
+	// with the associated creation response
 	_, err = client.Logical().Write("sys/audit/"+devicePath, deviceData)
 	require.NoError(t, err)
 

--- a/website/content/docs/audit/index.mdx
+++ b/website/content/docs/audit/index.mdx
@@ -121,6 +121,10 @@ curl \
     --data '{ "hmac": true }'
 ```
 
+Another way to identify the source of a request is through the User-Agent request header.
+Vault will automatically record this value as `user-agent` within the `headers` of a
+request entry within the audit log.
+
 
 ## Enabling/Disabling audit devices
 


### PR DESCRIPTION
### Description
This PR adds the [User-Agent](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent) as a default header in audit request entries. As with other request headers, this will not be hashed by default. One can override this and choose to HMAC the value via the[ /sys/config/auditing/request-headers/:name](https://developer.hashicorp.com/vault/api-docs/system/config-auditing#create-update-audit-request-header) endpoint.

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [x] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
