### PR TITLE
ensure the LifetimeWatcher returns an error if renewal fails until the lease expires

### DIFF
--- a/api/lifetime_watcher.go
+++ b/api/lifetime_watcher.go
@@ -315,14 +315,12 @@ func (r *LifetimeWatcher) doRenewWithOptions(tokenMode bool, nonRenewable bool, 
 				// Calculate remaining duration until initial token lease expires
 				remainingLeaseDuration = initialTime.Add(time.Duration(initLeaseDuration) * time.Second).Sub(time.Now())
 				if errorBackoff == nil {
-					errorBackoff = &backoff.ExponentialBackOff{
-						MaxElapsedTime:      remainingLeaseDuration,
-						RandomizationFactor: backoff.DefaultRandomizationFactor,
-						InitialInterval:     initialRetryInterval,
-						MaxInterval:         5 * time.Minute,
-						Multiplier:          2,
-						Clock:               backoff.SystemClock,
-					}
+					errorBackoff = backoff.NewExponentialBackOff(
+						backoff.WithMaxElapsedTime(remainingLeaseDuration),
+						backoff.WithInitialInterval(initialRetryInterval),
+						backoff.WithMaxInterval(5*time.Minute),
+						backoff.WithMultiplier(2),
+					)
 					errorBackoff.Reset()
 				}
 				break

--- a/api/renewer_test.go
+++ b/api/renewer_test.go
@@ -15,6 +15,8 @@ import (
 	"github.com/go-test/deep"
 )
 
+var errRenewFailure = fmt.Errorf("renew failure")
+
 func TestRenewer_NewRenewer(t *testing.T) {
 	t.Parallel()
 
@@ -133,7 +135,7 @@ func TestLifetimeWatcher(t *testing.T) {
 			renew: func(_ string, _ int) (*Secret, error) {
 				if caseOneErrorCount == 0 {
 					caseOneErrorCount++
-					return nil, fmt.Errorf("renew failure")
+					return nil, errRenewFailure
 				}
 				return renewedSecret, nil
 			},
@@ -150,7 +152,7 @@ func TestLifetimeWatcher(t *testing.T) {
 					return renewedSecret, nil
 				}
 				caseManyErrorsCount++
-				return nil, fmt.Errorf("renew failure")
+				return nil, errRenewFailure
 			},
 			expectError:   nil,
 			expectRenewal: true,
@@ -161,9 +163,9 @@ func TestLifetimeWatcher(t *testing.T) {
 			leaseDurationSeconds: 15,
 			incrementSeconds:     15,
 			renew: func(_ string, _ int) (*Secret, error) {
-				return nil, fmt.Errorf("renew failure")
+				return nil, errRenewFailure
 			},
-			expectError:   nil,
+			expectError:   errRenewFailure,
 			expectRenewal: false,
 		},
 		{


### PR DESCRIPTION
### Description
This PR ensures that the LifetimeWatcher returns an error when renewing fails continually until the lease expires.