### PR TITLE
[Docs] Add a missing parameter

### DIFF
--- a/website/content/docs/configuration/replication.mdx
+++ b/website/content/docs/configuration/replication.mdx
@@ -46,6 +46,11 @@ replication {
   time to see the resulting WAL present locally before returning a response to the client.
 - `allow_forwarding_via_token` `(string: "")` - When set to `new_token`, requests sent to non-active nodes
   are forwarded if the node does not yet have the token information in storage.
-- `replication_canary_write_interval_seconds` `(integer: 1)` - Interval in seconds between writes of the replication canary to the storage on the primary cluster.  Set to 0 to disable the canary.  See the page on [/vault/docs/enterprise/consistency#clock-skew-and-replication-lag](consistency) for details on the canary.
+- `replication_canary_write_interval_seconds` `(integer: 1)` - Interval in
+  seconds between writes of the replication canary to the storage on the primary
+  cluster. Set to 0 to disable the canary. Refer to the [Clock skew and
+  replication
+  lag](/vault/docs/enterprise/consistency#clock-skew-and-replication-lag) page
+  for details on the canary.
 
 Support for Server Side Consistent Tokens is now available. Refer to the [Server Side Consistent Token FAQ](/vault/docs/faq/ssct) for details.

--- a/website/content/docs/configuration/replication.mdx
+++ b/website/content/docs/configuration/replication.mdx
@@ -46,5 +46,9 @@ replication {
   time to see the resulting WAL present locally before returning a response to the client.
 - `allow_forwarding_via_token` `(string: "")` - When set to `new_token`, requests sent to non-active nodes
   are forwarded if the node does not yet have the token information in storage.
+- `replication_canary_write_interval_seconds` `(integer: 1)` - Enable monitoring
+  of the replication latency between the secondary cluster from its primary. It
+  publishes the value as `replication_lag` field when you invoke the replication
+  status endpoint. 
 
 Support for Server Side Consistent Tokens is now available. Refer to the [Server Side Consistent Token FAQ](/vault/docs/faq/ssct) for details.

--- a/website/content/docs/configuration/replication.mdx
+++ b/website/content/docs/configuration/replication.mdx
@@ -46,9 +46,6 @@ replication {
   time to see the resulting WAL present locally before returning a response to the client.
 - `allow_forwarding_via_token` `(string: "")` - When set to `new_token`, requests sent to non-active nodes
   are forwarded if the node does not yet have the token information in storage.
-- `replication_canary_write_interval_seconds` `(integer: 1)` - Enable monitoring
-  of the replication latency between the secondary cluster from its primary. It
-  publishes the value as `replication_lag` field when you invoke the replication
-  status endpoint. 
+- `replication_canary_write_interval_seconds` `(integer: 1)` - Interval in seconds between writes of the replication canary to the storage on the primary cluster.  Set to 0 to disable the canary.  See the page on [/vault/docs/enterprise/consistency#clock-skew-and-replication-lag](consistency) for details on the canary.
 
 Support for Server Side Consistent Tokens is now available. Refer to the [Server Side Consistent Token FAQ](/vault/docs/faq/ssct) for details.


### PR DESCRIPTION
### Description

🧵 [Slack thread](https://hashicorp.slack.com/archives/C012RTGJR1V/p1728322182350659)

🔍 [Deploy preview](https://vault-git-docs-add-ent-rep-parameter-hashicorp.vercel.app/vault/docs/configuration/replication)

It was reported that the [replication config doc](https://developer.hashicorp.com/vault/docs/configuration/replication) does not mention `replication_canary_write_interval_seconds`.

This PR adds the parameter to the doc page.


### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [ ] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
