### PR TITLE
Update index.mdx

### DIFF
--- a/website/content/docs/auth/jwt/index.mdx
+++ b/website/content/docs/auth/jwt/index.mdx
@@ -282,7 +282,7 @@ management tool.
 
    ```text
    $ vault write auth/jwt/config \
-       oidc_discovery_url="https://myco.auth0.com/" \
+       oidc_discovery_url="https://myco.auth0.com" \
        oidc_client_id="m5i8bj3iofytj" \
        oidc_client_secret="f4ubv72nfiu23hnsj" \
        default_role="demo"
@@ -292,7 +292,7 @@ management tool.
 
    ```text
    $ vault write auth/jwt/config \
-      oidc_discovery_url="https://MYDOMAIN.eu.auth0.com/" \
+      oidc_discovery_url="https://MYDOMAIN.eu.auth0.com" \
       oidc_client_id="" \
       oidc_client_secret="" \
   ```


### PR DESCRIPTION
The way it is currently written:

oidc_discovery_url="https://myco.auth0.com/"

with the forwarding slash after .com

it results to an error:

error checking oidc discovery URL

Screenshot attached:

<img width="853" alt="image" src="https://github.com/user-attachments/assets/a2a22560-59f7-4765-a480-ec5443ac3ef3">


`❯ vault write auth/jwt/config \
    oidc_discovery_url="https://dev-95068473.okta.com/" \
    oidc_client_id="0oak9ga7dmYT2a68H5d7" \
    oidc_client_secret="XZwCdCHq-8x34EU3o5DA4Gnpw0SnbJ_nqYymJqpr8wQkqJDzE3wLTNsy3Qwv0503" \
    default_role="demo"
Error writing data to auth/jwt/config: Error making API request.

URL: PUT http://127.0.0.1:8200/v1/auth/jwt/config
Code: 400. Errors:

* error checking oidc discovery URL
❯ vault write auth/jwt/config \
    oidc_discovery_url="https://dev-95068473.okta.com" \
    oidc_client_id="0oak9ga7dmYT2a68H5d7" \
    oidc_client_secret="XZwCdCHq-8x34EU3o5DA4Gnpw0SnbJ_nqYymJqpr8wQkqJDzE3wLTNsy3Qwv0503" \
    default_role="demo"
Success! Data written to: auth/jwt/config`

### Description
What does this PR do?

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [ ] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
