### PR TITLE
VAULT-31393: Return 500 for some gRPC errors during login on perf standbys

### DIFF
--- a/changelog/28807.txt
+++ b/changelog/28807.txt
@@ -1,0 +1,3 @@
+```release-note:change
+login (enterprise): Return a 500 error during logins when performance standby nodes make failed gRPC requests to the active node. 
+```

--- a/vault/request_handling_test.go
+++ b/vault/request_handling_test.go
@@ -4,6 +4,8 @@
 package vault
 
 import (
+	"context"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -15,6 +17,9 @@ import (
 	credUserpass "github.com/hashicorp/vault/builtin/credential/userpass"
 	"github.com/hashicorp/vault/helper/namespace"
 	"github.com/hashicorp/vault/sdk/logical"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func TestRequestHandling_Wrapping(t *testing.T) {
@@ -477,4 +482,61 @@ func TestRequestHandling_SecretLeaseMetric(t *testing.T) {
 			"creation_ttl":  "+Inf",
 		},
 	)
+}
+
+func TestRequestHandling_isRetryableRPCError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	testCases := []struct {
+		name string
+		ctx  context.Context
+		err  error
+		want bool
+	}{
+		{
+			name: "req context canceled",
+			ctx:  ctx,
+			err:  status.Error(codes.Canceled, "context canceled"),
+			want: false,
+		},
+		{
+			name: "server context canceled",
+			err:  status.Error(codes.Canceled, "context canceled"),
+			want: true,
+		},
+		{
+			name: "unavailable",
+			err:  status.Error(codes.Unavailable, "unavailable"),
+			want: true,
+		},
+		{
+			name: "other status",
+			err:  status.Error(codes.FailedPrecondition, "failed"),
+			want: false,
+		},
+		{
+			name: "other unknown",
+			err:  status.Error(codes.Unknown, "unknown"),
+			want: false,
+		},
+		{
+			name: "malformed header unknown",
+			err:  status.Error(codes.Unknown, "malformed header: missing HTTP content-type"),
+			want: true,
+		},
+		{
+			name: "other error",
+			err:  errors.New("other type of error"),
+			want: false,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			useCtx := tc.ctx
+			if tc.ctx == nil {
+				useCtx = context.Background()
+			}
+			require.Equal(t, tc.want, isRetryableRPCError(useCtx, tc.err))
+		})
+	}
 }

--- a/vault/request_handling_test.go
+++ b/vault/request_handling_test.go
@@ -484,6 +484,8 @@ func TestRequestHandling_SecretLeaseMetric(t *testing.T) {
 	)
 }
 
+// TestRequestHandling_isRetryableRPCError tests that a retryable RPC error
+// can be distinguished from a normal error
 func TestRequestHandling_isRetryableRPCError(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()


### PR DESCRIPTION
### Description
Enterprise PR: https://github.com/hashicorp/vault-enterprise/pull/6920

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [ ] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
