### PR TITLE
docs/vso: hvs rotating and dynamic secrets

### DIFF
--- a/website/content/docs/platform/k8s/vso/secret-transformation.mdx
+++ b/website/content/docs/platform/k8s/vso/secret-transformation.mdx
@@ -235,6 +235,30 @@ b64dec "aG9zdAo=" -> `host`
 get .Secrets "baz" -> `qux`
 ```
 
+Given a nested `map` input:
+
+```json
+{
+  "foo": {
+    "bar": "baz",
+    "quz": "quux"
+  }
+}
+```
+
+`get` can retrieve a specific value:
+```
+get (get .Secrets "foo") "bar" -> `baz`
+```
+
+`dig` can also retrieve a specific value, or return a default if any of the keys
+are not found:
+```
+dig "foo" "quz" "<not found>" .Secrets -> `quux`
+
+dig "foo" "nux" "<not found>" .Secrets -> `<not found>`
+```
+
 ## Related API references
 
 - [Transformation](/vault/docs/platform/k8s/vso/api-reference#transformation)

--- a/website/content/docs/platform/k8s/vso/sources/hvs.mdx
+++ b/website/content/docs/platform/k8s/vso/sources/hvs.mdx
@@ -22,6 +22,8 @@ changes to the secret source are properly reflected in the Kubernetes secret.
 - Supports all VSO features, including rollout-restarts on secret rotation or
   during drift remediation.
 - Supports authentication to HCP using [HCP service principals](/hcp/docs/hcp/admin/iam/service-principals).
+- Supports [static](#static-secrets), [auto-rotating and dynamic secrets](#auto-rotating-and-dynamic-secrets)
+  within an HCP Vault Secrets app.
 
 
 ### Supported HCP authentication methods
@@ -73,6 +75,58 @@ spec:
     name: vso-app-secret
 ```
 
+### Static Secrets
+
+VSO supports syncing [static secrets](/hcp/docs/vault-secrets/static-secrets/create-static-secret)
+from an HCP Vault Secrets app to a Kubernetes Secret. VSO syncs the secrets to
+Kubernetes on the [refreshAfter][hvsa-spec] interval set in the
+HCPVaultSecretsApp spec.
+
+### Auto-rotating and Dynamic Secrets
+
+<Tip title="Feature availability">
+
+  VSO v0.9.0
+
+</Tip>
+
+VSO also supports syncing [auto-rotating](/hcp/docs/vault-secrets/auto-rotation)
+and [dynamic](/hcp/docs/vault-secrets/dynamic-secrets) secrets from an HCP Vault
+Secrets app to a Kubernetes Secret.
+
+VSO syncs auto-rotating secrets along with static secrets on the
+[refreshAfter][hvsa-spec] interval, and rotation is handled by HCP. VSO
+syncs dynamic secrets when the [specified percentage](/vault/docs/platform/k8s/vso/api-reference#hvsdynamicsyncconfig)
+of their TTL has elapsed. Each sync of a dynamic secret generates a new set of
+credentials.
+
+An auto-rotating or dynamic secret can have multiple key-value pairs, which
+are rendered in the destination Kubernetes Secret as both a nested map and
+flattened key-value pairs. For example:
+
+```yaml
+apiVersion: v1
+kind: Secret
+data:
+  secret_name: {"key_one": "value_one", "key_two": "value_two"}
+  secret_name_key_one: "value_one"
+  secret_name_key_two: "value_two"
+...
+```
+
+Transformation [template commands like `get` and `dig`](/vault/docs/platform/k8s/vso/secret-transformation#map-functions)
+in the HCPVaultSecretsApp Destination can be used to extract values from the
+nested map format:
+
+```yaml
+    transformation:
+      templates:
+        secret_one:
+          text: '{{- get (get .Secrets "secret_name") "key_one" -}}'
+        secret_two:
+          text: '{{- dig "secret_name" "key_two" "<missing>" .Secrets -}}'
+```
+
 @include 'vso/blurb-api-reference.mdx'
 
 ## Tutorial
@@ -80,3 +134,5 @@ spec:
 Refer to the [HCP Vault Secrets with Vault Secrets Operator for
 Kubernetes](/vault/tutorials/hcp-vault-secrets-get-started/kubernetes-vso) tutorial to
 learn the end-to-end workflow using the Vault Secrets Operator.
+
+[hvsa-spec]: /vault/docs/platform/k8s/vso/api-reference#hcpvaultsecretsappspec

--- a/website/content/docs/platform/k8s/vso/sources/hvs.mdx
+++ b/website/content/docs/platform/k8s/vso/sources/hvs.mdx
@@ -79,8 +79,8 @@ spec:
 
 VSO supports syncing [static secrets](/hcp/docs/vault-secrets/static-secrets/create-static-secret)
 from an HCP Vault Secrets app to a Kubernetes Secret. VSO syncs the secrets to
-Kubernetes on the [refreshAfter][hvsa-spec] interval set in the
-HCPVaultSecretsApp spec.
+Kubernetes on the [refreshAfter](/vault/docs/platform/k8s/vso/api-reference#hcpvaultsecretsappspec)
+interval set in the HCPVaultSecretsApp spec.
 
 ### Auto-rotating and Dynamic Secrets
 
@@ -95,8 +95,9 @@ and [dynamic](/hcp/docs/vault-secrets/dynamic-secrets) secrets from an HCP Vault
 Secrets app to a Kubernetes Secret.
 
 VSO syncs auto-rotating secrets along with static secrets on the
-[refreshAfter][hvsa-spec] interval, and rotation is handled by HCP. VSO
-syncs dynamic secrets when the [specified percentage](/vault/docs/platform/k8s/vso/api-reference#hvsdynamicsyncconfig)
+[refreshAfter](/vault/docs/platform/k8s/vso/api-reference#hcpvaultsecretsappspec)
+interval, and rotation is handled by HCP. VSO syncs dynamic secrets when the
+[specified percentage](/vault/docs/platform/k8s/vso/api-reference#hvsdynamicsyncconfig)
 of their TTL has elapsed. Each sync of a dynamic secret generates a new set of
 credentials.
 
@@ -134,5 +135,3 @@ nested map format:
 Refer to the [HCP Vault Secrets with Vault Secrets Operator for
 Kubernetes](/vault/tutorials/hcp-vault-secrets-get-started/kubernetes-vso) tutorial to
 learn the end-to-end workflow using the Vault Secrets Operator.
-
-[hvsa-spec]: /vault/docs/platform/k8s/vso/api-reference#hcpvaultsecretsappspec


### PR DESCRIPTION
### Description
Documents usage of HVS rotating and dynamic secrets with VSO, part of VSO v0.9.0.

Preview links:
* https://vault-git-docs-vault-30504vault-30502vso-hvs-r-0297a3-hashicorp.vercel.app/vault/docs/platform/k8s/vso/sources/hvs
* https://vault-git-docs-vault-30504vault-30502vso-hvs-r-0297a3-hashicorp.vercel.app/vault/docs/platform/k8s/vso/secret-transformation#map-functions

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [-] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [-] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [-] **RFC:** If this change has an associated RFC, please link it in the description.
- [-] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
