### PR TITLE
UI: Add copy button for secret path

### DIFF
--- a/changelog/28629.txt
+++ b/changelog/28629.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: Add button to copy secret path in kv v1 and v2 secrets engines
+```

--- a/ui/app/templates/components/secret-edit.hbs
+++ b/ui/app/templates/components/secret-edit.hbs
@@ -22,6 +22,7 @@
           Edit Secret
         {{else}}
           {{@key.id}}
+          <Hds::Copy::Button @isIconOnly={{true}} @text="Copy your secret path" @textToCopy={{@key.id}} />
         {{/if}}
       </h1>
     </p.levelLeft>

--- a/ui/lib/kv/addon/components/kv-page-header.hbs
+++ b/ui/lib/kv/addon/components/kv-page-header.hbs
@@ -15,6 +15,7 @@
         <span class="tag">version 2</span>
       {{else}}
         {{@pageTitle}}
+        <Hds::Copy::Button @isIconOnly={{true}} @text="Copy your secret path" @textToCopy={{@pageTitle}} />
       {{/if}}
     </h1>
   </p.levelLeft>

--- a/ui/lib/kv/addon/components/kv-page-header.hbs
+++ b/ui/lib/kv/addon/components/kv-page-header.hbs
@@ -13,9 +13,11 @@
         <Icon @name="key-values" @size="24" class="has-text-grey-light" />
         {{@mountName}}
         <span class="tag">version 2</span>
+      {{else if @secretPath}}
+        {{@secretPath}}
+        <Hds::Copy::Button @isIconOnly={{true}} @text="Copy your secret path" @textToCopy={{@secretPath}} />
       {{else}}
         {{@pageTitle}}
-        <Hds::Copy::Button @isIconOnly={{true}} @text="Copy your secret path" @textToCopy={{@pageTitle}} />
       {{/if}}
     </h1>
   </p.levelLeft>
@@ -36,7 +38,7 @@
 {{/if}}
 
 {{#if (or (has-block "toolbarFilters") (has-block "toolbarActions"))}}
-  <Toolbar aria-label="menu items for managing {{or @mountName @pageTitle}}">
+  <Toolbar aria-label="menu items for managing {{or @mountName @secretPath @pageTitle}}">
     <ToolbarFilters aria-label="filters for secrets list">
       {{yield to="toolbarFilters"}}
     </ToolbarFilters>

--- a/ui/lib/kv/addon/components/page/secret/details.hbs
+++ b/ui/lib/kv/addon/components/page/secret/details.hbs
@@ -3,7 +3,7 @@
   SPDX-License-Identifier: BUSL-1.1
 ~}}
 
-<KvPageHeader @breadcrumbs={{@breadcrumbs}} @pageTitle={{@path}}>
+<KvPageHeader @breadcrumbs={{@breadcrumbs}} @secretPath={{@path}}>
   <:syncDetails>
     {{#if this.syncStatus}}
       <Hds::Alert data-test-sync-alert @type="inline" class="has-top-margin-s has-bottom-margin-m" @color="neutral" as |A|>

--- a/ui/lib/kv/addon/components/page/secret/metadata/details.hbs
+++ b/ui/lib/kv/addon/components/page/secret/metadata/details.hbs
@@ -3,7 +3,7 @@
   SPDX-License-Identifier: BUSL-1.1
 ~}}
 
-<KvPageHeader @breadcrumbs={{@breadcrumbs}} @pageTitle={{@path}}>
+<KvPageHeader @breadcrumbs={{@breadcrumbs}} @secretPath={{@path}}>
   <:tabLinks>
     <li>
       <LinkTo @route="secret.index" @models={{array @backend @path}} data-test-secrets-tab="Overview">Overview</LinkTo>

--- a/ui/lib/kv/addon/components/page/secret/metadata/version-history.hbs
+++ b/ui/lib/kv/addon/components/page/secret/metadata/version-history.hbs
@@ -3,7 +3,7 @@
   SPDX-License-Identifier: BUSL-1.1
 ~}}
 
-<KvPageHeader @breadcrumbs={{@breadcrumbs}} @pageTitle={{@path}}>
+<KvPageHeader @breadcrumbs={{@breadcrumbs}} @secretPath={{@path}}>
   <:tabLinks>
     <li>
       <LinkTo @route="secret.index" @models={{array @backend @path}} data-test-secrets-tab="Overview">Overview</LinkTo>

--- a/ui/lib/kv/addon/components/page/secret/overview.hbs
+++ b/ui/lib/kv/addon/components/page/secret/overview.hbs
@@ -3,7 +3,7 @@
   SPDX-License-Identifier: BUSL-1.1
 ~}}
 
-<KvPageHeader @breadcrumbs={{@breadcrumbs}} @pageTitle={{@path}}>
+<KvPageHeader @breadcrumbs={{@breadcrumbs}} @secretPath={{@path}}>
   <:tabLinks>
     <li>
       <LinkTo @route="secret.index" @models={{array @backend @path}} data-test-secrets-tab="Overview">Overview</LinkTo>

--- a/ui/lib/kv/addon/components/page/secret/paths.hbs
+++ b/ui/lib/kv/addon/components/page/secret/paths.hbs
@@ -3,7 +3,7 @@
   SPDX-License-Identifier: BUSL-1.1
 ~}}
 
-<KvPageHeader @breadcrumbs={{@breadcrumbs}} @pageTitle={{@path}}>
+<KvPageHeader @breadcrumbs={{@breadcrumbs}} @secretPath={{@path}}>
   <:tabLinks>
     <li>
       <LinkTo @route="secret.index" @models={{array @backend @path}} data-test-secrets-tab="Overview">Overview</LinkTo>

--- a/ui/tests/integration/components/kv/kv-page-header-test.js
+++ b/ui/tests/integration/components/kv/kv-page-header-test.js
@@ -54,13 +54,22 @@ module('Integration | Component | kv | kv-page-header', function (hooks) {
       .exists('final breadcrumb renders and it is not a link.');
   });
 
-  test('it renders a custom title for a non engine view', async function (assert) {
+  test('it renders a custom title for @pageTitle', async function (assert) {
     assert.expect(2);
     await render(hbs`<KvPageHeader @breadcrumbs={{this.breadcrumbs}} @pageTitle="Create new version"/>`, {
       owner: this.engine,
     });
     assert.dom('[data-test-header-title]').hasText('Create new version', 'displays custom title.');
     assert.dom('[data-test-header-title] svg').doesNotExist('Does not show icon if not at engine level.');
+  });
+
+  test('it renders a title and copy button for @secretPath', async function (assert) {
+    await render(hbs`<KvPageHeader @breadcrumbs={{this.breadcrumbs}} @secretPath="my/secret/path"/>`, {
+      owner: this.engine,
+    });
+    assert.dom('[data-test-header-title]').hasText('my/secret/path', 'displays path');
+    assert.dom('[data-test-header-title] button').exists('renders copy button for path');
+    assert.dom('[data-test-icon="clipboard-copy"]').exists('renders copy icon');
   });
 
   test('it renders a title, icon and tag if engine view', async function (assert) {


### PR DESCRIPTION
### Description
Adds a copy button for secret paths in both kv v2 and v1 secrets engines
<img width="1119" alt="Screenshot 2024-10-08 at 10 14 49 AM" src="https://github.com/user-attachments/assets/7d36c80c-77a8-4a9c-9630-5cdceffc3b18">

<img width="533" alt="Screenshot 2024-10-08 at 10 15 11 AM" src="https://github.com/user-attachments/assets/1e434da7-6cd8-4329-bd87-287fbec90d79">



### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [ ] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
