### PR TITLE
Change subject identifier and identity_token_audience to realistic example value

### DIFF
--- a/website/content/docs/secrets/azure.mdx
+++ b/website/content/docs/secrets/azure.mdx
@@ -333,7 +333,7 @@ To configure the secrets engine to use plugin WIF:
    `/.well-known/openid-configuration` suffix removed. For example:
    `https://host:port/v1/identity/oidc/plugins`.
    1. The subject identifier **must** match the unique `sub` claim issued by plugin identity tokens.
-   The subject identifier should have the form `plugin-identity:<NAMESPACE>:secret:<AZURE_MOUNT_ACCESSOR>`.
+   The subject identifier should have the form `plugin-identity:<NAMESPACE_ID>:secret:<AZURE_MOUNT_ACCESSOR>`.
    1. The audience should be under 600 characters. The default value in Azure is `api://AzureADTokenExchange`.
 
 1. Configure the Azure secrets engine with the subscription, client and tenant IDs and the OIDC audience value.
@@ -343,7 +343,7 @@ To configure the secrets engine to use plugin WIF:
      subscription_id=$AZURE_SUBSCRIPTION_ID \
      tenant_id=$AZURE_TENANT_ID \
      client_id=$AZURE_CLIENT_ID \
-     identity_token_audience="vault.example/v1/identity/oidc/plugins"
+     identity_token_audience="api://AzureADTokenExchange"
    ```
 
 Your secrets engine can now use plugin WIF for its configuration credentials.


### PR DESCRIPTION
### Description
Azure WIF Docs
- The subject identifier actual value is NAMESPACE_ID, so <NAMESPACE> is confusing.
- identity_token_audience has an audience value in Azure Federation, so examples like an existing vault URL are confusing.
