### PR TITLE
Update Vault PKCS11 Provider docs

### DIFF
--- a/website/content/docs/enterprise/pkcs11-provider/index.mdx
+++ b/website/content/docs/enterprise/pkcs11-provider/index.mdx
@@ -28,11 +28,12 @@ This library works with Vault Enterprise 1.11+ with the advanced data protection
 with the KMIP Secrets Engine.
 
 | Operating System | Architecture | Distribution      | glibc   |
-| ---------------- | -------------| ----------------- | ------- |
+| ---------------- | ------------ | ----------------- | ------- |
 | Linux            | x86-64       | RHEL 7 compatible | 2.17    |
 | Linux            | x86-64       | RHEL 8 compatible | 2.28    |
 | Linux            | x86-64       | RHEL 9 compatible | 2.34    |
 | macOS            | x86-64       | &mdash;           | &mdash; |
+| macOS            | arm64        | &mdash;           | &mdash; |
 
 _Note:_ `vault-pkcs11-provider` runs on _any_ glibc-based Linux distribution. The versions above are given in RHEL-compatible GLIBC versions; for your
 distro's glibc version, choose the `vault-pkcs11-provider` built against the same or older version as what your distro provides.
@@ -429,3 +430,33 @@ Due to the nature of Vault, the KMIP Secrets Engine, and PKCS#11, there are some
 - The object attribute cache is valid only for a single object per session, and will be cleared when another object's attributes are queried.
 - The random number generator function, `C_GenerateRandom`, is currently implemented in software in the library by calling out to Go's [`crypto/rand`](https://pkg.go.dev/crypto/rand) package,
   and does **not** call Vault.
+
+## Changelog
+
+### v0.2.1
+
+ * Go update to 1.22.7 and Go dependency updates
+ * Add license files to artifacts
+
+### v0.2.0
+
+ * Introduced support for RSA and HMAC operations
+
+### v0.1.3
+
+ * Go update to 1.19.4 and Go dependency updates
+ * Added missing checksum for EL9 builds
+
+### v0.1.2
+
+ * Added arm64 support on macOS
+ * Go update to 1.19.2 and Go dependency updates
+
+### v0.1.1
+
+  * KMIP: Set activation date attribute required by Vault 1.12
+  * KMIP: Revoke a key prior to destroy
+
+### v0.1.0
+
+  * Initial release


### PR DESCRIPTION
### Description

 - Add a missing architecture that we have published for a while to the existing table
 - Add a Changelog to the end of the page

### TODO only if you're a HashiCorp employee
- [X] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [ ] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [X] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
