### PR TITLE
Storing local clients to local storage paths ce changes

### DIFF
--- a/command/command_testonly/operator_usage_testonly_test.go
+++ b/command/command_testonly/operator_usage_testonly_test.go
@@ -53,7 +53,7 @@ func TestOperatorUsageCommandRun(t *testing.T) {
 
 	now := time.Now().UTC()
 
-	_, _, err = clientcountutil.NewActivityLogData(client).
+	_, _, _, err = clientcountutil.NewActivityLogData(client).
 		NewPreviousMonthData(1).
 		NewClientsSeen(6, clientcountutil.WithClientType("entity")).
 		NewClientsSeen(4, clientcountutil.WithClientType("non-entity-token")).

--- a/sdk/helper/clientcountutil/clientcountutil.go
+++ b/sdk/helper/clientcountutil/clientcountutil.go
@@ -282,42 +282,53 @@ func (d *ActivityLogDataGenerator) ToProto() *generation.ActivityLogMockInput {
 // Write writes the data to the API with the given write options. The method
 // returns the new paths that have been written. Note that the API endpoint will
 // only be present when Vault has been compiled with the "testonly" flag.
-func (d *ActivityLogDataGenerator) Write(ctx context.Context, writeOptions ...generation.WriteOptions) ([]string, []string, error) {
+func (d *ActivityLogDataGenerator) Write(ctx context.Context, writeOptions ...generation.WriteOptions) ([]string, []string, []string, error) {
 	d.data.Write = writeOptions
 	err := VerifyInput(d.data)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	data, err := d.ToJSON()
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	resp, err := d.client.Logical().WriteWithContext(ctx, "sys/internal/counters/activity/write", map[string]interface{}{"input": string(data)})
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	if resp.Data == nil {
-		return nil, nil, fmt.Errorf("received no data")
+		return nil, nil, nil, fmt.Errorf("received no data")
 	}
 	paths := resp.Data["paths"]
 	castedPaths, ok := paths.([]interface{})
 	if !ok {
-		return nil, nil, fmt.Errorf("invalid paths data: %v", paths)
+		return nil, nil, nil, fmt.Errorf("invalid paths data: %v", paths)
 	}
 	returnPaths := make([]string, 0, len(castedPaths))
 	for _, path := range castedPaths {
 		returnPaths = append(returnPaths, path.(string))
 	}
+
+	localPaths := resp.Data["local_paths"]
+	localCastedPaths, ok := localPaths.([]interface{})
+	if !ok {
+		return nil, nil, nil, fmt.Errorf("invalid local paths data: %v", localPaths)
+	}
+	returnLocalPaths := make([]string, 0, len(localCastedPaths))
+	for _, path := range localCastedPaths {
+		returnLocalPaths = append(returnLocalPaths, path.(string))
+	}
+
 	globalPaths := resp.Data["global_paths"]
 	globalCastedPaths, ok := globalPaths.([]interface{})
 	if !ok {
-		return nil, nil, fmt.Errorf("invalid global paths data: %v", globalPaths)
+		return nil, nil, nil, fmt.Errorf("invalid global paths data: %v", globalPaths)
 	}
 	returnGlobalPaths := make([]string, 0, len(globalCastedPaths))
 	for _, path := range globalCastedPaths {
 		returnGlobalPaths = append(returnGlobalPaths, path.(string))
 	}
-	return returnPaths, returnGlobalPaths, nil
+	return returnPaths, returnLocalPaths, returnGlobalPaths, nil
 }
 
 // VerifyInput checks that the input data is valid

--- a/sdk/helper/clientcountutil/clientcountutil_test.go
+++ b/sdk/helper/clientcountutil/clientcountutil_test.go
@@ -116,7 +116,7 @@ func TestNewCurrentMonthData_AddClients(t *testing.T) {
 // sent to the server is correct.
 func TestWrite(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, err := io.WriteString(w, `{"data":{"paths":["path1","path2"],"global_paths":["path2","path3"]}}`)
+		_, err := io.WriteString(w, `{"data":{"paths":["path1","path2"],"global_paths":["path2","path3"], "local_paths":["path3","path4"]}}`)
 		require.NoError(t, err)
 		body, err := io.ReadAll(r.Body)
 		require.NoError(t, err)
@@ -131,7 +131,7 @@ func TestWrite(t *testing.T) {
 		Address: ts.URL,
 	})
 	require.NoError(t, err)
-	paths, globalPaths, err := NewActivityLogData(client).
+	paths, localPaths, globalPaths, err := NewActivityLogData(client).
 		NewPreviousMonthData(3).
 		NewClientSeen().
 		NewPreviousMonthData(2).
@@ -142,6 +142,7 @@ func TestWrite(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []string{"path1", "path2"}, paths)
 	require.Equal(t, []string{"path2", "path3"}, globalPaths)
+	require.Equal(t, []string{"path3", "path4"}, localPaths)
 }
 
 func testAddClients(t *testing.T, makeGenerator func() *ActivityLogDataGenerator, getClient func(data *ActivityLogDataGenerator) *generation.Client) {

--- a/vault/activity_log_test.go
+++ b/vault/activity_log_test.go
@@ -626,6 +626,90 @@ func TestActivityLog_SaveEntitiesToStorage(t *testing.T) {
 	expectedEntityIDs(t, out, ids)
 }
 
+// TestActivityLog_SaveEntitiesToStorageCommon calls AddClientToFragment with clients with local and non-local mount accessors and then
+// writes the segment to storage. Read back from storage, and verify that client IDs exist in storage in the right local and non-local entity paths.
+func TestActivityLog_SaveEntitiesToStorageCommon(t *testing.T) {
+	t.Parallel()
+
+	storage := &logical.InmemStorage{}
+	coreConfig := &CoreConfig{
+		CredentialBackends: map[string]logical.Factory{
+			"userpass": userpass.Factory,
+		},
+		Physical: storage.Underlying(),
+	}
+
+	cluster := NewTestCluster(t, coreConfig, nil)
+	core := cluster.Cores[0].Core
+	TestWaitActive(t, core)
+
+	ctx := namespace.RootContext(nil)
+
+	a := core.activityLog
+	a.SetStartTimestamp(time.Now().Unix()) // set a nonzero segment
+
+	var err error
+
+	// create a local and non-local mount entry
+	nonLocalMountEntry := &MountEntry{
+		Table:    credentialTableType,
+		Path:     "nonLocalUserpass/",
+		Type:     "userpass",
+		Accessor: "nonLocalMountAccessor",
+	}
+	err = core.enableCredential(ctx, nonLocalMountEntry)
+	require.NoError(t, err)
+
+	localMountEntry := &MountEntry{
+		Table:    credentialTableType,
+		Path:     "localUserpass/",
+		Local:    true,
+		Type:     "userpass",
+		Accessor: "localMountAccessor",
+	}
+	err = core.enableCredential(ctx, localMountEntry)
+	require.NoError(t, err)
+
+	now := time.Now()
+	ids := []string{"non-local-client-id-1", "non-local-client-id-2", "local-client-id-1"}
+
+	globalPath := fmt.Sprintf("%sentity/%d/0", ActivityGlobalLogPrefix, a.GetStartTimestamp())
+	localPath := fmt.Sprintf("%sentity/%d/0", ActivityLogLocalPrefix, a.GetStartTimestamp())
+
+	// add clients with local and non-local mount accessors
+	a.AddClientToFragment(ids[0], "root", now.Unix(), false, "nonLocalMountAccessor")
+	a.AddClientToFragment(ids[1], "root", now.Unix(), false, "nonLocalMountAccessor")
+	a.AddClientToFragment(ids[2], "root", now.Unix(), false, "localMountAccessor")
+
+	err = a.saveCurrentSegmentToStorage(ctx, false)
+	if err != nil {
+		t.Fatalf("got error writing entities to storage: %v", err)
+	}
+	if a.fragment != nil {
+		t.Errorf("fragment was not reset after write to storage")
+	}
+
+	// read entity ids from non-local entity storage path
+	protoSegment := readSegmentFromStorage(t, core, globalPath)
+	out := &activity.EntityActivityLog{}
+	err = proto.Unmarshal(protoSegment.Value, out)
+	if err != nil {
+		t.Fatalf("could not unmarshal protobuf: %v", err)
+	}
+	expectedEntityIDs(t, out, ids[:2])
+
+	// read entity ids from local entity storage path
+	protoSegment = readSegmentFromStorage(t, core, localPath)
+	out = &activity.EntityActivityLog{}
+	err = proto.Unmarshal(protoSegment.Value, out)
+	if err != nil {
+		t.Fatalf("could not unmarshal protobuf: %v", err)
+	}
+
+	// local entity is local-client-id-1 in ids with index 2
+	expectedEntityIDs(t, out, ids[2:])
+}
+
 // TestActivityLog_StoreAndReadHyperloglog inserts into a hyperloglog, stores it and then reads it back. The test
 // verifies the estimate count is correct.
 func TestActivityLog_StoreAndReadHyperloglog(t *testing.T) {
@@ -1222,54 +1306,64 @@ func TestActivityLog_getLastEntitySegmentNumber(t *testing.T) {
 	a := core.activityLog
 	paths := [...]string{"entity/992/0", "entity/1000/-1", "entity/1001/foo", "entity/1111/0", "entity/1111/1"}
 	globalPaths := [...]string{"entity/992/0", "entity/1000/-1", "entity/1001/foo", "entity/1111/1"}
+	localPaths := [...]string{"entity/992/0", "entity/1000/-1", "entity/1001/foo", "entity/1111/0", "entity/1111/1"}
 	for _, path := range paths {
 		WriteToStorage(t, core, ActivityLogPrefix+path, []byte("test"))
 	}
 	for _, path := range globalPaths {
 		WriteToStorage(t, core, ActivityGlobalLogPrefix+path, []byte("test"))
 	}
+	for _, path := range localPaths {
+		WriteToStorage(t, core, ActivityLogLocalPrefix+path, []byte("test"))
+	}
 
 	testCases := []struct {
 		input             int64
 		expectedVal       uint64
 		expectedGlobalVal uint64
+		expectedLocalVal  uint64
 		expectExists      bool
 	}{
 		{
 			input:             992,
 			expectedVal:       0,
 			expectedGlobalVal: 0,
+			expectedLocalVal:  0,
 			expectExists:      true,
 		},
 		{
 			input:             1000,
 			expectedVal:       0,
 			expectedGlobalVal: 0,
+			expectedLocalVal:  0,
 			expectExists:      false,
 		},
 		{
 			input:             1001,
 			expectedVal:       0,
 			expectedGlobalVal: 0,
+			expectedLocalVal:  0,
 			expectExists:      false,
 		},
 		{
 			input:             1111,
 			expectedVal:       1,
 			expectedGlobalVal: 1,
+			expectedLocalVal:  1,
 			expectExists:      true,
 		},
 		{
 			input:             2222,
 			expectedVal:       0,
 			expectedGlobalVal: 0,
+			expectedLocalVal:  0,
 			expectExists:      false,
 		},
 	}
 
 	ctx := context.Background()
 	for _, tc := range testCases {
-		result, globalSegmentNumber, exists, err := a.getLastEntitySegmentNumber(ctx, time.Unix(tc.input, 0))
+		result, localSegmentNumber, globalSegmentNumber, exists, err := a.getLastEntitySegmentNumber(ctx, time.Unix(tc.input, 0))
 		if err != nil {
 			t.Fatalf("unexpected error for input %d: %v", tc.input, err)
 		}
@@ -1282,7 +1376,9 @@ func TestActivityLog_getLastEntitySegmentNumber(t *testing.T) {
 		if globalSegmentNumber != tc.expectedGlobalVal {
 			t.Errorf("expected: %d got: %d for input: %d", tc.expectedGlobalVal, globalSegmentNumber, tc.input)
 		}
-
+		if localSegmentNumber != tc.expectedLocalVal {
+			t.Errorf("expected: %d got: %d for input: %d", tc.expectedLocalVal, localSegmentNumber, tc.input)
+		}
 	}
 }
 
@@ -1417,6 +1513,24 @@ func (a *ActivityLog) resetEntitiesInMemory(t *testing.T) {
 		clientSequenceNumber: 0,
 	}
 
+	a.currentGlobalSegment = segmentInfo{
+		startTimestamp: time.Time{}.Unix(),
+		currentClients: &activity.EntityActivityLog{
+			Clients: make([]*activity.EntityRecord, 0),
+		},
+		tokenCount:           a.currentGlobalSegment.tokenCount,
+		clientSequenceNumber: 0,
+	}
+
+	a.currentLocalSegment = segmentInfo{
+		startTimestamp: time.Time{}.Unix(),
+		currentClients: &activity.EntityActivityLog{
+			Clients: make([]*activity.EntityRecord, 0),
+		},
+		tokenCount:           a.currentLocalSegment.tokenCount,
+		clientSequenceNumber: 0,
+	}
+
 	a.partialMonthClientTracker = make(map[string]*activity.EntityRecord)
 	a.partialMonthLocalClientTracker = make(map[string]*activity.EntityRecord)
 	a.globalPartialMonthClientTracker = make(map[string]*activity.EntityRecord)
@@ -1435,6 +1549,7 @@ func TestActivityLog_loadCurrentClientSegment(t *testing.T) {
 	}
 	a.l.Lock()
 	a.currentSegment.tokenCount = tokenCount
+	a.currentLocalSegment.tokenCount = tokenCount
 	a.l.Unlock()
 
 	// setup in-storage data to load for testing
@@ -1496,6 +1611,7 @@ func TestActivityLog_loadCurrentClientSegment(t *testing.T) {
 		}
 		WriteToStorage(t, core, ActivityLogPrefix+tc.path, data)
 		WriteToStorage(t, core, ActivityGlobalLogPrefix+tc.path, data)
+		WriteToStorage(t, core, ActivityLogLocalPrefix+tc.path, data)
 	}
 
 	ctx := context.Background()
@@ -1503,10 +1619,12 @@ func TestActivityLog_loadCurrentClientSegment(t *testing.T) {
 		a.l.Lock()
 		a.fragmentLock.Lock()
 		a.globalFragmentLock.Lock()
+		a.localFragmentLock.Lock()
 		// loadCurrentClientSegment requires us to grab the fragment lock and the
 		// activityLog lock, as per the comment in the loadCurrentClientSegment
 		// function
-		err := a.loadCurrentClientSegment(ctx, time.Unix(tc.time, 0), tc.seqNum, tc.seqNum)
+		err := a.loadCurrentClientSegment(ctx, time.Unix(tc.time, 0), tc.seqNum, tc.seqNum, tc.seqNum)
+		a.localFragmentLock.Unlock()
 		a.globalFragmentLock.Unlock()
 		a.fragmentLock.Unlock()
 		a.l.Unlock()
@@ -1519,19 +1637,24 @@ func TestActivityLog_loadCurrentClientSegment(t *testing.T) {
 		}
 
 		// verify accurate data in in-memory current segment
-		startTimestamp := a.GetStartTimestamp()
-		if startTimestamp != tc.time {
-			t.Errorf("bad timestamp loaded. expected: %v, got: %v for path %q", tc.time, startTimestamp, tc.path)
-		}
-
-		seqNum := a.GetEntitySequenceNumber()
-		if seqNum != tc.seqNum {
-			t.Errorf("bad sequence number loaded. expected: %v, got: %v for path %q", tc.seqNum, seqNum, tc.path)
-		}
+		require.Equal(t, tc.time, a.GetStartTimestamp())
+		require.Equal(t, tc.seqNum, a.GetEntitySequenceNumber())
+		require.Equal(t, tc.seqNum, a.GetGlobalEntitySequenceNumber())
+		require.Equal(t, tc.seqNum, a.GetLocalEntitySequenceNumber())
 
 		currentEntities := a.GetCurrentEntities()
 		if !entityRecordsEqual(t, currentEntities.Clients, tc.entities.Clients) {
 			t.Errorf("bad data loaded. expected: %v, got: %v for path %q", tc.entities.Clients, currentEntities, tc.path)
+		}
+
+		globalClients := core.GetActiveGlobalClientsList()
+		if err := ActiveEntitiesEqual(globalClients, tc.entities.Clients); err != nil {
+			t.Errorf("bad data loaded into active global entities. expected only set of EntityID from %v in %v for path %q: %v", tc.entities.Clients, globalClients, tc.path, err)
+		}
+
+		localClients := core.GetActiveLocalClientsList()
+		if err := ActiveEntitiesEqual(localClients, tc.entities.Clients); err != nil {
+			t.Errorf("bad data loaded into active local entities. expected only set of EntityID from %v in %v for path %q: %v", tc.entities.Clients, localClients, tc.path, err)
 		}
 
 		currentGlobalEntities := a.GetCurrentGlobalEntities()
@@ -1617,6 +1740,7 @@ func TestActivityLog_loadPriorEntitySegment(t *testing.T) {
 		}
 		WriteToStorage(t, core, ActivityLogPrefix+tc.path, data)
 		WriteToStorage(t, core, ActivityGlobalLogPrefix+tc.path, data)
+		WriteToStorage(t, core, ActivityLogLocalPrefix+tc.path, data)
 	}
 
 	ctx := context.Background()
@@ -1630,6 +1754,7 @@ func TestActivityLog_loadPriorEntitySegment(t *testing.T) {
 			a.globalPartialMonthClientTracker = make(map[string]*activity.EntityRecord)
 			a.currentSegment.startTimestamp = tc.time
 			a.currentGlobalSegment.startTimestamp = tc.time
+			a.currentLocalSegment.startTimestamp = tc.time
 			a.fragmentLock.Unlock()
 			a.localFragmentLock.Unlock()
 			a.l.Unlock()
@@ -1794,6 +1919,14 @@ func setupActivityRecordsInStorage(t *testing.T, base time.Time, includeEntities
 				},
 			}...)
 		}
+
+		// append some local entity data
+		entityRecords = append(entityRecords, &activity.EntityRecord{
+			ClientID:    "44444444-4444-4444-4444-444444444444",
+			NamespaceID: "ns1",
+			Timestamp:   time.Now().Unix(),
+		})
+
 		for i, entityRecord := range entityRecords {
 			entityData, err := proto.Marshal(&activity.EntityActivityLog{
 				Clients: []*activity.EntityRecord{entityRecord},
@@ -1801,10 +1934,15 @@ func setupActivityRecordsInStorage(t *testing.T, base time.Time, includeEntities
 			if err != nil {
 				t.Fatalf(err.Error())
 			}
-			if i == 0 {
+			switch i {
+			case 0:
 				WriteToStorage(t, core, ActivityLogPrefix+"entity/"+fmt.Sprint(monthsAgo.Unix())+"/0", entityData)
 				WriteToStorage(t, core, ActivityGlobalLogPrefix+"entity/"+fmt.Sprint(monthsAgo.Unix())+"/0", entityData)
-			} else {
+
+			case len(entityRecords) - 1:
+				// local data
+				WriteToStorage(t, core, ActivityLogLocalPrefix+"entity/"+fmt.Sprint(base.Unix())+"/"+strconv.Itoa(i-1), entityData)
+			default:
 				WriteToStorage(t, core, ActivityLogPrefix+"entity/"+fmt.Sprint(base.Unix())+"/"+strconv.Itoa(i-1), entityData)
 				WriteToStorage(t, core, ActivityGlobalLogPrefix+"entity/"+fmt.Sprint(base.Unix())+"/"+strconv.Itoa(i-1), entityData)
 			}
@@ -1853,6 +1991,9 @@ func TestActivityLog_refreshFromStoredLog(t *testing.T) {
 		Clients: expectedClientRecords[1:],
 	}
 	expectedCurrent := &activity.EntityActivityLog{
+		Clients: expectedClientRecords[len(expectedClientRecords)-2 : len(expectedClientRecords)-1],
+	}
+	expectedCurrentLocal := &activity.EntityActivityLog{
 		Clients: expectedClientRecords[len(expectedClientRecords)-1:],
 	}
 
@@ -1860,6 +2001,12 @@ func TestActivityLog_refreshFromStoredLog(t *testing.T) {
 	if !entityRecordsEqual(t, currentEntities.Clients, expectedCurrent.Clients) {
 		// we only expect the newest entity segment to be loaded (for the current month)
 		t.Errorf("bad activity entity logs loaded. expected: %v got: %v", expectedCurrent, currentEntities)
+	}
+
+	currentLocalEntities := a.GetCurrentLocalEntities()
+	if !entityRecordsEqual(t, currentLocalEntities.Clients, expectedCurrentLocal.Clients) {
+		// we only expect the newest local entity segment to be loaded (for the current month)
+		t.Errorf("bad activity entity logs loaded. expected: %v got: %v", expectedCurrentLocal, currentLocalEntities)
 	}
 
 	nsCount := a.GetStoredTokenCountByNamespaceID()
@@ -1896,14 +2043,31 @@ func TestActivityLog_refreshFromStoredLogWithBackgroundLoadingCancelled(t *testi
 	}
 	wg.Wait()
 
+	// refreshFromStoredLog loads the most recent segment and then loads the older segments in the background
+	// most recent global and local entity from setupActivityRecordsInStorage
 	expected := &activity.EntityActivityLog{
+		Clients: expectedClientRecords[len(expectedClientRecords)-2:],
+	}
+
+	// most recent global entity from setupActivityRecordsInStorage
+	expectedCurrent := &activity.EntityActivityLog{
+		Clients: expectedClientRecords[len(expectedClientRecords)-2 : len(expectedClientRecords)-1],
+	}
+	// most recent local entity from setupActivityRecordsInStorage
+	expectedCurrentLocal := &activity.EntityActivityLog{
 		Clients: expectedClientRecords[len(expectedClientRecords)-1:],
 	}
 
-	currentEntities := a.GetCurrentEntities()
-	if !entityRecordsEqual(t, currentEntities.Clients, expected.Clients) {
+	currentEntities := a.GetCurrentGlobalEntities()
+	if !entityRecordsEqual(t, currentEntities.Clients, expectedCurrent.Clients) {
 		// we only expect the newest entity segment to be loaded (for the current month)
-		t.Errorf("bad activity entity logs loaded. expected: %v got: %v", expected, currentEntities)
+		t.Errorf("bad activity entity logs loaded. expected: %v got: %v", expectedCurrent, currentEntities)
+	}
+
+	currentLocalEntities := a.GetCurrentLocalEntities()
+	if !entityRecordsEqual(t, currentLocalEntities.Clients, expectedCurrentLocal.Clients) {
+		// we only expect the newest local entity segment to be loaded (for the current month)
+		t.Errorf("bad activity entity logs loaded. expected: %v got: %v", expectedCurrentLocal, currentLocalEntities)
 	}
 
 	nsCount := a.GetStoredTokenCountByNamespaceID()
@@ -1951,6 +2115,12 @@ func TestActivityLog_refreshFromStoredLogNoTokens(t *testing.T) {
 		Clients: expectedClientRecords[1:],
 	}
 	expectedCurrent := &activity.EntityActivityLog{
+		Clients: expectedClientRecords[len(expectedClientRecords)-2 : len(expectedClientRecords)-1],
+	}
+	expectedCurrentGlobal := &activity.EntityActivityLog{
+		Clients: expectedClientRecords[len(expectedClientRecords)-2 : len(expectedClientRecords)-1],
+	}
+	expectedCurrentLocal := &activity.EntityActivityLog{
 		Clients: expectedClientRecords[len(expectedClientRecords)-1:],
 	}
 
@@ -1959,6 +2129,19 @@ func TestActivityLog_refreshFromStoredLogNoTokens(t *testing.T) {
 		// we expect all segments for the current month to be loaded
 		t.Errorf("bad activity entity logs loaded. expected: %v got: %v", expectedCurrent, currentEntities)
 	}
+
+	currentGlobalEntities := a.GetCurrentGlobalEntities()
+	if !entityRecordsEqual(t, currentGlobalEntities.Clients, expectedCurrentGlobal.Clients) {
+		// we only expect the newest entity segment to be loaded (for the current month)
+		t.Errorf("bad activity entity logs loaded. expected: %v got: %v", expectedCurrentGlobal, currentGlobalEntities)
+	}
+
+	currentLocalEntities := a.GetCurrentLocalEntities()
+	if !entityRecordsEqual(t, currentLocalEntities.Clients, expectedCurrentLocal.Clients) {
+		// we only expect the newest local entity segment to be loaded (for the current month)
+		t.Errorf("bad activity entity logs loaded. expected: %v got: %v", expectedCurrentLocal, currentLocalEntities)
+	}
+
 	activeClients := a.core.GetActiveClientsList()
 	if err := ActiveEntitiesEqual(activeClients, expectedActive.Clients); err != nil {
 		t.Error(err)
@@ -2058,7 +2241,7 @@ func TestActivityLog_refreshFromStoredLogPreviousMonth(t *testing.T) {
 		Clients: expectedClientRecords[1:],
 	}
 	expectedCurrent := &activity.EntityActivityLog{
-		Clients: expectedClientRecords[len(expectedClientRecords)-1:],
+		Clients: expectedClientRecords[len(expectedClientRecords)-2 : len(expectedClientRecords)-1],
 	}
 
 	currentEntities := a.GetCurrentEntities()
@@ -2162,6 +2345,16 @@ func TestActivityLog_DeleteWorker(t *testing.T) {
 		WriteToStorage(t, core, ActivityLogPrefix+path, []byte("test"))
 	}
 
+	localPaths := []string{
+		"entity/1111/1",
+		"entity/1111/2",
+		"entity/1111/3",
+		"entity/1112/1",
+	}
+	for _, path := range localPaths {
+		WriteToStorage(t, core, ActivityLogLocalPrefix+path, []byte("test"))
+	}
+
 	tokenPaths := []string{
 		"directtokens/1111/1",
 		"directtokens/1112/1",
@@ -2183,12 +2376,16 @@ func TestActivityLog_DeleteWorker(t *testing.T) {
 
 	// Check segments still present
 	readSegmentFromStorage(t, core, ActivityLogPrefix+"entity/1112/1")
+	readSegmentFromStorage(t, core, ActivityLogLocalPrefix+"entity/1112/1")
 	readSegmentFromStorage(t, core, ActivityLogLocalPrefix+"directtokens/1112/1")
 
 	// Check other segments not present
 	expectMissingSegment(t, core, ActivityLogPrefix+"entity/1111/1")
 	expectMissingSegment(t, core, ActivityLogPrefix+"entity/1111/2")
 	expectMissingSegment(t, core, ActivityLogPrefix+"entity/1111/3")
+	expectMissingSegment(t, core, ActivityLogLocalPrefix+"entity/1111/1")
+	expectMissingSegment(t, core, ActivityLogLocalPrefix+"entity/1111/2")
+	expectMissingSegment(t, core, ActivityLogLocalPrefix+"entity/1111/3")
 	expectMissingSegment(t, core, ActivityLogLocalPrefix+"directtokens/1111/1")
 }
 
@@ -2317,9 +2514,23 @@ func TestActivityLog_EndOfMonth(t *testing.T) {
 	// We only want *fake* end of months, *real* ones are too scary.
 	timeutil.SkipAtEndOfMonth(t)
 
-	core, _, _ := TestCoreUnsealed(t)
-	a := core.activityLog
+	t.Parallel()
+
+	storage := &logical.InmemStorage{}
+	coreConfig := &CoreConfig{
+		CredentialBackends: map[string]logical.Factory{
+			"userpass": userpass.Factory,
+		},
+		Physical: storage.Underlying(),
+	}
+
+	cluster := NewTestCluster(t, coreConfig, nil)
+	core := cluster.Cores[0].Core
+	TestWaitActive(t, core)
+
 	ctx := namespace.RootContext(nil)
+
+	a := core.activityLog
 
 	// Make sure we're enabled.
 	a.SetConfig(ctx, activityConfig{
@@ -2331,7 +2542,20 @@ func TestActivityLog_EndOfMonth(t *testing.T) {
 	id1 := "11111111-1111-1111-1111-111111111111"
 	id2 := "22222222-2222-2222-2222-222222222222"
 	id3 := "33333333-3333-3333-3333-333333333333"
+	id4 := "44444444-4444-4444-4444-444444444444"
 	a.AddEntityToFragment(id1, "root", time.Now().Unix())
+
+	// add local data
+	localMountEntry := &MountEntry{
+		Table:    credentialTableType,
+		Path:     "localUserpass/",
+		Local:    true,
+		Type:     "userpass",
+		Accessor: "localMountAccessor",
+	}
+	err := core.enableCredential(ctx, localMountEntry)
+	require.NoError(t, err)
+	a.AddClientToFragment(id4, "root", time.Now().Unix(), false, "localMountAccessor")
 
 	month0 := time.Now().UTC()
 	segment0 := a.GetStartTimestamp()
@@ -2345,10 +2569,12 @@ func TestActivityLog_EndOfMonth(t *testing.T) {
 	path := fmt.Sprintf("%ventity/%v/0", ActivityLogPrefix, segment0)
 	protoSegment := readSegmentFromStorage(t, core, path)
 	out := &activity.EntityActivityLog{}
-	err := proto.Unmarshal(protoSegment.Value, out)
+	err = proto.Unmarshal(protoSegment.Value, out)
 	if err != nil {
 		t.Fatal(err)
 	}
+	expectedEntityIDs(t, out, []string{id1, id4})
+
 	path = fmt.Sprintf("%ventity/%v/0", ActivityGlobalLogPrefix, segment0)
 	protoSegment = readSegmentFromStorage(t, core, path)
 	out = &activity.EntityActivityLog{}
@@ -2356,6 +2582,16 @@ func TestActivityLog_EndOfMonth(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	expectedEntityIDs(t, out, []string{id1})
+
+	path = fmt.Sprintf("%ventity/%v/0", ActivityLogLocalPrefix, segment0)
+	protoSegment = readSegmentFromStorage(t, core, path)
+	out = &activity.EntityActivityLog{}
+	err = proto.Unmarshal(protoSegment.Value, out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedEntityIDs(t, out, []string{id4})
 
 	segment1 := a.GetStartTimestamp()
 	expectedTimestamp := timeutil.StartOfMonth(month1).Unix()
@@ -2400,16 +2636,21 @@ func TestActivityLog_EndOfMonth(t *testing.T) {
 
 	// Check all three segments still present, with correct entities
 	testCases := []struct {
-		SegmentTimestamp  int64
-		ExpectedEntityIDs []string
+		SegmentTimestamp        int64
+		ExpectedGlobalEntityIDs []string
+		ExpectedLocalEntityIDs  []string
 	}{
-		{segment0, []string{id1}},
-		{segment1, []string{id2}},
-		{segment2, []string{id3}},
+		{segment0, []string{id1}, []string{id4}},
+		{segment1, []string{id2}, []string{}},
+		{segment2, []string{id3}, []string{}},
 	}
 
 	for i, tc := range testCases {
 		t.Logf("checking segment %v timestamp %v", i, tc.SegmentTimestamp)
+
+		expectedAllEntities := make([]string, 0)
+		expectedAllEntities = append(expectedAllEntities, tc.ExpectedGlobalEntityIDs...)
+		expectedAllEntities = append(expectedAllEntities, tc.ExpectedLocalEntityIDs...)
 		path := fmt.Sprintf("%ventity/%v/0", ActivityLogPrefix, tc.SegmentTimestamp)
 		protoSegment := readSegmentFromStorage(t, core, path)
 		out := &activity.EntityActivityLog{}
@@ -2417,7 +2658,7 @@ func TestActivityLog_EndOfMonth(t *testing.T) {
 		if err != nil {
 			t.Fatalf("could not unmarshal protobuf: %v", err)
 		}
-		expectedEntityIDs(t, out, tc.ExpectedEntityIDs)
+		expectedEntityIDs(t, out, expectedAllEntities)
 
 		// Check for global entities at global storage path
 		path = fmt.Sprintf("%ventity/%v/0", ActivityGlobalLogPrefix, tc.SegmentTimestamp)
@@ -2427,7 +2668,19 @@ func TestActivityLog_EndOfMonth(t *testing.T) {
 		if err != nil {
 			t.Fatalf("could not unmarshal protobuf: %v", err)
 		}
-		expectedEntityIDs(t, out, tc.ExpectedEntityIDs)
+		expectedEntityIDs(t, out, tc.ExpectedGlobalEntityIDs)
+
+		// Check for local entities at local storage path
+		if len(tc.ExpectedLocalEntityIDs) > 0 {
+			path = fmt.Sprintf("%ventity/%v/0", ActivityLogLocalPrefix, tc.SegmentTimestamp)
+			protoSegment = readSegmentFromStorage(t, core, path)
+			out = &activity.EntityActivityLog{}
+			err = proto.Unmarshal(protoSegment.Value, out)
+			if err != nil {
+				t.Fatalf("could not unmarshal protobuf: %v", err)
+			}
+			expectedEntityIDs(t, out, tc.ExpectedLocalEntityIDs)
+		}
 	}
 }
 
@@ -5560,6 +5813,81 @@ func TestCreateSegment_StoreSegment(t *testing.T) {
 			maxClientsPerFragment: ActivitySegmentClientCapacity,
 			global:                false,
 		},
+		{
+			testName:              "[local] max client size, drop clients",
+			numClients:            ActivitySegmentClientCapacity*2 + 1,
+			pathPrefix:            activityLocalPathPrefix,
+			maxClientsPerFragment: ActivitySegmentClientCapacity,
+			global:                false,
+		},
+		{
+			testName:              "[local, no-force] max client size, drop clients",
+			numClients:            ActivitySegmentClientCapacity*2 + 1,
+			pathPrefix:            activityLocalPathPrefix,
+			maxClientsPerFragment: ActivitySegmentClientCapacity,
+			global:                false,
+			forceStore:            true,
+		},
+		{
+			testName:              "[local] max segment size",
+			numClients:            ActivitySegmentClientCapacity,
+			pathPrefix:            activityLocalPathPrefix,
+			maxClientsPerFragment: ActivitySegmentClientCapacity,
+			global:                false,
+		},
+		{
+			testName:              "[local, no-force] max segment size",
+			numClients:            ActivitySegmentClientCapacity,
+			pathPrefix:            activityLocalPathPrefix,
+			maxClientsPerFragment: ActivitySegmentClientCapacity,
+			global:                false,
+			forceStore:            true,
+		},
+		{
+			testName:              "[local] max segment size, multiple fragments",
+			numClients:            ActivitySegmentClientCapacity,
+			pathPrefix:            activityLocalPathPrefix,
+			maxClientsPerFragment: ActivitySegmentClientCapacity - 1,
+			global:                false,
+		},
+		{
+			testName:              "[local, no-force] max segment size, multiple fragments",
+			numClients:            ActivitySegmentClientCapacity,
+			pathPrefix:            activityLocalPathPrefix,
+			maxClientsPerFragment: ActivitySegmentClientCapacity - 1,
+			global:                false,
+			forceStore:            true,
+		},
+		{
+			testName:              "[local] roll over",
+			numClients:            ActivitySegmentClientCapacity + 2,
+			pathPrefix:            activityLocalPathPrefix,
+			maxClientsPerFragment: ActivitySegmentClientCapacity,
+			global:                false,
+		},
+		{
+			testName:              "[local, no-force] roll over",
+			numClients:            ActivitySegmentClientCapacity + 2,
+			pathPrefix:            activityLocalPathPrefix,
+			maxClientsPerFragment: ActivitySegmentClientCapacity,
+			global:                false,
+			forceStore:            true,
+		},
+		{
+			testName:              "[local] max segment size, rollover multiple fragments",
+			numClients:            ActivitySegmentClientCapacity * 2,
+			pathPrefix:            activityLocalPathPrefix,
+			maxClientsPerFragment: ActivitySegmentClientCapacity - 1,
+			global:                false,
+		},
+		{
+			testName:              "[local, no-force] max segment size, rollover multiple fragments",
+			numClients:            ActivitySegmentClientCapacity * 2,
+			pathPrefix:            activityLocalPathPrefix,
+			maxClientsPerFragment: ActivitySegmentClientCapacity - 1,
+			global:                false,
+			forceStore:            true,
+		},
 	}
 
 	for _, test := range testCases {
@@ -5582,6 +5910,9 @@ func TestCreateSegment_StoreSegment(t *testing.T) {
 			segment := &a.currentGlobalSegment
 			if !test.global {
 				segment = &a.currentSegment
+				if test.pathPrefix == activityLocalPathPrefix {
+					segment = &a.currentLocalSegment
+				}
 			}
 
 			// Create segments and write to storage
@@ -5600,13 +5931,24 @@ func TestCreateSegment_StoreSegment(t *testing.T) {
 					clientTotal += len(entity.GetClients())
 				}
 			} else {
-				for {
-					entity, err := reader.ReadEntity(ctx)
-					if errors.Is(err, io.EOF) {
-						break
+				if test.pathPrefix == activityLocalPathPrefix {
+					for {
+						entity, err := reader.ReadLocalEntity(ctx)
+						if errors.Is(err, io.EOF) {
+							break
+						}
+						require.NoError(t, err)
+						clientTotal += len(entity.GetClients())
 					}
-					require.NoError(t, err)
-					clientTotal += len(entity.GetClients())
+				} else {
+					for {
+						entity, err := reader.ReadEntity(ctx)
+						if errors.Is(err, io.EOF) {
+							break
+						}
+						require.NoError(t, err)
+						clientTotal += len(entity.GetClients())
+					}
 				}
 			}
 

--- a/vault/activity_log_test.go
+++ b/vault/activity_log_test.go
@@ -646,6 +646,7 @@ func TestActivityLog_SaveEntitiesToStorageCommon(t *testing.T) {
 	ctx := namespace.RootContext(nil)
 
 	a := core.activityLog
+	a.SetEnable(true)
 	a.SetStartTimestamp(time.Now().Unix()) // set a nonzero segment
 
 	var err error
@@ -1923,7 +1924,7 @@ func setupActivityRecordsInStorage(t *testing.T, base time.Time, includeEntities
 		// append some local entity data
 		entityRecords = append(entityRecords, &activity.EntityRecord{
 			ClientID:    "44444444-4444-4444-4444-444444444444",
-			NamespaceID: "ns1",
+			NamespaceID: namespace.RootNamespaceID,
 			Timestamp:   time.Now().Unix(),
 		})
 

--- a/vault/activity_log_util_common.go
+++ b/vault/activity_log_util_common.go
@@ -427,6 +427,7 @@ type segmentReader struct {
 	tokens         *singleTypeSegmentReader
 	entities       *singleTypeSegmentReader
 	globalEntities *singleTypeSegmentReader
+	localEntities  *singleTypeSegmentReader
 }
 
 // SegmentReader is an interface that provides methods to read tokens and entities in order
@@ -434,6 +435,7 @@ type SegmentReader interface {
 	ReadToken(ctx context.Context) (*activity.TokenCount, error)
 	ReadEntity(ctx context.Context) (*activity.EntityActivityLog, error)
 	ReadGlobalEntity(ctx context.Context) (*activity.EntityActivityLog, error)
+	ReadLocalEntity(ctx context.Context) (*activity.EntityActivityLog, error)
 }
 
 func (a *ActivityLog) NewSegmentFileReader(ctx context.Context, startTime time.Time) (SegmentReader, error) {
@@ -445,11 +447,15 @@ func (a *ActivityLog) NewSegmentFileReader(ctx context.Context, startTime time.T
 	if err != nil {
 		return nil, err
 	}
+	localEntities, err := a.newSingleTypeSegmentReader(ctx, startTime, activityLocalPathPrefix+activityEntityBasePath)
+	if err != nil {
+		return nil, err
+	}
 	tokens, err := a.newSingleTypeSegmentReader(ctx, startTime, activityTokenLocalBasePath)
 	if err != nil {
 		return nil, err
 	}
-	return &segmentReader{entities: entities, globalEntities: globalEntities, tokens: tokens}, nil
+	return &segmentReader{entities: entities, globalEntities: globalEntities, localEntities: localEntities, tokens: tokens}, nil
 }
 
 func (a *ActivityLog) newSingleTypeSegmentReader(ctx context.Context, startTime time.Time, prefix string) (*singleTypeSegmentReader, error) {
@@ -520,6 +526,17 @@ func (e *segmentReader) ReadEntity(ctx context.Context) (*activity.EntityActivit
 func (e *segmentReader) ReadGlobalEntity(ctx context.Context) (*activity.EntityActivityLog, error) {
 	out := &activity.EntityActivityLog{}
 	err := e.globalEntities.nextValue(ctx, out)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// ReadLocalEntity reads a local entity from the local segment
+// If there is none available, then the error will be io.EOF
+func (e *segmentReader) ReadLocalEntity(ctx context.Context) (*activity.EntityActivityLog, error) {
+	out := &activity.EntityActivityLog{}
+	err := e.localEntities.nextValue(ctx, out)
 	if err != nil {
 		return nil, err
 	}

--- a/vault/activity_log_util_common_test.go
+++ b/vault/activity_log_util_common_test.go
@@ -998,6 +998,14 @@ func writeGlobalEntitySegment(t *testing.T, core *Core, ts time.Time, index int,
 	WriteToStorage(t, core, makeSegmentPath(t, activityGlobalPathPrefix+activityEntityBasePath, ts, index), protoItem)
 }
 
+// writeLocalEntitySegment writes a single local segment file with the given time and index for an entity
+func writeLocalEntitySegment(t *testing.T, core *Core, ts time.Time, index int, item *activity.EntityActivityLog) {
+	t.Helper()
+	protoItem, err := proto.Marshal(item)
+	require.NoError(t, err)
+	WriteToStorage(t, core, makeSegmentPath(t, activityLocalPathPrefix+activityEntityBasePath, ts, index), protoItem)
+}
+
 // writeEntitySegment writes a single segment file with the given time and index for an entity
 func writeEntitySegment(t *testing.T, core *Core, ts time.Time, index int, item *activity.EntityActivityLog) {
 	t.Helper()
@@ -1031,6 +1039,7 @@ func TestSegmentFileReader_BadData(t *testing.T) {
 	WriteToStorage(t, core, makeSegmentPath(t, activityTokenLocalBasePath, now, 0), []byte("fake data"))
 	WriteToStorage(t, core, makeSegmentPath(t, activityEntityBasePath, now, 0), []byte("fake data"))
 	WriteToStorage(t, core, makeSegmentPath(t, activityGlobalPathPrefix+activityEntityBasePath, now, 0), []byte("fake data"))
+	WriteToStorage(t, core, makeSegmentPath(t, activityLocalPathPrefix+activityEntityBasePath, now, 0), []byte("fake data"))
 
 	// write entity at index 1
 	entity := &activity.EntityActivityLog{Clients: []*activity.EntityRecord{
@@ -1042,6 +1051,9 @@ func TestSegmentFileReader_BadData(t *testing.T) {
 
 	// write global data at index 1
 	writeGlobalEntitySegment(t, core, now, 1, entity)
+
+	// write local data at index 1
+	writeLocalEntitySegment(t, core, now, 1, entity)
 
 	// write token at index 1
 	token := &activity.TokenCount{CountByNamespaceID: map[string]uint64{
@@ -1064,6 +1076,14 @@ func TestSegmentFileReader_BadData(t *testing.T) {
 	require.Error(t, err)
 	// then, the reader can read the good entity at index 1
 	gotEntity, err = reader.ReadGlobalEntity(context.Background())
+	require.True(t, proto.Equal(gotEntity, entity))
+	require.Nil(t, err)
+
+	// first the bad local entity is read, which returns an error
+	_, err = reader.ReadLocalEntity(context.Background())
+	require.Error(t, err)
+	// then, the reader can read the good entity at index 1
+	gotEntity, err = reader.ReadLocalEntity(context.Background())
 	require.True(t, proto.Equal(gotEntity, entity))
 	require.Nil(t, err)
 
@@ -1095,8 +1115,13 @@ func TestSegmentFileReader_MissingData(t *testing.T) {
 		},
 	}}
 	writeEntitySegment(t, core, now, 3, entity)
+
 	// write global entity at index 3
 	writeGlobalEntitySegment(t, core, now, 3, entity)
+
+	// write local entity at index 3
+	writeLocalEntitySegment(t, core, now, 3, entity)
+
 	// write token at index 3
 	token := &activity.TokenCount{CountByNamespaceID: map[string]uint64{
 		"ns": 1,
@@ -1110,6 +1135,7 @@ func TestSegmentFileReader_MissingData(t *testing.T) {
 		require.NoError(t, core.barrier.Delete(context.Background(), makeSegmentPath(t, activityTokenLocalBasePath, now, i)))
 		require.NoError(t, core.barrier.Delete(context.Background(), makeSegmentPath(t, activityEntityBasePath, now, i)))
 		require.NoError(t, core.barrier.Delete(context.Background(), makeSegmentPath(t, activityGlobalPathPrefix+activityEntityBasePath, now, i)))
+		require.NoError(t, core.barrier.Delete(context.Background(), makeSegmentPath(t, activityLocalPathPrefix+activityEntityBasePath, now, i)))
 	}
 
 	// we expect the reader to only return the data at index 3, and then be done
@@ -1129,6 +1155,12 @@ func TestSegmentFileReader_MissingData(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, proto.Equal(gotEntity, entity))
 	_, err = reader.ReadGlobalEntity(context.Background())
+	require.Equal(t, err, io.EOF)
+
+	gotEntity, err = reader.ReadLocalEntity(context.Background())
+	require.NoError(t, err)
+	require.True(t, proto.Equal(gotEntity, entity))
+	_, err = reader.ReadLocalEntity(context.Background())
 	require.Equal(t, err, io.EOF)
 }
 

--- a/vault/external_tests/activity_testonly/acme_regeneration_test.go
+++ b/vault/external_tests/activity_testonly/acme_regeneration_test.go
@@ -54,7 +54,7 @@ func TestACMERegeneration_RegenerateWithCurrentMonth(t *testing.T) {
 	})
 	require.NoError(t, err)
 	now := time.Now().UTC()
-	_, _, err = clientcountutil.NewActivityLogData(client).
+	_, _, _, err = clientcountutil.NewActivityLogData(client).
 		NewPreviousMonthData(3).
 		// 3 months ago, 15 non-entity clients and 10 ACME clients
 		NewClientsSeen(15, clientcountutil.WithClientType("non-entity-token")).
@@ -116,7 +116,7 @@ func TestACMERegeneration_RegenerateMuchOlder(t *testing.T) {
 	client := cluster.Cores[0].Client
 
 	now := time.Now().UTC()
-	_, _, err := clientcountutil.NewActivityLogData(client).
+	_, _, _, err := clientcountutil.NewActivityLogData(client).
 		NewPreviousMonthData(5).
 		// 5 months ago, 15 non-entity clients and 10 ACME clients
 		NewClientsSeen(15, clientcountutil.WithClientType("non-entity-token")).
@@ -159,7 +159,7 @@ func TestACMERegeneration_RegeneratePreviousMonths(t *testing.T) {
 	client := cluster.Cores[0].Client
 
 	now := time.Now().UTC()
-	_, _, err := clientcountutil.NewActivityLogData(client).
+	_, _, _, err := clientcountutil.NewActivityLogData(client).
 		NewPreviousMonthData(3).
 		// 3 months ago, 15 non-entity clients and 10 ACME clients
 		NewClientsSeen(15, clientcountutil.WithClientType("non-entity-token")).

--- a/vault/external_tests/activity_testonly/activity_testonly_oss_test.go
+++ b/vault/external_tests/activity_testonly/activity_testonly_oss_test.go
@@ -29,7 +29,7 @@ func Test_ActivityLog_Disable(t *testing.T) {
 		"enabled": "enable",
 	})
 	require.NoError(t, err)
-	_, _, err = clientcountutil.NewActivityLogData(client).
+	_, _, _, err = clientcountutil.NewActivityLogData(client).
 		NewPreviousMonthData(1).
 		NewClientsSeen(5).
 		NewCurrentMonthData().

--- a/vault/external_tests/activity_testonly/activity_testonly_test.go
+++ b/vault/external_tests/activity_testonly/activity_testonly_test.go
@@ -86,7 +86,7 @@ func Test_ActivityLog_LoseLeadership(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	_, _, err = clientcountutil.NewActivityLogData(client).
+	_, _, _, err = clientcountutil.NewActivityLogData(client).
 		NewCurrentMonthData().
 		NewClientsSeen(10).
 		Write(context.Background(), generation.WriteOptions_WRITE_ENTITIES)
@@ -121,7 +121,7 @@ func Test_ActivityLog_ClientsOverlapping(t *testing.T) {
 		"enabled": "enable",
 	})
 	require.NoError(t, err)
-	_, _, err = clientcountutil.NewActivityLogData(client).
+	_, _, _, err = clientcountutil.NewActivityLogData(client).
 		NewPreviousMonthData(1).
 		NewClientsSeen(7).
 		NewCurrentMonthData().
@@ -169,7 +169,7 @@ func Test_ActivityLog_ClientsNewCurrentMonth(t *testing.T) {
 		"enabled": "enable",
 	})
 	require.NoError(t, err)
-	_, _, err = clientcountutil.NewActivityLogData(client).
+	_, _, _, err = clientcountutil.NewActivityLogData(client).
 		NewPreviousMonthData(1).
 		NewClientsSeen(5).
 		NewCurrentMonthData().
@@ -203,7 +203,7 @@ func Test_ActivityLog_EmptyDataMonths(t *testing.T) {
 		"enabled": "enable",
 	})
 	require.NoError(t, err)
-	_, _, err = clientcountutil.NewActivityLogData(client).
+	_, _, _, err = clientcountutil.NewActivityLogData(client).
 		NewCurrentMonthData().
 		NewClientsSeen(10).
 		Write(context.Background(), generation.WriteOptions_WRITE_PRECOMPUTED_QUERIES, generation.WriteOptions_WRITE_ENTITIES)
@@ -243,7 +243,7 @@ func Test_ActivityLog_FutureEndDate(t *testing.T) {
 		"enabled": "enable",
 	})
 	require.NoError(t, err)
-	_, _, err = clientcountutil.NewActivityLogData(client).
+	_, _, _, err = clientcountutil.NewActivityLogData(client).
 		NewPreviousMonthData(1).
 		NewClientsSeen(10).
 		NewCurrentMonthData().
@@ -316,7 +316,7 @@ func Test_ActivityLog_ClientTypeResponse(t *testing.T) {
 			_, err := client.Logical().Write("sys/internal/counters/config", map[string]interface{}{
 				"enabled": "enable",
 			})
-			_, _, err = clientcountutil.NewActivityLogData(client).
+			_, _, _, err = clientcountutil.NewActivityLogData(client).
 				NewCurrentMonthData().
 				NewClientsSeen(10, clientcountutil.WithClientType(tc.clientType)).
 				Write(context.Background(), generation.WriteOptions_WRITE_ENTITIES)
@@ -369,7 +369,7 @@ func Test_ActivityLogCurrentMonth_Response(t *testing.T) {
 			_, err := client.Logical().Write("sys/internal/counters/config", map[string]interface{}{
 				"enabled": "enable",
 			})
-			_, _, err = clientcountutil.NewActivityLogData(client).
+			_, _, _, err = clientcountutil.NewActivityLogData(client).
 				NewCurrentMonthData().
 				NewClientsSeen(10, clientcountutil.WithClientType(tc.clientType)).
 				Write(context.Background(), generation.WriteOptions_WRITE_ENTITIES)
@@ -420,7 +420,7 @@ func Test_ActivityLog_Deduplication(t *testing.T) {
 			_, err := client.Logical().Write("sys/internal/counters/config", map[string]interface{}{
 				"enabled": "enable",
 			})
-			_, _, err = clientcountutil.NewActivityLogData(client).
+			_, _, _, err = clientcountutil.NewActivityLogData(client).
 				NewPreviousMonthData(3).
 				NewClientsSeen(10, clientcountutil.WithClientType(tc.clientType)).
 				NewPreviousMonthData(2).
@@ -462,7 +462,7 @@ func Test_ActivityLog_MountDeduplication(t *testing.T) {
 	require.NoError(t, err)
 	now := time.Now().UTC()
 
-	_, _, err = clientcountutil.NewActivityLogData(client).
+	_, localPaths, globalPaths, err := clientcountutil.NewActivityLogData(client).
 		NewPreviousMonthData(1).
 		NewClientSeen(clientcountutil.WithClientMount("sys")).
 		NewClientSeen(clientcountutil.WithClientMount("secret")).
@@ -473,6 +473,10 @@ func Test_ActivityLog_MountDeduplication(t *testing.T) {
 		NewClientSeen(clientcountutil.WithClientMount("sys")).
 		Write(context.Background(), generation.WriteOptions_WRITE_PRECOMPUTED_QUERIES, generation.WriteOptions_WRITE_ENTITIES)
 	require.NoError(t, err)
+	// cubbyhole is local, 2 segments must exist for 2 months seen
+	require.Len(t, localPaths, 2)
+	// 2 global segments must exist for 2 months seen
+	require.Len(t, globalPaths, 2)
 
 	resp, err := client.Logical().ReadWithData("sys/internal/counters/activity", map[string][]string{
 		"end_time":   {timeutil.EndOfMonth(now).Format(time.RFC3339)},
@@ -669,7 +673,7 @@ func Test_ActivityLog_Export_Sudo(t *testing.T) {
 
 	rootToken := client.Token()
 
-	_, _, err = clientcountutil.NewActivityLogData(client).
+	_, _, _, err = clientcountutil.NewActivityLogData(client).
 		NewCurrentMonthData().
 		NewClientsSeen(10).
 		Write(context.Background(), generation.WriteOptions_WRITE_ENTITIES)
@@ -845,7 +849,7 @@ func TestHandleQuery_MultipleMounts(t *testing.T) {
 			}
 
 			// Write all the client count data
-			_, _, err = activityLogGenerator.Write(context.Background(), generation.WriteOptions_WRITE_PRECOMPUTED_QUERIES, generation.WriteOptions_WRITE_ENTITIES)
+			_, _, _, err = activityLogGenerator.Write(context.Background(), generation.WriteOptions_WRITE_PRECOMPUTED_QUERIES, generation.WriteOptions_WRITE_ENTITIES)
 			require.NoError(t, err)
 
 			endOfCurrentMonth := timeutil.EndOfMonth(time.Now().UTC())


### PR DESCRIPTION
### Description
What does this PR do?
Saves all the local clients in local fragment to local segments and stores them in local/log/ entity
Jira: https://hashicorp.atlassian.net/browse/VAULT-31234
Ent approved PR: https://github.com/hashicorp/vault-enterprise/pull/7003

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
