### PR TITLE
VAULT-32158 docs for secret sync usage metrics

### DIFF
--- a/website/content/docs/enterprise/license/product-usage-reporting.mdx
+++ b/website/content/docs/enterprise/license/product-usage-reporting.mdx
@@ -106,70 +106,80 @@ HashiCorp collects the following product usage metrics as part of the `metrics` 
 [JSON payload that it collects for licence utilization](/vault/docs/enterprise/license/utilization-reporting#example-payloads).
 All of these metrics are numerical, and contain no sensitive values or additional metadata:
 
-| Metric Name                                 | Description                                                              |
-|---------------------------------------------|--------------------------------------------------------------------------|
-| `vault.namespaces.count`                    | Total number of namespaces.                                              |
-| `vault.leases.count`                        | Total number of leases within Vault.                                     |
-| `vault.quotas.ratelimit.count`              | Total number of rate limit quotas within Vault.                          |
-| `vault.quotas.leasecount.count`             | Total number of lease count quotas within Vault.                         |
-| `vault.kv.version1.secrets.count`           | Total number of KVv1 secrets within Vault.                               |
-| `vault.kv.version2.secrets.count`           | Total number of KVv2 secrets within Vault.                               |
-| `vault.kv.version1.secrets.namespace.max`   | The highest number of KVv1 secrets in a namespace in Vault, e.g. `1000`. |
-| `vault.kv.version2.secrets.namespace.max`   | The highest number of KVv2 secrets in a namespace in Vault, e.g. `1000`. |
-| `vault.kv.version1.secrets.namespace.min`   | The lowest number of KVv1 secrets in a namespace in Vault, e.g. `2`.     |
-| `vault.kv.version2.secrets.namespace.min`   | The highest number of KVv2 secrets in a namespace in Vault, e.g. `1000`. |
-| `vault.kv.version1.secrets.namespace.mean`  | The mean number of KVv1 secrets in namespaces in Vault, e.g. `52.8`.     |
-| `vault.kv.version2.secrets.namespace.mean`  | The mean number of KVv2 secrets in namespaces in Vault, e.g. `52.8`.     |
-| `vault.auth.method.approle.count`           | The total number of Approle auth mounts in Vault.                        |
-| `vault.auth.method.alicloud.count`          | The total number of Alicloud auth mounts in Vault.                       |
-| `vault.auth.method.aws.count`               | The total number of AWS auth mounts in Vault.                            |
-| `vault.auth.method.appid.count`             | The total number of App ID auth mounts in Vault.                         |
-| `vault.auth.method.azure.count`             | The total number of Azure auth mounts in Vault.                          |
-| `vault.auth.method.cloudfoundry.count`      | The total number of Cloud Foundry auth mounts in Vault.                  |
-| `vault.auth.method.github.count`            | The total number of GitHub auth mounts in Vault.                         |
-| `vault.auth.method.gcp.count`               | The total number of GCP auth mounts in Vault.                            |
-| `vault.auth.method.jwt.count`               | The total number of JWT auth mounts in Vault.                            |
-| `vault.auth.method.kerberos.count`          | The total number of Kerberos auth mounts in Vault.                       |
-| `vault.auth.method.kubernetes.count`        | The total number of kubernetes auth mounts in Vault.                     |
-| `vault.auth.method.ldap.count`              | The total number of LDAP auth mounts in Vault.                           |
-| `vault.auth.method.oci.count`               | The total number of OCI auth mounts in Vault.                            |
-| `vault.auth.method.okta.count`              | The total number of Okta auth mounts in Vault.                           |
-| `vault.auth.method.pcf.count`               | The total number of PCF auth mounts in Vault.                            |
-| `vault.auth.method.radius.count`            | The total number of Radius auth mounts in Vault.                         |
-| `vault.auth.method.saml.count`              | The total number of SAML auth mounts in Vault.                           |
-| `vault.auth.method.cert.count`              | The total number of Cert auth mounts in Vault.                           |
-| `vault.auth.method.oidc.count`              | The total number of OIDC auth mounts in Vault.                           |
-| `vault.auth.method.token.count`             | The total number of Token auth mounts in Vault.                          |
-| `vault.auth.method.userpass.count`          | The total number of Userpass auth mounts in Vault.                       |
-| `vault.auth.method.plugin.count`            | The total number of custom plugin auth mounts in Vault.                  |
-| `vault.secret.engine.activedirectory.count` | The total number of Active Directory secret engines in Vault.            |
-| `vault.secret.engine.alicloud.count`        | The total number of Alicloud secret engines in Vault.                    |
-| `vault.secret.engine.aws.count`             | The total number of AWS secret engines in Vault.                         |
-| `vault.secret.engine.azure.count`           | The total number of Azure secret engines in Vault.                       |
-| `vault.secret.engine.consul.count`          | The total number of Consul secret engines in Vault.                      |
-| `vault.secret.engine.gcp.count`             | The total number of GCP secret engines in Vault.                         |
-| `vault.secret.engine.gcpkms.count`          | The total number of GCPKMS secret engines in Vault.                      |
-| `vault.secret.engine.kubernetes.count`      | The total number of Kubernetes secret engines in Vault.                  |
-| `vault.secret.engine.cassandra.count`       | The total number of Cassandra secret engines in Vault.                   |
-| `vault.secret.engine.keymgmt.count`         | The total number of Keymgmt secret engines in Vault.                     |
-| `vault.secret.engine.kv.count`              | The total number of kv secret engines in Vault.                          |
-| `vault.secret.engine.kmip.count`            | The total number of KMIP secret engines in Vault.                        |
-| `vault.secret.engine.mongodb.count`         | The total number of MongoDB secret engines in Vault.                     |
-| `vault.secret.engine.mongodbatlas.count`    | The total number of MongoDBAtlas secret engines in Vault.                |
-| `vault.secret.engine.mssql.count`           | The total number of MSSql secret engines in Vault.                       |
-| `vault.secret.engine.postgresql.count`      | The total number of Postgresql secret engines in Vault.                  |
-| `vault.secret.engine.nomad.count`           | The total number of Nomad secret engines in Vault.                       |
-| `vault.secret.engine.ldap.count`            | The total number of LDAP secret engines in Vault.                        |
-| `vault.secret.engine.openldap.count`        | The total number of OpenLDAP secret engines in Vault.                    |
-| `vault.secret.engine.pki.count`             | The total number of PKI secret engines in Vault.                         |
-| `vault.secret.engine.rabbitmq.count`        | The total number of RabbitMQ secret engines in Vault.                    |
-| `vault.secret.engine.ssh.count`             | The total number of SSH secret engines in Vault.                         |
-| `vault.secret.engine.terraform.count`       | The total number of Terraform secret engines in Vault.                   |
-| `vault.secret.engine.totp.count`            | The total number of TOTP secret engines in Vault.                        |
-| `vault.secret.engine.transform.count`       | The total number of Transform secret engines in Vault.                   |
-| `vault.secret.engine.transit.count`         | The total number of Transit secret engines in Vault.                     |
-| `vault.secret.engine.database.count`        | The total number of Database secret engines in Vault.                    |
-| `vault.secret.engine.plugin.count`          | The total number of custom plugin secret engines in Vault.               |
+| Metric Name                                          | Description                                                                        |
+|------------------------------------------------------|------------------------------------------------------------------------------------|
+| `vault.namespaces.count`                             | Total number of namespaces.                                                        |
+| `vault.leases.count`                                 | Total number of leases within Vault.                                               |
+| `vault.quotas.ratelimit.count`                       | Total number of rate limit quotas within Vault.                                    |
+| `vault.quotas.leasecount.count`                      | Total number of lease count quotas within Vault.                                   |
+| `vault.kv.version1.secrets.count`                    | Total number of KVv1 secrets within Vault.                                         |
+| `vault.kv.version2.secrets.count`                    | Total number of KVv2 secrets within Vault.                                         |
+| `vault.kv.version1.secrets.namespace.max`            | The highest number of KVv1 secrets in a namespace in Vault, e.g. `1000`.           |
+| `vault.kv.version2.secrets.namespace.max`            | The highest number of KVv2 secrets in a namespace in Vault, e.g. `1000`.           |
+| `vault.kv.version1.secrets.namespace.min`            | The lowest number of KVv1 secrets in a namespace in Vault, e.g. `2`.               |
+| `vault.kv.version2.secrets.namespace.min`            | The highest number of KVv2 secrets in a namespace in Vault, e.g. `1000`.           |
+| `vault.kv.version1.secrets.namespace.mean`           | The mean number of KVv1 secrets in namespaces in Vault, e.g. `52.8`.               |
+| `vault.kv.version2.secrets.namespace.mean`           | The mean number of KVv2 secrets in namespaces in Vault, e.g. `52.8`.               |
+| `vault.auth.method.approle.count`                    | The total number of Approle auth mounts in Vault.                                  |
+| `vault.auth.method.alicloud.count`                   | The total number of Alicloud auth mounts in Vault.                                 |
+| `vault.auth.method.aws.count`                        | The total number of AWS auth mounts in Vault.                                      |
+| `vault.auth.method.appid.count`                      | The total number of App ID auth mounts in Vault.                                   |
+| `vault.auth.method.azure.count`                      | The total number of Azure auth mounts in Vault.                                    |
+| `vault.auth.method.cloudfoundry.count`               | The total number of Cloud Foundry auth mounts in Vault.                            |
+| `vault.auth.method.github.count`                     | The total number of GitHub auth mounts in Vault.                                   |
+| `vault.auth.method.gcp.count`                        | The total number of GCP auth mounts in Vault.                                      |
+| `vault.auth.method.jwt.count`                        | The total number of JWT auth mounts in Vault.                                      |
+| `vault.auth.method.kerberos.count`                   | The total number of Kerberos auth mounts in Vault.                                 |
+| `vault.auth.method.kubernetes.count`                 | The total number of kubernetes auth mounts in Vault.                               |
+| `vault.auth.method.ldap.count`                       | The total number of LDAP auth mounts in Vault.                                     |
+| `vault.auth.method.oci.count`                        | The total number of OCI auth mounts in Vault.                                      |
+| `vault.auth.method.okta.count`                       | The total number of Okta auth mounts in Vault.                                     |
+| `vault.auth.method.pcf.count`                        | The total number of PCF auth mounts in Vault.                                      |
+| `vault.auth.method.radius.count`                     | The total number of Radius auth mounts in Vault.                                   |
+| `vault.auth.method.saml.count`                       | The total number of SAML auth mounts in Vault.                                     |
+| `vault.auth.method.cert.count`                       | The total number of Cert auth mounts in Vault.                                     |
+| `vault.auth.method.oidc.count`                       | The total number of OIDC auth mounts in Vault.                                     |
+| `vault.auth.method.token.count`                      | The total number of Token auth mounts in Vault.                                    |
+| `vault.auth.method.userpass.count`                   | The total number of Userpass auth mounts in Vault.                                 |
+| `vault.auth.method.plugin.count`                     | The total number of custom plugin auth mounts in Vault.                            |
+| `vault.secret.engine.activedirectory.count`          | The total number of Active Directory secret engines in Vault.                      |
+| `vault.secret.engine.alicloud.count`                 | The total number of Alicloud secret engines in Vault.                              |
+| `vault.secret.engine.aws.count`                      | The total number of AWS secret engines in Vault.                                   |
+| `vault.secret.engine.azure.count`                    | The total number of Azure secret engines in Vault.                                 |
+| `vault.secret.engine.consul.count`                   | The total number of Consul secret engines in Vault.                                |
+| `vault.secret.engine.gcp.count`                      | The total number of GCP secret engines in Vault.                                   |
+| `vault.secret.engine.gcpkms.count`                   | The total number of GCPKMS secret engines in Vault.                                |
+| `vault.secret.engine.kubernetes.count`               | The total number of Kubernetes secret engines in Vault.                            |
+| `vault.secret.engine.cassandra.count`                | The total number of Cassandra secret engines in Vault.                             |
+| `vault.secret.engine.keymgmt.count`                  | The total number of Keymgmt secret engines in Vault.                               |
+| `vault.secret.engine.kv.count`                       | The total number of kv secret engines in Vault.                                    |
+| `vault.secret.engine.kmip.count`                     | The total number of KMIP secret engines in Vault.                                  |
+| `vault.secret.engine.mongodb.count`                  | The total number of MongoDB secret engines in Vault.                               |
+| `vault.secret.engine.mongodbatlas.count`             | The total number of MongoDBAtlas secret engines in Vault.                          |
+| `vault.secret.engine.mssql.count`                    | The total number of MSSql secret engines in Vault.                                 |
+| `vault.secret.engine.postgresql.count`               | The total number of Postgresql secret engines in Vault.                            |
+| `vault.secret.engine.nomad.count`                    | The total number of Nomad secret engines in Vault.                                 |
+| `vault.secret.engine.ldap.count`                     | The total number of LDAP secret engines in Vault.                                  |
+| `vault.secret.engine.openldap.count`                 | The total number of OpenLDAP secret engines in Vault.                              |
+| `vault.secret.engine.pki.count`                      | The total number of PKI secret engines in Vault.                                   |
+| `vault.secret.engine.rabbitmq.count`                 | The total number of RabbitMQ secret engines in Vault.                              |
+| `vault.secret.engine.ssh.count`                      | The total number of SSH secret engines in Vault.                                   |
+| `vault.secret.engine.terraform.count`                | The total number of Terraform secret engines in Vault.                             |
+| `vault.secret.engine.totp.count`                     | The total number of TOTP secret engines in Vault.                                  |
+| `vault.secret.engine.transform.count`                | The total number of Transform secret engines in Vault.                             |
+| `vault.secret.engine.transit.count`                  | The total number of Transit secret engines in Vault.                               |
+| `vault.secret.engine.database.count`                 | The total number of Database secret engines in Vault.                              |
+| `vault.secret.engine.plugin.count`                   | The total number of custom plugin secret engines in Vault.                         |
+| `vault.secretsync.sources.count`                     | The total number of secret sources configured for secret sync.                     |
+| `vault.secretsync.destinations.count`                | The total number of secret destinations configured for secret sync.                |
+| `vault.secretsync.destinations.aws-sm.count`         | The total number of AWS-SM secret destinations configured for secret sync.         |
+| `vault.secretsync.destinations.azure-kv.count`       | The total number of Azure-KV secret destinations configured for secret sync.       |
+| `vault.secretsync.destinations.gh.count`             | The total number of GH secret destinations configured for secret sync.             |
+| `vault.secretsync.destinations.vault.count`          | The total number of Vault secret destinations configured for secret sync.          |
+| `vault.secretsync.destinations.vercel-project.count` | The total number of Vercel Project secret destinations configured for secret sync. |
+| `vault.secretsync.destinations.terraform.count`      | The total number of Terraform secret destinations configured for secret sync.      |
+| `vault.secretsync.destinations.gitlab.count`         | The total number of GitLab secret destinations configured for secret sync.         |
+| `vault.secretsync.destinations.inmem.count`          | The total number of InMem secret destinations configured for secret sync.          |
 
 ## Usage metadata list
 


### PR DESCRIPTION
### Description

Docs PR for https://github.com/hashicorp/vault-enterprise/pull/7072

Will need to be backported and manually backported

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [x] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
