### PR TITLE
Add an option to allow cert-auth to return metadata about client cert that fails login

### DIFF
--- a/builtin/credential/cert/path_config.go
+++ b/builtin/credential/cert/path_config.go
@@ -42,6 +42,11 @@ func pathConfig(b *backend) *framework.Path {
 				Default:     defaultRoleCacheSize,
 				Description: `The size of the in memory role cache`,
 			},
+			"enable_metadata_on_failures": {
+				Type:        framework.TypeBool,
+				Default:     false,
+				Description: `If set, metadata of the client certificate will be returned on authentication failures.`,
+			},
 		},
 
 		Operations: map[logical.Operation]framework.OperationHandler{
@@ -87,6 +92,9 @@ func (b *backend) pathConfigWrite(ctx context.Context, req *logical.Request, dat
 		}
 		config.RoleCacheSize = cacheSize
 	}
+	if enableMetadataOnFailures, ok := data.GetOk("enable_metadata_on_failures"); ok {
+		config.EnableMetadataOnFailures = enableMetadataOnFailures.(bool)
+	}
 	if err := b.storeConfig(ctx, req.Storage, config); err != nil {
 		return nil, err
 	}
@@ -104,6 +112,7 @@ func (b *backend) pathConfigRead(ctx context.Context, req *logical.Request, d *f
 		"enable_identity_alias_metadata": cfg.EnableIdentityAliasMetadata,
 		"ocsp_cache_size":                cfg.OcspCacheSize,
 		"role_cache_size":                cfg.RoleCacheSize,
+		"enable_metadata_on_failures":    cfg.EnableMetadataOnFailures,
 	}
 
 	return &logical.Response{
@@ -133,4 +142,5 @@ type config struct {
 	EnableIdentityAliasMetadata bool `json:"enable_identity_alias_metadata"`
 	OcspCacheSize               int  `json:"ocsp_cache_size"`
 	RoleCacheSize               int  `json:"role_cache_size"`
+	EnableMetadataOnFailures    bool `json:"enable_metadata_on_failures"`
 }

--- a/changelog/29044.txt
+++ b/changelog/29044.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+auth/cert: Add new configuration option `enable_metadata_on_failures` to add client cert metadata on login failures to audit log and response
+```

--- a/sdk/logical/response.go
+++ b/sdk/logical/response.go
@@ -141,6 +141,15 @@ func ErrorResponse(text string, vargs ...interface{}) *Response {
 	}
 }
 
+// ErrorResponseWithData is used to format an error response with additional data returned
+// within the "data" sub-field of the Data field. Useful to return additional information to the client
+// and or appear within audited responses.
+func ErrorResponseWithData(data interface{}, text string, vargs ...interface{}) *Response {
+	resp := ErrorResponse(text, vargs...)
+	resp.Data["data"] = data
+	return resp
+}
+
 // ListResponse is used to format a response to a list operation.
 func ListResponse(keys []string) *Response {
 	resp := &Response{

--- a/sdk/logical/response_test.go
+++ b/sdk/logical/response_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: MPL-2.0
 
 package logical
 

--- a/sdk/logical/response_test.go
+++ b/sdk/logical/response_test.go
@@ -1,0 +1,24 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package logical
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestResponse_ErrorResponse validates that our helper functions produce responses
+// that we consider errors.
+func TestResponse_ErrorResponse(t *testing.T) {
+	simpleResp := ErrorResponse("a test %s", "error")
+	assert.True(t, simpleResp.IsError())
+
+	dataMap := map[string]string{
+		"test1": "testing",
+	}
+
+	withDataResp := ErrorResponseWithData(dataMap, "a test %s", "error")
+	assert.True(t, withDataResp.IsError())
+}

--- a/vault/identity_store_entities.go
+++ b/vault/identity_store_entities.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 
 	"github.com/golang/protobuf/ptypes"
-	memdb "github.com/hashicorp/go-memdb"
+	"github.com/hashicorp/go-memdb"
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/go-secure-stdlib/strutil"
 	"github.com/hashicorp/vault/helper/identity"
@@ -286,14 +286,7 @@ func (i *IdentityStore) pathEntityMergeID() framework.OperationFunc {
 				return logical.ErrorResponse(userErr.Error()), nil
 			}
 			// Alias clash error, so include additional details
-			resp := &logical.Response{
-				Data: map[string]interface{}{
-					"error": userErr.Error(),
-					"data":  aliases,
-				},
-			}
-
-			return resp, nil
+			return logical.ErrorResponseWithData(aliases, userErr.Error()), nil
 		}
 		if intErr != nil {
 			return nil, intErr

--- a/website/content/api-docs/auth/cert.mdx
+++ b/website/content/api-docs/auth/cert.mdx
@@ -367,6 +367,9 @@ Configuration options for the method.
   that this cache is used for all configured certificates.
 - `role_cache_size` `(int: 200)` - The size of the role cache.  Use `-1` to disable
   role caching.
+- `enable_metadata_on_failures` `(boolean: false)` - If set, metadata of the client
+  certificate such as common name, serial, subject key id and authority key id will
+  be returned on authentication failures and appear in auditing records.
 
 ### Sample payload
 


### PR DESCRIPTION
### Description

Add a new cert auth configuration flag called "enable_metadata_on_failures" that if manually enabled, upon failures logging into cert-auth with a client certificate we would return the fields common name, serial, subject key id and authority key id from the client certificate in the response which will also appear in the audit log.

With the feature enabled in configuration, these are the audit logs assuming the keys have been marked to not hmac (they will be by default)

```
{
...
  "response": {
    "data": {
      "data": {
        "authority_key_id": "1c:a7:bb:5a:97:4d:bd:0d:12:ad:78:cc:f7:34:61:8d:9e:03:0b:03",
        "common_name": "localhost.local",
        "serial_number": "74414280014409089681629505391221737844000336179",
        "subject_key_id": "72:e7:ae:72:a9:db:a8:1a:59:79:1b:2e:5b:97:4e:06:d1:d2:8a:ec"
      },
      "error": "failed to match all constraints for this login certificate; additionally got errors during verification: 2 errors occurred:\n\t* error doing GET request: GET https://127.0.0.1:8200/v1/pki2/ocsp/MFUwUzBRME8wTTAJBgUrDgMCGgUABBTLRxzCWh2HDDBuDoTSQ+sw/rMFkQQUHKe7WpdNvQ0SrXjM9zRhjZ4DCwMCFA0I2gpxkLWeafvGc0fQs0nBQqkz giving up after 1 attempt(s): Get \"https://127.0.0.1:8200/v1/pki2/ocsp/MFUwUzBRME8wTTAJBgUrDgMCGgUABBTLRxzCWh2HDDBuDoTSQ+sw/rMFkQQUHKe7WpdNvQ0SrXjM9zRhjZ4DCwMCFA0I2gpxkLWeafvGc0fQs0nBQqkz\": tls: failed to verify certificate: x509: “sclark-C02G800QMD6Q” certificate is not trusted\n\t* error doing POST request: POST https://127.0.0.1:8200/v1/pki2/ocsp giving up after 1 attempt(s): Post \"https://127.0.0.1:8200/v1/pki2/ocsp\": tls: failed to verify certificate: x509: “sclark-C02G800QMD6Q” certificate is not trusted\n\n"
    },
...
  "type": "response"
}
```

And the response the client now would receive

```
{
  "errors": [
    "failed to match all constraints for this login certificate; additionally got errors during verification: 2 errors occurred:\n\t* error doing GET request: GET https://127.0.0.1:8200/v1/pki2/ocsp/MFUwUzBRME8wTTAJBgUrDgMCGgUABBTLRxzCWh2HDDBuDoTSQ+sw/rMFkQQU/qwOLCZoVhwT1f9v0PqX4gVmqZ8CFB3mSmddKkg1rlYctC/zIxHlKX+Z giving up after 1 attempt(s): Get \"https://127.0.0.1:8200/v1/pki2/ocsp/MFUwUzBRME8wTTAJBgUrDgMCGgUABBTLRxzCWh2HDDBuDoTSQ+sw/rMFkQQU/qwOLCZoVhwT1f9v0PqX4gVmqZ8CFB3mSmddKkg1rlYctC/zIxHlKX+Z\": tls: failed to verify certificate: x509: “sclark-C02G800QMD6Q” certificate is not trusted\n\t* error doing POST request: POST https://127.0.0.1:8200/v1/pki2/ocsp giving up after 1 attempt(s): Post \"https://127.0.0.1:8200/v1/pki2/ocsp\": tls: failed to verify certificate: x509: “sclark-C02G800QMD6Q” certificate is not trusted\n\n"
  ],
  "data": {
    "authority_key_id": "fe:ac:0e:2c:26:68:56:1c:13:d5:ff:6f:d0:fa:97:e2:05:66:a9:9f",
    "common_name": "localhost.local",
    "serial_number": "170696385231633877302822184551262563551530287001",
    "subject_key_id": "ff:de:cb:08:82:79:95:a8:f4:d8:50:8b:f4:fd:cb:d1:ea:72:22:ee"
  }
}
```
### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
