### PR TITLE
[VAULT-28762] Run Autopilot upgrade tests on main and PRs to main on ENT if the AP code has changed

### DIFF
--- a/.github/actions/changed-files/action.yml
+++ b/.github/actions/changed-files/action.yml
@@ -19,6 +19,9 @@ outputs:
   ui-changed:
     description: Whether or not the web UI was modified.
     value: ${{ steps.changed-files.outputs.ui-changed }}
+  autopilot-changed:
+    description: Whether or not files pertaining to Autopilot were modified.
+    value: ${{ steps.changed-files.outputs.autopilot-changed }}
   files:
     description: All of the file names that changed.
     value: ${{ steps.changed-files.outputs.files }}

--- a/.github/actions/install-external-tools/action.yml
+++ b/.github/actions/install-external-tools/action.yml
@@ -19,6 +19,7 @@ runs:
     - uses: ./.github/actions/set-up-gotestsum
     - uses: ./.github/actions/set-up-misspell
     - uses: ./.github/actions/set-up-shfmt
+    - uses: ./.github/actions/set-up-sqlc
     - uses: ./.github/actions/set-up-staticcheck
       # We assume that the Go toolchain will be managed by the caller workflow so we don't set one
       # up here.

--- a/.github/actions/run-apupgrade-tests/action.yml
+++ b/.github/actions/run-apupgrade-tests/action.yml
@@ -1,0 +1,122 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+---
+name: Run Autopilot upgrade tests
+description: |
+  This action runs the Autopilot upgrade tests on Vault Enterprise.
+  It downloads the needed Vault Enterprise source version binaries from the releases page, checks out the specified ref
+  from the Vault Enterprise repository, builds the target version binary of Vault for Autopilot upgrade testing,
+  and runs the Autopilot upgrade tool with the specified source versions.
+inputs:
+  checkout-ref:
+    required: true
+    type: string
+    description: |
+      The branch, tag, or SHA to checkout from the Vault Enterprise repository, e.g. 'refs/heads/main'.
+      The target version binary of Vault for Autopilot upgrade testing will be built from this checkout.
+  github-token:
+    required: true
+    type: string
+    description: |
+      The GitHub token to use for checking out the needed repositories.
+  source-versions:
+    required: true
+    type: string
+    description: |
+      The source versions of Vault for Autopilot upgrade testing as a comma-separated string,
+      e.g. '1.16.9+ent,1.17.7+ent,1.18.0+ent'.
+
+runs:
+  using: composite
+  steps:
+    - name: Authenticate to Vault
+      id: vault-auth
+      shell: bash
+      run: vault-auth
+    - name: Fetch Secrets
+      id: secrets
+      uses: hashicorp/vault-action@d1720f055e0635fd932a1d2a48f87a666a57906c # v3.0.0
+      with:
+        url: ${{ steps.vault-auth.outputs.addr }}
+        caCertificate: ${{ steps.vault-auth.outputs.ca_certificate }}
+        token: ${{ steps.vault-auth.outputs.token }}
+        secrets: |
+          kv/data/github/${{ github.repository }}/github-token username-and-token | github-token;
+          kv/data/github/${{ github.repository }}/license license_1 | VAULT_LICENSE_CI;
+          kv/data/github/${{ github.repository }}/license license_2 | VAULT_LICENSE_2;
+    - name: Setup Git configuration (private)
+      id: setup-git-private
+      if: github.repository == 'hashicorp/vault-enterprise'
+      shell: bash
+      run: |
+        git config --global url."https://${{ steps.secrets.outputs.github-token }}@github.com".insteadOf https://github.com
+    - name: Check out the .release/versions.hcl file from Vault Enterprise repository
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      with:
+        ref: ${{ inputs.checkout-ref }}
+    - uses: ./.github/actions/set-up-go
+      with:
+        github-token: ${{ inputs.github-token }}
+    - name: Build external tools
+      uses: ./.github/actions/install-external-tools
+    - name: Checkout VCM repository
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      with:
+        repository: hashicorp/vcm
+        token: ${{ inputs.github-token }}
+        path: vcm
+    - name: Checkout Vault tools repository to get the Autopilot upgrade tool
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      with:
+        repository: hashicorp/vault-tools
+        token: ${{ inputs.github-token }}
+        path: vault-tools
+    - name: Install needed Vault versions
+      env:
+        GOPATH: /home/runner/go
+      shell: bash
+      run: |
+        # Split the matched versions into an array
+        IFS=',' read -r -a versions <<< "${{ inputs.source-versions }}"
+
+        for version in "${versions[@]}"; do
+          echo "Installing Vault version $version"
+          "${GITHUB_WORKSPACE}/vault-tools/vvm/vvm" install-ent "${version}"
+        done
+    - name: Build dev binary for binary tests
+      env:
+        GOPATH: /home/runner/go
+        GOPRIVATE: github.com/hashicorp/*
+      shell: bash
+      run: |
+        cd "${GITHUB_WORKSPACE}" || exit 1
+        time make prep dev
+
+        # Save the binary we just build under the current Vault version number to VVM
+        # for apupgrade to use as a target version
+        current_version=$(cat version/VERSION)
+        "${GITHUB_WORKSPACE}/vault-tools/vvm/vvm" save "${current_version}"
+        echo "VAULT_TARGET_VERSION=${current_version}" >> "${GITHUB_ENV}"
+    - name: Build VCM
+      shell: bash
+      run: |
+        cd "${GITHUB_WORKSPACE}/vcm" || exit 1
+        make
+    - name: Build Autopilot upgrade tool
+      shell: bash
+      run: |
+        cd "${GITHUB_WORKSPACE}/vault-tools/apupgrade" || exit 1
+        go build -o apupgrade .
+    - name: Run Autopilot upgrade tool
+      shell: bash
+      run: |
+        # Write the license to a file for VCM to use
+        echo "${{ steps.secrets.outputs.VAULT_LICENSE_CI }}" > "${GITHUB_WORKSPACE}/license.hclic"
+        export VAULT_LICENSE_PATH="${GITHUB_WORKSPACE}/license.hclic"
+
+        # Unset VAULT_ADDR to avoid any conflicts with VCM and apupgrade
+        unset VAULT_ADDR
+
+        echo "Running Autopilot upgrade tool with source versions: ${{ inputs.source-versions }} and target version: ${{ env.VAULT_TARGET_VERSION }}"
+        "${GITHUB_WORKSPACE}/vault-tools/apupgrade/apupgrade" -versions "${{ inputs.source-versions }},${VAULT_TARGET_VERSION}" -use-vvm

--- a/.github/actions/set-up-sqlc/action.yml
+++ b/.github/actions/set-up-sqlc/action.yml
@@ -1,0 +1,62 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+---
+name: Set up sqlc from Github releases
+description: Set up sqlc from Github releases
+
+inputs:
+  destination:
+    description: "Where to install the sqlc binary (default: $HOME/bin/sqlc)"
+    type: string
+    default: "$HOME/bin/sqlc"
+  version:
+    description: "The version to install (default: latest)"
+    type: string
+    default: Latest
+
+outputs:
+  destination:
+    description: Where the installed sqlc binary is
+    value: ${{ steps.install.outputs.destination }}
+  destination-dir:
+    description: The directory where the installed sqlc binary is
+    value: ${{ steps.install.outputs.destination-dir }}
+  version:
+    description: The installed version of sqlc
+    value: ${{ steps.install.outputs.version }}
+
+runs:
+  using: composite
+  steps:
+    - id: install
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        VERSION=$(./.github/scripts/retry-command.sh gh release list -R sqlc-dev/sqlc --exclude-drafts --exclude-pre-releases | grep ${{ inputs.version }} | cut -f1)
+
+        mkdir -p $(dirname ${{ inputs.destination }})
+        DESTINATION="$(readlink -f "${{ inputs.destination }}")"
+        DESTINATION_DIR="$(dirname "$DESTINATION")"
+        echo "$DESTINATION_DIR" >> "$GITHUB_PATH"
+
+        {
+          echo "destination=$DESTINATION"
+          echo "destination-dir=$DESTINATION_DIR"
+          echo "version=$VERSION"
+        } | tee -a "$GITHUB_OUTPUT"
+
+        ARCH="$(echo "$RUNNER_ARCH" | tr '[:upper:]' '[:lower:]')"
+        OS="$(echo "$RUNNER_OS" | tr '[:upper:]' '[:lower:]')"
+        if [ "$ARCH" = "x64" ]; then
+          export ARCH="amd64"
+        fi
+        if [ "$OS" = "macos" ]; then
+          export OS="darwin"
+        fi
+
+        ./.github/scripts/retry-command.sh gh release download "$VERSION" --clobber -p "sqlc*_${OS}_${ARCH}.zip" -O sqlc.zip -R sqlc-dev/sqlc
+        unzip sqlc.zip
+        chmod +x sqlc
+        mv sqlc "$DESTINATION"

--- a/.github/scripts/changed-files.sh
+++ b/.github/scripts/changed-files.sh
@@ -28,6 +28,7 @@ fi
 docs_changed=false
 ui_changed=false
 app_changed=false
+autopilot_changed=false
 
 if ! files="$(git diff "${base_commit}...${head_commit}" --name-only)"; then
   echo "failed to get changed files from git"
@@ -53,14 +54,26 @@ for file in $(awk -F "/" '{ print $1}' <<< "$files" | uniq); do
   app_changed=true
 done
 
+# if the app changed, check to see if anything referencing autopilot specifically was changed
+if [ "$app_changed" = true ]; then
+  for file in $files; do
+    if grep "raft-autopilot" "$file"; then
+      autopilot_changed=true
+      break
+    fi
+  done
+fi
+
 echo "app-changed=${app_changed}"
 echo "docs-changed=${docs_changed}"
 echo "ui-changed=${ui_changed}"
+echo "autopilot_changed=${autopilot_changed}"
 echo "files='${files}'"
 [ -n "$GITHUB_OUTPUT" ] && {
   echo "app-changed=${app_changed}"
   echo "docs-changed=${docs_changed}"
   echo "ui-changed=${ui_changed}"
+  echo "autopilot-changed=${autopilot_changed}"
   # Use a random delimiter for multiline strings.
   # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
   delimiter="$(openssl rand -hex 8)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
     # for our needs, since we're skipping stuff on PRs in draft mode.By adding the ready_for_review
     # type, when a draft pr is marked ready, we run everything, including the stuff we'd have
     # skipped up until now.
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [ opened, synchronize, reopened, ready_for_review ]
   push:
     branches:
       - main
@@ -21,6 +21,7 @@ jobs:
     runs-on: ${{ github.repository == 'hashicorp/vault' && 'ubuntu-latest' || fromJSON('["self-hosted","linux","small"]') }}
     outputs:
       app-changed: ${{ steps.changed-files.outputs.app-changed }}
+      autopilot-changed: ${{ steps.changed-files.outputs.autopilot-changed }}
       checkout-ref: ${{ steps.checkout.outputs.ref }}
       compute-small: ${{ steps.metadata.outputs.compute-small }}
       compute-test-go: ${{ steps.metadata.outputs.compute-test-go }}
@@ -45,6 +46,79 @@ jobs:
         with:
           github-token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
           no-restore: true # don't download them on a cache hit
+
+  test-autopilot-upgrade:
+    name: Run Autopilot upgrade tool
+    # Run the Autopilot upgrade tests if:
+    # - The Autopilot code has changed.
+    # - We're in the context of the vault enterprise repository.
+    # - The workflow was triggered by a push to main or a PR targeting main.
+    #
+    # The reason for the main branch restriction, is that the logic for automatically determining the source versions
+    # to test depends on the .release/versions.hcl file, which might not be up-to-date nor exist outside of main.
+    # If you'd like to run the autopilot tests for a specific git checkout or set of source versions,
+    # you can manually trigger the workflow, see the .github/workflows/run-apupgrade-tests-ent.yml file in the ENT repo.
+    if: |
+      needs.setup.outputs.autopilot-changed == 'true' &&
+      github.repository == 'hashicorp/vault-enterprise' &&
+      ((github.event_name == 'pull_request' && github.base_ref == 'main') ||
+      (github.event_name == 'push' && github.ref == 'refs/heads/main'))
+    needs: setup
+    permissions:
+      id-token: write
+      contents: read
+    runs-on: ${{ fromJSON(needs.setup.outputs.compute-small) }}
+    steps:
+      - name: Check out the .release/versions.hcl file from Vault Enterprise repository
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          ref: ${{ needs.setup.outputs.checkout-ref }}
+          sparse-checkout: |
+            .release/versions.hcl
+            .github
+      - name: Get Vault versions to test
+        id: get-versions
+        env:
+          GH_TOKEN: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
+        run: |
+          # Change to the Vault Enterprise repository directory or exit if it fails
+          cd "${GITHUB_WORKSPACE}" || exit 1
+
+          # Extract active major versions from the versions.hcl file, which is used for managing active release branches
+          active_major_versions=$(grep -Eo 'version\s+"[0-9]+\.[0-9]+\.x"' .release/versions.hcl | sed -E 's/version\s+"([0-9]+\.[0-9]+)\.x"/\1/')
+          active_major_versions=$(sort <<< "${active_major_versions}")
+
+          # List releases from the GitHub repository, process them with sed, and sort them in reverse order
+          releases=$(gh -R hashicorp/vault-enterprise release list --exclude-drafts --exclude-pre-releases --json=name --jq '.[].name' | \
+            sed -E 's/^v([0-9]+\.[0-9]+\.[0-9]+(\-rc[0-9]+)?)\+ent$/\1/' | \
+            sort -r)
+
+          # Initialize a variable to collect matched versions
+          matched_versions=""
+
+          # Read each version from the active major versions and match it against the newest release available
+          while IFS= read -r version; do
+            match=$(grep -m 1 "^${version}" <<< "${releases}" || true)
+            if [ -n "${match}" ]; then
+              if [ -n "${matched_versions}" ]; then
+                matched_versions+=","
+              fi
+              # Append the matched version to the variable, adding the +ent suffix, which is used for Vault Enterprise releases
+              matched_versions+="${match}+ent"
+            fi
+          done <<< "${active_major_versions}"
+
+          # Export the matched versions as a comma-separated string to an environment variable
+          echo "VAULT_SOURCE_VERSIONS=${matched_versions}" >> "${GITHUB_ENV}"
+      - name: Run Autopilot upgrade tests
+        uses: ./.github/actions/run-apupgrade-tests
+        env:
+          GOPATH: /home/runner/go
+          GOPRIVATE: github.com/hashicorp/*
+        with:
+          checkout-ref: ${{ needs.setup.outputs.checkout-ref }}
+          github-token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
+          source-versions: ${{ env.VAULT_SOURCE_VERSIONS }}
 
   test-go:
     # Run Go tests if the vault app changed
@@ -186,7 +260,7 @@ jobs:
       - if: needs.setup.outputs.is-enterprise == 'true'
         id: secrets
         name: Fetch secrets
-        uses: hashicorp/vault-action@v3
+        uses: hashicorp/vault-action@d1720f055e0635fd932a1d2a48f87a666a57906c # v3.0.0
         with:
           url: ${{ steps.vault-auth.outputs.addr }}
           caCertificate: ${{ steps.vault-auth.outputs.ca_certificate }}
@@ -253,6 +327,7 @@ jobs:
   tests-completed:
     needs:
       - setup
+      - test-autopilot-upgrade
       - test-go
       - test-go-testonly
       - test-go-race
@@ -304,7 +379,7 @@ jobs:
       - if: needs.setup.outputs.is-enterprise == 'true'
         id: secrets
         name: Fetch Vault Secrets
-        uses: hashicorp/vault-action@v3
+        uses: hashicorp/vault-action@d1720f055e0635fd932a1d2a48f87a666a57906c # v3.0.0
         with:
           url: ${{ steps.vault-auth.outputs.addr }}
           caCertificate: ${{ steps.vault-auth.outputs.ca_certificate }}


### PR DESCRIPTION
### Description
This PR adds automated Autopilot upgrade tests to our CI. The ability to manually run the workflow from the GitHub UI will be added in https://github.com/hashicorp/vault-enterprise/pull/6696.

Co-authored by @raskchanky.

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [x] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
