### PR TITLE
CI: Pin VCM version used in Run Autopilot upgrade tests workflow

### DIFF
--- a/.github/actions/run-apupgrade-tests/action.yml
+++ b/.github/actions/run-apupgrade-tests/action.yml
@@ -64,6 +64,7 @@ runs:
       uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       with:
         repository: hashicorp/vcm
+        ref: 1fcab6591e3bdc81d2921ca77441bfcf913c6a57
         token: ${{ inputs.github-token }}
         path: vcm
     - name: Checkout Vault tools repository to get the Autopilot upgrade tool


### PR DESCRIPTION
### Description
This PR does what it says on the tin. VCM is changing and we need to pin the version of it we use in CI to stop it from affecting our workflows.

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [ ] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
