### PR TITLE
Migrate `FlightIcon` to `Hds::Icon`

### DIFF
--- a/ui/app/components/dashboard/replication-state-text.hbs
+++ b/ui/app/components/dashboard/replication-state-text.hbs
@@ -23,8 +23,9 @@
     >
       {{or @state "not set up"}}
 
-      <FlightIcon
+      <Hds::Icon
         @name={{or @clusterStates.glyph "x-circle"}}
+        @isInline={{true}}
         class={{if @clusterStates.isOk "has-text-success" "has-text-danger"}}
       />
     </T.Trigger>

--- a/ui/app/styles/components/empty-state-component.scss
+++ b/ui/app/styles/components/empty-state-component.scss
@@ -57,7 +57,7 @@
 }
 
 .empty-state-icon > .hs-icon,
-.empty-state-icon > .flight-icon {
+.empty-state-icon > .hds-icon {
   float: left;
   margin-right: $spacing-8;
 }

--- a/ui/app/styles/components/icon.scss
+++ b/ui/app/styles/components/icon.scss
@@ -20,8 +20,8 @@
   color: $blue;
 }
 
-.flight-icon {
-  &.flight-icon-display-inline {
+.hds-icon {
+  &.hds-icon--is-inline {
     vertical-align: middle;
     margin-left: $spacing-4;
     margin-right: $spacing-4;

--- a/ui/app/templates/components/okta-number-challenge.hbs
+++ b/ui/app/templates/components/okta-number-challenge.hbs
@@ -20,7 +20,7 @@
       </h1>
     {{else}}
       <div class="has-top-margin-l has-bottom-margin-m is-flex-row">
-        <FlightIcon @name="loading" />
+        <Hds::Icon @name="loading" @isInline={{true}} />
         <p class="has-left-margin-xs" data-test-loading>Please wait...</p>
       </div>
     {{/if}}

--- a/ui/ember-cli-build.js
+++ b/ui/ember-cli-build.js
@@ -50,7 +50,6 @@ const appConfig = {
     precision: 4,
     includePaths: [
       './node_modules/@hashicorp/design-system-components/dist/styles',
-      './node_modules/@hashicorp/ember-flight-icons/dist/styles',
       './node_modules/@hashicorp/design-system-tokens/dist/products/css',
     ],
   },

--- a/ui/lib/core/addon/components/form-field.hbs
+++ b/ui/lib/core/addon/components/form-field.hbs
@@ -43,7 +43,7 @@
                 {{or val.label val.value val}}
                 {{#if val.helpText}}
                   <Hds::TooltipButton @text={{val.helpText}} aria-label="More information">
-                    <FlightIcon @name="info" />
+                    <Hds::Icon @name="info" @isInline={{true}} />
                   </Hds::TooltipButton>
                 {{/if}}
                 {{#if this.hasRadioSubText}}

--- a/ui/lib/core/addon/components/icon.hbs
+++ b/ui/lib/core/addon/components/icon.hbs
@@ -4,7 +4,7 @@
 ~}}
 
 {{#if this.isFlightIcon}}
-  <FlightIcon @name={{@name}} @size={{this.size}} @stretched={{@stretched}} ...attributes />
+  <Hds::Icon @name={{@name}} @size={{this.size}} @stretched={{@stretched}} @isInline={{true}} ...attributes />
 {{else}}
   <span class="hs-icon {{this.hsIconClass}}" aria-hidden="true" ...attributes>
     {{svg-jar @name}}

--- a/ui/lib/core/addon/components/icon.hbs
+++ b/ui/lib/core/addon/components/icon.hbs
@@ -3,7 +3,7 @@
   SPDX-License-Identifier: BUSL-1.1
 ~}}
 
-{{#if this.isFlightIcon}}
+{{#if this.isHdsIcon}}
   <Hds::Icon @name={{@name}} @size={{this.size}} @stretched={{@stretched}} @isInline={{true}} ...attributes />
 {{else}}
   <span class="hs-icon {{this.hsIconClass}}" aria-hidden="true" ...attributes>

--- a/ui/lib/core/addon/components/icon.js
+++ b/ui/lib/core/addon/components/icon.js
@@ -34,8 +34,8 @@ export default class IconComponent extends Component {
     return this.args.size || '16';
   }
 
-  // favor flight icon set and fall back to structure icons if not found
-  get isFlightIcon() {
+  // favor HDS icon set and fall back to structure icons if not found
+  get isHdsIcon() {
     return this.args.name ? flightIconNames.includes(this.args.name) : false;
   }
 

--- a/ui/lib/core/addon/components/stat-text.hbs
+++ b/ui/lib/core/addon/components/stat-text.hbs
@@ -12,7 +12,7 @@
     {{@label}}
     {{#if @tooltipText}}
       <Hds::TooltipButton @text={{@tooltipText}} aria-label="more information about {{@label}}">
-        <FlightIcon @name="info" />
+        <Hds::Icon @name="info" @isInline={{true}} />
       </Hds::TooltipButton>
     {{/if}}
   </div>

--- a/ui/lib/core/addon/components/string-list.hbs
+++ b/ui/lib/core/addon/components/string-list.hbs
@@ -53,7 +53,7 @@
         {{/if}}
       </div>
       {{#if (includes index this.indicesWithComma)}}
-        <FlightIcon @name="alert-triangle" @color="var(--token-color-foreground-warning)" @size="24" />
+        <Hds::Icon @name="alert-triangle" @color="var(--token-color-foreground-warning)" @size="24" @isInline={{true}} />
       {{/if}}
     </div>
   {{/each}}

--- a/ui/lib/core/package.json
+++ b/ui/lib/core/package.json
@@ -24,7 +24,6 @@
     "ember-svg-jar": "*",
     "ember-truth-helpers": "*",
     "escape-string-regexp": "*",
-    "@hashicorp/ember-flight-icons": "*",
     "@hashicorp/flight-icons": "*",
     "@hashicorp/design-system-components": "*",
     "codemirror": "*",

--- a/ui/lib/sync/addon/components/secrets/page/overview.hbs
+++ b/ui/lib/sync/addon/components/secrets/page/overview.hbs
@@ -99,7 +99,7 @@
                   aria-label="More information"
                   class="is-v-centered"
                 >
-                  <FlightIcon @name="info" />
+                  <Hds::Icon @name="info" @isInline={{true}} />
                 </Hds::TooltipButton>
               </H.Th>
               <H.Th @align="right">Last updated</H.Th>

--- a/ui/package.json
+++ b/ui/package.json
@@ -234,7 +234,6 @@
   "dependencies": {
     "@babel/core": "^7.24.0",
     "@hashicorp/design-system-components": "~4.13.0",
-    "@hashicorp/ember-flight-icons": "^5.1.3",
     "ember-auto-import": "^2.7.2",
     "handlebars": "4.7.7",
     "highlight.js": "^10.4.1",

--- a/ui/tests/acceptance/mfa-login-enforcement-test.js
+++ b/ui/tests/acceptance/mfa-login-enforcement-test.js
@@ -106,7 +106,7 @@ module('Acceptance | mfa-login-enforcement', function (hooks) {
     assert.dom('[data-test-list-item]').exists({ count: enforcements.length }, 'Enforcements list renders');
     assert
       .dom(`[data-test-list-item="${item.name}"] svg`)
-      .hasClass('flight-icon-lock', 'Lock icon renders for list item');
+      .hasClass('hds-icon-lock', 'Lock icon renders for list item');
     assert.dom(`[data-test-list-item-title="${item.name}"]`).hasText(item.name, 'Enforcement name renders');
 
     await click('[data-test-popup-menu-trigger]');
@@ -132,7 +132,7 @@ module('Acceptance | mfa-login-enforcement', function (hooks) {
     await click(`[data-test-list-item="${enforcement.name}"]`);
     // heading
     assert.dom('h1').includesText(enforcement.name, 'Name renders in title');
-    assert.dom('h1 svg').hasClass('flight-icon-lock', 'Lock icon renders in title');
+    assert.dom('h1 svg').hasClass('hds-icon-lock', 'Lock icon renders in title');
     assert.dom('[data-test-tab="targets"]').hasClass('active', 'Targets tab is active by default');
     await waitFor('[data-test-target]', { timeout: 5000 });
     assert.dom('[data-test-target]').exists({ count: 4 }, 'Targets render in list');

--- a/ui/tests/integration/components/chevron-test.js
+++ b/ui/tests/integration/components/chevron-test.js
@@ -17,13 +17,13 @@ module('Integration | Component | chevron', function (hooks) {
     // Handle any actions with this.set('myAction', function(val) { ... });
 
     await render(hbs`<Chevron />`);
-    assert.dom('.flight-icon').exists('renders');
+    assert.dom('.hds-icon').exists('renders');
 
     await render(hbs`<Chevron @isButton={{true}} />`);
-    assert.dom('.flight-icon').hasClass('hs-icon-button-right', 'renders');
+    assert.dom('.hds-icon').hasClass('hs-icon-button-right', 'renders');
 
     await render(hbs`<Chevron @direction='left' @isButton={{true}} />`);
-    assert.dom('.flight-icon').doesNotHaveClass('hs-icon-button-right', 'renders');
+    assert.dom('.hds-icon').doesNotHaveClass('hs-icon-button-right', 'renders');
 
     const promise = waitForError();
     render(hbs`<Chevron @direction='lol' />`);

--- a/ui/tests/integration/components/icon-test.js
+++ b/ui/tests/integration/components/icon-test.js
@@ -54,11 +54,11 @@ module('Integration | Component | icon', function (hooks) {
     );
   });
 
-  test('it should render FlightIcon', async function (assert) {
+  test('it should render Hds::Icon', async function (assert) {
     assert.expect(3);
 
     await render(hbs`<Icon @name="x" />`);
-    assert.dom('.hds-icon').exists('FlightIcon renders when provided name of icon in set');
+    assert.dom('.hds-icon').exists('Hds::Icon renders when provided name of icon in set');
     assert.dom('.hds-icon').hasAttribute('width', '16', 'Default size applied svg');
 
     await render(hbs`<Icon @name="x" @size="24" />`);

--- a/ui/tests/integration/components/icon-test.js
+++ b/ui/tests/integration/components/icon-test.js
@@ -58,10 +58,10 @@ module('Integration | Component | icon', function (hooks) {
     assert.expect(3);
 
     await render(hbs`<Icon @name="x" />`);
-    assert.dom('.flight-icon').exists('FlightIcon renders when provided name of icon in set');
-    assert.dom('.flight-icon').hasAttribute('width', '16', 'Default size applied svg');
+    assert.dom('.hds-icon').exists('FlightIcon renders when provided name of icon in set');
+    assert.dom('.hds-icon').hasAttribute('width', '16', 'Default size applied svg');
 
     await render(hbs`<Icon @name="x" @size="24" />`);
-    assert.dom('.flight-icon').hasAttribute('width', '24', 'Size applied to svg');
+    assert.dom('.hds-icon').hasAttribute('width', '24', 'Size applied to svg');
   });
 });

--- a/ui/tests/integration/components/info-table-row-test.js
+++ b/ui/tests/integration/components/info-table-row-test.js
@@ -133,17 +133,17 @@ module('Integration | Component | InfoTableRow', function (hooks) {
       @defaultShown={{this.default}}
     />`);
 
-    assert.dom('div.column.is-one-quarter .flight-icon').exists('Renders a dash (-) for the label');
+    assert.dom('div.column.is-one-quarter .hds-icon').exists('Renders a dash (-) for the label');
 
     this.set('value', '');
     this.set('label', LABEL);
-    assert.dom('div.column.is-flex-center .flight-icon').exists('Renders a dash (-) for empty string value');
+    assert.dom('div.column.is-flex-center .hds-icon').exists('Renders a dash (-) for empty string value');
 
     this.set('value', null);
-    assert.dom('div.column.is-flex-center .flight-icon').exists('Renders a dash (-) for null value');
+    assert.dom('div.column.is-flex-center .hds-icon').exists('Renders a dash (-) for null value');
 
     this.set('value', undefined);
-    assert.dom('div.column.is-flex-center .flight-icon').exists('Renders a dash (-) for undefined value');
+    assert.dom('div.column.is-flex-center .hds-icon').exists('Renders a dash (-) for undefined value');
 
     this.set('default', DEFAULT);
     assert.dom('[data-test-value-div]').hasText(DEFAULT, 'Renders default text if value is empty');
@@ -151,7 +151,7 @@ module('Integration | Component | InfoTableRow', function (hooks) {
     this.set('value', '');
     this.set('label', '');
     this.set('default', '');
-    const dashCount = document.querySelectorAll('.flight-icon').length;
+    const dashCount = document.querySelectorAll('.hds-icon').length;
     assert.strictEqual(
       dashCount,
       2,

--- a/ui/tests/integration/components/kubernetes/page/configuration-test.js
+++ b/ui/tests/integration/components/kubernetes/page/configuration-test.js
@@ -58,7 +58,7 @@ module('Integration | Component | kubernetes | Page::Configuration', function (h
 
   test('it should render tab page header, config cta and mount config', async function (assert) {
     await this.renderComponent();
-    assert.dom('.title svg').hasClass('flight-icon-kubernetes-color', 'Kubernetes icon renders in title');
+    assert.dom('.title svg').hasClass('hds-icon-kubernetes-color', 'Kubernetes icon renders in title');
     assert.dom('.title').hasText('kubernetes-test', 'Mount path renders in title');
     assert
       .dom('[data-test-toolbar-config-action]')
@@ -72,7 +72,7 @@ module('Integration | Component | kubernetes | Page::Configuration', function (h
     await this.renderComponent();
     assert
       .dom('[data-test-inferred-message] svg')
-      .hasClass('flight-icon-check-circle-fill', 'Inferred message icon renders');
+      .hasClass('hds-icon-check-circle-fill', 'Inferred message icon renders');
     const message =
       'These details were successfully inferred from Vault’s kubernetes environment and were not explicity set in this config.';
     assert.dom('[data-test-inferred-message]').hasText(message, 'Inferred message renders');
@@ -91,9 +91,7 @@ module('Integration | Component | kubernetes | Page::Configuration', function (h
 
     assert.dom('[data-test-row-label="Certificate"]').exists('Certificate label renders');
     assert.dom('[data-test-certificate-card]').exists('Certificate card component renders');
-    assert
-      .dom('[data-test-certificate-icon]')
-      .hasClass('flight-icon-certificate', 'Certificate icon renders');
+    assert.dom('[data-test-certificate-icon]').hasClass('hds-icon-certificate', 'Certificate icon renders');
     assert
       .dom('[data-test-certificate-card] [data-test-copy-button]')
       .exists('Certificate copy button renders');

--- a/ui/tests/integration/components/kubernetes/page/roles-test.js
+++ b/ui/tests/integration/components/kubernetes/page/roles-test.js
@@ -53,7 +53,7 @@ module('Integration | Component | kubernetes | Page::Roles', function (hooks) {
   test('it should render tab page header and config cta', async function (assert) {
     this.promptConfig = true;
     await this.renderComponent();
-    assert.dom('.title svg').hasClass('flight-icon-kubernetes-color', 'Kubernetes icon renders in title');
+    assert.dom('.title svg').hasClass('hds-icon-kubernetes-color', 'Kubernetes icon renders in title');
     assert.dom('.title').hasText('kubernetes-test', 'Mount path renders in title');
     assert
       .dom('[data-test-toolbar-roles-action]')
@@ -70,7 +70,7 @@ module('Integration | Component | kubernetes | Page::Roles', function (hooks) {
     assert.dom('[data-test-toolbar-roles-action]').hasText('Create role', 'Toolbar action has correct text');
     assert
       .dom('[data-test-toolbar-roles-action] svg')
-      .hasClass('flight-icon-plus', 'Toolbar action has correct icon');
+      .hasClass('hds-icon-plus', 'Toolbar action has correct icon');
     assert.dom(GENERAL.filterInputExplicit).exists('Roles filter input renders');
     assert.dom('[data-test-empty-state-title]').hasText('No roles yet', 'Title renders');
     assert
@@ -92,7 +92,7 @@ module('Integration | Component | kubernetes | Page::Roles', function (hooks) {
 
   test('it should render roles list', async function (assert) {
     await this.renderComponent();
-    assert.dom('[data-test-list-item-content] svg').hasClass('flight-icon-user', 'List item icon renders');
+    assert.dom('[data-test-list-item-content] svg').hasClass('hds-icon-user', 'List item icon renders');
     assert.dom('[data-test-list-item-content]').hasText(this.roles[0].name, 'List item name renders');
     await click('[data-test-popup-menu-trigger]');
     assert.dom('[data-test-details]').hasText('Details', 'Details link renders in menu');

--- a/ui/tests/integration/components/kubernetes/tab-page-header-test.js
+++ b/ui/tests/integration/components/kubernetes/tab-page-header-test.js
@@ -58,7 +58,7 @@ module('Integration | Component | kubernetes | TabPageHeader', function (hooks) 
     );
     assert
       .dom('[data-test-header-title] svg')
-      .hasClass('flight-icon-kubernetes-color', 'Correct icon renders in title');
+      .hasClass('hds-icon-kubernetes-color', 'Correct icon renders in title');
     assert.dom('[data-test-header-title]').hasText(this.mount, 'Mount path renders in title');
   });
 

--- a/ui/tests/integration/components/ldap/page/configuration-test.js
+++ b/ui/tests/integration/components/ldap/page/configuration-test.js
@@ -68,7 +68,7 @@ module('Integration | Component | ldap | Page::Configuration', function (hooks) 
 
     await this.renderComponent();
 
-    assert.dom('.title svg').hasClass('flight-icon-folder-users', 'LDAP icon renders in title');
+    assert.dom('.title svg').hasClass('hds-icon-folder-users', 'LDAP icon renders in title');
     assert.dom('.title').hasText('ldap-test', 'Mount path renders in title');
     assert
       .dom(selectors.rotateAction)

--- a/ui/tests/integration/components/ldap/page/libraries-test.js
+++ b/ui/tests/integration/components/ldap/page/libraries-test.js
@@ -58,7 +58,7 @@ module('Integration | Component | ldap | Page::Libraries', function (hooks) {
 
     await this.renderComponent();
 
-    assert.dom('.title svg').hasClass('flight-icon-folder-users', 'LDAP icon renders in title');
+    assert.dom('.title svg').hasClass('hds-icon-folder-users', 'LDAP icon renders in title');
     assert.dom('.title').hasText('ldap-test', 'Mount path renders in title');
     assert
       .dom('[data-test-toolbar-action="config"]')
@@ -76,7 +76,7 @@ module('Integration | Component | ldap | Page::Libraries', function (hooks) {
       .hasText('Create library', 'Toolbar action has correct text');
     assert
       .dom('[data-test-toolbar-action="library"] svg')
-      .hasClass('flight-icon-plus', 'Toolbar action has correct icon');
+      .hasClass('hds-icon-plus', 'Toolbar action has correct icon');
     assert
       .dom('[data-test-filter-input]')
       .doesNotExist('Libraries filter input is hidden when libraries have not been created');
@@ -92,7 +92,7 @@ module('Integration | Component | ldap | Page::Libraries', function (hooks) {
   test('it should render libraries list', async function (assert) {
     await this.renderComponent();
 
-    assert.dom('[data-test-list-item-content] svg').hasClass('flight-icon-folder', 'List item icon renders');
+    assert.dom('[data-test-list-item-content] svg').hasClass('hds-icon-folder', 'List item icon renders');
     assert.dom('[data-test-library]').hasText(this.libraries[0].name, 'List item name renders');
 
     await click('[data-test-popup-menu-trigger]');

--- a/ui/tests/integration/components/ldap/page/library/check-out-test.js
+++ b/ui/tests/integration/components/ldap/page/library/check-out-test.js
@@ -76,7 +76,7 @@ module('Integration | Component | ldap | Page::Library::CheckOut', function (hoo
       .hasText('ldap/library/test/check-out/123', 'Lease ID renders');
     assert
       .dom('[data-test-value-div="Lease renewable"] svg')
-      .hasClass('flight-icon-check-circle', 'Lease renewable true icon renders');
+      .hasClass('hds-icon-check-circle', 'Lease renewable true icon renders');
     assert
       .dom('[data-test-value-div="Lease renewable"] svg')
       .hasClass('has-text-success', 'Lease renewable true icon color renders');
@@ -86,7 +86,7 @@ module('Integration | Component | ldap | Page::Library::CheckOut', function (hoo
     await this.renderComponent();
     assert
       .dom('[data-test-value-div="Lease renewable"] svg')
-      .hasClass('flight-icon-x-circle', 'Lease renewable false icon renders');
+      .hasClass('hds-icon-x-circle', 'Lease renewable false icon renders');
     assert
       .dom('[data-test-value-div="Lease renewable"] svg')
       .hasClass('has-text-danger', 'Lease renewable false icon color renders');

--- a/ui/tests/integration/components/ldap/page/library/details/configuration-test.js
+++ b/ui/tests/integration/components/ldap/page/library/details/configuration-test.js
@@ -52,7 +52,7 @@ module('Integration | Component | ldap | Page::Library::Details::Configuration',
 
     assert
       .dom('[data-test-check-in-icon]')
-      .hasClass('flight-icon-check-circle', 'Correct icon renders for enabled check in enforcement');
+      .hasClass('hds-icon-check-circle', 'Correct icon renders for enabled check in enforcement');
     assert
       .dom('[data-test-check-in-icon]')
       .hasClass('icon-true', 'Correct class renders for enabled check in enforcement');
@@ -62,7 +62,7 @@ module('Integration | Component | ldap | Page::Library::Details::Configuration',
 
     assert
       .dom('[data-test-check-in-icon]')
-      .hasClass('flight-icon-x-square', 'Correct icon renders for disabled check in enforcement');
+      .hasClass('hds-icon-x-square', 'Correct icon renders for disabled check in enforcement');
     assert
       .dom('[data-test-check-in-icon]')
       .hasClass('icon-false', 'Correct class renders for disabled check in enforcement');

--- a/ui/tests/integration/components/ldap/page/overview-test.js
+++ b/ui/tests/integration/components/ldap/page/overview-test.js
@@ -70,7 +70,7 @@ module('Integration | Component | ldap | Page::Overview', function (hooks) {
 
     await this.renderComponent();
 
-    assert.dom('.title svg').hasClass('flight-icon-folder-users', 'LDAP icon renders in title');
+    assert.dom('.title svg').hasClass('hds-icon-folder-users', 'LDAP icon renders in title');
     assert.dom('.title').hasText('ldap-test', 'Mount path renders in title');
     assert.dom('[data-test-toolbar-action="config"]').hasText('Configure LDAP', 'Toolbar action renders');
     assert.dom('[data-test-config-cta]').exists('Config cta renders');

--- a/ui/tests/integration/components/ldap/page/roles-test.js
+++ b/ui/tests/integration/components/ldap/page/roles-test.js
@@ -63,7 +63,7 @@ module('Integration | Component | ldap | Page::Roles', function (hooks) {
 
     await this.renderComponent();
 
-    assert.dom('.title svg').hasClass('flight-icon-folder-users', 'LDAP icon renders in title');
+    assert.dom('.title svg').hasClass('hds-icon-folder-users', 'LDAP icon renders in title');
     assert.dom('.title').hasText('ldap-test', 'Mount path renders in title');
     assert
       .dom('[data-test-toolbar-action="config"]')
@@ -79,7 +79,7 @@ module('Integration | Component | ldap | Page::Roles', function (hooks) {
     assert.dom('[data-test-toolbar-action="role"]').hasText('Create role', 'Toolbar action has correct text');
     assert
       .dom('[data-test-toolbar-action="role"] svg')
-      .hasClass('flight-icon-plus', 'Toolbar action has correct icon');
+      .hasClass('hds-icon-plus', 'Toolbar action has correct icon');
     assert
       .dom('[data-test-filter-input]')
       .doesNotExist('Roles filter input is hidden when roles have not been created');
@@ -95,7 +95,7 @@ module('Integration | Component | ldap | Page::Roles', function (hooks) {
   test('it should render roles list', async function (assert) {
     await this.renderComponent();
 
-    assert.dom('[data-test-list-item-content] svg').hasClass('flight-icon-user', 'List item icon renders');
+    assert.dom('[data-test-list-item-content] svg').hasClass('hds-icon-user', 'List item icon renders');
     assert
       .dom(LDAP_SELECTORS.roleItem('static', 'static-test'))
       .hasText(this.roles[0].name, 'List item name renders');

--- a/ui/tests/integration/components/ldap/tab-page-header-test.js
+++ b/ui/tests/integration/components/ldap/tab-page-header-test.js
@@ -47,7 +47,7 @@ module('Integration | Component | ldap | TabPageHeader', function (hooks) {
     });
     assert
       .dom('[data-test-header-title] svg')
-      .hasClass('flight-icon-folder-users', 'Correct icon renders in title');
+      .hasClass('hds-icon-folder-users', 'Correct icon renders in title');
     assert.dom('[data-test-header-title]').hasText(this.mount, 'Mount path renders in title');
   });
 

--- a/ui/tests/integration/components/mfa-login-enforcement-header-test.js
+++ b/ui/tests/integration/components/mfa-login-enforcement-header-test.js
@@ -32,7 +32,7 @@ module('Integration | Component | mfa-login-enforcement-header', function (hooks
     await render(hbs`<Mfa::MfaLoginEnforcementHeader @heading="New enforcement" />`);
 
     assert.dom('[data-test-mleh-title]').includesText('New enforcement');
-    assert.dom('[data-test-mleh-title] svg').hasClass('flight-icon-lock', 'Lock icon renders');
+    assert.dom('[data-test-mleh-title] svg').hasClass('hds-icon-lock', 'Lock icon renders');
     assert
       .dom('[data-test-mleh-description]')
       .includesText('An enforcement will define which auth types', 'Description renders');

--- a/ui/tests/integration/components/sync/secrets/page/destinations-test.js
+++ b/ui/tests/integration/components/sync/secrets/page/destinations-test.js
@@ -134,7 +134,7 @@ module('Integration | Component | sync | Page::Destinations', function (hooks) {
 
     const { icon, name, type, deleteAction } = destinations.list;
 
-    assert.dom(icon).hasClass('flight-icon-aws-color', 'Correct icon renders');
+    assert.dom(icon).hasClass('hds-icon-aws-color', 'Correct icon renders');
     assert.dom(name).hasText('destination-aws', 'Name renders');
     assert.dom(type).hasText('AWS Secrets Manager', 'Type renders');
 

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -2355,19 +2355,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hashicorp/ember-flight-icons@npm:^5.1.3":
-  version: 5.1.3
-  resolution: "@hashicorp/ember-flight-icons@npm:5.1.3"
-  dependencies:
-    "@embroider/addon-shim": ^1.8.7
-    "@hashicorp/flight-icons": ^3.5.0
-    decorator-transforms: ^1.1.0
-    ember-get-config: ^2.1.1
-  checksum: 62a6f4bcd6f1826afb1d9f3a52e073983ddca402f50217f9a2df20e42df44803d84b5bd7dc512c083e9b81b896f12243f433cbec77236a9010ac8ed183dde5b6
-  languageName: node
-  linkType: hard
-
-"@hashicorp/flight-icons@npm:^3.5.0, @hashicorp/flight-icons@npm:^3.7.0":
+"@hashicorp/flight-icons@npm:^3.7.0":
   version: 3.7.0
   resolution: "@hashicorp/flight-icons@npm:3.7.0"
   checksum: 9d043a8df428ce47475a8f2605ad31119a9da766b2310eeba207fd311ae5c0422c19fb91b636b744c590a5c0d19075cb295787961d3e46fdd5e21ef17b2df606
@@ -18182,7 +18170,6 @@ __metadata:
     "@glimmer/component": ^1.1.2
     "@glimmer/tracking": ^1.1.2
     "@hashicorp/design-system-components": ~4.13.0
-    "@hashicorp/ember-flight-icons": ^5.1.3
     "@icholy/duration": ^5.1.0
     "@lineal-viz/lineal": ^0.5.1
     "@tsconfig/ember": ^2.0.0


### PR DESCRIPTION
### Description

In this PR we:
 - migrate `<FlightIcon>` instances to `<Hds::Icon>`
   - the components share the same API with the only difference being that `@isInline` is false by default, so we set it to `{{true}}` in vault instances
 - update selectors from `flight-icon` to `hds-icon`
 - remove the `@hashicorp/ember-flight-icons` dependency
 - (optional) I renamed the `isFlightIcon` getter in the `<Icon>` component to `isHdsIcon`

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
