### PR TITLE
UI: Ember data upgrade prep: cleanup store and lazyPaginatedQuery

### DIFF
--- a/ui/app/components/console/ui-panel.js
+++ b/ui/app/components/console/ui-panel.js
@@ -108,7 +108,7 @@ export default Component.extend({
     const currentRoute = owner.lookup(`router:main`).currentRouteName;
 
     try {
-      this.store.clearAllDatasets();
+      this.store.clearDataset();
       yield this.router.transitionTo(currentRoute);
       this.logAndOutput(null, { type: 'success', content: 'The current screen has been refreshed!' });
     } catch (error) {

--- a/ui/app/components/generated-item-list.js
+++ b/ui/app/components/generated-item-list.js
@@ -32,7 +32,7 @@ export default class GeneratedItemList extends Component {
   @action
   refreshItemList() {
     const route = getOwner(this).lookup(`route:${this.router.currentRouteName}`);
-    this.store.clearAllDatasets();
+    this.store.clearDataset();
     route.refresh();
   }
 }

--- a/ui/app/routes/vault/cluster/access/identity/aliases/index.js
+++ b/ui/app/routes/vault/cluster/access/identity/aliases/index.js
@@ -38,12 +38,12 @@ export default Route.extend(ListRoute, {
     willTransition(transition) {
       window.scrollTo(0, 0);
       if (!transition || transition.targetName !== this.routeName) {
-        this.store.clearAllDatasets();
+        this.store.clearDataset();
       }
       return true;
     },
     reload() {
-      this.store.clearAllDatasets();
+      this.store.clearDataset();
       this.refresh();
     },
   },

--- a/ui/app/routes/vault/cluster/access/identity/index.js
+++ b/ui/app/routes/vault/cluster/access/identity/index.js
@@ -38,12 +38,12 @@ export default Route.extend(ListRoute, {
     willTransition(transition) {
       window.scrollTo(0, 0);
       if (transition.targetName !== this.routeName) {
-        this.store.clearAllDatasets();
+        this.store.clearDataset();
       }
       return true;
     },
     reload() {
-      this.store.clearAllDatasets();
+      this.store.clearDataset();
       this.refresh();
     },
   },

--- a/ui/app/routes/vault/cluster/access/leases/list.js
+++ b/ui/app/routes/vault/cluster/access/leases/list.js
@@ -104,7 +104,7 @@ export default Route.extend({
     willTransition(transition) {
       window.scrollTo(0, 0);
       if (transition.targetName !== this.routeName) {
-        this.store.clearAllDatasets();
+        this.store.clearDataset();
       }
       return true;
     },

--- a/ui/app/routes/vault/cluster/access/method/item/list.js
+++ b/ui/app/routes/vault/cluster/access/method/item/list.js
@@ -46,12 +46,12 @@ export default Route.extend(ListRoute, {
     willTransition(transition) {
       window.scrollTo(0, 0);
       if (transition.targetName !== this.routeName) {
-        this.store.clearAllDatasets();
+        this.store.clearDataset();
       }
       return true;
     },
     reload() {
-      this.store.clearAllDatasets();
+      this.store.clearDataset();
       this.refresh();
     },
   },

--- a/ui/app/routes/vault/cluster/access/namespaces/index.js
+++ b/ui/app/routes/vault/cluster/access/namespaces/index.js
@@ -74,12 +74,12 @@ export default Route.extend(UnloadModel, {
     willTransition(transition) {
       window.scrollTo(0, 0);
       if (!transition || transition.targetName !== this.routeName) {
-        this.store.clearAllDatasets();
+        this.store.clearDataset();
       }
       return true;
     },
     reload() {
-      this.store.clearAllDatasets();
+      this.store.clearDataset();
       this.refresh();
     },
   },

--- a/ui/app/routes/vault/cluster/policies/index.js
+++ b/ui/app/routes/vault/cluster/policies/index.js
@@ -65,12 +65,12 @@ export default Route.extend(ClusterRoute, ListRoute, {
     willTransition(transition) {
       window.scrollTo(0, 0);
       if (!transition || transition.targetName !== this.routeName) {
-        this.store.clearAllDatasets();
+        this.store.clearDataset();
       }
       return true;
     },
     reload() {
-      this.store.clearAllDatasets();
+      this.store.clearDataset();
       this.refresh();
     },
   },

--- a/ui/app/routes/vault/cluster/secrets/backend/list.js
+++ b/ui/app/routes/vault/cluster/secrets/backend/list.js
@@ -163,7 +163,7 @@ export default Route.extend({
     const has404 = this.has404;
     // only clear store cache if this is a new model
     if (secret !== controller?.baseKey?.id) {
-      this.store.clearAllDatasets();
+      this.store.clearDataset();
     }
     controller.set('hasModel', true);
     controller.setProperties({
@@ -220,12 +220,12 @@ export default Route.extend({
     willTransition(transition) {
       window.scrollTo(0, 0);
       if (transition.targetName !== this.routeName) {
-        this.store.clearAllDatasets();
+        this.store.clearDataset();
       }
       return true;
     },
     reload() {
-      this.store.clearAllDatasets();
+      this.store.clearDataset();
       this.refresh();
     },
   },

--- a/ui/app/services/store.js
+++ b/ui/app/services/store.js
@@ -206,8 +206,4 @@ export default class StoreService extends Store {
     }
     this.lazyCaches.clear();
   }
-
-  clearAllDatasets() {
-    this.clearDataset();
-  }
 }

--- a/ui/app/services/store.js
+++ b/ui/app/services/store.js
@@ -210,30 +210,4 @@ export default class StoreService extends Store {
   clearAllDatasets() {
     this.clearDataset();
   }
-
-  /**
-   * this is designed to be a temporary workaround to an issue in the test environment after upgrading to Ember 4.12
-   * when performing an unloadAll or unloadRecord for auth-method or secret-engine models within the app code an error breaks the tests
-   * after the test run is finished during teardown an unloadAll happens and the error "Expected a stable identifier" is thrown
-   * it seems that when the unload happens in the app, for some reason the mount-config relationship models are not unloaded
-   * then when the unloadAll happens a second time during test teardown there seems to be an issue since those records should already have been unloaded
-   * when logging in the teardownRecord hook, it appears that other embedded inverse: null relationships such as replication-attributes are torn down when the parent model is unloaded
-   * the following fixes the issue by explicitly unloading the mount-config models associated to the parent
-   * this should be looked into further to find the root cause, at which time these overrides may be removed
-   */
-  unloadAll(modelName) {
-    const hasMountConfig = ['auth-method', 'secret-engine'];
-    if (hasMountConfig.includes(modelName)) {
-      this.peekAll(modelName).forEach((record) => this.unloadRecord(record));
-    } else {
-      super.unloadAll(modelName);
-    }
-  }
-  unloadRecord(record) {
-    const hasMountConfig = ['auth-method', 'secret-engine'];
-    if (record && hasMountConfig.includes(record.constructor.modelName) && record.config) {
-      super.unloadRecord(record.config);
-    }
-    super.unloadRecord(record);
-  }
 }

--- a/ui/lib/core/addon/mixins/list-route.js
+++ b/ui/lib/core/addon/mixins/list-route.js
@@ -35,12 +35,12 @@ export default Mixin.create({
     willTransition(transition) {
       window.scrollTo(0, 0);
       if (transition.targetName !== this.routeName) {
-        this.store.clearAllDatasets();
+        this.store.clearDataset();
       }
       return true;
     },
     reload() {
-      this.store.clearAllDatasets();
+      this.store.clearDataset();
       this.refresh();
     },
   },

--- a/ui/lib/kmip/addon/routes/scopes/index.js
+++ b/ui/lib/kmip/addon/routes/scopes/index.js
@@ -31,12 +31,12 @@ export default Route.extend(ListRoute, {
     willTransition(transition) {
       window.scrollTo(0, 0);
       if (transition.targetName !== this.routeName) {
-        this.store.clearAllDatasets();
+        this.store.clearDataset();
       }
       return true;
     },
     reload() {
-      this.store.clearAllDatasets();
+      this.store.clearDataset();
       this.refresh();
     },
   },

--- a/ui/tests/unit/services/store-test.js
+++ b/ui/tests/unit/services/store-test.js
@@ -68,14 +68,14 @@ module('Unit | Service | store', function (hooks) {
     assert.notOk(this.store.get('lazyCaches').has('transit-key'), 'cache is no longer stored');
   });
 
-  test('store.clearAllDatasets', function (assert) {
+  test('store.clearDataset with no args clears entire cache', function (assert) {
     const arr = ['one', 'two'];
     const arr2 = ['one', 'two', 'three', 'four'];
     this.store.storeDataset('data', { id: 1 }, {}, arr);
     this.store.storeDataset('transit-key', { id: 2 }, {}, arr2);
     assert.strictEqual(this.store.get('lazyCaches').size, 2, 'it stores both keys');
 
-    this.store.clearAllDatasets();
+    this.store.clearDataset();
     assert.strictEqual(this.store.get('lazyCaches').size, 0, 'deletes all of the keys');
     assert.notOk(this.store.get('lazyCaches').has('transit-key'), 'first cache key is no longer stored');
     assert.notOk(this.store.get('lazyCaches').has('data'), 'second cache key is no longer stored');


### PR DESCRIPTION
### Description
Slowly chipping away at cleaning up our manual store. This PR removes stubbed methods `unloadAll` and `unloadRecord` which are no longer necessary due to fixes released in ember data 4.12

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [ ] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
