### PR TITLE
Update DB Static role rotation logic to generate new password if retried password fails

### DIFF
--- a/builtin/logical/database/path_roles_test.go
+++ b/builtin/logical/database/path_roles_test.go
@@ -1087,6 +1087,9 @@ func TestBackend_StaticRole_Role_name_check(t *testing.T) {
 	}
 }
 
+// TestStaticRole_NewCredentialGeneration verifies that new
+// credentials are generated if a retried credential continues
+// to fail
 func TestStaticRole_NewCredentialGeneration(t *testing.T) {
 	ctx := context.Background()
 	b, storage, mockDB := getBackend(t)

--- a/builtin/logical/database/rotation.go
+++ b/builtin/logical/database/rotation.go
@@ -421,6 +421,7 @@ func (b *databaseBackend) setStaticAccount(ctx context.Context, s logical.Storag
 	// Use credential from input if available. This happens if we're restoring from
 	// a WAL item or processing the rotation queue with an item that has a WAL
 	// associated with it
+	var usedExistingCredential bool
 	if output.WALID != "" {
 		wal, err := b.findStaticWAL(ctx, s, output.WALID)
 		if err != nil {
@@ -448,6 +449,7 @@ func (b *databaseBackend) setStaticAccount(ctx context.Context, s logical.Storag
 				Statements:  statements,
 			}
 			input.Role.StaticAccount.Password = wal.NewPassword
+			usedExistingCredential = true
 		case wal.CredentialType == v5.CredentialTypeRSAPrivateKey:
 			// Roll forward by using the credential in the existing WAL entry
 			updateReq.CredentialType = v5.CredentialTypeRSAPrivateKey
@@ -456,6 +458,7 @@ func (b *databaseBackend) setStaticAccount(ctx context.Context, s logical.Storag
 				Statements:   statements,
 			}
 			input.Role.StaticAccount.PrivateKey = wal.NewPrivateKey
+			usedExistingCredential = true
 		}
 	}
 
@@ -530,6 +533,16 @@ func (b *databaseBackend) setStaticAccount(ctx context.Context, s logical.Storag
 	_, err = dbi.database.UpdateUser(ctx, updateReq, false)
 	if err != nil {
 		b.CloseIfShutdown(dbi, err)
+		if usedExistingCredential {
+			// A retried password has failed again. Delete WAL and try with fresh password
+			b.Logger().Debug("credential stored in WAL failed, deleting WAL", "role", input.RoleName, "WAL ID", output.WALID)
+			if err := framework.DeleteWAL(ctx, s, output.WALID); err != nil {
+				b.Logger().Warn("failed to delete WAL", "error", err, "WAL ID", output.WALID)
+			}
+
+			// Generate a new WAL entry and credential for next attempt
+			output.WALID = ""
+		}
 		return output, fmt.Errorf("error setting credentials: %w", err)
 	}
 	modified = true

--- a/changelog/28989.txt
+++ b/changelog/28989.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+secret/db: Update static role rotation to generate new password if retried password fails.
+```

--- a/changelog/28989.txt
+++ b/changelog/28989.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-secret/db: Update static role rotation to generate new password if retried password fails.
+secret/db: Update static role rotation to generate a new password after 2 failed attempts.
 ```


### PR DESCRIPTION
### Description
Previously, when a static role rotation failed, we would store the password in the WAL entry. Upon retries, this same stored password would be reused. This leads customers to infinite loop cases where a failing password is infinitely retried.

This PR adds a fix which will generate a new credential and delete the existing WAL entry if it has failed on a retry. This will unblock customers until we can provide them with more control over their password policies so that password rotation failures don't happen as often.

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [x] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
