### PR TITLE
Docs: Fix command to pull Kuberentes cluster root CA certificate in Standalone Server w/ TLS example

### DIFF
--- a/changelog/29040.txt
+++ b/changelog/29040.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+COMPONENT: Updates the command to pull the Kubernetes root CA certificate for the Standalone Server w/ TLS example doc
+```

--- a/changelog/29040.txt
+++ b/changelog/29040.txt
@@ -1,3 +1,3 @@
-```release-note:bug
-COMPONENT: Updates the command to pull the Kubernetes root CA certificate for the Standalone Server w/ TLS example doc
+```release-note:improvement
+website/docs: Updates the command to pull the Kubernetes root CA certificate for the Standalone Server w/ TLS example doc
 ```

--- a/website/content/docs/platform/k8s/helm/examples/standalone-tls.mdx
+++ b/website/content/docs/platform/k8s/helm/examples/standalone-tls.mdx
@@ -151,9 +151,7 @@ e is 65537 (0x10001)
 3. Retrieve Kubernetes CA.
 
    ```bash
-   kubectl get secret \
-     -o jsonpath="{.items[?(@.type==\"kubernetes.io/service-account-token\")].data['ca\.crt']}" \
-     | base64 --decode > ${TMPDIR}/vault.ca
+   kubectl get cm kube-root-ca.crt -o jsonpath="{['data']['ca\.crt']}" > ${TMPDIR}/vault.ca
    ```
 
 4. Create the namespace.


### PR DESCRIPTION
### Description
What does this PR do?

- Fixes #29039 
- Removes the kubectl get secret command that is failing to retrieve the Kubernetes root CA
- Replaces it with a kubectl get cm command that successfully retrieves the Kubernetes root CA and stores it in a file called vault.ca

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
