### PR TITLE
Remove InternalError wrapping for storage errors

### DIFF
--- a/builtin/logical/pki/cert_util.go
+++ b/builtin/logical/pki/cert_util.go
@@ -246,7 +246,7 @@ func fetchCertBySerial(sc pki_backend.StorageContext, prefix, serial string) (*l
 		return nil, nil
 	}
 	if certEntry.Value == nil || len(certEntry.Value) == 0 {
-		return nil, fmt.Errorf("returned certificate bytes for serial %s were empty", serial)
+		return nil, errutil.InternalError{Err: fmt.Sprintf("returned certificate bytes for serial %s were empty", serial)}
 	}
 
 	// Update old-style paths to new-style paths

--- a/builtin/logical/pki/cert_util.go
+++ b/builtin/logical/pki/cert_util.go
@@ -223,7 +223,7 @@ func fetchCertBySerial(sc pki_backend.StorageContext, prefix, serial string) (*l
 
 	certEntry, err = sc.GetStorage().Get(sc.GetContext(), path)
 	if err != nil {
-		return nil, errutil.InternalError{Err: fmt.Sprintf("error fetching certificate %s: %s", serial, err)}
+		return nil, fmt.Errorf("error fetching certificate %s: %s", serial, err)
 	}
 	if certEntry != nil {
 		if certEntry.Value == nil || len(certEntry.Value) == 0 {
@@ -246,7 +246,7 @@ func fetchCertBySerial(sc pki_backend.StorageContext, prefix, serial string) (*l
 		return nil, nil
 	}
 	if certEntry.Value == nil || len(certEntry.Value) == 0 {
-		return nil, errutil.InternalError{Err: fmt.Sprintf("returned certificate bytes for serial %s were empty", serial)}
+		return nil, fmt.Errorf("returned certificate bytes for serial %s were empty", serial)
 	}
 
 	// Update old-style paths to new-style paths
@@ -254,7 +254,7 @@ func fetchCertBySerial(sc pki_backend.StorageContext, prefix, serial string) (*l
 	certCounter := sc.GetCertificateCounter()
 	certsCounted := certCounter.IsInitialized()
 	if err = sc.GetStorage().Put(sc.GetContext(), certEntry); err != nil {
-		return nil, errutil.InternalError{Err: fmt.Sprintf("error saving certificate with serial %s to new location: %s", serial, err)}
+		return nil, fmt.Errorf("error saving certificate with serial %s to new location: %s", serial, err)
 	}
 	if err = sc.GetStorage().Delete(sc.GetContext(), legacyPath); err != nil {
 		// If we fail here, we have an extra (copy) of a cert in storage, add to metrics:
@@ -264,7 +264,7 @@ func fetchCertBySerial(sc pki_backend.StorageContext, prefix, serial string) (*l
 		default:
 			certCounter.IncrementTotalCertificatesCount(certsCounted, path)
 		}
-		return nil, errutil.InternalError{Err: fmt.Sprintf("error deleting certificate with serial %s from old location", serial)}
+		return nil, fmt.Errorf("error deleting certificate with serial %s from old location", serial)
 	}
 
 	return certEntry, nil

--- a/builtin/logical/pki/crl_util.go
+++ b/builtin/logical/pki/crl_util.go
@@ -1865,7 +1865,7 @@ func getLocalRevokedCertEntries(sc *storageContext, issuerIDCertMap map[issuing.
 
 	revokedSerials, err := sc.Storage.List(sc.Context, listingPath)
 	if err != nil {
-		return nil, nil, errutil.InternalError{Err: fmt.Sprintf("error fetching list of revoked certs: %s", err)}
+		return nil, nil, fmt.Errorf("error fetching list of revoked certs: %s", err)
 	}
 
 	// Build a mapping of issuer serial -> certificate.
@@ -1884,7 +1884,7 @@ func getLocalRevokedCertEntries(sc *storageContext, issuerIDCertMap map[issuing.
 		var revInfo revocation.RevocationInfo
 		revokedEntry, err := sc.Storage.Get(sc.Context, revokedPath+serial)
 		if err != nil {
-			return nil, nil, errutil.InternalError{Err: fmt.Sprintf("unable to fetch revoked cert with serial %s: %s", serial, err)}
+			return nil, nil, fmt.Errorf("unable to fetch revoked cert with serial %s: %s", serial, err)
 		}
 
 		if revokedEntry == nil {
@@ -2199,7 +2199,7 @@ WRITE:
 		Value: crlBytes,
 	})
 	if err != nil {
-		return nil, errutil.InternalError{Err: fmt.Sprintf("error storing CRL: %s", err)}
+		return nil, fmt.Errorf("error storing CRL: %s", err)
 	}
 
 	return &nextUpdate, nil

--- a/builtin/logical/pki/issuing/issuers.go
+++ b/builtin/logical/pki/issuing/issuers.go
@@ -336,7 +336,7 @@ func FetchIssuerById(ctx context.Context, s logical.Storage, issuerId IssuerID) 
 
 	entry, err := s.Get(ctx, IssuerPrefix+issuerId.String())
 	if err != nil {
-		return nil, errutil.InternalError{Err: fmt.Sprintf("unable to fetch pki issuer: %v", err)}
+		return nil, fmt.Errorf("unable to fetch pki issuer: %v", err)
 	}
 	if entry == nil {
 		return nil, errutil.UserError{Err: fmt.Sprintf("pki issuer id %s does not exist", issuerId.String())}

--- a/builtin/logical/pki/issuing/keys.go
+++ b/builtin/logical/pki/issuing/keys.go
@@ -58,7 +58,7 @@ func FetchKeyById(ctx context.Context, s logical.Storage, keyId KeyID) (*KeyEntr
 
 	entry, err := s.Get(ctx, KeyPrefix+keyId.String())
 	if err != nil {
-		return nil, errutil.InternalError{Err: fmt.Sprintf("unable to fetch pki key: %v", err)}
+		return nil, fmt.Errorf("unable to fetch pki key: %v", err)
 	}
 	if entry == nil {
 		return nil, errutil.UserError{Err: fmt.Sprintf("pki key id %s does not exist", keyId.String())}


### PR DESCRIPTION
### Description
What does this PR do?

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [ ] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
