### PR TITLE
Added Stubs to Stop Breaking Builds in Ent

### DIFF
--- a/vault/activity_log_stubs_oss.go
+++ b/vault/activity_log_stubs_oss.go
@@ -1,0 +1,15 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+//go:build !enterprise
+
+package vault
+
+import "context"
+
+//go:generate go run github.com/hashicorp/vault/tools/stubmaker
+
+// sendGlobalClients is a no-op on CE
+func (a *ActivityLog) sendGlobalClients(ctx context.Context) error {
+	return nil
+}

--- a/vault/activity_log_util.go
+++ b/vault/activity_log_util.go
@@ -13,8 +13,3 @@ import (
 func (a *ActivityLog) sendCurrentFragment(ctx context.Context) error {
 	return nil
 }
-
-// sendGlobalClients is a no-op on CE
-func (a *ActivityLog) sendGlobalClients(ctx context.Context) error {
-	return nil
-}


### PR DESCRIPTION
### Description
Moves the method to a stub so that ENT no longer breaks

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [ ] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
