### PR TITLE
[DOCS] Move the tutorial content to the doc

### DIFF
--- a/website/content/docs/auth/approle/approle-pattern.mdx
+++ b/website/content/docs/auth/approle/approle-pattern.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: AppRole recommended pattern
+page_title: AppRole recommended pattern and best practices
 description: >-
   The recommended pattern and best practices when you are using AppRole auth method to validate the identity of your application workloads.
 ---
 
-# AppRole recommended pattern
+# AppRole recommended pattern and best practices
 
 At the core of Vault's usage is authentication and authorization. Understanding the methods that Vault surfaces these to the client is the key to understanding how to configure and manage Vault.
 
@@ -14,10 +14,6 @@ At the core of Vault's usage is authentication and authorization. Understanding 
 - Vault provides authorization to a client by the use of [policies](/vault/docs/concepts/policies).
 
 Vault provides several internal and external authentication methods. External methods are called _trusted third-party authenticators_ such as AWS, LDAP, GitHub, and so on. A trusted third-party authenticator is not available in some situations, so Vault has an alternate approach which is **AppRole**. If another platform method of authentication is available via a trusted third-party authenticator, the best practice is to use that instead of AppRole.
-
-This guide will detail the high-level concepts of AppRole and outline two detailed uses following the recommended patterns explored in the high-level concepts. This guide will also detail anti-patterns to help readers avoid insecure use of this feature.
-
-## Vault best practice
 
 This guide relies heavily on two fundamental principles for Vault: limiting both the blast-radius of an identity and the duration of authentication.
 
@@ -29,21 +25,21 @@ Vault is an identity-based secrets management solution, where access to a secret
 
 When Vault verifies an entity's identity, Vault then provides that entity with a [token](/vault/docs/concepts/tokens). The client uses this token for all subsequent interactions with Vault to prove authentication, so this token should be both handled securely and have a limited lifetime. A token should only live for as long as access to the secrets it authorizes access to are needed.
 
-## Glossary
+## Glossary of terms
 
 - **Authentication** - The process of confirming identity. Often abbreviated to _AuthN_
 - **Authorization** - The process of verifying what an entity has access to and at what level. Often abbreviated to _AuthZ_
-- **RoleID** - The semi-secret identifier for the role that will authenticate to Vault. Think of this as the username portion of an authentication pair.
-- **SecretID** - The secret identifier for the role that will authenticate to Vault. Think of this as the password portion of an authentication pair.
+- **RoleID** - The semi-secret identifier for the role that will authenticate to Vault. Think of this as the _username_ portion of an authentication pair.
+- **SecretID** - The secret identifier for the role that will authenticate to Vault. Think of this as the _password_ portion of an authentication pair.
 - **AppRole role** - The role configured in Vault that contains the authorization and usage parameters for the authentication.
 
-## AppRole auth method overview
+## What is AppRole auth method?
 
 The AppRole authentication method is for machine authentication to Vault. Because AppRole is designed to be flexible, it has many ways to be configured. The burden of security is on the configurator rather than a trusted third party, as is the case in other Vault auth methods.
 
 AppRole is not a trusted third-party authenticator, but a _trusted broker_ method. The difference is that in AppRole authentication, the onus of trust rests in a securely-managed broker system that brokers authentication between clients and Vault.
 
-The central tenet of this security is that during the brokering of the authentication to Vault, the RoleID and SecretID are only ever together on the end-user system that needs to consume the secret.
+The central tenet of this security is that during the brokering of the authentication to Vault, the **RoleID** and **SecretID** are only ever together on the end-user system that needs to consume the secret.
 
 In an AppRole authentication, there are three players:
 
@@ -51,16 +47,146 @@ In an AppRole authentication, there are three players:
 - **The broker** - This is the trusted and secured system that brokers the authentication.
 - **The secret consumer** - This is the final consumer of the secret from Vault.
 
-## AppRole in a CI pipeline
 
-In this scenario, the CI needs to run a job requiring some data classified as secret and stored in Vault. The CI has a master and a worker node (such as Jenkins). The worker node runs jobs on spawned container runners that are short-lived. The process here should be:
+## Platform credential delivery method
 
-1. CI Worker authenticates to Vault
+To prevent any one system, other than the target client, from obtaining the complete set of credentials (RoleID and SecretID), the recommended implementation is to deliver those values separately through two different channels. This enables you to provide narrowly-scoped tokens to each trusted orchestrator to access either RoleID or SecretID, but never both.
+
+### RoleID delivery best practices
+
+RoleID is an identifier that selects the AppRole against which the other credentials are evaluated. Think of it as a username for an application; therefore, RoleID is not a secret value. It's a static UUID that identifies a specific role configuration. Generally, you create a role per application to ensure that each application will have a unique RoleID.
+
+Because it is not a secret, you can embed the RoleID value into a machine image or container as a text file or environment variable.
+
+For example:
+
+- Build an image with [Packer](/packer/tutorials/) with RoleID stored as an environment variable.
+- Use [Terraform](/terraform/tutorials/) to provision a machine embedded with RoleID.
+
+There are a number of different patterns through which this value can be delivered.
+
+The application running on the machine or container will read the RoleID from the file or environment variable to authenticate with Vault.
+
+#### Policy requirement
+
+An appropriate policy is required to read RoleID from Vault. For example, to get the RoleID for a role named, "jenkins", the policy should look as below.
+
+```hcl
+# Grant 'read' permission on the 'auth/approle/role/<role_name>/role-id' path
+path "auth/approle/role/jenkins/role-id" {
+   capabilities = [ "read" ]
+}
+```
+
+### SecretID delivery best practices
+
+SecretID is a credential that is required by default for any login and is intended to always be secret. While RoleID is similar to a username, SecretID is equivalent to a password for its corresponding RoleID.
+
+There are two additional considerations when distributing the SecretID, since it is a secret and should be secured so that only the intended recipient is able to read it.
+
+1. Binding CIDRs
+1. AppRole response wrapping
+
+#### Binding CIDRs
+
+When defining an AppRole, you can use the [`secretid_bound_cidrs`](/vault/api-docs/auth/approle#secret_id_bound_cidrs) parameter to specify blocks of IP addresses which can perform the login operation for this role. You can further limit the IP range per token using [`token_bound_cidrs`](/vault/api-docs/auth/approle#token_bound_cidrs).
+
+**Example:**
+
+```shell-session
+$ vault write auth/approle/role/jenkins \
+      secret_id_bound_cidrs="0.0.0.0/0","127.0.0.1/32" \
+      secret_id_ttl=60m \
+      secret_id_num_uses=5 \
+      enable_local_secret_ids=false \
+      token_bound_cidrs="0.0.0.0/0","127.0.0.1/32" \
+      token_num_uses=10 \
+      token_ttl=1h \
+      token_max_ttl=3h \
+      token_type=default \
+      period="" \
+      policies="default","test"
+```
+
+<Tip title="CIDR consideration">
+
+While there is no hard limit to how many CIDR blocks you can set using the
+`token_bound_cidrs` parameter, there are limiting factors. One is the amount of
+time it takes for the Vault to compare an IP with the list provided. Another is
+the maximum request size of the HTTP when you create the list.
+
+</Tip>
+
+#### AppRole response wrapping
+
+To guarantee confidentiality, integrity, and non-repudiation of SecretID, you can use the `-wrap-ttl` flag when generating the SecretID. Instead of providing the SecretID in plaintext, it puts it into a new token’s Cubbyhole with a token use count of 1. When the application attempts to read the SecretID, we can guarantee that only this application can read it.
+
+**Example:** The following CLI command retrieves the SecretID for a role named, "jenkins". The generated SecretID is wrapped in a token which is valid for 60 seconds to unwrap.
+
+```shell-session
+$ vault write -wrap-ttl=60s -force auth/approle/role/jenkins/secret-id
+
+Key                              Value
+---                              -----
+wrapping_token:                  s.yzbznr9NlZNzsgEtz3SI56pX
+wrapping_accessor:               Smi4CO0Sdhn8FJvL8XvOT30y
+wrapping_token_ttl:              1m
+wrapping_token_creation_time:    2021-06-07 20:02:01.019838 -0700 PDT
+wrapping_token_creation_path:    auth/approle/role/jenkins/secret-id
+```
+
+Finally, you can monitor your audit logs for attempted read access of your SecretID. If Vault throws a use-limit error when an application tries to read the SecretID, you know that someone else has read the SecretID and alert on that. The audit logs will indicate where the SecretID read attempt originated.
+
+#### Policy requirement
+
+An appropriate policy is required to read SecretID from Vault. For example, to get the SecretID for a role named, "jenkins", the policy should look as below.
+
+```hcl
+# Grant 'update' permission on the 'auth/approle/role/<role_name>/secret-id' path
+path "auth/approle/role/jenkins/secret-id" {
+   capabilities = [ "update" ]
+}
+```
+
+## Token lifetime considerations
+
+Tokens must be maintained client side and upon expiration can be renewed. For short lived workflows, traditionally tokens would be created with a lifetime that would match the average deploy time and left to expire, securing new tokens with each deployment.
+
+A long token time-to-live (TTL) can cause out of memory when trying to purge millions of AppRole leases. To avoid this, we recommend that you reduce TTLs for AppRole tokens and implement token renewal where possible. You can increase the memory on the Vault server; however, it won't be a long-term solution.
+
+In general, with any auth method, it's preferable for applications to keep using the same Vault token to fetch secrets repeatedly instead of a new authentication each time. Authentication is an expensive operation and results in a token that Vault must keep track of. If high authentication throughput, 1000s of authentications per second, are expected we recommend using batch tokens which are issued from memory and do not consume storage.
+
+### Vault Agent
+
+Consider running [Vault Agent](/vault/docs/agent-and-proxy/agent) on the client host, and let the agent manage the token's lifecycle. Vault Agent reduces the number of tokens used by the client applications. In addition, it eliminates the need to implement the Vault APIs to authenticate with Vault and renew the token TTL if necessary.
+
+To learn more about Vault Agent, read the following tutorials:
+
+- [Vault Agent with AWS](/vault/tutorials/vault-agent/agent-aws)
+- [Vault Agent with Kubernetes](/vault/tutorials/kubernetes/agent-kubernetes)
+- [Vault Agent Templates](/vault/tutorials/vault-agent/agent-templates)
+- [Vault Agent Caching](/vault/tutorials/vault-agent/agent-caching)
+
+## Jenkins CI/CD
+
+When you are using Jenkins as a CI tool, Jenkins itself will need an identity; however, you should never have Jenkins log into Vault and pass a client token to the application via workflow. Jenkins needs to give the application its own identity so that the application gets its own secret. The best practice is to use the Vault Agent as much as possible with Jenkins so that Vault token is not managed by Jenkins. You can deliver a SecretID every morning or before every run for x number of uses. Let Vault Agent authenticate with Vault and get the token for Jenkins. Then, Jenkins uses that token for x number of operations against Vault.
+
+A key benefit of AppRole for applications is that it enables you to more easily migrate the application between platforms.
+
+When you use an AppRole for the application, the best practice is to obscure the RoleID from Jenkins but allow Jenkins to deliver a wrapped SecretID to the application. 
+
+### Example scenario
+
+Jenkins needs to run a job requiring some data classified as secret and stored in Vault. It has a master and a worker node where the worker node runs jobs on spawned container runners that are short-lived. 
+
+The process would look like:
+
+1. Jenkins worker authenticates to Vault
 2. Vault returns a token
-3. Worker uses token to retrieve a wrapped secretID for the **role** of the job it will spawn
-4. Wrapped secretID returned by Vault
-5. Worker spawns job runner and passes wrapped secretID as a variable to the job
-6. Runner container requests unwrap of secretID
+3. Worker uses token to retrieve a wrapped SecretID for the **role** of the job it will spawn
+4. Wrapped SecretID returned by Vault
+5. Worker spawns job runner and passes wrapped SecretID as a variable to the job
+6. Runner container requests unwrap of SecretID
 7. Vault returns SecretID
 8. Runner uses RoleID and SecretID to authenticate to Vault
 9. Vault returns a token with policies that allow read of the required secrets
@@ -72,7 +198,7 @@ Here are more details on the more complicated steps of that process.
 
 <Note title="Secrets wrapping">
 
-If you are unfamiliar with secrets wrapping, refer to the [response wraping](/vault/docs/concepts/response-wrapping) documentation and the [Cubbyhole response wrapping](/vault/tutorials/secrets-management/cubbyhole-response-wrapping) tutorial.
+If you are unfamiliar with secrets wrapping, refer to the [response wraping](/vault/docs/concepts/response-wrapping) documentation.
 
 </Note>
 
@@ -181,8 +307,6 @@ In both cases, this shows that the trusted-broker workflow has likely been compr
 ## Reference materials
 
 - [How (and Why) to Use AppRole Correctly in HashiCorp Vault](https://www.hashicorp.com/blog/how-and-why-to-use-approle-correctly-in-hashicorp-vault)
-- [AppRole pull authentication](/vault/tutorials/auth-methods/approle) tutorial
 - [Response wrapping concept](/vault/docs/concepts/response-wrapping)
-- [Cubbyhole response wrapping](/vault/tutorials/secrets-management/cubbyhole-response-wrapping) tutorial
-- [ACL policies](/vault/tutorials/policies/policies)
+- [ACL policies](/vault/docs/concepts/policies)
 - [Token periods and TTLs](/vault/docs/concepts/tokens#token-time-to-live-periodic-tokens-and-explicit-max-ttls)


### PR DESCRIPTION
### Description

🎫 [Jira](https://hashicorp.atlassian.net/browse/SPE-1080)

This PR moves the contents of the [AppRole usage best practices](https://developer.hashicorp.com/vault/tutorials/auth-methods/approle-best-practices) tutorial to the appropriate docs page.

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
