### PR TITLE
Sample separating LDAP roles by type

### DIFF
--- a/ui/app/adapters/ldap/role/dynamic.js
+++ b/ui/app/adapters/ldap/role/dynamic.js
@@ -1,0 +1,8 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import LdapRoleAdapter from '../role';
+
+export default class LdapDynamicAdapter extends LdapRoleAdapter {}

--- a/ui/app/adapters/ldap/role/static.js
+++ b/ui/app/adapters/ldap/role/static.js
@@ -1,0 +1,8 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import LdapRoleAdapter from '../role';
+
+export default class LdapRoleStaticAdapter extends LdapRoleAdapter {}

--- a/ui/app/models/ldap/role.js
+++ b/ui/app/models/ldap/role.js
@@ -8,46 +8,8 @@ import { withFormFields } from 'vault/decorators/model-form-fields';
 import { withModelValidations } from 'vault/decorators/model-validations';
 import lazyCapabilities, { apiPath } from 'vault/macros/lazy-capabilities';
 
-const creationLdifExample = `# The example below is treated as a comment and will not be submitted
-# dn: cn={{.Username}},ou=users,dc=learn,dc=example
-# objectClass: person
-# objectClass: top
-`;
-const deletionLdifExample = `# The example below is treated as a comment and will not be submitted
-# dn: cn={{.Username}},ou=users,dc=learn,dc=example
-# changetype: delete
-`;
-const rollbackLdifExample = `# The example below is treated as a comment and will not be submitted
-# dn: cn={{.Username}},ou=users,dc=learn,dc=example
-# changetype: delete
-`;
-
 const validations = {
   name: [{ type: 'presence', message: 'Name is required' }],
-  username: [
-    {
-      validator: (model) => (model.isStatic && !model.username ? false : true),
-      message: 'Username is required.',
-    },
-  ],
-  rotation_period: [
-    {
-      validator: (model) => (model.isStatic && !model.rotation_period ? false : true),
-      message: 'Rotation Period is required.',
-    },
-  ],
-  creation_ldif: [
-    {
-      validator: (model) => (model.isDynamic && !model.creation_ldif ? false : true),
-      message: 'Creation LDIF is required.',
-    },
-  ],
-  deletion_ldif: [
-    {
-      validator: (model) => (model.isDynamic && !model.creation_ldif ? false : true),
-      message: 'Deletion LDIF is required.',
-    },
-  ],
 };
 
 export const staticRoleFields = ['username', 'dn', 'rotation_period'];
@@ -63,12 +25,7 @@ export const dynamicRoleFields = [
 @withModelValidations(validations)
 @withFormFields()
 export default class LdapRoleModel extends Model {
-  @attr('string') backend; // dynamic path of secret -- set on response from value passed to queryRecord
-
-  @attr('string', {
-    defaultValue: 'static',
-  })
-  type; // this must be set to either static or dynamic in order for the adapter to build the correct url and for the correct form fields to display
+  @attr backend; // dynamic path of secret -- set on response from value passed to queryRecord
 
   @attr('string', {
     label: 'Role name',
@@ -76,91 +33,6 @@ export default class LdapRoleModel extends Model {
     editDisabled: true,
   })
   name;
-
-  // static role properties
-  @attr('string', {
-    label: 'Distinguished name',
-    subText: 'Distinguished name (DN) of entry Vault should manage.',
-  })
-  dn;
-
-  @attr('string', {
-    label: 'Username',
-    subText:
-      "The name of the user to be used when logging in. This is useful when DN isn't used for login purposes.",
-  })
-  username;
-
-  @attr({
-    editType: 'ttl',
-    label: 'Rotation period',
-    helperTextEnabled:
-      'Specifies the amount of time Vault should wait before rotating the password. The minimum is 5 seconds.',
-    hideToggle: true,
-  })
-  rotation_period;
-
-  // dynamic role properties
-  @attr({
-    editType: 'ttl',
-    label: 'Generated credential’s time-to-live (TTL)',
-    detailsLabel: 'TTL',
-    helperTextDisabled: 'Vault will use the default of 1 hour.',
-    defaultValue: '1h',
-    defaultShown: 'Engine default',
-  })
-  default_ttl;
-
-  @attr({
-    editType: 'ttl',
-    label: 'Generated credential’s maximum time-to-live (Max TTL)',
-    detailsLabel: 'Max TTL',
-    helperTextDisabled: 'Vault will use the engine default of 24 hours.',
-    defaultValue: '24h',
-    defaultShown: 'Engine default',
-  })
-  max_ttl;
-
-  @attr('string', {
-    editType: 'optionalText',
-    label: 'Username template',
-    subText: 'Enter the custom username template to use.',
-    defaultSubText:
-      'Template describing how dynamic usernames are generated. Vault will use the default for this plugin.',
-    docLink: '/vault/docs/concepts/username-templating',
-    defaultShown: 'Default',
-  })
-  username_template;
-
-  @attr('string', {
-    editType: 'json',
-    label: 'Creation LDIF',
-    helpText: 'Specifies the LDIF statements executed to create a user. May optionally be base64 encoded.',
-    example: creationLdifExample,
-    mode: 'ruby',
-    sectionHeading: 'LDIF Statements', // render section heading before form field
-  })
-  creation_ldif;
-
-  @attr('string', {
-    editType: 'json',
-    label: 'Deletion LDIF',
-    helpText:
-      'Specifies the LDIF statements executed to delete a user once its TTL has expired. May optionally be base64 encoded.',
-    example: deletionLdifExample,
-    mode: 'ruby',
-  })
-  deletion_ldif;
-
-  @attr('string', {
-    editType: 'json',
-    label: 'Rollback LDIF',
-    helpText:
-      'Specifies the LDIF statement to attempt to rollback any changes if the creation results in an error. May optionally be base64 encoded.',
-    example: rollbackLdifExample,
-    mode: 'ruby',
-  })
-  rollback_ldif;
 
   get isStatic() {
     return this.type === 'static';
@@ -175,13 +47,6 @@ export default class LdapRoleModel extends Model {
       ? ['username', 'dn', 'rotation_period']
       : ['default_ttl', 'max_ttl', 'username_template', 'creation_ldif', 'deletion_ldif', 'rollback_ldif'];
   }
-  get formFields() {
-    // filter all fields and return only those relevant to type
-    return this.allFields.filter((field) => {
-      // name is the only common field
-      return field.name === 'name' || this.fieldsForType.includes(field.name);
-    });
-  }
 
   get displayFields() {
     // insert type after role name
@@ -190,15 +55,8 @@ export default class LdapRoleModel extends Model {
     return [name, typeField, ...rest];
   }
 
-  get roleUri() {
-    return this.isStatic ? 'static-role' : 'role';
-  }
-  get credsUri() {
-    return this.isStatic ? 'static-cred' : 'creds';
-  }
   @lazyCapabilities(apiPath`${'backend'}/${'roleUri'}/${'name'}`, 'backend', 'roleUri', 'name') rolePath;
   @lazyCapabilities(apiPath`${'backend'}/${'credsUri'}/${'name'}`, 'backend', 'credsUri', 'name') credsPath;
-  @lazyCapabilities(apiPath`${'backend'}/rotate-role/${'name'}`, 'backend', 'name') staticRotateCredsPath;
 
   get canCreate() {
     return this.rolePath.get('canCreate') !== false;
@@ -217,9 +75,6 @@ export default class LdapRoleModel extends Model {
   }
   get canReadCreds() {
     return this.credsPath.get('canRead') !== false;
-  }
-  get canRotateStaticCreds() {
-    return this.isStatic && this.staticRotateCredsPath.get('canCreate') !== false;
   }
 
   fetchCredentials() {

--- a/ui/app/models/ldap/role/dynamic.js
+++ b/ui/app/models/ldap/role/dynamic.js
@@ -1,0 +1,115 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import LdapRoleModel from '../role';
+import { attr } from '@ember-data/model';
+import { withModelValidations } from 'vault/decorators/model-validations';
+import { withFormFields } from 'vault/decorators/model-form-fields';
+
+const creationLdifExample = `# The example below is treated as a comment and will not be submitted
+# dn: cn={{.Username}},ou=users,dc=learn,dc=example
+# objectClass: person
+# objectClass: top
+`;
+const deletionLdifExample = `# The example below is treated as a comment and will not be submitted
+# dn: cn={{.Username}},ou=users,dc=learn,dc=example
+# changetype: delete
+`;
+const rollbackLdifExample = `# The example below is treated as a comment and will not be submitted
+# dn: cn={{.Username}},ou=users,dc=learn,dc=example
+# changetype: delete
+`;
+
+const validations = {
+  creation_ldif: [
+    {
+      validator: (model) => (!model.creation_ldif ? false : true),
+      message: 'Creation LDIF is required.',
+    },
+  ],
+  deletion_ldif: [
+    {
+      validator: (model) => (!model.creation_ldif ? false : true),
+      message: 'Deletion LDIF is required.',
+    },
+  ],
+};
+
+// determines form input rendering order
+@withFormFields([
+  'name',
+  'default_ttl',
+  'max_ttl',
+  'username_template',
+  'creation_ldif',
+  'deletion_ldif',
+  'rollback_ldif',
+])
+@withModelValidations(validations)
+export default class LdapRoleDynamicModel extends LdapRoleModel {
+  type = 'dynamic';
+  roleUri = 'role';
+  credsUri = 'creds';
+
+  @attr({
+    editType: 'ttl',
+    label: 'Generated credential’s time-to-live (TTL)',
+    detailsLabel: 'TTL',
+    helperTextDisabled: 'Vault will use the default of 1 hour.',
+    defaultValue: '1h',
+    defaultShown: 'Engine default',
+  })
+  default_ttl;
+
+  @attr({
+    editType: 'ttl',
+    label: 'Generated credential’s maximum time-to-live (Max TTL)',
+    detailsLabel: 'Max TTL',
+    helperTextDisabled: 'Vault will use the engine default of 24 hours.',
+    defaultValue: '24h',
+    defaultShown: 'Engine default',
+  })
+  max_ttl;
+
+  @attr('string', {
+    editType: 'optionalText',
+    label: 'Username template',
+    subText: 'Enter the custom username template to use.',
+    defaultSubText:
+      'Template describing how dynamic usernames are generated. Vault will use the default for this plugin.',
+    docLink: '/vault/docs/concepts/username-templating',
+    defaultShown: 'Default',
+  })
+  username_template;
+
+  @attr('string', {
+    editType: 'json',
+    label: 'Creation LDIF',
+    helpText: 'Specifies the LDIF statements executed to create a user. May optionally be base64 encoded.',
+    example: creationLdifExample,
+    mode: 'ruby',
+  })
+  creation_ldif;
+
+  @attr('string', {
+    editType: 'json',
+    label: 'Deletion LDIF',
+    helpText:
+      'Specifies the LDIF statements executed to delete a user once its TTL has expired. May optionally be base64 encoded.',
+    example: deletionLdifExample,
+    mode: 'ruby',
+  })
+  deletion_ldif;
+
+  @attr('string', {
+    editType: 'json',
+    label: 'Rollback LDIF',
+    helpText:
+      'Specifies the LDIF statement to attempt to rollback any changes if the creation results in an error. May optionally be base64 encoded.',
+    example: rollbackLdifExample,
+    mode: 'ruby',
+  })
+  rollback_ldif;
+}

--- a/ui/app/models/ldap/role/static.js
+++ b/ui/app/models/ldap/role/static.js
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import LdapRoleModel from '../role';
+import { attr } from '@ember-data/model';
+import { withModelValidations } from 'vault/decorators/model-validations';
+import { withFormFields } from 'vault/decorators/model-form-fields';
+
+const validations = {
+  username: [
+    {
+      validator: (model) => (!model.username ? false : true),
+      message: 'Username is required.',
+    },
+  ],
+  rotation_period: [
+    {
+      validator: (model) => (!model.rotation_period ? false : true),
+      message: 'Rotation Period is required.',
+    },
+  ],
+};
+
+// determines form input rendering order
+@withFormFields(['name', 'username', 'dn', 'rotation_period'])
+@withModelValidations(validations)
+export default class LdapRoleStaticModel extends LdapRoleModel {
+  type = 'static';
+  roleUri = 'static-role';
+  credsUri = 'static-cred';
+
+  @attr('string', {
+    label: 'Distinguished name',
+    subText: 'Distinguished name (DN) of entry Vault should manage.',
+  })
+  dn;
+
+  @attr('string', {
+    label: 'Username',
+    subText:
+      "The name of the user to be used when logging in. This is useful when DN isn't used for login purposes.",
+  })
+  username;
+
+  @attr({
+    editType: 'ttl',
+    label: 'Rotation period',
+    helperTextEnabled:
+      'Specifies the amount of time Vault should wait before rotating the password. The minimum is 5 seconds.',
+    hideToggle: true,
+  })
+  rotation_period;
+
+  get canRotateStaticCreds() {
+    return this.staticRotateCredsPath.get('canCreate') !== false;
+  }
+}

--- a/ui/app/serializers/ldap/role/dynamic.js
+++ b/ui/app/serializers/ldap/role/dynamic.js
@@ -1,0 +1,8 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import LdapRoleSerializer from '../role';
+
+export default class LdapRoleDynamicSerializer extends LdapRoleSerializer {}

--- a/ui/app/serializers/ldap/role/static.js
+++ b/ui/app/serializers/ldap/role/static.js
@@ -1,0 +1,8 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import LdapRoleSerializer from '../role';
+
+export default class LdapRoleStaticSerializer extends LdapRoleSerializer {}

--- a/ui/lib/ldap/addon/routes/overview.ts
+++ b/ui/lib/ldap/addon/routes/overview.ts
@@ -61,6 +61,8 @@ export default class LdapOverviewRoute extends Route {
       promptConfig: this.promptConfig,
       backendModel: this.modelFor('application'),
       roles: this.store.query('ldap/role', { backend }).catch(() => []),
+      staticRoles: this.store.query('ldap/role/static', { backend }).catch(() => []),
+      dynamicRoles: this.store.query('ldap/role/dynamic', { backend }).catch(() => []),
       libraries,
       librariesStatus: this.fetchLibrariesStatus(libraries as Array<LdapLibraryModel>),
     });

--- a/ui/lib/ldap/addon/templates/overview.hbs
+++ b/ui/lib/ldap/addon/templates/overview.hbs
@@ -7,6 +7,8 @@
   @promptConfig={{this.model.promptConfig}}
   @backendModel={{this.model.backendModel}}
   @roles={{this.model.roles}}
+  @staticRoles={{this.model.staticRoles}}
+  @dynamicRoles={{this.model.dynamicRoles}}
   @libraries={{this.model.libraries}}
   @librariesStatus={{this.model.librariesStatus}}
   @breadcrumbs={{this.breadcrumbs}}


### PR DESCRIPTION
### Description
What does this PR do?

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [ ] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
