### PR TITLE
adding local clients to local fragments  ce changes

### DIFF
--- a/vault/activity_log.go
+++ b/vault/activity_log.go
@@ -152,7 +152,7 @@ type ActivityLog struct {
 	// standbyLocalFragmentsReceived.
 	localFragmentLock sync.RWMutex
 
-	// globalFragmentLock protects enable secondaryGlobalClientFragments, currentGlobalFragment
+	// globalFragmentLock protects enable secondaryGlobalClientFragments, standbyGlobalFragmentsReceived, currentGlobalFragment
 	// and globalPartialMonthClientTracker
 	globalFragmentLock sync.RWMutex
 

--- a/vault/activity_log.go
+++ b/vault/activity_log.go
@@ -148,6 +148,10 @@ type ActivityLog struct {
 	// standbyFragmentsReceived.
 	fragmentLock sync.RWMutex
 
+	// localFragmentLock protects partialMonthLocalClientTracker, localFragment,
+	// standbyLocalFragmentsReceived.
+	localFragmentLock sync.RWMutex
+
 	// globalFragmentLock protects enable secondaryGlobalClientFragments, currentGlobalFragment
 	// and globalPartialMonthClientTracker
 	globalFragmentLock sync.RWMutex
@@ -180,6 +184,9 @@ type ActivityLog struct {
 	// so it's appropriate to start the timer.
 	newFragmentCh chan struct{}
 
+	// current local log fragment (may be nil)
+	localFragment *activity.LogFragment
+
 	// Channel to signal a new global fragment has been created
 	// so it's appropriate to start the timer. Once the timer finishes
 	// the secondary will send currentGlobalFragment to the primary
@@ -196,6 +203,12 @@ type ActivityLog struct {
 
 	// Fragments received from performance standbys
 	standbyFragmentsReceived []*activity.LogFragment
+
+	// Local fragments received from performance standbys
+	standbyLocalFragmentsReceived []*activity.LogFragment
+
+	// Global fragments received from performance standbys
+	standbyGlobalFragmentsReceived []*activity.LogFragment
 
 	// Fragments of global clients received from performance secondaries
 	secondaryGlobalClientFragments []*activity.LogFragment
@@ -218,6 +231,9 @@ type ActivityLog struct {
 
 	// partialMonthClientTracker tracks active clients this month.  Protected by fragmentLock.
 	partialMonthClientTracker map[string]*activity.EntityRecord
+
+	// partialMonthLocalClientTracker tracks active local clients this month.  Protected by localFragmentLock.
+	partialMonthLocalClientTracker map[string]*activity.EntityRecord
 
 	// globalPartialMonthClientTracker tracks active clients this month.  Protected by globalFragmentLock.
 	globalPartialMonthClientTracker map[string]*activity.EntityRecord
@@ -258,6 +274,10 @@ type ActivityLogCoreConfig struct {
 	// GlobalFragmentSendInterval sets the interval to send global data from the secondary to the primary
 	// This is only for testing purposes
 	GlobalFragmentSendInterval time.Duration
+
+	// PerfStandbyFragmentSendInterval sets the interval to send fragment data from the perf standby to the active
+	// This is only for testing purposes
+	PerfStandbyFragmentSendInterval time.Duration
 }
 
 // ActivityLogExportRecord is the output structure for activity export
@@ -335,10 +355,11 @@ func NewActivityLog(core *Core, logger log.Logger, view *BarrierView, metrics me
 		metrics:                         metrics,
 		nodeID:                          hostname,
 		newFragmentCh:                   make(chan struct{}, 1),
-		newGlobalClientFragmentCh:       make(chan struct{}, 1),
 		sendCh:                          make(chan struct{}, 1), // buffered so it can be triggered by fragment size
 		doneCh:                          make(chan struct{}, 1),
 		partialMonthClientTracker:       make(map[string]*activity.EntityRecord),
+		partialMonthLocalClientTracker:  make(map[string]*activity.EntityRecord),
+		newGlobalClientFragmentCh:       make(chan struct{}, 1),
 		globalPartialMonthClientTracker: make(map[string]*activity.EntityRecord),
 		clock:                           clock,
 		currentSegment: segmentInfo{
@@ -355,6 +376,8 @@ func NewActivityLog(core *Core, logger log.Logger, view *BarrierView, metrics me
 			clientSequenceNumber: 0,
 		},
 		standbyFragmentsReceived:       make([]*activity.LogFragment, 0),
+		standbyLocalFragmentsReceived:  make([]*activity.LogFragment, 0),
+		standbyGlobalFragmentsReceived: make([]*activity.LogFragment, 0),
 		secondaryGlobalClientFragments: make([]*activity.LogFragment, 0),
 		inprocessExport:                atomic.NewBool(false),
 		precomputedQueryWritten:        make(chan struct{}),
@@ -400,11 +423,10 @@ func (a *ActivityLog) saveCurrentSegmentToStorageLocked(ctx context.Context, for
 	defer a.metrics.MeasureSinceWithLabels([]string{"core", "activity", "segment_write"},
 		a.clock.Now(), []metricsutil.Label{})
 
-	// Swap out the pending fragments
+	// Swap out the pending regular fragments
 	a.fragmentLock.Lock()
-	localFragment := a.fragment
+	currentFragment := a.fragment
 	a.fragment = nil
-
 	standbys := a.standbyFragmentsReceived
 	a.standbyFragmentsReceived = make([]*activity.LogFragment, 0)
 	a.fragmentLock.Unlock()
@@ -443,14 +465,38 @@ func (a *ActivityLog) saveCurrentSegmentToStorageLocked(ctx context.Context, for
 		return nil
 	}
 
-	// Measure the current fragment
-	if localFragment != nil {
+	// Measure the current regular fragment
+	if currentFragment != nil {
 		a.metrics.IncrCounterWithLabels([]string{"core", "activity", "fragment_size"},
-			float32(len(localFragment.Clients)),
+			float32(len(currentFragment.Clients)),
 			[]metricsutil.Label{
 				{"type", "entity"},
 			})
 		a.metrics.IncrCounterWithLabels([]string{"core", "activity", "fragment_size"},
+			float32(len(currentFragment.NonEntityTokens)),
+			[]metricsutil.Label{
+				{"type", "direct_token"},
+			})
+	}
+
+	// Swap out the pending local fragments
+	a.localFragmentLock.Lock()
+	localFragment := a.localFragment
+	a.localFragment = nil
+
+	// standbyLocalFragments := a.standbyLocalFragmentsReceived
+	// a.standbyLocalFragmentsReceived = make([]*activity.LogFragment, 0)
+
+	a.localFragmentLock.Unlock()
+
+	// Measure the current local fragment
+	if localFragment != nil {
+		a.metrics.IncrCounterWithLabels([]string{"core", "activity", "local_fragment_size"},
+			float32(len(localFragment.Clients)),
+			[]metricsutil.Label{
+				{"type", "entity"},
+			})
+		a.metrics.IncrCounterWithLabels([]string{"core", "activity", "local_fragment_size"},
 			float32(len(localFragment.NonEntityTokens)),
 			[]metricsutil.Label{
 				{"type", "direct_token"},
@@ -460,7 +506,7 @@ func (a *ActivityLog) saveCurrentSegmentToStorageLocked(ctx context.Context, for
 	// Collect new entities and new tokens.
 	saveChanges := false
 	newEntities := make(map[string]*activity.EntityRecord)
-	for _, f := range append(standbys, localFragment) {
+	for _, f := range append(standbys, currentFragment) {
 		if f == nil {
 			continue
 		}
@@ -470,7 +516,7 @@ func (a *ActivityLog) saveCurrentSegmentToStorageLocked(ctx context.Context, for
 		for _, e := range f.Clients {
 			// We could sort by timestamp to see which is first.
 			// We'll ignore that; the order of the append above means
-			// that we choose entries in localFragment over those
+			// that we choose entries in currentFragment over those
 			// from standby nodes.
 			newEntities[e.ClientID] = e
 		}
@@ -1549,6 +1595,12 @@ func (a *ActivityLog) perfStandbyFragmentWorker(ctx context.Context) {
 		endOfMonth.Stop()
 	}
 
+	sendInterval := activityFragmentSendInterval
+	// This changes the interval to a duration that was set for testing purposes
+	if a.configOverrides.PerfStandbyFragmentSendInterval.Microseconds() > 0 {
+		sendInterval = a.configOverrides.PerfStandbyFragmentSendInterval
+	}
+
 	sendFunc := func() {
 		ctx, cancel := context.WithTimeout(ctx, activityFragmentSendTimeout)
 		defer cancel()
@@ -1576,7 +1628,7 @@ func (a *ActivityLog) perfStandbyFragmentWorker(ctx context.Context) {
 				fragmentWaiting = true
 				if !a.configOverrides.DisableTimers {
 					a.logger.Trace("reset fragment timer")
-					timer.Reset(activityFragmentSendInterval)
+					timer.Reset(sendInterval)
 				}
 			}
 		case <-timer.C:
@@ -1612,6 +1664,11 @@ func (a *ActivityLog) perfStandbyFragmentWorker(ctx context.Context) {
 			a.partialMonthClientTracker = make(map[string]*activity.EntityRecord)
 
 			a.fragmentLock.Unlock()
+
+			// clear local active entity set
+			a.localFragmentLock.Lock()
+			a.partialMonthLocalClientTracker = make(map[string]*activity.EntityRecord)
+			a.localFragmentLock.Unlock()
 
 			// Set timer for next month.
 			// The current segment *probably* hasn't been set yet (via invalidation),
@@ -1784,17 +1841,28 @@ func (c *Core) ResetActivityLog() []*activity.LogFragment {
 
 	allFragments := make([]*activity.LogFragment, 1)
 	a.fragmentLock.Lock()
+
 	allFragments[0] = a.fragment
 	a.fragment = nil
-
 	allFragments = append(allFragments, a.standbyFragmentsReceived...)
 	a.standbyFragmentsReceived = make([]*activity.LogFragment, 0)
 	a.secondaryGlobalClientFragments = make([]*activity.LogFragment, 0)
 	a.partialMonthClientTracker = make(map[string]*activity.EntityRecord)
 	a.fragmentLock.Unlock()
 
+	// local fragments
+	a.localFragmentLock.Lock()
+	allFragments = append(allFragments, a.localFragment)
+	a.localFragment = nil
+	allFragments = append(allFragments, a.standbyLocalFragmentsReceived...)
+	a.standbyLocalFragmentsReceived = make([]*activity.LogFragment, 0)
+	a.partialMonthLocalClientTracker = make(map[string]*activity.EntityRecord)
+	a.localFragmentLock.Unlock()
+
+	// global fragments
 	a.globalFragmentLock.Lock()
 	a.globalPartialMonthClientTracker = make(map[string]*activity.EntityRecord)
+	a.standbyGlobalFragmentsReceived = make([]*activity.LogFragment, 0)
 	a.globalFragmentLock.Unlock()
 	return allFragments
 }
@@ -1833,11 +1901,16 @@ func (a *ActivityLog) AddActivityToFragment(clientID string, namespaceID string,
 
 	a.fragmentLock.RLock()
 	if a.enabled {
-		_, present = a.partialMonthClientTracker[clientID]
+		_, presentInRegularClientMap := a.partialMonthClientTracker[clientID]
+		_, presentInLocalClientmap := a.partialMonthLocalClientTracker[clientID]
+		if presentInRegularClientMap || presentInLocalClientmap {
+			present = true
+		}
 	} else {
 		present = true
 	}
 	a.fragmentLock.RUnlock()
+
 	if present {
 		return
 	}
@@ -1846,17 +1919,24 @@ func (a *ActivityLog) AddActivityToFragment(clientID string, namespaceID string,
 	a.fragmentLock.Lock()
 	defer a.fragmentLock.Unlock()
 
+	a.localFragmentLock.Lock()
+	defer a.localFragmentLock.Unlock()
+
 	a.globalFragmentLock.Lock()
 	defer a.globalFragmentLock.Unlock()
 
 	// Re-check entity ID after re-acquiring lock
-	_, present = a.partialMonthClientTracker[clientID]
+	_, presentInRegularClientMap := a.partialMonthClientTracker[clientID]
+	_, presentInLocalClientmap := a.partialMonthLocalClientTracker[clientID]
+	if presentInRegularClientMap || presentInLocalClientmap {
+		present = true
+	}
 	if present {
 		return
 	}
 
+	// create fragments if doesn't already exist
 	a.createCurrentFragment()
-	a.createCurrentGlobalFragment()
 
 	clientRecord := &activity.EntityRecord{
 		ClientID:      clientID,
@@ -1874,18 +1954,22 @@ func (a *ActivityLog) AddActivityToFragment(clientID string, namespaceID string,
 		clientRecord.NonEntity = true
 	}
 
+	// add the clients to the regular fragment
 	a.fragment.Clients = append(a.fragment.Clients, clientRecord)
+	a.partialMonthClientTracker[clientRecord.ClientID] = clientRecord
 
-	// Check if the client is local
-	if local, _ := a.isClientLocal(clientRecord); !local {
-		// If the client is not local and has not already been seen, then add the client
-		// to the current global fragment
+	if local, _ := a.isClientLocal(clientRecord); local {
+		// If the client is local then add the client to the current local fragment
+		a.localFragment.Clients = append(a.localFragment.Clients, clientRecord)
+		a.partialMonthLocalClientTracker[clientRecord.ClientID] = clientRecord
+	} else {
 		if _, ok := a.globalPartialMonthClientTracker[clientRecord.ClientID]; !ok {
-			a.globalPartialMonthClientTracker[clientRecord.ClientID] = clientRecord
+			// If the client is not local and has not already been seen, then add the client
+			// to the current global fragment
 			a.currentGlobalFragment.Clients = append(a.currentGlobalFragment.Clients, clientRecord)
+			a.globalPartialMonthClientTracker[clientRecord.ClientID] = clientRecord
 		}
 	}
-	a.partialMonthClientTracker[clientRecord.ClientID] = clientRecord
 }
 
 // isClientLocal checks whether the given client is on a local mount.
@@ -1908,25 +1992,25 @@ func (a *ActivityLog) isClientLocal(client *activity.EntityRecord) (bool, error)
 	return false, nil
 }
 
-// Create the current fragment if it doesn't already exist.
-// Must be called with the lock held.
+// Create the fragments (regular fragment, local fragment and global fragment) if it doesn't already exist.
+// Must be called with the fragmentLock, localFragmentLock and globalFragmentLock held.
 func (a *ActivityLog) createCurrentFragment() {
 	if a.fragment == nil {
+		// create regular fragment
 		a.fragment = &activity.LogFragment{
 			OriginatingNode: a.nodeID,
 			Clients:         make([]*activity.EntityRecord, 0, 120),
 			NonEntityTokens: make(map[string]uint64),
 		}
-		// Signal that a new segment is available, start
-		// the timer to send it.
-		a.newFragmentCh <- struct{}{}
-	}
-}
 
-// Create the current fragment to track global clients seen
-// on cluster. Must be called with the globalFragmentLock held
-func (a *ActivityLog) createCurrentGlobalFragment() {
-	if a.currentGlobalFragment == nil {
+		// create local fragment
+		a.localFragment = &activity.LogFragment{
+			OriginatingNode: a.nodeID,
+			Clients:         make([]*activity.EntityRecord, 0, 120),
+			NonEntityTokens: make(map[string]uint64),
+		}
+
+		// create global fragment
 		a.currentGlobalFragment = &activity.LogFragment{
 			OriginatingCluster: a.core.ClusterID(),
 			Clients:            make([]*activity.EntityRecord, 0),
@@ -1937,6 +2021,10 @@ func (a *ActivityLog) createCurrentGlobalFragment() {
 			// the timer to send it
 			a.newGlobalClientFragmentCh <- struct{}{}
 		}
+
+		// Signal that a new segment is available, start
+		// the timer to send it.
+		a.newFragmentCh <- struct{}{}
 	}
 }
 
@@ -1960,31 +2048,59 @@ func (a *ActivityLog) receivedGlobalClientFragments(fragment *activity.LogFragme
 func (a *ActivityLog) receivedFragment(fragment *activity.LogFragment) {
 	a.logger.Trace("received fragment from standby", "node", fragment.OriginatingNode)
 
-	a.fragmentLock.Lock()
-	defer a.fragmentLock.Unlock()
-
+	isLocalFragment := false
 	if !a.enabled {
 		return
 	}
 
-	a.globalFragmentLock.Lock()
-	defer a.globalFragmentLock.Unlock()
-	a.createCurrentGlobalFragment()
+	a.fragmentLock.Lock()
+	defer a.fragmentLock.Unlock()
+
+	// Check if the received fragment from standby is a local fragment.
+	// A fragment can have all local clients or all non-local clients except for regular fragment (which has both currently but will be modified to only hold non-local clients later).
+	// Check the first client to identify the type of fragment.
+	if len(fragment.Clients) > 0 {
+		client := fragment.Clients[0]
+		if local, _ := a.isClientLocal(client); local {
+			isLocalFragment = true
+
+			a.localFragmentLock.Lock()
+			defer a.localFragmentLock.Unlock()
+		} else {
+			a.globalFragmentLock.Lock()
+			defer a.globalFragmentLock.Unlock()
+		}
+	}
 
 	for _, e := range fragment.Clients {
 		a.partialMonthClientTracker[e.ClientID] = e
-
-		// If the client is global, then add to global maps and keep in a global fragment
-		if local, _ := a.isClientLocal(e); !local {
+		if isLocalFragment {
+			a.partialMonthLocalClientTracker[e.ClientID] = e
+		} else {
 			a.globalPartialMonthClientTracker[e.ClientID] = e
-			a.currentGlobalFragment.Clients = append(a.currentGlobalFragment.Clients, e)
 		}
-
 	}
 
 	a.standbyFragmentsReceived = append(a.standbyFragmentsReceived, fragment)
 
+	if isLocalFragment {
+		a.standbyLocalFragmentsReceived = append(a.standbyLocalFragmentsReceived, fragment)
+	} else {
+		a.standbyGlobalFragmentsReceived = append(a.standbyGlobalFragmentsReceived, fragment)
+	}
+
 	// TODO: check if current segment is full and should be written
+}
+
+// returns the active local and global clients for the current month
+func (a *ActivityLog) GetAllPartialMonthClients() (map[string]*activity.EntityRecord, map[string]*activity.EntityRecord) {
+	a.localFragmentLock.Lock()
+	defer a.localFragmentLock.Unlock()
+
+	a.globalFragmentLock.Lock()
+	defer a.globalFragmentLock.Unlock()
+
+	return a.partialMonthLocalClientTracker, a.globalPartialMonthClientTracker
 }
 
 type ResponseCounts struct {


### PR DESCRIPTION
### Description
What does this PR do?
Jira: https://hashicorp.atlassian.net/browse/VAULT-31928
Approved ENT PR: https://github.com/hashicorp/vault-enterprise/pull/6906
As part of this ticket, whenever we use a client, we check if it is local.

If a client is local, it is written to a local fragment and is tracked using partialMonthLocalClientTracker. For now, this is also added to current fragment and partialMonthClientTracker as to not break tests as these values are not written to storage.
When receiving fragments from standby nodes, these local clients are tracked in partialMonthLocalClientTracker and standbyLocalFragmentsReceived. For now, this is also added to partialMonthClientTracker and standbyFragmentsReceivedas to not break tests as these values are not written to storage.
Next ticket to work on to add these values to storage: https://hashicorp.atlassian.net/browse/VAULT-31234


### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [ ] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
