### PR TITLE
VAULT-21710 - prevent duplicate audit file_path targets

### DIFF
--- a/changelog/28751.txt
+++ b/changelog/28751.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+audit: Prevent the audit process from allowing duplicate file path targets
+```

--- a/changelog/28751.txt
+++ b/changelog/28751.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-audit: Prevent the audit process from allowing duplicate file path targets
+audit: Prevent users from enabling multiple audit devices of file type with the same file_path to write to.
 ```

--- a/vault/audit.go
+++ b/vault/audit.go
@@ -116,7 +116,7 @@ func (c *Core) enableAudit(ctx context.Context, entry *MountEntry, updateStorage
 			return fmt.Errorf("path already in use: %w", audit.ErrExternalOptions)
 		}
 
-		// Check if argument file_path vs current vault file_path
+		// Ensure that the provided file_path argument isn't already used for another audit device's file_path.
 		if entry.Type == "file" {
 			if entry.Options["file_path"] == ent.Options["file_path"] {
 				return fmt.Errorf("file_path already in use: %w", audit.ErrExternalOptions)

--- a/vault/audit.go
+++ b/vault/audit.go
@@ -117,8 +117,10 @@ func (c *Core) enableAudit(ctx context.Context, entry *MountEntry, updateStorage
 		}
 
 		// Check if argument file_path vs current vault file_path
-		if entry.Options["file_path"] == ent.Options["file_path"] {
-			return fmt.Errorf("file_path already in use: %w", audit.ErrExternalOptions)
+		if entry.Type == "file" {
+			if entry.Options["file_path"] == ent.Options["file_path"] {
+				return fmt.Errorf("file_path already in use: %w", audit.ErrExternalOptions)
+			}
 		}
 	}
 

--- a/vault/audit.go
+++ b/vault/audit.go
@@ -107,7 +107,6 @@ func (c *Core) enableAudit(ctx context.Context, entry *MountEntry, updateStorage
 
 	// Look for matching name
 	for _, ent := range c.audit.Entries {
-
 		switch {
 		// Existing is sql/mysql/ new is sql/ or
 		// existing is sql/ and new is sql/mysql/

--- a/vault/audit.go
+++ b/vault/audit.go
@@ -107,6 +107,7 @@ func (c *Core) enableAudit(ctx context.Context, entry *MountEntry, updateStorage
 
 	// Look for matching name
 	for _, ent := range c.audit.Entries {
+
 		switch {
 		// Existing is sql/mysql/ new is sql/ or
 		// existing is sql/ and new is sql/mysql/
@@ -114,6 +115,11 @@ func (c *Core) enableAudit(ctx context.Context, entry *MountEntry, updateStorage
 			fallthrough
 		case strings.HasPrefix(entry.Path, ent.Path):
 			return fmt.Errorf("path already in use: %w", audit.ErrExternalOptions)
+		}
+
+		// Check if argument file_path vs current vault file_path
+		if entry.Options["file_path"] == ent.Options["file_path"] {
+			return fmt.Errorf("file_path already in use: %w", audit.ErrExternalOptions)
 		}
 	}
 

--- a/vault/audit_test.go
+++ b/vault/audit_test.go
@@ -105,10 +105,12 @@ func TestCore_EnableAudit(t *testing.T) {
 	}
 }
 
-// Test handling of duplicate file_path in vault audit options across multiple paths
+// TestCore_EnableExistingAudit tests the handling of enabling existing audit backends,
+// specifically checking for duplicate file paths in audit options across multiple paths.
 func TestCore_EnableExistingAudit(t *testing.T) {
 	c, _, _ := TestCoreUnsealed(t)
 
+	// First audit backend entry
 	me := &MountEntry{
 		Table: auditTableType,
 		Path:  "foo",
@@ -118,6 +120,7 @@ func TestCore_EnableExistingAudit(t *testing.T) {
 		},
 	}
 
+	// Second audit backend entry
 	me2 := &MountEntry{
 		Table: auditTableType,
 		Path:  "foo2",

--- a/vault/audit_test.go
+++ b/vault/audit_test.go
@@ -105,6 +105,7 @@ func TestCore_EnableAudit(t *testing.T) {
 	}
 }
 
+// Test vault audit option duplicate file_path for multiple path
 func TestCore_EnableExistingAudit(t *testing.T) {
 	c, _, _ := TestCoreUnsealed(t)
 

--- a/vault/audit_test.go
+++ b/vault/audit_test.go
@@ -105,6 +105,45 @@ func TestCore_EnableAudit(t *testing.T) {
 	}
 }
 
+func TestCore_EnableExistingAudit(t *testing.T) {
+	c, _, _ := TestCoreUnsealed(t)
+
+	me := &MountEntry{
+		Table: auditTableType,
+		Path:  "foo",
+		Type:  audit.TypeFile,
+		Options: map[string]string{
+			"file_path": "testdata/audit_test.log",
+		},
+	}
+
+	me2 := &MountEntry{
+		Table: auditTableType,
+		Path:  "foo2",
+		Type:  audit.TypeFile,
+		Options: map[string]string{
+			"file_path": "testdata/audit_test.log",
+		},
+	}
+
+	// Enable first audit backend
+	err := c.enableAudit(namespace.RootContext(context.Background()), me, true)
+	if err != nil {
+		t.Errorf("failed to enable audit for path 'foo': %v", err)
+	}
+
+	// Check if the first audit backend is registered
+	if !c.auditBroker.IsRegistered("foo/") {
+		t.Errorf("audit backend for path 'foo/' is not registered")
+	}
+
+	// Enable second audit backend
+	err = c.enableAudit(namespace.RootContext(context.Background()), me2, true)
+	if err != nil {
+		t.Errorf("failed to enable audit for path 'foo2': %v", err)
+	}
+}
+
 func TestCore_EnableAudit_MixedFailures(t *testing.T) {
 	c, _, _ := TestCoreUnsealed(t)
 

--- a/vault/audit_test.go
+++ b/vault/audit_test.go
@@ -105,7 +105,7 @@ func TestCore_EnableAudit(t *testing.T) {
 	}
 }
 
-// Test vault audit option duplicate file_path for multiple path
+// Test handling of duplicate file_path in vault audit options across multiple paths
 func TestCore_EnableExistingAudit(t *testing.T) {
 	c, _, _ := TestCoreUnsealed(t)
 

--- a/vault/audit_test.go
+++ b/vault/audit_test.go
@@ -105,8 +105,8 @@ func TestCore_EnableAudit(t *testing.T) {
 	}
 }
 
-// TestCore_EnableExistingAudit tests the handling of enabling existing audit backends,
-// specifically checking for duplicate file paths in audit options across multiple paths.
+// TestCore_EnableExistingAudit ensures that we don't allow enabling a file audit device
+// with the same `file_path` as one of the existing ones.
 func TestCore_EnableExistingAudit(t *testing.T) {
 	c, _, _ := TestCoreUnsealed(t)
 

--- a/vault/audit_test.go
+++ b/vault/audit_test.go
@@ -113,7 +113,7 @@ func TestCore_EnableExistingAudit(t *testing.T) {
 		Path:  "foo",
 		Type:  audit.TypeFile,
 		Options: map[string]string{
-			"file_path": "testdata/audit_test.log",
+			"file_path": "stdout",
 		},
 	}
 
@@ -122,7 +122,7 @@ func TestCore_EnableExistingAudit(t *testing.T) {
 		Path:  "foo2",
 		Type:  audit.TypeFile,
 		Options: map[string]string{
-			"file_path": "testdata/audit_test.log",
+			"file_path": "stdout",
 		},
 	}
 

--- a/vault/audit_test.go
+++ b/vault/audit_test.go
@@ -139,8 +139,8 @@ func TestCore_EnableExistingAudit(t *testing.T) {
 
 	// Enable second audit backend
 	err = c.enableAudit(namespace.RootContext(context.Background()), me2, true)
-	if err != nil {
-		t.Errorf("failed to enable audit for path 'foo2': %v", err)
+	if err == nil {
+		t.Errorf("Should not be able to enable audit for path 'foo2' due to duplication: %v", err)
 	}
 }
 


### PR DESCRIPTION
### Description
Prevent the audit process from allowing duplicate file path targets

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [ ] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
