### PR TITLE
docs: sys/internal/counters/activity, explain deprecation for current…

### DIFF
--- a/website/content/api-docs/system/internal-counters.mdx
+++ b/website/content/api-docs/system/internal-counters.mdx
@@ -377,7 +377,7 @@ is unknown.
 - `current_billing_period` `(bool, optional)` - **DEPRECATED** Uses the builtin billing start
   timestamp as `start_time` and the current time as the `end_time`, returning a
   response with the current billing period information without having to
-  explicitly provide a start and end time.
+  explicitly provide a start and end time. This parameter is deprecated, as this option is now the default, so no parameter is needed to specify.
 
 
 ### Sample request


### PR DESCRIPTION
…_billing_period

per discussion
https://hashicorp.slack.com/archives/CPEPB6WRL/p1729786785076429 the reason this parameter is deprecated is because it's no longer required. make that clear in the docs.

### Description
What does this PR do?

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [ ] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
