### PR TITLE
Fix docs - server command - log-file parameter - path value example

### DIFF
--- a/website/content/docs/commands/server.mdx
+++ b/website/content/docs/commands/server.mdx
@@ -69,7 +69,7 @@ flags](/vault/docs/commands) included on all commands.
 
   | `log-file`              | Full log file           | Rotated log file                    |
   |-------------------------|-------------------------|-------------------------------------|
-  | `/var/log`              | `/var/log/vault.log`    | `/var/log/vault-{timestamp}.log`    |
+  | `/var/log/`             | `/var/log/vault.log`    | `/var/log/vault-{timestamp}.log`    |
   | `/var/log/my-diary`     | `/var/log/my-diary.log` | `/var/log/my-diary-{timestamp}.log` |
   | `/var/log/my-diary.txt` | `/var/log/my-diary.txt` | `/var/log/my-diary-{timestamp}.txt` |
 


### PR DESCRIPTION
### Description
[Docs - Vault CLI - server command - log-file parameter](https://developer.hashicorp.com/vault/docs/commands/server#_log_file)
path value needs "ending with a path separator".
