### PR TITLE
Prevent node activation while Vault initialization is in progress

### DIFF
--- a/vault/init.go
+++ b/vault/init.go
@@ -319,6 +319,14 @@ func (c *Core) Initialize(ctx context.Context, initParams *InitParams) (*InitRes
 		SecretShares: [][]byte{},
 	}
 
+	// Write an entry to storage to indicate that initialization is in progress.
+	// It is used to prevent that nodes use stored keys to unseal while initialization
+	// is still in progress. This can happen when using the Consul backend (maybe others?).
+	if err := c.seal.SetInitializationFlag(ctx); err != nil {
+		c.logger.Error("failed to write initialization flag to storage", "error", err)
+		return nil, fmt.Errorf("failed to write initialization flag to storage: %w", err)
+	}
+
 	// If we are storing shares, pop them out of the returned results and push
 	// them through the seal
 	switch c.seal.StoredKeysSupported() {
@@ -419,6 +427,11 @@ func (c *Core) Initialize(ctx context.Context, initParams *InitParams) (*InitRes
 		return nil, err
 	}
 
+	if err := c.seal.ClearInitializationFlag(ctx); err != nil {
+		c.logger.Error("Error clearing initialization flag", "error", err)
+		return nil, fmt.Errorf("error clearing initialization flag: %w", err)
+	}
+
 	if c.serviceRegistration != nil {
 		if err := c.serviceRegistration.NotifyInitializedStateChange(true); err != nil {
 			if c.logger.IsWarn() {
@@ -461,6 +474,16 @@ func (c *Core) UnsealWithStoredKeys(ctx context.Context) error {
 	keys, err := c.seal.GetStoredKeys(ctx)
 	if err != nil {
 		return NewNonFatalError(fmt.Errorf("fetching stored unseal keys failed: %w", err))
+	}
+
+	// Check whether Vault initialization is still in progress. If it is is, then
+	// bail out to give it a chance to complete.
+	isInitializing, err := c.seal.IsInitializationFlagSet(ctx)
+	if err != nil {
+		return NewNonFatalError(fmt.Errorf("fetching seal initialization flag failed: %w", err))
+	}
+	if isInitializing {
+		return NewNonFatalError(errors.New("stored unseal keys found, but flag indicates Vault initialization is still in progress"))
 	}
 
 	// This usually happens when auto-unseal is configured, but the servers have

--- a/vault/seal_autoseal.go
+++ b/vault/seal_autoseal.go
@@ -118,6 +118,18 @@ func (d *autoSeal) SetStoredKeys(ctx context.Context, keys [][]byte) error {
 	return writeStoredKeys(ctx, d.core.physical, d.Access, keys)
 }
 
+func (d *autoSeal) SetInitializationFlag(ctx context.Context) error {
+	return writeInitializationFlag(ctx, d.core.physical, true)
+}
+
+func (d *autoSeal) ClearInitializationFlag(ctx context.Context) error {
+	return writeInitializationFlag(ctx, d.core.physical, false)
+}
+
+func (d *autoSeal) IsInitializationFlagSet(ctx context.Context) (bool, error) {
+	return isInitializationFlagSet(ctx, d.core.physical)
+}
+
 // GetStoredKeys retrieves the key shares by unwrapping the encrypted key using the
 // autoseal.
 func (d *autoSeal) GetStoredKeys(ctx context.Context) ([][]byte, error) {


### PR DESCRIPTION
### Description
Prevent node activation while Vault initialization is in progress.

Store a value to storage to signal that initialization is in progress. Look for this entry when trying to unseal using stored keys, and bail out if the entry is found.

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [ ] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [X] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
