### PR TITLE
Support trimming trailing slashes via a mount tuneable to support CMPv2

### DIFF
--- a/api/sys_mounts.go
+++ b/api/sys_mounts.go
@@ -290,23 +290,23 @@ type MountInput struct {
 }
 
 type MountConfigInput struct {
-	Options                   map[string]string       `json:"options" mapstructure:"options"`
-	DefaultLeaseTTL           string                  `json:"default_lease_ttl" mapstructure:"default_lease_ttl"`
-	Description               *string                 `json:"description,omitempty" mapstructure:"description"`
-	MaxLeaseTTL               string                  `json:"max_lease_ttl" mapstructure:"max_lease_ttl"`
-	ForceNoCache              bool                    `json:"force_no_cache" mapstructure:"force_no_cache"`
-	AuditNonHMACRequestKeys   []string                `json:"audit_non_hmac_request_keys,omitempty" mapstructure:"audit_non_hmac_request_keys"`
-	AuditNonHMACResponseKeys  []string                `json:"audit_non_hmac_response_keys,omitempty" mapstructure:"audit_non_hmac_response_keys"`
-	ListingVisibility         string                  `json:"listing_visibility,omitempty" mapstructure:"listing_visibility"`
-	PassthroughRequestHeaders []string                `json:"passthrough_request_headers,omitempty" mapstructure:"passthrough_request_headers"`
-	AllowedResponseHeaders    []string                `json:"allowed_response_headers,omitempty" mapstructure:"allowed_response_headers"`
-	TokenType                 string                  `json:"token_type,omitempty" mapstructure:"token_type"`
-	AllowedManagedKeys        []string                `json:"allowed_managed_keys,omitempty" mapstructure:"allowed_managed_keys"`
-	PluginVersion             string                  `json:"plugin_version,omitempty"`
-	UserLockoutConfig         *UserLockoutConfigInput `json:"user_lockout_config,omitempty"`
-	DelegatedAuthAccessors    []string                `json:"delegated_auth_accessors,omitempty" mapstructure:"delegated_auth_accessors"`
-	IdentityTokenKey          string                  `json:"identity_token_key,omitempty" mapstructure:"identity_token_key"`
-
+	Options                    map[string]string       `json:"options" mapstructure:"options"`
+	DefaultLeaseTTL            string                  `json:"default_lease_ttl" mapstructure:"default_lease_ttl"`
+	Description                *string                 `json:"description,omitempty" mapstructure:"description"`
+	MaxLeaseTTL                string                  `json:"max_lease_ttl" mapstructure:"max_lease_ttl"`
+	ForceNoCache               bool                    `json:"force_no_cache" mapstructure:"force_no_cache"`
+	AuditNonHMACRequestKeys    []string                `json:"audit_non_hmac_request_keys,omitempty" mapstructure:"audit_non_hmac_request_keys"`
+	AuditNonHMACResponseKeys   []string                `json:"audit_non_hmac_response_keys,omitempty" mapstructure:"audit_non_hmac_response_keys"`
+	ListingVisibility          string                  `json:"listing_visibility,omitempty" mapstructure:"listing_visibility"`
+	PassthroughRequestHeaders  []string                `json:"passthrough_request_headers,omitempty" mapstructure:"passthrough_request_headers"`
+	AllowedResponseHeaders     []string                `json:"allowed_response_headers,omitempty" mapstructure:"allowed_response_headers"`
+	TokenType                  string                  `json:"token_type,omitempty" mapstructure:"token_type"`
+	AllowedManagedKeys         []string                `json:"allowed_managed_keys,omitempty" mapstructure:"allowed_managed_keys"`
+	PluginVersion              string                  `json:"plugin_version,omitempty"`
+	UserLockoutConfig          *UserLockoutConfigInput `json:"user_lockout_config,omitempty"`
+	DelegatedAuthAccessors     []string                `json:"delegated_auth_accessors,omitempty" mapstructure:"delegated_auth_accessors"`
+	IdentityTokenKey           string                  `json:"identity_token_key,omitempty" mapstructure:"identity_token_key"`
+	TrimRequestTrailingSlashes bool                    `json:"trim_request_trailing_slashes,omitempty" mapstructure:"trim_request_trailing_slashes"`
 	// Deprecated: This field will always be blank for newer server responses.
 	PluginName string `json:"plugin_name,omitempty" mapstructure:"plugin_name"`
 }

--- a/api/sys_mounts.go
+++ b/api/sys_mounts.go
@@ -306,7 +306,7 @@ type MountConfigInput struct {
 	UserLockoutConfig          *UserLockoutConfigInput `json:"user_lockout_config,omitempty"`
 	DelegatedAuthAccessors     []string                `json:"delegated_auth_accessors,omitempty" mapstructure:"delegated_auth_accessors"`
 	IdentityTokenKey           string                  `json:"identity_token_key,omitempty" mapstructure:"identity_token_key"`
-	TrimRequestTrailingSlashes bool                    `json:"trim_request_trailing_slashes,omitempty" mapstructure:"trim_request_trailing_slashes"`
+	TrimRequestTrailingSlashes *bool                   `json:"trim_request_trailing_slashes,omitempty" mapstructure:"trim_request_trailing_slashes"`
 	// Deprecated: This field will always be blank for newer server responses.
 	PluginName string `json:"plugin_name,omitempty" mapstructure:"plugin_name"`
 }

--- a/api/sys_mounts.go
+++ b/api/sys_mounts.go
@@ -328,19 +328,20 @@ type MountOutput struct {
 }
 
 type MountConfigOutput struct {
-	DefaultLeaseTTL           int                      `json:"default_lease_ttl" mapstructure:"default_lease_ttl"`
-	MaxLeaseTTL               int                      `json:"max_lease_ttl" mapstructure:"max_lease_ttl"`
-	ForceNoCache              bool                     `json:"force_no_cache" mapstructure:"force_no_cache"`
-	AuditNonHMACRequestKeys   []string                 `json:"audit_non_hmac_request_keys,omitempty" mapstructure:"audit_non_hmac_request_keys"`
-	AuditNonHMACResponseKeys  []string                 `json:"audit_non_hmac_response_keys,omitempty" mapstructure:"audit_non_hmac_response_keys"`
-	ListingVisibility         string                   `json:"listing_visibility,omitempty" mapstructure:"listing_visibility"`
-	PassthroughRequestHeaders []string                 `json:"passthrough_request_headers,omitempty" mapstructure:"passthrough_request_headers"`
-	AllowedResponseHeaders    []string                 `json:"allowed_response_headers,omitempty" mapstructure:"allowed_response_headers"`
-	TokenType                 string                   `json:"token_type,omitempty" mapstructure:"token_type"`
-	AllowedManagedKeys        []string                 `json:"allowed_managed_keys,omitempty" mapstructure:"allowed_managed_keys"`
-	UserLockoutConfig         *UserLockoutConfigOutput `json:"user_lockout_config,omitempty"`
-	DelegatedAuthAccessors    []string                 `json:"delegated_auth_accessors,omitempty" mapstructure:"delegated_auth_accessors"`
-	IdentityTokenKey          string                   `json:"identity_token_key,omitempty" mapstructure:"identity_token_key"`
+	DefaultLeaseTTL            int                      `json:"default_lease_ttl" mapstructure:"default_lease_ttl"`
+	MaxLeaseTTL                int                      `json:"max_lease_ttl" mapstructure:"max_lease_ttl"`
+	ForceNoCache               bool                     `json:"force_no_cache" mapstructure:"force_no_cache"`
+	AuditNonHMACRequestKeys    []string                 `json:"audit_non_hmac_request_keys,omitempty" mapstructure:"audit_non_hmac_request_keys"`
+	AuditNonHMACResponseKeys   []string                 `json:"audit_non_hmac_response_keys,omitempty" mapstructure:"audit_non_hmac_response_keys"`
+	ListingVisibility          string                   `json:"listing_visibility,omitempty" mapstructure:"listing_visibility"`
+	PassthroughRequestHeaders  []string                 `json:"passthrough_request_headers,omitempty" mapstructure:"passthrough_request_headers"`
+	AllowedResponseHeaders     []string                 `json:"allowed_response_headers,omitempty" mapstructure:"allowed_response_headers"`
+	TokenType                  string                   `json:"token_type,omitempty" mapstructure:"token_type"`
+	AllowedManagedKeys         []string                 `json:"allowed_managed_keys,omitempty" mapstructure:"allowed_managed_keys"`
+	UserLockoutConfig          *UserLockoutConfigOutput `json:"user_lockout_config,omitempty"`
+	DelegatedAuthAccessors     []string                 `json:"delegated_auth_accessors,omitempty" mapstructure:"delegated_auth_accessors"`
+	IdentityTokenKey           string                   `json:"identity_token_key,omitempty" mapstructure:"identity_token_key"`
+	TrimRequestTrailingSlashes bool                     `json:"trim_request_trailing_slashes,omitempty" mapstructure:"trim_request_trailing_slashes"`
 
 	// Deprecated: This field will always be blank for newer server responses.
 	PluginName string `json:"plugin_name,omitempty" mapstructure:"plugin_name"`

--- a/changelog/28752.txt
+++ b/changelog/28752.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+core: Add a mount tuneable that trims trailing slashes of request paths during POST.  Needed to support CMPv2 in PKI.
+```

--- a/command/auth_enable.go
+++ b/command/auth_enable.go
@@ -23,24 +23,25 @@ var (
 type AuthEnableCommand struct {
 	*BaseCommand
 
-	flagDescription               string
-	flagPath                      string
-	flagDefaultLeaseTTL           time.Duration
-	flagMaxLeaseTTL               time.Duration
-	flagAuditNonHMACRequestKeys   []string
-	flagAuditNonHMACResponseKeys  []string
-	flagListingVisibility         string
-	flagPluginName                string
-	flagPassthroughRequestHeaders []string
-	flagAllowedResponseHeaders    []string
-	flagOptions                   map[string]string
-	flagLocal                     bool
-	flagSealWrap                  bool
-	flagExternalEntropyAccess     bool
-	flagTokenType                 string
-	flagVersion                   int
-	flagPluginVersion             string
-	flagIdentityTokenKey          string
+	flagDescription                string
+	flagPath                       string
+	flagDefaultLeaseTTL            time.Duration
+	flagMaxLeaseTTL                time.Duration
+	flagAuditNonHMACRequestKeys    []string
+	flagAuditNonHMACResponseKeys   []string
+	flagListingVisibility          string
+	flagPluginName                 string
+	flagPassthroughRequestHeaders  []string
+	flagAllowedResponseHeaders     []string
+	flagOptions                    map[string]string
+	flagLocal                      bool
+	flagSealWrap                   bool
+	flagExternalEntropyAccess      bool
+	flagTokenType                  string
+	flagVersion                    int
+	flagPluginVersion              string
+	flagIdentityTokenKey           string
+	flagTrimRequestTrailingSlashes BoolPtr
 }
 
 func (c *AuthEnableCommand) Synopsis() string {
@@ -217,6 +218,12 @@ func (c *AuthEnableCommand) Flags() *FlagSets {
 		Usage:   "Select the key used to sign plugin identity tokens.",
 	})
 
+	f.BoolPtrVar(&BoolPtrVar{
+		Name:   flagNameTrimRequestTrailingSlashes,
+		Target: &c.flagTrimRequestTrailingSlashes,
+		Usage:  "Whether to trim trailing slashes for incoming requests to this mount",
+	})
+
 	return set
 }
 
@@ -323,6 +330,11 @@ func (c *AuthEnableCommand) Run(args []string) int {
 
 		if fl.Name == flagNameIdentityTokenKey {
 			authOpts.Config.IdentityTokenKey = c.flagIdentityTokenKey
+		}
+
+		if fl.Name == flagNameTrimRequestTrailingSlashes && c.flagTrimRequestTrailingSlashes.IsSet() {
+			val := c.flagTrimRequestTrailingSlashes.Get()
+			authOpts.Config.TrimRequestTrailingSlashes = &val
 		}
 	})
 

--- a/command/auth_enable_test.go
+++ b/command/auth_enable_test.go
@@ -100,6 +100,7 @@ func TestAuthEnableCommand_Run(t *testing.T) {
 			"-allowed-response-headers", "authorization",
 			"-listing-visibility", "unauth",
 			"-identity-token-key", "default",
+			"-trim-request-trailing-slashes=true",
 			"userpass",
 		})
 		if exp := 0; code != exp {
@@ -126,6 +127,9 @@ func TestAuthEnableCommand_Run(t *testing.T) {
 		}
 		if exp := "The best kind of test"; authInfo.Description != exp {
 			t.Errorf("expected %q to be %q", authInfo.Description, exp)
+		}
+		if !authInfo.Config.TrimRequestTrailingSlashes {
+			t.Errorf("expected trim_request_trailing_slashes to be enabled")
 		}
 		if diff := deep.Equal([]string{"authorization,authentication", "www-authentication"}, authInfo.Config.PassthroughRequestHeaders); len(diff) > 0 {
 			t.Errorf("Failed to find expected values in PassthroughRequestHeaders. Difference is: %v", diff)

--- a/command/auth_tune.go
+++ b/command/auth_tune.go
@@ -196,17 +196,18 @@ func (c *AuthTuneCommand) Flags() *FlagSets {
 		Usage: "Select the semantic version of the plugin to run. The new version must be registered in " +
 			"the plugin catalog, and will not start running until the plugin is reloaded.",
 	})
-	f.StringVar(&StringVar{
-		Name:    flagNameIdentityTokenKey,
-		Target:  &c.flagIdentityTokenKey,
-		Default: "default",
-		Usage:   "Select the key used to sign plugin identity tokens.",
-	})
 	f.BoolVar(&BoolVar{
 		Name:    flagNameTrimRequestTrailingSlashes,
 		Target:  &c.flagTrimRequestTrailingSlashes,
 		Default: false,
 		Usage:   "Whether to trim trailing slashes for incoming requests to this mount",
+	})
+
+	f.StringVar(&StringVar{
+		Name:    flagNameIdentityTokenKey,
+		Target:  &c.flagIdentityTokenKey,
+		Default: "default",
+		Usage:   "Select the key used to sign plugin identity tokens.",
 	})
 
 	return set

--- a/command/auth_tune.go
+++ b/command/auth_tune.go
@@ -40,7 +40,7 @@ type AuthTuneCommand struct {
 	flagUserLockoutCounterResetDuration time.Duration
 	flagUserLockoutDisable              bool
 	flagIdentityTokenKey                string
-	flagTrimRequestTrailingSlashes      bool
+	flagTrimRequestTrailingSlashes      BoolPtr
 }
 
 func (c *AuthTuneCommand) Synopsis() string {
@@ -196,11 +196,10 @@ func (c *AuthTuneCommand) Flags() *FlagSets {
 		Usage: "Select the semantic version of the plugin to run. The new version must be registered in " +
 			"the plugin catalog, and will not start running until the plugin is reloaded.",
 	})
-	f.BoolVar(&BoolVar{
-		Name:    flagNameTrimRequestTrailingSlashes,
-		Target:  &c.flagTrimRequestTrailingSlashes,
-		Default: false,
-		Usage:   "Whether to trim trailing slashes for incoming requests to this mount",
+	f.BoolPtrVar(&BoolPtrVar{
+		Name:   flagNameTrimRequestTrailingSlashes,
+		Target: &c.flagTrimRequestTrailingSlashes,
+		Usage:  "Whether to trim trailing slashes for incoming requests to this mount",
 	})
 
 	f.StringVar(&StringVar{
@@ -314,8 +313,9 @@ func (c *AuthTuneCommand) Run(args []string) int {
 			mountConfigInput.IdentityTokenKey = c.flagIdentityTokenKey
 		}
 
-		if fl.Name == flagNameTrimRequestTrailingSlashes {
-			mountConfigInput.TrimRequestTrailingSlashes = c.flagTrimRequestTrailingSlashes
+		if fl.Name == flagNameTrimRequestTrailingSlashes && c.flagTrimRequestTrailingSlashes.IsSet() {
+			val := c.flagTrimRequestTrailingSlashes.Get()
+			mountConfigInput.TrimRequestTrailingSlashes = &val
 		}
 	})
 

--- a/command/auth_tune.go
+++ b/command/auth_tune.go
@@ -196,13 +196,6 @@ func (c *AuthTuneCommand) Flags() *FlagSets {
 		Usage: "Select the semantic version of the plugin to run. The new version must be registered in " +
 			"the plugin catalog, and will not start running until the plugin is reloaded.",
 	})
-	f.BoolVar(&BoolVar{
-		Name:    flagNameTrimRequestTrailingSlashes,
-		Target:  &c.flagTrimRequestTrailingSlashes,
-		Default: false,
-		Usage:   "Whether to trim trailing slashes for incoming requests to this mount",
-	})
-
 	f.StringVar(&StringVar{
 		Name:    flagNameIdentityTokenKey,
 		Target:  &c.flagIdentityTokenKey,

--- a/command/auth_tune.go
+++ b/command/auth_tune.go
@@ -323,10 +323,6 @@ func (c *AuthTuneCommand) Run(args []string) int {
 		if fl.Name == flagNameTrimRequestTrailingSlashes {
 			mountConfigInput.TrimRequestTrailingSlashes = c.flagTrimRequestTrailingSlashes
 		}
-
-		if fl.Name == flagNameTrimRequestTrailingSlashes {
-			mountConfigInput.TrimRequestTrailingSlashes = c.flagTrimRequestTrailingSlashes
-		}
 	})
 
 	// Append /auth (since that's where auths live) and a trailing slash to

--- a/command/auth_tune.go
+++ b/command/auth_tune.go
@@ -40,6 +40,7 @@ type AuthTuneCommand struct {
 	flagUserLockoutCounterResetDuration time.Duration
 	flagUserLockoutDisable              bool
 	flagIdentityTokenKey                string
+	flagTrimRequestTrailingSlashes      bool
 }
 
 func (c *AuthTuneCommand) Synopsis() string {
@@ -195,12 +196,24 @@ func (c *AuthTuneCommand) Flags() *FlagSets {
 		Usage: "Select the semantic version of the plugin to run. The new version must be registered in " +
 			"the plugin catalog, and will not start running until the plugin is reloaded.",
 	})
+	f.BoolVar(&BoolVar{
+		Name:    flagNameTrimRequestTrailingSlashes,
+		Target:  &c.flagTrimRequestTrailingSlashes,
+		Default: false,
+		Usage:   "Whether to trim trailing slashes for incoming requests to this mount",
+	})
 
 	f.StringVar(&StringVar{
 		Name:    flagNameIdentityTokenKey,
 		Target:  &c.flagIdentityTokenKey,
 		Default: "default",
 		Usage:   "Select the key used to sign plugin identity tokens.",
+	})
+	f.BoolVar(&BoolVar{
+		Name:    flagNameTrimRequestTrailingSlashes,
+		Target:  &c.flagTrimRequestTrailingSlashes,
+		Default: false,
+		Usage:   "Whether to trim trailing slashes for incoming requests to this mount",
 	})
 
 	return set
@@ -305,6 +318,14 @@ func (c *AuthTuneCommand) Run(args []string) int {
 
 		if fl.Name == flagNameIdentityTokenKey {
 			mountConfigInput.IdentityTokenKey = c.flagIdentityTokenKey
+		}
+
+		if fl.Name == flagNameTrimRequestTrailingSlashes {
+			mountConfigInput.TrimRequestTrailingSlashes = c.flagTrimRequestTrailingSlashes
+		}
+
+		if fl.Name == flagNameTrimRequestTrailingSlashes {
+			mountConfigInput.TrimRequestTrailingSlashes = c.flagTrimRequestTrailingSlashes
 		}
 	})
 

--- a/command/auth_tune_test.go
+++ b/command/auth_tune_test.go
@@ -120,6 +120,7 @@ func TestAuthTuneCommand_Run(t *testing.T) {
 				"-listing-visibility", "unauth",
 				"-plugin-version", version,
 				"-identity-token-key", "default",
+				"-trim-request-trailing-slashes",
 				"my-auth/",
 			})
 			if exp := 0; code != exp {
@@ -155,6 +156,9 @@ func TestAuthTuneCommand_Run(t *testing.T) {
 			}
 			if exp := 3600; mountInfo.Config.MaxLeaseTTL != exp {
 				t.Errorf("expected %d to be %d", mountInfo.Config.MaxLeaseTTL, exp)
+			}
+			if mountInfo.Config.TrimRequestTrailingSlashes {
+				t.Errorf("expected trim_request_trailing_slashes to be enabled")
 			}
 			if diff := deep.Equal([]string{"authorization", "www-authentication"}, mountInfo.Config.PassthroughRequestHeaders); len(diff) > 0 {
 				t.Errorf("Failed to find expected values in PassthroughRequestHeaders. Difference is: %v", diff)

--- a/command/auth_tune_test.go
+++ b/command/auth_tune_test.go
@@ -120,7 +120,7 @@ func TestAuthTuneCommand_Run(t *testing.T) {
 				"-listing-visibility", "unauth",
 				"-plugin-version", version,
 				"-identity-token-key", "default",
-				"-trim-request-trailing-slashes",
+				"-trim-request-trailing-slashes=true",
 				"my-auth/",
 			})
 			if exp := 0; code != exp {

--- a/command/auth_tune_test.go
+++ b/command/auth_tune_test.go
@@ -157,7 +157,7 @@ func TestAuthTuneCommand_Run(t *testing.T) {
 			if exp := 3600; mountInfo.Config.MaxLeaseTTL != exp {
 				t.Errorf("expected %d to be %d", mountInfo.Config.MaxLeaseTTL, exp)
 			}
-			if mountInfo.Config.TrimRequestTrailingSlashes {
+			if !mountInfo.Config.TrimRequestTrailingSlashes {
 				t.Errorf("expected trim_request_trailing_slashes to be enabled")
 			}
 			if diff := deep.Equal([]string{"authorization", "www-authentication"}, mountInfo.Config.PassthroughRequestHeaders); len(diff) > 0 {

--- a/command/commands.go
+++ b/command/commands.go
@@ -97,6 +97,8 @@ const (
 	flagNamePluginVersion = "plugin-version"
 	// flagNameIdentityTokenKey selects the key used to sign plugin identity tokens
 	flagNameIdentityTokenKey = "identity-token-key"
+	// flagNameTrimRequestTrailingSlashes selects the key used to determine whether to trim trailing slashes
+	flagNameTrimRequestTrailingSlashes = "trim-request-trailing-slashes"
 	// flagNameUserLockoutThreshold is the flag name used for tuning the auth mount lockout threshold parameter
 	flagNameUserLockoutThreshold = "user-lockout-threshold"
 	// flagNameUserLockoutDuration is the flag name used for tuning the auth mount lockout duration parameter

--- a/command/secrets_enable.go
+++ b/command/secrets_enable.go
@@ -43,7 +43,7 @@ type SecretsEnableCommand struct {
 	flagAllowedManagedKeys         []string
 	flagDelegatedAuthAccessors     []string
 	flagIdentityTokenKey           string
-	flagTrimRequestTrailingSlashes bool
+	flagTrimRequestTrailingSlashes BoolPtr
 }
 
 func (c *SecretsEnableCommand) Synopsis() string {
@@ -246,11 +246,10 @@ func (c *SecretsEnableCommand) Flags() *FlagSets {
 		Usage:   "Select the key used to sign plugin identity tokens.",
 	})
 
-	f.BoolVar(&BoolVar{
-		Name:    flagNameTrimRequestTrailingSlashes,
-		Target:  &c.flagTrimRequestTrailingSlashes,
-		Default: false,
-		Usage:   "Whether to trim trailing slashes for incoming requests to this mount",
+	f.BoolPtrVar(&BoolPtrVar{
+		Name:   flagNameTrimRequestTrailingSlashes,
+		Target: &c.flagTrimRequestTrailingSlashes,
+		Usage:  "Whether to trim trailing slashes for incoming requests to this mount",
 	})
 
 	return set
@@ -368,8 +367,9 @@ func (c *SecretsEnableCommand) Run(args []string) int {
 			mountInput.Config.IdentityTokenKey = c.flagIdentityTokenKey
 		}
 
-		if fl.Name == flagNameTrimRequestTrailingSlashes {
-			mountInput.Config.TrimRequestTrailingSlashes = c.flagTrimRequestTrailingSlashes
+		if fl.Name == flagNameTrimRequestTrailingSlashes && c.flagTrimRequestTrailingSlashes.IsSet() {
+			val := c.flagTrimRequestTrailingSlashes.Get()
+			mountInput.Config.TrimRequestTrailingSlashes = &val
 		}
 	})
 

--- a/command/secrets_enable.go
+++ b/command/secrets_enable.go
@@ -23,26 +23,27 @@ var (
 type SecretsEnableCommand struct {
 	*BaseCommand
 
-	flagDescription               string
-	flagPath                      string
-	flagDefaultLeaseTTL           time.Duration
-	flagMaxLeaseTTL               time.Duration
-	flagAuditNonHMACRequestKeys   []string
-	flagAuditNonHMACResponseKeys  []string
-	flagListingVisibility         string
-	flagPassthroughRequestHeaders []string
-	flagAllowedResponseHeaders    []string
-	flagForceNoCache              bool
-	flagPluginName                string
-	flagPluginVersion             string
-	flagOptions                   map[string]string
-	flagLocal                     bool
-	flagSealWrap                  bool
-	flagExternalEntropyAccess     bool
-	flagVersion                   int
-	flagAllowedManagedKeys        []string
-	flagDelegatedAuthAccessors    []string
-	flagIdentityTokenKey          string
+	flagDescription                string
+	flagPath                       string
+	flagDefaultLeaseTTL            time.Duration
+	flagMaxLeaseTTL                time.Duration
+	flagAuditNonHMACRequestKeys    []string
+	flagAuditNonHMACResponseKeys   []string
+	flagListingVisibility          string
+	flagPassthroughRequestHeaders  []string
+	flagAllowedResponseHeaders     []string
+	flagForceNoCache               bool
+	flagPluginName                 string
+	flagPluginVersion              string
+	flagOptions                    map[string]string
+	flagLocal                      bool
+	flagSealWrap                   bool
+	flagExternalEntropyAccess      bool
+	flagVersion                    int
+	flagAllowedManagedKeys         []string
+	flagDelegatedAuthAccessors     []string
+	flagIdentityTokenKey           string
+	flagTrimRequestTrailingSlashes bool
 }
 
 func (c *SecretsEnableCommand) Synopsis() string {
@@ -245,6 +246,13 @@ func (c *SecretsEnableCommand) Flags() *FlagSets {
 		Usage:   "Select the key used to sign plugin identity tokens.",
 	})
 
+	f.BoolVar(&BoolVar{
+		Name:    flagNameTrimRequestTrailingSlashes,
+		Target:  &c.flagTrimRequestTrailingSlashes,
+		Default: false,
+		Usage:   "Whether to trim trailing slashes for incoming requests to this mount",
+	})
+
 	return set
 }
 
@@ -358,6 +366,10 @@ func (c *SecretsEnableCommand) Run(args []string) int {
 
 		if fl.Name == flagNameIdentityTokenKey {
 			mountInput.Config.IdentityTokenKey = c.flagIdentityTokenKey
+		}
+
+		if fl.Name == flagNameTrimRequestTrailingSlashes {
+			mountInput.Config.TrimRequestTrailingSlashes = c.flagTrimRequestTrailingSlashes
 		}
 	})
 

--- a/command/secrets_enable_test.go
+++ b/command/secrets_enable_test.go
@@ -120,6 +120,7 @@ func TestSecretsEnableCommand_Run(t *testing.T) {
 			"-allowed-managed-keys", "key1,key2",
 			"-identity-token-key", "default",
 			"-delegated-auth-accessors", "authAcc1,authAcc2",
+			"-trim-request-trailing-slashes=true",
 			"-force-no-cache",
 			"pki",
 		})
@@ -156,6 +157,9 @@ func TestSecretsEnableCommand_Run(t *testing.T) {
 		}
 		if exp := true; mountInfo.Config.ForceNoCache != exp {
 			t.Errorf("expected %t to be %t", mountInfo.Config.ForceNoCache, exp)
+		}
+		if !mountInfo.Config.TrimRequestTrailingSlashes {
+			t.Errorf("expected trim_request_trailing_slashes to be enabled")
 		}
 		if diff := deep.Equal([]string{"authorization,authentication", "www-authentication"}, mountInfo.Config.PassthroughRequestHeaders); len(diff) > 0 {
 			t.Errorf("Failed to find expected values in PassthroughRequestHeaders. Difference is: %v", diff)

--- a/command/secrets_tune.go
+++ b/command/secrets_tune.go
@@ -23,20 +23,21 @@ var (
 type SecretsTuneCommand struct {
 	*BaseCommand
 
-	flagAuditNonHMACRequestKeys   []string
-	flagAuditNonHMACResponseKeys  []string
-	flagDefaultLeaseTTL           time.Duration
-	flagDescription               string
-	flagListingVisibility         string
-	flagMaxLeaseTTL               time.Duration
-	flagPassthroughRequestHeaders []string
-	flagAllowedResponseHeaders    []string
-	flagOptions                   map[string]string
-	flagVersion                   int
-	flagPluginVersion             string
-	flagAllowedManagedKeys        []string
-	flagDelegatedAuthAccessors    []string
-	flagIdentityTokenKey          string
+	flagAuditNonHMACRequestKeys    []string
+	flagAuditNonHMACResponseKeys   []string
+	flagDefaultLeaseTTL            time.Duration
+	flagDescription                string
+	flagListingVisibility          string
+	flagMaxLeaseTTL                time.Duration
+	flagPassthroughRequestHeaders  []string
+	flagAllowedResponseHeaders     []string
+	flagOptions                    map[string]string
+	flagVersion                    int
+	flagPluginVersion              string
+	flagAllowedManagedKeys         []string
+	flagDelegatedAuthAccessors     []string
+	flagIdentityTokenKey           string
+	flagTrimRequestTrailingSlashes bool
 }
 
 func (c *SecretsTuneCommand) Synopsis() string {
@@ -175,6 +176,13 @@ func (c *SecretsTuneCommand) Flags() *FlagSets {
 		Usage:   "Select the key used to sign plugin identity tokens.",
 	})
 
+	f.BoolVar(&BoolVar{
+		Name:    flagNameTrimRequestTrailingSlashes,
+		Target:  &c.flagTrimRequestTrailingSlashes,
+		Default: false,
+		Usage:   "Whether to trim trailing slashes for incoming requests to this mount",
+	})
+
 	return set
 }
 
@@ -266,6 +274,9 @@ func (c *SecretsTuneCommand) Run(args []string) int {
 
 		if fl.Name == flagNameIdentityTokenKey {
 			mountConfigInput.IdentityTokenKey = c.flagIdentityTokenKey
+		}
+		if fl.Name == flagNameTrimRequestTrailingSlashes {
+			mountConfigInput.TrimRequestTrailingSlashes = c.flagTrimRequestTrailingSlashes
 		}
 	})
 

--- a/command/secrets_tune.go
+++ b/command/secrets_tune.go
@@ -37,7 +37,7 @@ type SecretsTuneCommand struct {
 	flagAllowedManagedKeys         []string
 	flagDelegatedAuthAccessors     []string
 	flagIdentityTokenKey           string
-	flagTrimRequestTrailingSlashes bool
+	flagTrimRequestTrailingSlashes BoolPtr
 }
 
 func (c *SecretsTuneCommand) Synopsis() string {
@@ -176,11 +176,10 @@ func (c *SecretsTuneCommand) Flags() *FlagSets {
 		Usage:   "Select the key used to sign plugin identity tokens.",
 	})
 
-	f.BoolVar(&BoolVar{
-		Name:    flagNameTrimRequestTrailingSlashes,
-		Target:  &c.flagTrimRequestTrailingSlashes,
-		Default: false,
-		Usage:   "Whether to trim trailing slashes for incoming requests to this mount",
+	f.BoolPtrVar(&BoolPtrVar{
+		Name:   flagNameTrimRequestTrailingSlashes,
+		Target: &c.flagTrimRequestTrailingSlashes,
+		Usage:  "Whether to trim trailing slashes for incoming requests to this mount",
 	})
 
 	return set
@@ -275,8 +274,9 @@ func (c *SecretsTuneCommand) Run(args []string) int {
 		if fl.Name == flagNameIdentityTokenKey {
 			mountConfigInput.IdentityTokenKey = c.flagIdentityTokenKey
 		}
-		if fl.Name == flagNameTrimRequestTrailingSlashes {
-			mountConfigInput.TrimRequestTrailingSlashes = c.flagTrimRequestTrailingSlashes
+		if fl.Name == flagNameTrimRequestTrailingSlashes && c.flagTrimRequestTrailingSlashes.IsSet() {
+			val := c.flagTrimRequestTrailingSlashes.Get()
+			mountConfigInput.TrimRequestTrailingSlashes = &val
 		}
 	})
 

--- a/command/secrets_tune_test.go
+++ b/command/secrets_tune_test.go
@@ -196,6 +196,7 @@ func TestSecretsTuneCommand_Run(t *testing.T) {
 				"-listing-visibility", "unauth",
 				"-plugin-version", version,
 				"-delegated-auth-accessors", "authAcc1,authAcc2",
+				"-trim-request-trailing-slashes=true",
 				"mount_tune_integration/",
 			})
 			if exp := 0; code != exp {
@@ -231,6 +232,9 @@ func TestSecretsTuneCommand_Run(t *testing.T) {
 			}
 			if exp := 3600; mountInfo.Config.MaxLeaseTTL != exp {
 				t.Errorf("expected %d to be %d", mountInfo.Config.MaxLeaseTTL, exp)
+			}
+			if !mountInfo.Config.TrimRequestTrailingSlashes {
+				t.Errorf("expected trim_request_trailing_slashes to be enabled")
 			}
 			if diff := deep.Equal([]string{"authorization", "www-authentication"}, mountInfo.Config.PassthroughRequestHeaders); len(diff) > 0 {
 				t.Errorf("Failed to find expected values for PassthroughRequestHeaders. Difference is: %v", diff)

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -2155,8 +2155,8 @@ func (b *SystemBackend) handleTuneReadCommon(ctx context.Context, path string) (
 		resp.Data["identity_token_key"] = rawVal.(string)
 	}
 
-	if rawVal, ok := mountEntry.synthesizedConfigCache.Load("trim_request_trailing_slashes"); ok {
-		resp.Data["trim_request_trailing_slashes"] = rawVal.(string)
+	if mountEntry.Config.TrimRequestTrailingSlashes {
+		resp.Data["trim_request_trailing_slashes"] = mountEntry.Config.TrimRequestTrailingSlashes
 	}
 
 	if mountEntry.Config.UserLockoutConfig != nil {

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -2779,32 +2779,6 @@ func (b *SystemBackend) handleTuneWriteCommon(ctx context.Context, path string, 
 		}
 	}
 
-	if rawVal, ok := data.GetOk("trim_request_trailing_slashes"); ok {
-		trimRequestTrailingSlashes := rawVal.(bool)
-
-		oldVal := mountEntry.Config.TrimRequestTrailingSlashes
-		mountEntry.Config.TrimRequestTrailingSlashes = trimRequestTrailingSlashes
-
-		// Update the mount table
-		var err error
-		switch {
-		case strings.HasPrefix(path, "auth/"):
-			err = b.Core.persistAuth(ctx, b.Core.auth, &mountEntry.Local)
-		default:
-			err = b.Core.persistMounts(ctx, b.Core.mounts, &mountEntry.Local)
-		}
-		if err != nil {
-			mountEntry.Config.TrimRequestTrailingSlashes = oldVal
-			return handleError(err)
-		}
-
-		mountEntry.SyncCache()
-
-		if b.Core.logger.IsInfo() {
-			b.Core.logger.Info("mount tuning of delegated_auth_accessors successful", "path", path)
-		}
-	}
-
 	var err error
 	var resp *logical.Response
 	var options map[string]string

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -7212,8 +7212,4 @@ This path responds to the following HTTP methods.
 		`Whether to trim a trailing slash on incoming requests to this mount`,
 		"",
 	},
-	"trim_request_trailing_slashes": {
-		`Whether to trim a trailing slash on incoming requests to this mount`,
-		"",
-	},
 }

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -3303,6 +3303,7 @@ func (b *SystemBackend) handleEnableAuth(ctx context.Context, req *logical.Reque
 		return logical.ErrorResponse(fmt.Sprintf("invalid listing_visibility %s", apiConfig.ListingVisibility)), nil
 	}
 	config.ListingVisibility = apiConfig.ListingVisibility
+	config.TrimRequestTrailingSlashes = apiConfig.TrimRequestTrailingSlashes
 
 	if len(apiConfig.AuditNonHMACRequestKeys) > 0 {
 		config.AuditNonHMACRequestKeys = apiConfig.AuditNonHMACRequestKeys

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -2753,6 +2753,58 @@ func (b *SystemBackend) handleTuneWriteCommon(ctx context.Context, path string, 
 		}
 	}
 
+	if rawVal, ok := data.GetOk("trim_request_trailing_slashes"); ok {
+		trimRequestTrailingSlashes := rawVal.(bool)
+
+		oldVal := mountEntry.Config.TrimRequestTrailingSlashes
+		mountEntry.Config.TrimRequestTrailingSlashes = trimRequestTrailingSlashes
+
+		// Update the mount table
+		var err error
+		switch {
+		case strings.HasPrefix(path, "auth/"):
+			err = b.Core.persistAuth(ctx, b.Core.auth, &mountEntry.Local)
+		default:
+			err = b.Core.persistMounts(ctx, b.Core.mounts, &mountEntry.Local)
+		}
+		if err != nil {
+			mountEntry.Config.TrimRequestTrailingSlashes = oldVal
+			return handleError(err)
+		}
+
+		mountEntry.SyncCache()
+
+		if b.Core.logger.IsInfo() {
+			b.Core.logger.Info("mount tuning of delegated_auth_accessors successful", "path", path)
+		}
+	}
+
+	if rawVal, ok := data.GetOk("trim_request_trailing_slashes"); ok {
+		trimRequestTrailingSlashes := rawVal.(bool)
+
+		oldVal := mountEntry.Config.TrimRequestTrailingSlashes
+		mountEntry.Config.TrimRequestTrailingSlashes = trimRequestTrailingSlashes
+
+		// Update the mount table
+		var err error
+		switch {
+		case strings.HasPrefix(path, "auth/"):
+			err = b.Core.persistAuth(ctx, b.Core.auth, &mountEntry.Local)
+		default:
+			err = b.Core.persistMounts(ctx, b.Core.mounts, &mountEntry.Local)
+		}
+		if err != nil {
+			mountEntry.Config.TrimRequestTrailingSlashes = oldVal
+			return handleError(err)
+		}
+
+		mountEntry.SyncCache()
+
+		if b.Core.logger.IsInfo() {
+			b.Core.logger.Info("mount tuning of delegated_auth_accessors successful", "path", path)
+		}
+	}
+
 	var err error
 	var resp *logical.Response
 	var options map[string]string
@@ -7154,6 +7206,14 @@ This path responds to the following HTTP methods.
 
 	"well-known-label": {
 		`The label representing a path-prefix within the /.well-known/ path`,
+		"",
+	},
+	"trim_request_trailing_slashes": {
+		`Whether to trim a trailing slash on incoming requests to this mount`,
+		"",
+	},
+	"trim_request_trailing_slashes": {
+		`Whether to trim a trailing slash on incoming requests to this mount`,
 		"",
 	},
 }

--- a/vault/logical_system_paths.go
+++ b/vault/logical_system_paths.go
@@ -3826,6 +3826,10 @@ func (b *SystemBackend) authPaths() []*framework.Path {
 					Description: strings.TrimSpace(sysHelp["identity_token_key"][0]),
 					Required:    false,
 				},
+				"trim_request_trailing_slashes": {
+					Type:     framework.TypeBool,
+					Required: false,
+				},
 			},
 			Operations: map[logical.Operation]framework.OperationHandler{
 				logical.ReadOperation: &framework.PathOperation{
@@ -3914,6 +3918,10 @@ func (b *SystemBackend) authPaths() []*framework.Path {
 								},
 								"identity_token_key": {
 									Type:     framework.TypeString,
+									Required: false,
+								},
+								"trim_request_trailing_slashes": {
+									Type:     framework.TypeBool,
 									Required: false,
 								},
 							},
@@ -4686,6 +4694,10 @@ func (b *SystemBackend) mountPaths() []*framework.Path {
 					Type:        framework.TypeString,
 					Description: strings.TrimSpace(sysHelp["identity_token_key"][0]),
 				},
+				"trim_request_trailing_slashes": {
+					Type:        framework.TypeBool,
+					Description: strings.TrimSpace(sysHelp["trim_request_trailing_slashes"][0]),
+				},
 			},
 
 			Operations: map[logical.Operation]framework.OperationHandler{
@@ -4786,6 +4798,10 @@ func (b *SystemBackend) mountPaths() []*framework.Path {
 								},
 								"identity_token_key": {
 									Type:     framework.TypeString,
+									Required: false,
+								},
+								"trim_request_trailing_slashes": {
+									Type:     framework.TypeBool,
 									Required: false,
 								},
 							},

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -349,19 +349,20 @@ type MountEntry struct {
 
 // MountConfig is used to hold settable options
 type MountConfig struct {
-	DefaultLeaseTTL           time.Duration         `json:"default_lease_ttl,omitempty" structs:"default_lease_ttl" mapstructure:"default_lease_ttl"` // Override for global default
-	MaxLeaseTTL               time.Duration         `json:"max_lease_ttl,omitempty" structs:"max_lease_ttl" mapstructure:"max_lease_ttl"`             // Override for global default
-	ForceNoCache              bool                  `json:"force_no_cache,omitempty" structs:"force_no_cache" mapstructure:"force_no_cache"`          // Override for global default
-	AuditNonHMACRequestKeys   []string              `json:"audit_non_hmac_request_keys,omitempty" structs:"audit_non_hmac_request_keys" mapstructure:"audit_non_hmac_request_keys"`
-	AuditNonHMACResponseKeys  []string              `json:"audit_non_hmac_response_keys,omitempty" structs:"audit_non_hmac_response_keys" mapstructure:"audit_non_hmac_response_keys"`
-	ListingVisibility         ListingVisibilityType `json:"listing_visibility,omitempty" structs:"listing_visibility" mapstructure:"listing_visibility"`
-	PassthroughRequestHeaders []string              `json:"passthrough_request_headers,omitempty" structs:"passthrough_request_headers" mapstructure:"passthrough_request_headers"`
-	AllowedResponseHeaders    []string              `json:"allowed_response_headers,omitempty" structs:"allowed_response_headers" mapstructure:"allowed_response_headers"`
-	TokenType                 logical.TokenType     `json:"token_type,omitempty" structs:"token_type" mapstructure:"token_type"`
-	AllowedManagedKeys        []string              `json:"allowed_managed_keys,omitempty" mapstructure:"allowed_managed_keys"`
-	UserLockoutConfig         *UserLockoutConfig    `json:"user_lockout_config,omitempty" mapstructure:"user_lockout_config"`
-	DelegatedAuthAccessors    []string              `json:"delegated_auth_accessors,omitempty" mapstructure:"delegated_auth_accessors"`
-	IdentityTokenKey          string                `json:"identity_token_key,omitempty" mapstructure:"identity_token_key"`
+	DefaultLeaseTTL            time.Duration         `json:"default_lease_ttl,omitempty" structs:"default_lease_ttl" mapstructure:"default_lease_ttl"` // Override for global default
+	MaxLeaseTTL                time.Duration         `json:"max_lease_ttl,omitempty" structs:"max_lease_ttl" mapstructure:"max_lease_ttl"`             // Override for global default
+	ForceNoCache               bool                  `json:"force_no_cache,omitempty" structs:"force_no_cache" mapstructure:"force_no_cache"`          // Override for global default
+	AuditNonHMACRequestKeys    []string              `json:"audit_non_hmac_request_keys,omitempty" structs:"audit_non_hmac_request_keys" mapstructure:"audit_non_hmac_request_keys"`
+	AuditNonHMACResponseKeys   []string              `json:"audit_non_hmac_response_keys,omitempty" structs:"audit_non_hmac_response_keys" mapstructure:"audit_non_hmac_response_keys"`
+	ListingVisibility          ListingVisibilityType `json:"listing_visibility,omitempty" structs:"listing_visibility" mapstructure:"listing_visibility"`
+	PassthroughRequestHeaders  []string              `json:"passthrough_request_headers,omitempty" structs:"passthrough_request_headers" mapstructure:"passthrough_request_headers"`
+	AllowedResponseHeaders     []string              `json:"allowed_response_headers,omitempty" structs:"allowed_response_headers" mapstructure:"allowed_response_headers"`
+	TokenType                  logical.TokenType     `json:"token_type,omitempty" structs:"token_type" mapstructure:"token_type"`
+	AllowedManagedKeys         []string              `json:"allowed_managed_keys,omitempty" mapstructure:"allowed_managed_keys"`
+	UserLockoutConfig          *UserLockoutConfig    `json:"user_lockout_config,omitempty" mapstructure:"user_lockout_config"`
+	DelegatedAuthAccessors     []string              `json:"delegated_auth_accessors,omitempty" mapstructure:"delegated_auth_accessors"`
+	IdentityTokenKey           string                `json:"identity_token_key,omitempty" mapstructure:"identity_token_key"`
+	TrimRequestTrailingSlashes bool                  `json:"trim_request_trailing_slashes,omitempty` // If requests to this mount should have trailing slashes trimmed
 
 	// PluginName is the name of the plugin registered in the catalog.
 	//

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -362,7 +362,7 @@ type MountConfig struct {
 	UserLockoutConfig          *UserLockoutConfig    `json:"user_lockout_config,omitempty" mapstructure:"user_lockout_config"`
 	DelegatedAuthAccessors     []string              `json:"delegated_auth_accessors,omitempty" mapstructure:"delegated_auth_accessors"`
 	IdentityTokenKey           string                `json:"identity_token_key,omitempty" mapstructure:"identity_token_key"`
-	TrimRequestTrailingSlashes bool                  `json:"trim_request_trailing_slashes,omitempty` // If requests to this mount should have trailing slashes trimmed
+	TrimRequestTrailingSlashes bool                  `json:"trim_request_trailing_slashes,omitempty" mapstructure:"trim_request_trailing_slashes"` // If requests to this mount should have trailing slashes trimmed
 
 	// PluginName is the name of the plugin registered in the catalog.
 	//
@@ -390,20 +390,21 @@ type APIUserLockoutConfig struct {
 
 // APIMountConfig is an embedded struct of api.MountConfigInput
 type APIMountConfig struct {
-	DefaultLeaseTTL           string                `json:"default_lease_ttl" structs:"default_lease_ttl" mapstructure:"default_lease_ttl"`
-	MaxLeaseTTL               string                `json:"max_lease_ttl" structs:"max_lease_ttl" mapstructure:"max_lease_ttl"`
-	ForceNoCache              bool                  `json:"force_no_cache" structs:"force_no_cache" mapstructure:"force_no_cache"`
-	AuditNonHMACRequestKeys   []string              `json:"audit_non_hmac_request_keys,omitempty" structs:"audit_non_hmac_request_keys" mapstructure:"audit_non_hmac_request_keys"`
-	AuditNonHMACResponseKeys  []string              `json:"audit_non_hmac_response_keys,omitempty" structs:"audit_non_hmac_response_keys" mapstructure:"audit_non_hmac_response_keys"`
-	ListingVisibility         ListingVisibilityType `json:"listing_visibility,omitempty" structs:"listing_visibility" mapstructure:"listing_visibility"`
-	PassthroughRequestHeaders []string              `json:"passthrough_request_headers,omitempty" structs:"passthrough_request_headers" mapstructure:"passthrough_request_headers"`
-	AllowedResponseHeaders    []string              `json:"allowed_response_headers,omitempty" structs:"allowed_response_headers" mapstructure:"allowed_response_headers"`
-	TokenType                 string                `json:"token_type" structs:"token_type" mapstructure:"token_type"`
-	AllowedManagedKeys        []string              `json:"allowed_managed_keys,omitempty" mapstructure:"allowed_managed_keys"`
-	UserLockoutConfig         *UserLockoutConfig    `json:"user_lockout_config,omitempty" mapstructure:"user_lockout_config"`
-	PluginVersion             string                `json:"plugin_version,omitempty" mapstructure:"plugin_version"`
-	DelegatedAuthAccessors    []string              `json:"delegated_auth_accessors,omitempty" mapstructure:"delegated_auth_accessors"`
-	IdentityTokenKey          string                `json:"identity_token_key,omitempty" mapstructure:"identity_token_key"`
+	DefaultLeaseTTL            string                `json:"default_lease_ttl" structs:"default_lease_ttl" mapstructure:"default_lease_ttl"`
+	MaxLeaseTTL                string                `json:"max_lease_ttl" structs:"max_lease_ttl" mapstructure:"max_lease_ttl"`
+	ForceNoCache               bool                  `json:"force_no_cache" structs:"force_no_cache" mapstructure:"force_no_cache"`
+	AuditNonHMACRequestKeys    []string              `json:"audit_non_hmac_request_keys,omitempty" structs:"audit_non_hmac_request_keys" mapstructure:"audit_non_hmac_request_keys"`
+	AuditNonHMACResponseKeys   []string              `json:"audit_non_hmac_response_keys,omitempty" structs:"audit_non_hmac_response_keys" mapstructure:"audit_non_hmac_response_keys"`
+	ListingVisibility          ListingVisibilityType `json:"listing_visibility,omitempty" structs:"listing_visibility" mapstructure:"listing_visibility"`
+	PassthroughRequestHeaders  []string              `json:"passthrough_request_headers,omitempty" structs:"passthrough_request_headers" mapstructure:"passthrough_request_headers"`
+	AllowedResponseHeaders     []string              `json:"allowed_response_headers,omitempty" structs:"allowed_response_headers" mapstructure:"allowed_response_headers"`
+	TokenType                  string                `json:"token_type" structs:"token_type" mapstructure:"token_type"`
+	AllowedManagedKeys         []string              `json:"allowed_managed_keys,omitempty" mapstructure:"allowed_managed_keys"`
+	UserLockoutConfig          *UserLockoutConfig    `json:"user_lockout_config,omitempty" mapstructure:"user_lockout_config"`
+	PluginVersion              string                `json:"plugin_version,omitempty" mapstructure:"plugin_version"`
+	DelegatedAuthAccessors     []string              `json:"delegated_auth_accessors,omitempty" mapstructure:"delegated_auth_accessors"`
+	IdentityTokenKey           string                `json:"identity_token_key,omitempty" mapstructure:"identity_token_key"`
+	TrimRequestTrailingSlashes bool                  `json:"trim_request_trailing_slashes,omitempty" mapstructure:"trim_request_trailing_slashes"` // If requests to this mount should have trailing slashes trimmed
 
 	// PluginName is the name of the plugin registered in the catalog.
 	//

--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -1012,6 +1012,23 @@ func (c *Core) handleRequest(ctx context.Context, req *logical.Request) (retResp
 		if rawVals, ok := entry.synthesizedConfigCache.Load("audit_non_hmac_request_keys"); ok {
 			nonHMACReqDataKeys = rawVals.([]string)
 		}
+
+		// Allowing writing to a path ending in / makes it extremely difficult to
+		// understand user intent for the filesystem-like backends (kv,
+		// cubbyhole) -- did they want a key named foo/ or did they want to write
+		// to a directory foo/ with no (or forgotten) key, or...? It also affects
+		// lookup, because paths ending in / are considered prefixes by some
+		// backends. Basically, it's all just terrible, so don't allow it.
+		if strings.HasSuffix(req.Path, "/") &&
+			(req.Operation == logical.UpdateOperation ||
+				req.Operation == logical.CreateOperation ||
+				req.Operation == logical.PatchOperation) {
+			if !entry.Config.TrimRequestTrailingSlashes {
+				return logical.ErrorResponse("cannot write to a path ending in '/'"), nil, nil
+			} else {
+				req.Path = strings.TrimSuffix(req.Path, "/")
+			}
+		}
 	}
 
 	ns, err := namespace.FromContext(ctx)

--- a/vault/router.go
+++ b/vault/router.go
@@ -373,23 +373,28 @@ func (r *Router) MatchingMountByAccessor(mountAccessor string) *MountEntry {
 // MatchingMount returns the mount prefix that would be used for a path
 func (r *Router) MatchingMount(ctx context.Context, path string) string {
 	r.l.RLock()
-	mount := r.matchingMountInternal(ctx, path)
+	mount, _ := r.matchingMountInternal(ctx, path)
 	r.l.RUnlock()
 	return mount
 }
 
-func (r *Router) matchingMountInternal(ctx context.Context, path string) string {
+// MatchingMountAndEntry returns the MountEntry used for a path and it's router path
+func (r *Router) MatchingMountAndEntry(ctx context.Context, path string) (string, *MountEntry) {
+	return r.matchingMountInternal(ctx, path)
+}
+
+func (r *Router) matchingMountInternal(ctx context.Context, path string) (string, *MountEntry) {
 	ns, err := namespace.FromContext(ctx)
 	if err != nil {
-		return ""
+		return "", nil
 	}
 	path = ns.Path + path
 
-	mount, _, ok := r.root.LongestPrefix(path)
+	mount, raw, ok := r.root.LongestPrefix(path)
 	if !ok {
-		return ""
+		return "", nil
 	}
-	return mount
+	return mount, raw.(*MountEntry)
 }
 
 // matchingPrefixInternal returns a mount prefix that a path may be a part of
@@ -416,7 +421,7 @@ func (r *Router) matchingPrefixInternal(ctx context.Context, path string) string
 func (r *Router) MountConflict(ctx context.Context, path string) string {
 	r.l.RLock()
 	defer r.l.RUnlock()
-	if exactMatch := r.matchingMountInternal(ctx, path); exactMatch != "" {
+	if exactMatch, _ := r.matchingMountInternal(ctx, path); exactMatch != "" {
 		return exactMatch
 	}
 	if prefixMatch := r.matchingPrefixInternal(ctx, path); prefixMatch != "" {

--- a/website/content/docs/commands/auth/enable.mdx
+++ b/website/content/docs/commands/auth/enable.mdx
@@ -89,6 +89,10 @@ flags](/vault/docs/commands) included on all commands.
 - `-token-type` `(string: "")` - Specifies the type of tokens that should be
   returned by the auth method.
 
+- `-trim-request-trailing-slashes` `(bool: false)` - If true, requests to
+  this mount with trailing slashes will have those slashes trimmed.
+  Necessary for some standards based APIs handled by Vault.
+
 - `-plugin-version` `(string: "")` - Configures the semantic version of the plugin
   to use. If unspecified, implies the built-in or any matching unversioned plugin
   that may have been registered.

--- a/website/content/docs/commands/auth/tune.mdx
+++ b/website/content/docs/commands/auth/tune.mdx
@@ -168,6 +168,10 @@ flags](/vault/docs/commands) included on all commands.
 - `-token-type` `(string: "")` - Specifies the type of tokens that should be
   returned by the auth method.
 
+- `-trim-request-trailing-slashes` `(bool: false)` - If true, requests to
+  this mount with trailing slashes will have those slashes trimmed. 
+  Necessary for some standards based APIs handled by Vault.
+
 - `-plugin-version` `(string: "")` - Configures the semantic version of the plugin
   to use. The new version will not start running until the mount is
   [reloaded](/vault/docs/commands/plugin/reload).

--- a/website/content/docs/commands/secrets/enable.mdx
+++ b/website/content/docs/commands/secrets/enable.mdx
@@ -111,6 +111,10 @@ flags](/vault/docs/commands) included on all commands.
   backend can delegate authentication to. To allow multiple accessors, provide
   the `delegated-auth-accessors` multiple times, each time with 1 accessor.
 
+- `-trim-request-trailing-slashes` `(bool: false)` - If true, requests to
+  this mount with trailing slashes will have those slashes trimmed.
+  Necessary for some standards based APIs handled by Vault.
+
 - `-plugin-version` `(string: "")` - Configures the semantic version of the plugin
   to use. If unspecified, implies the built-in or any matching unversioned plugin
   that may have been registered.

--- a/website/content/docs/commands/secrets/tune.mdx
+++ b/website/content/docs/commands/secrets/tune.mdx
@@ -97,6 +97,10 @@ flags](/vault/docs/commands) included on all commands.
   backend can delegate authentication to. To allow multiple accessors, provide
   the `delegated-auth-accessors` multiple times, each time with 1 accessor.
 
+- `-trim-request-trailing-slashes` `(bool: false)` - If true, requests to
+  this mount with trailing slashes will have those slashes trimmed. 
+  Necessary for some standards based APIs handled by Vault.
+
 - `-plugin-version` `(string: "")` - Configures the semantic version of the plugin
   to use. The new version will not start running until the mount is
   [reloaded](/vault/docs/commands/plugin/reload).

--- a/website/content/docs/secrets/pki/cmpv2.mdx
+++ b/website/content/docs/secrets/pki/cmpv2.mdx
@@ -87,10 +87,10 @@ To get an authentication mount's accessor field, the following command can be us
 $ vault read -field=accessor sys/auth/auth/cert
 ```
 
-For CMP to work within certain clients, a few response headers need to be explicitly allowed
-along with configuring the list of accessors the mount can delegate authentication towards.
-The following will grant the required response headers, you will need to replace the values for the `delegated-auth-accessors`
-to match your values.
+For CMP to work within certain clients, a few response headers need to be explicitly
+allowed, trailing slashes must be trimmed, and the list of accessors the mount can delegate authentication towards
+must be configured. The following will grant the required response headers, you will need to replace the values for 
+the `delegated-auth-accessors` to match your values.
 
 ```shell-session
 $ vault secrets tune \
@@ -98,6 +98,7 @@ $ vault secrets tune \
   -allowed-response-headers="Content-Length" \
   -allowed-response-headers="WWW-Authenticate" \
   -delegated-auth-accessors="auth_cert_4088ac2d" \
+  -trim-request-trailing-slashes="true" \
   pki
 ```
 


### PR DESCRIPTION
### Description

CMPv2 specifies that the cmp path may or may not end in a trailing slash. 
Vault's request processing has a requirement that they do not for POST.  To
make this work, add a tuneable to the mount that will trim slashes if
enabled.  All existing mounts will default to off, preserving the existing
behavior.  CMPv2 capable PKI mounts will enable this.

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [ ] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.