### PR TITLE
Add PKI issuer config fields to enable check disablement parameters 

### DIFF
--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
-	"github.com/hashicorp/vault/helper/constants"
 	"math"
 	"math/big"
 	mathrand "math/rand"
@@ -7082,16 +7081,16 @@ func TestProperAuthing(t *testing.T) {
 	}
 }
 
+type patchIssuerTestCase struct {
+	Field   string
+	Before  interface{}
+	Patched interface{}
+}
+
 func TestPatchIssuer(t *testing.T) {
 	t.Parallel()
 
-	type TestCase struct {
-		Field   string
-		IsEnt   bool
-		Before  interface{}
-		Patched interface{}
-	}
-	testCases := []TestCase{
+	testCases := []patchIssuerTestCase{
 		{
 			Field:   "issuer_name",
 			Before:  "root",
@@ -7137,105 +7136,83 @@ func TestPatchIssuer(t *testing.T) {
 			Before:  []string(nil),
 			Patched: []string{"self"},
 		},
-		{
-			Field:   "allow_disable_critical_extension_checks",
-			IsEnt:   true,
-			Before:  false,
-			Patched: true,
-		},
-		{
-			Field:   "allow_disable_path_length_checks",
-			IsEnt:   true,
-			Before:  false,
-			Patched: true,
-		},
-		{
-			Field:   "allow_disable_name_checks",
-			IsEnt:   true,
-			Before:  false,
-			Patched: true,
-		},
-		{
-			Field:   "allow_disable_name_constraint_checks",
-			IsEnt:   true,
-			Before:  false,
-			Patched: true,
-		},
 	}
+	testPatchIssuer(t, testCases)
+}
+
+func testPatchIssuer(t *testing.T, testCases []patchIssuerTestCase) {
 	for _, testCase := range testCases {
-		if testCase.IsEnt && !constants.IsEnterprise {
-			continue
-		}
+		t.Run(testCase.Field, func(t *testing.T) {
+			b, s := CreateBackendWithStorage(t)
 
-		b, s := CreateBackendWithStorage(t)
+			// 1. Setup root issuer.
+			resp, err := CBWrite(b, s, "root/generate/internal", map[string]interface{}{
+				"common_name": "Vault Root CA",
+				"key_type":    "ec",
+				"ttl":         "7200h",
+				"issuer_name": "root",
+			})
+			requireSuccessNonNilResponse(t, resp, err, "failed generating root issuer")
+			id := string(resp.Data["issuer_id"].(issuing.IssuerID))
 
-		// 1. Setup root issuer.
-		resp, err := CBWrite(b, s, "root/generate/internal", map[string]interface{}{
-			"common_name": "Vault Root CA",
-			"key_type":    "ec",
-			"ttl":         "7200h",
-			"issuer_name": "root",
+			// 2. Enable Cluster paths
+			resp, err = CBWrite(b, s, "config/urls", map[string]interface{}{
+				"path":     "https://localhost/v1/pki",
+				"aia_path": "http://localhost/v1/pki",
+			})
+			requireSuccessNonNilResponse(t, resp, err, "failed updating AIA config")
+
+			// 3. Add AIA information
+			resp, err = CBPatch(b, s, "issuer/default", map[string]interface{}{
+				"issuing_certificates":    "http://localhost/v1/pki-1/ca",
+				"crl_distribution_points": "http://localhost/v1/pki-1/crl",
+				"ocsp_servers":            "http://localhost/v1/pki-1/ocsp",
+			})
+			requireSuccessNonNilResponse(t, resp, err, "failed setting up issuer")
+
+			// 4. Read the issuer before.
+			resp, err = CBRead(b, s, "issuer/default")
+			requireSuccessNonNilResponse(t, resp, err, "failed reading root issuer before")
+			require.Equal(t, testCase.Before, resp.Data[testCase.Field], "bad expectations")
+
+			// 5. Perform modification.
+			resp, err = CBPatch(b, s, "issuer/default", map[string]interface{}{
+				testCase.Field: testCase.Patched,
+			})
+			requireSuccessNonNilResponse(t, resp, err, "failed patching root issuer")
+
+			if testCase.Field != "manual_chain" {
+				require.Equal(t, testCase.Patched, resp.Data[testCase.Field], "failed persisting value")
+			} else {
+				// self->id
+				require.Equal(t, []string{id}, resp.Data[testCase.Field], "failed persisting value")
+			}
+
+			// 6. Ensure it stuck
+			resp, err = CBRead(b, s, "issuer/default")
+			requireSuccessNonNilResponse(t, resp, err, "failed reading root issuer after")
+
+			if testCase.Field != "manual_chain" {
+				require.Equal(t, testCase.Patched, resp.Data[testCase.Field])
+			} else {
+				// self->id
+				require.Equal(t, []string{id}, resp.Data[testCase.Field], "failed persisting value")
+			}
+
+			// 7. Patch it back
+			resp, err = CBPatch(b, s, "issuer/default", map[string]interface{}{
+				testCase.Field: testCase.Before,
+			})
+			requireSuccessNonNilResponse(t, resp, err, "failed patching root issuer")
+
+			require.Equal(t, testCase.Before, resp.Data[testCase.Field], "failed persisting value")
+
+			// 8. Ensure it stuck
+			resp, err = CBRead(b, s, "issuer/default")
+			requireSuccessNonNilResponse(t, resp, err, "failed reading root issuer after")
+
+			require.Equal(t, testCase.Before, resp.Data[testCase.Field])
 		})
-		requireSuccessNonNilResponse(t, resp, err, "failed generating root issuer")
-		id := string(resp.Data["issuer_id"].(issuing.IssuerID))
-
-		// 2. Enable Cluster paths
-		resp, err = CBWrite(b, s, "config/urls", map[string]interface{}{
-			"path":     "https://localhost/v1/pki",
-			"aia_path": "http://localhost/v1/pki",
-		})
-		requireSuccessNonNilResponse(t, resp, err, "failed updating AIA config")
-
-		// 3. Add AIA information
-		resp, err = CBPatch(b, s, "issuer/default", map[string]interface{}{
-			"issuing_certificates":    "http://localhost/v1/pki-1/ca",
-			"crl_distribution_points": "http://localhost/v1/pki-1/crl",
-			"ocsp_servers":            "http://localhost/v1/pki-1/ocsp",
-		})
-		requireSuccessNonNilResponse(t, resp, err, "failed setting up issuer")
-
-		// 4. Read the issuer before.
-		resp, err = CBRead(b, s, "issuer/default")
-		requireSuccessNonNilResponse(t, resp, err, "failed reading root issuer before")
-		require.Equal(t, testCase.Before, resp.Data[testCase.Field], "bad expectations")
-
-		// 5. Perform modification.
-		resp, err = CBPatch(b, s, "issuer/default", map[string]interface{}{
-			testCase.Field: testCase.Patched,
-		})
-		requireSuccessNonNilResponse(t, resp, err, "failed patching root issuer")
-
-		if testCase.Field != "manual_chain" {
-			require.Equal(t, testCase.Patched, resp.Data[testCase.Field], "failed persisting value")
-		} else {
-			// self->id
-			require.Equal(t, []string{id}, resp.Data[testCase.Field], "failed persisting value")
-		}
-
-		// 6. Ensure it stuck
-		resp, err = CBRead(b, s, "issuer/default")
-		requireSuccessNonNilResponse(t, resp, err, "failed reading root issuer after")
-
-		if testCase.Field != "manual_chain" {
-			require.Equal(t, testCase.Patched, resp.Data[testCase.Field])
-		} else {
-			// self->id
-			require.Equal(t, []string{id}, resp.Data[testCase.Field], "failed persisting value")
-		}
-
-		// 7. Patch it back
-		resp, err = CBPatch(b, s, "issuer/default", map[string]interface{}{
-			testCase.Field: testCase.Before,
-		})
-		requireSuccessNonNilResponse(t, resp, err, "failed patching root issuer")
-
-		require.Equal(t, testCase.Before, resp.Data[testCase.Field], "failed persisting value")
-
-		// 8. Ensure it stuck
-		resp, err = CBRead(b, s, "issuer/default")
-		requireSuccessNonNilResponse(t, resp, err, "failed reading root issuer after")
-
-		require.Equal(t, testCase.Before, resp.Data[testCase.Field])
 	}
 }
 

--- a/builtin/logical/pki/issuing/issuers.go
+++ b/builtin/logical/pki/issuing/issuers.go
@@ -137,11 +137,7 @@ type IssuerEntry struct {
 	AIAURIs              *AiaConfigEntry           `json:"aia_uris,omitempty"`
 	LastModified         time.Time                 `json:"last_modified"`
 	Version              uint                      `json:"version"`
-	/* The AllowDisable* fields are for an ENT feature. */
-	AllowDisableCriticalExtensionChecks bool `json:"allow_disable_critical_extension_checks"`
-	AllowDisablePathLengthChecks        bool `json:"allow_disable_path_length_checks"`
-	AllowDisableNameChecks              bool `json:"allow_disable_name_checks"`
-	AllowDisableNameConstraintChecks    bool `json:"allow_disable_name_constraint_checks"`
+	entIssuerEntry
 }
 
 // GetCertificate returns a x509.Certificate of the CA certificate

--- a/builtin/logical/pki/issuing/issuers.go
+++ b/builtin/logical/pki/issuing/issuers.go
@@ -137,6 +137,11 @@ type IssuerEntry struct {
 	AIAURIs              *AiaConfigEntry           `json:"aia_uris,omitempty"`
 	LastModified         time.Time                 `json:"last_modified"`
 	Version              uint                      `json:"version"`
+	/* The AllowDisable* fields are for an ENT feature. */
+	AllowDisableCriticalExtensionChecks bool `json:"allow_disable_critical_extension_checks"`
+	AllowDisablePathLengthChecks        bool `json:"allow_disable_path_length_checks"`
+	AllowDisableNameChecks              bool `json:"allow_disable_name_checks"`
+	AllowDisableNameConstraintChecks    bool `json:"allow_disable_name_constraint_checks"`
 }
 
 // GetCertificate returns a x509.Certificate of the CA certificate

--- a/builtin/logical/pki/issuing/issuers_oss.go
+++ b/builtin/logical/pki/issuing/issuers_oss.go
@@ -1,0 +1,8 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+//go:build !enterprise
+
+package issuing
+
+type entIssuerEntry struct{}

--- a/builtin/logical/pki/path_fetch_issuers.go
+++ b/builtin/logical/pki/path_fetch_issuers.go
@@ -210,18 +210,7 @@ to be set on all PR secondary clusters.`,
 		Default: false,
 	}
 	addEntPathIssuerFields(fields)
-	updateIssuerFields := commonIssuerResponseFields()
-	// TODO: Why aren't these on the revoke response? Should they be?
-	updateIssuerFields["enable_aia_url_templating"] = &framework.FieldSchema{
-		Type:        framework.TypeBool,
-		Description: `Whether or not templating is enabled for AIA fields`,
-		Required:    false,
-	}
-	updateIssuerFields["allow_disable_critical_extension_checks"] = &framework.FieldSchema{
-		Type:        framework.TypeBool,
-		Description: `Whether parameter disable_critical_extension_checks can be used when issuing certificates`,
-		Required:    false,
-	}
+	updateIssuerFields := issuerResponseFields()
 
 	updateIssuerSchema := map[int][]framework.Response{
 		http.StatusOK: {{
@@ -274,7 +263,7 @@ to be set on all PR secondary clusters.`,
 	}
 }
 
-func commonIssuerResponseFields() map[string]*framework.FieldSchema {
+func issuerResponseFields() map[string]*framework.FieldSchema {
 	fields := map[string]*framework.FieldSchema{
 		"issuer_id": {
 			Type:        framework.TypeString,
@@ -347,6 +336,16 @@ func commonIssuerResponseFields() map[string]*framework.FieldSchema {
 		"ocsp_servers": {
 			Type:        framework.TypeStringSlice,
 			Description: `OCSP Servers`,
+			Required:    false,
+		},
+		"enable_aia_url_templating": {
+			Type:        framework.TypeBool,
+			Description: `Whether or not templating is enabled for AIA fields`,
+			Required:    false,
+		},
+		"allow_disable_critical_extension_checks": {
+			Type:        framework.TypeBool,
+			Description: `Whether parameter disable_critical_extension_checks can be used when issuing certificates`,
 			Required:    false,
 		},
 	}

--- a/builtin/logical/pki/path_fetch_issuers.go
+++ b/builtin/logical/pki/path_fetch_issuers.go
@@ -316,12 +316,14 @@ func issuerResponseFields() map[string]*framework.FieldSchema {
 			Required:    false,
 		},
 		"revocation_time": {
-			Type:     framework.TypeInt,
-			Required: false,
+			Type:        framework.TypeInt,
+			Description: `Revocation time`,
+			Required:    false,
 		},
 		"revocation_time_rfc3339": {
-			Type:     framework.TypeString,
-			Required: false,
+			Type:        framework.TypeString,
+			Description: `Revocation time RFC 3339 formatted`,
+			Required:    false,
 		},
 		"issuing_certificates": {
 			Type:        framework.TypeStringSlice,

--- a/builtin/logical/pki/path_fetch_issuers.go
+++ b/builtin/logical/pki/path_fetch_issuers.go
@@ -345,11 +345,6 @@ func issuerResponseFields(required bool) map[string]*framework.FieldSchema {
 			Description: `Whether or not templating is enabled for AIA fields`,
 			Required:    required,
 		},
-		"allow_disable_critical_extension_checks": {
-			Type:        framework.TypeBool,
-			Description: `Whether parameter disable_critical_extension_checks can be used when issuing certificates`,
-			Required:    required,
-		},
 	}
 
 	addEntPathIssuerResponseFields(fields)
@@ -483,6 +478,8 @@ func respondReadIssuer(issuer *issuing.IssuerEntry) (*logical.Response, error) {
 		data["crl_distribution_points"] = issuer.AIAURIs.CRLDistributionPoints
 		data["ocsp_servers"] = issuer.AIAURIs.OCSPServers
 		data["enable_aia_url_templating"] = issuer.AIAURIs.EnableTemplating
+	} else {
+		data["enable_aia_url_templating"] = false
 	}
 
 	response := &logical.Response{

--- a/builtin/logical/pki/path_fetch_issuers.go
+++ b/builtin/logical/pki/path_fetch_issuers.go
@@ -210,7 +210,7 @@ to be set on all PR secondary clusters.`,
 		Default: false,
 	}
 	addEntPathIssuerFields(fields)
-	updateIssuerFields := issuerResponseFields()
+	updateIssuerFields := issuerResponseFields(false)
 
 	updateIssuerSchema := map[int][]framework.Response{
 		http.StatusOK: {{
@@ -263,92 +263,92 @@ to be set on all PR secondary clusters.`,
 	}
 }
 
-func issuerResponseFields() map[string]*framework.FieldSchema {
+func issuerResponseFields(required bool) map[string]*framework.FieldSchema {
 	fields := map[string]*framework.FieldSchema{
 		"issuer_id": {
 			Type:        framework.TypeString,
 			Description: `Issuer Id`,
-			Required:    false,
+			Required:    required,
 		},
 		"issuer_name": {
 			Type:        framework.TypeString,
 			Description: `Issuer Name`,
-			Required:    false,
+			Required:    required,
 		},
 		"key_id": {
 			Type:        framework.TypeString,
 			Description: `Key Id`,
-			Required:    false,
+			Required:    required,
 		},
 		"certificate": {
 			Type:        framework.TypeString,
 			Description: `Certificate`,
-			Required:    false,
+			Required:    required,
 		},
 		"manual_chain": {
 			Type:        framework.TypeStringSlice,
 			Description: `Manual Chain`,
-			Required:    false,
+			Required:    required,
 		},
 		"ca_chain": {
 			Type:        framework.TypeStringSlice,
 			Description: `CA Chain`,
-			Required:    false,
+			Required:    required,
 		},
 		"leaf_not_after_behavior": {
 			Type:        framework.TypeString,
 			Description: `Leaf Not After Behavior`,
-			Required:    false,
+			Required:    required,
 		},
 		"usage": {
 			Type:        framework.TypeString,
 			Description: `Usage`,
-			Required:    false,
+			Required:    required,
 		},
 		"revocation_signature_algorithm": {
 			Type:        framework.TypeString,
 			Description: `Revocation Signature Alogrithm`,
-			Required:    false,
+			Required:    required,
 		},
 		"revoked": {
 			Type:        framework.TypeBool,
 			Description: `Revoked`,
-			Required:    false,
+			Required:    required,
 		},
 		"revocation_time": {
 			Type:        framework.TypeInt,
 			Description: `Revocation time`,
-			Required:    false,
+			Required:    required,
 		},
 		"revocation_time_rfc3339": {
 			Type:        framework.TypeString,
 			Description: `Revocation time RFC 3339 formatted`,
-			Required:    false,
+			Required:    required,
 		},
 		"issuing_certificates": {
 			Type:        framework.TypeStringSlice,
 			Description: `Issuing Certificates`,
-			Required:    false,
+			Required:    required,
 		},
 		"crl_distribution_points": {
 			Type:        framework.TypeStringSlice,
 			Description: `CRL Distribution Points`,
-			Required:    false,
+			Required:    required,
 		},
 		"ocsp_servers": {
 			Type:        framework.TypeStringSlice,
 			Description: `OCSP Servers`,
-			Required:    false,
+			Required:    required,
 		},
 		"enable_aia_url_templating": {
 			Type:        framework.TypeBool,
 			Description: `Whether or not templating is enabled for AIA fields`,
-			Required:    false,
+			Required:    required,
 		},
 		"allow_disable_critical_extension_checks": {
 			Type:        framework.TypeBool,
 			Description: `Whether parameter disable_critical_extension_checks can be used when issuing certificates`,
-			Required:    false,
+			Required:    required,
 		},
 	}
 

--- a/builtin/logical/pki/path_fetch_issuers_stubs_oss.go
+++ b/builtin/logical/pki/path_fetch_issuers_stubs_oss.go
@@ -1,0 +1,21 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+//go:build !enterprise
+
+package pki
+
+import (
+	"github.com/hashicorp/vault/builtin/logical/pki/issuing"
+	"github.com/hashicorp/vault/sdk/framework"
+)
+
+//go:generate go run github.com/hashicorp/vault/tools/stubmaker
+
+func addEntPathIssuerFields(fields map[string]*framework.FieldSchema)         {}
+func addEntPathIssuerResponseFields(fields map[string]*framework.FieldSchema) {}
+func setEntIssuerData(data map[string]any, issuer *issuing.IssuerEntry)       {}
+
+func updateEntIssuerFields(issuer *issuing.IssuerEntry, data *framework.FieldData, ignoreNotPresent bool) bool {
+	return false
+}

--- a/builtin/logical/pki/path_manage_issuers.go
+++ b/builtin/logical/pki/path_manage_issuers.go
@@ -516,6 +516,7 @@ secret-keys.
 
 func pathRevokeIssuer(b *backend) *framework.Path {
 	fields := addIssuerRefField(map[string]*framework.FieldSchema{})
+	responseFields := commonIssuerResponseFields()
 
 	return &framework.Path{
 		Pattern: "issuer/" + framework.GenericNameRegex(issuerRefParam) + "/revoke",
@@ -534,83 +535,7 @@ func pathRevokeIssuer(b *backend) *framework.Path {
 				Responses: map[int][]framework.Response{
 					http.StatusOK: {{
 						Description: "OK",
-						Fields: map[string]*framework.FieldSchema{
-							"issuer_id": {
-								Type:        framework.TypeString,
-								Description: `ID of the issuer`,
-								Required:    true,
-							},
-							"issuer_name": {
-								Type:        framework.TypeString,
-								Description: `Name of the issuer`,
-								Required:    true,
-							},
-							"key_id": {
-								Type:        framework.TypeString,
-								Description: `ID of the Key`,
-								Required:    true,
-							},
-							"certificate": {
-								Type:        framework.TypeString,
-								Description: `Certificate`,
-								Required:    true,
-							},
-							"manual_chain": {
-								Type:        framework.TypeCommaStringSlice,
-								Description: `Manual Chain`,
-								Required:    true,
-							},
-							"ca_chain": {
-								Type:        framework.TypeCommaStringSlice,
-								Description: `Certificate Authority Chain`,
-								Required:    true,
-							},
-							"leaf_not_after_behavior": {
-								Type:        framework.TypeString,
-								Description: ``,
-								Required:    true,
-							},
-							"usage": {
-								Type:        framework.TypeString,
-								Description: `Allowed usage`,
-								Required:    true,
-							},
-							"revocation_signature_algorithm": {
-								Type:        framework.TypeString,
-								Description: `Which signature algorithm to use when building CRLs`,
-								Required:    true,
-							},
-							"revoked": {
-								Type:        framework.TypeBool,
-								Description: `Whether the issuer was revoked`,
-								Required:    true,
-							},
-							"issuing_certificates": {
-								Type:        framework.TypeCommaStringSlice,
-								Description: `Specifies the URL values for the Issuing Certificate field`,
-								Required:    true,
-							},
-							"crl_distribution_points": {
-								Type:        framework.TypeStringSlice,
-								Description: `Specifies the URL values for the CRL Distribution Points field`,
-								Required:    true,
-							},
-							"ocsp_servers": {
-								Type:        framework.TypeStringSlice,
-								Description: `Specifies the URL values for the OCSP Servers field`,
-								Required:    true,
-							},
-							"revocation_time": {
-								Type:        framework.TypeInt64,
-								Description: `Time of revocation`,
-								Required:    false,
-							},
-							"revocation_time_rfc3339": {
-								Type:        framework.TypeTime,
-								Description: `RFC formatted time of revocation`,
-								Required:    false,
-							},
-						},
+						Fields:      responseFields,
 					}},
 				},
 				// Read more about why these flags are set in backend.go

--- a/builtin/logical/pki/path_manage_issuers.go
+++ b/builtin/logical/pki/path_manage_issuers.go
@@ -516,7 +516,7 @@ secret-keys.
 
 func pathRevokeIssuer(b *backend) *framework.Path {
 	fields := addIssuerRefField(map[string]*framework.FieldSchema{})
-	responseFields := commonIssuerResponseFields()
+	responseFields := issuerResponseFields()
 
 	return &framework.Path{
 		Pattern: "issuer/" + framework.GenericNameRegex(issuerRefParam) + "/revoke",

--- a/builtin/logical/pki/path_manage_issuers.go
+++ b/builtin/logical/pki/path_manage_issuers.go
@@ -516,7 +516,7 @@ secret-keys.
 
 func pathRevokeIssuer(b *backend) *framework.Path {
 	fields := addIssuerRefField(map[string]*framework.FieldSchema{})
-	responseFields := issuerResponseFields()
+	responseFields := issuerResponseFields(true)
 
 	return &framework.Path{
 		Pattern: "issuer/" + framework.GenericNameRegex(issuerRefParam) + "/revoke",


### PR DESCRIPTION
### Description

Add PKI issuer config fields to enable check disablement parameters, an upcoming ENT feature.

Add the following new configuration fields for issuers:

allow_disable_critical_extension_checks
allow_disable_path_length_checks
allow_disable_name_checks
allow_disable_name_constraint_checks

The ENT PR is https://github.com/hashicorp/vault-enterprise/pull/6924.

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [ ] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
