### PR TITLE
[DOCS] Clarify maintenance table

### DIFF
--- a/website/content/docs/enterprise/lts.mdx
+++ b/website/content/docs/enterprise/lts.mdx
@@ -117,7 +117,6 @@ with patches for bugs that may cause outages and critical vulnerabilities and ex
 Maintenance updates               | Standard maintenance | Extended maintenance
 --------------------------------- | -------------------- | --------------------
 Performance improvements          | YES                  | NO
-Feature updates and improvements  | YES                  | NO
 Bug fixes                         | YES                  | OUTAGE-RISK ONLY
 Security patches                  | YES                  | HIGH-RISK ONLY
 CVE patches                       | YES                  | YES


### PR DESCRIPTION
### Description

The "Feature updates and improvements" line is misleading since we do not backport feature updates to N-1 or N-2. Since the answer is "no" for both columns, it creates less confusion to just delete it.
