### PR TITLE
Fix flaky TestRaft_Removed

### DIFF
--- a/physical/raft/raft_test.go
+++ b/physical/raft/raft_test.go
@@ -777,6 +777,10 @@ func TestRaft_Removed(t *testing.T) {
 		addPeer(t, raft1, raft3)
 		physical.ExerciseBackend(t, raft1)
 
+		commitIdx := raft1.CommittedIndex()
+		ensureCommitApplied(t, commitIdx, raft2)
+		ensureCommitApplied(t, commitIdx, raft3)
+
 		require.False(t, raft1.IsRemoved())
 		require.False(t, raft2.IsRemoved())
 		require.False(t, raft3.IsRemoved())
@@ -784,7 +788,7 @@ func TestRaft_Removed(t *testing.T) {
 		err := raft1.RemovePeer(context.Background(), raft3.NodeID())
 		require.NoError(t, err)
 
-		require.Eventually(t, raft3.IsRemoved, 5*time.Second, 500*time.Millisecond)
+		require.Eventually(t, raft3.IsRemoved, 15*time.Second, 500*time.Millisecond)
 		require.False(t, raft1.IsRemoved())
 		require.False(t, raft2.IsRemoved())
 	})


### PR DESCRIPTION
### Description
Hopefully deflakes TestRaft_Removed.


### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [ ] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
