### PR TITLE
docs: Make it clear that an Enterprise Vault binary is required to use the License subcommands

### DIFF
--- a/website/content/docs/commands/license/get.mdx
+++ b/website/content/docs/commands/license/get.mdx
@@ -7,6 +7,8 @@ description: |-
 
 # license get
 
+@include 'alerts/enterprise-only.mdx'
+
 The `license get` command reports on the license in use.  With the `-signed`
 flag, it will return the actual license string, but only if the license
 is stored, as opposed to [autoloaded](/vault/docs/enterprise/license/autoloading).

--- a/website/content/docs/commands/license/index.mdx
+++ b/website/content/docs/commands/license/index.mdx
@@ -7,6 +7,8 @@ description: |-
 
 # license
 
+@include 'alerts/enterprise-only.mdx'
+
 The `license` command groups subcommands for interacting with Vault licenses
 
 For more information, please see the [license documentation](/vault/docs/enterprise/license)

--- a/website/content/docs/commands/license/inspect.mdx
+++ b/website/content/docs/commands/license/inspect.mdx
@@ -7,6 +7,8 @@ description: |-
 
 # license inspect
 
+@include 'alerts/enterprise-only.mdx'
+
 The `license inspect` command describes the contents of a signed license string.
 
 ## Examples


### PR DESCRIPTION
### Description
Adds the "Vault Enterprise" banner on the docs for these subcommands. As we're interacting with a Vault license... this is kinda implied. But this should make it clear that you explicitly need an enterprise binary if you want to inspect an enterprise license (and that you cannot inspect a license with a CE binary).


The wording isn't 100% clear here; the partial
https://github.com/hashicorp/vault/blob/main/website/content/partials/alerts/enterprise-only.mdx says that an enterprise _license_ is required to run this command...
But I think the implication may be sufficient.

For example, the operator import command:
https://github.com/hashicorp/vault/blob/main/website/content/docs/commands/operator/import.mdx

Needs both an enterprise license, and an enterprise binary.

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [ ] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.


^ HashiCorp employee, but none of the above apply