### PR TITLE
UI: Update disabling replication copy 

### DIFF
--- a/ui/lib/core/addon/templates/components/replication-action-disable.hbs
+++ b/ui/lib/core/addon/templates/components/replication-action-disable.hbs
@@ -50,7 +50,6 @@
   <ul class="bullet">
     {{#if this.model.replicationAttrs.isPrimary}}
       <li>Secondaries will no longer be able to connect</li>
-      <li>We will wipe the underlying storage of connected secondaries</li>
       <li>Secondaries connecting back to the cluster will require a wipe of the underlying storage</li>
     {{else}}
       <li>We will wipe the underlying storage of this secondary when connected to a primary</li>


### PR DESCRIPTION
### Description
The modal originally read the following which is incorrect. Secondary storage is not wiped when disabling replication on the primary.
![image](https://github.com/user-attachments/assets/7c8fb1ed-72e2-4f75-b280-7ac50a75cba8)

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [ ] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
