### PR TITLE
Fix OSS sealunwrapper adding extra get + put request to all storage get requests

### DIFF
--- a/changelog/29050.txt
+++ b/changelog/29050.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+core: fix bug in seal unwrapper that caused high storage latency in Vault CE. For every storage read request, the
+seal unwrapper was performing the read twice, and would also issue an unnecessary storage write.
+```

--- a/sdk/physical/inmem/inmem_ha.go
+++ b/sdk/physical/inmem/inmem_ha.go
@@ -83,6 +83,13 @@ func (i *InmemHABackend) HAEnabled() bool {
 	return true
 }
 
+func (i *InmemHABackend) Underlying() *InmemBackend {
+	if txBackend, ok := i.Backend.(*TransactionalInmemBackend); ok {
+		return &txBackend.InmemBackend
+	}
+	return i.Backend.(*InmemBackend)
+}
+
 // InmemLock is an in-memory Lock implementation for the HABackend
 type InmemLock struct {
 	in    *InmemHABackend


### PR DESCRIPTION
### Problem
Starting after commit 0ec3524, for each `GET` request Vault makes to the storage backend, the OSS seal unwrapper will make 1 additional `GET` request plus 1 additional `PUT` request. This is because the seal unwrapper now tries to unwrap all storage entries, even if the entry was not wrapped in the first place! Prior to 0ec3524, there was a check to see if the storage entry was wrapped before proceeding with the unwrap procedure, which prevented this behavior.

The increased storage latency, writes, and traffic  resulting from the extra requests causes noticeable performance degradation for some workloads. 0ec3524 was first included in Vault `v1.15.0`, and after upgrading from Vault `v1.14.9` to `v1.15.6`, some of our Vault clusters would take 2-3x longer to start up.

Other users have also reported storage-related issues after upgrading to Vault `v1.15+`: https://github.com/hashicorp/vault/issues/24726.

### Description

This PR restores the check to prevent Vault from unwrapping a storage entry if the storage entry is not wrapped. This should eliminate the extra `GET` and `PUT` requests.

### Testing

A small test is included in this PR to confirm that at least the extra `PUT` request is no longer being made.

I also ran some benchmarks using [vault-benchmark](https://github.com/hashicorp/vault-benchmark) (awesome tool BTW!) + a small [wrapper script](https://github.com/hashicorp/vault/compare/main...andybao-dd:vault:andyb/BENCHMARKING#diff-253824d6673282074bd7bc3ea31615ebf4d90a60565fc4ac03e29e8f0a41f61c). The chart below shows the p90 of the time needed to perform different benchmark operations on a sample Vault instance. The Vault instance was configured with _Amazon S3_ for storage and _caching was explicitly disabled_.

[![p90 operation latency for Vault on S3 with caching disabled, compared across multiple Vault versions](https://github.com/user-attachments/assets/143748de-bf74-4e3e-8abb-192c8de023bd)
[📊 Additional benchmark results can be found here.]](https://itty.bitty.site/#charts.html/data:text/html;format=gz;base64,eJytk8GK2zAQhu99ClVQsNmNZTsb29nYprRNoafuoZeeyliSYy+yZKRJsibk3SsnoYWFXsqC0D9iRp9GI035/sv3zz9+Pm1Jh4Oq35WzEAV6V1GpaV12EkRdDhKB8A6sk1jRPbaLgrK6ZFdvY8RUl47bfkTiLK9ohzi6R8a40NGzE1L1BxtpiUyPAxsAu2d4+biM0ihl0q0YypeFO+x8qD+RXUH/Bo7KYKQmNquaFmmU+BENvX61X/QH0ouKznnjr5gSrsC5it727SyM3cIHUeJwUrKix15g95jE8YfNzPGu15DkLSDpW0CW/we51RSn0QcMRuyVpHUAbtI8CKv6xI123l0FeA9+/XRh+5c7zlYgDN8PUmO0k7hVcjY/Td9EcMuJ3kF4j+EG7XQK4Ag9XmfSSuRd8OcRd73ziB67fbN30vozcYZyMzDQYmrALIRgPE5bSFqeNQkv8qJ5WLdFlubgtWmTNmEWjixfrfNC8iVfNVyslmseLxORZbKN13mWxlIkfLWGJmON1NyXBxD8LzGahuFFA6+tsVvw+WF45oAX44SdNUcCSloM6FfolRQEDVEGBLlUmswo6q97PodBuPn769i1G9i1n34DRJchrA==)

From the graph, it seems like:
- Operations on commit 0ec3524 of Vault (labeled `post-0ec3524` in the graph) take significantly longer compared to operations made on a build of the parent commit (labeled `pre-0ec3524`).
- As of today, Vault built off of the `main` branch continues to exhibit similar slow operation issues.
- Vault built off of this PR branch (labeled `main+fix`) shows improved performance, matching the performance level of `pre-0ec3524`.

### Other notes

#### Why did you disable caching during the benchmarks?
Due to how `vault-benchmark` benchmarks are structured, it is difficult to evaluate storage performance without disabling caching. `vault-benchmark` benchmarks start off with an empty cluster and then write a bunch of state to it. Then they might read that state back or perform other write operations.

The problem is that with a few exceptions, all write operations will write to both the storage and the in-memory cache. So by starting off with an empty cluster and then setting up the state by performing writes, we have effectively written the entire cluster state to the in-memory cache. Therefore most read benchmarks we perform will be benchmarking the in-memory cache instead of the actual storage codepath.

I have still included the benchmark results with the cache enabled however, in case they are helpful.