### PR TITLE
Address Deprecation no-a-wth-array-like

### DIFF
--- a/ui/app/components/mfa/mfa-login-enforcement-form.js
+++ b/ui/app/components/mfa/mfa-login-enforcement-form.js
@@ -49,6 +49,7 @@ export default class MfaLoginEnforcementForm extends Component {
     selected: [],
   };
   @tracked authMethods = [];
+  @tracked mfaMethods = [];
   @tracked modelErrors;
 
   constructor() {
@@ -59,6 +60,8 @@ export default class MfaLoginEnforcementForm extends Component {
     this.resetTargetState();
     // only auth method types that have mounts can be selected as targets -- fetch from sys/auth and map by type
     this.fetchAuthMethods();
+    // this.args.model.mfa_methods returns a PromiseManyArray. We need to resolve this before using it in the template.
+    this.fetchMfaMethods();
   }
 
   async flattenTargets() {
@@ -92,6 +95,12 @@ export default class MfaLoginEnforcementForm extends Component {
   async fetchAuthMethods() {
     const mounts = await this.store.findAll('auth-method');
     this.authMethods = mounts.map((auth) => auth.type);
+  }
+
+  async fetchMfaMethods() {
+    // mfa_methods is a PromiseManyArray, because it's fetch via a belongsToRelationship on the. Before it can be accessed on the template we need to resolve it first.
+    // here we set the tracked property mfaMethods to a Promise Array
+    this.mfaMethods = await this.args.model.mfa_methods;
   }
 
   get selectedTarget() {

--- a/ui/app/components/mfa/mfa-login-enforcement-form.js
+++ b/ui/app/components/mfa/mfa-login-enforcement-form.js
@@ -49,8 +49,9 @@ export default class MfaLoginEnforcementForm extends Component {
     selected: [],
   };
   @tracked authMethods = [];
-  @tracked mfaMethods = [];
   @tracked modelErrors;
+
+  mfaMethods = []; // does not change after initial fetch, thus not tracked
 
   constructor() {
     super(...arguments);
@@ -60,7 +61,6 @@ export default class MfaLoginEnforcementForm extends Component {
     this.resetTargetState();
     // only auth method types that have mounts can be selected as targets -- fetch from sys/auth and map by type
     this.fetchAuthMethods();
-    // this.args.model.mfa_methods returns a PromiseManyArray. We need to resolve this before using it in the template.
     this.fetchMfaMethods();
   }
 
@@ -94,7 +94,7 @@ export default class MfaLoginEnforcementForm extends Component {
   }
   async fetchAuthMethods() {
     const mounts = await this.store.findAll('auth-method');
-    this.authMethods = mounts.map((auth) => auth.type);
+    this.authMethods = mounts.map((auth) => auth.type).uniq();
   }
 
   async fetchMfaMethods() {

--- a/ui/app/components/mfa/mfa-login-enforcement-form.js
+++ b/ui/app/components/mfa/mfa-login-enforcement-form.js
@@ -98,8 +98,7 @@ export default class MfaLoginEnforcementForm extends Component {
   }
 
   async fetchMfaMethods() {
-    // mfa_methods is a PromiseManyArray, because it's fetch via a belongsToRelationship on the. Before it can be accessed on the template we need to resolve it first.
-    // here we set the tracked property mfaMethods to a Promise Array
+    // mfa_methods is a hasMany on the model, thus returning a PromiseProxyArray. Before it can be accessed on the template we need to resolve it first.
     this.mfaMethods = await this.args.model.mfa_methods;
   }
 

--- a/ui/app/templates/components/mfa/mfa-login-enforcement-form.hbs
+++ b/ui/app/templates/components/mfa/mfa-login-enforcement-form.hbs
@@ -37,7 +37,7 @@
         <SearchSelect
           @id="methods"
           @placeholder="Type to search for existing MFA methods"
-          @inputValue={{map-by "id" @model.mfa_methods}}
+          @inputValue={{map-by "id" this.mfaMethods}}
           @shouldRenderName={{true}}
           @disallowNewItems={{true}}
           @models={{array "mfa-method"}}

--- a/ui/config/deprecation-workflow.js
+++ b/ui/config/deprecation-workflow.js
@@ -14,7 +14,6 @@ self.deprecationWorkflow.config = {
   workflow: [
     { handler: 'silence', matchId: 'ember-engines.deprecation-router-service-from-host' },
     // ember-data
-    { handler: 'silence', matchId: 'ember-data:no-a-with-array-like' }, // MFA
     { handler: 'silence', matchId: 'ember-data:deprecate-promise-many-array-behaviors' }, // MFA
   ],
 };


### PR DESCRIPTION
### Description
Address Ember data 5 deprecation No A with Array Like—see [here](https://deprecations.emberjs.com/id/ember-data-no-a-with-array-like/).

Running the whole test suite with the flag on, it only showed up in the mfa create enforcements form. 
In the template, we use  `map-to` on the search select, passing in the model property `mfa_methods`. However, `mfa-methods` is a hasMany model property, which means when it's called directly it returns a PromiseManyProxy. I followed the established component pattern of fetching methods in the constructor of the component and setting to a tracked property, resolving this issue. Note: this was also an issue in another use of mfa_methods, resolved [here](https://github.com/hashicorp/vault/pull/25952/files).

- [x] Enterprise test pass
