### PR TITLE
UI: Display error message if no key name

### DIFF
--- a/ui/app/components/transit-edit.js
+++ b/ui/app/components/transit-edit.js
@@ -22,6 +22,7 @@ export default Component.extend(FocusOnInsertMixin, {
   onDataChange() {},
   onRefresh() {},
   key: null,
+  errorMessage: '',
   autoRotateInvalid: false,
   requestInFlight: or('key.isLoading', 'key.isReloading', 'key.isSaving'),
 
@@ -104,11 +105,14 @@ export default Component.extend(FocusOnInsertMixin, {
   actions: {
     createOrUpdateKey(type, event) {
       event.preventDefault();
+      // reset error message
+      set(this, 'errorMessage', '');
 
       const keyId = this.key.id || this.key.name;
-      // prevent from submitting if there's no key
-      // maybe do something fancier later
+
       if (type === 'create' && isBlank(keyId)) {
+        // manually set error message
+        set(this, 'errorMessage', 'Name is required.');
         return;
       }
 

--- a/ui/app/templates/components/transit-edit.hbs
+++ b/ui/app/templates/components/transit-edit.hbs
@@ -29,6 +29,7 @@
     @derivedChange={{action "derivedChange" value="target.checked"}}
     @convergentEncryptionChange={{action "convergentEncryptionChange" value="target.checked"}}
     @key={{this.key}}
+    @errorMessage={{this.errorMessage}}
     @requestInFlight={{this.requestInFlight}}
   />
 {{else if (eq this.mode "edit")}}

--- a/ui/app/templates/components/transit-form-create.hbs
+++ b/ui/app/templates/components/transit-form-create.hbs
@@ -5,7 +5,7 @@
 
 <form data-test-transit-create-form onsubmit={{@createOrUpdateKey}}>
   <div class="box is-sideless is-fullwidth is-marginless">
-    <MessageError @model={{@key}} />
+    <MessageError @model={{@key}} @errorMessage={{@errorMessage}} />
     <NamespaceReminder @mode="create" @noun="transit key" />
     <div class="field">
       <label for="key-name" class="is-label">Name</label>


### PR DESCRIPTION
### Description
<img width="1110" alt="Screenshot 2024-10-29 at 12 44 47 PM" src="https://github.com/user-attachments/assets/672a7218-4dd8-437f-9f8b-27add5be266f">


### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [ ] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
