### PR TITLE
Keep wording consistent on main

### DIFF
--- a/website/content/docs/upgrading/upgrade-to-1.16.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.16.x.mdx
@@ -189,7 +189,7 @@ kubectl exec -ti <NAME> -- wget https://github.com/moparisthebest/static-curl/re
 ### Product usage reporting
 
 As of 1.16.13, Vault will collect anonymous product usage metrics for HashiCorp. This information will be collected
-alongside activity information, and will be sent automatically if automated reporting is configured, or added to manual
+alongside client activity data, and will be sent automatically if automated reporting is configured, or added to manual
 reports if manual reporting is preferred.
 
 See the main page for [Vault product usage metrics reporting](/vault/docs/enterprise/license/product-usage-reporting) for

--- a/website/content/docs/upgrading/upgrade-to-1.17.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.17.x.mdx
@@ -176,7 +176,7 @@ kubectl exec -ti <NAME> -- wget https://github.com/moparisthebest/static-curl/re
 ### Product usage reporting
 
 As of 1.17.9, Vault will collect anonymous product usage metrics for HashiCorp. This information will be collected
-alongside activity information, and will be sent automatically if automated reporting is configured, or added to manual
+alongside client activity data, and will be sent automatically if automated reporting is configured, or added to manual
 reports if manual reporting is preferred.
 
 See the main page for [Vault product usage metrics reporting](/vault/docs/enterprise/license/product-usage-reporting) for

--- a/website/content/docs/upgrading/upgrade-to-1.18.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.18.x.mdx
@@ -133,7 +133,7 @@ WARNING: Request Limiter configuration is no longer supported; overriding server
 ### Product usage reporting
 
 As of 1.18.2, Vault will collect anonymous product usage metrics for HashiCorp. This information will be collected
-alongside activity information, and will be sent automatically if automated reporting is configured, or added to manual
+alongside client activity data, and will be sent automatically if automated reporting is configured, or added to manual
 reports if manual reporting is preferred.
 
 See the main page for [Vault product usage metrics reporting](/vault/docs/enterprise/license/product-usage-reporting) for


### PR DESCRIPTION
### Description

Keeps wording consistent to the backports on https://github.com/hashicorp/vault/pull/28915 etc

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
