### PR TITLE
Sets a default codeowner for the repo

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -31,7 +31,7 @@
 /vault/plugin_catalog.go      @hashicorp/vault-ecosystem
 
 /website/content/ @hashicorp/vault-education-approvers
-/website/content/docs/plugin-portal.mdx   @acahn @hashicorp/vault-education-approvers
+/website/content/docs/plugin-portal.mdx   @hashicorp/vault-education-approvers
 
 # Plugin docs
 /website/content/docs/plugins/              @hashicorp/vault-ecosystem @hashicorp/vault-education-approvers

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,7 +4,7 @@
 #
 # More on CODEOWNERS files: https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
 # Default CODEOWNER primarily for contact purposes
-* @hashicorp/contact-vault-team
+* @hashicorp/vault
 
 # Select Auth engines are owned by Ecosystem
 /builtin/credential/aws/      @hashicorp/vault-ecosystem

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,6 +3,8 @@
 # those areas of the code.
 #
 # More on CODEOWNERS files: https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
+# Default CODEOWNER primarily for contact purposes
+* @hashicorp/contact-vault-team
 
 # Select Auth engines are owned by Ecosystem
 /builtin/credential/aws/      @hashicorp/vault-ecosystem


### PR DESCRIPTION
### Description
The default codeowner will be used as a point of contact for the repository.

This should make us conformant with CODEOWNER requirements in RND-010, and give a GitHub group that can serve as a default point of contact for the vault and vault-enterprise repositories.

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [ ] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [X] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
