### PR TITLE
Fix a race condition in mount lookups

### DIFF
--- a/vault/router.go
+++ b/vault/router.go
@@ -378,8 +378,10 @@ func (r *Router) MatchingMount(ctx context.Context, path string) string {
 	return mount
 }
 
-// MatchingMountAndEntry returns the MountEntry used for a path and it's router path
+// MatchingMountAndEntry returns the mount prefix and MountEntry used for a path
 func (r *Router) MatchingMountAndEntry(ctx context.Context, path string) (string, *MountEntry) {
+	r.l.RLock()
+	defer r.l.RUnlock()
 	return r.matchingMountInternal(ctx, path)
 }
 


### PR DESCRIPTION
### Description

When adding the new method `MatchingMountAndEntry` within https://github.com/hashicorp/vault/pull/28752, no locks were being acquired which lead to some race conditions on mount creations. This has not made it into any released versions of Vault.

```
WARNING: DATA RACE
Write at 0x00c000b493f8 by goroutine 4501:
  github.com/armon/go-radix.(*node).addEdge()
      /home/runner/go/pkg/mod/github.com/armon/go-radix@v1.0.0/radix.go:43 +0x3ce
  github.com/armon/go-radix.(*Tree).Insert()
      /home/runner/go/pkg/mod/github.com/armon/go-radix@v1.0.0/radix.go:184 +0x2fd
  github.com/hashicorp/vault/vault.(*Router).Mount()
      /home/runner/work/vault/vault/vault/router.go:239 +0x8b4
  github.com/hashicorp/vault/vault.(*Core).enableCredentialInternal()
      /home/runner/work/vault/vault/vault/auth.go:220 +0x1e26
  github.com/hashicorp/vault/vault.(*Core).enableCredential()
      /home/runner/work/vault/vault/vault/auth.go:69 +0x24cb
  github.com/hashicorp/vault/vault.(*SystemBackend).handleEnableAuth()
      /home/runner/work/vault/vault/vault/logical_system.go:3384 +0x2491
  github.com/hashicorp/vault/vault.(*SystemBackend).handleEnableAuth-fm()

...

Previous read at 0x00c000b493f8 by goroutine 4691:
  github.com/armon/go-radix.(*node).getEdge()
      /home/runner/go/pkg/mod/github.com/armon/go-radix@v1.0.0/radix.go:60 +0x3c
  github.com/armon/go-radix.(*Tree).LongestPrefix()
      /home/runner/go/pkg/mod/github.com/armon/go-radix@v1.0.0/radix.go:395 +0xd5
  github.com/hashicorp/vault/vault.(*Router).matchingMountInternal()
      /home/runner/work/vault/vault/vault/router.go:393 +0xe6
  github.com/hashicorp/vault/vault.(*Router).MatchingMountAndEntry()
      /home/runner/work/vault/vault/vault/router.go:383 +0x131
  github.com/hashicorp/vault/vault.(*Core).handleCancelableRequest()
      /home/runner/work/vault/vault/vault/request_handling.go:632 +0x72
```

### TODO only if you're a HashiCorp employee
- [X] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [ ] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
