### PR TITLE
Backport 1.18.x: UI LDAP Hierarchical roles 

### DIFF
--- a/changelog/28824.txt
+++ b/changelog/28824.txt
@@ -1,0 +1,6 @@
+```release-note:improvement
+ui: Adds navigation for LDAP hierarchical roles
+```
+```release-note:bug
+ui: Fixes rendering issues of LDAP dynamic and static roles with the same name
+```

--- a/ui/app/models/ldap/role.js
+++ b/ui/app/models/ldap/role.js
@@ -63,7 +63,8 @@ export const dynamicRoleFields = [
 @withModelValidations(validations)
 @withFormFields()
 export default class LdapRoleModel extends Model {
-  @attr('string') backend; // dynamic path of secret -- set on response from value passed to queryRecord
+  @attr('string') backend; // mount path of ldap engine -- set on response from value passed to queryRecord
+  @attr('string') path_to_role; // ancestral path to the role added in the adapter (only exists for nested roles)
 
   @attr('string', {
     defaultValue: 'static',

--- a/ui/app/serializers/ldap/role.js
+++ b/ui/app/serializers/ldap/role.js
@@ -6,8 +6,6 @@
 import ApplicationSerializer from '../application';
 
 export default class LdapRoleSerializer extends ApplicationSerializer {
-  primaryKey = 'name';
-
   serialize(snapshot) {
     // remove all fields that are not relevant to specified role type
     const { fieldsForType } = snapshot.record;

--- a/ui/lib/core/addon/components/page/breadcrumbs.ts
+++ b/ui/lib/core/addon/components/page/breadcrumbs.ts
@@ -6,16 +6,10 @@
 import Component from '@glimmer/component';
 import { assert } from '@ember/debug';
 
+import type { Breadcrumb } from 'vault/vault/app-types';
+
 interface Args {
   breadcrumbs: Array<Breadcrumb>;
-}
-interface Breadcrumb {
-  label: string;
-  route?: string; // Do not provide for current route
-  icon?: string;
-  model?: string;
-  models?: string[];
-  linkToExternal?: boolean;
 }
 
 /**

--- a/ui/lib/ldap/addon/components/page/overview.hbs
+++ b/ui/lib/ldap/addon/components/page/overview.hbs
@@ -53,7 +53,10 @@
       class="is-flex-half"
     />
     <div>
-      <OverviewCard @cardTitle="Generate credentials" @subText="Quickly generate credentials by typing the role name.">
+      <OverviewCard
+        @cardTitle="Generate credentials"
+        @subText="Quickly generate credentials by typing the role name. Only the engine's top-level roles are listed here."
+      >
         <:content>
           <div class="has-top-margin-m is-flex">
             <SearchSelect
@@ -61,11 +64,14 @@
               @ariaLabel="Role"
               @placeholder="Select a role"
               @disallowNewItems={{true}}
-              @options={{@roles}}
+              @options={{this.roleOptions}}
               @selectLimit="1"
               @fallbackComponent="input-search"
               @onChange={{this.selectRole}}
               @renderInPlace={{true}}
+              @passObject={{true}}
+              @objectKeys={{array "id" "name" "type"}}
+              @shouldRenderName={{true}}
             />
             <div>
               <Hds::Button

--- a/ui/lib/ldap/addon/components/page/overview.ts
+++ b/ui/lib/ldap/addon/components/page/overview.ts
@@ -24,15 +24,35 @@ interface Args {
   breadcrumbs: Array<Breadcrumb>;
 }
 
+interface Option {
+  id: string;
+  name: string;
+  type: string;
+}
+
 export default class LdapLibrariesPageComponent extends Component<Args> {
   @service declare readonly router: RouterService;
 
   @tracked selectedRole: LdapRoleModel | undefined;
 
+  get roleOptions() {
+    const options = this.args.roles
+      // hierarchical roles are not selectable
+      .filter((r: LdapRoleModel) => !r.name.endsWith('/'))
+      // *hack alert* - type is set as id so it renders beside name in search select
+      // this is to avoid more changes to search select and is okay here because
+      // we use the type and name to select the item below, not the id
+      .map((r: LdapRoleModel) => ({ id: r.type, name: r.name, type: r.type }));
+    return options;
+  }
+
   @action
-  selectRole([roleName]: Array<string>) {
-    const model = this.args.roles.find((role) => role.name === roleName);
-    this.selectedRole = model;
+  async selectRole([option]: Array<Option>) {
+    if (option) {
+      const { name, type } = option;
+      const model = this.args.roles.find((role) => role.name === name && role.type === type);
+      this.selectedRole = model;
+    }
   }
 
   @action

--- a/ui/lib/ldap/addon/components/page/roles.hbs
+++ b/ui/lib/ldap/addon/components/page/roles.hbs
@@ -43,48 +43,59 @@
 {{else}}
   <div class="has-bottom-margin-s">
     {{#each @roles as |role|}}
-      <ListItem @linkPrefix={{this.mountPoint}} @linkParams={{array "roles.role.details" role.type role.name}} as |Item|>
+      <ListItem @linkPrefix={{this.mountPoint}} @linkParams={{this.linkParams role}} as |Item|>
         <Item.content>
           <Icon @name="user" />
-          <span data-test-role={{role.name}}>{{role.name}}</span>
+          <span data-test-role="{{role.type}} {{role.name}}">{{role.name}}</span>
           <Hds::Badge @text={{role.type}} data-test-role-type-badge={{role.name}} />
         </Item.content>
         <Item.menu>
           <Hds::Dropdown @isInline={{true}} @listPosition="bottom-right" as |dd|>
-            <dd.ToggleIcon @icon="more-horizontal" @text="More options" @hasChevron={{false}} data-test-popup-menu-trigger />
-            {{#if role.canEdit}}
-              <dd.Interactive @text="Edit" data-test-edit @route="roles.role.edit" @models={{array role.type role.name}} />
-            {{/if}}
-            {{#if role.canReadCreds}}
-              <dd.Interactive
-                @text="Get credentials"
-                data-test-get-creds
-                @route="roles.role.credentials"
-                @models={{array role.type role.name}}
-              />
-            {{/if}}
-            {{#if role.canRotateStaticCreds}}
-              <dd.Interactive
-                @text="Rotate credentials"
-                data-test-rotate-creds
-                @color="critical"
-                {{on "click" (fn (mut this.credsToRotate) role)}}
-              />
-            {{/if}}
-            <dd.Interactive
-              @text="Details"
-              data-test-details
-              @route="roles.role.details"
-              {{! this will force the roles.role model hook to fire since we may only have a partial model loaded in the list view }}
-              @models={{array role.type role.name}}
+            <dd.ToggleIcon
+              @icon="more-horizontal"
+              @text="More options"
+              @hasChevron={{false}}
+              data-test-popup-menu-trigger="{{role.type}} {{role.name}}"
             />
-            {{#if role.canDelete}}
+            {{#if (this.isHierarchical role.name)}}
               <dd.Interactive
-                @text="Delete"
-                data-test-delete
-                @color="critical"
-                {{on "click" (fn (mut this.roleToDelete) role)}}
-              />
+                data-test-subdirectory
+                @route="roles.subdirectory"
+                @models={{array role.type (concat role.path_to_role role.name)}}
+              >Content</dd.Interactive>
+            {{else}}
+              {{#if role.canEdit}}
+                <dd.Interactive
+                  data-test-edit
+                  @route="roles.role.edit"
+                  @models={{array role.type role.name}}
+                >Edit</dd.Interactive>
+              {{/if}}
+              {{#if role.canReadCreds}}
+                <dd.Interactive data-test-get-creds @route="roles.role.credentials" @models={{array role.type role.name}}>
+                  Get credentials
+                </dd.Interactive>
+              {{/if}}
+              {{#if role.canRotateStaticCreds}}
+                <dd.Interactive
+                  data-test-rotate-creds
+                  @color="critical"
+                  {{on "click" (fn (mut this.credsToRotate) role)}}
+                >Rotate credentials</dd.Interactive>
+              {{/if}}
+              <dd.Interactive
+                data-test-details
+                @route="roles.role.details"
+                {{! this will force the roles.role model hook to fire since we may only have a partial model loaded in the list view }}
+                @models={{array role.type role.name}}
+              >Details</dd.Interactive>
+              {{#if role.canDelete}}
+                <dd.Interactive
+                  data-test-delete
+                  @color="critical"
+                  {{on "click" (fn (mut this.roleToDelete) role)}}
+                >Delete</dd.Interactive>
+              {{/if}}
             {{/if}}
           </Hds::Dropdown>
         </Item.menu>
@@ -110,7 +121,9 @@
     <Hds::Pagination::Numbered
       @currentPage={{@roles.meta.currentPage}}
       @currentPageSize={{@roles.meta.pageSize}}
-      @route="roles"
+      {{! localName will be either "index" or "subdirectory" }}
+      @route="roles.{{this.router.currentRoute.localName}}"
+      @models={{@currentRouteParams}}
       @showSizeSelector={{false}}
       @totalItems={{@roles.meta.filteredTotal}}
       @queryFunction={{this.paginationQueryParams}}

--- a/ui/lib/ldap/addon/components/page/roles.hbs
+++ b/ui/lib/ldap/addon/components/page/roles.hbs
@@ -59,42 +59,45 @@
             />
             {{#if (this.isHierarchical role.name)}}
               <dd.Interactive
+                @text="Content"
                 data-test-subdirectory
                 @route="roles.subdirectory"
                 @models={{array role.type (concat role.path_to_role role.name)}}
-              >Content</dd.Interactive>
+              />
             {{else}}
               {{#if role.canEdit}}
-                <dd.Interactive
-                  data-test-edit
-                  @route="roles.role.edit"
-                  @models={{array role.type role.name}}
-                >Edit</dd.Interactive>
+                <dd.Interactive @text="Edit" data-test-edit @route="roles.role.edit" @models={{array role.type role.name}} />
               {{/if}}
               {{#if role.canReadCreds}}
-                <dd.Interactive data-test-get-creds @route="roles.role.credentials" @models={{array role.type role.name}}>
-                  Get credentials
-                </dd.Interactive>
+                <dd.Interactive
+                  @text="Get credentials"
+                  data-test-get-creds
+                  @route="roles.role.credentials"
+                  @models={{array role.type role.name}}
+                />
               {{/if}}
               {{#if role.canRotateStaticCreds}}
                 <dd.Interactive
+                  @text="Rotate credentials"
                   data-test-rotate-creds
                   @color="critical"
                   {{on "click" (fn (mut this.credsToRotate) role)}}
-                >Rotate credentials</dd.Interactive>
+                />
               {{/if}}
               <dd.Interactive
+                @text="Details"
                 data-test-details
                 @route="roles.role.details"
                 {{! this will force the roles.role model hook to fire since we may only have a partial model loaded in the list view }}
                 @models={{array role.type role.name}}
-              >Details</dd.Interactive>
+              />
               {{#if role.canDelete}}
                 <dd.Interactive
+                  @text="Delete"
                   data-test-delete
                   @color="critical"
                   {{on "click" (fn (mut this.roleToDelete) role)}}
-                >Delete</dd.Interactive>
+                />
               {{/if}}
             {{/if}}
           </Hds::Dropdown>

--- a/ui/lib/ldap/addon/components/page/roles.ts
+++ b/ui/lib/ldap/addon/components/page/roles.ts
@@ -16,7 +16,6 @@ import type FlashMessageService from 'vault/services/flash-messages';
 import type { Breadcrumb, EngineOwner } from 'vault/vault/app-types';
 import type RouterService from '@ember/routing/router-service';
 import type StoreService from 'vault/services/store';
-import { tracked } from '@glimmer/tracking';
 
 interface Args {
   roles: Array<LdapRoleModel>;

--- a/ui/lib/ldap/addon/components/page/roles.ts
+++ b/ui/lib/ldap/addon/components/page/roles.ts
@@ -8,6 +8,7 @@ import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { getOwner } from '@ember/owner';
 import errorMessage from 'vault/utils/error-message';
+import { tracked } from '@glimmer/tracking';
 
 import type LdapRoleModel from 'vault/models/ldap/role';
 import type SecretEngineModel from 'vault/models/secret-engine';
@@ -32,6 +33,16 @@ export default class LdapRolesPageComponent extends Component<Args> {
   @tracked credsToRotate: LdapRoleModel | null = null;
   @tracked roleToDelete: LdapRoleModel | null = null;
 
+  isHierarchical = (name: string) => name.endsWith('/');
+
+  linkParams = (role: LdapRoleModel) => {
+    const route = this.isHierarchical(role.name) ? 'roles.subdirectory' : 'roles.role.details';
+    // if there is a path_to_role we're in a subdirectory
+    // and must concat the ancestors with the leaf name to get the full role path
+    const roleName = role.path_to_role ? role.path_to_role + role.name : role.name;
+    return [route, role.type, roleName];
+  };
+
   get mountPoint(): string {
     const owner = getOwner(this) as EngineOwner;
     return owner.mountPoint;
@@ -43,7 +54,8 @@ export default class LdapRolesPageComponent extends Component<Args> {
 
   @action
   onFilterChange(pageFilter: string) {
-    this.router.transitionTo('vault.cluster.secrets.backend.ldap.roles', { queryParams: { pageFilter } });
+    // refresh route, which fires off lazyPaginatedQuery to re-request and filter response
+    this.router.transitionTo(this.router?.currentRoute?.name, { queryParams: { pageFilter } });
   }
 
   @action

--- a/ui/lib/ldap/addon/controllers/roles/subdirectory.ts
+++ b/ui/lib/ldap/addon/controllers/roles/subdirectory.ts
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import Controller from '@ember/controller';
+
+export default class LdapRolesSubdirectoryController extends Controller {
+  queryParams = ['pageFilter', 'page'];
+}

--- a/ui/lib/ldap/addon/routes.js
+++ b/ui/lib/ldap/addon/routes.js
@@ -9,6 +9,8 @@ export default buildRoutes(function () {
   this.route('overview');
   this.route('roles', function () {
     this.route('create');
+    // wildcard route so we can traverse hierarchical roles i.e. prod/admin/my-role
+    this.route('subdirectory', { path: '/:type/subdirectory/*path_to_role' });
     this.route('role', { path: '/:type/:name' }, function () {
       this.route('details');
       this.route('edit');

--- a/ui/lib/ldap/addon/routes/configuration.ts
+++ b/ui/lib/ldap/addon/routes/configuration.ts
@@ -16,14 +16,14 @@ import type Controller from '@ember/controller';
 import type { Breadcrumb } from 'vault/vault/app-types';
 import type AdapterError from 'ember-data/adapter'; // eslint-disable-line ember/use-ember-data-rfc-395-imports
 
-interface LdapConfigurationRouteModel {
+interface RouteModel {
   backendModel: SecretEngineModel;
   configModel: LdapConfigModel;
   configError: AdapterError;
 }
-interface LdapConfigurationController extends Controller {
+interface RouteController extends Controller {
   breadcrumbs: Array<Breadcrumb>;
-  model: LdapConfigurationRouteModel;
+  model: RouteModel;
 }
 
 @withConfig('ldap/config')
@@ -42,11 +42,7 @@ export default class LdapConfigurationRoute extends Route {
     };
   }
 
-  setupController(
-    controller: LdapConfigurationController,
-    resolvedModel: LdapConfigurationRouteModel,
-    transition: Transition
-  ) {
+  setupController(controller: RouteController, resolvedModel: RouteModel, transition: Transition) {
     super.setupController(controller, resolvedModel, transition);
 
     controller.breadcrumbs = [

--- a/ui/lib/ldap/addon/routes/configure.ts
+++ b/ui/lib/ldap/addon/routes/configure.ts
@@ -14,7 +14,7 @@ import type LdapConfigModel from 'vault/models/ldap/config';
 import type Controller from '@ember/controller';
 import type { Breadcrumb } from 'vault/vault/app-types';
 
-interface LdapConfigureController extends Controller {
+interface RouteController extends Controller {
   breadcrumbs: Array<Breadcrumb>;
 }
 
@@ -30,11 +30,7 @@ export default class LdapConfigureRoute extends Route {
     return this.configModel || this.store.createRecord('ldap/config', { backend });
   }
 
-  setupController(
-    controller: LdapConfigureController,
-    resolvedModel: LdapConfigModel,
-    transition: Transition
-  ) {
+  setupController(controller: RouteController, resolvedModel: LdapConfigModel, transition: Transition) {
     super.setupController(controller, resolvedModel, transition);
 
     controller.breadcrumbs = [

--- a/ui/lib/ldap/addon/routes/overview.ts
+++ b/ui/lib/ldap/addon/routes/overview.ts
@@ -18,10 +18,10 @@ import type Controller from '@ember/controller';
 import type { Breadcrumb } from 'vault/vault/app-types';
 import { LdapLibraryAccountStatus } from 'vault/vault/adapters/ldap/library';
 
-interface LdapOverviewController extends Controller {
+interface RouteController extends Controller {
   breadcrumbs: Array<Breadcrumb>;
 }
-interface LdapOverviewRouteModel {
+interface RouteModel {
   backendModel: SecretEngineModel;
   promptConfig: boolean;
   roles: Array<LdapRoleModel>;
@@ -66,11 +66,7 @@ export default class LdapOverviewRoute extends Route {
     });
   }
 
-  setupController(
-    controller: LdapOverviewController,
-    resolvedModel: LdapOverviewRouteModel,
-    transition: Transition
-  ) {
+  setupController(controller: RouteController, resolvedModel: RouteModel, transition: Transition) {
     super.setupController(controller, resolvedModel, transition);
 
     controller.breadcrumbs = [

--- a/ui/lib/ldap/addon/routes/roles.ts
+++ b/ui/lib/ldap/addon/routes/roles.ts
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+
+import type SecretMountPath from 'vault/services/secret-mount-path';
+import type StoreService from 'vault/services/store';
+
+// Base class for roles/index and roles/subdirectory routes
+export default class LdapRolesRoute extends Route {
+  @service declare readonly secretMountPath: SecretMountPath;
+  @service declare readonly store: StoreService;
+
+  lazyQuery(backendId: string, params: { page?: string; pageFilter: string }, adapterOptions: object) {
+    const page = Number(params.page) || 1;
+    return this.store.lazyPaginatedQuery(
+      'ldap/role',
+      {
+        backend: backendId,
+        page,
+        pageFilter: params.pageFilter,
+        responsePath: 'data.keys',
+        skipCache: page === 1,
+      },
+      { adapterOptions }
+    );
+  }
+}

--- a/ui/lib/ldap/addon/routes/roles/create.ts
+++ b/ui/lib/ldap/addon/routes/roles/create.ts
@@ -13,7 +13,7 @@ import type Controller from '@ember/controller';
 import type Transition from '@ember/routing/transition';
 import type { Breadcrumb } from 'vault/vault/app-types';
 
-interface LdapRolesCreateController extends Controller {
+interface RouteController extends Controller {
   breadcrumbs: Array<Breadcrumb>;
   model: LdapRoleModel;
 }
@@ -27,11 +27,7 @@ export default class LdapRolesCreateRoute extends Route {
     return this.store.createRecord('ldap/role', { backend });
   }
 
-  setupController(
-    controller: LdapRolesCreateController,
-    resolvedModel: LdapRoleModel,
-    transition: Transition
-  ) {
+  setupController(controller: RouteController, resolvedModel: LdapRoleModel, transition: Transition) {
     super.setupController(controller, resolvedModel, transition);
 
     controller.breadcrumbs = [

--- a/ui/lib/ldap/addon/routes/roles/role.ts
+++ b/ui/lib/ldap/addon/routes/roles/role.ts
@@ -6,19 +6,17 @@
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
 
+import { ModelFrom } from 'vault/vault/route';
 import type Store from '@ember-data/store';
 import type SecretMountPath from 'vault/services/secret-mount-path';
 
-interface LdapRoleRouteParams {
-  name: string;
-  type: string;
-}
+export type LdapRolesRoleRouteModel = ModelFrom<LdapRolesRoleRoute>;
 
-export default class LdapRoleRoute extends Route {
+export default class LdapRolesRoleRoute extends Route {
   @service declare readonly store: Store;
   @service declare readonly secretMountPath: SecretMountPath;
 
-  model(params: LdapRoleRouteParams) {
+  model(params: { name: string; type: string }) {
     const backend = this.secretMountPath.currentPath;
     const { name, type } = params;
     return this.store.queryRecord('ldap/role', { backend, name, type });

--- a/ui/lib/ldap/addon/routes/roles/role/credentials.ts
+++ b/ui/lib/ldap/addon/routes/roles/role/credentials.ts
@@ -5,6 +5,7 @@
 
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
+import { ldapBreadcrumbs } from 'ldap/utils/ldap-breadcrumbs';
 
 import type Store from '@ember-data/store';
 import type LdapRoleModel from 'vault/models/ldap/role';
@@ -13,7 +14,7 @@ import type Transition from '@ember/routing/transition';
 import type { Breadcrumb } from 'vault/vault/app-types';
 import type AdapterError from 'ember-data/adapter'; // eslint-disable-line ember/use-ember-data-rfc-395-imports
 
-export interface LdapStaticRoleCredentials {
+export interface StaticCredentials {
   dn: string;
   last_vault_rotation: string;
   password: string;
@@ -23,7 +24,7 @@ export interface LdapStaticRoleCredentials {
   username: string;
   type: string;
 }
-export interface LdapDynamicRoleCredentials {
+export interface DynamicCredentials {
   distinguished_names: Array<string>;
   password: string;
   username: string;
@@ -32,13 +33,13 @@ export interface LdapDynamicRoleCredentials {
   renewable: boolean;
   type: string;
 }
-interface LdapRoleCredentialsRouteModel {
-  credentials: undefined | LdapStaticRoleCredentials | LdapDynamicRoleCredentials;
+interface RouteModel {
+  credentials: undefined | StaticCredentials | DynamicCredentials;
   error: undefined | AdapterError;
 }
-interface LdapRoleCredentialsController extends Controller {
+interface RouteController extends Controller {
   breadcrumbs: Array<Breadcrumb>;
-  model: LdapRoleCredentialsRouteModel;
+  model: RouteModel;
 }
 
 export default class LdapRoleCredentialsRoute extends Route {
@@ -53,19 +54,16 @@ export default class LdapRoleCredentialsRoute extends Route {
       return { error };
     }
   }
-  setupController(
-    controller: LdapRoleCredentialsController,
-    resolvedModel: LdapRoleCredentialsRouteModel,
-    transition: Transition
-  ) {
+  setupController(controller: RouteController, resolvedModel: RouteModel, transition: Transition) {
     super.setupController(controller, resolvedModel, transition);
 
     const role = this.modelFor('roles.role') as LdapRoleModel;
     controller.breadcrumbs = [
+      { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: role.backend, route: 'overview' },
-      { label: 'roles', route: 'roles' },
-      { label: role.name, route: 'roles.role' },
-      { label: 'credentials' },
+      { label: 'Roles', route: 'roles' },
+      ...ldapBreadcrumbs(role.name, role.type, role.backend),
+      { label: 'Credentials' },
     ];
   }
 }

--- a/ui/lib/ldap/addon/routes/roles/role/details.ts
+++ b/ui/lib/ldap/addon/routes/roles/role/details.ts
@@ -4,29 +4,31 @@
  */
 
 import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+import { ldapBreadcrumbs } from 'ldap/utils/ldap-breadcrumbs';
 
-import type LdapRoleModel from 'vault/models/ldap/role';
-import type Controller from '@ember/controller';
-import type Transition from '@ember/routing/transition';
 import type { Breadcrumb } from 'vault/vault/app-types';
+import type Controller from '@ember/controller';
+import type LdapRoleModel from 'vault/models/ldap/role';
+import type SecretMountPath from 'vault/services/secret-mount-path';
+import type Transition from '@ember/routing/transition';
 
-interface LdapRoleDetailsController extends Controller {
+interface RouteController extends Controller {
   breadcrumbs: Array<Breadcrumb>;
   model: LdapRoleModel;
 }
 
-export default class LdapRoleEditRoute extends Route {
-  setupController(
-    controller: LdapRoleDetailsController,
-    resolvedModel: LdapRoleModel,
-    transition: Transition
-  ) {
+export default class LdapRolesRoleDetailsRoute extends Route {
+  @service declare readonly secretMountPath: SecretMountPath;
+
+  setupController(controller: RouteController, resolvedModel: LdapRoleModel, transition: Transition) {
     super.setupController(controller, resolvedModel, transition);
 
     controller.breadcrumbs = [
+      { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: resolvedModel.backend, route: 'overview' },
-      { label: 'roles', route: 'roles' },
-      { label: resolvedModel.name },
+      { label: 'Roles', route: 'roles' },
+      ...ldapBreadcrumbs(resolvedModel.name, resolvedModel.type, this.secretMountPath.currentPath, true),
     ];
   }
 }

--- a/ui/lib/ldap/addon/routes/roles/role/edit.ts
+++ b/ui/lib/ldap/addon/routes/roles/role/edit.ts
@@ -4,26 +4,28 @@
  */
 
 import Route from '@ember/routing/route';
+import { ldapBreadcrumbs } from 'ldap/utils/ldap-breadcrumbs';
 
 import type LdapRoleModel from 'vault/models/ldap/role';
 import type Controller from '@ember/controller';
 import type Transition from '@ember/routing/transition';
 import type { Breadcrumb } from 'vault/vault/app-types';
 
-interface LdapRoleEditController extends Controller {
+interface RouteController extends Controller {
   breadcrumbs: Array<Breadcrumb>;
   model: LdapRoleModel;
 }
 
 export default class LdapRoleEditRoute extends Route {
-  setupController(controller: LdapRoleEditController, resolvedModel: LdapRoleModel, transition: Transition) {
+  setupController(controller: RouteController, resolvedModel: LdapRoleModel, transition: Transition) {
     super.setupController(controller, resolvedModel, transition);
 
     controller.breadcrumbs = [
+      { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: resolvedModel.backend, route: 'overview' },
-      { label: 'roles', route: 'roles' },
-      { label: resolvedModel.name, route: 'roles.role' },
-      { label: 'edit' },
+      { label: 'Roles', route: 'roles' },
+      ...ldapBreadcrumbs(resolvedModel.name, resolvedModel.type, resolvedModel.backend),
+      { label: 'Edit' },
     ];
   }
 }

--- a/ui/lib/ldap/addon/templates/roles/subdirectory.hbs
+++ b/ui/lib/ldap/addon/templates/roles/subdirectory.hbs
@@ -1,0 +1,15 @@
+{{!
+  Copyright (c) HashiCorp, Inc.
+  SPDX-License-Identifier: BUSL-1.1
+~}}
+
+{{#let this.model.roleAncestry.type this.model.roleAncestry.path_to_role as |roleType path_to_role|}}
+  <Page::Roles
+    @roles={{this.model.roles}}
+    @promptConfig={{false}}
+    @backendModel={{this.model.backendModel}}
+    @breadcrumbs={{this.breadcrumbs}}
+    @pageFilter={{this.pageFilter}}
+    @currentRouteParams={{array this.model.backendModel.id roleType path_to_role}}
+  />
+{{/let}}

--- a/ui/lib/ldap/addon/utils/ldap-breadcrumbs.ts
+++ b/ui/lib/ldap/addon/utils/ldap-breadcrumbs.ts
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+import type { Breadcrumb } from 'vault/vault/app-types';
+
+export const ldapBreadcrumbs = (
+  fullPath: string | undefined, // i.e. path/to/item
+  roleType: string,
+  mountPath: string,
+  lastItemCurrent = false // this array of objects can be spread anywhere within the crumbs array
+): Breadcrumb[] => {
+  if (!fullPath) return [];
+  const ancestry = fullPath.split('/').filter((path) => path !== '');
+  const isDirectory = fullPath.endsWith('/');
+
+  return ancestry.map((name: string, idx: number) => {
+    const isLast = ancestry.length === idx + 1;
+    // if the end of the path is the current route, don't return a route link
+    if (isLast && lastItemCurrent) return { label: name };
+
+    // each segment is a continued concatenation of ancestral paths.
+    // for example, if the full path to an item is "prod/admin/west"
+    // the segments will be: prod/, prod/admin/, prod/admin/west.
+    // LIST or GET requests can then be made for each crumb accordingly.
+    const segment = ancestry.slice(0, idx + 1).join('/');
+
+    const itemPath = isLast && !isDirectory ? segment : `${segment}/`;
+    const routeParams = [mountPath, roleType, itemPath];
+    return {
+      label: name,
+      route: isLast && !isDirectory ? 'roles.role.details' : 'roles.subdirectory',
+      models: routeParams,
+    };
+  });
+};

--- a/ui/mirage/scenarios/ldap.js
+++ b/ui/mirage/scenarios/ldap.js
@@ -7,5 +7,11 @@ export default function (server) {
   server.create('ldap-config', { path: 'kubernetes' });
   server.create('ldap-role', 'static', { name: 'static-role' });
   server.create('ldap-role', 'dynamic', { name: 'dynamic-role' });
+  // hierarchical roles
+  server.create('ldap-role', 'static', { name: 'admin/child-static-role' });
+  server.create('ldap-role', 'dynamic', { name: 'admin/child-dynamic-role' });
+  // use same name for both role types to test edge cases
+  server.create('ldap-role', 'static', { name: 'my-role' });
+  server.create('ldap-role', 'dynamic', { name: 'my-role' });
   server.create('ldap-library', { name: 'test-library' });
 }

--- a/ui/tests/acceptance/secrets/backend/ldap/roles-test.js
+++ b/ui/tests/acceptance/secrets/backend/ldap/roles-test.js
@@ -9,8 +9,10 @@ import { setupMirage } from 'ember-cli-mirage/test-support';
 import ldapMirageScenario from 'vault/mirage/scenarios/ldap';
 import ldapHandlers from 'vault/mirage/handlers/ldap';
 import authPage from 'vault/tests/pages/auth';
-import { click, fillIn } from '@ember/test-helpers';
-import { isURL, visitURL } from 'vault/tests/helpers/ldap/ldap-helpers';
+import { click, fillIn, waitFor } from '@ember/test-helpers';
+import { assertURL, isURL, visitURL } from 'vault/tests/helpers/ldap/ldap-helpers';
+import { GENERAL } from 'vault/tests/helpers/general-selectors';
+import { LDAP_SELECTORS } from 'vault/tests/helpers/ldap/ldap-selectors';
 
 module('Acceptance | ldap | roles', function (hooks) {
   setupApplicationTest(hooks);
@@ -29,37 +31,46 @@ module('Acceptance | ldap | roles', function (hooks) {
   });
 
   test('it should transition to role details route on list item click', async function (assert) {
-    await click('[data-test-list-item-link]:nth-of-type(1) a');
-    assert.true(
-      isURL('roles/dynamic/dynamic-role/details'),
-      'Transitions to role details route on list item click'
-    );
+    let path;
 
-    await click('[data-test-breadcrumb="roles"] a');
-    await click('[data-test-list-item-link]:nth-of-type(2) a');
-    assert.true(
-      isURL('roles/static/static-role/details'),
-      'Transitions to role details route on list item click'
-    );
+    await click(LDAP_SELECTORS.roleItem('dynamic', 'dynamic-role'));
+    path = 'roles/dynamic/dynamic-role/details';
+    assertURL(assert, this.backend, path);
+    await click(GENERAL.breadcrumbLink('Roles'));
+
+    await click(LDAP_SELECTORS.roleItem('static', 'static-role'));
+    path = 'roles/static/static-role/details';
+    assertURL(assert, this.backend, path);
+    await click(GENERAL.breadcrumbLink('Roles'));
+
+    // edge case, roles of different type with same name
+    await click(LDAP_SELECTORS.roleItem('dynamic', 'my-role'));
+    path = 'roles/dynamic/my-role/details';
+    assertURL(assert, this.backend, path);
+    await click(GENERAL.breadcrumbLink('Roles'));
+
+    await click(LDAP_SELECTORS.roleItem('static', 'my-role'));
+    path = 'roles/static/my-role/details';
+    assertURL(assert, this.backend, path);
   });
 
   test('it should transition to routes from list item action menu', async function (assert) {
     assert.expect(3);
 
     for (const action of ['edit', 'get-creds', 'details']) {
-      await click('[data-test-popup-menu-trigger]');
-      await click(`[data-test-${action}]`);
+      await click(LDAP_SELECTORS.roleMenu('dynamic', 'dynamic-role'));
+      await click(LDAP_SELECTORS.action(action));
       const uri = action === 'get-creds' ? 'credentials' : action;
       assert.true(
         isURL(`roles/dynamic/dynamic-role/${uri}`),
         `Transitions to ${uri} route on list item action menu click`
       );
-      await click('[data-test-breadcrumb="roles"] a');
+      await click(GENERAL.breadcrumbLink('Roles'));
     }
   });
 
   test('it should transition to routes from role details toolbar links', async function (assert) {
-    await click('[data-test-list-item-link]:nth-of-type(1) a');
+    await click(LDAP_SELECTORS.roleItem('dynamic', 'dynamic-role'));
     await click('[data-test-get-credentials]');
     assert.true(
       isURL('roles/dynamic/dynamic-role/credentials'),
@@ -79,5 +90,61 @@ module('Acceptance | ldap | roles', function (hooks) {
     await click('[data-test-tab="libraries"]');
     await click('[data-test-tab="roles"]');
     assert.dom('[data-test-filter-input]').hasNoValue('Roles page filter value cleared on route exit');
+  });
+
+  module('subdirectory', function () {
+    test('it navigates to hierarchical roles', async function (assert) {
+      let path;
+      // hierarchical paths
+      await click(LDAP_SELECTORS.roleItem('dynamic', 'admin/'));
+      path = 'roles/dynamic/subdirectory/admin/';
+      assertURL(assert, this.backend, path);
+
+      await click(LDAP_SELECTORS.roleItem('dynamic', 'child-dynamic-role'));
+      path = 'roles/dynamic/admin%2Fchild-dynamic-role/details';
+      assertURL(assert, this.backend, path);
+
+      // navigate out via breadcrumbs to test
+      await click(GENERAL.breadcrumbLink('admin'));
+      path = 'roles/dynamic/subdirectory/admin/';
+      assertURL(assert, this.backend, path);
+
+      await click(GENERAL.breadcrumbLink('Roles'));
+
+      await click(LDAP_SELECTORS.roleItem('static', 'admin/'));
+      path = 'roles/static/subdirectory/admin/';
+      assertURL(assert, this.backend, path);
+      await click(LDAP_SELECTORS.roleItem('static', 'child-static-role'));
+      path = 'roles/static/admin%2Fchild-static-role/details';
+      assertURL(assert, this.backend, path);
+
+      // navigate out via breadcrumbs to test
+      await click(GENERAL.breadcrumbLink('admin'));
+      path = 'roles/static/subdirectory/admin/';
+      assertURL(assert, this.backend, path);
+    });
+
+    test('it should transition to subdirectory from hierarchical role popup menu', async function (assert) {
+      assert.expect(4);
+
+      await click(LDAP_SELECTORS.roleMenu('dynamic', 'admin/'));
+      for (const action of ['edit', 'get-creds', 'details']) {
+        assert.dom(LDAP_SELECTORS.action(action)).doesNotExist(`${action} does not render in popup menu`);
+      }
+      await click(LDAP_SELECTORS.action('subdirectory'));
+      assertURL(assert, this.backend, 'roles/dynamic/subdirectory/admin/');
+    });
+
+    test('it should clear roles page filter value on route exit', async function (assert) {
+      await visitURL('roles/static/subdirectory/admin/', this.backend);
+      await fillIn('[data-test-filter-input]', 'foo');
+      assert
+        .dom('[data-test-filter-input]')
+        .hasValue('foo', 'Roles page filter value set after model refresh and rerender');
+      await waitFor(GENERAL.emptyStateTitle);
+      await click('[data-test-tab="libraries"]');
+      await click('[data-test-tab="roles"]');
+      assert.dom('[data-test-filter-input]').hasNoValue('Roles page filter value cleared on route exit');
+    });
   });
 });

--- a/ui/tests/acceptance/secrets/backend/ldap/roles-test.js
+++ b/ui/tests/acceptance/secrets/backend/ldap/roles-test.js
@@ -21,6 +21,7 @@ module('Acceptance | ldap | roles', function (hooks) {
   hooks.beforeEach(async function () {
     ldapHandlers(this.server);
     ldapMirageScenario(this.server);
+    this.backend = 'ldap-test';
     await authPage.login();
     return visitURL('roles');
   });

--- a/ui/tests/helpers/ldap/ldap-helpers.js
+++ b/ui/tests/helpers/ldap/ldap-helpers.js
@@ -28,11 +28,11 @@ export const generateBreadcrumbs = (backend, childRoute) => {
   return breadcrumbs;
 };
 
-const baseURL = '/vault/secrets/ldap-test/ldap/';
+const baseURL = (backend) => `/vault/secrets/${backend}/ldap/`;
 const stripLeadingSlash = (uri) => (uri.charAt(0) === '/' ? uri.slice(1) : uri);
 
-export const isURL = (uri) => {
-  return currentURL() === `${baseURL}${stripLeadingSlash(uri)}`;
+export const isURL = (uri, backend = 'ldap-test') => {
+  return currentURL() === `${baseURL(backend)}${stripLeadingSlash(uri)}`;
 };
 
 export const assertURL = (assert, backend, path) => {

--- a/ui/tests/helpers/ldap/ldap-helpers.js
+++ b/ui/tests/helpers/ldap/ldap-helpers.js
@@ -35,6 +35,10 @@ export const isURL = (uri) => {
   return currentURL() === `${baseURL}${stripLeadingSlash(uri)}`;
 };
 
-export const visitURL = (uri) => {
-  return visit(`${baseURL}${stripLeadingSlash(uri)}`);
+export const assertURL = (assert, backend, path) => {
+  assert.strictEqual(currentURL(), baseURL(backend) + path, `url is ${path}`);
+};
+
+export const visitURL = (uri, backend = 'ldap-test') => {
+  return visit(`${baseURL(backend)}${stripLeadingSlash(uri)}`);
 };

--- a/ui/tests/helpers/ldap/ldap-selectors.ts
+++ b/ui/tests/helpers/ldap/ldap-selectors.ts
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+export const LDAP_SELECTORS = {
+  roleItem: (type: string, name: string) => `[data-test-role="${type} ${name}"]`,
+  roleMenu: (type: string, name: string) => `[data-test-popup-menu-trigger="${type} ${name}"]`,
+  action: (action: string) => `[data-test-${action}]`,
+};

--- a/ui/tests/integration/components/ldap/page/role/details-test.js
+++ b/ui/tests/integration/components/ldap/page/role/details-test.js
@@ -11,6 +11,7 @@ import { render, click } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import sinon from 'sinon';
 import { duration } from 'core/helpers/format-duration';
+import { ldapRoleID } from 'vault/adapters/ldap/role';
 
 module('Integration | Component | ldap | Page::Role::Details', function (hooks) {
   setupRenderingTest(hooks);
@@ -25,6 +26,7 @@ module('Integration | Component | ldap | Page::Role::Details', function (hooks) 
     }));
     this.renderComponent = (type) => {
       const data = this.server.create('ldap-role', type);
+      data.id = ldapRoleID(type, data.name);
       const store = this.owner.lookup('service:store');
       store.pushPayload('ldap/role', {
         modelName: 'ldap/role',
@@ -32,7 +34,7 @@ module('Integration | Component | ldap | Page::Role::Details', function (hooks) 
         type,
         ...data,
       });
-      this.model = store.peekRecord('ldap/role', data.name);
+      this.model = store.peekRecord('ldap/role', ldapRoleID(type, data.name));
       this.breadcrumbs = [
         { label: this.model.backend, route: 'overview' },
         { label: 'roles', route: 'roles' },

--- a/ui/tests/unit/utils/ldap-breadcrumbs-test.js
+++ b/ui/tests/unit/utils/ldap-breadcrumbs-test.js
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import { ldapBreadcrumbs } from 'ldap/utils/ldap-breadcrumbs';
+import { module, test } from 'qunit';
+
+module('Unit | Utility | ldap breadcrumbs', function (hooks) {
+  hooks.beforeEach(async function () {
+    this.mountPath = 'my-engine';
+    this.roleType = 'static';
+    this.testCrumbs = (path, { lastItemCurrent }) => {
+      return ldapBreadcrumbs(path, this.roleType, this.mountPath, lastItemCurrent);
+    };
+  });
+
+  test('it generates crumbs when the path is a directory', function (assert) {
+    const path = 'prod/org/';
+    let actual = this.testCrumbs(path, { lastItemCurrent: true });
+    let expected = [
+      { label: 'prod', route: 'roles.subdirectory', models: [this.mountPath, this.roleType, 'prod/'] },
+      { label: 'org' },
+    ];
+    assert.propEqual(actual, expected, 'crumbs are correct when lastItemCurrent = true');
+
+    actual = this.testCrumbs(path, { lastItemCurrent: false });
+    expected = [
+      { label: 'prod', route: 'roles.subdirectory', models: [this.mountPath, this.roleType, 'prod/'] },
+      { label: 'org', route: 'roles.subdirectory', models: [this.mountPath, this.roleType, 'prod/org/'] },
+    ];
+    assert.propEqual(actual, expected, 'crumbs are correct when lastItemCurrent = false');
+  });
+
+  test('it generates crumbs when the path is not a directory', function (assert) {
+    const path = 'prod/org/admin';
+    let actual = this.testCrumbs(path, { lastItemCurrent: true });
+    let expected = [
+      { label: 'prod', route: 'roles.subdirectory', models: [this.mountPath, this.roleType, 'prod/'] },
+      { label: 'org', route: 'roles.subdirectory', models: [this.mountPath, this.roleType, 'prod/org/'] },
+      { label: 'admin' },
+    ];
+    assert.propEqual(actual, expected, 'crumbs are correct when lastItemCurrent = true');
+
+    actual = this.testCrumbs(path, { lastItemCurrent: false });
+    expected = [
+      { label: 'prod', route: 'roles.subdirectory', models: [this.mountPath, this.roleType, 'prod/'] },
+      { label: 'org', route: 'roles.subdirectory', models: [this.mountPath, this.roleType, 'prod/org/'] },
+      {
+        label: 'admin',
+        route: 'roles.role.details',
+        models: [this.mountPath, this.roleType, 'prod/org/admin'],
+      },
+    ];
+    assert.propEqual(actual, expected, 'crumbs are correct when lastItemCurrent = false');
+  });
+
+  test('it generates crumbs when the path is the top-level', function (assert) {
+    const path = 'prod/';
+    let actual = this.testCrumbs(path, { lastItemCurrent: true });
+    let expected = [{ label: 'prod' }];
+    assert.propEqual(actual, expected, 'crumbs are correct when lastItemCurrent = true');
+
+    actual = this.testCrumbs(path, { lastItemCurrent: false });
+    expected = [
+      { label: 'prod', route: 'roles.subdirectory', models: [this.mountPath, this.roleType, 'prod/'] },
+    ];
+    assert.propEqual(actual, expected, 'crumbs are correct when lastItemCurrent = false');
+  });
+
+  test('it fails gracefully when no path', function (assert) {
+    const path = undefined;
+    const actual = this.testCrumbs(path, { lastItemCurrent: false });
+    assert.propEqual(actual, [], 'returns empty array when path is null');
+  });
+});

--- a/ui/types/vault/app-types.ts
+++ b/ui/types/vault/app-types.ts
@@ -63,6 +63,9 @@ export interface WithFormFieldsAndValidationsModel extends WithFormFieldsModel, 
 export interface Breadcrumb {
   label: string;
   route?: string;
+  icon?: string;
+  model?: string;
+  models?: string[];
   linkExternal?: boolean;
 }
 
@@ -71,12 +74,6 @@ export interface TtlEvent {
   seconds: number;
   timeString: string;
   goSafeTimeString: string;
-}
-
-export interface Breadcrumb {
-  label: string;
-  route?: string;
-  linkExternal?: boolean;
 }
 
 export interface EngineOwner extends Owner {

--- a/ui/types/vault/models/ldap/role.d.ts
+++ b/ui/types/vault/models/ldap/role.d.ts
@@ -7,8 +7,10 @@ import type { FormField } from 'vault/app-types';
 import CapabilitiesModel from '../capabilities';
 import { LdapDynamicRoleCredentials, LdapStaticRoleCredentials } from 'ldap/routes/roles/role/credentials';
 export default interface LdapRoleModel extends WithFormFieldsAndValidationsModel {
+  id: string;
   type: string;
   backend: string;
+  path_to_role: string;
   name: string;
   dn: string;
   username: string;


### PR DESCRIPTION
### Description
Backport of https://github.com/hashicorp/vault/pull/28824, manual due to changes from https://github.com/hashicorp/vault/pull/28432 and https://github.com/hashicorp/vault/pull/28695 

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [ ] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
