### PR TITLE
VAULT-28520: Docs describing active node/leadership election timing

### DIFF
--- a/website/content/docs/internals/high-availability.mdx
+++ b/website/content/docs/internals/high-availability.mdx
@@ -49,10 +49,11 @@ network connectivity.
 
 # Becoming an active node
 
-The active node in an HA configuration is the node that holds an HA lock. When a node relinquishes active duty, either
-because it's unavailable or because an operator has invoked [`vault operator step-down`](/vault/docs/commands/operator/step-down),
-all the nodes in the cluster will attempt to grab the HA lock. Only one node will succeed and this node will become the new active
-node.
+Active nodes in an HA configuration holds an HA lock. When active nodes become
+unavailable or step down because an operator invokes 
+[`vault operator step-down`](/vault/docs/commands/operator/step-down), all the 
+nodes in the cluster attempt to grab the HA lock. The first node that succeeds 
+in grabbing and holding the lock becomes the new active node.
 
 The HA lock competition process depends on the HA storage backend of the cluster.
 For example, with raft integrated storage, Vault always gives the HA lock to 

--- a/website/content/docs/internals/high-availability.mdx
+++ b/website/content/docs/internals/high-availability.mdx
@@ -47,7 +47,41 @@ the request, the request is forwarded to the active server. Read-only requests a
 Like traditional HA standbys, a Performance Standby Node becomes the active instance when the active node is sealed, fails, or loses
 network connectivity.
 
-# Tutorial 
+# Becoming an active node
+
+The active node in an HA configuration is the node that holds an HA lock. When a node relinquishes active duty, either
+because it's unavailable or because an operator has invoked [`vault operator step-down`](/vault/docs/commands/operator/step-down),
+all the nodes in the cluster will attempt to grab the HA lock. Only one node will succeed and this node will become the new active
+node.
+
+How the HA lock works is dependent on which HA storage backend the cluster is running. In Integrated Storage, the HA
+lock is always given to the node which wins the [Raft leadership election](/vault/docs/internals/integrated-storage#leadership-elections).
+
+Once a node has grabbed the HA lock it will perform a number of setup steps. The node will:
+* Seal
+* Reload the seal configuration
+* Migrate the seal, if needed
+* Reload keys
+* Create a new HA intra-cluster TLS certificate
+* Write an entry to storage advertising that this node is the active node
+
+Finally, the new active node will unseal and perform its post-unseal setup tasks. In the post-unseal tasks, this new
+active node will support receiving connections from the other nodes in the cluster. Once post-unseal setup completes
+the node will be able to respond to new client requests.
+
+Other standby nodes in the cluster check the leadership storage entry every 2.5 seconds. When a standby node sees that
+there is a new active node, the node will create a new request forwarding connection to that node and attempt to connect
+to it. It’s possible that the connection fails (for example because the active node hasn't yet reached the step where it
+can support receiving standby connections). The standby node will continue trying to connect every 5 seconds as a
+heartbeat. The standby node can accept new client requests at this time, and the node try again to form a connection to
+the active node (if one does not exist) when a client request comes in that needs to be forwarded.
+
+Assuming that performance standbys are enabled, a standby node will attempt to promote itself to a performance standby
+after it has found a new active node. The standby will send a message to the active node and receive from the active
+node a certificate and key pair to use to receive replicated data from the active node. The node will then seal, perform
+setup tasks, and complete its post-unseal setup and then be ready to serve new client requests.
+
+# Tutorial
 
 Refer to the following tutorials to learn more.
 

--- a/website/content/docs/internals/high-availability.mdx
+++ b/website/content/docs/internals/high-availability.mdx
@@ -74,12 +74,12 @@ to formally become the active node for its cluster:
 After completing the inauguration steps, the new active node beings responding to new 
 client requests.
 
-Other standby nodes in the cluster check the leadership storage entry every 2.5 seconds. When a standby node sees that
-there is a new active node, the node will create a new request forwarding connection to that node and attempt to connect
-to it. It’s possible that the connection fails (for example because the active node hasn't yet reached the step where it
-can support receiving standby connections). The standby node will continue trying to connect every 5 seconds as a
-heartbeat. The standby node can accept new client requests at this time, and the node try again to form a connection to
-the active node (if one does not exist) when a client request comes in that needs to be forwarded.
+HA standby nodes check for active node updates every 2.5 seconds. 
+When the active node changes, standby nodes update their forwarding connection
+and open a connection to the new active node. The connection will fail until the
+new active node starts accepting connections from other nodes in the cluster, so
+standby nodes retry the connection every 5 seconds as a heartbeat, or whenever a
+new client request arrives that requires forwarding.
 
 Assuming that performance standbys are enabled, a standby node will attempt to promote itself to a performance standby
 after it has found a new active node. The standby will send a message to the active node and receive from the active

--- a/website/content/docs/internals/high-availability.mdx
+++ b/website/content/docs/internals/high-availability.mdx
@@ -54,8 +54,10 @@ because it's unavailable or because an operator has invoked [`vault operator ste
 all the nodes in the cluster will attempt to grab the HA lock. Only one node will succeed and this node will become the new active
 node.
 
-How the HA lock works is dependent on which HA storage backend the cluster is running. In Integrated Storage, the HA
-lock is always given to the node which wins the [Raft leadership election](/vault/docs/internals/integrated-storage#leadership-elections).
+The HA lock competition process depends on the HA storage backend of the cluster.
+For example, with raft integrated storage, Vault always gives the HA lock to 
+whichever node wins the
+[Raft leadership election](/vault/docs/internals/integrated-storage#leadership-elections).
 
 Once a node has grabbed the HA lock it will perform a number of setup steps. The node will:
 * Seal

--- a/website/content/docs/internals/high-availability.mdx
+++ b/website/content/docs/internals/high-availability.mdx
@@ -59,17 +59,20 @@ For example, with raft integrated storage, Vault always gives the HA lock to
 whichever node wins the
 [Raft leadership election](/vault/docs/internals/integrated-storage#leadership-elections).
 
-Once a node has grabbed the HA lock it will perform a number of setup steps. The node will:
-* Seal
-* Reload the seal configuration
-* Migrate the seal, if needed
-* Reload keys
-* Create a new HA intra-cluster TLS certificate
-* Write an entry to storage advertising that this node is the active node
+After obtaining an HA lock, the node goes through a series of inauguration steps
+to formally become the active node for its cluster:
 
-Finally, the new active node will unseal and perform its post-unseal setup tasks. In the post-unseal tasks, this new
-active node will support receiving connections from the other nodes in the cluster. Once post-unseal setup completes
-the node will be able to respond to new client requests.
+1. Seals the local Vault instance.
+1. Reloads the seal configuration.
+1. Migrates the seal, if needed.
+1. Reloads encryption keys.
+1. Creates a new HA intra-cluster TLS certificate.
+1. Writes an entry to storage advertising its status as the active node.
+1. Unseals the local Vault instance.
+1. Start accepting connections from other nodes in the cluster.
+
+After completing the inauguration steps, the new active node beings responding to new 
+client requests.
 
 Other standby nodes in the cluster check the leadership storage entry every 2.5 seconds. When a standby node sees that
 there is a new active node, the node will create a new request forwarding connection to that node and attempt to connect

--- a/website/content/docs/internals/high-availability.mdx
+++ b/website/content/docs/internals/high-availability.mdx
@@ -81,10 +81,11 @@ new active node starts accepting connections from other nodes in the cluster, so
 standby nodes retry the connection every 5 seconds as a heartbeat, or whenever a
 new client request arrives that requires forwarding.
 
-Assuming that performance standbys are enabled, a standby node will attempt to promote itself to a performance standby
-after it has found a new active node. The standby will send a message to the active node and receive from the active
-node a certificate and key pair to use to receive replicated data from the active node. The node will then seal, perform
-setup tasks, and complete its post-unseal setup and then be ready to serve new client requests.
+With performance replication, standby nodes also promote themselves as
+performance standbys the active node updates. The standby requests a certificate 
+and key pair from the active node to receive replicated data. Once the standby 
+node seals, performs the necessary setup tasks, completes its post-unseal setup,
+it can server serve new client requests with data replicated from the active node.
 
 # Tutorial
 

--- a/website/content/docs/internals/high-availability.mdx
+++ b/website/content/docs/internals/high-availability.mdx
@@ -49,14 +49,14 @@ network connectivity.
 
 # Becoming an active node
 
-Active nodes in an HA configuration holds an HA lock. When active nodes become
-unavailable or step down because an operator invokes 
-[`vault operator step-down`](/vault/docs/commands/operator/step-down), all the 
-nodes in the cluster attempt to grab the HA lock. The first node that succeeds 
+An active node in an HA configuration holds an HA lock. When the active node becomes
+unavailable or steps down because an operator invokes
+[`vault operator step-down`](/vault/docs/commands/operator/step-down), all the
+nodes in the cluster attempt to grab the HA lock. The first node that succeeds
 in grabbing and holding the lock becomes the new active node.
 
 The HA lock competition process depends on the HA storage backend of the cluster.
-For example, with raft integrated storage, Vault always gives the HA lock to 
+For example, with raft integrated storage, Vault always gives the HA lock to
 whichever node wins the
 [Raft leadership election](/vault/docs/internals/integrated-storage#leadership-elections).
 
@@ -72,21 +72,21 @@ to formally become the active node for its cluster:
 1. Unseals the local Vault instance.
 1. Start accepting connections from other nodes in the cluster.
 
-After completing the inauguration steps, the new active node beings responding to new 
+After completing the inauguration steps, the new active node beings responding to new
 client requests.
 
-HA standby nodes check for active node updates every 2.5 seconds. 
+HA standby nodes check for active node updates every 2.5 seconds.
 When the active node changes, standby nodes update their forwarding connection
 and open a connection to the new active node. The connection will fail until the
 new active node starts accepting connections from other nodes in the cluster, so
 standby nodes retry the connection every 5 seconds as a heartbeat, or whenever a
 new client request arrives that requires forwarding.
 
-With performance replication, standby nodes also promote themselves as
-performance standbys the active node updates. The standby requests a certificate 
-and key pair from the active node to receive replicated data. Once the standby 
+With performance standbys enabled, standby nodes also promote themselves as
+performance standbys the active node updates. The standby requests a certificate
+and key pair from the active node to receive replicated data. Once the standby
 node seals, performs the necessary setup tasks, completes its post-unseal setup,
-it can server serve new client requests with data replicated from the active node.
+it can serve new client requests.
 
 # Tutorial
 

--- a/website/content/docs/internals/integrated-storage.mdx
+++ b/website/content/docs/internals/integrated-storage.mdx
@@ -140,25 +140,25 @@ are followers.
 
 ## Leadership elections
 
-Nodes become the active Raft storage node through Raft leadership elections. 
+Nodes become the Raft leader through Raft leadership elections.
 
-All nodes in a Raft cluster start as **followers**. Followers monitor leader 
-health through a **leader heartbeat**. If a follower does not receive a heartbeat 
-within the  configured **heartbeat timeout**, the node becomes a **candidate**. 
-Candidates watch for election notices from other nodes in the cluster. If the 
+All nodes in a Raft cluster start as **followers**. Followers monitor leader
+health through a **leader heartbeat**. If a follower does not receive a heartbeat
+within the  configured **heartbeat timeout**, the node becomes a **candidate**.
+Candidates watch for election notices from other nodes in the cluster. If the
 **election timeout** period expires, the candidate starts an election for
 leader. If the candidate gets responses from a quorum of other nodes in the
 cluster, the candidate becomes the new leader node.
 
-Raft leaders may step down  voluntarily if the node cannot connect to a quorum 
+Raft leaders may step down voluntarily if the node cannot connect to a quorum
 of nodes with the **leader lease timeout** period.
 
-The relevant timeout periods (heartbeat timeout, election timeout, leader lease 
-timeout) scale according to the [`performance_multiplier`](/vault/docs/configuration/storage/raft#performance-multiplier) setting in your Vault configuration. By default, 
+The relevant timeout periods (heartbeat timeout, election timeout, leader lease
+timeout) scale according to the [`performance_multiplier`](/vault/docs/configuration/storage/raft#performance-multiplier) setting in your Vault configuration. By default,
 the `performance_multiplier` is 5, which translates to the following timeout
 values:
 
-Timeout            | Default duration
+Timeout              | Default duration
 -------------------- | ----------------
 Heartbeat timeout    | 5 seconds
 Election timeout     | 5 seconds

--- a/website/content/docs/internals/integrated-storage.mdx
+++ b/website/content/docs/internals/integrated-storage.mdx
@@ -140,13 +140,15 @@ are followers.
 
 ## Leadership elections
 
-A Raft leader is chosen through a Raft leadership election. All nodes in the Raft
-cluster start as followers, wait up to a *heartbeat timeout* duration to receive
-a heartbeat from a leader. If no heartbeat arrives, the node will enter the
-candidate state. The node waits up to the *election timeout* to be informed of
-an election from another node. If the node doesn't hear of an election, it will
-start an election itself. Once the node gets a response from a quorum of other
-nodes, it be elected the leader.
+Nodes become the active Raft storage node through Raft leadership elections. 
+
+All nodes in a Raft cluster start as **followers**. Followers monitor leader 
+health through a **leader heartbeat**. If a follower does not receive a heartbeat 
+within the  configured **heartbeat timeout**, the node becomes a **candidate**. 
+Candidates watch for election notices from other nodes in the cluster. If the 
+**election timeout** period expires, the candidate starts an election for
+leader. If the candidate gets responses from a quorum of other nodes in the
+cluster, the candidate becomes the new leader node.
 
 A Raft leader will also voluntarily step down if it hasn't been able to
 successfully contact a quorum of nodes. The leader will wait the *leader lease

--- a/website/content/docs/internals/integrated-storage.mdx
+++ b/website/content/docs/internals/integrated-storage.mdx
@@ -154,18 +154,21 @@ A Raft leader will also voluntarily step down if it hasn't been able to
 successfully contact a quorum of nodes. The leader will wait the *leader lease
 timeout* before stepping down.
 
-The heartbeat timeout, election timeout, and leader lease timeout can't be
-controlled individually. Rather, they can be scaled by setting the [`performance_multiplier`](/vault/docs/configuration/storage/raft#performance-multiplier),
-which must be an integer between 0 and 10. By default, the `performance_multiplier` is set to 5
- which translates to the following timeout values:
-* Heartbeat timeout: 5 seconds
-* Election timeout: 5 seconds
-* Leader lease timeout: 2.5 seconds
+The relevant timeout periods (heartbeat timeout, election timeout, leader lease 
+timeout) scale according to the [`performance_multiplier`](/vault/docs/configuration/storage/raft#performance-multiplier) setting in your Vault configuration. By default, 
+the `performance_multiplier` is 5, which translates to the following timeout
+values:
 
-The default of 5 is suitable for most platforms and scenarios. You should only
-adjust the timing value when platform telemetry indicators that a change is
-needed or different timing is required due to the overall reliability your
-platform (network, etc.).
+Timeout            | Default duration
+-------------------- | ----------------
+Heartbeat timeout    | 5 seconds
+Election timeout     | 5 seconds
+Leader lease timeout | 2.5 seconds
+
+We recommend using the default multiplier unless one of the following is true:
+
+- Platform telemetry strongly indicates the default behavior is insufficient.
+- The reliability of your platform or network requires different behavior.
 
 ## BoltDB Raft logs
 

--- a/website/content/docs/internals/integrated-storage.mdx
+++ b/website/content/docs/internals/integrated-storage.mdx
@@ -138,6 +138,33 @@ In a [high availability](/vault/docs/internals/high-availability#design-overview
 configuration, the active Vault node is the leader node and all standby nodes
 are followers.
 
+## Leadership elections
+
+A Raft leader is chosen through a Raft leadership election. All nodes in the Raft
+cluster start as followers, wait up to a *heartbeat timeout* duration to receive
+a heartbeat from a leader. If no heartbeat arrives, the node will enter the
+candidate state. The node waits up to the *election timeout* to be informed of
+an election from another node. If the node doesn't hear of an election, it will
+start an election itself. Once the node gets a response from a quorum of other
+nodes, it be elected the leader.
+
+A Raft leader will also voluntarily step down if it hasn't been able to
+successfully contact a quorum of nodes. The leader will wait the *leader lease
+timeout* before stepping down.
+
+The heartbeat timeout, election timeout, and leader lease timeout can't be
+controlled individually. Rather, they can be scaled by setting the [`performance_multiplier`](/vault/docs/configuration/storage/raft#performance-multiplier),
+which must be an integer between 0 and 10. By default, the `performance_multiplier` is set to 5
+ which translates to the following timeout values:
+* Heartbeat timeout: 5 seconds
+* Election timeout: 5 seconds
+* Leader lease timeout: 2.5 seconds
+
+The default of 5 is suitable for most platforms and scenarios. You should only
+adjust the timing value when platform telemetry indicators that a change is
+needed or different timing is required due to the overall reliability your
+platform (network, etc.).
+
 ## BoltDB Raft logs
 
 BoltDB is a single file database, which means BoltDB cannot shrink the file on

--- a/website/content/docs/internals/integrated-storage.mdx
+++ b/website/content/docs/internals/integrated-storage.mdx
@@ -150,9 +150,8 @@ Candidates watch for election notices from other nodes in the cluster. If the
 leader. If the candidate gets responses from a quorum of other nodes in the
 cluster, the candidate becomes the new leader node.
 
-A Raft leader will also voluntarily step down if it hasn't been able to
-successfully contact a quorum of nodes. The leader will wait the *leader lease
-timeout* before stepping down.
+Raft leaders may step down  voluntarily if the node cannot connect to a quorum 
+of nodes with the **leader lease timeout** period.
 
 The relevant timeout periods (heartbeat timeout, election timeout, leader lease 
 timeout) scale according to the [`performance_multiplier`](/vault/docs/configuration/storage/raft#performance-multiplier) setting in your Vault configuration. By default, 


### PR DESCRIPTION
### Description
Adds explanations of the HA active node elections and timing parameters for leadership elections

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [ ] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
