### PR TITLE
VAULT-29153: Update docs with IPv6 compliance info

### DIFF
--- a/website/content/docs/configuration/listener/tcp/index.mdx
+++ b/website/content/docs/configuration/listener/tcp/index.mdx
@@ -8,6 +8,8 @@ description: >-
 
 # `tcp` listener
 
+@include 'alerts/ipv6-compliance.mdx'
+
 The TCP listener configures Vault to listen on a TCP address/port.
 
 ```hcl

--- a/website/content/docs/interoperability-matrix.mdx
+++ b/website/content/docs/interoperability-matrix.mdx
@@ -23,7 +23,7 @@ advanced data protection features.
 ## IPv6 validation and compliance
 
 [Vault Enterprise supports IPv6](https://www.hashicorp.com/trust/compliance/vault-enterprise)
-in compliance with  OMB Mandate M-21-07 and Federal IPv6 policy requirements
+in compliance with OMB Mandate M-21-07 and Federal IPv6 policy requirements
 for the following operating systems and storage backends. 
 
 **Self-attested testing covers functionality related to  HSM, FIPS 140-2, and

--- a/website/content/docs/interoperability-matrix.mdx
+++ b/website/content/docs/interoperability-matrix.mdx
@@ -26,7 +26,7 @@ advanced data protection features.
 in compliance with OMB Mandate M-21-07 and Federal IPv6 policy requirements
 for the following operating systems and storage backends. 
 
-**Self-attested testing covers functionality related to  HSM, FIPS 140-2, and
+**Self-attested testing covers functionality related to HSM, FIPS 140-2, and
 HSM/FIPS 140-2.**
 
 Operating system | OS version                     | Validation   | Vault version

--- a/website/content/docs/interoperability-matrix.mdx
+++ b/website/content/docs/interoperability-matrix.mdx
@@ -1,102 +1,197 @@
 ---
 layout: docs
-page_title: Vault Interoperability Matrix
-description: Guide to viewing which partners Vault integrates with.
+page_title: Vault interoperability matrix
+description: >-
+  Reference list of Vault integration partners
 ---
 
 # Vault interoperability matrix
 
-Vault integrates with various appliances, platforms and applications for different use cases. Below are two tables indicating the partner’s product that has been verified to work with Vault for [Auto Unsealing](/vault/docs/concepts/seal#auto-unseal) / [HSM Support](/vault/docs/enterprise/hsm) and [External Key Management](https://www.vaultproject.io/use-cases/key-management).
+To support a variety of use cases, Vault verifies protocol implementation and
+integrations with partner products, appliances, and applications that support
+advanced data protection features.
 
-Auto Unseal and HSM Support was developed to aid in reducing the operational complexity of keeping the unseal key secure. This feature delegates the responsibility of securing the unseal key from users to a trusted device or service. At startup Vault will connect to the device or service implementing the seal and ask it to decrypt the root key Vault read from storage.
+<Highlight title="Is your integration missing?">
 
-Vault centrally manages and automates encryption keys across environments allowing customers to control their own encryption keys used in third party services or products.
+  Join the [Vault integration program](/vault/docs/partnerships) to get your
+  integration verified and added or reach out to
+  [technologypartners@hashicorp.com](mailto:technologypartners@hashicorp.com)
+  with questions. 
 
-## Vault seal and HSM interoperability
+</Highlight>
 
-The below table shows the partner product and if the partner’s technology works with each individual seal component.
+## IPv6 validation and compliance
 
-| Partner           | Product                                | Auto Unseal <br/> (Vault 0.9+)  | Entropy Augmentation <br/>(Vault 1.3+) | Seal Wrap  <br/>(Vault 0.9+)   | Managed Keys  <br/> (Vault 1.10+) | Min. Vault Version Verified |
-| ----------------- | -------------------------------------- | ------------ | -------------------- | ------------ |-------------- | --------------------------- |
-| AliCloud          | AliCloud KMS                           | Yes          | No                   | Yes          | No            | 0.11.2                      |
-| Atos              | Trustway Proteccio HSM                 | Yes          | Yes                  | Yes          | No            | 1.9                         |
-| AWS               | AWS KMS                                | Yes          | Yes                  | Yes          | Yes           | 0.9                         |
-| Crypto4a          | QxEDGE™️ HSP                            | Yes          | Yes                  | Yes          | Yes           | 1.9                         |
-| Entrust           | nShield HSM                            | Yes          | Yes                  | Yes          | Yes           | 1.3                         |
-| Fortanix          | FX2200 Series                          | Yes          | Yes                  | Yes          | No            | 0.10                        |
-| FutureX           | Vectera Plus, KMES Series 3            | Yes          | Yes                  | Yes          | Yes           | 1.5                         |
-| FutureX           | VirtuCrypt cloud HSM                   | Yes          | Yes                  | Yes          | Yes           | 1.5                         |
-| Google            | GCP Cloud KMS                          | Yes          | No                   | Yes          | Yes           | 0.9                         |
-| Marvell           | Cavium HSM                             | Yes          | Yes                  | Yes          | Yes           | 1.11                        |
-| Microsoft         | Azure Key Vault                        | Yes          | No                   | Yes          | Yes           | 0.10.2                      |
-| Oracle            | OCI KMS                                | Yes          | No                   | Yes          | No            | 1.2.3                       |
-| PrimeKey          | SignServer Hardware Appliance          | Yes          | Yes                  | Yes          | No            | 1.6                         |
-| Private Machines  | ENFORCER Blade                         | Yes          | No                   | Yes          | No            | 1.17.3                      | 
-| Qrypt             | Quantum Entropy Service                | No           | Yes                  | No           | No            | 1.11                        |
-| Quintessence Labs | TSF  400                               | Yes          | Yes                  | Yes          | No            | 1.4                         |
-| Securosys SA      | Primus HSM                             | Yes          | Yes                  | Yes          | Yes           | 1.7                         |
-| Thales            | Luna HSM                               | Yes          | Yes                  | Yes          | Yes           | 1.4                         |
-| Thales            | Luna TCT HSM                           | Yes          | Yes                  | Yes          | Yes           | 1.4                         |   
-| Thales            | CipherTrust Manager                    | Yes          | Yes                  | Yes          | No            | 1.7                         |
-| Utimaco           | HSM                                    | Yes          | Yes                  | Yes          | Yes           | 1.4                         |
-| Yubico            | YubiHSM 2                              | Yes          | Yes                  | Yes          | Yes           | 1.17.2                      |
-<span style={{display:'block', textAlign:'right', fontSize:'12px'}}><em>Last Updated May 03, 2023</em></span>
+[Vault Enterprise supports IPv6](https://www.hashicorp.com/trust/compliance/vault-enterprise)
+in compliance with  OMB Mandate M-21-07 and Federal IPv6 policy requirements
+for the following operating systems and storage backends. 
 
-## Vault as an external key management system (EKMS)
+**Self-attested testing covers functionality related to  HSM, FIPS 140-2, and
+HSM/FIPS 140-2.**
 
-Partners who integrate with Vault to have Vault store and/or manage encryption keys with their products
-
-~> Note: HCP Vault Verified means that the integration has been verified to work with HCP Vault Dedicated. All integrations have been verified with Vault self-managed.
-
-<span style={{fontSize:'12px'}}>
-Vault Secrets Engine Key: EKM Provider = <a href="/docs/platform/mssql">Vault EKM provider for SQL server</a>; KV = <a href="/docs/secrets/kv">KV secrets engine</a>; KMSE = <a href="/docs/secrets/key-management">Key Management Secrets Engine</a>; KMIP = <a href="/docs/secrets/kmip">KMIP Secrets Engine</a>; PKCS#11 = <a href="/docs/enterprise/pkcs11-provider">PKCS#11 Provider</a>; Transit = <a href="/docs/secrets/transit">Transit Secrets Engine</a>
+Operating system | OS version                     | Validation   | Vault version
+---------------- | ------------------------------ | ------------ | -----------------------
+FreeBSD          | N/A                            | N/A           | Untested
+Linux            | Amazon Linux (versions 2023)   | Self-attested | ent-1.18+
+Linux            | openSUSE Leap (version 15.6)   | Self-attested | ent-1.18+
+Linux            | RHEL (versions 8.10, 9.4)      | Self-attested | ent-1.18+
+Linux            | SUSE SLES (version 15.6)       | Self-attested | ent-1.18+
+Linux            | Ubuntu (versions 20.04, 24.04) | Self-attested | ent-1.18+
+MacOS            | N/A                            | N/A           | Untested
+NetBSD           | N/A                            | N/A           | Untested
+OpenBSD          | N/A                            | N/A           | Untested
+Windows          | N/A                            | N/A           | Untested
+<span style={{display:'block', textAlign:'right', fontSize:'12px'}}>
+  <em>
+    <b>Last Updated</b>:
+    October 14, 2024
+  </em>
 </span>
 
-| Partner           | Product                  | Vault Secrets Engine | Min. Vault Version Verified | HCP Vault Verified |
-| ----------------- | ------------------------ | -------------------- | --------------------------- | ------------------- |
-| AWS               | AWS KMS                  | KMSE                 | 1.8                         | Yes                 |
-| Baffle            | Shield                   | KV                  | 1.3                         | No                  |
-| Bloombase         | StoreSafe                | KMIP                 | 1.9                         | N/A                 |
-| Cloudian          | HyperStore 7.5.1         | KMIP                 | 1.12                        | N/A                 |
-| Cockroach Labs    | Cockroach Cloud DB       | KMSE                 | 1.10                        | N/A                 |
-| Cockroach Labs    | Cockroach DB             | Transit              | 1.10                        | Yes                 |
-| Cohesity          | Cohesity DataPlatform    | KMIP                 | 1.13.2                      | N/A                 |
-| Commvault Systems | CommVault                | KMIP                 | 1.9                         | N/A                 |
-| Cribl             | Cribl Stream             | KV                  | 1.8                         | Yes                 |
-| DataStax          | DataStax Enterprise      | KMIP                 | 1.11                        | Yes                 |
-| Dell              | PowerMax                 | KMIP                 | 1.12.1                      | N/A                 |
-| Dell              | PowerProtect DDOS 8.0.X  | KMIP                 | 1.15.2                      | N/A                 | 
-| EnterpriseDB      | Postgres Advanced Server | KMIP                 | 1.12.6                      | N/A                 |
-| Garantir          | GaraSign                 | Transit              | 1.5                         | Yes                 |
-| Google            | Google KMS               | KMSE                 | 1.9                         | N/A                 |
-| HPE               | Exmeral Data Fabric      | KMIP                 | 1.2                         | N/A                 |
-| Intel             | Key Broker Service       | KMIP                 | 1.11                        | N/A                 |
-| JumpWire          | JumpWire                 | KV                  | 1.12                        | Yes                 |
-| Micro Focus       | Connected Mx             | Transit              | 1.7                         | No                  |
-| Microsoft         | Azure Key Vault          | KMSE                 | 1.6                         | N/A                 |
-| Microsoft         | MSSSQL                   | EKM Provider         | 1.9                         | No                  |
-| MinIO             | Key Encryption Service   | KV                  | 1.11                        | No                  |
-| MongoDB           | Atlas                    | KMSE                 | 1.6                         | N/A                 |
-| MongoDB           | MongoDB Enterprise       | KMIP                 | 1.2                         | N/A                 |
-| MongoDB           | Client Libraries         | KMIP                 | 1.9                         | N/A                 |
-| NetApp            | ONTAP                    | KMIP                 | 1.2                         | N/A                 |
-| NetApp            | StorageGrid              | KMIP                 | 1.2                         | N/A                 |
-| Nutanix           | AHV/AOS 6.5.1.6          | KMIP                 | 1.12                        | N/A                 |
-| Ondat             | Trousseau                | Transit              | 1.9                         | Yes                 |
-| Oracle            | MySQL                    | KMIP                 | 1.2                         | N/A                 |
-| Oracle            | Oracle 19c               | PKCS#11              | 1.11                        | N/A                 |
-| Percona           | Server 8.0               | KMIP                 | 1.9                         | N/A                 |
-| Percona           | XtraBackup 8.0           | KMIP                 | 1.9                         | N/A                 |
-| Rubrik            | CDM 9.1 (Edge)           | KMIP                 | 1.16.2                      | N/A                 | 
-| Scality           | Scality RING             | KMIP                 | 1.12                        | N/A                 |
-| Snowflake         | Snowflake                | KMSE                 | 1.6                         | N/A                 |
-| Veeam             | Karsten K10              | Transit              | 1.9                         | N/A                 |
-| Veritas           | NetBackup                | KMIP                 | 1.13.9                      | N/A                 |
-| VMware            | vSphere 7.0, 8.0         | KMIP                 | 1.2                         | N/A                 |
-| VMware            | vSan 7.0, 8.0            | KMIP                 | 1.2                         | N/A                 |
-| Yugabyte          | Yugabyte Platform        | Transit              | 1.9                         | No                  |
-<span style={{display:'block', textAlign:'right', fontSize:'12px'}}><em>Last Updated August 25, 2023</em></span>
+<Note title="IPv6 limitations for Windows">
 
-Please reach out to [technologypartners@hashicorp.com](mailto:technologypartners@hashicorp.com) if there are any questions on the above tables. 
+  IPv6 does not work with external plugins (plugins not built into Vault) when
+  running on Windows in server mode because they default to IPv4 and Vault
+  cannot override that behavior.
 
-Missing an integration? Join the [Vault Integration Program](/vault/docs/partnerships) and get the integration listed.
+</Note>
+
+Backend storage system  | Validation    | Vault version
+----------------------- | ------------- | -----------------------
+Consul                  | N/A           | Untested
+Integrated Raft storage | Self-attested | ent-1.18+
+<span style={{display:'block', textAlign:'right', fontSize:'12px'}}>
+  <em>
+    <b>Last Updated</b>:
+    October 14, 2024
+  </em>
+</span>
+
+## Auto unsealing and HSM support
+
+Hardware Security Module (HSM) support reduces the operational complexity of
+securing unseal keys by delegating the responsibility of securing unseal keys to
+trusted devices or services (instead of humans). At startup, Vault connects to
+the delegate device or service and provides an encrypted root key for
+decryption.
+
+Vault implements HSM support with the following features:
+
+Feature                                                              | Introduced
+-------------------------------------------------------------------- | ----------
+[Auto unsealing](/vault/docs/concepts/seal#auto-unseal)              | Vault 0.9
+[Entropy augmentation](/vault/docs/enterprise/entropy-augmentation)  | Vault 1.3
+[Seal wrapping](/vault/docs/enterprise/sealwrap)                     | Vault 0.9
+
+The following table outlines the implementation status of HSM-related features
+for partners products and the minimum Vault version required for verified
+functionality.
+
+| Partner           | Product                                | Auto unseal | Entropy augment | Seal wrap | Managed keys | Vault verified
+| ----------------- | -------------------------------------- | ----------- | --------------- | --------- |------------- | -------------
+| AliCloud          | AliCloud KMS                           | Yes         | **No**          | Yes       | **No**       | 0.11.2+
+| Atos              | Trustway Proteccio HSM                 | Yes         | Yes             | Yes       | **No**       | 1.9+
+| AWS               | AWS KMS                                | Yes         | Yes             | Yes       | Yes          | 0.9+
+| Crypto4a          | QxEDGE&tm; HSP                         | Yes         | Yes             | Yes       | Yes          | 1.9+
+| Entrust           | nShield HSM                            | Yes         | Yes             | Yes       | Yes          | 1.3+
+| Fortanix          | FX2200 Series                          | Yes         | Yes             | Yes       | **No**       | 0.10+
+| FutureX           | Vectera Plus, KMES Series 3            | Yes         | Yes             | Yes       | Yes          | 1.5+
+| FutureX           | VirtuCrypt cloud HSM                   | Yes         | Yes             | Yes       | Yes          | 1.5+
+| Google            | GCP Cloud KMS                          | Yes         | **No**          | Yes       | Yes          | 0.9+
+| Marvell           | Cavium HSM                             | Yes         | Yes             | Yes       | Yes          | 1.11+
+| Microsoft         | Azure Key Vault                        | Yes         | **No**          | Yes       | Yes          | 0.10.2+
+| Oracle            | OCI KMS                                | Yes         | **No**          | Yes       | **No**       | 1.2.3+
+| PrimeKey          | SignServer Hardware Appliance          | Yes         | Yes             | Yes       | **No**       | 1.6+
+| Private Machines  | ENFORCER Blade                         | Yes         | **No**          | Yes       | **No**       | 1.17.3+
+| Qrypt             | Quantum Entropy Service                | **No**      | Yes             | **No**    | **No**       | 1.11+
+| Quintessence Labs | TSF  400                               | Yes         | Yes             | Yes       | **No**       | 1.4+
+| Securosys SA      | Primus HSM                             | Yes         | Yes             | Yes       | Yes          | 1.7+
+| Thales            | Luna HSM                               | Yes         | Yes             | Yes       | Yes          | 1.4+
+| Thales            | Luna TCT HSM                           | Yes         | Yes             | Yes       | Yes          | 1.4+
+| Thales            | CipherTrust Manager                    | Yes         | Yes             | Yes       | **No**       | 1.7+
+| Utimaco           | HSM                                    | Yes         | Yes             | Yes       | Yes          | 1.4+
+| Yubico            | YubiHSM 2                              | Yes         | Yes             | Yes       | Yes          | 1.17.2+
+<span style={{display:'block', textAlign:'right', fontSize:'12px'}}>
+  <em>
+    <b>Last Updated</b>:
+    May 03, 2023
+  </em>
+</span>
+
+
+## External key management (EKMS)
+
+Vault centrally manages and automates encryption keys across environments so
+customers can [manage external encryption keys](/vault/docs/secrets/key-management)
+used in third party services and products with the following plugins:
+
+Abbreviation | Full plugin name
+------------ | ----------------
+EKMMSSQL     | [Vault EKM provider for SQL server](/vault/docs/platform/mssql)
+KV           | [Key/Value secrets engine](/vault/docs/secrets/kv)
+KMSE         | [Key Management secrets engine](/vault/docs/secrets/key-management)
+KMIP         | [KMIP secrets engine](/vault/docs/secrets/kmip)
+PKCS#11      | [PKCS#11 provider](/vault/docs/enterprise/pkcs11-provider)
+Transit      | [Transit secrets engine](/vault/docs/secrets/transit)
+
+<Note title="Vault verified vs HCP Vault verified">
+
+  HCP Vault verified integrations work with the current version HCP Vault
+  Dedicated. Self-managed Vault instances must meet the required minimum version
+  for verification guarantees.
+
+</Note>
+
+The table below indicates the plugin support for partner products, the
+verification status for HCP Vault Dedicated and the minimum Vault version
+required for verified behavior in self-managed Vault instances:
+
+| Partner           | Product                  | Vault plugin | Vault verified | HCP Vault verified
+| ----------------- | ------------------------ | ------------ | -------------- | ------------------
+| AWS               | AWS KMS                  | KMSE         | 1.8+           | Yes
+| Baffle            | Shield                   | KV           | 1.3+           | **No**
+| Bloombase         | StoreSafe                | KMIP         | 1.9+           | N/A
+| Cloudian          | HyperStore 7.5.1         | KMIP         | 1.12+          | N/A
+| Cockroach Labs    | Cockroach Cloud DB       | KMSE         | 1.10+          | N/A
+| Cockroach Labs    | Cockroach DB             | Transit      | 1.10+          | Yes
+| Cohesity          | Cohesity DataPlatform    | KMIP         | 1.13.2+        | N/A
+| Commvault Systems | CommVault                | KMIP         | 1.9+           | N/A
+| Cribl             | Cribl Stream             | KV           | 1.8+           | Yes
+| DataStax          | DataStax Enterprise      | KMIP         | 1.11+          | Yes
+| Dell              | PowerMax                 | KMIP         | 1.12.1+        | N/A
+| Dell              | PowerProtect DDOS 8.0.X  | KMIP         | 1.15.2+        | N/A 
+| EnterpriseDB      | Postgres Advanced Server | KMIP         | 1.12.6+        | N/A
+| Garantir          | GaraSign                 | Transit      | 1.5+           | Yes
+| Google            | Google KMS               | KMSE         | 1.9+           | N/A
+| HPE               | Exmeral Data Fabric      | KMIP         | 1.2+           | N/A
+| Intel             | Key Broker Service       | KMIP         | 1.11+          | N/A
+| JumpWire          | JumpWire                 | KV           | 1.12+          | Yes
+| Micro Focus       | Connected Mx             | Transit      | 1.7+           | **No**
+| Microsoft         | Azure Key Vault          | KMSE         | 1.6+           | N/A
+| Microsoft         | MSSSQL                   | EKMMSSQL     | 1.9+           | **No**
+| MinIO             | Key Encryption Service   | KV           | 1.11+          | **No**
+| MongoDB           | Atlas                    | KMSE         | 1.6+           | N/A
+| MongoDB           | MongoDB Enterprise       | KMIP         | 1.2+           | N/A
+| MongoDB           | Client Libraries         | KMIP         | 1.9+           | N/A
+| NetApp            | ONTAP                    | KMIP         | 1.2+           | N/A
+| NetApp            | StorageGrid              | KMIP         | 1.2+           | N/A
+| Nutanix           | AHV/AOS 6.5.1.6          | KMIP         | 1.12+          | N/A
+| Ondat             | Trousseau                | Transit      | 1.9+           | Yes
+| Oracle            | MySQL                    | KMIP         | 1.2+           | N/A
+| Oracle            | Oracle 19c               | PKCS#11      | 1.11+          | N/A
+| Percona           | Server 8.0               | KMIP         | 1.9+           | N/A
+| Percona           | XtraBackup 8.0           | KMIP         | 1.9+           | N/A
+| Rubrik            | CDM 9.1 (Edge)           | KMIP         | 1.16.2+        | N/A 
+| Scality           | Scality RING             | KMIP         | 1.12+          | N/A
+| Snowflake         | Snowflake                | KMSE         | 1.6+           | N/A
+| Veeam             | Karsten K10              | Transit      | 1.9+           | N/A
+| Veritas           | NetBackup                | KMIP         | 1.13.9+        | N/A
+| VMware            | vSphere 7.0, 8.0         | KMIP         | 1.2+           | N/A
+| VMware            | vSan 7.0, 8.0            | KMIP         | 1.2+           | N/A
+| Yugabyte          | Yugabyte Platform        | Transit      | 1.9+           | **No**
+<span style={{display:'block', textAlign:'right', fontSize:'12px'}}>
+  <em>
+    <b>Last Updated</b>:
+    August 25, 2023
+  </em>
+</span>

--- a/website/content/partials/alerts/ipv6-compliance.mdx
+++ b/website/content/partials/alerts/ipv6-compliance.mdx
@@ -1,0 +1,7 @@
+<Note title="IPv6 compliance">
+
+  Vault Enterprise is compliant with **OMB Mandate M-21-07** and
+  **Federal IPv6 policy requirements**
+  for [specific operating systems and storage backends](/vault/docs/interoperability-matrix#ipv6-validation-and-compliance).
+
+</Note>

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -1996,7 +1996,7 @@
     "path": "partnerships"
   },
   {
-    "title": "Vault Interoperability Matrix",
+    "title": "Vault interoperability matrix",
     "path": "interoperability-matrix"
   },
   {


### PR DESCRIPTION
Add information about IPv6 compliance per the conversation in [VAULT-29153](https://hashicorp.atlassian.net/browse/VAULT-29153)

Interoperability page preview: https://vault-git-docs-ipv6-updates-hashicorp.vercel.app/vault/docs/interoperability-matrix
TCP listener page preview: https://vault-git-docs-ipv6-updates-hashicorp.vercel.app/vault/docs/configuration/listener/tcp

[VAULT-29153]: https://hashicorp.atlassian.net/browse/VAULT-29153?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ