### PR TITLE
Add 1.19.x upgrade note around Transit API change for Ed25519ph signatures

### DIFF
--- a/website/content/docs/upgrading/upgrade-to-1.19.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.19.x.mdx
@@ -1,0 +1,44 @@
+---
+layout: docs
+page_title: Upgrade to Vault 1.19.x - Guides
+description: |-
+  Deprecations, important or breaking changes, and remediation recommendations
+  for anyone upgrading to 1.19.x from Vault 1.18.x.
+---
+
+# Overview
+
+The Vault 1.19.x upgrade guide contains information on deprecations, important
+or breaking changes, and remediation recommendations for anyone upgrading from
+Vault 1.18. **Please read carefully**.
+
+## Important changes
+
+### Transit support for Ed25519ph and Ed25519ctx signatures
+
+**NOTE**: This only applies to Transit Ed25519 keys.
+
+On prior versions of Vault, when the sign and verify API endpoints backed by an Ed25519
+key received the prehashed=true or the hash_algorithm=sha2-512 parameters they were ignored,
+returning back or verifying a Pure Ed25519 signature. As of 1.19.x, setting these values
+on Enterprise editions of Vault will now return an Ed25519ph signature and assume the
+input has been hashed using the SHA-512 algorithm.
+
+If neither prehashed nor hash_algorithm values are provided, the existing default of using
+Pure Ed25519 signatures remains unchanged for both Enterprise and CE Vault editions. The change
+is if those values had been overridden they were previously ignored but now will be enforced
+based on the table below.
+
+| Vault Edition | prehashed | hash_algorithm                | 1.19.x Signature                           | Previous Vault Versions Signature |
+|:--------------|:----------|:------------------------------|:-------------------------------------------|:----------------------------------|
+| Enterprise    | not set   | not set                       | Pure Ed25519                               | Pure Ed25519                      |
+| Enterprise    | false     | any value other than sha2-512 | Pure Ed25519                               | Pure Ed25519                      |
+| Enterprise    | false     | sha2-512                      | An error is returned                       | Pure Ed25519                      |
+| Enterprise    | true      | any value other than sha2-512 | An error is returned                       | Pure Ed25519                      |
+| Enterprise    | true      | sha2-512                      | Ed25519ph                                  | Pure Ed25519                      |
+| CE            | not set   | not set                       | Pure Ed25519                               | Pure Ed25519                      |
+| CE            | false     | any value other than sha2-512 | Pure Ed25519                               | Pure Ed25519                      |
+| CE            | false     | sha2-512                      | An error is returned                       | Pure Ed25519                      |
+| CE            | true      | any value other than sha2-512 | An error is returned                       | Pure Ed25519                      |
+| CE            | true      | sha2-512                      | An error is returned (not supported on CE) | Pure Ed25519                      |
+

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -644,7 +644,7 @@
           {
             "title": "<code>generate-config</code>",
             "path": "commands/agent/generate-config"
-          }    
+          }
         ]
       },
       {
@@ -1950,7 +1950,6 @@
                 "path": "auth/saml/troubleshoot-adfs/adfs-event-320"
               }
             ]
-            
           }
         ]
       },
@@ -2418,6 +2417,10 @@
       {
         "title": "Upgrade to Raft WAL",
         "path": "upgrading/raft-wal"
+      },
+      {
+        "title": "Upgrade to 1.19.x",
+        "path": "upgrading/upgrade-to-1.19.x"
       },
       {
         "title": "Upgrade to 1.18.x",


### PR DESCRIPTION
### Description

Add a 1.19.x upgrade note around Transit API change for Ed25519ph signatures.

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [ ] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
