### PR TITLE
pipeline: include the version in the dynamic config key

### DIFF
--- a/.github/actions/create-dynamic-config/action.yml
+++ b/.github/actions/create-dynamic-config/action.yml
@@ -27,7 +27,7 @@ runs:
         # Uses GITHUB_ENV instead of GITHUB_OUTPUT because composite actions are broken,
         # see: https://github.com/actions/cache/issues/803#issuecomment-1793565071
         {
-          echo "DYNAMIC_CONFIG_KEY=$(date +%Y-%m-%U)"
+          echo "DYNAMIC_CONFIG_KEY=${{ inputs.vault-version }}-$(date +%Y-%m-%U)"
           echo "DYNAMIC_CONFIG_PATH=enos/enos-dynamic-config.hcl"
         } | tee -a "$GITHUB_ENV"
     - name: Try to restore dynamic config from cache


### PR DESCRIPTION
### Description

[Cache scopes allow other branches to inherit default branch scopes](https://github.com/actions/cache?tab=readme-ov-file#cache-scopes). In practice this means that release branches can restore dynamic config from `main`. Instead, we now include the vault version as part of the cache key to ensure we don't include versions that are incompatible with our version.

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [x] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
