### PR TITLE
VAULT-31751, VAULT-31752: `removed_from_cluster` in vault status

### DIFF
--- a/api/sys_seal.go
+++ b/api/sys_seal.go
@@ -96,24 +96,25 @@ func sealStatusRequestWithContext(ctx context.Context, c *Sys, r *Request) (*Sea
 }
 
 type SealStatusResponse struct {
-	Type              string   `json:"type"`
-	Initialized       bool     `json:"initialized"`
-	Sealed            bool     `json:"sealed"`
-	T                 int      `json:"t"`
-	N                 int      `json:"n"`
-	Progress          int      `json:"progress"`
-	Nonce             string   `json:"nonce"`
-	Version           string   `json:"version"`
-	BuildDate         string   `json:"build_date"`
-	Migration         bool     `json:"migration"`
-	ClusterName       string   `json:"cluster_name,omitempty"`
-	ClusterID         string   `json:"cluster_id,omitempty"`
-	RecoverySeal      bool     `json:"recovery_seal"`
-	RecoverySealType  string   `json:"recovery_seal_type,omitempty"`
-	StorageType       string   `json:"storage_type,omitempty"`
-	HCPLinkStatus     string   `json:"hcp_link_status,omitempty"`
-	HCPLinkResourceID string   `json:"hcp_link_resource_ID,omitempty"`
-	Warnings          []string `json:"warnings,omitempty"`
+	Type               string   `json:"type"`
+	Initialized        bool     `json:"initialized"`
+	Sealed             bool     `json:"sealed"`
+	T                  int      `json:"t"`
+	N                  int      `json:"n"`
+	Progress           int      `json:"progress"`
+	Nonce              string   `json:"nonce"`
+	Version            string   `json:"version"`
+	BuildDate          string   `json:"build_date"`
+	Migration          bool     `json:"migration"`
+	ClusterName        string   `json:"cluster_name,omitempty"`
+	ClusterID          string   `json:"cluster_id,omitempty"`
+	RecoverySeal       bool     `json:"recovery_seal"`
+	RecoverySealType   string   `json:"recovery_seal_type,omitempty"`
+	StorageType        string   `json:"storage_type,omitempty"`
+	HCPLinkStatus      string   `json:"hcp_link_status,omitempty"`
+	HCPLinkResourceID  string   `json:"hcp_link_resource_ID,omitempty"`
+	RemovedFromCluster *bool    `json:"removed_from_cluster,omitempty"`
+	Warnings           []string `json:"warnings,omitempty"`
 }
 
 type UnsealOpts struct {

--- a/changelog/28938.txt
+++ b/changelog/28938.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+core: Add `removed_from_cluster` field to sys/seal-status and vault status output to indicate whether the node has been removed from the HA cluster. 
+```

--- a/command/command_test.go
+++ b/command/command_test.go
@@ -22,6 +22,8 @@ import (
 	"github.com/hashicorp/vault/builtin/logical/ssh"
 	"github.com/hashicorp/vault/builtin/logical/transit"
 	"github.com/hashicorp/vault/helper/builtinplugins"
+	"github.com/hashicorp/vault/helper/testhelpers"
+	"github.com/hashicorp/vault/helper/testhelpers/teststorage"
 	vaulthttp "github.com/hashicorp/vault/http"
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/hashicorp/vault/sdk/physical/inmem"
@@ -159,6 +161,23 @@ func testVaultServerUnsealWithKVVersionWithSeal(tb testing.TB, kvVersion string,
 		NumCores:    1,
 		KVVersion:   kvVersion,
 	})
+}
+
+func testVaultRaftCluster(tb testing.TB) *vault.TestCluster {
+	conf := &vault.CoreConfig{
+		CredentialBackends: defaultVaultCredentialBackends,
+		AuditBackends:      defaultVaultAuditBackends,
+		LogicalBackends:    defaultVaultLogicalBackends,
+		BuiltinRegistry:    builtinplugins.Registry,
+	}
+	opts := &vault.TestClusterOptions{
+		HandlerFunc: vaulthttp.Handler,
+		NumCores:    3,
+	}
+	teststorage.RaftBackendSetup(conf, opts)
+	cluster := vault.NewTestCluster(tb, conf, opts)
+	testhelpers.WaitForActiveNodeAndStandbys(tb, cluster)
+	return cluster
 }
 
 // testVaultServerUnseal creates a test vault cluster and returns a configured

--- a/command/format.go
+++ b/command/format.go
@@ -357,6 +357,10 @@ func (t TableFormatter) OutputSealStatusStruct(ui cli.Ui, secret *api.Secret, da
 		out = append(out, fmt.Sprintf("Cluster ID | %s", status.ClusterID))
 	}
 
+	if status.RemovedFromCluster != nil {
+		out = append(out, fmt.Sprintf("Removed From Cluster | %t", *status.RemovedFromCluster))
+	}
+
 	// Output if HCP link is configured
 	if status.HCPLinkStatus != "" {
 		out = append(out, fmt.Sprintf("HCP Link Status | %s", status.HCPLinkStatus))

--- a/website/content/api-docs/system/seal-status.mdx
+++ b/website/content/api-docs/system/seal-status.mdx
@@ -30,18 +30,19 @@ The "t" parameter is the threshold, and "n" is the number of shares.
 
 ```json
 {
-  "type": "shamir",
+  "build_date": "2024-11-15T14:17:42Z",
   "initialized": true,
-  "sealed": true,
-  "t": 3,
-  "n": 5,
-  "progress": 2,
-  "nonce": "",
-  "version": "1.11.0",
-  "build_date": "2022-05-03T08:34:11Z",
   "migration": false,
+  "n": 3,
+  "nonce": "",
+  "progress": 1,
   "recovery_seal": false,
-  "storage_type": "file"
+  "removed_from_cluster": false,
+  "sealed": true,
+  "storage_type": "raft",
+  "t": 2,
+  "type": "shamir",
+  "version": "1.19.0-beta1"
 }
 ```
 
@@ -49,19 +50,20 @@ Sample response when Vault is unsealed.
 
 ```json
 {
-  "type": "shamir",
+  "build_date": "2024-11-14T18:11:15Z",
+  "cluster_id": "ebdd80fb-0c7f-bce9-f9b9-a0fa86aa3249",
+  "cluster_name": "vault-cluster-f090409a",
   "initialized": true,
-  "sealed": false,
-  "t": 3,
-  "n": 5,
-  "progress": 0,
-  "nonce": "",
-  "version": "1.11.0",
-  "build_date": "2022-05-03T08:34:11Z",
   "migration": false,
-  "cluster_name": "vault-cluster-336172e1",
-  "cluster_id": "f94053ad-d80e-4270-2006-2efd67d0910a",
+  "n": 3,
+  "nonce": "",
+  "progress": 0,
   "recovery_seal": false,
-  "storage_type": "file"
+  "removed_from_cluster": false,
+  "sealed": false,
+  "storage_type": "raft",
+  "t": 2,
+  "type": "shamir",
+  "version": "1.19.0-beta1"
 }
 ```

--- a/website/content/docs/commands/status.mdx
+++ b/website/content/docs/commands/status.mdx
@@ -54,7 +54,7 @@ By default, the output is displayed in "table" format.
 
 #### Output fields
 
-1. The field for total shares is displayed as `"n"` instead of `n` in yaml outputs. 
+1. The field for total shares is displayed as `"n"` instead of `n` in yaml outputs.
 2. The following fields in "table" format are displayed only when relevant:
 - "Unseal Progress" and "Unseal Nonce" are displayed when vault is sealed.
 - "HCP Link Status" and "HCP Link Resource ID" are displayed when HCP link is configured.
@@ -67,3 +67,4 @@ By default, the output is displayed in "table" format.
   - "HA Mode".
   - "Active Since" is displayed if the node is active and has a valid active time.
   - "Performance Standby" Node and "Performance Standby Last Remote WAL" are displayed for performance standby nodes.
+- The "Removed From Cluster" field is only displayed when the storage or HA backend is raft.


### PR DESCRIPTION
### Description
This PR adds an optional field to the sys/seal-status endpoint and vault status output. If the storage/HA backend supports removability (currently this is only raft), then `removed_from_cluster` is included in the output with a value of true or false.

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
