### PR TITLE
Fix data race around static secret capability manager

### DIFF
--- a/command/agentproxyshared/cache/static_secret_capability_manager.go
+++ b/command/agentproxyshared/cache/static_secret_capability_manager.go
@@ -144,8 +144,8 @@ func (sscm *StaticSecretCapabilityManager) StartRenewingCapabilities(indexToRene
 		capabilitiesIndex.IndexLock.RLock()
 		token := capabilitiesIndex.Token
 		indexReadablePathsMap := capabilitiesIndex.ReadablePaths
-		capabilitiesIndex.IndexLock.RUnlock()
 		indexReadablePaths := maps.Keys(indexReadablePathsMap)
+		capabilitiesIndex.IndexLock.RUnlock()
 
 		client, err := sscm.client.Clone()
 		if err != nil {

--- a/command/agentproxyshared/cache/static_secret_capability_manager.go
+++ b/command/agentproxyshared/cache/static_secret_capability_manager.go
@@ -143,9 +143,11 @@ func (sscm *StaticSecretCapabilityManager) StartRenewingCapabilities(indexToRene
 
 		capabilitiesIndex.IndexLock.RLock()
 		token := capabilitiesIndex.Token
-		indexReadablePathsMap := capabilitiesIndex.ReadablePaths
-		indexReadablePaths := maps.Keys(indexReadablePathsMap)
+		indexReadablePathsMap := map[string]struct{}{}
+		maps.Copy(indexReadablePathsMap, capabilitiesIndex.ReadablePaths)
 		capabilitiesIndex.IndexLock.RUnlock()
+
+		indexReadablePaths := maps.Keys(indexReadablePathsMap)
 
 		client, err := sscm.client.Clone()
 		if err != nil {


### PR DESCRIPTION
### Description

Needed to copy the map behind the locking.

```
WARNING: DATA RACE
Write at 0x00c01a2f3470 by goroutine 86930:
  runtime.mapassign_faststr()
      /home/runner/actions-runner/_work/_tool/go/1.22.7/x64/src/runtime/map_faststr.go:203 +0x0
  github.com/hashicorp/vault/command/agentproxyshared/cache.(*LeaseCache).storeStaticSecretIndex()
      /home/runner/actions-runner/_work/vault-enterprise/vault-enterprise/command/agentproxyshared/cache/lease_cache.go:801 +0x5e4
  github.com/hashicorp/vault/command/agentproxyshared/cache.(*LeaseCache).cacheStaticSecret()
      /home/runner/actions-runner/_work/vault-enterprise/vault-enterprise/command/agentproxyshared/cache/lease_cache.go:696 +0x145e
  github.com/hashicorp/vault/command/agentproxyshared/cache.(*LeaseCache).Send()
      /home/runner/actions-runner/_work/vault-enterprise/vault-enterprise/command/agentproxyshared/cache/lease_cache.go:502 +0x22d6
  github.com/hashicorp/vault/command.(*ProxyCommand).Run.ProxyHandler.func13()
      /home/runner/actions-runner/_work/vault-enterprise/vault-enterprise/command/agentproxyshared/cache/handler.go:63 +0x5e5
  net/http.HandlerFunc.ServeHTTP()
      /home/runner/actions-runner/_work/_tool/go/1.22.7/x64/src/net/http/server.go:2171 +0x47
  net/http.(*ServeMux).ServeHTTP()
      /home/runner/actions-runner/_work/_tool/go/1.22.7/x64/src/net/http/server.go:2688 +0x1ef
  net/http.serverHandler.ServeHTTP()
      /home/runner/actions-runner/_work/_tool/go/1.22.7/x64/src/net/http/server.go:3142 +0x2a1
  net/http.(*conn).serve()
      /home/runner/actions-runner/_work/_tool/go/1.22.7/x64/src/net/http/server.go:2044 +0x13c4
  net/http.(*Server).Serve.gowrap3()
      /home/runner/actions-runner/_work/_tool/go/1.22.7/x64/src/net/http/server.go:3290 +0x4f

Previous read at 0x00c01a2f3470 by goroutine 87090:
  golang.org/x/exp/maps.Keys[go.shape.map[string]struct {},go.shape.string,go.shape.struct {}]()
      /home/runner/go/pkg/mod/golang.org/x/exp@v0.0.0-20240904232852-e7e105dedf7e/maps/maps.go:11 +0x27b
  github.com/hashicorp/vault/command/agentproxyshared/cache.(*StaticSecretCapabilityManager).StartRenewingCapabilities.func1()
      /home/runner/actions-runner/_work/vault-enterprise/vault-enterprise/command/agentproxyshared/cache/static_secret_capability_manager.go:148 +0x305
  github.com/gammazero/workerpool.worker()
      /home/runner/go/pkg/mod/github.com/gammazero/workerpool@v1.1.3/workerpool.go:237 +0x35
  github.com/gammazero/workerpool.(*WorkerPool).dispatch.gowrap2()
      /home/runner/go/pkg/mod/github.com/gammazero/workerpool@v1.1.3/workerpool.go:197 +0x4f
```

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [x] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
