### PR TITLE
Update Azure SDK logger variable in docs

### DIFF
--- a/website/content/docs/auth/azure.mdx
+++ b/website/content/docs/auth/azure.mdx
@@ -261,7 +261,7 @@ To enable the Azure debug logs, set the following environment variable on the Va
 server:
 
 ```shell
-AZURE_GO_SDK_LOG_LEVEL=DEBUG
+AZURE_SDK_GO_LOGGING=all
 ```
 
 ## Plugin Workload Identity Federation (WIF)

--- a/website/content/docs/secrets/azure.mdx
+++ b/website/content/docs/secrets/azure.mdx
@@ -401,11 +401,11 @@ Azure service principal configured with the same permissions.
 The Azure secret engine plugin supports debug logging which includes additional information
 about requests and responses from the Azure API.
 
-To enable the Azure debug logs, set the `AZURE_GO_SDK_LOG_LEVEL`  environment variable to `DEBUG` on your Vault
+To enable the Azure debug logs, set the `AZURE_SDK_GO_LOGGING`  environment variable to `all` on your Vault
 server:
 
 ```shell
-AZURE_GO_SDK_LOG_LEVEL=DEBUG
+AZURE_SDK_GO_LOGGING=all
 ```
 
 ## Help &amp; support


### PR DESCRIPTION
Update Azure secrets engine docs to use AZURE_SDK_GO_LOGGING for Azure debug

### Description
What does this PR do?

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [ ] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
