### PR TITLE
Dont add the error from validating via issuer signature if the subsequent verification from extraCas succeeds

### DIFF
--- a/changelog/28597.txt
+++ b/changelog/28597.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+auth/cert: When using ocsp_ca_certificates, an error was produced though extra certs validation succeeded.
+```

--- a/sdk/helper/ocsp/client.go
+++ b/sdk/helper/ocsp/client.go
@@ -495,12 +495,11 @@ func validateOCSPParsedResponse(ocspRes *ocsp.Response, subject, issuer *x509.Ce
 			var matchedCA *x509.Certificate
 
 			// Assumption 1 failed, try 2
-			if err := ocspRes.Certificate.CheckSignatureFrom(issuer); err != nil {
+			if sigFromIssuerErr := ocspRes.Certificate.CheckSignatureFrom(issuer); sigFromIssuerErr != nil {
 				// Assumption 2 failed, try 3
-				overallErr = multierror.Append(overallErr, err)
-
 				m, err := verifySignature(ocspRes, extraCas)
 				if err != nil {
+					overallErr = multierror.Append(sigFromIssuerErr, err)
 					overallErr = multierror.Append(overallErr, err)
 				} else {
 					matchedCA = m


### PR DESCRIPTION
### Description
What does this PR do?

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [ ] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.