### PR TITLE
CLI: add an option for renew command fail on non-fulfillable request…

### DIFF
--- a/changelog/29060.txt
+++ b/changelog/29060.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+CLI: adds an optional flag (--fail-if-not-fulfilled) to the renew command, which lets the renew command fail on unfulfillable requests and allows command chaining to allow further executions.
+```

--- a/command/token_renew_test.go
+++ b/command/token_renew_test.go
@@ -56,6 +56,18 @@ func TestTokenRenewCommand_Run(t *testing.T) {
 			"",
 			0,
 		},
+		{
+			"fail_if_not_fulfilled_exceeds_max_ttl",
+			[]string{"-increment", "33d", "--fail-if-not-fulfilled"},
+			"Token renewal completed with capped duration, failing the command because of --fail-if-not-fulfilled",
+			1,
+		},
+		{
+			"fail_if_not_fulfilled_within_max_ttl",
+			[]string{"-increment", "30m", "--fail-if-not-fulfilled"},
+			"",
+			0,
+		},
 	}
 
 	t.Run("validations", func(t *testing.T) {

--- a/website/content/docs/commands/token/renew.mdx
+++ b/website/content/docs/commands/token/renew.mdx
@@ -36,6 +36,12 @@ Renew a token requesting a specific increment value:
 $ vault token renew -increment=30m 96ddf4bc-d217-f3ba-f9bd-017055595017
 ```
 
+Fail if the requested TTL increment cannot be fully fulfilled:
+
+```shell-session
+$ vault token renew -increment=30m 96ddf4bc-d217-f3ba-f9bd-017055595017 --fail-if-not-fulfilled || vault login
+```
+
 ## Usage
 
 The following flags are available in addition to the [standard set of
@@ -56,3 +62,7 @@ flags](/vault/docs/commands) included on all commands.
 
 - `-accessor` `(bool: false)` - Treat the argument as an accessor instead of a
 token. When this option is selected, the output will NOT include the token.
+
+- `--fail-if-not-fulfilled` - Fail if the requested TTL increment cannot be
+fully fulfilled. Vault allows command chaining and token renewal request
+completion with capped duration even if renew request fails.


### PR DESCRIPTION
### Description
What does this PR do?
This pull request adds an optional flag (--fail-if-not-fulfilled) to the renew command, which lets the renew command fail on unfulfillable requests and allows command chaining to allow further executions.

Related Issue: #28710 
