### PR TITLE
Update vault-plugin-secrets-openldap to v0.14.2

### DIFF
--- a/changelog/28704.txt
+++ b/changelog/28704.txt
@@ -1,0 +1,3 @@
+```release-note:change
+secrets/openldap: Update plugin to v0.14.2
+```

--- a/go.mod
+++ b/go.mod
@@ -150,7 +150,7 @@ require (
 	github.com/hashicorp/vault-plugin-secrets-kubernetes v0.9.0
 	github.com/hashicorp/vault-plugin-secrets-kv v0.20.0
 	github.com/hashicorp/vault-plugin-secrets-mongodbatlas v0.13.0
-	github.com/hashicorp/vault-plugin-secrets-openldap v0.14.1
+	github.com/hashicorp/vault-plugin-secrets-openldap v0.14.2
 	github.com/hashicorp/vault-plugin-secrets-terraform v0.10.0
 	github.com/hashicorp/vault-testing-stepwise v0.3.1
 	github.com/hashicorp/vault/api v1.15.0

--- a/go.sum
+++ b/go.sum
@@ -1593,8 +1593,8 @@ github.com/hashicorp/vault-plugin-secrets-kv v0.20.0 h1:p1RVmd4x1rgGK0tN8DDu21J2
 github.com/hashicorp/vault-plugin-secrets-kv v0.20.0/go.mod h1:bCpMggD3Z0+H+3dOmTCoQjBHC53jA08lPqOLmFrHBi8=
 github.com/hashicorp/vault-plugin-secrets-mongodbatlas v0.13.0 h1:BeDS7luTeOW0braIbtuyairFF8SEz7k3nvi9e+mJ2Ok=
 github.com/hashicorp/vault-plugin-secrets-mongodbatlas v0.13.0/go.mod h1:sprde+S70PBIbgOLUAKDxR+xNF714ksBBVh77O3hnWc=
-github.com/hashicorp/vault-plugin-secrets-openldap v0.14.1 h1:5l7/83OCZsHL1PYkFJd8xjLtKQEz3vpbIbaEzHL5qeU=
-github.com/hashicorp/vault-plugin-secrets-openldap v0.14.1/go.mod h1:wqOf/QJqrrNXjnm0eLUnm5Ju9s/LIZUl6wEKmnFL9Uo=
+github.com/hashicorp/vault-plugin-secrets-openldap v0.14.2 h1:M4VhcerVlKPpxpsJi2YlRxI+o9CNI3Ug4tvJLQ/pscU=
+github.com/hashicorp/vault-plugin-secrets-openldap v0.14.2/go.mod h1:wqOf/QJqrrNXjnm0eLUnm5Ju9s/LIZUl6wEKmnFL9Uo=
 github.com/hashicorp/vault-plugin-secrets-terraform v0.10.0 h1:YzOJrpuDRNrw5SQ4i7IEjedF40I/7ejupQy+gAyQ6Zg=
 github.com/hashicorp/vault-plugin-secrets-terraform v0.10.0/go.mod h1:j2nbB//xAQMD+5JivVDalwDEyzJY3AWzKIkw6k65xJQ=
 github.com/hashicorp/vault-testing-stepwise v0.3.1 h1:SqItnMWOOknQfJJR49Fps34ZfBMWSqBFFTx6NoTHzNw=


### PR DESCRIPTION
This PR was generated by a GitHub Action. Full log: https://github.com/hashicorp/vault/actions/runs/11335146286