### PR TITLE
Docs: remove link to archived tutorial

### DIFF
--- a/website/content/docs/commands/operator/rekey.mdx
+++ b/website/content/docs/commands/operator/rekey.mdx
@@ -21,9 +21,6 @@ An unseal key may be provided directly on the command line as an argument to the
 command. If key is specified as "-", the command will read from stdin. If a TTY
 is available, the command will prompt for text.
 
-Please see the [rotating and rekeying](/vault/tutorials/operations/rekeying-and-rotating) for
-step-by-step instructions.
-
 ## Examples
 
 Initialize a rekey:


### PR DESCRIPTION
### Description
The rekey and rotate tutorial is being deprecated, so this link pointing to it needs to be removed.
Part of user journey/SEO [SPE-1010](https://hashicorp.atlassian.net/browse/SPE-1010)

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [ ] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.


[SPE-1010]: https://hashicorp.atlassian.net/browse/SPE-1010?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ