### PR TITLE
Update AOP config docs

### DIFF
--- a/website/content/docs/configuration/adaptive-overload-protection.mdx
+++ b/website/content/docs/configuration/adaptive-overload-protection.mdx
@@ -10,7 +10,9 @@ description: |-
 
 @include 'alerts/enterprise-only.mdx'
 
-@include 'alerts/beta.mdx'
+<Note title="Enabled by default">
+  As of Vault 1.18.0, adaptive overload protection is enabled by default
+</Note>
 
 Configure the `adaptive_overload_protection` stanza to control overload
 protection features for your Vault server.
@@ -41,6 +43,5 @@ These parameters apply to the `adaptive_overload_protection` stanza in the Vault
 configuration file:
 
 - `disable_write_controller` `(bool: <optional>)`: Disables the adaptive write
-  overload controller. Defaults to `true` (controller disabled). Set
-  `disable_write_controller` to `false` to enable the write controller and opt
-  in to the beta functionality.
+  overload controller. Defaults to `false` (controller enabled). Set
+  `disable_write_controller` to `true` to disable the write controller.

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -578,6 +578,11 @@
       },
       {
         "title": "Adaptive overload protection",
+        "badge": {
+          "text": "ENTERPRISE",
+          "type": "outlined",
+          "color": "neutral"
+        },
         "path": "configuration/adaptive-overload-protection"
       },
       {


### PR DESCRIPTION
### Description
The Adaptive Overload Protection configuration documentation required updating for the latest release.

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [ ] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
