### PR TITLE
CE Changes for Auth Method Usage Metrics

### DIFF
--- a/helper/builtinplugins/registry.go
+++ b/helper/builtinplugins/registry.go
@@ -19,6 +19,30 @@ import (
 	"github.com/hashicorp/vault/sdk/logical"
 )
 
+const (
+	AuthTypeAliCloud   = "alicloud"
+	AuthTypeAppId      = "app-id"
+	AuthTypeAWS        = "aws"
+	AuthTypeAzure      = "azure"
+	AuthTypeCF         = "cf"
+	AuthTypeGCP        = "gcp"
+	AuthTypeGitHub     = "github"
+	AuthTypeKerberos   = "kerberos"
+	AuthTypeKubernetes = "kubernetes"
+	AuthTypeLDAP       = "ldap"
+	AuthTypeOCI        = "oci"
+	AuthTypeOkta       = "okta"
+	AuthTypePCF        = "pcf"
+	AuthTypeRadius     = "radius"
+	AuthTypeToken      = "token"
+	AuthTypeCert       = "cert"
+	AuthTypeOIDC       = "oidc"
+	AuthTypeUserpass   = "userpass"
+	AuthTypeSAML       = "saml"
+	AuthTypeApprole    = "approle"
+	AuthTypeJWT        = "jwt"
+)
+
 // Registry is inherently thread-safe because it's immutable.
 // Thus, rather than creating multiple instances of it, we only need one.
 var Registry = newRegistry()

--- a/helper/builtinplugins/registry_full.go
+++ b/helper/builtinplugins/registry_full.go
@@ -54,26 +54,26 @@ import (
 func newFullAddonRegistry() *registry {
 	return &registry{
 		credentialBackends: map[string]credentialBackend{
-			"alicloud": {Factory: credAliCloud.Factory},
-			"app-id": {
+			AuthTypeAliCloud: {Factory: credAliCloud.Factory},
+			AuthTypeAppId: {
 				Factory:           removedFactory,
 				DeprecationStatus: consts.Removed,
 			},
-			"aws":        {Factory: credAws.Factory},
-			"azure":      {Factory: credAzure.Factory},
-			"cf":         {Factory: credCF.Factory},
-			"gcp":        {Factory: credGcp.Factory},
-			"github":     {Factory: credGitHub.Factory},
-			"kerberos":   {Factory: credKerb.Factory},
-			"kubernetes": {Factory: credKube.Factory},
-			"ldap":       {Factory: credLdap.Factory},
-			"oci":        {Factory: credOCI.Factory},
-			"okta":       {Factory: credOkta.Factory},
-			"pcf": {
+			AuthTypeAWS:        {Factory: credAws.Factory},
+			AuthTypeAzure:      {Factory: credAzure.Factory},
+			AuthTypeCF:         {Factory: credCF.Factory},
+			AuthTypeGCP:        {Factory: credGcp.Factory},
+			AuthTypeGitHub:     {Factory: credGitHub.Factory},
+			AuthTypeKerberos:   {Factory: credKerb.Factory},
+			AuthTypeKubernetes: {Factory: credKube.Factory},
+			AuthTypeLDAP:       {Factory: credLdap.Factory},
+			AuthTypeOCI:        {Factory: credOCI.Factory},
+			AuthTypeOkta:       {Factory: credOkta.Factory},
+			AuthTypePCF: {
 				Factory:           credCF.Factory,
 				DeprecationStatus: consts.Deprecated,
 			},
-			"radius": {Factory: credRadius.Factory},
+			AuthTypeRadius: {Factory: credRadius.Factory},
 		},
 		databasePlugins: map[string]databasePlugin{
 			// These four plugins all use the same mysql implementation but with

--- a/website/content/docs/enterprise/license/product-usage-reporting.mdx
+++ b/website/content/docs/enterprise/license/product-usage-reporting.mdx
@@ -119,7 +119,29 @@ All of these metrics are numerical, and contain no sensitive values or additiona
 | `vault.kv.version1.secrets.namespace.min`  | The lowest number of KVv1 secrets in a namespace in Vault, e.g. `2`.     |
 | `vault.kv.version2.secrets.namespace.min`  | The highest number of KVv2 secrets in a namespace in Vault, e.g. `1000`. |
 | `vault.kv.version1.secrets.namespace.mean` | The mean number of KVv1 secrets in namespaces in Vault, e.g. `52.8`.     |
-| `vault.kv.version1.secrets.namespace.mean` | The mean number of KVv2 secrets in namespaces in Vault, e.g. `52.8`.     |
+| `vault.kv.version2.secrets.namespace.mean` | The mean number of KVv2 secrets in namespaces in Vault, e.g. `52.8`.     |
+| `vault.auth.method.approle.count`          | The total number of Approle auth mounts in Vault.                        |
+| `vault.auth.method.alicloud.count`         | The total number of Alicloud auth mounts in Vault.                       |
+| `vault.auth.method.aws.count`              | The total number of AWS auth mounts in Vault.                            |
+| `vault.auth.method.appid.count`            | The total number of App ID auth mounts in Vault.                         |
+| `vault.auth.method.azure.count`            | The total number of Azure auth mounts in Vault.                          |
+| `vault.auth.method.cloudfoundry.count`     | The total number of Cloud Foundry auth mounts in Vault.                  |
+| `vault.auth.method.github.count`           | The total number of GitHub auth mounts in Vault.                         |
+| `vault.auth.method.gcp.count`              | The total number of GCP auth mounts in Vault.                            |
+| `vault.auth.method.jwt.count`              | The total number of JWT auth mounts in Vault.                            |
+| `vault.auth.method.kerberos.count`         | The total number of Kerberos auth mounts in Vault.                       |
+| `vault.auth.method.kubernetes.count`       | The total number of kubernetes auth mounts in Vault.                     |
+| `vault.auth.method.ldap.count`             | The total number of LDAP auth mounts in Vault.                           |
+| `vault.auth.method.oci.count`              | The total number of OCI auth mounts in Vault.                            |
+| `vault.auth.method.okta.count`             | The total number of Okta auth mounts in Vault.                           |
+| `vault.auth.method.pcf.count`              | The total number of PCF auth mounts in Vault.                            |
+| `vault.auth.method.radius.count`           | The total number of Radius auth mounts in Vault.                         |
+| `vault.auth.method.saml.count`             | The total number of SAML auth mounts in Vault.                           |
+| `vault.auth.method.cert.count`             | The total number of Cert auth mounts in Vault.                           |
+| `vault.auth.method.oidc.count`             | The total number of OIDC auth mounts in Vault.                           |
+| `vault.auth.method.token.count`            | The total number of Token auth mounts in Vault.                          |
+| `vault.auth.method.userpass.count`         | The total number of Userpass auth mounts in Vault.                       |
+| `vault.auth.method.plugin.count`           | The total number of custom plugin auth mounts in Vault.                  |
 
 ## Usage metadata list
 


### PR DESCRIPTION
### Description

CE PR for https://github.com/hashicorp/vault-enterprise/pull/6997

Will need to be backported

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
