### PR TITLE
Release notes backport for 1.18

### DIFF
--- a/website/content/docs/release-notes/1.16.1.mdx
+++ b/website/content/docs/release-notes/1.16.1.mdx
@@ -13,21 +13,24 @@ description: |-
 
 ## Important changes
 
-| Version         | Change                                                                                                                                                                                       |
-|-----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 1.16.0+         | [Existing clusters do not show the current Vault version in UI by default](/vault/docs/upgrading/upgrade-to-1.16.x#default-policy-changes)                                                   |
-| 1.16.0+         | [Default LCQ enabled when upgrading pre-1.9](/vault/docs/upgrading/upgrade-to-1.16.x#default-lcq-pre-1.9-upgrade)                                                                            |
-| 1.16.0+         | [External plugin environment variables take precedence over server variables](/vault/docs/upgrading/upgrade-to-1.16.x#external-plugin-variables)                                             |
-| 1.16.0+         | [LDAP auth entity alias names no longer include upndomain](/vault/docs/upgrading/upgrade-to-1.16.x#ldap-auth-entity-alias-names-no-longer-include-upndomain)                                 |
-| 1.16.0+         | [Secrets Sync now requires a one-time flag to operate](/vault/docs/upgrading/upgrade-to-1.16.x#secrets-sync-now-requires-setting-a-one-time-flag-before-use)                                 |
-| 1.16.0+         | [Azure secrets engine role creation failing](/vault/docs/upgrading/upgrade-to-1.16.x#azure-secrets-engine-role-creation-failing)                                                             |
-| 1.16.1 - 1.16.3 | [New nodes added by autopilot upgrades provisioned with the wrong version](/vault/docs/upgrading/upgrade-to-1.15.x#new-nodes-added-by-autopilot-upgrades-provisioned-with-the-wrong-version) |
-| 1.15.8+         | [Autopilot upgrade for Vault Enterprise fails](/vault/docs/upgrading/upgrade-to-1.15.x#autopilot)                                                                                            |
-| 1.16.5          | [Listener stops listening on untrusted upstream connection with particular config settings](/vault/docs/upgrading/upgrade-to-1.16.x#listener-proxy-protocol-config)                          |
-| 1.16.3 - 1.16.6 | [Vault standby nodes not deleting removed entity-aliases from in-memory database](/vault/docs/upgrading/upgrade-to-1.16.x#dangling-entity-alias-in-memory)                                   |
-| 0.7.0+          | [Duplicate identity groups created](/vault/docs/upgrading/upgrade-to-1.16.x#duplicate-identity-groups-created-when-concurrent-requests-sent-to-the-primary-and-pr-secondary-cluster)         |                                                                                       |
-| Known Issue (0.7.0+) | [Manual entity merges fail](/vault/docs/upgrading/upgrade-to-1.16.x#manual-entity-merges-sent-to-a-pr-secondary-cluster-are-not-persisted-to-storage) 
-| Known Issue (1.16.7-1.16.8)    | [Some values in the audit logs not hmac'd properly](/vault/docs/upgrading/upgrade-to-1.16.x#client-tokens-and-token-accessors-audited-in-plaintext)                                  |
+| Version                     | Change                                                                                                                                                                                       |
+|-----------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 1.16.0+                     | [Existing clusters do not show the current Vault version in UI by default](/vault/docs/upgrading/upgrade-to-1.16.x#default-policy-changes)                                                   |
+| 1.16.0+                     | [Default LCQ enabled when upgrading pre-1.9](/vault/docs/upgrading/upgrade-to-1.16.x#default-lcq-pre-1.9-upgrade)                                                                            |
+| 1.16.0+                     | [External plugin environment variables take precedence over server variables](/vault/docs/upgrading/upgrade-to-1.16.x#external-plugin-variables)                                             |
+| 1.16.0+                     | [LDAP auth entity alias names no longer include upndomain](/vault/docs/upgrading/upgrade-to-1.16.x#ldap-auth-entity-alias-names-no-longer-include-upndomain)                                 |
+| 1.16.0+                     | [Secrets Sync now requires a one-time flag to operate](/vault/docs/upgrading/upgrade-to-1.16.x#secrets-sync-now-requires-setting-a-one-time-flag-before-use)                                 |
+| 1.16.0+                     | [Azure secrets engine role creation failing](/vault/docs/upgrading/upgrade-to-1.16.x#azure-secrets-engine-role-creation-failing)                                                             |
+| 1.16.1 - 1.16.3             | [New nodes added by autopilot upgrades provisioned with the wrong version](/vault/docs/upgrading/upgrade-to-1.15.x#new-nodes-added-by-autopilot-upgrades-provisioned-with-the-wrong-version) |
+| 1.15.8+                     | [Autopilot upgrade for Vault Enterprise fails](/vault/docs/upgrading/upgrade-to-1.15.x#autopilot)                                                                                            |
+| 1.16.5                      | [Listener stops listening on untrusted upstream connection with particular config settings](/vault/docs/upgrading/upgrade-to-1.16.x#listener-proxy-protocol-config)                          |
+| 1.16.3 - 1.16.6             | [Vault standby nodes not deleting removed entity-aliases from in-memory database](/vault/docs/upgrading/upgrade-to-1.16.x#dangling-entity-alias-in-memory)                                   |
+| 0.7.0+                      | [Duplicate identity groups created](/vault/docs/upgrading/upgrade-to-1.16.x#duplicate-identity-groups-created-when-concurrent-requests-sent-to-the-primary-and-pr-secondary-cluster)         |                                                                                       |
+| Known Issue (0.7.0+)        | [Manual entity merges fail](/vault/docs/upgrading/upgrade-to-1.16.x#manual-entity-merges-sent-to-a-pr-secondary-cluster-are-not-persisted-to-storage)                                        |
+| Known Issue (1.16.7-1.16.8) | [Some values in the audit logs not hmac'd properly](/vault/docs/upgrading/upgrade-to-1.16.x#client-tokens-and-token-accessors-audited-in-plaintext)                                          |
+| New default (1.16.13)       | [Vault product usage metrics reporting](/vault/docs/upgrading/upgrade-to-1.6.x#product-usage-reporting)                                                                                      |
+| Deprecation (1.16.13)       | [`default_report_months` is deprecated for the `sys/internal/counters` API](/vault/docs/upgrading/upgrade-to-1.16.x#activity-log-changes)                                                    |
+
 
 ## Vault companion updates
 

--- a/website/content/docs/release-notes/1.17.0.mdx
+++ b/website/content/docs/release-notes/1.17.0.mdx
@@ -13,19 +13,22 @@ description: |-
 
 ## Important changes
 
-| Change                                         | Description                                                                                                                                                         |
-|------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| New default (1.17)                             | [Allowed audit headers now have unremovable defaults](/vault/docs/upgrading/upgrade-to-1.17.x#audit-headers)                                                        |
-| Opt out feature (1.17)                         | [PKI sign-intermediate now truncates `notAfter` field to signing issuer](/vault/docs/upgrading/upgrade-to-1.17.x#pki-truncate)                                      |
-| Beta feature deprecated (1.17)                 | [Request limiter deprecated](/vault/docs/upgrading/upgrade-to-1.17.x#request-limiter)                                                                               |
-| Known issue (1.17.0+)                          | [PKI OCSP GET requests can return HTTP redirect responses](/vault/docs/upgrading/upgrade-to-1.17.x#pki-ocsp)                                                        |
-| Known issue (1.17.0)                           | [Vault Agent and Vault Proxy consume excessive amounts of CPU](/vault/docs/upgrading/upgrade-to-1.17.x#agent-proxy-cpu-1-17)                                        |
-| Known issue (1.15.8 - 1.15.9, 1.16.0 - 1.16.3) | [Autopilot upgrade for Vault Enterprise fails](/vault/docs/upgrading/upgrade-to-1.16.x#new-nodes-added-by-autopilot-upgrades-provisioned-with-the-wrong-version)    |
-| Known issue (1.17.0 - 1.17.2)  | [Vault standby nodes not deleting removed entity-aliases from in-memory database](/vault/docs/upgrading/upgrade-to-1.17.x#dangling-entity-alias-in-memory)          |
-| Known Issue (0.7.0+)           | [Duplicate identity groups created](/vault/docs/upgrading/upgrade-to-1.17.x#duplicate-identity-groups-created-when-concurrent-requests-sent-to-the-primary-and-pr-secondary-cluster)
-| Known Issue (0.7.0+)           | [Manual entity merges fail](/vault/docs/upgrading/upgrade-to-1.17.x#manual-entity-merges-sent-to-a-pr-secondary-cluster-are-not-persisted-to-storage)
-| Known Issue (1.17.3-1.17.4)    | [Some values in the audit logs not hmac'd properly](/vault/docs/upgrading/upgrade-to-1.17.x#client-tokens-and-token-accessors-audited-in-plaintext)
-| Known Issue (1.17.0-1.17.5)    | [Cached activation flags for secrets sync on follower nodes are not updated](/vault/docs/upgrading/upgrade-to-1.17.x#cached-activation-flags-for-secrets-sync-on-follower-nodes-are-not-updated)
+| Change                                         | Description                                                                                                                                                                                      |
+|------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| New default (1.17)                             | [Allowed audit headers now have unremovable defaults](/vault/docs/upgrading/upgrade-to-1.17.x#audit-headers)                                                                                     |
+| Opt out feature (1.17)                         | [PKI sign-intermediate now truncates `notAfter` field to signing issuer](/vault/docs/upgrading/upgrade-to-1.17.x#pki-truncate)                                                                   |
+| Beta feature deprecated (1.17)                 | [Request limiter deprecated](/vault/docs/upgrading/upgrade-to-1.17.x#request-limiter)                                                                                                            |
+| Known issue (1.17.0+)                          | [PKI OCSP GET requests can return HTTP redirect responses](/vault/docs/upgrading/upgrade-to-1.17.x#pki-ocsp)                                                                                     |
+| Known issue (1.17.0)                           | [Vault Agent and Vault Proxy consume excessive amounts of CPU](/vault/docs/upgrading/upgrade-to-1.17.x#agent-proxy-cpu-1-17)                                                                     |
+| Known issue (1.15.8 - 1.15.9, 1.16.0 - 1.16.3) | [Autopilot upgrade for Vault Enterprise fails](/vault/docs/upgrading/upgrade-to-1.16.x#new-nodes-added-by-autopilot-upgrades-provisioned-with-the-wrong-version)                                 |
+| Known issue (1.17.0 - 1.17.2)                  | [Vault standby nodes not deleting removed entity-aliases from in-memory database](/vault/docs/upgrading/upgrade-to-1.17.x#dangling-entity-alias-in-memory)                                       |
+| Known issue (1.17.0 - 1.17.3)                  | [AWS Auth AssumeRole requires an external ID even if none is set](/vault/docs/upgrading/upgrade-to-1.17.x#aws-auth-role-configuration-requires-an-external_id)                                   |
+| Known Issue (0.7.0+)                           | [Duplicate identity groups created](/vault/docs/upgrading/upgrade-to-1.17.x#duplicate-identity-groups-created-when-concurrent-requests-sent-to-the-primary-and-pr-secondary-cluster)             |
+| Known Issue (0.7.0+)                           | [Manual entity merges fail](/vault/docs/upgrading/upgrade-to-1.17.x#manual-entity-merges-sent-to-a-pr-secondary-cluster-are-not-persisted-to-storage)                                            |
+| Known Issue (1.17.3-1.17.4)                    | [Some values in the audit logs not hmac'd properly](/vault/docs/upgrading/upgrade-to-1.17.x#client-tokens-and-token-accessors-audited-in-plaintext)                                              |
+| Known Issue (1.17.0-1.17.5)                    | [Cached activation flags for secrets sync on follower nodes are not updated](/vault/docs/upgrading/upgrade-to-1.17.x#cached-activation-flags-for-secrets-sync-on-follower-nodes-are-not-updated) |
+| New default (1.17.9)                           | [Vault product usage metrics reporting](/vault/docs/upgrading/upgrade-to-1.17.x#product-usage-reporting)                                                                                         |
+| Deprecation (1.17.9)                           | [`default_report_months` is deprecated for the `sys/internal/counters` API](/vault/docs/upgrading/upgrade-to-1.17.x#activity-log-changes)                                                        |
 
 ## Vault companion updates
 

--- a/website/content/docs/release-notes/1.18.0.mdx
+++ b/website/content/docs/release-notes/1.18.0.mdx
@@ -13,11 +13,12 @@ description: |-
 
 ## Important changes
 
-| Change                      | Description
-| --------------------------- | -----------
-| New default (1.18.0)        | [Default activity log querying period](/vault/docs/upgrading/upgrade-to-1.18.x#default-activity-log-querying-period)
-| New default (1.18.0)        | [Docker image no longer contains curl](/vault/docs/upgrading/upgrade-to-1.18.x#docker-image-no-longer-contains-curl)
-| Beta feature removed (1.18) | [Request limiter removed](/vault/docs/upgrading/upgrade-to-1.18.x#request-limiter-configuration-removal)
+| Change                      | Description                                                                                                          |
+|-----------------------------|----------------------------------------------------------------------------------------------------------------------|
+| New default (1.18.0)        | [Default activity log querying period](/vault/docs/upgrading/upgrade-to-1.18.x#default-activity-log-querying-period) |
+| New default (1.18.0)        | [Docker image no longer contains curl](/vault/docs/upgrading/upgrade-to-1.18.x#docker-image-no-longer-contains-curl) |
+| Beta feature removed (1.18) | [Request limiter removed](/vault/docs/upgrading/upgrade-to-1.18.x#request-limiter-configuration-removal)             |
+| New default (1.18.2)        | [Vault product usage metrics reporting](/vault/docs/upgrading/upgrade-to-1.18.x#product-usage-reporting)             |
 
 ## Vault companion updates
 
@@ -63,7 +64,7 @@ Follow the learn more links for more information, or browse the list of
     </td>
     <td style={{verticalAlign: 'middle', textAlign: 'center'}}>ENHANCED</td>
     <td style={{verticalAlign: 'middle'}}>
-      Overall stability improvements. 
+      Overall stability improvements.
       <br /><br />
       Learn more: <a href="/vault/docs/concepts/integrated-storage/autopilot">Autopilot overview</a>
     </td>
@@ -71,7 +72,7 @@ Follow the learn more links for more information, or browse the list of
 
   <tr>
     <td style={{verticalAlign: 'middle'}}>
-      Client count 
+      Client count
     </td>
     <td style={{verticalAlign: 'middle', textAlign: 'center'}}>ENHANCED</td>
     <td style={{verticalAlign: 'middle'}}>
@@ -88,7 +89,7 @@ Follow the learn more links for more information, or browse the list of
     <td style={{verticalAlign: 'middle', textAlign: 'center'}}>GA</td>
     <td style={{verticalAlign: 'middle'}}>
       Enable PKI support for automated certificate enrollment with CMPv2
-      protocols for 5G networks per 3G PP standards. 
+      protocols for 5G networks per 3G PP standards.
       <br /><br />
       Learn more: <a href="/vault/docs/secrets/pki/cmpv2">CMPv2 in the Vault PKI plugin</a>
     </td>

--- a/website/content/docs/upgrading/upgrade-to-1.16.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.16.x.mdx
@@ -94,6 +94,50 @@ operation called an activation-flag. The feature is gated until a Vault operator
 decides to trigger the flag. More information can be found in the
 [secrets sync documentation](/vault/docs/sync#activating-the-feature).
 
+### Activity Log Changes
+
+#### Default Activity Log Querying Period
+
+As of 1.16.13 and later, the field `default_report_months` can no longer be configured or read. Any previously set values
+will be ignored by the system.
+
+
+Attempts to modify `default_report_months` through the
+[/sys/internal/counters/config](/vault/api-docs/system/internal-counters#update-the-client-count-configuration)
+endpoint, will result in the following warning from Vault:
+
+<CodeBlockConfig hideClipboard>
+
+  ```shell-session
+
+  WARNING! The following warnings were returned from Vault:
+
+  * default_report_months is deprecated: defaulting to billing start time
+
+
+  ```
+
+</CodeBlockConfig>
+
+
+The `current_billing_period` toggle for `/sys/internal/counters/activity` is also deprecated, as this will be set
+true by default.
+
+Attempts to set `current_billing_period` will result in the following warning from Vault:
+
+<CodeBlockConfig hideClipboard>
+
+  ```shell-session
+
+  WARNING! The following warnings were returned from Vault:
+
+  * current_billing_period is deprecated; unless otherwise specified, all requests will default to the current billing period
+
+
+  ```
+
+</CodeBlockConfig>
+
 ### Auto-rolled billing start date
 
 As of 1.16.7 and later, the billing start date (license start date if not configured) automatically rolls over to the latest billing year at the end of the last cycle.
@@ -141,6 +185,15 @@ kubectl exec -ti <NAME> -- wget https://github.com/moparisthebest/static-curl/re
 ```
 
 **NOTE:** When using this option you'll want to verify that the static binary comes from a trusted source.
+
+### Product usage reporting
+
+As of 1.16.13, Vault will collect anonymous product usage metrics for HashiCorp. This information will be collected
+alongside activity information, and will be sent automatically if automated reporting is configured, or added to manual
+reports if manual reporting is preferred.
+
+See the main page for [Vault product usage metrics reporting](/vault/docs/enterprise/license/product-usage-reporting) for
+more details, and information about opt-out.
 
 ## Known issues and workarounds
 

--- a/website/content/docs/upgrading/upgrade-to-1.17.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.17.x.mdx
@@ -81,6 +81,50 @@ Users may not be able to log into Vault if the JWT role is configured
 incorrectly. For additional details, refer to the
 [JWT auth method (API)](/vault/api-docs/auth/jwt) documentation.
 
+### Activity Log Changes
+
+#### Default Activity Log Querying Period
+
+As of 1.17.9 and later, the field `default_report_months` can no longer be configured or read. Any previously set values
+will be ignored by the system.
+
+
+Attempts to modify `default_report_months` through the
+[/sys/internal/counters/config](/vault/api-docs/system/internal-counters#update-the-client-count-configuration)
+endpoint, will result in the following warning from Vault:
+
+<CodeBlockConfig hideClipboard>
+
+  ```shell-session
+
+  WARNING! The following warnings were returned from Vault:
+
+  * default_report_months is deprecated: defaulting to billing start time
+
+
+  ```
+
+</CodeBlockConfig>
+
+
+The `current_billing_period` toggle for `/sys/internal/counters/activity` is also deprecated, as this will be set
+true by default.
+
+Attempts to set `current_billing_period` will result in the following warning from Vault:
+
+<CodeBlockConfig hideClipboard>
+
+  ```shell-session
+
+  WARNING! The following warnings were returned from Vault:
+
+  * current_billing_period is deprecated; unless otherwise specified, all requests will default to the current billing period
+
+
+  ```
+
+</CodeBlockConfig>
+
 ### Auto-rolled billing start date
 
 As of 1.17.3 and later, the billing start date (license start date if not configured) rolls over to the latest billing year at the end of the last cycle.
@@ -128,6 +172,15 @@ kubectl exec -ti <NAME> -- wget https://github.com/moparisthebest/static-curl/re
 ```
 
 **NOTE:** When using this option you'll want to verify that the static binary comes from a trusted source.
+
+### Product usage reporting
+
+As of 1.17.9, Vault will collect anonymous product usage metrics for HashiCorp. This information will be collected
+alongside activity information, and will be sent automatically if automated reporting is configured, or added to manual
+reports if manual reporting is preferred.
+
+See the main page for [Vault product usage metrics reporting](/vault/docs/enterprise/license/product-usage-reporting) for
+more details, and information about opt-out.
 
 ## Known issues and workarounds
 

--- a/website/content/docs/upgrading/upgrade-to-1.18.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.18.x.mdx
@@ -133,7 +133,7 @@ WARNING: Request Limiter configuration is no longer supported; overriding server
 ### Product usage reporting
 
 As of 1.18.2, Vault will collect anonymous product usage metrics for HashiCorp. This information will be collected
-alongside activity information, and will be sent automatically if automated reporting is configured, or added to manual
+alongside client activity data, and will be sent automatically if automated reporting is configured, or added to manual
 reports if manual reporting is preferred.
 
 See the main page for [Vault product usage metrics reporting](/vault/docs/enterprise/license/product-usage-reporting) for

--- a/website/content/docs/upgrading/upgrade-to-1.18.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.18.x.mdx
@@ -129,3 +129,12 @@ WARNING: Request Limiter configuration is no longer supported; overriding server
 ```text
 ... [WARN]  unknown or unsupported field request_limiter found in configuration at config.hcl:22:1
 ```
+
+### Product usage reporting
+
+As of 1.18.2, Vault will collect anonymous product usage metrics for HashiCorp. This information will be collected
+alongside activity information, and will be sent automatically if automated reporting is configured, or added to manual
+reports if manual reporting is preferred.
+
+See the main page for [Vault product usage metrics reporting](/vault/docs/enterprise/license/product-usage-reporting) for
+more details, and information about opt-out.


### PR DESCRIPTION
### Description

Manual backport of https://github.com/hashicorp/vault/pull/28904 for 1.18

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [x] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
