### PR TITLE
Remove all references to current fragments, standbyfragments and partialMonthTracker

### DIFF
--- a/builtin/logical/pki/acme_billing_test.go
+++ b/builtin/logical/pki/acme_billing_test.go
@@ -104,15 +104,17 @@ func TestACMEBilling(t *testing.T) {
 	expectedCount = validateClientCount(t, client, "ns2/pki", expectedCount+1, "unique identifier in a different namespace")
 
 	// Check the current fragment
-	fragment := cluster.Cores[0].Core.ResetActivityLog()[0]
-	if fragment == nil {
+	localFragment, globalFragment := cluster.Cores[0].Core.ResetActivityLog()
+	if globalFragment == nil || localFragment == nil {
 		t.Fatal("no fragment created")
 	}
-	validateAcmeClientTypes(t, fragment, expectedCount)
+	validateAcmeClientTypes(t, localFragment[0], 0)
+	validateAcmeClientTypes(t, globalFragment[0], expectedCount)
 }
 
 func validateAcmeClientTypes(t *testing.T, fragment *activity.LogFragment, expectedCount int64) {
 	t.Helper()
+
 	if int64(len(fragment.Clients)) != expectedCount {
 		t.Fatalf("bad number of entities, expected %v: got %v, entities are: %v", expectedCount, len(fragment.Clients), fragment.Clients)
 	}

--- a/command/command_testonly/operator_usage_testonly_test.go
+++ b/command/command_testonly/operator_usage_testonly_test.go
@@ -53,7 +53,7 @@ func TestOperatorUsageCommandRun(t *testing.T) {
 
 	now := time.Now().UTC()
 
-	_, _, _, err = clientcountutil.NewActivityLogData(client).
+	_, _, err = clientcountutil.NewActivityLogData(client).
 		NewPreviousMonthData(1).
 		NewClientsSeen(6, clientcountutil.WithClientType("entity")).
 		NewClientsSeen(4, clientcountutil.WithClientType("non-entity-token")).

--- a/sdk/helper/clientcountutil/clientcountutil_test.go
+++ b/sdk/helper/clientcountutil/clientcountutil_test.go
@@ -116,7 +116,7 @@ func TestNewCurrentMonthData_AddClients(t *testing.T) {
 // sent to the server is correct.
 func TestWrite(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, err := io.WriteString(w, `{"data":{"paths":["path1","path2"],"global_paths":["path2","path3"], "local_paths":["path3","path4"]}}`)
+		_, err := io.WriteString(w, `{"data":{"global_paths":["path2","path3"], "local_paths":["path3","path4"]}}`)
 		require.NoError(t, err)
 		body, err := io.ReadAll(r.Body)
 		require.NoError(t, err)
@@ -131,7 +131,7 @@ func TestWrite(t *testing.T) {
 		Address: ts.URL,
 	})
 	require.NoError(t, err)
-	paths, localPaths, globalPaths, err := NewActivityLogData(client).
+	localPaths, globalPaths, err := NewActivityLogData(client).
 		NewPreviousMonthData(3).
 		NewClientSeen().
 		NewPreviousMonthData(2).
@@ -140,7 +140,6 @@ func TestWrite(t *testing.T) {
 		NewCurrentMonthData().Write(context.Background(), generation.WriteOptions_WRITE_ENTITIES)
 
 	require.NoError(t, err)
-	require.Equal(t, []string{"path1", "path2"}, paths)
 	require.Equal(t, []string{"path2", "path3"}, globalPaths)
 	require.Equal(t, []string{"path3", "path4"}, localPaths)
 }

--- a/vault/activity_log_test.go
+++ b/vault/activity_log_test.go
@@ -34,7 +34,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestActivityLog_Creation calls AddEntityToFragment and verifies that it appears correctly in a.fragment.
+// TestActivityLog_Creation calls AddEntityToFragment and verifies that it appears correctly in a.currentGlobalFragment.
 func TestActivityLog_Creation(t *testing.T) {
 	storage := &logical.InmemStorage{}
 	coreConfig := &CoreConfig{
@@ -56,11 +56,13 @@ func TestActivityLog_Creation(t *testing.T) {
 	if a.logger == nil || a.view == nil {
 		t.Fatal("activity log not initialized")
 	}
-	if a.fragment != nil || a.currentGlobalFragment != nil {
-		t.Fatal("activity log already has fragment")
+	currentGlobalFragment := core.GetActiveGlobalFragment()
+	if currentGlobalFragment != nil {
+		t.Fatal("activity log already has global fragment")
 	}
 
-	if a.localFragment != nil {
+	localFragment := core.GetActiveLocalFragment()
+	if localFragment != nil {
 		t.Fatal("activity log already has a local fragment")
 	}
 
@@ -69,44 +71,29 @@ func TestActivityLog_Creation(t *testing.T) {
 	ts := time.Now()
 
 	a.AddEntityToFragment(entity_id, namespace_id, ts.Unix())
-	if a.fragment == nil || a.currentGlobalFragment == nil {
+	currentGlobalFragment = core.GetActiveGlobalFragment()
+	localFragment = core.GetActiveLocalFragment()
+
+	if currentGlobalFragment == nil {
 		t.Fatal("no fragment created")
 	}
 
-	if a.fragment.OriginatingNode != a.nodeID {
-		t.Errorf("mismatched node ID, %q vs %q", a.fragment.OriginatingNode, a.nodeID)
+	if a.currentGlobalFragment.OriginatingNode != a.nodeID {
+		t.Errorf("mismatched node ID, %q vs %q", currentGlobalFragment.OriginatingNode, a.nodeID)
 	}
-	if a.currentGlobalFragment.OriginatingCluster != a.core.ClusterID() {
-		t.Errorf("mismatched cluster ID, %q vs %q", a.currentGlobalFragment.GetOriginatingCluster(), a.core.ClusterID())
+	if currentGlobalFragment.OriginatingCluster != a.core.ClusterID() {
+		t.Errorf("mismatched cluster ID, %q vs %q", currentGlobalFragment.GetOriginatingCluster(), a.core.ClusterID())
 	}
 
-	if a.fragment.Clients == nil || a.currentGlobalFragment.Clients == nil {
+	if currentGlobalFragment.Clients == nil {
 		t.Fatal("no fragment entity slice")
 	}
 
-	if a.fragment.NonEntityTokens == nil {
-		t.Fatal("no fragment token map")
+	if len(currentGlobalFragment.Clients) != 1 {
+		t.Fatalf("wrong number of entities %v", len(currentGlobalFragment.Clients))
 	}
 
-	if len(a.fragment.Clients) != 1 {
-		t.Fatalf("wrong number of entities %v", len(a.fragment.Clients))
-	}
-	if len(a.currentGlobalFragment.Clients) != 1 {
-		t.Fatalf("wrong number of entities %v", len(a.currentGlobalFragment.Clients))
-	}
-
-	er := a.fragment.Clients[0]
-	if er.ClientID != entity_id {
-		t.Errorf("mimatched entity ID, %q vs %q", er.ClientID, entity_id)
-	}
-	if er.NamespaceID != namespace_id {
-		t.Errorf("mimatched namespace ID, %q vs %q", er.NamespaceID, namespace_id)
-	}
-	if er.Timestamp != ts.Unix() {
-		t.Errorf("mimatched timestamp, %v vs %v", er.Timestamp, ts.Unix())
-	}
-
-	er = a.currentGlobalFragment.Clients[0]
+	er := currentGlobalFragment.Clients[0]
 	if er.ClientID != entity_id {
 		t.Errorf("mimatched entity ID, %q vs %q", er.ClientID, entity_id)
 	}
@@ -118,20 +105,12 @@ func TestActivityLog_Creation(t *testing.T) {
 	}
 
 	// Reset and test the other code path
-	a.fragment = nil
 	a.AddTokenToFragment(namespace_id)
+	currentGlobalFragment = core.GetActiveGlobalFragment()
+	localFragment = core.GetActiveLocalFragment()
 
-	if a.fragment == nil {
+	if currentGlobalFragment == nil {
 		t.Fatal("no fragment created")
-	}
-
-	if a.fragment.NonEntityTokens == nil {
-		t.Fatal("no fragment token map")
-	}
-
-	actual := a.fragment.NonEntityTokens[namespace_id]
-	if actual != 1 {
-		t.Errorf("mismatched number of tokens, %v vs %v", actual, 1)
 	}
 
 	// test local fragment
@@ -149,24 +128,25 @@ func TestActivityLog_Creation(t *testing.T) {
 	local_ts := time.Now()
 
 	a.AddClientToFragment(local_entity_id, "root", local_ts.Unix(), false, "local_mount_accessor")
+	localFragment = core.GetActiveLocalFragment()
 
-	if a.localFragment.OriginatingNode != a.nodeID {
-		t.Errorf("mismatched node ID, %q vs %q", a.localFragment.OriginatingNode, a.nodeID)
+	if localFragment.OriginatingNode != a.nodeID {
+		t.Errorf("mismatched node ID, %q vs %q", localFragment.OriginatingNode, a.nodeID)
 	}
 
-	if a.localFragment.Clients == nil {
+	if localFragment.Clients == nil {
 		t.Fatal("no local fragment entity slice")
 	}
 
-	if a.localFragment.NonEntityTokens == nil {
+	if localFragment.NonEntityTokens == nil {
 		t.Fatal("no local fragment token map")
 	}
 
-	if len(a.localFragment.Clients) != 1 {
-		t.Fatalf("wrong number of entities %v", len(a.localFragment.Clients))
+	if len(localFragment.Clients) != 1 {
+		t.Fatalf("wrong number of entities %v", len(localFragment.Clients))
 	}
 
-	er = a.localFragment.Clients[0]
+	er = localFragment.Clients[0]
 	if er.ClientID != local_entity_id {
 		t.Errorf("mimatched entity ID, %q vs %q", er.ClientID, local_entity_id)
 	}
@@ -192,17 +172,13 @@ func TestActivityLog_Creation_WrappingTokens(t *testing.T) {
 	if a.logger == nil || a.view == nil {
 		t.Fatal("activity log not initialized")
 	}
-	a.fragmentLock.Lock()
-	if a.fragment != nil || a.currentGlobalFragment != nil {
+	if core.GetActiveGlobalFragment() != nil {
 		t.Fatal("activity log already has fragment")
 	}
-	a.fragmentLock.Unlock()
 
-	a.localFragmentLock.Lock()
-	if a.localFragment != nil {
+	if core.GetActiveLocalFragment() != nil {
 		t.Fatal("activity log already has local fragment")
 	}
-	a.localFragmentLock.Unlock()
 
 	const namespace_id = "ns123"
 
@@ -220,11 +196,9 @@ func TestActivityLog_Creation_WrappingTokens(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	a.fragmentLock.Lock()
-	if a.fragment != nil || a.currentGlobalFragment != nil {
+	if core.GetActiveGlobalFragment() != nil {
 		t.Fatal("fragment created")
 	}
-	a.fragmentLock.Unlock()
 
 	teNew := &logical.TokenEntry{
 		Path:         "test",
@@ -240,11 +214,9 @@ func TestActivityLog_Creation_WrappingTokens(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	a.fragmentLock.Lock()
-	if a.fragment != nil || a.currentGlobalFragment != nil {
+	if core.GetActiveGlobalFragment() != nil {
 		t.Fatal("fragment created")
 	}
-	a.fragmentLock.Unlock()
 }
 
 func checkExpectedEntitiesInMap(t *testing.T, a *ActivityLog, entityIDs []string) {
@@ -280,36 +252,15 @@ func TestActivityLog_UniqueEntities(t *testing.T) {
 	a.AddEntityToFragment(id2, "root", t3.Unix())
 	a.AddEntityToFragment(id1, "root", t3.Unix())
 
-	if a.fragment == nil || a.currentGlobalFragment == nil {
-		t.Fatal("no current fragment")
+	currentGlobalFragment := core.GetActiveGlobalFragment()
+	if currentGlobalFragment == nil {
+		t.Fatal("no current global fragment")
+	}
+	if len(currentGlobalFragment.Clients) != 2 {
+		t.Fatalf("number of entities is %v", len(currentGlobalFragment.Clients))
 	}
 
-	if len(a.fragment.Clients) != 2 {
-		t.Fatalf("number of entities is %v", len(a.fragment.Clients))
-	}
-	if len(a.currentGlobalFragment.Clients) != 2 {
-		t.Fatalf("number of entities is %v", len(a.currentGlobalFragment.Clients))
-	}
-
-	for i, e := range a.fragment.Clients {
-		expectedID := id1
-		expectedTime := t1.Unix()
-		expectedNS := "root"
-		if i == 1 {
-			expectedID = id2
-			expectedTime = t2.Unix()
-		}
-		if e.ClientID != expectedID {
-			t.Errorf("%v: expected %q, got %q", i, expectedID, e.ClientID)
-		}
-		if e.NamespaceID != expectedNS {
-			t.Errorf("%v: expected %q, got %q", i, expectedNS, e.NamespaceID)
-		}
-		if e.Timestamp != expectedTime {
-			t.Errorf("%v: expected %v, got %v", i, expectedTime, e.Timestamp)
-		}
-	}
-	for i, e := range a.currentGlobalFragment.Clients {
+	for i, e := range currentGlobalFragment.Clients {
 		expectedID := id1
 		expectedTime := t1.Unix()
 		expectedNS := "root"
@@ -410,11 +361,11 @@ func TestActivityLog_SaveTokensToStorage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("got error writing tokens to storage: %v", err)
 	}
-	if a.fragment != nil || a.currentGlobalFragment != nil {
+	if core.GetActiveGlobalFragment() != nil {
 		t.Errorf("fragment was not reset after write to storage")
 	}
 
-	if a.localFragment != nil {
+	if core.GetActiveLocalFragment() != nil {
 		t.Errorf("local fragment was not reset after write to storage")
 	}
 
@@ -446,11 +397,12 @@ func TestActivityLog_SaveTokensToStorage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("got error writing tokens to storage: %v", err)
 	}
-	if a.fragment != nil || a.currentGlobalFragment != nil {
+
+	if core.GetActiveGlobalFragment() != nil {
 		t.Errorf("fragment was not reset after write to storage")
 	}
 
-	if a.localFragment != nil {
+	if core.GetActiveLocalFragment() != nil {
 		t.Errorf("local fragment was not reset after write to storage")
 	}
 
@@ -492,7 +444,8 @@ func TestActivityLog_SaveTokensToStorageDoesNotUpdateTokenCount(t *testing.T) {
 	a.SetStartTimestamp(time.Now().Unix()) // set a nonzero segment
 
 	tokenPath := fmt.Sprintf("%sdirecttokens/%d/0", ActivityLogLocalPrefix, a.GetStartTimestamp())
-	clientPath := fmt.Sprintf("sys/counters/activity/log/entity/%d/0", a.GetStartTimestamp())
+	clientPath := fmt.Sprintf("sys/counters/activity/global/log/entity/%d/0", a.GetStartTimestamp())
+	localPath := fmt.Sprintf("sys/counters/activity/local/log/entity/%d/0", a.GetStartTimestamp())
 	// Create some entries without entityIDs
 	tokenEntryOne := logical.TokenEntry{NamespaceID: namespace.RootNamespaceID, Policies: []string{"hi"}}
 	entityEntry := logical.TokenEntry{EntityID: "foo", NamespaceID: namespace.RootNamespaceID, Policies: []string{"hi"}}
@@ -506,6 +459,9 @@ func TestActivityLog_SaveTokensToStorageDoesNotUpdateTokenCount(t *testing.T) {
 		}
 	}
 
+	// verify that the client got added to a local fragment
+	require.Len(t, core.GetActiveLocalFragment().Clients, 1)
+
 	idEntity, isTWE := entityEntry.CreateClientID()
 	for i := 0; i < 2; i++ {
 		err := a.HandleTokenUsage(ctx, &entityEntry, idEntity, isTWE)
@@ -513,35 +469,53 @@ func TestActivityLog_SaveTokensToStorageDoesNotUpdateTokenCount(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
+
+	// verify that the client got added to the global fragment
+	require.Len(t, core.GetActiveGlobalFragment().Clients, 1)
+
 	err := a.saveCurrentSegmentToStorage(ctx, false)
 	if err != nil {
 		t.Fatalf("got error writing TWEs to storage: %v", err)
 	}
 
 	// Assert that new elements have been written to the fragment
-	if a.fragment != nil || a.currentGlobalFragment != nil {
+	if core.GetActiveGlobalFragment() != nil {
 		t.Errorf("fragment was not reset after write to storage")
 	}
 
-	if a.localFragment != nil {
+	if core.GetActiveLocalFragment() != nil {
 		t.Errorf("local fragment was not reset after write to storage")
 	}
 
 	// Assert that no tokens have been written to the fragment
 	readSegmentFromStorageNil(t, core, tokenPath)
 
+	allClients := make([]*activity.EntityRecord, 0)
 	e := readSegmentFromStorage(t, core, clientPath)
 	out := &activity.EntityActivityLog{}
 	err = proto.Unmarshal(e.Value, out)
 	if err != nil {
 		t.Fatalf("could not unmarshal protobuf: %v", err)
 	}
-	if len(out.Clients) != 2 {
-		t.Fatalf("added 3 distinct TWEs and 2 distinct entity tokens that should all result in the same ID, got: %d", len(out.Clients))
+	if len(out.Clients) != 1 {
+		t.Fatalf("added 2 distinct entity tokens that should all result in the same ID, got: %d", len(out.Clients))
 	}
+	allClients = append(allClients, out.Clients...)
+
+	e = readSegmentFromStorage(t, core, localPath)
+	out = &activity.EntityActivityLog{}
+	err = proto.Unmarshal(e.Value, out)
+	if err != nil {
+		t.Fatalf("could not unmarshal protobuf: %v", err)
+	}
+	if len(out.Clients) != 1 {
+		t.Fatalf("added 3 distinct TWEs that should all result in the same ID, got: %d", len(out.Clients))
+	}
+	allClients = append(allClients, out.Clients...)
+
 	nonEntityTokenFlag := false
 	entityTokenFlag := false
-	for _, client := range out.Clients {
+	for _, client := range allClients {
 		if client.NonEntity == true {
 			nonEntityTokenFlag = true
 			if client.ClientID != idNonEntity {
@@ -578,7 +552,6 @@ func TestActivityLog_SaveEntitiesToStorage(t *testing.T) {
 		now.Add(1 * time.Second).Unix(),
 		now.Add(2 * time.Second).Unix(),
 	}
-	path := fmt.Sprintf("%sentity/%d/0", ActivityLogPrefix, a.GetStartTimestamp())
 	globalPath := fmt.Sprintf("%sentity/%d/0", ActivityGlobalLogPrefix, a.GetStartTimestamp())
 
 	a.AddEntityToFragment(ids[0], "root", times[0])
@@ -587,14 +560,14 @@ func TestActivityLog_SaveEntitiesToStorage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("got error writing entities to storage: %v", err)
 	}
-	if a.fragment != nil || a.currentGlobalFragment != nil {
+	if core.GetActiveGlobalFragment() != nil {
 		t.Errorf("fragment was not reset after write to storage")
 	}
 
-	if a.localFragment != nil {
+	if core.GetActiveLocalFragment() != nil {
 		t.Errorf("local fragment was not reset after write to storage")
 	}
-	protoSegment := readSegmentFromStorage(t, core, path)
+	protoSegment := readSegmentFromStorage(t, core, globalPath)
 	out := &activity.EntityActivityLog{}
 	err = proto.Unmarshal(protoSegment.Value, out)
 	if err != nil {
@@ -608,14 +581,6 @@ func TestActivityLog_SaveEntitiesToStorage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("got error writing segments to storage: %v", err)
 	}
-
-	protoSegment = readSegmentFromStorage(t, core, path)
-	out = &activity.EntityActivityLog{}
-	err = proto.Unmarshal(protoSegment.Value, out)
-	if err != nil {
-		t.Fatalf("could not unmarshal protobuf: %v", err)
-	}
-	expectedEntityIDs(t, out, ids)
 
 	protoSegment = readSegmentFromStorage(t, core, globalPath)
 	out = &activity.EntityActivityLog{}
@@ -686,7 +651,7 @@ func TestActivityLog_SaveEntitiesToStorageCommon(t *testing.T) {
 	if err != nil {
 		t.Fatalf("got error writing entities to storage: %v", err)
 	}
-	if a.fragment != nil {
+	if core.GetActiveGlobalFragment() != nil || core.GetActiveLocalFragment() != nil {
 		t.Errorf("fragment was not reset after write to storage")
 	}
 
@@ -775,8 +740,8 @@ func TestModifyResponseMonthsNilAppend(t *testing.T) {
 }
 
 // TestActivityLog_ReceivedFragment calls receivedFragment with a fragment and verifies it gets added to
-// standbyFragmentsReceived and standbyGlobalFragmentsReceived. Send the same fragment again and then verify that it doesn't change the entity map but does
-// get added to standbyFragmentsReceived and standbyGlobalFragmentsReceived.
+// standbyGlobalFragmentsReceived. Send the same fragment again and then verify that it doesn't change the entity map but does
+// get added to standbyGlobalFragmentsReceived.
 func TestActivityLog_ReceivedFragment(t *testing.T) {
 	core, _, _ := TestCoreUnsealed(t)
 	a := core.activityLog
@@ -806,17 +771,13 @@ func TestActivityLog_ReceivedFragment(t *testing.T) {
 		NonEntityTokens: make(map[string]uint64),
 	}
 
-	if len(a.standbyFragmentsReceived) != 0 {
+	if len(a.standbyGlobalFragmentsReceived) != 0 {
 		t.Fatalf("fragment already received")
 	}
 
 	a.receivedFragment(fragment)
 
 	checkExpectedEntitiesInMap(t, a, ids)
-
-	if len(a.standbyFragmentsReceived) != 1 {
-		t.Fatalf("fragment count is %v, expected 1", len(a.standbyFragmentsReceived))
-	}
 
 	if len(a.standbyGlobalFragmentsReceived) != 1 {
 		t.Fatalf("fragment count is %v, expected 1", len(a.standbyGlobalFragmentsReceived))
@@ -827,9 +788,6 @@ func TestActivityLog_ReceivedFragment(t *testing.T) {
 
 	checkExpectedEntitiesInMap(t, a, ids)
 
-	if len(a.standbyFragmentsReceived) != 2 {
-		t.Fatalf("fragment count is %v, expected 2", len(a.standbyFragmentsReceived))
-	}
 	if len(a.standbyGlobalFragmentsReceived) != 2 {
 		t.Fatalf("fragment count is %v, expected 2", len(a.standbyGlobalFragmentsReceived))
 	}
@@ -856,12 +814,17 @@ func TestActivityLog_availableLogs(t *testing.T) {
 	// set up a few files in storage
 	core, _, _ := TestCoreUnsealed(t)
 	a := core.activityLog
-	paths := [...]string{"entity/1111/1", "entity/992/3"}
+	globalPaths := [...]string{"entity/1111/1", "entity/992/3", "entity/991/1"}
+	localPaths := [...]string{"entity/1111/1", "entity/992/3", "entity/990/1"}
 	tokenPaths := [...]string{"directtokens/1111/1", "directtokens/1000000/1", "directtokens/992/1"}
-	expectedTimes := [...]time.Time{time.Unix(1000000, 0), time.Unix(1111, 0), time.Unix(992, 0)}
+	expectedTimes := [...]time.Time{time.Unix(1000000, 0), time.Unix(1111, 0), time.Unix(992, 0), time.Unix(991, 0), time.Unix(990, 0)}
 
-	for _, path := range paths {
-		WriteToStorage(t, core, ActivityLogPrefix+path, []byte("test"))
+	for _, path := range globalPaths {
+		WriteToStorage(t, core, ActivityGlobalLogPrefix+path, []byte("test"))
+	}
+
+	for _, path := range localPaths {
+		WriteToStorage(t, core, ActivityLogLocalPrefix+path, []byte("test"))
 	}
 
 	for _, path := range tokenPaths {
@@ -950,7 +913,7 @@ func TestActivityLog_createRegenerationIntentLog(t *testing.T) {
 			}
 
 			for _, subPath := range paths {
-				fullPath := ActivityLogPrefix + subPath
+				fullPath := ActivityGlobalLogPrefix + subPath
 				WriteToStorage(t, core, fullPath, []byte("test"))
 				deletePaths = append(deletePaths, fullPath)
 			}
@@ -999,9 +962,9 @@ func TestActivityLog_MultipleFragmentsAndSegments(t *testing.T) {
 	a.SetStartTimestamp(time.Now().Unix()) // set a nonzero segment
 
 	startTimestamp := a.GetStartTimestamp()
-	path0 := fmt.Sprintf("sys/counters/activity/log/entity/%d/0", startTimestamp)
-	path1 := fmt.Sprintf("sys/counters/activity/log/entity/%d/1", startTimestamp)
-	path2 := fmt.Sprintf("sys/counters/activity/log/entity/%d/2", startTimestamp)
+	path0 := fmt.Sprintf("sys/counters/activity/global/log/entity/%d/0", startTimestamp)
+	path1 := fmt.Sprintf("sys/counters/activity/global/log/entity/%d/1", startTimestamp)
+	path2 := fmt.Sprintf("sys/counters/activity/global/log/entity/%d/2", startTimestamp)
 	tokenPath := fmt.Sprintf("sys/counters/activity/local/log/directtokens/%d/0", startTimestamp)
 
 	genID := func(i int) string {
@@ -1092,11 +1055,6 @@ func TestActivityLog_MultipleFragmentsAndSegments(t *testing.T) {
 	err = a.saveCurrentSegmentToStorage(context.Background(), false)
 	if err != nil {
 		t.Fatalf("got error writing entities to storage: %v", err)
-	}
-
-	seqNum := a.GetEntitySequenceNumber()
-	if seqNum != 2 {
-		t.Fatalf("expected sequence number 2, got %v", seqNum)
 	}
 
 	protoSegment0 = readSegmentFromStorage(t, core, path0)
@@ -1305,12 +1263,8 @@ func TestActivityLog_parseSegmentNumberFromPath(t *testing.T) {
 func TestActivityLog_getLastEntitySegmentNumber(t *testing.T) {
 	core, _, _ := TestCoreUnsealed(t)
 	a := core.activityLog
-	paths := [...]string{"entity/992/0", "entity/1000/-1", "entity/1001/foo", "entity/1111/0", "entity/1111/1"}
 	globalPaths := [...]string{"entity/992/0", "entity/1000/-1", "entity/1001/foo", "entity/1111/1"}
 	localPaths := [...]string{"entity/992/0", "entity/1000/-1", "entity/1001/foo", "entity/1111/0", "entity/1111/1"}
-	for _, path := range paths {
-		WriteToStorage(t, core, ActivityLogPrefix+path, []byte("test"))
-	}
 	for _, path := range globalPaths {
 		WriteToStorage(t, core, ActivityGlobalLogPrefix+path, []byte("test"))
 	}
@@ -1320,42 +1274,36 @@ func TestActivityLog_getLastEntitySegmentNumber(t *testing.T) {
 
 	testCases := []struct {
 		input             int64
-		expectedVal       uint64
 		expectedGlobalVal uint64
 		expectedLocalVal  uint64
 		expectExists      bool
 	}{
 		{
 			input:             992,
-			expectedVal:       0,
 			expectedGlobalVal: 0,
 			expectedLocalVal:  0,
 			expectExists:      true,
 		},
 		{
 			input:             1000,
-			expectedVal:       0,
 			expectedGlobalVal: 0,
 			expectedLocalVal:  0,
 			expectExists:      false,
 		},
 		{
 			input:             1001,
-			expectedVal:       0,
 			expectedGlobalVal: 0,
 			expectedLocalVal:  0,
 			expectExists:      false,
 		},
 		{
 			input:             1111,
-			expectedVal:       1,
 			expectedGlobalVal: 1,
 			expectedLocalVal:  1,
 			expectExists:      true,
 		},
 		{
 			input:             2222,
-			expectedVal:       0,
 			expectedGlobalVal: 0,
 			expectedLocalVal:  0,
 			expectExists:      false,
@@ -1364,15 +1312,12 @@ func TestActivityLog_getLastEntitySegmentNumber(t *testing.T) {
 
 	ctx := context.Background()
 	for _, tc := range testCases {
-		result, localSegmentNumber, globalSegmentNumber, exists, err := a.getLastEntitySegmentNumber(ctx, time.Unix(tc.input, 0))
+		localSegmentNumber, globalSegmentNumber, exists, err := a.getLastEntitySegmentNumber(ctx, time.Unix(tc.input, 0))
 		if err != nil {
 			t.Fatalf("unexpected error for input %d: %v", tc.input, err)
 		}
 		if exists != tc.expectExists {
 			t.Errorf("expected result exists: %t, got: %t for input: %d", tc.expectExists, exists, tc.input)
-		}
-		if result != tc.expectedVal {
-			t.Errorf("expected: %d got: %d for input: %d", tc.expectedVal, result, tc.input)
 		}
 		if globalSegmentNumber != tc.expectedGlobalVal {
 			t.Errorf("expected: %d got: %d for input: %d", tc.expectedGlobalVal, globalSegmentNumber, tc.input)
@@ -1505,15 +1450,6 @@ func (a *ActivityLog) resetEntitiesInMemory(t *testing.T) {
 	a.globalFragmentLock.Lock()
 	defer a.globalFragmentLock.Unlock()
 
-	a.currentSegment = segmentInfo{
-		startTimestamp: time.Time{}.Unix(),
-		currentClients: &activity.EntityActivityLog{
-			Clients: make([]*activity.EntityRecord, 0),
-		},
-		tokenCount:           a.currentSegment.tokenCount,
-		clientSequenceNumber: 0,
-	}
-
 	a.currentGlobalSegment = segmentInfo{
 		startTimestamp: time.Time{}.Unix(),
 		currentClients: &activity.EntityActivityLog{
@@ -1532,7 +1468,6 @@ func (a *ActivityLog) resetEntitiesInMemory(t *testing.T) {
 		clientSequenceNumber: 0,
 	}
 
-	a.partialMonthClientTracker = make(map[string]*activity.EntityRecord)
 	a.partialMonthLocalClientTracker = make(map[string]*activity.EntityRecord)
 	a.globalPartialMonthClientTracker = make(map[string]*activity.EntityRecord)
 }
@@ -1549,7 +1484,6 @@ func TestActivityLog_loadCurrentClientSegment(t *testing.T) {
 		CountByNamespaceID: tokenRecords,
 	}
 	a.l.Lock()
-	a.currentSegment.tokenCount = tokenCount
 	a.currentLocalSegment.tokenCount = tokenCount
 	a.l.Unlock()
 
@@ -1610,7 +1544,6 @@ func TestActivityLog_loadCurrentClientSegment(t *testing.T) {
 		if err != nil {
 			t.Fatalf(err.Error())
 		}
-		WriteToStorage(t, core, ActivityLogPrefix+tc.path, data)
 		WriteToStorage(t, core, ActivityGlobalLogPrefix+tc.path, data)
 		WriteToStorage(t, core, ActivityLogLocalPrefix+tc.path, data)
 	}
@@ -1624,7 +1557,7 @@ func TestActivityLog_loadCurrentClientSegment(t *testing.T) {
 		// loadCurrentClientSegment requires us to grab the fragment lock and the
 		// activityLog lock, as per the comment in the loadCurrentClientSegment
 		// function
-		err := a.loadCurrentClientSegment(ctx, time.Unix(tc.time, 0), tc.seqNum, tc.seqNum, tc.seqNum)
+		err := a.loadCurrentClientSegment(ctx, time.Unix(tc.time, 0), tc.seqNum, tc.seqNum)
 		a.localFragmentLock.Unlock()
 		a.globalFragmentLock.Unlock()
 		a.fragmentLock.Unlock()
@@ -1639,14 +1572,8 @@ func TestActivityLog_loadCurrentClientSegment(t *testing.T) {
 
 		// verify accurate data in in-memory current segment
 		require.Equal(t, tc.time, a.GetStartTimestamp())
-		require.Equal(t, tc.seqNum, a.GetEntitySequenceNumber())
 		require.Equal(t, tc.seqNum, a.GetGlobalEntitySequenceNumber())
 		require.Equal(t, tc.seqNum, a.GetLocalEntitySequenceNumber())
-
-		currentEntities := a.GetCurrentEntities()
-		if !entityRecordsEqual(t, currentEntities.Clients, tc.entities.Clients) {
-			t.Errorf("bad data loaded. expected: %v, got: %v for path %q", tc.entities.Clients, currentEntities, tc.path)
-		}
 
 		globalClients := core.GetActiveGlobalClientsList()
 		if err := ActiveEntitiesEqual(globalClients, tc.entities.Clients); err != nil {
@@ -1739,7 +1666,6 @@ func TestActivityLog_loadPriorEntitySegment(t *testing.T) {
 		if err != nil {
 			t.Fatalf(err.Error())
 		}
-		WriteToStorage(t, core, ActivityLogPrefix+tc.path, data)
 		WriteToStorage(t, core, ActivityGlobalLogPrefix+tc.path, data)
 		WriteToStorage(t, core, ActivityLogLocalPrefix+tc.path, data)
 	}
@@ -1748,20 +1674,22 @@ func TestActivityLog_loadPriorEntitySegment(t *testing.T) {
 	for _, tc := range testCases {
 		if tc.refresh {
 			a.l.Lock()
-			a.fragmentLock.Lock()
 			a.localFragmentLock.Lock()
-			a.partialMonthClientTracker = make(map[string]*activity.EntityRecord)
 			a.partialMonthLocalClientTracker = make(map[string]*activity.EntityRecord)
 			a.globalPartialMonthClientTracker = make(map[string]*activity.EntityRecord)
-			a.currentSegment.startTimestamp = tc.time
 			a.currentGlobalSegment.startTimestamp = tc.time
 			a.currentLocalSegment.startTimestamp = tc.time
-			a.fragmentLock.Unlock()
 			a.localFragmentLock.Unlock()
 			a.l.Unlock()
 		}
 
-		err := a.loadPriorEntitySegment(ctx, time.Unix(tc.time, 0), tc.seqNum)
+		// load global segments
+		err := a.loadPriorEntitySegment(ctx, time.Unix(tc.time, 0), tc.seqNum, false)
+		if err != nil {
+			t.Fatalf("got error loading data for %q: %v", tc.path, err)
+		}
+		// load local segments
+		err = a.loadPriorEntitySegment(ctx, time.Unix(tc.time, 0), tc.seqNum, true)
 		if err != nil {
 			t.Fatalf("got error loading data for %q: %v", tc.path, err)
 		}
@@ -1937,14 +1865,12 @@ func setupActivityRecordsInStorage(t *testing.T, base time.Time, includeEntities
 			}
 			switch i {
 			case 0:
-				WriteToStorage(t, core, ActivityLogPrefix+"entity/"+fmt.Sprint(monthsAgo.Unix())+"/0", entityData)
 				WriteToStorage(t, core, ActivityGlobalLogPrefix+"entity/"+fmt.Sprint(monthsAgo.Unix())+"/0", entityData)
 
 			case len(entityRecords) - 1:
 				// local data
 				WriteToStorage(t, core, ActivityLogLocalPrefix+"entity/"+fmt.Sprint(base.Unix())+"/"+strconv.Itoa(i-1), entityData)
 			default:
-				WriteToStorage(t, core, ActivityLogPrefix+"entity/"+fmt.Sprint(base.Unix())+"/"+strconv.Itoa(i-1), entityData)
 				WriteToStorage(t, core, ActivityGlobalLogPrefix+"entity/"+fmt.Sprint(base.Unix())+"/"+strconv.Itoa(i-1), entityData)
 			}
 		}
@@ -1988,14 +1914,22 @@ func TestActivityLog_refreshFromStoredLog(t *testing.T) {
 	}
 	wg.Wait()
 
+	// active clients for the entire month
 	expectedActive := &activity.EntityActivityLog{
 		Clients: expectedClientRecords[1:],
 	}
-	expectedCurrent := &activity.EntityActivityLog{
-		Clients: expectedClientRecords[len(expectedClientRecords)-2 : len(expectedClientRecords)-1],
+	expectedActiveGlobal := &activity.EntityActivityLog{
+		Clients: expectedClientRecords[1 : len(expectedClientRecords)-1],
 	}
+
+	// local client is only added to the newest segment for the current month. This should also appear in the active clients for the entire month.
 	expectedCurrentLocal := &activity.EntityActivityLog{
 		Clients: expectedClientRecords[len(expectedClientRecords)-1:],
+	}
+
+	// global clients added to the newest local entity segment
+	expectedCurrent := &activity.EntityActivityLog{
+		Clients: expectedClientRecords[len(expectedClientRecords)-2 : len(expectedClientRecords)-1],
 	}
 
 	currentEntities := a.GetCurrentGlobalEntities()
@@ -2020,6 +1954,19 @@ func TestActivityLog_refreshFromStoredLog(t *testing.T) {
 	if err := ActiveEntitiesEqual(activeClients, expectedActive.Clients); err != nil {
 		// we expect activeClients to be loaded for the entire month
 		t.Errorf("bad data loaded into active entities. expected only set of EntityID from %v in %v: %v", expectedActive.Clients, activeClients, err)
+	}
+
+	// verify active global clients list
+	activeGlobalClients := a.core.GetActiveGlobalClientsList()
+	if err := ActiveEntitiesEqual(activeGlobalClients, expectedActiveGlobal.Clients); err != nil {
+		// we expect activeClients to be loaded for the entire month
+		t.Errorf("bad data loaded into active global entities. expected only set of EntityID from %v in %v: %v", expectedActiveGlobal.Clients, activeGlobalClients, err)
+	}
+	// verify active local clients list
+	activeLocalClients := a.core.GetActiveLocalClientsList()
+	if err := ActiveEntitiesEqual(activeLocalClients, expectedCurrentLocal.Clients); err != nil {
+		// we expect activeClients to be loaded for the entire month
+		t.Errorf("bad data loaded into active local entities. expected only set of EntityID from %v in %v: %v", expectedCurrentLocal.Clients, activeLocalClients, err)
 	}
 }
 
@@ -2082,6 +2029,18 @@ func TestActivityLog_refreshFromStoredLogWithBackgroundLoadingCancelled(t *testi
 		// we only expect activeClients to be loaded for the newest segment (for the current month)
 		t.Error(err)
 	}
+
+	// verify if the right global clients are loaded for the newest segment (for the current month)
+	activeGlobalClients := a.core.GetActiveGlobalClientsList()
+	if err := ActiveEntitiesEqual(activeGlobalClients, expectedCurrent.Clients); err != nil {
+		t.Error(err)
+	}
+
+	// the right local clients are loaded for the newest segment (for the current month)
+	activeLocalClients := a.core.GetActiveLocalClientsList()
+	if err := ActiveEntitiesEqual(activeLocalClients, currentLocalEntities.Clients); err != nil {
+		t.Error(err)
+	}
 }
 
 // TestActivityLog_refreshFromStoredLogContextCancelled writes data from 3 months ago to this month and calls
@@ -2115,20 +2074,11 @@ func TestActivityLog_refreshFromStoredLogNoTokens(t *testing.T) {
 	expectedActive := &activity.EntityActivityLog{
 		Clients: expectedClientRecords[1:],
 	}
-	expectedCurrent := &activity.EntityActivityLog{
-		Clients: expectedClientRecords[len(expectedClientRecords)-2 : len(expectedClientRecords)-1],
-	}
 	expectedCurrentGlobal := &activity.EntityActivityLog{
 		Clients: expectedClientRecords[len(expectedClientRecords)-2 : len(expectedClientRecords)-1],
 	}
 	expectedCurrentLocal := &activity.EntityActivityLog{
 		Clients: expectedClientRecords[len(expectedClientRecords)-1:],
-	}
-
-	currentEntities := a.GetCurrentEntities()
-	if !entityRecordsEqual(t, currentEntities.Clients, expectedCurrent.Clients) {
-		// we expect all segments for the current month to be loaded
-		t.Errorf("bad activity entity logs loaded. expected: %v got: %v", expectedCurrent, currentEntities)
 	}
 
 	currentGlobalEntities := a.GetCurrentGlobalEntities()
@@ -2174,7 +2124,7 @@ func TestActivityLog_refreshFromStoredLogNoEntities(t *testing.T) {
 		t.Errorf("bad activity token counts loaded. expected: %v got: %v", expectedTokenCounts, nsCount)
 	}
 
-	currentEntities := a.GetCurrentEntities()
+	currentEntities := a.GetCurrentGlobalEntities()
 	if len(currentEntities.Clients) > 0 {
 		t.Errorf("expected no current entity segment to be loaded. got: %v", currentEntities)
 	}
@@ -2245,7 +2195,7 @@ func TestActivityLog_refreshFromStoredLogPreviousMonth(t *testing.T) {
 		Clients: expectedClientRecords[len(expectedClientRecords)-2 : len(expectedClientRecords)-1],
 	}
 
-	currentEntities := a.GetCurrentEntities()
+	currentEntities := a.GetCurrentGlobalEntities()
 	if !entityRecordsEqual(t, currentEntities.Clients, expectedCurrent.Clients) {
 		// we only expect the newest entity segment to be loaded (for the current month)
 		t.Errorf("bad activity entity logs loaded. expected: %v got: %v", expectedCurrent, currentEntities)
@@ -2343,16 +2293,7 @@ func TestActivityLog_DeleteWorker(t *testing.T) {
 		"entity/1112/1",
 	}
 	for _, path := range paths {
-		WriteToStorage(t, core, ActivityLogPrefix+path, []byte("test"))
-	}
-
-	localPaths := []string{
-		"entity/1111/1",
-		"entity/1111/2",
-		"entity/1111/3",
-		"entity/1112/1",
-	}
-	for _, path := range localPaths {
+		WriteToStorage(t, core, ActivityGlobalLogPrefix+path, []byte("test"))
 		WriteToStorage(t, core, ActivityLogLocalPrefix+path, []byte("test"))
 	}
 
@@ -2376,14 +2317,14 @@ func TestActivityLog_DeleteWorker(t *testing.T) {
 	}
 
 	// Check segments still present
-	readSegmentFromStorage(t, core, ActivityLogPrefix+"entity/1112/1")
+	readSegmentFromStorage(t, core, ActivityGlobalLogPrefix+"entity/1112/1")
 	readSegmentFromStorage(t, core, ActivityLogLocalPrefix+"entity/1112/1")
 	readSegmentFromStorage(t, core, ActivityLogLocalPrefix+"directtokens/1112/1")
 
 	// Check other segments not present
-	expectMissingSegment(t, core, ActivityLogPrefix+"entity/1111/1")
-	expectMissingSegment(t, core, ActivityLogPrefix+"entity/1111/2")
-	expectMissingSegment(t, core, ActivityLogPrefix+"entity/1111/3")
+	expectMissingSegment(t, core, ActivityGlobalLogPrefix+"entity/1111/1")
+	expectMissingSegment(t, core, ActivityGlobalLogPrefix+"entity/1111/2")
+	expectMissingSegment(t, core, ActivityGlobalLogPrefix+"entity/1111/3")
 	expectMissingSegment(t, core, ActivityLogLocalPrefix+"entity/1111/1")
 	expectMissingSegment(t, core, ActivityLogLocalPrefix+"entity/1111/2")
 	expectMissingSegment(t, core, ActivityLogLocalPrefix+"entity/1111/3")
@@ -2473,7 +2414,7 @@ func TestActivityLog_EnableDisable(t *testing.T) {
 	}
 
 	// verify segment exists
-	path := fmt.Sprintf("%ventity/%v/0", ActivityLogPrefix, seg1)
+	path := fmt.Sprintf("%ventity/%v/0", ActivityGlobalLogPrefix, seg1)
 	readSegmentFromStorage(t, core, path)
 
 	// Add in-memory fragment
@@ -2503,7 +2444,7 @@ func TestActivityLog_EnableDisable(t *testing.T) {
 		}
 
 		// Verify empty segments are present
-		path = fmt.Sprintf("%ventity/%v/0", ActivityLogPrefix, seg2)
+		path = fmt.Sprintf("%ventity/%v/0", ActivityGlobalLogPrefix, seg2)
 		readSegmentFromStorage(t, core, path)
 
 		path = fmt.Sprintf("%vdirecttokens/%v/0", ActivityLogLocalPrefix, seg2)
@@ -2544,6 +2485,8 @@ func TestActivityLog_EndOfMonth(t *testing.T) {
 	id2 := "22222222-2222-2222-2222-222222222222"
 	id3 := "33333333-3333-3333-3333-333333333333"
 	id4 := "44444444-4444-4444-4444-444444444444"
+
+	// add global data
 	a.AddEntityToFragment(id1, "root", time.Now().Unix())
 
 	// add local data
@@ -2567,18 +2510,9 @@ func TestActivityLog_EndOfMonth(t *testing.T) {
 	a.HandleEndOfMonth(ctx, month1)
 
 	// Check segment is present, with 1 entity
-	path := fmt.Sprintf("%ventity/%v/0", ActivityLogPrefix, segment0)
+	path := fmt.Sprintf("%ventity/%v/0", ActivityGlobalLogPrefix, segment0)
 	protoSegment := readSegmentFromStorage(t, core, path)
 	out := &activity.EntityActivityLog{}
-	err = proto.Unmarshal(protoSegment.Value, out)
-	if err != nil {
-		t.Fatal(err)
-	}
-	expectedEntityIDs(t, out, []string{id1, id4})
-
-	path = fmt.Sprintf("%ventity/%v/0", ActivityGlobalLogPrefix, segment0)
-	protoSegment = readSegmentFromStorage(t, core, path)
-	out = &activity.EntityActivityLog{}
 	err = proto.Unmarshal(protoSegment.Value, out)
 	if err != nil {
 		t.Fatal(err)
@@ -2648,18 +2582,6 @@ func TestActivityLog_EndOfMonth(t *testing.T) {
 
 	for i, tc := range testCases {
 		t.Logf("checking segment %v timestamp %v", i, tc.SegmentTimestamp)
-
-		expectedAllEntities := make([]string, 0)
-		expectedAllEntities = append(expectedAllEntities, tc.ExpectedGlobalEntityIDs...)
-		expectedAllEntities = append(expectedAllEntities, tc.ExpectedLocalEntityIDs...)
-		path := fmt.Sprintf("%ventity/%v/0", ActivityLogPrefix, tc.SegmentTimestamp)
-		protoSegment := readSegmentFromStorage(t, core, path)
-		out := &activity.EntityActivityLog{}
-		err = proto.Unmarshal(protoSegment.Value, out)
-		if err != nil {
-			t.Fatalf("could not unmarshal protobuf: %v", err)
-		}
-		expectedEntityIDs(t, out, expectedAllEntities)
 
 		// Check for global entities at global storage path
 		path = fmt.Sprintf("%ventity/%v/0", ActivityGlobalLogPrefix, tc.SegmentTimestamp)
@@ -2844,7 +2766,7 @@ func TestActivityLog_CalculatePrecomputedQueriesWithMixedTWEs(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		path := fmt.Sprintf("%ventity/%v/%v", ActivityLogPrefix, segment.StartTime, segment.Segment)
+		path := fmt.Sprintf("%ventity/%v/%v", ActivityGlobalLogPrefix, segment.StartTime, segment.Segment)
 		WriteToStorage(t, core, path, data)
 	}
 	expectedCounts := []struct {
@@ -3125,10 +3047,10 @@ func TestActivityLog_SaveAfterDisable(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	path := ActivityLogPrefix + "entity/0/0"
+	path := ActivityGlobalLogPrefix + "entity/0/0"
 	expectMissingSegment(t, core, path)
 
-	path = fmt.Sprintf("%ventity/%v/0", ActivityLogPrefix, startTimestamp)
+	path = fmt.Sprintf("%ventity/%v/0", ActivityGlobalLogPrefix, startTimestamp)
 	expectMissingSegment(t, core, path)
 }
 
@@ -3229,7 +3151,7 @@ func TestActivityLog_Precompute(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		path := fmt.Sprintf("%ventity/%v/%v", ActivityLogPrefix, segment.StartTime, segment.Segment)
+		path := fmt.Sprintf("%ventity/%v/%v", ActivityGlobalLogPrefix, segment.StartTime, segment.Segment)
 		WriteToStorage(t, core, path, data)
 	}
 
@@ -3540,7 +3462,7 @@ func TestActivityLog_Precompute_SkipMonth(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		path := fmt.Sprintf("%ventity/%v/%v", ActivityLogPrefix, segment.StartTime, segment.Segment)
+		path := fmt.Sprintf("%ventity/%v/%v", ActivityGlobalLogPrefix, segment.StartTime, segment.Segment)
 		WriteToStorage(t, core, path, data)
 	}
 
@@ -3757,7 +3679,7 @@ func TestActivityLog_PrecomputeNonEntityTokensWithID(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		path := fmt.Sprintf("%ventity/%v/%v", ActivityLogPrefix, segment.StartTime, segment.Segment)
+		path := fmt.Sprintf("%ventity/%v/%v", ActivityGlobalLogPrefix, segment.StartTime, segment.Segment)
 		WriteToStorage(t, core, path, data)
 	}
 
@@ -4146,7 +4068,7 @@ func TestActivityLog_Deletion(t *testing.T) {
 	for i, start := range times {
 		// no entities in some months, just for fun
 		for j := 0; j < (i+3)%5; j++ {
-			entityPath := fmt.Sprintf("%ventity/%v/%v", ActivityLogPrefix, start.Unix(), j)
+			entityPath := fmt.Sprintf("%ventity/%v/%v", ActivityGlobalLogPrefix, start.Unix(), j)
 			paths[i] = append(paths[i], entityPath)
 			WriteToStorage(t, core, entityPath, []byte("test"))
 		}
@@ -4522,7 +4444,7 @@ func TestActivityLog_partialMonthClientCountWithMultipleMountPaths(t *testing.T)
 		if err != nil {
 			t.Fatalf(err.Error())
 		}
-		storagePath := fmt.Sprintf("%sentity/%d/%d", ActivityLogPrefix, timeutil.StartOfMonth(now).Unix(), i)
+		storagePath := fmt.Sprintf("%sentity/%d/%d", ActivityGlobalLogPrefix, timeutil.StartOfMonth(now).Unix(), i)
 		WriteToStorage(t, core, storagePath, entityData)
 	}
 
@@ -5162,7 +5084,6 @@ func TestAddActivityToFragment(t *testing.T) {
 	a := core.activityLog
 	a.SetEnable(true)
 
-	require.Nil(t, a.fragment)
 	require.Nil(t, a.localFragment)
 	require.Nil(t, a.currentGlobalFragment)
 
@@ -5254,10 +5175,6 @@ func TestAddActivityToFragment(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			var mountAccessor string
-			a.fragmentLock.RLock()
-			numClientsBefore := len(a.fragment.Clients)
-			a.fragmentLock.RUnlock()
-
 			a.globalFragmentLock.RLock()
 			globalClientsBefore := len(a.currentGlobalFragment.Clients)
 			a.globalFragmentLock.RUnlock()
@@ -5281,9 +5198,6 @@ func TestAddActivityToFragment(t *testing.T) {
 				a.AddActivityToFragment(tc.id, ns, 0, tc.activityType, mount)
 			}
 
-			a.fragmentLock.RLock()
-			defer a.fragmentLock.RUnlock()
-			numClientsAfter := len(a.fragment.Clients)
 			a.globalFragmentLock.RLock()
 			defer a.globalFragmentLock.RUnlock()
 			globalClientsAfter := len(a.currentGlobalFragment.Clients)
@@ -5311,24 +5225,6 @@ func TestAddActivityToFragment(t *testing.T) {
 					require.Equal(t, globalClientsBefore, globalClientsAfter)
 				}
 			}
-
-			// for now local clients are added to both regular fragment and local fragment.
-			// this will be modified in ticket vault-31234
-			if tc.isAdded {
-				require.Equal(t, numClientsBefore+1, numClientsAfter)
-			} else {
-				require.Equal(t, numClientsBefore, numClientsAfter)
-			}
-
-			require.Contains(t, a.partialMonthClientTracker, tc.expectedID)
-			require.True(t, proto.Equal(&activity.EntityRecord{
-				ClientID:      tc.expectedID,
-				NamespaceID:   ns,
-				Timestamp:     0,
-				NonEntity:     tc.isNonEntity,
-				MountAccessor: mountAccessor,
-				ClientType:    tc.activityType,
-			}, a.partialMonthClientTracker[tc.expectedID]))
 
 			if tc.isLocal {
 				require.Contains(t, a.partialMonthLocalClientTracker, tc.expectedID)
@@ -5371,7 +5267,6 @@ func TestGetAllPartialMonthClients(t *testing.T) {
 	a := core.activityLog
 	a.SetEnable(true)
 
-	require.Nil(t, a.fragment)
 	require.Nil(t, a.localFragment)
 	require.Nil(t, a.currentGlobalFragment)
 
@@ -5385,7 +5280,6 @@ func TestGetAllPartialMonthClients(t *testing.T) {
 	a.AddActivityToFragment(clientID, ns, 0, entityActivityType, mount)
 
 	require.NotNil(t, a.localFragment)
-	require.NotNil(t, a.fragment)
 	require.NotNil(t, a.currentGlobalFragment)
 
 	// create a local mount accessor
@@ -5783,37 +5677,6 @@ func TestCreateSegment_StoreSegment(t *testing.T) {
 			global:                true,
 			forceStore:            true,
 		},
-
-		{
-			testName:              "[non-global] max segment size",
-			numClients:            ActivitySegmentClientCapacity,
-			maxClientsPerFragment: ActivitySegmentClientCapacity,
-			global:                false,
-		},
-		{
-			testName:              "[non-global] max segment size, multiple fragments",
-			numClients:            ActivitySegmentClientCapacity,
-			maxClientsPerFragment: ActivitySegmentClientCapacity - 1,
-			global:                false,
-		},
-		{
-			testName:              "[non-global] roll over",
-			numClients:            ActivitySegmentClientCapacity + 2,
-			maxClientsPerFragment: ActivitySegmentClientCapacity,
-			global:                false,
-		},
-		{
-			testName:              "[non-global] max segment size, rollover multiple fragments",
-			numClients:            ActivitySegmentClientCapacity * 2,
-			maxClientsPerFragment: ActivitySegmentClientCapacity - 1,
-			global:                false,
-		},
-		{
-			testName:              "[non-global] max client size, drop clients",
-			numClients:            ActivitySegmentClientCapacity*2 + 1,
-			maxClientsPerFragment: ActivitySegmentClientCapacity,
-			global:                false,
-		},
 		{
 			testName:              "[local] max client size, drop clients",
 			numClients:            ActivitySegmentClientCapacity*2 + 1,
@@ -5910,10 +5773,7 @@ func TestCreateSegment_StoreSegment(t *testing.T) {
 
 			segment := &a.currentGlobalSegment
 			if !test.global {
-				segment = &a.currentSegment
-				if test.pathPrefix == activityLocalPathPrefix {
-					segment = &a.currentLocalSegment
-				}
+				segment = &a.currentLocalSegment
 			}
 
 			// Create segments and write to storage
@@ -5932,24 +5792,13 @@ func TestCreateSegment_StoreSegment(t *testing.T) {
 					clientTotal += len(entity.GetClients())
 				}
 			} else {
-				if test.pathPrefix == activityLocalPathPrefix {
-					for {
-						entity, err := reader.ReadLocalEntity(ctx)
-						if errors.Is(err, io.EOF) {
-							break
-						}
-						require.NoError(t, err)
-						clientTotal += len(entity.GetClients())
+				for {
+					entity, err := reader.ReadLocalEntity(ctx)
+					if errors.Is(err, io.EOF) {
+						break
 					}
-				} else {
-					for {
-						entity, err := reader.ReadEntity(ctx)
-						if errors.Is(err, io.EOF) {
-							break
-						}
-						require.NoError(t, err)
-						clientTotal += len(entity.GetClients())
-					}
+					require.NoError(t, err)
+					clientTotal += len(entity.GetClients())
 				}
 			}
 

--- a/vault/external_tests/activity_testonly/acme_regeneration_test.go
+++ b/vault/external_tests/activity_testonly/acme_regeneration_test.go
@@ -54,7 +54,7 @@ func TestACMERegeneration_RegenerateWithCurrentMonth(t *testing.T) {
 	})
 	require.NoError(t, err)
 	now := time.Now().UTC()
-	_, _, _, err = clientcountutil.NewActivityLogData(client).
+	_, _, err = clientcountutil.NewActivityLogData(client).
 		NewPreviousMonthData(3).
 		// 3 months ago, 15 non-entity clients and 10 ACME clients
 		NewClientsSeen(15, clientcountutil.WithClientType("non-entity-token")).
@@ -116,7 +116,7 @@ func TestACMERegeneration_RegenerateMuchOlder(t *testing.T) {
 	client := cluster.Cores[0].Client
 
 	now := time.Now().UTC()
-	_, _, _, err := clientcountutil.NewActivityLogData(client).
+	_, _, err := clientcountutil.NewActivityLogData(client).
 		NewPreviousMonthData(5).
 		// 5 months ago, 15 non-entity clients and 10 ACME clients
 		NewClientsSeen(15, clientcountutil.WithClientType("non-entity-token")).
@@ -159,7 +159,7 @@ func TestACMERegeneration_RegeneratePreviousMonths(t *testing.T) {
 	client := cluster.Cores[0].Client
 
 	now := time.Now().UTC()
-	_, _, _, err := clientcountutil.NewActivityLogData(client).
+	_, _, err := clientcountutil.NewActivityLogData(client).
 		NewPreviousMonthData(3).
 		// 3 months ago, 15 non-entity clients and 10 ACME clients
 		NewClientsSeen(15, clientcountutil.WithClientType("non-entity-token")).

--- a/vault/external_tests/activity_testonly/activity_testonly_oss_test.go
+++ b/vault/external_tests/activity_testonly/activity_testonly_oss_test.go
@@ -29,7 +29,7 @@ func Test_ActivityLog_Disable(t *testing.T) {
 		"enabled": "enable",
 	})
 	require.NoError(t, err)
-	_, _, _, err = clientcountutil.NewActivityLogData(client).
+	_, _, err = clientcountutil.NewActivityLogData(client).
 		NewPreviousMonthData(1).
 		NewClientsSeen(5).
 		NewCurrentMonthData().

--- a/vault/logical_system_activity_write_testonly.go
+++ b/vault/logical_system_activity_write_testonly.go
@@ -85,14 +85,13 @@ func (b *SystemBackend) handleActivityWriteData(ctx context.Context, request *lo
 	for _, opt := range input.Write {
 		opts[opt] = struct{}{}
 	}
-	paths, localPaths, globalPaths, err := generated.write(ctx, opts, b.Core.activityLog, now)
+	localPaths, globalPaths, err := generated.write(ctx, opts, b.Core.activityLog, now)
 	if err != nil {
 		b.logger.Debug("failed to write activity log data", "error", err.Error())
 		return logical.ErrorResponse("failed to write data"), err
 	}
 	return &logical.Response{
 		Data: map[string]interface{}{
-			"paths":        paths,
 			"local_paths":  localPaths,
 			"global_paths": globalPaths,
 		},
@@ -101,15 +100,10 @@ func (b *SystemBackend) handleActivityWriteData(ctx context.Context, request *lo
 
 // singleMonthActivityClients holds a single month's client IDs, in the order they were seen
 type singleMonthActivityClients struct {
-	// clients are indexed by ID
-	clients []*activity.EntityRecord
 	// globalClients are indexed by ID
 	globalClients []*activity.EntityRecord
 	// localClients are indexed by ID
 	localClients []*activity.EntityRecord
-	// predefinedSegments map from the segment number to the client's index in
-	// the clients slice
-	predefinedSegments map[int][]int
 	// predefinedGlobalSegments map from the segment number to the client's index in
 	// the clients slice
 	predefinedGlobalSegments map[int][]int
@@ -126,17 +120,13 @@ type multipleMonthsActivityClients struct {
 	months []*singleMonthActivityClients
 }
 
-func (s *singleMonthActivityClients) addEntityRecord(core *Core, record *activity.EntityRecord, segmentIndex *int) {
-	s.clients = append(s.clients, record)
-	local, _ := core.activityLog.isClientLocal(record)
+func (s *singleMonthActivityClients) addEntityRecord(core *Core, record *activity.EntityRecord, segmentIndex *int, local bool) {
 	if !local {
 		s.globalClients = append(s.globalClients, record)
 	} else {
 		s.localClients = append(s.localClients, record)
 	}
 	if segmentIndex != nil {
-		index := len(s.clients) - 1
-		s.predefinedSegments[*segmentIndex] = append(s.predefinedSegments[*segmentIndex], index)
 		if !local {
 			globalIndex := len(s.globalClients) - 1
 			s.predefinedGlobalSegments[*segmentIndex] = append(s.predefinedGlobalSegments[*segmentIndex], globalIndex)
@@ -230,9 +220,15 @@ func (s *singleMonthActivityClients) addNewClients(c *generation.Client, mountAc
 	if c.Count > 1 {
 		count = int(c.Count)
 	}
-	isNonEntity := c.ClientType != entityActivityType
 	ts := timeutil.MonthsPreviousTo(int(monthsAgo), now)
 
+	// identify is client is local or global
+	isLocal, err := isClientLocal(core, c.ClientType, mountAccessor)
+	if err != nil {
+		return err
+	}
+
+	isNonEntity := c.ClientType != entityActivityType
 	for i := 0; i < count; i++ {
 		record := &activity.EntityRecord{
 			ClientID:      c.Id,
@@ -250,7 +246,7 @@ func (s *singleMonthActivityClients) addNewClients(c *generation.Client, mountAc
 			}
 		}
 
-		s.addEntityRecord(core, record, segmentIndex)
+		s.addEntityRecord(core, record, segmentIndex, isLocal)
 	}
 	return nil
 }
@@ -359,13 +355,25 @@ func (m *multipleMonthsActivityClients) addRepeatedClients(monthsAgo int32, c *g
 		repeatedFromMonth = c.RepeatedFromMonth
 	}
 	repeatedFrom := m.months[repeatedFromMonth]
+
+	// identify is client is local or global
+	isLocal, err := isClientLocal(core, c.ClientType, mountAccessor)
+	if err != nil {
+		return err
+	}
+
 	numClients := 1
 	if c.Count > 0 {
 		numClients = int(c.Count)
 	}
-	for _, client := range repeatedFrom.clients {
+
+	repeatedClients := repeatedFrom.globalClients
+	if isLocal {
+		repeatedClients = repeatedFrom.localClients
+	}
+	for _, client := range repeatedClients {
 		if c.ClientType == client.ClientType && mountAccessor == client.MountAccessor && c.Namespace == client.NamespaceID {
-			addingTo.addEntityRecord(core, client, segmentIndex)
+			addingTo.addEntityRecord(core, client, segmentIndex, isLocal)
 			numClients--
 			if numClients == 0 {
 				break
@@ -376,6 +384,23 @@ func (m *multipleMonthsActivityClients) addRepeatedClients(monthsAgo int32, c *g
 		return fmt.Errorf("missing repeated %d clients matching given parameters", numClients)
 	}
 	return nil
+}
+
+// isClientLocal checks whether the given client is on a local mount.
+// In all other cases, we will assume it is a global client.
+func isClientLocal(core *Core, clientType string, mountAccessor string) (bool, error) {
+	// Tokens are not replicated to performance secondary clusters
+	if clientType == nonEntityTokenActivityType {
+		return true, nil
+	}
+	mountEntry := core.router.MatchingMountByAccessor(mountAccessor)
+	// If the mount entry is nil, this means the mount has been deleted. We will assume it was replicated because we do not want to
+	// over count clients
+	if mountEntry != nil && mountEntry.Local {
+		return true, nil
+	}
+
+	return false, nil
 }
 
 func (m *multipleMonthsActivityClients) addMissingCurrentMonth() {
@@ -395,8 +420,7 @@ func (m *multipleMonthsActivityClients) timestampForMonth(i int, now time.Time) 
 	return now
 }
 
-func (m *multipleMonthsActivityClients) write(ctx context.Context, opts map[generation.WriteOptions]struct{}, activityLog *ActivityLog, now time.Time) ([]string, []string, []string, error) {
-	paths := []string{}
+func (m *multipleMonthsActivityClients) write(ctx context.Context, opts map[generation.WriteOptions]struct{}, activityLog *ActivityLog, now time.Time) ([]string, []string, error) {
 	globalPaths := []string{}
 	localPaths := []string{}
 
@@ -411,30 +435,10 @@ func (m *multipleMonthsActivityClients) write(ctx context.Context, opts map[gene
 			continue
 		}
 		timestamp := m.timestampForMonth(i, now)
-		segments, err := month.populateSegments(month.predefinedSegments, month.clients)
-		if err != nil {
-			return nil, nil, nil, err
-		}
-		for segmentIndex, segment := range segments {
-			if segment == nil {
-				// skip the index
-				continue
-			}
-			entityPath, err := activityLog.saveSegmentEntitiesInternal(ctx, segmentInfo{
-				startTimestamp:       timestamp.Unix(),
-				currentClients:       &activity.EntityActivityLog{Clients: segment},
-				clientSequenceNumber: uint64(segmentIndex),
-				tokenCount:           &activity.TokenCount{},
-			}, true, "")
-			if err != nil {
-				return nil, nil, nil, err
-			}
-			paths = append(paths, entityPath)
-		}
 		if len(month.globalClients) > 0 {
 			globalSegments, err := month.populateSegments(month.predefinedGlobalSegments, month.globalClients)
 			if err != nil {
-				return nil, nil, nil, err
+				return nil, nil, err
 			}
 			for segmentIndex, segment := range globalSegments {
 				if segment == nil {
@@ -448,7 +452,7 @@ func (m *multipleMonthsActivityClients) write(ctx context.Context, opts map[gene
 					tokenCount:           &activity.TokenCount{},
 				}, true, activityGlobalPathPrefix)
 				if err != nil {
-					return nil, nil, nil, err
+					return nil, nil, err
 				}
 				globalPaths = append(globalPaths, entityPath)
 			}
@@ -456,7 +460,7 @@ func (m *multipleMonthsActivityClients) write(ctx context.Context, opts map[gene
 		if len(month.localClients) > 0 {
 			localSegments, err := month.populateSegments(month.predefinedLocalSegments, month.localClients)
 			if err != nil {
-				return nil, nil, nil, err
+				return nil, nil, err
 			}
 			for segmentIndex, segment := range localSegments {
 				if segment == nil {
@@ -470,7 +474,7 @@ func (m *multipleMonthsActivityClients) write(ctx context.Context, opts map[gene
 					tokenCount:           &activity.TokenCount{},
 				}, true, activityLocalPathPrefix)
 				if err != nil {
-					return nil, nil, nil, err
+					return nil, nil, err
 				}
 				localPaths = append(localPaths, entityPath)
 			}
@@ -495,16 +499,16 @@ func (m *multipleMonthsActivityClients) write(ctx context.Context, opts map[gene
 	if writeIntentLog {
 		err := activityLog.writeIntentLog(ctx, m.latestTimestamp(now, false).Unix(), m.latestTimestamp(now, true).UTC())
 		if err != nil {
-			return nil, nil, nil, err
+			return nil, nil, err
 		}
 	}
 	wg := sync.WaitGroup{}
 	err := activityLog.refreshFromStoredLog(ctx, &wg, now)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, err
 	}
 	wg.Wait()
-	return paths, localPaths, globalPaths, nil
+	return localPaths, globalPaths, nil
 }
 
 func (m *multipleMonthsActivityClients) latestTimestamp(now time.Time, includeCurrentMonth bool) time.Time {
@@ -532,7 +536,6 @@ func newMultipleMonthsActivityClients(numberOfMonths int) *multipleMonthsActivit
 	}
 	for i := 0; i < numberOfMonths; i++ {
 		m.months[i] = &singleMonthActivityClients{
-			predefinedSegments:       make(map[int][]int),
 			predefinedGlobalSegments: make(map[int][]int),
 			predefinedLocalSegments:  make(map[int][]int),
 		}
@@ -582,13 +585,4 @@ func (p *sliceSegmentReader) ReadLocalEntity(ctx context.Context) (*activity.Ent
 
 func (p *sliceSegmentReader) ReadToken(ctx context.Context) (*activity.TokenCount, error) {
 	return nil, io.EOF
-}
-
-func (p *sliceSegmentReader) ReadEntity(ctx context.Context) (*activity.EntityActivityLog, error) {
-	if p.i == len(p.records) {
-		return nil, io.EOF
-	}
-	record := p.records[p.i]
-	p.i++
-	return &activity.EntityActivityLog{Clients: record}, nil
 }

--- a/vault/logical_system_activity_write_testonly_test.go
+++ b/vault/logical_system_activity_write_testonly_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/vault/builtin/credential/userpass"
 	"github.com/hashicorp/vault/helper/namespace"
 	"github.com/hashicorp/vault/helper/timeutil"
 	"github.com/hashicorp/vault/sdk/helper/clientcountutil/generation"
@@ -26,11 +27,12 @@ import (
 // correctly validated
 func TestSystemBackend_handleActivityWriteData(t *testing.T) {
 	testCases := []struct {
-		name      string
-		operation logical.Operation
-		input     map[string]interface{}
-		wantError error
-		wantPaths int
+		name            string
+		operation       logical.Operation
+		input           map[string]interface{}
+		hasLocalClients bool
+		wantError       error
+		wantPaths       int
 	}{
 		{
 			name:      "read fails",
@@ -84,6 +86,13 @@ func TestSystemBackend_handleActivityWriteData(t *testing.T) {
 			input:     map[string]interface{}{"input": `{"write":["WRITE_ENTITIES"],"data":[{"current_month":true,"num_segments":3,"all":{"clients":[{"count":5}]}}]}`},
 			wantPaths: 3,
 		},
+		{
+			name:            "entities with multiple segments",
+			operation:       logical.UpdateOperation,
+			input:           map[string]interface{}{"input": `{"write":["WRITE_ENTITIES"],"data":[{"current_month":true,"num_segments":3,"all":{"clients":[{"count":5, "mount":"cubbyhole/"}]}}]}`},
+			hasLocalClients: true,
+			wantPaths:       3,
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -95,8 +104,16 @@ func TestSystemBackend_handleActivityWriteData(t *testing.T) {
 				require.Equal(t, tc.wantError, err, resp.Error())
 			} else {
 				require.NoError(t, err)
-				paths := resp.Data["paths"].([]string)
-				require.Len(t, paths, tc.wantPaths)
+				globalPaths := resp.Data["global_paths"].([]string)
+				localPaths := resp.Data["local_paths"].([]string)
+				if tc.hasLocalClients {
+					require.Len(t, globalPaths, 0)
+					require.Len(t, localPaths, tc.wantPaths)
+				} else {
+					require.Len(t, globalPaths, tc.wantPaths)
+					require.Len(t, localPaths, 0)
+				}
+
 			}
 		})
 	}
@@ -116,6 +133,7 @@ func Test_singleMonthActivityClients_addNewClients(t *testing.T) {
 		wantNamespace string
 		wantMount     string
 		wantID        string
+		isLocal       bool
 		segmentIndex  *int
 	}{
 		{
@@ -154,6 +172,13 @@ func Test_singleMonthActivityClients_addNewClients(t *testing.T) {
 			},
 		},
 		{
+			name: "non entity token client",
+			clients: &generation.Client{
+				ClientType: nonEntityTokenActivityType,
+			},
+			isLocal: true,
+		},
+		{
 			name: "acme client",
 			clients: &generation.Client{
 				ClientType: "acme",
@@ -169,8 +194,8 @@ func Test_singleMonthActivityClients_addNewClients(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			core, _, _ := TestCoreUnsealed(t)
 			m := &singleMonthActivityClients{
-				predefinedSegments:       make(map[int][]int),
 				predefinedGlobalSegments: make(map[int][]int),
+				predefinedLocalSegments:  make(map[int][]int),
 			}
 			err := m.addNewClients(tt.clients, tt.mount, tt.segmentIndex, 0, time.Now().UTC(), core)
 			require.NoError(t, err)
@@ -178,8 +203,16 @@ func Test_singleMonthActivityClients_addNewClients(t *testing.T) {
 			if numNew == 0 {
 				numNew = 1
 			}
-			require.Len(t, m.clients, int(numNew))
-			for i, rec := range m.clients {
+
+			var clients []*activity.EntityRecord
+			if tt.isLocal {
+				require.Len(t, m.localClients, int(numNew))
+				clients = m.localClients
+			} else {
+				require.Len(t, m.globalClients, int(numNew))
+				clients = m.globalClients
+			}
+			for i, rec := range clients {
 				require.NotNil(t, rec)
 				require.Equal(t, tt.wantNamespace, rec.NamespaceID)
 				require.Equal(t, tt.wantMount, rec.MountAccessor)
@@ -189,8 +222,11 @@ func Test_singleMonthActivityClients_addNewClients(t *testing.T) {
 				} else {
 					require.NotEqual(t, "", rec.ClientID)
 				}
-				if tt.segmentIndex != nil {
-					require.Contains(t, m.predefinedSegments[*tt.segmentIndex], i)
+				if tt.segmentIndex != nil && tt.isLocal {
+					require.Contains(t, m.predefinedLocalSegments[*tt.segmentIndex], i)
+				}
+				if tt.segmentIndex != nil && !tt.isLocal {
+					require.Contains(t, m.predefinedGlobalSegments[*tt.segmentIndex], i)
 				}
 			}
 		})
@@ -206,6 +242,7 @@ func Test_multipleMonthsActivityClients_processMonth(t *testing.T) {
 		name      string
 		clients   *generation.Data
 		wantError bool
+		isLocal   bool
 		numMonths int
 	}{
 		{
@@ -217,6 +254,16 @@ func Test_multipleMonthsActivityClients_processMonth(t *testing.T) {
 				}}}},
 			},
 			numMonths: 1,
+		},
+		{
+			name: "specified namespace and local mount exist",
+			clients: &generation.Data{
+				Clients: &generation.Data_All{All: &generation.Clients{Clients: []*generation.Client{{
+					Mount: "cubbyhole/",
+				}}}},
+			},
+			numMonths: 1,
+			isLocal:   true,
 		},
 		{
 			name: "mount missing slash",
@@ -282,13 +329,24 @@ func Test_multipleMonthsActivityClients_processMonth(t *testing.T) {
 				require.Error(t, err)
 			} else {
 				require.NoError(t, err)
-				require.Len(t, m.months[tt.clients.GetMonthsAgo()].clients, len(tt.clients.GetAll().Clients))
-				for _, month := range m.months {
-					for _, c := range month.clients {
-						require.NotEmpty(t, c.NamespaceID)
-						require.NotEmpty(t, c.MountAccessor)
+				if tt.isLocal {
+					require.Len(t, m.months[tt.clients.GetMonthsAgo()].localClients, len(tt.clients.GetAll().Clients))
+					for _, month := range m.months {
+						for _, c := range month.localClients {
+							require.NotEmpty(t, c.NamespaceID)
+							require.NotEmpty(t, c.MountAccessor)
+						}
+					}
+				} else {
+					require.Len(t, m.months[tt.clients.GetMonthsAgo()].globalClients, len(tt.clients.GetAll().Clients))
+					for _, month := range m.months {
+						for _, c := range month.globalClients {
+							require.NotEmpty(t, c.NamespaceID)
+							require.NotEmpty(t, c.MountAccessor)
+						}
 					}
 				}
+
 			}
 		})
 	}
@@ -323,58 +381,95 @@ func Test_multipleMonthsActivityClients_processMonth_segmented(t *testing.T) {
 	m := newMultipleMonthsActivityClients(1)
 	core, _, _ := TestCoreUnsealed(t)
 	require.NoError(t, m.processMonth(context.Background(), core, data, time.Now().UTC()))
-	require.Len(t, m.months[0].predefinedSegments, 3)
-	require.Len(t, m.months[0].clients, 3)
+	require.Len(t, m.months[0].predefinedGlobalSegments, 3)
+	require.Len(t, m.months[0].globalClients, 3)
 
 	// segment indexes are correct
-	require.Contains(t, m.months[0].predefinedSegments, 0)
-	require.Contains(t, m.months[0].predefinedSegments, 1)
-	require.Contains(t, m.months[0].predefinedSegments, 7)
+	require.Contains(t, m.months[0].predefinedGlobalSegments, 0)
+	require.Contains(t, m.months[0].predefinedGlobalSegments, 1)
+	require.Contains(t, m.months[0].predefinedGlobalSegments, 7)
 
 	// the data in each segment is correct
-	require.Contains(t, m.months[0].predefinedSegments[0], 0)
-	require.Contains(t, m.months[0].predefinedSegments[1], 1)
-	require.Contains(t, m.months[0].predefinedSegments[7], 2)
+	require.Contains(t, m.months[0].predefinedGlobalSegments[0], 0)
+	require.Contains(t, m.months[0].predefinedGlobalSegments[1], 1)
+	require.Contains(t, m.months[0].predefinedGlobalSegments[7], 2)
 }
 
 // Test_multipleMonthsActivityClients_addRepeatedClients adds repeated clients
 // from 1 month ago and 2 months ago, and verifies that the correct clients are
 // added based on namespace, mount, and non-entity attributes
 func Test_multipleMonthsActivityClients_addRepeatedClients(t *testing.T) {
-	core, _, _ := TestCoreUnsealed(t)
+	storage := &logical.InmemStorage{}
+	coreConfig := &CoreConfig{
+		CredentialBackends: map[string]logical.Factory{
+			"userpass": userpass.Factory,
+		},
+		Physical: storage.Underlying(),
+	}
+
+	cluster := NewTestCluster(t, coreConfig, nil)
+	core := cluster.Cores[0].Core
 	now := time.Now().UTC()
 
 	m := newMultipleMonthsActivityClients(3)
 	defaultMount := "default"
 
+	// add global clients
 	require.NoError(t, m.addClientToMonth(2, &generation.Client{Count: 2}, "identity", nil, now, core))
 	require.NoError(t, m.addClientToMonth(2, &generation.Client{Count: 2, Namespace: "other_ns"}, defaultMount, nil, now, core))
 	require.NoError(t, m.addClientToMonth(1, &generation.Client{Count: 2}, defaultMount, nil, now, core))
 	require.NoError(t, m.addClientToMonth(1, &generation.Client{Count: 2, ClientType: "non-entity"}, defaultMount, nil, now, core))
 
-	month2Clients := m.months[2].clients
-	month1Clients := m.months[1].clients
+	// create a local mount
+	localMount := "localMountAccessor"
+	localMe := &MountEntry{
+		Table:    credentialTableType,
+		Path:     "userpass-local/",
+		Type:     "userpass",
+		Local:    true,
+		Accessor: localMount,
+	}
+	err := core.enableCredential(namespace.RootContext(nil), localMe)
+	require.NoError(t, err)
+
+	// add a local client
+	require.NoError(t, m.addClientToMonth(2, &generation.Client{Count: 2}, localMount, nil, now, core))
+	require.NoError(t, m.addClientToMonth(1, &generation.Client{Count: 2}, localMount, nil, now, core))
+
+	month2GlobalClients := m.months[2].globalClients
+	month1GlobalClients := m.months[1].globalClients
+
+	month2LocalClients := m.months[2].localClients
+	month1LocalClients := m.months[1].localClients
 
 	thisMonth := m.months[0]
 	// this will match the first client in month 1
 	require.NoError(t, m.addRepeatedClients(0, &generation.Client{Count: 1, Repeated: true}, defaultMount, nil, core))
-	require.Contains(t, month1Clients, thisMonth.clients[0])
+	require.Contains(t, month1GlobalClients, thisMonth.globalClients[0])
+
+	// this will match the first local client in month 1
+	require.NoError(t, m.addRepeatedClients(0, &generation.Client{Count: 1, Repeated: true}, localMount, nil, core))
+	require.Contains(t, month1LocalClients, thisMonth.localClients[0])
 
 	// this will match the 3rd client in month 1
 	require.NoError(t, m.addRepeatedClients(0, &generation.Client{Count: 1, Repeated: true, ClientType: "non-entity"}, defaultMount, nil, core))
-	require.Equal(t, month1Clients[2], thisMonth.clients[1])
+	require.Equal(t, month1GlobalClients[2], thisMonth.globalClients[1])
 
 	// this will match the first two clients in month 1
 	require.NoError(t, m.addRepeatedClients(0, &generation.Client{Count: 2, Repeated: true}, defaultMount, nil, core))
-	require.Equal(t, month1Clients[0:2], thisMonth.clients[2:4])
+	require.Equal(t, month1GlobalClients[0:2], thisMonth.globalClients[2:4])
 
 	// this will match the first client in month 2
 	require.NoError(t, m.addRepeatedClients(0, &generation.Client{Count: 1, RepeatedFromMonth: 2}, "identity", nil, core))
-	require.Equal(t, month2Clients[0], thisMonth.clients[4])
+	require.Equal(t, month2GlobalClients[0], thisMonth.globalClients[4])
+
+	// this will match the first local client in month 2
+	require.NoError(t, m.addRepeatedClients(0, &generation.Client{Count: 1, RepeatedFromMonth: 2}, localMount, nil, core))
+	require.Equal(t, month2LocalClients[0], thisMonth.localClients[1])
 
 	// this will match the 3rd client in month 2
 	require.NoError(t, m.addRepeatedClients(0, &generation.Client{Count: 1, RepeatedFromMonth: 2, Namespace: "other_ns"}, defaultMount, nil, core))
-	require.Equal(t, month2Clients[2], thisMonth.clients[5])
+	require.Equal(t, month2GlobalClients[2], thisMonth.globalClients[5])
 
 	require.Error(t, m.addRepeatedClients(0, &generation.Client{Count: 1, RepeatedFromMonth: 2, Namespace: "other_ns"}, "other_mount", nil, core))
 }
@@ -458,8 +553,8 @@ func Test_singleMonthActivityClients_populateSegments(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			s := singleMonthActivityClients{predefinedSegments: tc.segments, clients: clients, generationParameters: &generation.Data{EmptySegmentIndexes: tc.emptyIndexes, SkipSegmentIndexes: tc.skipIndexes, NumSegments: int32(tc.numSegments)}}
-			gotSegments, err := s.populateSegments(s.predefinedSegments, s.clients)
+			s := singleMonthActivityClients{predefinedGlobalSegments: tc.segments, globalClients: clients, generationParameters: &generation.Data{EmptySegmentIndexes: tc.emptyIndexes, SkipSegmentIndexes: tc.skipIndexes, NumSegments: int32(tc.numSegments)}}
+			gotSegments, err := s.populateSegments(s.predefinedGlobalSegments, s.globalClients)
 			require.NoError(t, err)
 			require.Equal(t, tc.wantSegments, gotSegments)
 		})
@@ -529,7 +624,7 @@ func Test_handleActivityWriteData(t *testing.T) {
 		req.Data = map[string]interface{}{"input": string(marshaled)}
 		resp, err := core.systemBackend.HandleRequest(namespace.RootContext(nil), req)
 		require.NoError(t, err)
-		paths := resp.Data["paths"].([]string)
+		paths := resp.Data["global_paths"].([]string)
 		require.Len(t, paths, 9)
 
 		times, err := core.activityLog.availableLogs(context.Background(), time.Now())


### PR DESCRIPTION
### Description
Link to ENT PR: https://github.com/hashicorp/vault-enterprise/pull/7040

What does this PR do?
Jira: https://hashicorp.atlassian.net/browse/VAULT-32420

Removes fragment, standbyFragmentsReceived, partialMonthClientTracker
fragmentLock is still maintained to protect enable
currentSegment is replaced with currentGlobalSegment and currentLocalSegment
updated some tests in vault/logical_system_activity_write_testonly_test.go to test local and global storage paths

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
