### PR TITLE
Tweak the ocsp_ca_certificate param docs to be more clear about what kind of cert it wants

### DIFF
--- a/website/content/api-docs/auth/cert.mdx
+++ b/website/content/api-docs/auth/cert.mdx
@@ -69,7 +69,7 @@ Sets a CA cert and associated parameters in a role name.
   by a dash (-) instead of a dot (.) to allow usage in ACL templates.
 - `ocsp_enabled` `(bool: false)` - If enabled, validate certificates' revocation
   status using OCSP.
-- `ocsp_ca_certificates` `(string: "")` Any additional CA certificates needed to
+- `ocsp_ca_certificates` `(string: "")` Any additional OCSP responder certificates needed to
   verify OCSP responses.  Provided as base64 encoded PEM data.
 - `ocsp_servers_override` `(array: [])`: A comma-separated list of OCSP server
   addresses.  If unset, the OCSP server is determined from the AuthorityInformationAccess


### PR DESCRIPTION
### Description
What does this PR do?

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [ ] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.