### PR TITLE
Seal and cleanup cluster before test teardown for TestRaftHA_Recover_Cluster

### DIFF
--- a/vault/external_tests/raftha/raft_ha_test.go
+++ b/vault/external_tests/raftha/raft_ha_test.go
@@ -177,9 +177,6 @@ func testRaftHARecoverCluster(t *testing.T, physBundle *vault.PhysicalBackendBun
 	_, err = leaderClient.Logical().Write("kv/data/test_known_data", kvData)
 	require.NoError(t, err)
 
-	// We delete the current cluster. We keep the storage backend so we can recover the cluster
-	cluster.Cleanup()
-
 	// We now have a raft HA cluster with a KVv2 backend enabled and a test data.
 	// We're now going to delete the cluster and create a new raft HA cluster with the same backend storage
 	// and ensure we can recover to a working vault cluster and don't lose the data from the backend storage.

--- a/vault/external_tests/raftha/raft_ha_test.go
+++ b/vault/external_tests/raftha/raft_ha_test.go
@@ -219,6 +219,11 @@ func testRaftHARecoverCluster(t *testing.T, physBundle *vault.PhysicalBackendBun
 	dataAsMap := data.(map[string]interface{})
 	require.NotNil(t, dataAsMap)
 	require.Equal(t, "awesome", dataAsMap["kittens"])
+
+	// Ensure no writes are happening before we try to clean it up, to prevent
+	// issues deleting the files.
+	clusterRestored.EnsureCoresSealed(t)
+	clusterRestored.Cleanup()
 }
 
 func TestRaft_HA_ExistingCluster(t *testing.T) {


### PR DESCRIPTION
### Description

This test has been failing with the following:
```
=== FAIL: vault/external_tests/raftha TestRaftHA_Recover_Cluster/file (32.37s)
    teststorage.go:98: unlinkat /tmp/vault-integ-file-1848360437: directory not empty
```

This is since Vault is still writing to it when we attempt to clean it up. Hopefully, calling cleanup manually and removing the cleanup earlier in the function should fix it.

Running untilfail locally didn't seem to reproduce the issue, so hopefully this works? If not, we can iterate more.

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [x] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
