### PR TITLE
adding logic to handle cloud-init error code 2

### DIFF
--- a/enos/modules/install_packages/scripts/synchronize-repos.sh
+++ b/enos/modules/install_packages/scripts/synchronize-repos.sh
@@ -105,7 +105,7 @@ synchronize_repos() {
 # We run as sudo because Amazon Linux 2 throws Python 2.7 errors when running `cloud-init status` as
 # non-root user (known bug).
 check_cloud_init() {
-  local max_retries=1
+  local max_retries=2
   local retry_count=0
   local exit_code
 

--- a/enos/modules/install_packages/scripts/synchronize-repos.sh
+++ b/enos/modules/install_packages/scripts/synchronize-repos.sh
@@ -105,7 +105,7 @@ synchronize_repos() {
 # We run as sudo because Amazon Linux 2 throws Python 2.7 errors when running `cloud-init status` as
 # non-root user (known bug).
 check_cloud_init() {
-  local max_retries=2
+  local max_retries=1
   local retry_count=0
   local exit_code
 

--- a/enos/modules/install_packages/scripts/synchronize-repos.sh
+++ b/enos/modules/install_packages/scripts/synchronize-repos.sh
@@ -149,4 +149,3 @@ while [ "$(date +%s)" -lt "$end_time" ]; do
 done
 
 fail "Timed out waiting for distro repos to be set up"
-

--- a/enos/modules/install_packages/scripts/synchronize-repos.sh
+++ b/enos/modules/install_packages/scripts/synchronize-repos.sh
@@ -132,7 +132,12 @@ check_cloud_init() {
   return $exit_code
 }
 
+# Checking cloud-init
 check_cloud_init
+if [ $? -eq 1 ]; then
+   exit 1
+fi
+
 begin_time=$(date +%s)
 end_time=$((begin_time + TIMEOUT_SECONDS))
 while [ "$(date +%s)" -lt "$end_time" ]; do

--- a/enos/modules/install_packages/scripts/synchronize-repos.sh
+++ b/enos/modules/install_packages/scripts/synchronize-repos.sh
@@ -105,7 +105,7 @@ synchronize_repos() {
 # We run as sudo because Amazon Linux 2 throws Python 2.7 errors when running `cloud-init status` as
 # non-root user (known bug).
 check_cloud_init() {
-  local max_retries=1
+  local max_retries=0
   local retry_count=0
   local exit_code
 
@@ -133,7 +133,6 @@ check_cloud_init() {
 }
 
 # Checking cloud-init
-echo $?
 check_cloud_init
 if [ $? -eq 1 ]; then
    exit 1
@@ -141,9 +140,7 @@ fi
 
 begin_time=$(date +%s)
 end_time=$((begin_time + TIMEOUT_SECONDS))
-echo "--begin---${begin_time}-----end--${end_time}-----$?"
 while [ "$(date +%s)" -lt "$end_time" ]; do
-  echo "in while loop------"
   if synchronize_repos; then
     exit 0
   fi

--- a/enos/modules/install_packages/scripts/synchronize-repos.sh
+++ b/enos/modules/install_packages/scripts/synchronize-repos.sh
@@ -105,7 +105,7 @@ synchronize_repos() {
 # We run as sudo because Amazon Linux 2 throws Python 2.7 errors when running `cloud-init status` as
 # non-root user (known bug).
 check_cloud_init() {
-  local max_retries=0
+  local max_retries=1
   local retry_count=0
   local exit_code
 

--- a/enos/modules/install_packages/scripts/synchronize-repos.sh
+++ b/enos/modules/install_packages/scripts/synchronize-repos.sh
@@ -107,7 +107,7 @@ synchronize_repos() {
 check_cloud_init() {
   sudo cloud-init status --wait
   exit_code=$?
-  if [ "$?" -ne 0 ] && [ "$?" -ne 2 ]; then
+  if [ "$exit_code" -ne 0 ] && [ "$exit_code" -ne 2 ]; then
     echo "cloud-init did not complete successfully. Exit code: $exit_code" 1>&2
     echo "Here are the logs for the failure:"
     cat /var/log/cloud-init-* | grep "Failed"

--- a/enos/modules/install_packages/scripts/synchronize-repos.sh
+++ b/enos/modules/install_packages/scripts/synchronize-repos.sh
@@ -133,6 +133,7 @@ check_cloud_init() {
 }
 
 # Checking cloud-init
+echo $?
 check_cloud_init
 if [ $? -eq 1 ]; then
    exit 1
@@ -140,7 +141,9 @@ fi
 
 begin_time=$(date +%s)
 end_time=$((begin_time + TIMEOUT_SECONDS))
+echo "--begin---${begin_time}-----end--${end_time}-----$?"
 while [ "$(date +%s)" -lt "$end_time" ]; do
+  echo "in while loop------"
   if synchronize_repos; then
     exit 0
   fi

--- a/enos/modules/install_packages/scripts/synchronize-repos.sh
+++ b/enos/modules/install_packages/scripts/synchronize-repos.sh
@@ -130,7 +130,7 @@ wait_for_cloud_init() {
         cat /var/log/cloud-init-*
       } 1>&2
       return 1
-    ;;
+      ;;
   esac
 }
 

--- a/enos/modules/install_packages/scripts/synchronize-repos.sh
+++ b/enos/modules/install_packages/scripts/synchronize-repos.sh
@@ -104,19 +104,19 @@ synchronize_repos() {
 # so it doesn't race with any of our package installations.
 # We run as sudo because Amazon Linux 2 throws Python 2.7 errors when running `cloud-init status` as
 # non-root user (known bug).
-check_cloud_init() {
+wait_for_cloud_init() {
   sudo cloud-init status --wait
   exit_code=$?
+  # We are not failing exit status 2 because cloud-init is up to date
   if [ "$exit_code" -ne 0 ] && [ "$exit_code" -ne 2 ]; then
     echo "cloud-init did not complete successfully. Exit code: $exit_code" 1>&2
     echo "Here are the logs for the failure:"
-    cat /var/log/cloud-init-* | grep "Failed"
-    exit 1
+    cat /var/log/cloud-init-*
   fi
 }
 
-# Checking cloud-init
-check_cloud_init
+# Wait for cloud-init
+wait_for_cloud_init
 
 # Synchronizing repos
 begin_time=$(date +%s)


### PR DESCRIPTION
### Description
Enos test job handling exit code 2 on ubuntu 24.04 repo sync

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [ ] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
