### PR TITLE
Pull versioned golang images in Zlint testsuite to avoid pulling with latest

### DIFF
--- a/builtin/logical/pkiext/zlint_test.go
+++ b/builtin/logical/pkiext/zlint_test.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"runtime"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -23,11 +25,13 @@ var (
 )
 
 func buildZLintContainer(t *testing.T) {
-	containerfile := `
-FROM docker.mirror.hashicorp.services/library/golang:latest
-
+	// Leverage the Go version running the test to pull a version tagged image
+	// to avoid the issues we sometimes encounter pulling images with the latest tag
+	goVersion := strings.TrimPrefix(runtime.Version(), "go")
+	containerfile := fmt.Sprintf(`
+FROM docker.mirror.hashicorp.services/library/golang:%s
 RUN go install github.com/zmap/zlint/v3/cmd/zlint@v3.6.2
-`
+`, goVersion)
 
 	bCtx := docker.NewBuildContext()
 

--- a/builtin/logical/pkiext/zlint_test.go
+++ b/builtin/logical/pkiext/zlint_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"runtime"
 	"strings"
 	"sync"
@@ -22,12 +23,19 @@ import (
 var (
 	zRunner        *docker.Runner
 	buildZLintOnce sync.Once
+	releaseRegex   = regexp.MustCompile(`^go\d+\.\d+\.\d+$`)
 )
 
 func buildZLintContainer(t *testing.T) {
 	// Leverage the Go version running the test to pull a version tagged image
 	// to avoid the issues we sometimes encounter pulling images with the latest tag
-	goVersion := strings.TrimPrefix(runtime.Version(), "go")
+	runtimeVer := runtime.Version()
+	goVersion := "latest"
+	// The version returned from Go might not be a release tag such as go1.23.2, if it
+	// isn't fallback to latest
+	if releaseRegex.MatchString(runtimeVer) {
+		goVersion = strings.TrimPrefix(runtime.Version(), "go")
+	}
 	containerfile := fmt.Sprintf(`
 FROM docker.mirror.hashicorp.services/library/golang:%s
 RUN go install github.com/zmap/zlint/v3/cmd/zlint@v3.6.2


### PR DESCRIPTION
### Description

 - Leverage the versioned golang images which should be more static avoiding issues we somtimes encounter pulling latest images from our docker mirror.
 - We use the golang runtime version to avoid having to update this test continuously.

### TODO only if you're a HashiCorp employee
- [X] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [ ] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
