### PR TITLE
Add hook for ENT tweaking of PKI contraints verification options

### DIFF
--- a/builtin/logical/pki/issuing/cert_verify.go
+++ b/builtin/logical/pki/issuing/cert_verify.go
@@ -4,7 +4,9 @@
 package issuing
 
 import (
+	"context"
 	"fmt"
+	"github.com/hashicorp/vault/sdk/logical"
 	"os"
 	"strconv"
 	"time"
@@ -33,7 +35,7 @@ func isCertificateVerificationDisabled() (bool, error) {
 	return disable, nil
 }
 
-func VerifyCertificate(parsedBundle *certutil.ParsedCertBundle) error {
+func VerifyCertificate(ctx context.Context, storage logical.Storage, issuerId IssuerID, parsedBundle *certutil.ParsedCertBundle) error {
 	if verificationDisabled, err := isCertificateVerificationDisabled(); err != nil {
 		return err
 	} else if verificationDisabled {
@@ -66,6 +68,10 @@ func VerifyCertificate(parsedBundle *certutil.ParsedCertBundle) error {
 		DisableNameChecks:              false,
 		DisablePathLenChecks:           false,
 		DisableNameConstraintChecks:    false,
+	}
+
+	if err := entSetCertVerifyOptions(ctx, storage, issuerId, &options); err != nil {
+		return err
 	}
 
 	certificate, err := convertCertificate(parsedBundle.CertificateBytes)

--- a/builtin/logical/pki/issuing/issuing_stubs_oss.go
+++ b/builtin/logical/pki/issuing/issuing_stubs_oss.go
@@ -1,0 +1,19 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+//go:build !enterprise
+
+package issuing
+
+import (
+	"context"
+
+	ctx509 "github.com/google/certificate-transparency-go/x509"
+	"github.com/hashicorp/vault/sdk/logical"
+)
+
+//go:generate go run github.com/hashicorp/vault/tools/stubmaker
+
+func entSetCertVerifyOptions(ctx context.Context, storage logical.Storage, issuerId IssuerID, options *ctx509.VerifyOptions) error {
+	return nil
+}

--- a/builtin/logical/pki/path_issue_sign.go
+++ b/builtin/logical/pki/path_issue_sign.go
@@ -432,7 +432,7 @@ func (b *backend) pathIssueSignCert(ctx context.Context, req *logical.Request, d
 		}
 	}
 
-	if err := issuing.VerifyCertificate(parsedBundle); err != nil {
+	if err := issuing.VerifyCertificate(sc.GetContext(), sc.GetStorage(), issuerId, parsedBundle); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
This PR is part of the re-implementation of PR #28921.

### Description

Add hook for ENT tweaking of PKI contraints verification options.


### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
