### PR TITLE
[VAULT-31754] Check removed status in sys/unseal and error out if the node has been removed from the cluster

### DIFF
--- a/http/sys_seal.go
+++ b/http/sys_seal.go
@@ -85,6 +85,14 @@ func handleSysUnseal(core *vault.Core) http.Handler {
 			return
 		}
 
+		// Check if this node was removed from the cluster. If so, respond with an error and return,
+		// since we don't want a removed node to be able to unseal.
+		removed, ok := core.IsRemovedFromCluster()
+		if ok && removed {
+			respondError(w, http.StatusInternalServerError, errors.New("node was removed from a HA cluster"))
+			return
+		}
+
 		// Parse the request
 		var req UnsealRequest
 		if _, err := parseJSONRequest(core.PerfStandby(), r, w, &req); err != nil {

--- a/vault/core.go
+++ b/vault/core.go
@@ -4573,3 +4573,24 @@ func (c *Core) setupAuditedHeadersConfig(ctx context.Context) error {
 
 	return nil
 }
+
+// IsRemovedFromCluster checks whether this node has been removed from the
+// cluster. This is only applicable to physical HA backends that satisfy the
+// RemovableNodeHABackend interface. The value of the `ok` result will be false
+// if the HA and underlyingPhysical backends are nil or do not support this operation.
+func (c *Core) IsRemovedFromCluster() (removed, ok bool) {
+	var haBackend any
+	if c.ha != nil {
+		haBackend = c.ha
+	} else if c.underlyingPhysical != nil {
+		haBackend = c.underlyingPhysical
+	} else {
+		return false, false
+	}
+	removableNodeHA, ok := haBackend.(physical.RemovableNodeHABackend)
+	if !ok {
+		return false, false
+	}
+
+	return removableNodeHA.IsRemoved(), true
+}


### PR DESCRIPTION
### Description
This PR adds a check for whether the node was removed from a cluster in the handler for `/sys/unseal`.
If the node was indeed removed, we will respond with a status code `500` and an error saying `node was removed from a HA cluster`.  

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [x] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
