### PR TITLE
Ember data remove deprecation Ember Promise Many Array behaviors

### DIFF
--- a/ui/app/controllers/vault/cluster/access/mfa/methods/create.js
+++ b/ui/app/controllers/vault/cluster/access/mfa/methods/create.js
@@ -96,8 +96,9 @@ export default class MfaMethodCreateController extends Controller {
         // first save method
         yield this.method.save();
         if (this.enforcement) {
-          // mfa_methods is type PromiseManyArray so slice in necessary to convert it to an Array
-          this.enforcement.mfa_methods = addToArray(this.enforcement.mfa_methods.slice(), this.method);
+          // mfa_methods is type PromiseManyArray. Array methods like slice are no longer allowed on PromiseManyArray. We must yield the promise first, then call the method.
+          const mfaMethods = yield this.enforcement.mfa_methods;
+          this.enforcement.mfa_methods = addToArray(mfaMethods.slice(), this.method);
           try {
             // now save enforcement and catch error separately
             yield this.enforcement.save();

--- a/ui/config/deprecation-workflow.js
+++ b/ui/config/deprecation-workflow.js
@@ -11,8 +11,5 @@ self.deprecationWorkflow.config = {
 
 self.deprecationWorkflow.config = {
   // current output from deprecationWorkflow.flushDeprecations();
-  workflow: [
-    // ember-data
-    { handler: 'silence', matchId: 'ember-data:deprecate-promise-many-array-behaviors' }, // MFA
-  ],
+  workflow: [],
 };


### PR DESCRIPTION
### Description
Removes any of the no longer supported methods on PromiseManyArray's. There was only one remaining use case left—we we're using slice() in an MFA methods workflow.

[Here](https://deprecations.emberjs.com/id/ember-data-deprecate-promise-many-array-behaviors/) are the deprecation notes
[Here](https://rfcs.emberjs.com/id/0745-ember-data-deprecate-methods-on-promise-many-array/) is an RFC mentioning that `slice()` is no longer supported.

- [x] Ent tests pass (I ran with the throw flag).

