### PR TITLE
Update HCP not supported alert

### DIFF
--- a/website/content/docs/secrets/aws.mdx
+++ b/website/content/docs/secrets/aws.mdx
@@ -86,7 +86,7 @@ management tool.
     In some cases, you cannot set sensitive IAM security credentials in your
     Vault configuration. For example, your organization may require that all
     security credentials are short-lived or explicitly tied to a machine identity.
-    
+
     To provide IAM security credentials to Vault, we recommend using Vault
     [plugin workload identity federation](#plugin-workload-identity-federation-wif)
     (WIF).
@@ -305,11 +305,11 @@ them).
 
 ## Plugin Workload Identity Federation (WIF)
 
-<EnterpriseAlert product="vault" />
+@include 'alerts/enterprise-only.mdx'
 
 The AWS secrets engine supports the Plugin WIF workflow, and has a source of identity called
-a plugin identity token. The plugin identity token is a JWT that is internally signed by Vault's 
-[plugin identity token issuer](/vault/api-docs/secret/identity/tokens#read-plugin-workload-identity-issuer-s-openid-configuration). 
+a plugin identity token. The plugin identity token is a JWT that is internally signed by Vault's
+[plugin identity token issuer](/vault/api-docs/secret/identity/tokens#read-plugin-workload-identity-issuer-s-openid-configuration).
 
 If there is a trust relationship configured between Vault and AWS through
 [Web Identity Federation](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_oidc.html),
@@ -323,15 +323,15 @@ credentials.
 To configure the secrets engine to use plugin WIF:
 
 1. Ensure that Vault [openid-configuration](/vault/api-docs/secret/identity/tokens#read-plugin-identity-token-issuer-s-openid-configuration)
-   and [public JWKS](/vault/api-docs/secret/identity/tokens#read-plugin-identity-token-issuer-s-public-jwks) 
+   and [public JWKS](/vault/api-docs/secret/identity/tokens#read-plugin-identity-token-issuer-s-public-jwks)
    APIs are network-reachable by AWS. We recommend using an API proxy or gateway
-   if you need to limit Vault API exposure.  
+   if you need to limit Vault API exposure.
 
 1. Create an
    [IAM OIDC identity provider](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc.html)
    in AWS.
    1. The provider URL **must** point at your [Vault plugin identity token issuer](/vault/api-docs/secret/identity/tokens#read-plugin-workload-identity-issuer-s-openid-configuration) with the
-   `/.well-known/openid-configuration` suffix removed. For example: 
+   `/.well-known/openid-configuration` suffix removed. For example:
    `https://host:port/v1/identity/oidc/plugins`.
    1. The audience should uniquely identify the recipient of the plugin identity
    token. In AWS, the recipient is the identity provider. We recommend using
@@ -350,11 +350,11 @@ $ vault write aws/config/root \
     role_arn="arn:aws:iam::123456789123:role/example-web-identity-role"
 ```
 
-Your secrets engine can now use plugin WIF for its configuration credentials. 
-By default, WIF [credentials](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRoleWithWebIdentity.html) 
+Your secrets engine can now use plugin WIF for its configuration credentials.
+By default, WIF [credentials](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRoleWithWebIdentity.html)
 have a time-to-live of 1 hour and automatically refresh when they expire.
 
-Please see the [API documentation](/vault/api-docs/secret/aws#configure-root-credentials) 
+Please see the [API documentation](/vault/api-docs/secret/aws#configure-root-credentials)
 for more details on the fields associated with plugin WIF.
 
 ## STS credentials

--- a/website/content/partials/alerts/enterprise-only.mdx
+++ b/website/content/partials/alerts/enterprise-only.mdx
@@ -1,4 +1,7 @@
 <EnterpriseAlert product="vault">
-  Appropriate <a href="https://www.hashicorp.com/products/vault/pricing">Vault Enterprise</a>
-  &nbsp; license required
+  Appropriate <a href="https://www.hashicorp.com/products/vault/pricing">
+    Vault Enterprise
+  </a> license required. Not supported in <a href="/hcp/docs/vault/get-started/deployment-considerations/constraints-and-limitations">
+    HCP Vault Dedicated
+  </a>.
 </EnterpriseAlert>


### PR DESCRIPTION
### Description
What does this PR do?

Update alert where HCP is not supported
Still in draft

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
