### PR TITLE
VAULT-31755: Add removed and HA health to the sys/health endpoint

### DIFF
--- a/api/sys_health.go
+++ b/api/sys_health.go
@@ -25,6 +25,8 @@ func (c *Sys) HealthWithContext(ctx context.Context) (*HealthResponse, error) {
 	r.Params.Add("standbycode", "299")
 	r.Params.Add("drsecondarycode", "299")
 	r.Params.Add("performancestandbycode", "299")
+	r.Params.Add("removedcode", "299")
+	r.Params.Add("haunhealthycode", "299")
 
 	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err != nil {
@@ -38,19 +40,22 @@ func (c *Sys) HealthWithContext(ctx context.Context) (*HealthResponse, error) {
 }
 
 type HealthResponse struct {
-	Initialized                       bool   `json:"initialized"`
-	Sealed                            bool   `json:"sealed"`
-	Standby                           bool   `json:"standby"`
-	PerformanceStandby                bool   `json:"performance_standby"`
-	ReplicationPerformanceMode        string `json:"replication_performance_mode"`
-	ReplicationDRMode                 string `json:"replication_dr_mode"`
-	ServerTimeUTC                     int64  `json:"server_time_utc"`
-	Version                           string `json:"version"`
-	ClusterName                       string `json:"cluster_name,omitempty"`
-	ClusterID                         string `json:"cluster_id,omitempty"`
-	LastWAL                           uint64 `json:"last_wal,omitempty"`
-	Enterprise                        bool   `json:"enterprise"`
-	EchoDurationMillis                int64  `json:"echo_duration_ms"`
-	ClockSkewMillis                   int64  `json:"clock_skew_ms"`
-	ReplicationPrimaryCanaryAgeMillis int64  `json:"replication_primary_canary_age_ms"`
+	Initialized                          bool   `json:"initialized"`
+	Sealed                               bool   `json:"sealed"`
+	Standby                              bool   `json:"standby"`
+	PerformanceStandby                   bool   `json:"performance_standby"`
+	ReplicationPerformanceMode           string `json:"replication_performance_mode"`
+	ReplicationDRMode                    string `json:"replication_dr_mode"`
+	ServerTimeUTC                        int64  `json:"server_time_utc"`
+	Version                              string `json:"version"`
+	ClusterName                          string `json:"cluster_name,omitempty"`
+	ClusterID                            string `json:"cluster_id,omitempty"`
+	LastWAL                              uint64 `json:"last_wal,omitempty"`
+	Enterprise                           bool   `json:"enterprise"`
+	EchoDurationMillis                   int64  `json:"echo_duration_ms"`
+	ClockSkewMillis                      int64  `json:"clock_skew_ms"`
+	ReplicationPrimaryCanaryAgeMillis    int64  `json:"replication_primary_canary_age_ms"`
+	RemovedFromCluster                   bool   `json:"removed_from_cluster"`
+	HAConnectionHealthy                  bool   `json:"ha_connection_healthy"`
+	LastRequestForwardingHeartbeatMillis int64  `json:"last_request_forwarding_heartbeat_ms,omitempty"`
 }

--- a/api/sys_health.go
+++ b/api/sys_health.go
@@ -55,7 +55,7 @@ type HealthResponse struct {
 	EchoDurationMillis                   int64  `json:"echo_duration_ms"`
 	ClockSkewMillis                      int64  `json:"clock_skew_ms"`
 	ReplicationPrimaryCanaryAgeMillis    int64  `json:"replication_primary_canary_age_ms"`
-	RemovedFromCluster                   bool   `json:"removed_from_cluster"`
-	HAConnectionHealthy                  bool   `json:"ha_connection_healthy"`
+	RemovedFromCluster                   *bool  `json:"removed_from_cluster,omitempty"`
+	HAConnectionHealthy                  *bool  `json:"ha_connection_healthy,omitempty"`
 	LastRequestForwardingHeartbeatMillis int64  `json:"last_request_forwarding_heartbeat_ms,omitempty"`
 }

--- a/changelog/28991.txt
+++ b/changelog/28991.txt
@@ -1,0 +1,6 @@
+```release-note:change
+api: Add to sys/health whether the node has been removed from the HA cluster. If the node has been removed, return code 530 by default or the value of the `removedcode` query parameter.   
+```
+```release-note:change
+api: Add to sys/health whether the standby node has been able to successfully send heartbeats to the active node and the time in milliseconds since the last heartbeat. If the standby has been unable to send a heartbeat, return code 474 by default or the value of the `haunhealthycode` query parameter.    
+```

--- a/http/sys_health.go
+++ b/http/sys_health.go
@@ -158,6 +158,20 @@ func getSysHealth(core *vault.Core, r *http.Request) (int, *HealthResponse, erro
 		perfStandbyCode = code
 	}
 
+	haUnhealthyCode := 474
+	if code, found, ok := fetchStatusCode(r, "haunhealthycode"); !ok {
+		return http.StatusBadRequest, nil, nil
+	} else if found {
+		haUnhealthyCode = code
+	}
+
+	removedCode := 530
+	if code, found, ok := fetchStatusCode(r, "removedcode"); !ok {
+		return http.StatusBadRequest, nil, nil
+	} else if found {
+		removedCode = code
+	}
+
 	ctx := context.Background()
 
 	// Check system status
@@ -175,13 +189,21 @@ func getSysHealth(core *vault.Core, r *http.Request) (int, *HealthResponse, erro
 		return http.StatusInternalServerError, nil, err
 	}
 
+	removed, shouldIncludeRemoved := core.IsRemovedFromCluster()
+
+	haHealthy, lastHeartbeat := core.GetHAHeartbeatHealth()
+
 	// Determine the status code
 	code := activeCode
 	switch {
 	case !init:
 		code = uninitCode
+	case removed:
+		code = removedCode
 	case sealed:
 		code = sealedCode
+	case !haHealthy:
+		code = haUnhealthyCode
 	case replicationState.HasState(consts.ReplicationDRSecondary):
 		code = drSecondaryCode
 	case perfStandby:
@@ -233,6 +255,17 @@ func getSysHealth(core *vault.Core, r *http.Request) (int, *HealthResponse, erro
 		return http.StatusInternalServerError, nil, err
 	}
 
+	if shouldIncludeRemoved {
+		body.RemovedFromCluster = &removed
+	}
+
+	if !haHealthy {
+		body.HAConnectionHealthy = &haHealthy
+	}
+	if lastHeartbeat != nil {
+		body.LastRequestForwardingHeartbeatMillis = lastHeartbeat.Milliseconds()
+	}
+
 	if licenseState != nil {
 		body.License = &HealthResponseLicense{
 			State:      licenseState.State,
@@ -257,20 +290,23 @@ type HealthResponseLicense struct {
 }
 
 type HealthResponse struct {
-	Initialized                       bool                   `json:"initialized"`
-	Sealed                            bool                   `json:"sealed"`
-	Standby                           bool                   `json:"standby"`
-	PerformanceStandby                bool                   `json:"performance_standby"`
-	ReplicationPerformanceMode        string                 `json:"replication_performance_mode"`
-	ReplicationDRMode                 string                 `json:"replication_dr_mode"`
-	ServerTimeUTC                     int64                  `json:"server_time_utc"`
-	Version                           string                 `json:"version"`
-	Enterprise                        bool                   `json:"enterprise"`
-	ClusterName                       string                 `json:"cluster_name,omitempty"`
-	ClusterID                         string                 `json:"cluster_id,omitempty"`
-	LastWAL                           uint64                 `json:"last_wal,omitempty"`
-	License                           *HealthResponseLicense `json:"license,omitempty"`
-	EchoDurationMillis                int64                  `json:"echo_duration_ms"`
-	ClockSkewMillis                   int64                  `json:"clock_skew_ms"`
-	ReplicationPrimaryCanaryAgeMillis int64                  `json:"replication_primary_canary_age_ms"`
+	Initialized                          bool                   `json:"initialized"`
+	Sealed                               bool                   `json:"sealed"`
+	Standby                              bool                   `json:"standby"`
+	PerformanceStandby                   bool                   `json:"performance_standby"`
+	ReplicationPerformanceMode           string                 `json:"replication_performance_mode"`
+	ReplicationDRMode                    string                 `json:"replication_dr_mode"`
+	ServerTimeUTC                        int64                  `json:"server_time_utc"`
+	Version                              string                 `json:"version"`
+	Enterprise                           bool                   `json:"enterprise"`
+	ClusterName                          string                 `json:"cluster_name,omitempty"`
+	ClusterID                            string                 `json:"cluster_id,omitempty"`
+	LastWAL                              uint64                 `json:"last_wal,omitempty"`
+	License                              *HealthResponseLicense `json:"license,omitempty"`
+	EchoDurationMillis                   int64                  `json:"echo_duration_ms"`
+	ClockSkewMillis                      int64                  `json:"clock_skew_ms"`
+	ReplicationPrimaryCanaryAgeMillis    int64                  `json:"replication_primary_canary_age_ms"`
+	RemovedFromCluster                   *bool                  `json:"removed_from_cluster,omitempty"`
+	HAConnectionHealthy                  *bool                  `json:"ha_connection_healthy,omitempty"`
+	LastRequestForwardingHeartbeatMillis int64                  `json:"last_request_forwarding_heartbeat_ms,omitempty"`
 }

--- a/http/sys_health.go
+++ b/http/sys_health.go
@@ -248,6 +248,7 @@ func getSysHealth(core *vault.Core, r *http.Request) (int, *HealthResponse, erro
 	}
 	if standby {
 		body.ReplicationPrimaryCanaryAgeMillis = core.GetReplicationLagMillisIgnoreErrs()
+		body.HAConnectionHealthy = &haHealthy
 	}
 
 	licenseState, err := core.EntGetLicenseState()
@@ -259,9 +260,6 @@ func getSysHealth(core *vault.Core, r *http.Request) (int, *HealthResponse, erro
 		body.RemovedFromCluster = &removed
 	}
 
-	if !haHealthy {
-		body.HAConnectionHealthy = &haHealthy
-	}
 	if lastHeartbeat != nil {
 		body.LastRequestForwardingHeartbeatMillis = lastHeartbeat.Milliseconds()
 	}

--- a/http/sys_health.go
+++ b/http/sys_health.go
@@ -202,7 +202,7 @@ func getSysHealth(core *vault.Core, r *http.Request) (int, *HealthResponse, erro
 		code = removedCode
 	case sealed:
 		code = sealedCode
-	case !haHealthy:
+	case !haHealthy && lastHeartbeat != nil:
 		code = haUnhealthyCode
 	case replicationState.HasState(consts.ReplicationDRSecondary):
 		code = drSecondaryCode
@@ -248,7 +248,6 @@ func getSysHealth(core *vault.Core, r *http.Request) (int, *HealthResponse, erro
 	}
 	if standby {
 		body.ReplicationPrimaryCanaryAgeMillis = core.GetReplicationLagMillisIgnoreErrs()
-		body.HAConnectionHealthy = &haHealthy
 	}
 
 	licenseState, err := core.EntGetLicenseState()
@@ -262,6 +261,7 @@ func getSysHealth(core *vault.Core, r *http.Request) (int, *HealthResponse, erro
 
 	if lastHeartbeat != nil {
 		body.LastRequestForwardingHeartbeatMillis = lastHeartbeat.Milliseconds()
+		body.HAConnectionHealthy = &haHealthy
 	}
 
 	if licenseState != nil {

--- a/vault/core.go
+++ b/vault/core.go
@@ -528,6 +528,8 @@ type Core struct {
 	rpcClientConn *grpc.ClientConn
 	// The grpc forwarding client
 	rpcForwardingClient *forwardingClient
+	// The time of the last successful request forwarding heartbeat
+	rpcLastSuccessfulHeartbeat *atomic.Value
 	// The UUID used to hold the leader lock. Only set on active node
 	leaderUUID string
 
@@ -1091,6 +1093,7 @@ func CreateCore(conf *CoreConfig) (*Core, error) {
 		echoDuration:                   uberAtomic.NewDuration(0),
 		activeNodeClockSkewMillis:      uberAtomic.NewInt64(0),
 		periodicLeaderRefreshInterval:  conf.PeriodicLeaderRefreshInterval,
+		rpcLastSuccessfulHeartbeat:     new(atomic.Value),
 	}
 
 	c.standbyStopCh.Store(make(chan struct{}))

--- a/vault/external_tests/raft/raft_test.go
+++ b/vault/external_tests/raft/raft_test.go
@@ -1488,7 +1488,7 @@ func TestSysHealth_Raft(t *testing.T) {
 
 		// now that the node can connect again, it will start getting the removed
 		// error when trying to connect. The code should be removed, and the ha
-		// connection should be unhealthy
+		// connection will be nil because there is no ha connection
 		testhelpers.RetryUntil(t, 10*time.Second, func() error {
 			resp, err := followerClient.Logical().ReadRawWithData("sys/health", map[string][]string{
 				"perfstandbyok": {"true"},
@@ -1506,6 +1506,6 @@ func TestSysHealth_Raft(t *testing.T) {
 		})
 		r := parseHealthBody(t, erroredResponse)
 		require.True(t, true, *r.RemovedFromCluster)
-		require.False(t, false, *r.HAConnectionHealthy)
+		require.Nil(t, false, r.HAConnectionHealthy)
 	})
 }

--- a/vault/external_tests/raft/raft_test.go
+++ b/vault/external_tests/raft/raft_test.go
@@ -1506,6 +1506,6 @@ func TestSysHealth_Raft(t *testing.T) {
 		})
 		r := parseHealthBody(t, erroredResponse)
 		require.True(t, true, *r.RemovedFromCluster)
-		require.Nil(t, false, r.HAConnectionHealthy)
+		require.Nil(t, r.HAConnectionHealthy)
 	})
 }

--- a/vault/external_tests/raft/raft_test.go
+++ b/vault/external_tests/raft/raft_test.go
@@ -1451,6 +1451,9 @@ func TestSysHealth_Raft(t *testing.T) {
 				"standbyok":     {"true"},
 			})
 			if err == nil {
+				if resp != nil && resp.Body != nil {
+					resp.Body.Close()
+				}
 				return errors.New("expected error")
 			}
 			if resp.StatusCode != 474 {
@@ -1495,6 +1498,9 @@ func TestSysHealth_Raft(t *testing.T) {
 				"standbyok":     {"true"},
 			})
 			if err == nil {
+				if resp != nil && resp.Body != nil {
+					resp.Body.Close()
+				}
 				return fmt.Errorf("expected error")
 			}
 			if resp.StatusCode != 530 {

--- a/vault/ha.go
+++ b/vault/ha.go
@@ -1239,14 +1239,18 @@ func (c *Core) getRemovableHABackend() physical.RemovableNodeHABackend {
 	return haBackend
 }
 
+// GetHAHeartbeatHealth returns whether a node's last successful heartbeat was
+// more than 2 intervals ago. If the node's request forwarding clients were
+// cleared (due to the node being sealed or finding a new leader), or the node
+// is uninitialized, healthy will be false.
 func (c *Core) GetHAHeartbeatHealth() (healthy bool, sinceLastHeartbeat *time.Duration) {
 	heartbeat := c.rpcLastSuccessfulHeartbeat.Load()
 	if heartbeat == nil {
-		return true, nil
+		return false, nil
 	}
 	lastHeartbeat := heartbeat.(time.Time)
 	if lastHeartbeat.IsZero() {
-		return true, nil
+		return false, nil
 	}
 	diff := time.Now().Sub(lastHeartbeat)
 	heartbeatInterval := c.clusterHeartbeatInterval

--- a/vault/ha_test.go
+++ b/vault/ha_test.go
@@ -10,6 +10,8 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 // TestGrabLockOrStop is a non-deterministic test to detect deadlocks in the
@@ -84,4 +86,77 @@ func TestGrabLockOrStop(t *testing.T) {
 		}()
 	}
 	workerWg.Wait()
+}
+
+// TestGetHAHeartbeatHealth checks that heartbeat health is correctly determined
+// for a variety of scenarios
+func TestGetHAHeartbeatHealth(t *testing.T) {
+	now := time.Now().UTC()
+	oldLastHeartbeat := now.Add(-1 * time.Hour)
+	futureHeartbeat := now.Add(10 * time.Second)
+	zeroHeartbeat := time.Time{}
+	testCases := []struct {
+		name              string
+		lastHeartbeat     *time.Time
+		heartbeatInterval time.Duration
+		wantHealthy       bool
+	}{
+		{
+			name:              "old heartbeat",
+			lastHeartbeat:     &oldLastHeartbeat,
+			heartbeatInterval: 5 * time.Second,
+			wantHealthy:       false,
+		},
+		{
+			name:              "no heartbeat",
+			lastHeartbeat:     nil,
+			heartbeatInterval: 5 * time.Second,
+			wantHealthy:       true,
+		},
+		{
+			name:              "recent heartbeat",
+			lastHeartbeat:     &now,
+			heartbeatInterval: 20 * time.Second,
+			wantHealthy:       true,
+		},
+		{
+			name:              "recent heartbeat, empty interval",
+			lastHeartbeat:     &futureHeartbeat,
+			heartbeatInterval: 0,
+			wantHealthy:       true,
+		},
+		{
+			name:              "old heartbeat, empty interval",
+			lastHeartbeat:     &oldLastHeartbeat,
+			heartbeatInterval: 0,
+			wantHealthy:       false,
+		},
+		{
+			name:              "zero value heartbeat",
+			lastHeartbeat:     &zeroHeartbeat,
+			heartbeatInterval: 5 * time.Second,
+			wantHealthy:       true,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			v := new(atomic.Value)
+			if tc.lastHeartbeat != nil {
+				v.Store(*tc.lastHeartbeat)
+			}
+			c := &Core{
+				rpcLastSuccessfulHeartbeat: v,
+				clusterHeartbeatInterval:   tc.heartbeatInterval,
+			}
+
+			now := time.Now()
+			gotHealthy, gotLastHeartbeat := c.GetHAHeartbeatHealth()
+			require.Equal(t, tc.wantHealthy, gotHealthy)
+			if tc.lastHeartbeat != nil && !tc.lastHeartbeat.IsZero() {
+				require.InDelta(t, now.Sub(*tc.lastHeartbeat).Milliseconds(), gotLastHeartbeat.Milliseconds(), float64(3*time.Second.Milliseconds()))
+			} else {
+				require.Nil(t, gotLastHeartbeat)
+			}
+		})
+	}
 }

--- a/vault/ha_test.go
+++ b/vault/ha_test.go
@@ -111,7 +111,7 @@ func TestGetHAHeartbeatHealth(t *testing.T) {
 			name:              "no heartbeat",
 			lastHeartbeat:     nil,
 			heartbeatInterval: 5 * time.Second,
-			wantHealthy:       true,
+			wantHealthy:       false,
 		},
 		{
 			name:              "recent heartbeat",
@@ -135,7 +135,7 @@ func TestGetHAHeartbeatHealth(t *testing.T) {
 			name:              "zero value heartbeat",
 			lastHeartbeat:     &zeroHeartbeat,
 			heartbeatInterval: 5 * time.Second,
-			wantHealthy:       true,
+			wantHealthy:       false,
 		},
 	}
 	for _, tc := range testCases {

--- a/vault/request_forwarding.go
+++ b/vault/request_forwarding.go
@@ -442,6 +442,7 @@ func (c *Core) clearForwardingClients() {
 		clusterListener.RemoveClient(consts.RequestForwardingALPN)
 	}
 	c.clusterLeaderParams.Store((*ClusterLeaderParams)(nil))
+	c.rpcLastSuccessfulHeartbeat.Store(time.Time{})
 }
 
 // ForwardRequest forwards a given request to the active node and returns the

--- a/vault/request_forwarding_rpc.go
+++ b/vault/request_forwarding_rpc.go
@@ -201,6 +201,7 @@ func (c *forwardingClient) startHeartbeat() {
 				c.core.logger.Debug("forwarding: error sending echo request to active node", "error", err)
 				return
 			}
+			c.core.rpcLastSuccessfulHeartbeat.Store(now)
 			if resp == nil {
 				c.core.logger.Debug("forwarding: empty echo response from active node")
 				return

--- a/vault/request_forwarding_rpc.go
+++ b/vault/request_forwarding_rpc.go
@@ -215,6 +215,9 @@ func (c *forwardingClient) startHeartbeat() {
 			atomic.StoreUint32(c.core.activeNodeReplicationState, resp.ReplicationState)
 		}
 
+		// store a value before the first tick to indicate that we've started
+		// sending heartbeats
+		c.core.rpcLastSuccessfulHeartbeat.Store(time.Now())
 		tick()
 
 		for {

--- a/vault/testing.go
+++ b/vault/testing.go
@@ -977,6 +977,10 @@ func (c *TestClusterCore) ClusterListener() *cluster.Listener {
 	return c.getClusterListener()
 }
 
+func (c *TestClusterCore) NetworkLayer() cluster.NetworkLayer {
+	return c.Core.clusterNetworkLayer
+}
+
 func (c *TestCluster) Cleanup() {
 	c.Logger.Info("cleaning up vault cluster")
 	if tl, ok := c.Logger.(*corehelpers.TestLogger); ok {
@@ -1451,6 +1455,7 @@ func NewTestCluster(t testing.TB, base *CoreConfig, opts *TestClusterOptions) *T
 	}
 
 	if base != nil {
+		coreConfig.ClusterHeartbeatInterval = base.ClusterHeartbeatInterval
 		coreConfig.DetectDeadlocks = TestDeadlockDetection
 		coreConfig.RawConfig = base.RawConfig
 		coreConfig.DisableCache = base.DisableCache

--- a/vault/testing.go
+++ b/vault/testing.go
@@ -977,6 +977,10 @@ func (c *TestClusterCore) ClusterListener() *cluster.Listener {
 	return c.getClusterListener()
 }
 
+// NetworkLayer returns the network layer for the cluster core. This can be used
+// in conjunction with the cluster.InmemLayer to disconnect specific nodes from
+// the cluster when we need to simulate abrupt node failure or a network
+// partition in NewTestCluster tests.
 func (c *TestClusterCore) NetworkLayer() cluster.NetworkLayer {
 	return c.Core.clusterNetworkLayer
 }


### PR DESCRIPTION
### Description
This PR adds HA health and removed as statuses to the sys/health endpoint. 
- If a node has been removed from the cluster, its status code will be 530 (or the value from the `removedcode` query parameter) 
- If a node has missed 2 request forwarding heartbeats, its status code will be 474 (or the value from the `haunhealthycode` query parameter) 

The health response has new fields:

```
type HealthResponse struct {
...
  RemovedFromCluster  *bool    // present when raft is the HA/storage backend
  HAConnectionHealthy *bool    // present when the node is a standby/perf standby

  LastRequestForwardingHeartbeatMillis int64   // non-zero when the node has completed at least one request forwarding heartbeat 
}
```

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
