### PR TITLE
Fix VAULT_CACERT environment variable

### DIFF
--- a/website/content/partials/global-settings/both/ca-cert.mdx
+++ b/website/content/partials/global-settings/both/ca-cert.mdx
@@ -1,6 +1,6 @@
 <a id="global-ca-cert" />
 
-**`[-ca-cert | VAULT_CA_CERT] (string : "")`**
+**`[-ca-cert | VAULT_CACERT] (string : "")`**
 
 Path to a PEM-encoded CA certificate file on the local disk. Used to verify SSL
 certificates for the server. **Takes precedence over `-ca_path`**.
@@ -8,5 +8,5 @@ certificates for the server. **Takes precedence over `-ca_path`**.
 **Examples**:
 
 - CLI flag: `-ca-cert "/path/to/certs/mycert.pem"`
-- Environment variable: `export VAULT_CA_CERT="/path/to/certs/mycert.pem"`
+- Environment variable: `export VAULT_CACERT="/path/to/certs/mycert.pem"`
 


### PR DESCRIPTION
### Description
Fixes references to VAULT_CACERT. Closes #28725

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [ ] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
