### PR TITLE
VAULT-31264: Limit raft joins

### DIFF
--- a/vault/core.go
+++ b/vault/core.go
@@ -28,6 +28,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	lru "github.com/hashicorp/golang-lru/v2"
+
 	"github.com/armon/go-metrics"
 	"github.com/hashicorp/errwrap"
 	log "github.com/hashicorp/go-hclog"
@@ -628,7 +630,7 @@ type Core struct {
 	// Stop channel for raft TLS rotations
 	raftTLSRotationStopCh chan struct{}
 	// Stores the pending peers we are waiting to give answers
-	pendingRaftPeers *sync.Map
+	pendingRaftPeers *lru.Cache[string, *raftBootstrapChallenge]
 
 	// rawConfig stores the config as-is from the provided server configuration.
 	rawConfig *atomic.Value

--- a/vault/core.go
+++ b/vault/core.go
@@ -630,6 +630,8 @@ type Core struct {
 	raftTLSRotationStopCh chan struct{}
 	// Stores the pending peers we are waiting to give answers
 	pendingRaftPeers *lru.Cache[string, *raftBootstrapChallenge]
+	// holds the lock for modifying pendingRaftPeers
+	pendingRaftPeersLock sync.RWMutex
 
 	// rawConfig stores the config as-is from the provided server configuration.
 	rawConfig *atomic.Value

--- a/vault/core.go
+++ b/vault/core.go
@@ -28,8 +28,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	lru "github.com/hashicorp/golang-lru/v2"
-
 	"github.com/armon/go-metrics"
 	"github.com/hashicorp/errwrap"
 	log "github.com/hashicorp/go-hclog"
@@ -42,6 +40,7 @@ import (
 	"github.com/hashicorp/go-secure-stdlib/strutil"
 	"github.com/hashicorp/go-secure-stdlib/tlsutil"
 	"github.com/hashicorp/go-uuid"
+	lru "github.com/hashicorp/golang-lru/v2"
 	kv "github.com/hashicorp/vault-plugin-secrets-kv"
 	"github.com/hashicorp/vault/api"
 	"github.com/hashicorp/vault/audit"

--- a/vault/external_tests/raft/raft_test.go
+++ b/vault/external_tests/raft/raft_test.go
@@ -259,12 +259,12 @@ func TestRaft_ChallengeSpam(t *testing.T) {
 	// refills.
 	var someLaterFailed bool
 	var someLaterSucceeded bool
-	for n := 0; n < 2*vault.MaxInFlightRaftChallenges; n++ {
+	for n := 0; n < 2*vault.RaftInitialChallengeLimit; n++ {
 		_, err := cluster.Cores[0].Client.Logical().Write("sys/storage/raft/bootstrap/challenge", map[string]interface{}{
 			"server_id": fmt.Sprintf("core-%d", n),
 		})
 		// First MaxInFlightRequests should succeed for sure
-		if n < vault.MaxInFlightRaftChallenges {
+		if n < vault.RaftInitialChallengeLimit {
 			require.NoError(t, err)
 		} else {
 			// slow down to twice the configured rps

--- a/vault/external_tests/raft/raft_test.go
+++ b/vault/external_tests/raft/raft_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/md5"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"io"
@@ -16,7 +17,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/golang/protobuf/proto"
 	"github.com/hashicorp/go-cleanhttp"
+	wrapping "github.com/hashicorp/go-kms-wrapping/v2"
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/vault/api"
 	credUserpass "github.com/hashicorp/vault/builtin/credential/userpass"
@@ -248,6 +251,99 @@ func TestRaft_Retry_Join(t *testing.T) {
 	})
 }
 
+// TestRaftChallenge_sameAnswerSameID verifies that repeated bootstrap requests
+// with the same node ID return the same challenge, but that a different node ID
+// returns a different challenge
+func TestRaftChallenge_sameAnswerSameID(t *testing.T) {
+	t.Parallel()
+
+	cluster, _ := raftCluster(t, &RaftClusterOpts{
+		DisableFollowerJoins: true,
+		NumCores:             1,
+	})
+	defer cluster.Cleanup()
+	client := cluster.Cores[0].Client
+	res, err := client.Logical().Write("sys/storage/raft/bootstrap/challenge", map[string]interface{}{
+		"server_id": "node1",
+	})
+	require.NoError(t, err)
+
+	// querying the same ID returns the same challenge
+	challenge := res.Data["challenge"]
+	resSameID, err := client.Logical().Write("sys/storage/raft/bootstrap/challenge", map[string]interface{}{
+		"server_id": "node1",
+	})
+	require.NoError(t, err)
+	require.Equal(t, challenge, resSameID.Data["challenge"])
+
+	// querying a different ID returns a new challenge
+	resDiffID, err := client.Logical().Write("sys/storage/raft/bootstrap/challenge", map[string]interface{}{
+		"server_id": "node2",
+	})
+	require.NoError(t, err)
+	require.NotEqual(t, challenge, resDiffID.Data["challenge"])
+}
+
+// TestRaftChallenge_evicted verifies that a valid answer errors if there have
+// been more than 20 challenge requests after it, because our cache of pending
+// bootstraps is limited to 20
+func TestRaftChallenge_evicted(t *testing.T) {
+	t.Parallel()
+	cluster, _ := raftCluster(t, &RaftClusterOpts{
+		DisableFollowerJoins: true,
+		NumCores:             1,
+	})
+	defer cluster.Cleanup()
+	firstResponse := map[string]interface{}{}
+	client := cluster.Cores[0].Client
+	for i := 0; i < vault.RaftInitialChallengeLimit+1; i++ {
+		if i == vault.RaftInitialChallengeLimit {
+			// wait before sending the last request, so we don't get rate
+			// limited
+			time.Sleep(2 * time.Second)
+		}
+		res, err := client.Logical().Write("sys/storage/raft/bootstrap/challenge", map[string]interface{}{
+			"server_id": fmt.Sprintf("node-%d", i),
+		})
+		require.NoError(t, err)
+
+		// save the response from the first challenge
+		if i == 0 {
+			firstResponse = res.Data
+		}
+	}
+
+	// get the answer to the challenge
+	challengeRaw, err := base64.StdEncoding.DecodeString(firstResponse["challenge"].(string))
+	require.NoError(t, err)
+	eBlob := &wrapping.BlobInfo{}
+	err = proto.Unmarshal(challengeRaw, eBlob)
+	require.NoError(t, err)
+	access := cluster.Cores[0].SealAccess().GetAccess()
+	multiWrapValue := &vaultseal.MultiWrapValue{
+		Generation: access.Generation(),
+		Slots:      []*wrapping.BlobInfo{eBlob},
+	}
+	plaintext, _, err := access.Decrypt(context.Background(), multiWrapValue)
+	require.NoError(t, err)
+
+	// send the answer
+	_, err = client.Logical().Write("sys/storage/raft/bootstrap/answer", map[string]interface{}{
+		"answer":          base64.StdEncoding.EncodeToString(plaintext),
+		"server_id":       "node-0",
+		"cluster_addr":    "127.0.0.1:8200",
+		"sdk_version":     "1.1.1",
+		"upgrade_version": "1.2.3",
+		"non_voter":       false,
+	})
+
+	require.ErrorContains(t, err, "no expected answer for the server id provided")
+}
+
+// TestRaft_ChallengeSpam creates 40 raft bootstrap challenges. The first 20
+// should succeed. After 20 challenges have been created, slow down the requests
+// so that there are 2.5 occurring per second. Some of these will fail, due to
+// rate limiting, but others will succeed.
 func TestRaft_ChallengeSpam(t *testing.T) {
 	t.Parallel()
 	cluster, _ := raftCluster(t, &RaftClusterOpts{

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -25,8 +25,6 @@ import (
 	"time"
 	"unicode"
 
-	"golang.org/x/time/rate"
-
 	"github.com/hashicorp/errwrap"
 	log "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-memdb"
@@ -58,6 +56,7 @@ import (
 	"github.com/hashicorp/vault/version"
 	"github.com/mitchellh/mapstructure"
 	"golang.org/x/crypto/sha3"
+	"golang.org/x/time/rate"
 )
 
 const (
@@ -101,7 +100,7 @@ func NewSystemBackend(core *Core, logger log.Logger, config *logical.BackendConf
 		logger:               logger,
 		mfaBackend:           NewPolicyMFABackend(core, logger),
 		syncBackend:          syncBackend,
-		raftChallengeLimiter: rate.NewLimiter(rate.Limit(RaftChallengesPerSecond), MaxInFlightRaftChallenges),
+		raftChallengeLimiter: rate.NewLimiter(rate.Limit(RaftChallengesPerSecond), RaftInitialChallengeLimit),
 	}
 
 	b.Backend = &framework.Backend{

--- a/vault/logical_system_raft.go
+++ b/vault/logical_system_raft.go
@@ -371,11 +371,11 @@ func (b *SystemBackend) handleRaftBootstrapAnswerWrite() framework.OperationFunc
 			return logical.ErrorResponse("no expected answer for the server id provided"), logical.ErrInvalidRequest
 		}
 
+		b.Core.pendingRaftPeers.Remove(serverID)
+
 		if subtle.ConstantTimeCompare(answer, expectedChallenge.answer) == 0 {
 			return logical.ErrorResponse("invalid answer given"), logical.ErrInvalidRequest
 		}
-
-		b.Core.pendingRaftPeers.Remove(serverID)
 
 		tlsKeyringEntry, err := b.Core.barrier.Get(ctx, raftTLSStoragePath)
 		if err != nil {

--- a/vault/logical_system_raft.go
+++ b/vault/logical_system_raft.go
@@ -26,11 +26,9 @@ import (
 	"github.com/mitchellh/mapstructure"
 )
 
-var (
-	// These constants are debatable
-	MaxInFlightRaftChallenges = 10
-	RaftChallengesPerSecond   = 10
-	MaxInFlightChallengeDelay = 100 * time.Millisecond
+const (
+	MaxInFlightRaftChallenges = 20 // allow an initial burst to 20
+	RaftChallengesPerSecond   = 5  // equating to an average 200ms min time
 )
 
 type raftBootstrapChallenge struct {
@@ -319,8 +317,6 @@ func (b *SystemBackend) handleRaftBootstrapChallengeWrite(makeSealer func() snap
 				}
 				b.Core.pendingRaftPeers.Add(serverID, challenge)
 			} else {
-				// 429 with delay
-				time.Sleep(MaxInFlightChallengeDelay)
 				return logical.RespondWithStatusCode(logical.ErrorResponse("too many raft challenges in flight"), req, http.StatusTooManyRequests)
 			}
 		}

--- a/vault/logical_system_raft.go
+++ b/vault/logical_system_raft.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	MaxInFlightRaftChallenges = 20 // allow an initial burst to 20
+	RaftInitialChallengeLimit = 20 // allow an initial burst to 20
 	RaftChallengesPerSecond   = 5  // equating to an average 200ms min time
 )
 

--- a/vault/logical_system_raft.go
+++ b/vault/logical_system_raft.go
@@ -320,7 +320,6 @@ func (b *SystemBackend) handleRaftBootstrapChallengeWrite(makeSealer func() snap
 					challenge: protoBlob,
 				}
 				b.Core.pendingRaftPeers.Add(serverID, challenge)
-				b.logger.Info("creating challenge", "node", serverID)
 			}
 		}
 

--- a/vault/logical_system_raft.go
+++ b/vault/logical_system_raft.go
@@ -379,11 +379,11 @@ func (b *SystemBackend) handleRaftBootstrapAnswerWrite() framework.OperationFunc
 			return logical.ErrorResponse("no expected answer for the server id provided"), logical.ErrInvalidRequest
 		}
 
-		b.Core.pendingRaftPeers.Remove(serverID)
-
 		if subtle.ConstantTimeCompare(answer, expectedChallenge.answer) == 0 {
 			return logical.ErrorResponse("invalid answer given"), logical.ErrInvalidRequest
 		}
+
+		b.Core.pendingRaftPeers.Remove(serverID)
 
 		tlsKeyringEntry, err := b.Core.barrier.Get(ctx, raftTLSStoragePath)
 		if err != nil {

--- a/vault/raft.go
+++ b/vault/raft.go
@@ -316,7 +316,7 @@ func (c *Core) setupRaftActiveNode(ctx context.Context) error {
 	c.logger.Info("starting raft active node")
 
 	var err error
-	c.pendingRaftPeers, err = lru.New[string, *raftBootstrapChallenge](MaxInFlightRaftChallenges)
+	c.pendingRaftPeers, err = lru.New[string, *raftBootstrapChallenge](RaftInitialChallengeLimit)
 	if err != nil {
 		return err
 	}

--- a/vault/raft.go
+++ b/vault/raft.go
@@ -37,6 +37,9 @@ import (
 )
 
 const (
+	RaftInitialChallengeLimit = 20 // allow an initial burst to 20
+	RaftChallengesPerSecond   = 5  // equating to an average 200ms min time
+
 	// undoLogMonitorInterval is how often the leader checks to see
 	// if all the cluster members it knows about are new enough to support
 	// undo logs.
@@ -56,6 +59,12 @@ var (
 
 	ErrJoinWithoutAutoloading = errors.New("attempt to join a cluster using autoloaded licenses while not using autoloading ourself")
 )
+
+type raftBootstrapChallenge struct {
+	serverID  string
+	answer    []byte // the random answer
+	challenge []byte // the Sealed answer
+}
 
 // GetRaftNodeID returns the raft node ID if there is one, or an empty string if there's not
 func (c *Core) GetRaftNodeID() string {

--- a/vault/raft.go
+++ b/vault/raft.go
@@ -316,7 +316,7 @@ func (c *Core) setupRaftActiveNode(ctx context.Context) error {
 	c.logger.Info("starting raft active node")
 
 	var err error
-	c.pendingRaftPeers, err = lru.New[string, *raftBootstrapChallenge](maxInFlightRaftChallenges)
+	c.pendingRaftPeers, err = lru.New[string, *raftBootstrapChallenge](MaxInFlightRaftChallenges)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### Description
Adds limits for raft challenges. Ent PR: https://github.com/hashicorp/vault-enterprise/pull/6865

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [ ] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
