### PR TITLE
Adds copy button to entity, alias and mfa method ID fields

### DIFF
--- a/changelog/28742.txt
+++ b/changelog/28742.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: Adds copy button to identity entity, alias and mfa method IDs
+```

--- a/ui/app/templates/components/identity/item-alias/alias-details.hbs
+++ b/ui/app/templates/components/identity/item-alias/alias-details.hbs
@@ -4,12 +4,11 @@
 ~}}
 
 <InfoTableRow @label="Name" @value={{@model.name}} data-test-alias-name={{true}} />
-<InfoTableRow @label="ID" @value={{@model.id}} />
+<InfoTableRow @label="ID" @value={{@model.id}} @addCopyButton={{true}} />
 <InfoTableRow @label={{if (eq @model.identityType "entity-alias") "Entity ID" "Group ID"}} @value={{this.model.canonicalId}}>
   <LinkTo
     @route="vault.cluster.access.identity.show"
     @models={{array (if (eq @model.identityType "entity-alias") "entities" "groups") @model.canonicalId "details"}}
-    class="has-text-black is-font-mono"
   >
     {{@model.canonicalId}}
   </LinkTo>

--- a/ui/app/templates/components/identity/item-details.hbs
+++ b/ui/app/templates/components/identity/item-details.hbs
@@ -19,7 +19,7 @@
   {{/if}}
   <InfoTableRow @label="Name" @value={{@model.name}} data-test-identity-item-name={{true}} />
   <InfoTableRow @label="Type" @value={{@model.type}} />
-  <InfoTableRow @label="ID" @value={{@model.id}} />
+  <InfoTableRow @label="ID" @value={{@model.id}} @addCopyButton={{true}} />
   <InfoTableRow @label="Merged Ids" @value={{@model.mergedEntityIds}}>
     <div>
       {{#each @model.mergedEntityIds as |id|}}

--- a/ui/app/templates/vault/cluster/access/mfa/methods/method/index.hbs
+++ b/ui/app/templates/vault/cluster/access/mfa/methods/method/index.hbs
@@ -60,6 +60,7 @@
     </ToolbarActions>
   </Toolbar>
   <div class="box is-fullwidth is-sideless is-paddingless is-marginless">
+    <InfoTableRow @label="ID" @value={{this.model.method.id}} @addCopyButton={{true}} />
     {{#each this.model.method.attrs as |attr|}}
       {{#if (eq attr.type "object")}}
         <InfoTableRow


### PR DESCRIPTION
### Description

Adds copy buttons to ids for entities, aliases and mfa methods
<hr>

### entity & alias details
<img width="1094" alt="Screenshot 2024-10-21 at 10 23 41 AM" src="https://github.com/user-attachments/assets/f3444057-f9d8-4cc7-8566-a804e2956b28">
<img width="1100" alt="Screenshot 2024-10-21 at 10 24 07 AM" src="https://github.com/user-attachments/assets/5c591bcf-aea5-4d69-b3e4-e5f9b687e7b8">

<hr>


#### mfa method
<img width="1151" alt="Screenshot 2024-10-21 at 10 23 20 AM" src="https://github.com/user-attachments/assets/1ed7e222-a00c-4f81-94a5-ef7455c58c2b">

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [ ] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
