### PR TITLE
Adds ACME specific error types to errors returned by challenge validation functions.

### DIFF
--- a/builtin/logical/pki/acme_errors.go
+++ b/builtin/logical/pki/acme_errors.go
@@ -142,8 +142,7 @@ func (e *ErrorResponse) Marshal() (*logical.Response, error) {
 	return &resp, nil
 }
 
-func FindType(given error) (err error, id string, code int, found bool) {
-	matchedError := false
+func FindType(given error) (err error, id string, code int, matchedError bool) {
 	for err, id = range errIdMappings {
 		if errors.Is(given, err) {
 			matchedError = true

--- a/builtin/logical/pki/path_acme_test.go
+++ b/builtin/logical/pki/path_acme_test.go
@@ -1469,7 +1469,7 @@ func TestAcmeValidationError(t *testing.T) {
 	require.Error(t, err, "Should have been prevented to accept challenge 2")
 
 	// Make sure our challenge returns errors
-	testhelpers.RetryUntil(t, 10*time.Second, func() error {
+	testhelpers.RetryUntil(t, 30*time.Second, func() error {
 		challenge, err := acmeClient.GetChallenge(testCtx, authorizations[0].Challenges[0].URI)
 		if err != nil {
 			return err

--- a/builtin/logical/pki/path_acme_test.go
+++ b/builtin/logical/pki/path_acme_test.go
@@ -1484,7 +1484,7 @@ func TestAcmeValidationError(t *testing.T) {
 			return fmt.Errorf("unexpected error back: %v", err)
 		}
 
-		if acmeError.ProblemType != "urn:ietf:params:acme:error:connection" {
+		if acmeError.ProblemType != "urn:ietf:params:acme:error:incorrectResponse" {
 			return fmt.Errorf("unexpected ACME error back: %v", acmeError)
 		}
 

--- a/builtin/logical/pki/path_acme_test.go
+++ b/builtin/logical/pki/path_acme_test.go
@@ -1469,7 +1469,7 @@ func TestAcmeValidationError(t *testing.T) {
 	require.Error(t, err, "Should have been prevented to accept challenge 2")
 
 	// Make sure our challenge returns errors
-	testhelpers.RetryUntil(t, 30*time.Second, func() error {
+	testhelpers.RetryUntil(t, 10*time.Second, func() error {
 		challenge, err := acmeClient.GetChallenge(testCtx, authorizations[0].Challenges[0].URI)
 		if err != nil {
 			return err
@@ -1484,7 +1484,7 @@ func TestAcmeValidationError(t *testing.T) {
 			return fmt.Errorf("unexpected error back: %v", err)
 		}
 
-		if acmeError.ProblemType != "urn:ietf:params:acme:error:incorrectResponse" {
+		if acmeError.ProblemType != "urn:ietf:params:acme:error:connection" {
 			return fmt.Errorf("unexpected ACME error back: %v", acmeError)
 		}
 

--- a/changelog/28678.txt
+++ b/changelog/28678.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+secrets/pki: Add ACME error types to errors encountered during challenge validation.
+```


### PR DESCRIPTION
### Description
What does this PR do?

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [ ] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.