### PR TITLE
Docs: update move commands

### DIFF
--- a/website/content/docs/commands/auth/move.mdx
+++ b/website/content/docs/commands/auth/move.mdx
@@ -28,7 +28,21 @@ Move the existing auth method at ns1/approle/ to ns2/new-approle/:
 $ vault auth move ns1/auth/approle/ ns2/auth/new-approle/
 ```
 
+Move the existing auth method `auth/userpass` to the `education/certification/approle` namespace.
+
+```shell-session
+$ vault auth move auth/userpass education/certification/auth/userpass
+```
+
 ## Usage
 
 There are no flags beyond the [standard set of flags](/vault/docs/commands)
 included on all commands.
+
+## Post-move considerations
+
+Each namespace has its own policies, auth methods, secrets engines, tokens,
+identity entities and groups. You must consider the following after moving a mount across namespaces:
+
+- Necessary policies exist in the target namespace
+- Entities and groups might need updates after an auth method move

--- a/website/content/docs/commands/secrets/move.mdx
+++ b/website/content/docs/commands/secrets/move.mdx
@@ -28,7 +28,22 @@ Move the existing secrets engine at ns1/secret/ to ns2/kv/:
 $ vault secrets move ns1/secret/ ns2/kv/
 ```
 
+Move the existing secrets in `team-vault` to the `vault-edu/` namespace.
+
+```shell-session
+$ vault secrets move team-vault \
+    vault-edu/team-vault
+```
+
 ## Usage
 
 There are no flags beyond the [standard set of flags](/vault/docs/commands)
 included on all commands.
+
+## Post-move considerations
+
+Each namespace has its own policies, auth methods, secrets engines, tokens,
+identity entities and groups. You must consider the following after moving a mount across namespaces:
+
+- Necessary policies exist in the target namespace
+- Entities and groups might need updating after an auth mount migration


### PR DESCRIPTION
### Description

Update secret and auth method move command documentation as part of [SPE-897](https://hashicorp.atlassian.net/browse/SPE-897):

- Add a namespace example for secrets move
- Add a namespace example for auth method move
- Add post-move considerations for both

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this PR is in the ENT repo and needs to be backported, backport  
  to N, N-1, and N-2, using the `backport/ent/x.x.x+ent` labels. If this PR is in the CE repo, you should only backport to N, using the `backport/x.x.x` label, not the enterprise labels.
    - [ ] If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.


[SPE-897]: https://hashicorp.atlassian.net/browse/SPE-897?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ