### PR TITLE
VAULT-31075 CE changes

### DIFF
--- a/vault/core_metrics.go
+++ b/vault/core_metrics.go
@@ -6,6 +6,7 @@ package vault
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"strings"
 	"time"
@@ -403,7 +404,7 @@ func (c *Core) findKvMounts() []*kvMount {
 	for _, entry := range c.mounts.Entries {
 		if entry.Type == "kv" || entry.Type == "generic" {
 			version, ok := entry.Options["version"]
-			if !ok {
+			if !ok || version == "" {
 				version = "1"
 			}
 			mounts = append(mounts, &kvMount{
@@ -452,9 +453,13 @@ func (c *Core) walkKvMountSecrets(ctx context.Context, m *kvMount) {
 		resp, err := c.router.Route(ctx, listRequest)
 		if err != nil {
 			c.kvCollectionErrorCount()
-			// ErrUnsupportedPath probably means that the mount is not there any more,
+			// ErrUnsupportedPath probably means that the mount is not there anymore,
 			// don't log those cases.
-			if !strings.Contains(err.Error(), logical.ErrUnsupportedPath.Error()) {
+			if !strings.Contains(err.Error(), logical.ErrUnsupportedPath.Error()) &&
+				// ErrSetupReadOnly means the mount's currently being set up.
+				// Nothing is wrong and there's no cause for alarm, just that we can't get data from it
+				// yet. We also shouldn't log these cases
+				!strings.Contains(err.Error(), logical.ErrSetupReadOnly.Error()) {
 				c.logger.Error("failed to perform internal KV list", "mount_point", m.MountPoint, "error", err)
 				break
 			}
@@ -483,6 +488,90 @@ func (c *Core) walkKvMountSecrets(ctx context.Context, m *kvMount) {
 			}
 		}
 	}
+}
+
+// getMinNamespaceSecrets is expected to be called on the output
+// of GetKvUsageMetrics to get the min number of secrets in a single namespace.
+func getMinNamespaceSecrets(mapOfNamespacesToSecrets map[string]int) int {
+	currentMin := 0
+	for _, n := range mapOfNamespacesToSecrets {
+		if n < currentMin || currentMin == 0 {
+			currentMin = n
+		}
+	}
+	return currentMin
+}
+
+// getMaxNamespaceSecrets is expected to be called on the output
+// of GetKvUsageMetrics to get the max number of secrets in a single namespace.
+func getMaxNamespaceSecrets(mapOfNamespacesToSecrets map[string]int) int {
+	currentMax := 0
+	for _, n := range mapOfNamespacesToSecrets {
+		if n > currentMax {
+			currentMax = n
+		}
+	}
+	return currentMax
+}
+
+// getTotalSecretsAcrossAllNamespaces is expected to be called on the output
+// of GetKvUsageMetrics to get the total number of secrets across namespaces.
+func getTotalSecretsAcrossAllNamespaces(mapOfNamespacesToSecrets map[string]int) int {
+	total := 0
+	for _, n := range mapOfNamespacesToSecrets {
+		total += n
+	}
+	return total
+}
+
+// getMeanNamespaceSecrets is expected to be called on the output
+// of GetKvUsageMetrics to get the mean number of secrets across namespaces.
+func getMeanNamespaceSecrets(mapOfNamespacesToSecrets map[string]int) int {
+	length := len(mapOfNamespacesToSecrets)
+	// Avoid divide by zero:
+	if length == 0 {
+		return length
+	}
+	return getTotalSecretsAcrossAllNamespaces(mapOfNamespacesToSecrets) / length
+}
+
+// GetKvUsageMetrics returns a map of namespace paths to KV secret counts within those namespaces.
+func (c *Core) GetKvUsageMetrics(ctx context.Context, kvVersion string) (map[string]int, error) {
+	mounts := c.findKvMounts()
+	results := make(map[string]int)
+
+	if kvVersion == "1" || kvVersion == "2" {
+		var newMounts []*kvMount
+		for _, mount := range mounts {
+			if mount.Version == kvVersion {
+				newMounts = append(newMounts, mount)
+			}
+		}
+		mounts = newMounts
+	} else if kvVersion != "0" {
+		return results, fmt.Errorf("kv version %s not supported, must be 0, 1, or 2", kvVersion)
+	}
+
+	for _, m := range mounts {
+		select {
+		case <-ctx.Done():
+			return nil, fmt.Errorf("context expired")
+		default:
+			break
+		}
+
+		c.walkKvMountSecrets(ctx, m)
+
+		_, ok := results[m.Namespace.Path]
+		if ok {
+			// we need to add, not overwrite
+			results[m.Namespace.Path] += m.NumSecrets
+		} else {
+			results[m.Namespace.Path] = m.NumSecrets
+		}
+	}
+
+	return results, nil
 }
 
 func (c *Core) kvSecretGaugeCollector(ctx context.Context) ([]metricsutil.GaugeLabelValues, error) {

--- a/vault/core_metrics_test.go
+++ b/vault/core_metrics_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/vault/helper/namespace"
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCoreMetrics_KvSecretGauge(t *testing.T) {
@@ -244,6 +245,32 @@ func TestCoreMetrics_KvSecretGaugeError(t *testing.T) {
 	if counter.Count != 1 {
 		t.Errorf("Counter number of samples %v is not 1.", counter.Count)
 	}
+}
+
+// TestCoreMetrics_KvUsageMetricsHelperFunctions tests the KV Product Usage
+// metrics helper functions designed to be used on the output of GetKvUsageMetrics.
+func TestCoreMetrics_KvUsageMetricsHelperFunctions(t *testing.T) {
+	// This is just "", but it makes it clearer
+	rootNsPath := namespace.RootNamespace.Path
+
+	testMap := map[string]int{
+		rootNsPath: 10,
+		"ns1":      20,
+		"ns3":      30,
+	}
+
+	require.Equal(t, 60, getTotalSecretsAcrossAllNamespaces(testMap))
+	require.Equal(t, 0, getTotalSecretsAcrossAllNamespaces(map[string]int{}))
+	require.Equal(t, 10, getTotalSecretsAcrossAllNamespaces(map[string]int{rootNsPath: 10}))
+	require.Equal(t, 20, getMeanNamespaceSecrets(testMap))
+	require.Equal(t, 0, getMeanNamespaceSecrets(map[string]int{}))
+	require.Equal(t, 10, getMeanNamespaceSecrets(map[string]int{rootNsPath: 10}))
+	require.Equal(t, 30, getMaxNamespaceSecrets(testMap))
+	require.Equal(t, 0, getMaxNamespaceSecrets(map[string]int{}))
+	require.Equal(t, 10, getMaxNamespaceSecrets(map[string]int{rootNsPath: 10}))
+	require.Equal(t, 10, getMinNamespaceSecrets(testMap))
+	require.Equal(t, 0, getMinNamespaceSecrets(map[string]int{}))
+	require.Equal(t, 10, getMinNamespaceSecrets(map[string]int{rootNsPath: 10}))
 }
 
 func metricLabelsMatch(t *testing.T, actual []metrics.Label, expected map[string]string) {


### PR DESCRIPTION
### Description

CE side changes for https://github.com/hashicorp/vault-enterprise/pull/6923

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [x] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
