### PR TITLE
Manual backport of Update Azure SDK logger variable in docs (#28622)

### DIFF
--- a/website/content/docs/auth/azure.mdx
+++ b/website/content/docs/auth/azure.mdx
@@ -226,7 +226,7 @@ To enable the Azure debug logs, set the following environment variable on the Va
 server:
 
 ```shell
-AZURE_GO_SDK_LOG_LEVEL=DEBUG
+AZURE_SDK_GO_LOGGING=all
 ```
 
 ## API

--- a/website/content/docs/secrets/azure.mdx
+++ b/website/content/docs/secrets/azure.mdx
@@ -314,11 +314,11 @@ Azure service principal configured with the same permissions.
 The Azure secret engine plugin supports debug logging which includes additional information
 about requests and responses from the Azure API.
 
-To enable the Azure debug logs, set the `AZURE_GO_SDK_LOG_LEVEL`  environment variable to `DEBUG` on your Vault
+To enable the Azure debug logs, set the `AZURE_SDK_GO_LOGGING`  environment variable to `all` on your Vault
 server:
 
 ```shell
-AZURE_GO_SDK_LOG_LEVEL=DEBUG
+AZURE_SDK_GO_LOGGING=all
 ```
 
 ## Help &amp; support


### PR DESCRIPTION
### Description

This PR updates the 1.16.x docs to reflect that `AZURE_SDK_GO_LOGGING` is the correct environment variable to set if you want to enable Azure-level logging.

@ram-parameswaran already updated the docs for both the [latest](https://developer.hashicorp.com/vault/docs/secrets/azure#azure-debug-logs) and [1.17.x ](https://developer.hashicorp.com/vault/docs/v1.17.x/secrets/azure#azure-debug-logs) versions of the Azure plugin docs to have the [new AZURE_SDK_GO_LOGGING](https://github.com/Azure/azure-sdk-for-go/blob/main/documentation/new-version-guideline.md#logging) variable provided by the azcore package, instead of the [old AZURE_GO_SDK_LOG_LEVEL](https://github.com/Azure/azure-sdk-for-go/blob/main/documentation/previous-versions-quickstart.md#built-in-basic-requestresponse-logging) variable used in the old version of the Azure SDK, which used the logger from the autorest package.

However, the 1.16.x branch was not backported to, and I have verified that the new variable comes in at Vault [1.16.0](https://github.com/hashicorp/vault/blob/main/CHANGELOG.md#1160), due to the [update](https://github.com/hashicorp/vault/commit/51c4f7c61b4774965ec68d5b0ee5af789e9cd55f#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L150) from [v0.16.3](https://github.com/hashicorp/vault-plugin-secrets-azure/blob/v0.16.3/go.mod#L7) of the Azure secrets engine plugin, marking the end of our use of the go-autorest package that provided the old variable in favor of the new azcore one. Same thing happens in [v0.16.0](https://github.com/hashicorp/vault-plugin-auth-azure/blob/v0.16.0/go.mod) of the Azure auth plugin, which we [update](https://github.com/hashicorp/vault/pull/22795/files) past in 1.16.0 of Vault.

This PR manually backports that change to the 1.16.x docs as well, so that users don't get confused. 

### TODO only if you're a HashiCorp employee
- [N/A] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [N/A] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [N/A] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [N/A] **RFC:** If this change has an associated RFC, please link it in the description.
- [N/A] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
