### PR TITLE
Fail sign/verify apis when Ed25519ph/ctx arguments are provided on CE

### DIFF
--- a/builtin/logical/transit/path_sign_verify_ce.go
+++ b/builtin/logical/transit/path_sign_verify_ce.go
@@ -9,19 +9,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/helper/keysutil"
 )
-
-// addEntSignFieldArgs adds the enterprise only fields to the field schema definition
-func addEntSignFieldArgs(_ map[string]*framework.FieldSchema) {
-	// Do nothing
-}
-
-// addEntVerifyFieldArgs adds the enterprise only fields to the field schema definition
-func addEntVerifyFieldArgs(_ map[string]*framework.FieldSchema) {
-	// Do nothing
-}
 
 // validateSignApiArgsVersionSpecific will perform a validation of the Sign API parameters
 // from the Enterprise or CE point of view.
@@ -41,13 +30,44 @@ func validateSignApiArgsVersionSpecific(p *keysutil.Policy, apiArgs commonSignVe
 
 // populateEntPolicySigning augments or tweaks the input parameters to the SDK policy.SignWithOptions for
 // Enterprise usage.
-func (b *backend) populateEntPolicySigningOptions(_ context.Context, _ *keysutil.Policy, _ signApiArgs, _ batchRequestSignItem, _ *policySignArgs) error {
-	return nil
+func (b *backend) populateEntPolicySigningOptions(_ context.Context, p *keysutil.Policy, args signApiArgs, item batchRequestSignItem, _ *policySignArgs) error {
+	return _forbidEd25519EntBehavior(p, args.commonSignVerifyApiArgs, item["signature_context"])
 }
 
 // populateEntPolicyVerifyOptions augments or tweaks the input parameters to the SDK policy.VerifyWithOptions for
 // Enterprise usage.
-func (b *backend) populateEntPolicyVerifyOptions(ctx context.Context, p *keysutil.Policy, args verifyApiArgs, item batchRequestVerifyItem, vsa *policyVerifyArgs) error {
+func (b *backend) populateEntPolicyVerifyOptions(_ context.Context, p *keysutil.Policy, args verifyApiArgs, item batchRequestVerifyItem, _ *policyVerifyArgs) error {
+	sigContext, err := _validateString(item, "signature_context")
+	if err != nil {
+		return err
+	}
+	return _forbidEd25519EntBehavior(p, args.commonSignVerifyApiArgs, sigContext)
+}
+
+func _validateString(item batchRequestVerifyItem, key string) (string, error) {
+	if itemVal, exists := item[key]; exists {
+		if itemStrVal, ok := itemVal.(string); ok {
+			return itemStrVal, nil
+		}
+		return "", fmt.Errorf("expected string for key=%q, got=%q", key, itemVal)
+	}
+	return "", nil
+}
+
+func _forbidEd25519EntBehavior(p *keysutil.Policy, apiArgs commonSignVerifyApiArgs, sigContext string) error {
+	if p.Type != keysutil.KeyType_ED25519 {
+		return nil
+	}
+
+	switch {
+	case apiArgs.prehashed:
+		return fmt.Errorf("only Pure Ed25519 signatures supported, prehashed must be false")
+	case apiArgs.hashAlgorithm == keysutil.HashTypeSHA2512:
+		return fmt.Errorf("only Pure Ed25519 signatures supported, hash_alogithm should not be set")
+	case sigContext != "":
+		return fmt.Errorf("only Pure Ed25519 signatures supported, signature_context must be empty")
+	}
+
 	return nil
 }
 

--- a/website/content/api-docs/secret/transit.mdx
+++ b/website/content/api-docs/secret/transit.mdx
@@ -1480,6 +1480,9 @@ supports signing.
      signature rather than the `PKCSv1_5_DERnull` signature type usually
      created. See [RFC 3447 Section 9.2](https://www.rfc-editor.org/rfc/rfc3447#section-9.2).
 
+  ~> **Note**: using `hash_algorithm=sha2-512` requires setting `prehashed=true`
+  for Ed25519 backed keys which enabled Ed25519ph signature support on Enterprise.
+
 - `input` `(string: "")` – Specifies the **base64 encoded** input data. One of
   `input` or `batch_input` must be supplied.
 
@@ -1526,9 +1529,9 @@ supports signing.
   data you want signed, when set, `input` is expected to be base64-encoded
   binary hashed data, not hex-formatted. (As an example, on the command line,
   you could generate a suitable input via `openssl dgst -sha256 -binary | base64`.)
-  On Enterprise <EnterpriseAlert inline="true" />, enabling this will activate
-  Ed25519ph signatures for Ed25519 keys along with hash_algorithm being either `none`
-  or `sha2-512`.
+  On Enterprise <EnterpriseAlert inline="true" />, enabling this along with
+  hash_algorithm being set to `sha2-512` will activate Ed25519ph signatures for
+  Ed25519 keys
 
 - `signature_algorithm` `(string: "pss")` – When using a RSA key, specifies the RSA
   signature algorithm to use for signing. Supported signature types are:
@@ -1669,6 +1672,9 @@ or [generate CMAC](#generate-cmac) API calls.
      signature rather than the `PKCSv1_5_DERnull` signature type usually
      verified. See [RFC 3447 Section 9.2](https://www.rfc-editor.org/rfc/rfc3447#section-9.2).
 
+  ~> **Note**: using `hash_algorithm=sha2-512` requires setting `prehashed=true`
+  for Ed25519 backed keys which enabled Ed25519ph signature support on Enterprise.
+
 - `input` `(string: "")` – Specifies the **base64 encoded** input data. One of
   `input` or `batch_input` must be supplied.
 
@@ -1730,9 +1736,9 @@ or [generate CMAC](#generate-cmac) API calls.
   data you want signed, when set, `input` is expected to be base64-encoded
   binary hashed data, not hex-formatted. (As an example, on the command line,
   you could generate a suitable input via `openssl dgst -sha256 -binary | base64`.)
-  On Enterprise <EnterpriseAlert inline="true" />, enabling this will activate
-  Ed25519ph signatures for Ed25519 keys along with hash_algorithm being either `none`
-  or `sha2-512`.
+  On Enterprise <EnterpriseAlert inline="true" />, enabling this along with
+  hash_algorithm being set to `sha2-512` will activate Ed25519ph signatures for
+  Ed25519 keys
 
 - `signature_algorithm` `(string: "pss")` – When using a RSA key, specifies the RSA
   signature algorithm to use for signature verification. Supported signature types


### PR DESCRIPTION
### Description

1. Only accept sha2-512 hash_algorithm values for Ed25519ph signatures. It made things easier to understand instead of accepting both none or sha2-512 values.
2. Fix a bug in the sign api that an error was being swallowed
3. Add the new fields to CE schema definition as we want to accept a value for them and error out to the end-user if they are provided on CE. This is mainly to make sure end-users get an error on CE instead of a Pure Ed25519 signature as before and then get different values when they upgrade to ENT and they start getting a ph/ctx signature back.
4. Add a few more tests for Ed25519 modes with invalid data.


### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [ ] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [X] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [X] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [X] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
