### PR TITLE
Document the encryption algorithms used in ADP auditing purposes

### DIFF
--- a/website/content/docs/secrets/transform/index.mdx
+++ b/website/content/docs/secrets/transform/index.mdx
@@ -152,7 +152,8 @@ data transformation.
 
 Format Preserving Encryption (FPE) performs cryptographically secure
 transformation via FF3-1 to encode input values while maintaining its data
-format and length.
+format and length.  FF3-1 is a construction that uses AES-256 for
+encryption.
 
 #### Tweak and tweak source
 

--- a/website/content/docs/secrets/transform/tokenization.mdx
+++ b/website/content/docs/secrets/transform/tokenization.mdx
@@ -23,7 +23,9 @@ endpoint that lets one query whether a plaintext exists in the system.
 
 Depending on the mapping mode, the plaintext may be decoded only with possession
 of the distributed token, or may be recoverable in the export operation. See
-[Security Considerations](#security-considerations) for more.
+[Security Considerations](#security-considerations) for more. 
+Tokenization's cryptosystem uses AES256-GCM96 for encryption of its token
+store, with keys derived from the token and a tokenization root key.
 
 ### Convergence
 


### PR DESCRIPTION
### Description
What does this PR do?

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [ ] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.