### PR TITLE
Fix Windows chown error

### DIFF
--- a/changelog/28748.txt
+++ b/changelog/28748.txt
@@ -1,0 +1,6 @@
+```release-note:bug
+agent: Fix chown error running agent on Windows with an auto-auth file sinks. 
+```
+```release-note:bug
+proxy: Fix chown error running proxy on Windows with an auto-auth file sink.
+```

--- a/command/agentproxyshared/sink/file/file_sink.go
+++ b/command/agentproxyshared/sink/file/file_sink.go
@@ -13,6 +13,7 @@ import (
 	hclog "github.com/hashicorp/go-hclog"
 	uuid "github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/vault/command/agentproxyshared/sink"
+	"github.com/hashicorp/vault/helper/osutil"
 )
 
 // fileSink is a Sink implementation that writes a token to a file
@@ -117,7 +118,7 @@ func (f *fileSink) WriteToken(token string) error {
 		return fmt.Errorf("error opening temp file in dir %s for writing: %w", targetDir, err)
 	}
 
-	if err := tmpFile.Chown(f.owner, f.group); err != nil {
+	if err := osutil.Chown(tmpFile, f.owner, f.group); err != nil {
 		return fmt.Errorf("error changing ownership of %s: %w", tmpFile.Name(), err)
 	}
 

--- a/helper/osutil/fileinfo_unix.go
+++ b/helper/osutil/fileinfo_unix.go
@@ -8,6 +8,7 @@ package osutil
 import (
 	"fmt"
 	"io/fs"
+	"os"
 	"os/user"
 	"strconv"
 	"syscall"
@@ -58,4 +59,8 @@ func FileUidMatch(info fs.FileInfo, path string, uid int) (err error) {
 // Sets new umask and returns old umask
 func Umask(newmask int) int {
 	return syscall.Umask(newmask)
+}
+
+func Chown(f *os.File, owner, group int) error {
+	return f.Chown(owner, group)
 }

--- a/helper/osutil/fileinfo_windows.go
+++ b/helper/osutil/fileinfo_windows.go
@@ -7,6 +7,7 @@ package osutil
 
 import (
 	"io/fs"
+	"os"
 )
 
 func FileUidMatch(info fs.FileInfo, path string, uid int) error {
@@ -16,4 +17,8 @@ func FileUidMatch(info fs.FileInfo, path string, uid int) error {
 // Umask does nothing for windows for now
 func Umask(newmask int) int {
 	return 0
+}
+
+func Chown(f *os.File, owner, group int) error {
+	return nil
 }


### PR DESCRIPTION
### Description
Closes #28734

Sets chown to a noop on windows, instead of erroring. 

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [ ] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
