### PR TITLE
add fragment locks to GetActiveLocalFragment and GetActiveFragment

### DIFF
--- a/vault/activity_log_testing_util.go
+++ b/vault/activity_log_testing_util.go
@@ -265,10 +265,14 @@ func (c *Core) GetActivityLog() *ActivityLog {
 }
 
 func (c *Core) GetActiveGlobalFragment() *activity.LogFragment {
+	c.activityLog.globalFragmentLock.RLock()
+	defer c.activityLog.globalFragmentLock.RUnlock()
 	return c.activityLog.currentGlobalFragment
 }
 
 func (c *Core) GetSecondaryGlobalFragments() []*activity.LogFragment {
+	c.activityLog.globalFragmentLock.RLock()
+	defer c.activityLog.globalFragmentLock.RUnlock()
 	return c.activityLog.secondaryGlobalClientFragments
 }
 

--- a/vault/activity_log_testing_util.go
+++ b/vault/activity_log_testing_util.go
@@ -273,9 +273,13 @@ func (c *Core) GetSecondaryGlobalFragments() []*activity.LogFragment {
 }
 
 func (c *Core) GetActiveLocalFragment() *activity.LogFragment {
+	c.activityLog.localFragmentLock.RLock()
+	defer c.activityLog.localFragmentLock.RUnlock()
 	return c.activityLog.localFragment
 }
 
 func (c *Core) GetActiveFragment() *activity.LogFragment {
+	c.activityLog.fragmentLock.RLock()
+	defer c.activityLog.fragmentLock.RUnlock()
 	return c.activityLog.fragment
 }


### PR DESCRIPTION
### Description
What does this PR do?
Jira: https://hashicorp.atlassian.net/browse/VAULT-31928
Approved ENT PR: https://github.com/hashicorp/vault-enterprise/pull/6906

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [ ] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
