### PR TITLE
Update buf to 1.45.0

### DIFF
--- a/.github/actions/install-external-tools/action.yml
+++ b/.github/actions/install-external-tools/action.yml
@@ -13,7 +13,7 @@ runs:
   steps:
     - uses: ./.github/actions/set-up-buf
       with:
-        version: v1.25.0 # This should match the version in tools/tool.sh
+        version: v1.45.0 # This should match the version in tools/tool.sh
     - uses: ./.github/actions/set-up-gofumpt
     - uses: ./.github/actions/set-up-gosimports
     - uses: ./.github/actions/set-up-gotestsum

--- a/tools/tools.sh
+++ b/tools/tools.sh
@@ -38,7 +38,7 @@ install_external() {
   #
   tools=(
     honnef.co/go/tools/cmd/staticcheck@latest
-    github.com/bufbuild/buf/cmd/buf@v1.25.0
+    github.com/bufbuild/buf/cmd/buf@v1.45.0
     github.com/favadi/protoc-go-inject-tag@latest
     github.com/golangci/misspell/cmd/misspell@latest
     github.com/golangci/revgrep/cmd/revgrep@latest


### PR DESCRIPTION
### Description

Update our version of buf to the latest 1.45.0 as version 1.25.0 has fallen off the first page of the `gh list` causing builds to fail. 

I imagine this will require an additional run of something, but let CI figure that out for me.

### TODO only if you're a HashiCorp employee
- [X] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [ ] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
