### PR TITLE
Vault installation fails when from source file

### DIFF
--- a/tools/tools.sh
+++ b/tools/tools.sh
@@ -7,6 +7,9 @@ set -euo pipefail
 # Determine the root directory of the repository
 repo_root() {
   git rev-parse --show-toplevel
+  if [ $? -ne 0 ]; then
+        echo "."
+  fi
 }
 
 # Install an external Go tool.


### PR DESCRIPTION
### Description
What does this PR do?
 Using  `make tools` for vault from source file will give an error because vault is not in a git repository. This was added [here](https://github.com/hashicorp/vault/commit/ce5885279b6545b548c0ac48d1e6c8542ba4851b#diff-d2606fa85bec4eb5140ba8fb30ccb7fa6f60111cc7774ec7dbd6294c5ba97558)
```
==> Installing internal tools...
++ repo_root
++ git rev-parse --show-toplevel
fatal: not a git repository (or any of the parent directories): .git
+ pushd /tools
```
If `.git` is not present, will return current location.

