### PR TITLE
VAULT-31748: add removable node HA backend interface and raft implementation

### DIFF
--- a/sdk/physical/physical.go
+++ b/sdk/physical/physical.go
@@ -60,6 +60,25 @@ type HABackend interface {
 	HAEnabled() bool
 }
 
+// RemovableNodeHABackend is used for HA backends that can remove nodes from
+// their cluster
+type RemovableNodeHABackend interface {
+	HABackend
+
+	// IsNodeRemoved checks if the node with the given ID has been removed.
+	// This will only be called on the active node.
+	IsNodeRemoved(ctx context.Context, nodeID string) (bool, error)
+
+	// NodeID returns the ID for this node
+	NodeID() string
+
+	// IsRemoved checks if this node has been removed
+	IsRemoved() bool
+
+	// RemoveSelf marks this node as being removed
+	RemoveSelf() error
+}
+
 // FencingHABackend is an HABackend which provides the additional guarantee that
 // each Lock it returns from LockWith is also a FencingLock. A FencingLock
 // provides a mechanism to retrieve a fencing token that can be included by


### PR DESCRIPTION
### Description
This PR creates a new interface and the raft implementation of that interface, in order to support handling of removed nodes from an HA cluster 

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [ ] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
