### PR TITLE
VAULT-31409: trace unsealInternal function

### DIFF
--- a/helper/trace/debug_trace.go
+++ b/helper/trace/debug_trace.go
@@ -1,0 +1,27 @@
+package trace
+
+import (
+	"fmt"
+	"os"
+	"runtime/trace"
+	"time"
+)
+
+func StartDebugTrace(filePrefix string) (file string, stop func(), err error) {
+	path := fmt.Sprintf("%s/%s_%s", os.TempDir(), filePrefix, time.Now().Format(time.RFC3339))
+	traceFile, err := os.Create(path)
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to create trace file: %s", err)
+	}
+
+	if err := trace.Start(traceFile); err != nil {
+		return "", nil, fmt.Errorf("failed to start trace: %s", err)
+	}
+
+	stop = func() {
+		trace.Stop()
+		traceFile.Close()
+	}
+
+	return traceFile.Name(), stop, nil
+}


### PR DESCRIPTION
### Description

This PR adds the environment variable `VAULT_ENABLE_UNSEAL_TRACE` that when enabled will cause Vault to write a Go trace file to the `/tmp` directory, like `/tmp/trace_unsealInternal_2024-11-13T12:06:13-03:00`. This file can be inspected using the `go tool trace` command and will help us debug cases where the unseal operation takes too long.

Jira: [VAULT-31409](https://hashicorp.atlassian.net/browse/VAULT-31409)

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [ ] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
