### PR TITLE
VAULT-24466: Quotas and replication docs

### DIFF
--- a/website/content/docs/concepts/resource-quotas.mdx
+++ b/website/content/docs/concepts/resource-quotas.mdx
@@ -66,6 +66,24 @@ resource quotas by updating the `rate_limit_exempt_paths` configuration field.
 - `sys/seal-status`
 - `sys/unseal`
 
+## Replication
+
+When creating or modifying a quota on a performance secondary cluster, the path
+referred to by the quota must exist on the secondary cluster. Vault will error if
+you attempt to create or update a quota for a path that doesn't exist.
+
+Quotas are stored on the primary cluster and all requests to create, update, or
+delete quotas get forwarded to the primary cluster. This has several implications:
+
+1. It is not possible to create a quota for local mount on a performance secondary
+cluster.
+1. Quotas can be read on a performance secondary cluster, even when the path
+referred to by the quota is local to the primary cluster.
+1. If you create a performance primary and performance secondary cluster and
+set up a local mount on both clusters with the same path, a user that only has
+access to the performance secondary cluster can create/update a quota for this
+path that will apply to the performance primary cluster.
+
 ## Tutorial
 
 Refer to [Protecting Vault with Resource
@@ -74,5 +92,7 @@ step-by-step tutorial.
 
 ## API
 
-Rate limit quotas can be managed over the HTTP API. Please see
-[Rate Limit Quotas API](/vault/api-docs/system/rate-limit-quotas) for more details.
+Resource quotas can be managed over the HTTP API. Please see
+[Rate Limit Quotas API](/vault/api-docs/system/rate-limit-quotas),
+[Lease Count Quotas API](/vault/api-docs/system/lease-count-quotas), and [Quotas
+Config API](/vault/api-docs/system/quotas-config) for more details.


### PR DESCRIPTION
### Description
Updates docs to describe how resource quotas work with replication.

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [ ] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
