### PR TITLE
Docs: Update rotate encryption key command doc

### DIFF
--- a/website/content/docs/commands/operator/rotate.mdx
+++ b/website/content/docs/commands/operator/rotate.mdx
@@ -10,14 +10,18 @@ description: |-
 
 # operator rotate
 
-The `operator rotate` rotates the underlying encryption key which is used to
-secure data written to the storage backend. This installs a new key in the key
-ring. This new key is used to encrypted new data, while older keys in the ring
-are used to decrypt older data.
+The `operator rotate` command rotates the underlying encryption key, which
+secures data written to storage. This installs a new key in the key ring. 
+This new key encrypts new data, while older keys in the ring decrypt
+older data.
 
-This is an online operation and does not cause downtime. This command is run
+This is an online operation and does not cause downtime. This command runs
 per-cluster (not per-server), since Vault servers in HA mode share the same
-storage backend.
+storage.
+
+As of **Vault 1.7**, Vault will automatically rotate the encryption key before
+reaching 2<sup>32</sup> encryption operations, in adherence with NIST SP800-32D
+guidelines.
 
 ## Examples
 
@@ -27,6 +31,26 @@ Rotate Vault's encryption key:
 $ vault operator rotate
 Key Term        3
 Install Time    01 May 17 10:30 UTC
+```
+
+View the current automatic rotation policy:
+
+```shell-session
+$ vault read sys/rotate/config
+```
+
+Configure a time interval for automatic key rotation:
+
+```shell-session
+$ vault write sys/rotate/config interval=2160h
+Success! Data written to: sys/rotate/config
+```
+
+Configure the maximum number of encryption operations per key:
+
+```shell-session
+$ vault write sys/rotate/config max_operations=123456789
+Success! Data written to: sys/rotate/config
 ```
 
 ## Usage


### PR DESCRIPTION
### Description

Update rotate encryption key doc.

- Add command examples from the tutorial (as part of user journey/SEO) [SPE-1010](https://hashicorp.atlassian.net/browse/SPE-1010)

- Update for linting

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [ ] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.


[SPE-1010]: https://hashicorp.atlassian.net/browse/SPE-1010?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ