### PR TITLE
Add notes within the documentation about the generate_key flag

### DIFF
--- a/website/content/api-docs/system/managed-keys.mdx
+++ b/website/content/api-docs/system/managed-keys.mdx
@@ -85,6 +85,9 @@ $ curl \
 - `allow_generate_key` `(string: "false")` - If no existing key can be found in the referenced backend, instructs
   Vault to generate a key within the backend.
 
+  ~> **NOTE**: Once the initial key creation has occurred, it is advisable to disable this flag to prevent any
+  unintended key creation in the future.
+
 - `allow_replace_key` `(string: "false")` - Controls the ability for Vault to replace through generation or importing
   a key into the configured backend even if a key is present, if set to false those operations are forbidden
   if a key exists.

--- a/website/content/docs/configuration/seal/pkcs11.mdx
+++ b/website/content/docs/configuration/seal/pkcs11.mdx
@@ -156,6 +156,10 @@ These parameters apply to the `seal` stanza in the Vault configuration file:
   circumstances, such as if proprietary vendor extensions are required to
   create keys of a suitable type.
 
+  ~> **NOTE**: Once the initial key creation has occurred post cluster
+  initialization, it is advisable to disable this flag to prevent any
+  unintended key creation in the future.
+
 - `force_rw_session` `(string: "false")`: Force all operations to open up
   a read-write session to the HSM. This is a boolean expressed as a string (e.g.
   `"true"`). May also be specified by the `VAULT_HSM_FORCE_RW_SESSION` environment


### PR DESCRIPTION
### Description

Add a note that one should disable the `generate_key` flag in PKCS#11 and managed_key scenarios after the initial key was created to prevent any unwanted key creations in the future.

### TODO only if you're a HashiCorp employee
- [X] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [ ] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
