### PR TITLE
Add Azure configuration details view

### DIFF
--- a/ui/app/adapters/azure/config.js
+++ b/ui/app/adapters/azure/config.js
@@ -19,4 +19,25 @@ export default class AzureConfig extends ApplicationAdapter {
       };
     });
   }
+
+  createOrUpdate(store, type, snapshot) {
+    const serializer = store.serializerFor(type.modelName);
+    const data = serializer.serialize(snapshot);
+    const backend = snapshot.record.backend;
+    return this.ajax(`${this.buildURL()}/${backend}/config`, 'POST', { data }).then((resp) => {
+      // ember data requires an id on the response
+      return {
+        ...resp,
+        id: backend,
+      };
+    });
+  }
+
+  createRecord() {
+    return this.createOrUpdate(...arguments);
+  }
+
+  updateRecord() {
+    return this.createOrUpdate(...arguments);
+  }
 }

--- a/ui/app/adapters/azure/config.js
+++ b/ui/app/adapters/azure/config.js
@@ -9,35 +9,18 @@ import { encodePath } from 'vault/utils/path-encoding-helpers';
 export default class AzureConfig extends ApplicationAdapter {
   namespace = 'v1';
 
+  _url(backend) {
+    return `${this.buildURL()}/${encodePath(backend)}/config`;
+  }
+
   queryRecord(store, type, query) {
     const { backend } = query;
-    return this.ajax(`${this.buildURL()}/${encodePath(backend)}/config`, 'GET').then((resp) => {
+    return this.ajax(this._url(backend), 'GET').then((resp) => {
       return {
         ...resp,
         id: backend,
         backend,
       };
     });
-  }
-
-  createOrUpdate(store, type, snapshot) {
-    const serializer = store.serializerFor(type.modelName);
-    const data = serializer.serialize(snapshot);
-    const backend = snapshot.record.backend;
-    return this.ajax(`${this.buildURL()}/${backend}/config`, 'POST', { data }).then((resp) => {
-      // ember data requires an id on the response
-      return {
-        ...resp,
-        id: backend,
-      };
-    });
-  }
-
-  createRecord() {
-    return this.createOrUpdate(...arguments);
-  }
-
-  updateRecord() {
-    return this.createOrUpdate(...arguments);
   }
 }

--- a/ui/app/adapters/azure/config.js
+++ b/ui/app/adapters/azure/config.js
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import ApplicationAdapter from '../application';
+import { encodePath } from 'vault/utils/path-encoding-helpers';
+
+export default class AzureConfig extends ApplicationAdapter {
+  namespace = 'v1';
+
+  queryRecord(store, type, query) {
+    const { backend } = query;
+    return this.ajax(`${this.buildURL()}/${encodePath(backend)}/config`, 'GET').then((resp) => {
+      return {
+        ...resp,
+        id: backend,
+        backend,
+      };
+    });
+  }
+}

--- a/ui/app/components/secret-engine/configuration-details.hbs
+++ b/ui/app/components/secret-engine/configuration-details.hbs
@@ -37,7 +37,7 @@
   <EmptyState
     data-test-config-cta
     @title="{{@typeDisplay}} not configured"
-    @message="Get started by configuring your {{@typeDisplay}} engine."
+    @message="Get started by configuring your {{@typeDisplay}} secrets engine."
   >
     {{#unless (eq @typeDisplay "Azure")}}
       <Hds::Link::Standalone

--- a/ui/app/components/secret-engine/configuration-details.hbs
+++ b/ui/app/components/secret-engine/configuration-details.hbs
@@ -5,7 +5,7 @@
 
 {{#if @configModels.length}}
   {{#each @configModels as |configModel|}}
-    {{#each configModel.attrs as |attr|}}
+    {{#each configModel.displayAttrs as |attr|}}
       {{! public key while not sensitive when editing/creating, should be hidden by default on viewing }}
       {{#if (or attr.options.sensitive (eq attr.name "publicKey"))}}
         <InfoTableRow

--- a/ui/app/components/secret-engine/configuration-details.hbs
+++ b/ui/app/components/secret-engine/configuration-details.hbs
@@ -39,6 +39,7 @@
     @title="{{@typeDisplay}} not configured"
     @message="Get started by configuring your {{@typeDisplay}} secrets engine."
   >
+    {{! TODO: short-term conditional to be removed once configuration for azure is merged. }}
     {{#unless (eq @typeDisplay "Azure")}}
       <Hds::Link::Standalone
         @icon="chevron-right"

--- a/ui/app/components/secret-engine/configuration-details.hbs
+++ b/ui/app/components/secret-engine/configuration-details.hbs
@@ -3,34 +3,27 @@
   SPDX-License-Identifier: BUSL-1.1
 ~}}
 
-{{#if @configModels.length}}
-  {{#each @configModels as |configModel|}}
-    {{#each configModel.displayAttrs as |attr|}}
-      {{! public key while not sensitive when editing/creating, should be hidden by default on viewing }}
-      {{#if (or attr.options.sensitive (eq attr.name "publicKey"))}}
-        <InfoTableRow
-          alwaysRender={{not (is-empty-value (get configModel attr.name))}}
-          @label={{or attr.options.label (to-label attr.name)}}
-          @value={{get configModel (or attr.options.fieldValue attr.name)}}
-        >
-          {{#if (or attr.options.sensitive (eq attr.name "publicKey"))}}
-            <MaskedInput
-              @value={{get configModel attr.name}}
-              @name={{attr.name}}
-              @displayOnly={{true}}
-              @allowCopy={{true}}
-            />
-          {{/if}}
-        </InfoTableRow>
-      {{else}}
-        <InfoTableRow
-          @alwaysRender={{not (is-empty-value (get @model attr.name))}}
-          @label={{or attr.options.label (to-label attr.name)}}
-          @value={{get configModel (or attr.options.fieldValue attr.name)}}
-          @formatTtl={{eq attr.options.editType "ttl"}}
-        />
-      {{/if}}
-    {{/each}}
+{{#each @configModels as |configModel|}}
+  {{#each configModel.displayAttrs as |attr|}}
+    {{! public key while not sensitive when editing/creating, should be hidden by default on viewing }}
+    {{#if (or attr.options.sensitive (eq attr.name "publicKey"))}}
+      <InfoTableRow
+        alwaysRender={{not (is-empty-value (get configModel attr.name))}}
+        @label={{or attr.options.label (to-label attr.name)}}
+        @value={{get configModel (or attr.options.fieldValue attr.name)}}
+      >
+        {{#if (or attr.options.sensitive (eq attr.name "publicKey"))}}
+          <MaskedInput @value={{get configModel attr.name}} @name={{attr.name}} @displayOnly={{true}} @allowCopy={{true}} />
+        {{/if}}
+      </InfoTableRow>
+    {{else}}
+      <InfoTableRow
+        @alwaysRender={{not (is-empty-value (get @model attr.name))}}
+        @label={{or attr.options.label (to-label attr.name)}}
+        @value={{get configModel (or attr.options.fieldValue attr.name)}}
+        @formatTtl={{eq attr.options.editType "ttl"}}
+      />
+    {{/if}}
   {{/each}}
 {{else}}
   {{! Prompt user to configure the secret engine }}
@@ -50,4 +43,4 @@
       />
     {{/unless}}
   </EmptyState>
-{{/if}}
+{{/each}}

--- a/ui/app/components/secret-engine/configuration-details.hbs
+++ b/ui/app/components/secret-engine/configuration-details.hbs
@@ -27,6 +27,7 @@
           @alwaysRender={{not (is-empty-value (get @model attr.name))}}
           @label={{or attr.options.label (to-label attr.name)}}
           @value={{get configModel (or attr.options.fieldValue attr.name)}}
+          @formatTtl={{@formatTtl}}
         />
       {{/if}}
     {{/each}}
@@ -38,12 +39,14 @@
     @title="{{@typeDisplay}} not configured"
     @message="Get started by configuring your {{@typeDisplay}} engine."
   >
-    <Hds::Link::Standalone
-      @icon="chevron-right"
-      @iconPosition="trailing"
-      @text="Configure {{@typeDisplay}}"
-      @route="vault.cluster.secrets.backend.configuration.edit"
-      @model={{@id}}
-    />
+    {{#unless (eq @typeDisplay "Azure")}}
+      <Hds::Link::Standalone
+        @icon="chevron-right"
+        @iconPosition="trailing"
+        @text="Configure {{@typeDisplay}}"
+        @route="vault.cluster.secrets.backend.configuration.edit"
+        @model={{@id}}
+      />
+    {{/unless}}
   </EmptyState>
 {{/if}}

--- a/ui/app/components/secret-engine/configuration-details.hbs
+++ b/ui/app/components/secret-engine/configuration-details.hbs
@@ -27,7 +27,7 @@
           @alwaysRender={{not (is-empty-value (get @model attr.name))}}
           @label={{or attr.options.label (to-label attr.name)}}
           @value={{get configModel (or attr.options.fieldValue attr.name)}}
-          @formatTtl={{@formatTtl}}
+          @formatTtl={{eq attr.options.editType "ttl"}}
         />
       {{/if}}
     {{/each}}

--- a/ui/app/components/secret-engine/configuration-details.hbs
+++ b/ui/app/components/secret-engine/configuration-details.hbs
@@ -12,9 +12,7 @@
         @label={{or attr.options.label (to-label attr.name)}}
         @value={{get configModel (or attr.options.fieldValue attr.name)}}
       >
-        {{#if (or attr.options.sensitive (eq attr.name "publicKey"))}}
-          <MaskedInput @value={{get configModel attr.name}} @name={{attr.name}} @displayOnly={{true}} @allowCopy={{true}} />
-        {{/if}}
+        <MaskedInput @value={{get configModel attr.name}} @name={{attr.name}} @displayOnly={{true}} @allowCopy={{true}} />
       </InfoTableRow>
     {{else}}
       <InfoTableRow

--- a/ui/app/components/secret-engine/configure-aws.hbs
+++ b/ui/app/components/secret-engine/configure-aws.hbs
@@ -56,7 +56,7 @@
     {{/if}}
     {{#if (eq this.accessType "wif")}}
       {{! WIF Fields }}
-      {{#each @issuerConfig.attrs as |attr|}}
+      {{#each @issuerConfig.displayAttrs as |attr|}}
         <FormField @attr={{attr}} @model={{@issuerConfig}} />
       {{/each}}
       <FormFieldGroups
@@ -82,7 +82,7 @@
     Leases
   </h2>
   <div class="box is-fullwidth is-sideless is-bottomless">
-    {{#each @leaseConfig.attrs as |attr|}}
+    {{#each @leaseConfig.displayAttrs as |attr|}}
       <FormField @attr={{attr}} @model={{@leaseConfig}} @modelValidations={{this.modelValidationsLease}} />
     {{/each}}
   </div>

--- a/ui/app/helpers/mountable-secret-engines.js
+++ b/ui/app/helpers/mountable-secret-engines.js
@@ -156,7 +156,7 @@ export const CONFIGURABLE_SECRET_ENGINES = ['aws', 'azure', 'ssh'];
 export function mountableEngines() {
   return MOUNTABLE_SECRET_ENGINES.slice();
 }
-// Secret Engines that can be mounted but have no other type of configuration or actions available via the UI.
+// secret engines that have not other views than the mount view and mount details view
 export const UN_SUPPORTED_ENGINES = ['alicloud', 'consul', 'gcp', 'gcpkms', 'nomad', 'rabbitmq', 'totp'];
 
 export function unSupportedEngines() {

--- a/ui/app/helpers/mountable-secret-engines.js
+++ b/ui/app/helpers/mountable-secret-engines.js
@@ -159,7 +159,7 @@ export function mountableEngines() {
 // secret engines that have not other views than the mount view and mount details view
 export const UNSUPPORTED_ENGINES = ['alicloud', 'consul', 'gcp', 'gcpkms', 'nomad', 'rabbitmq', 'totp'];
 
-export function unSupportedEngines() {
+export function unsupportedEngines() {
   return UNSUPPORTED_ENGINES.slice();
 }
 

--- a/ui/app/helpers/mountable-secret-engines.js
+++ b/ui/app/helpers/mountable-secret-engines.js
@@ -157,10 +157,10 @@ export function mountableEngines() {
   return MOUNTABLE_SECRET_ENGINES.slice();
 }
 // secret engines that have not other views than the mount view and mount details view
-export const UN_SUPPORTED_ENGINES = ['alicloud', 'consul', 'gcp', 'gcpkms', 'nomad', 'rabbitmq', 'totp'];
+export const UNSUPPORTED_ENGINES = ['alicloud', 'consul', 'gcp', 'gcpkms', 'nomad', 'rabbitmq', 'totp'];
 
 export function unSupportedEngines() {
-  return UN_SUPPORTED_ENGINES.slice();
+  return UNSUPPORTED_ENGINES.slice();
 }
 
 export function allEngines() {

--- a/ui/app/helpers/mountable-secret-engines.js
+++ b/ui/app/helpers/mountable-secret-engines.js
@@ -135,16 +135,23 @@ const MOUNTABLE_SECRET_ENGINES = [
 ];
 
 // A list of Workload Identity Federation engines.
-// Will eventually include Azure and GCP.
-export const WIF_ENGINES = ['aws'];
+export const WIF_ENGINES = ['aws', 'azure'];
 
 export function wifEngines() {
   return WIF_ENGINES.slice();
 }
 
+// A list of configuration only secret engines. These engines should only see a configuration tab.
+// Will eventually include gcp.
+export const CONFIGURATION_ONLY = ['azure'];
+
+export function configurationOnly() {
+  return CONFIGURATION_ONLY.slice();
+}
+
 // Secret engines that have their own configuration page and actions
 // These engines do not exist in their own Ember engine.
-export const CONFIGURABLE_SECRET_ENGINES = ['aws', 'ssh'];
+export const CONFIGURABLE_SECRET_ENGINES = ['aws', 'azure', 'ssh'];
 
 export function configurableSecretEngines() {
   return MOUNTABLE_SECRET_ENGINES.slice();

--- a/ui/app/helpers/mountable-secret-engines.js
+++ b/ui/app/helpers/mountable-secret-engines.js
@@ -141,7 +141,7 @@ export function wifEngines() {
   return WIF_ENGINES.slice();
 }
 
-// A list of configuration only secret engines. These engines should only see a configuration tab.
+// The UI only supports configuration views for these secrets engines. The CLI must be used to manage other engine resources (i.e. roles, credentials).
 // Will eventually include gcp.
 export const CONFIGURATION_ONLY = ['azure'];
 

--- a/ui/app/helpers/mountable-secret-engines.js
+++ b/ui/app/helpers/mountable-secret-engines.js
@@ -153,12 +153,14 @@ export function configurationOnly() {
 // These engines do not exist in their own Ember engine.
 export const CONFIGURABLE_SECRET_ENGINES = ['aws', 'azure', 'ssh'];
 
-export function configurableSecretEngines() {
-  return MOUNTABLE_SECRET_ENGINES.slice();
-}
-
 export function mountableEngines() {
   return MOUNTABLE_SECRET_ENGINES.slice();
+}
+// Secret Engines that can be mounted but have no other type of configuration or actions available via the UI.
+export const UN_SUPPORTED_ENGINES = ['alicloud', 'consul', 'gcp', 'gcpkms', 'nomad', 'rabbitmq', 'totp'];
+
+export function unSupportedEngines() {
+  return UN_SUPPORTED_ENGINES.slice();
 }
 
 export function allEngines() {

--- a/ui/app/helpers/supported-secret-backends.js
+++ b/ui/app/helpers/supported-secret-backends.js
@@ -7,6 +7,7 @@ import { helper as buildHelper } from '@ember/component/helper';
 
 const SUPPORTED_SECRET_BACKENDS = [
   'aws',
+  'azure',
   'cubbyhole',
   'database',
   'generic',

--- a/ui/app/models/aws/lease-config.js
+++ b/ui/app/models/aws/lease-config.js
@@ -32,7 +32,7 @@ export default class AwsLeaseConfig extends Model {
   })
   lease;
 
-  get attrs() {
+  get displayAttrs() {
     const keys = ['lease', 'leaseMax'];
     return expandAttributeMeta(this, keys);
   }

--- a/ui/app/models/aws/root-config.js
+++ b/ui/app/models/aws/root-config.js
@@ -50,7 +50,7 @@ export default class AwsRootConfig extends Model {
   })
   maxRetries;
 
-  get attrs() {
+  get displayAttrs() {
     const keys = [
       'roleArn',
       'identityTokenAudience',

--- a/ui/app/models/azure/config.js
+++ b/ui/app/models/azure/config.js
@@ -57,8 +57,8 @@ export default class AzureConfig extends Model {
   }
 
   get isConfigured() {
-    const params = this.displayAttrs.map((attr) => attr.name);
-    return params.some((param) => this[param]);
+    // if every value is falsy, this engine has not been configured yet
+    return !this.configurableParams.every((param) => !this[param]);
   }
 
   // formFields are iterated through to generate the edit/create view

--- a/ui/app/models/azure/config.js
+++ b/ui/app/models/azure/config.js
@@ -4,30 +4,24 @@
  */
 
 import Model, { attr } from '@ember-data/model';
-import fieldToAttrs, { expandAttributeMeta } from 'vault/utils/field-to-attrs';
+import { expandAttributeMeta } from 'vault/utils/field-to-attrs';
 
 // Note: while the API docs indicate subscriptionId and tenantId are required, the UI does not enforce this because the user may pass these values in as environment variables.
 // https://developer.hashicorp.com/vault/api-docs/secret/azure#configure-access
 export default class AzureConfig extends Model {
   @attr('string') backend; // dynamic path of secret -- set on response from value passed to queryRecord
-  @attr('string', {
-    label: 'Subscription ID',
-  })
-  subscriptionId;
-  @attr('string', {
-    label: 'Tenant ID',
-  })
-  tenantId;
-  @attr('string', {
-    label: 'Client ID',
-  })
-  clientId;
+  @attr('string', { label: 'Subscription ID' }) subscriptionId;
+  @attr('string', { label: 'Tenant ID' }) tenantId;
+  @attr('string', { label: 'Client ID' }) clientId;
   @attr('string', { sensitive: true }) clientSecret; // obfuscated, never returned by API
+  @attr('string') environment;
+
   @attr('string', {
     subText:
       'The audience claim value for plugin identity tokens. Must match an allowed audience configured for the target IAM OIDC identity provider.',
   })
   identityTokenAudience;
+
   @attr({
     label: 'Identity token TTL',
     helperTextDisabled:
@@ -36,7 +30,7 @@ export default class AzureConfig extends Model {
     editType: 'ttl',
   })
   identityTokenTtl;
-  @attr('string') environment;
+
   @attr({
     label: 'Root password TTL',
     editType: 'ttl',
@@ -56,48 +50,6 @@ export default class AzureConfig extends Model {
       'identityTokenTtl',
       'environment',
       'rootPasswordTtl',
-    ];
-    return expandAttributeMeta(this, keys);
-  }
-
-  // "filedGroupsWif" and "fieldGroupsAzure" are passed to the FormFieldGroups component to determine which group to show in the form (ex: @groupName="fieldGroupsWif")
-  get fieldGroupsWif() {
-    return fieldToAttrs(this, this.formFieldGroups('wif'));
-  }
-
-  get fieldGroupsAzure() {
-    return fieldToAttrs(this, this.formFieldGroups('azure'));
-  }
-
-  formFieldGroups(accessType = 'azure') {
-    const formFieldGroups = [];
-    formFieldGroups.push({
-      default: ['subscriptionId', 'tenantId', 'clientId', 'environment'],
-    });
-    if (accessType === 'wif') {
-      formFieldGroups.push({
-        default: ['identityTokenAudience', 'identityTokenTtl'],
-      });
-    }
-    if (accessType === 'azure') {
-      formFieldGroups.push({
-        default: ['clientSecret', 'rootPasswordTtl'],
-      });
-    }
-    return formFieldGroups;
-  }
-
-  // formFields are iterated through to generate the edit/create view
-  get formFields() {
-    const keys = [
-      'subscriptionId',
-      'tenantId',
-      'clientId',
-      'clientSecret',
-      'identityTokenAudience',
-      'identityTokenTtl',
-      'rootPasswordTtl',
-      'environment',
     ];
     return expandAttributeMeta(this, keys);
   }

--- a/ui/app/models/azure/config.js
+++ b/ui/app/models/azure/config.js
@@ -4,7 +4,7 @@
  */
 
 import Model, { attr } from '@ember-data/model';
-import { expandAttributeMeta } from 'vault/utils/field-to-attrs';
+import fieldToAttrs, { expandAttributeMeta } from 'vault/utils/field-to-attrs';
 
 // Note: while the API docs indicate subscriptionId and tenantId are required, the UI does not enforce this because the user may pass these values in as environment variables.
 // https://developer.hashicorp.com/vault/api-docs/secret/azure#configure-access
@@ -56,6 +56,48 @@ export default class AzureConfig extends Model {
       'identityTokenTtl',
       'environment',
       'rootPasswordTtl',
+    ];
+    return expandAttributeMeta(this, keys);
+  }
+
+  // "filedGroupsWif" and "fieldGroupsAzure" are passed to the FormFieldGroups component to determine which group to show in the form (ex: @groupName="fieldGroupsWif")
+  get fieldGroupsWif() {
+    return fieldToAttrs(this, this.formFieldGroups('wif'));
+  }
+
+  get fieldGroupsAzure() {
+    return fieldToAttrs(this, this.formFieldGroups('azure'));
+  }
+
+  formFieldGroups(accessType = 'azure') {
+    const formFieldGroups = [];
+    formFieldGroups.push({
+      default: ['subscriptionId', 'tenantId', 'clientId', 'environment'],
+    });
+    if (accessType === 'wif') {
+      formFieldGroups.push({
+        default: ['identityTokenAudience', 'identityTokenTtl'],
+      });
+    }
+    if (accessType === 'azure') {
+      formFieldGroups.push({
+        default: ['clientSecret', 'rootPasswordTtl'],
+      });
+    }
+    return formFieldGroups;
+  }
+
+  // formFields are iterated through to generate the edit/create view
+  get formFields() {
+    const keys = [
+      'subscriptionId',
+      'tenantId',
+      'clientId',
+      'clientSecret',
+      'identityTokenAudience',
+      'identityTokenTtl',
+      'rootPasswordTtl',
+      'environment',
     ];
     return expandAttributeMeta(this, keys);
   }

--- a/ui/app/models/azure/config.js
+++ b/ui/app/models/azure/config.js
@@ -41,15 +41,21 @@ export default class AzureConfig extends Model {
 
   // for configuration details view
   // do not include clientSecret because it is never returned by the API
-  get attrs() {
+  get displayAttrs() {
+    return this.formFields.filter((attr) => attr.name !== 'clientSecret');
+  }
+
+  // formFields are iterated through to generate the edit/create view
+  get formFields() {
     const keys = [
       'subscriptionId',
       'tenantId',
       'clientId',
+      'clientSecret',
       'identityTokenAudience',
       'identityTokenTtl',
-      'environment',
       'rootPasswordTtl',
+      'environment',
     ];
     return expandAttributeMeta(this, keys);
   }

--- a/ui/app/models/azure/config.js
+++ b/ui/app/models/azure/config.js
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import Model, { attr } from '@ember-data/model';
+import { expandAttributeMeta } from 'vault/utils/field-to-attrs';
+
+// Note: while the API docs indicate subscriptionId and tenantId are required, the UI does not enforce this because the user may pass these values in as environment variables.
+// https://developer.hashicorp.com/vault/api-docs/secret/azure#configure-access
+export default class AzureConfig extends Model {
+  @attr('string') backend; // dynamic path of secret -- set on response from value passed to queryRecord
+  @attr('string', {
+    label: 'Subscription ID',
+  })
+  subscriptionId;
+  @attr('string', {
+    label: 'Tenant ID',
+  })
+  tenantId;
+  @attr('string', {
+    label: 'Client ID',
+  })
+  clientId;
+  @attr('string', { sensitive: true }) clientSecret; // obfuscated, never returned by API
+  @attr('string', {
+    subText:
+      'The audience claim value for plugin identity tokens. Must match an allowed audience configured for the target IAM OIDC identity provider.',
+  })
+  identityTokenAudience;
+  @attr({
+    label: 'Identity token TTL',
+    helperTextDisabled:
+      'The TTL of generated tokens. Defaults to 1 hour, turn on the toggle to specify a different value.',
+    helperTextEnabled: 'The TTL of generated tokens.',
+    editType: 'ttl',
+  })
+  identityTokenTtl;
+  @attr('string') environment;
+  @attr({
+    label: 'Root password TTL',
+    editType: 'ttl',
+    helperTextDisabled:
+      'Specifies how long the root password is valid for in Azure when rotate-root generates a new client secret. Defaults to 182 days or 6 months, 1 day and 13 hours.',
+  })
+  rootPasswordTtl;
+
+  // for configuration details view
+  // do not include clientSecret because it is never returned by the API
+  get attrs() {
+    const keys = [
+      'subscriptionId',
+      'tenantId',
+      'clientId',
+      'identityTokenAudience',
+      'identityTokenTtl',
+      'environment',
+      'rootPasswordTtl',
+    ];
+    return expandAttributeMeta(this, keys);
+  }
+}

--- a/ui/app/models/azure/config.js
+++ b/ui/app/models/azure/config.js
@@ -39,24 +39,30 @@ export default class AzureConfig extends Model {
   })
   rootPasswordTtl;
 
+  configurableParams = [
+    'subscriptionId',
+    'tenantId',
+    'clientId',
+    'clientSecret',
+    'identityTokenAudience',
+    'identityTokenTtl',
+    'rootPasswordTtl',
+    'environment',
+  ];
+
   // for configuration details view
   // do not include clientSecret because it is never returned by the API
   get displayAttrs() {
     return this.formFields.filter((attr) => attr.name !== 'clientSecret');
   }
 
+  get isConfigured() {
+    const params = this.displayAttrs.map((attr) => attr.name);
+    return params.some((param) => this[param]);
+  }
+
   // formFields are iterated through to generate the edit/create view
   get formFields() {
-    const keys = [
-      'subscriptionId',
-      'tenantId',
-      'clientId',
-      'clientSecret',
-      'identityTokenAudience',
-      'identityTokenTtl',
-      'rootPasswordTtl',
-      'environment',
-    ];
-    return expandAttributeMeta(this, keys);
+    return expandAttributeMeta(this, this.configurableParams);
   }
 }

--- a/ui/app/models/identity/oidc/config.js
+++ b/ui/app/models/identity/oidc/config.js
@@ -16,7 +16,7 @@ export default class IdentityOidcConfig extends Model {
   })
   issuer;
 
-  get attrs() {
+  get displayAttrs() {
     const keys = ['issuer'];
     return expandAttributeMeta(this, keys);
   }

--- a/ui/app/models/ssh/ca-config.js
+++ b/ui/app/models/ssh/ca-config.js
@@ -42,9 +42,8 @@ export default class SshCaConfig extends Model {
   generateSigningKey;
 
   // do not return private key for configuration.index view
-  get attrs() {
-    const keys = ['publicKey', 'generateSigningKey'];
-    return expandAttributeMeta(this, keys);
+  get displayAttrs() {
+    return this.formFields.filter((attr) => attr.name !== 'privateKey');
   }
   // return private key for edit/create view
   get formFields() {

--- a/ui/app/routes/vault/cluster/secrets/backend/configuration/index.js
+++ b/ui/app/routes/vault/cluster/secrets/backend/configuration/index.js
@@ -162,8 +162,5 @@ export default class SecretsBackendConfigurationRoute extends Route {
     )?.displayName;
     controller.isConfigurable = CONFIGURABLE_SECRET_ENGINES.includes(resolvedModel.secretEngineModel.type);
     controller.modelId = resolvedModel.secretEngineModel.id;
-    // Azure configuration TTLs are in seconds, so we want to format them to a readable timestamp, ex: 15768000 -> 6 months 1 day 13 hours
-    // Other engines have TTLs returned in strings that do not need formatting, ex: maxLease on aws "12h15m10s"
-    controller.formatTtl = resolvedModel.secretEngineModel.type === 'azure';
   }
 }

--- a/ui/app/routes/vault/cluster/secrets/backend/configuration/index.js
+++ b/ui/app/routes/vault/cluster/secrets/backend/configuration/index.js
@@ -51,7 +51,7 @@ export default class SecretsBackendConfigurationRoute extends Route {
       }
     }
     // If the engine is configurable fetch the config model(s) for the engine and return it alongside the model
-    if (CONFIGURABLE_SECRET_ENGINES.includes(secretEngineModel.type) || secretEngineModel.type === 'azure') {
+    if (CONFIGURABLE_SECRET_ENGINES.includes(secretEngineModel.type)) {
       let configModels = await this.fetchConfig(secretEngineModel.type, secretEngineModel.id);
       configModels = this.standardizeConfigModels(configModels);
 

--- a/ui/app/routes/vault/cluster/secrets/backend/configuration/index.js
+++ b/ui/app/routes/vault/cluster/secrets/backend/configuration/index.js
@@ -128,23 +128,17 @@ export default class SecretsBackendConfigurationRoute extends Route {
 
   async fetchAzureConfig(id) {
     try {
-      let azureModel = await this.store.queryRecord('azure/config', { backend: id });
+      const azureModel = await this.store.queryRecord('azure/config', { backend: id });
       let issuer = null;
-      if (azureModel.isConfigured) {
-        if (this.version.isEnterprise) {
-          // Issuer is an enterprise only related feature
-          // Issuer is also a global endpoint that doesn't mean anything in the Azure secret details context if WIF related fields on the azureConfig have not been set.
-          const WIF_FIELDS = ['identityTokenAudience', 'identityTokenTtl'];
-          WIF_FIELDS.some((field) => azureModel[field]) ? (issuer = await this.fetchIssuer()) : null;
-        }
-      } else {
-        // azure will return a 200 if the config is set or not set.
-        // thus, we set the model to null if no params have been configured.
-        azureModel = null;
+      if (this.version.isEnterprise) {
+        // Issuer is an enterprise only related feature
+        // Issuer is also a global endpoint that doesn't mean anything in the Azure secret details context if WIF related fields on the azureConfig have not been set.
+        const WIF_FIELDS = ['identityTokenAudience', 'identityTokenTtl'];
+        WIF_FIELDS.some((field) => azureModel[field]) ? (issuer = await this.fetchIssuer()) : null;
       }
-
       const configArray = [];
-      configArray.push(azureModel, issuer);
+      if (azureModel.isConfigured) configArray.push(azureModel);
+      if (issuer) configArray.push(issuer);
       return configArray;
     } catch (e) {
       if (e.httpStatus === 404) {

--- a/ui/app/routes/vault/cluster/secrets/backend/list.js
+++ b/ui/app/routes/vault/cluster/secrets/backend/list.js
@@ -7,7 +7,7 @@ import { set } from '@ember/object';
 import { hash } from 'rsvp';
 import Route from '@ember/routing/route';
 import { supportedSecretBackends } from 'vault/helpers/supported-secret-backends';
-import { allEngines, isAddonEngine } from 'vault/helpers/mountable-secret-engines';
+import { allEngines, isAddonEngine, CONFIGURATION_ONLY } from 'vault/helpers/mountable-secret-engines';
 import { service } from '@ember/service';
 import { normalizePath } from 'vault/utils/path-encoding-helpers';
 import { assert } from '@ember/debug';
@@ -84,6 +84,10 @@ export default Route.extend({
     const secretEngine = this.store.peekRecord('secret-engine', backend);
     const type = secretEngine?.engineType;
     assert('secretEngine.engineType is not defined', !!type);
+    // if configuration only, redirect to configuration route
+    CONFIGURATION_ONLY.includes(type) &&
+      this.router.transitionTo('vault.cluster.secrets.backend.configuration', backend);
+
     const engineRoute = allEngines().find((engine) => engine.type === type)?.engineRoute;
 
     if (!type || !SUPPORTED_BACKENDS.includes(type)) {

--- a/ui/app/routes/vault/cluster/secrets/backend/list.js
+++ b/ui/app/routes/vault/cluster/secrets/backend/list.js
@@ -85,11 +85,11 @@ export default Route.extend({
     const type = secretEngine?.engineType;
     assert('secretEngine.engineType is not defined', !!type);
     // if configuration only, redirect to configuration route
-    CONFIGURATION_ONLY.includes(type) &&
-      this.router.transitionTo('vault.cluster.secrets.backend.configuration', backend);
+    if (CONFIGURATION_ONLY.includes(type)) {
+      return this.router.transitionTo('vault.cluster.secrets.backend.configuration', backend);
+    }
 
     const engineRoute = allEngines().find((engine) => engine.type === type)?.engineRoute;
-
     if (!type || !SUPPORTED_BACKENDS.includes(type)) {
       return this.router.transitionTo('vault.cluster.secrets');
     }

--- a/ui/app/serializers/azure/config.js
+++ b/ui/app/serializers/azure/config.js
@@ -10,13 +10,6 @@ export default class AzureConfigSerializer extends ApplicationSerializer {
     if (!payload.data) {
       return super.normalizeResponse(...arguments);
     }
-    // remove rootPasswordTtl and identityTokenTtl if the API's default value of 0. We don't want to display this value on configuration details if they haven't changed the default value
-    if (payload.data.root_password_ttl === 0) {
-      delete payload.data.root_password_ttl;
-    }
-    if (payload.data.identity_token_ttl === 0) {
-      delete payload.data.identity_token_ttl;
-    }
 
     const normalizedPayload = {
       id: payload.id,

--- a/ui/app/serializers/azure/config.js
+++ b/ui/app/serializers/azure/config.js
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import ApplicationSerializer from '../application';
+
+export default class AzureConfigSerializer extends ApplicationSerializer {
+  normalizeResponse(store, primaryModelClass, payload, id, requestType) {
+    if (!payload.data) {
+      return super.normalizeResponse(...arguments);
+    }
+    // remove rootPasswordTtl and identityTokenTtl if the API's default value of 0. We don't want to display this value on configuration details if they haven't changed the default value
+    if (payload.data.root_password_ttl === 0) {
+      delete payload.data.root_password_ttl;
+    }
+    if (payload.data.identity_token_ttl === 0) {
+      delete payload.data.identity_token_ttl;
+    }
+
+    const normalizedPayload = {
+      id: payload.id,
+      backend: payload.backend,
+      data: {
+        ...payload.data,
+      },
+    };
+    return super.normalizeResponse(store, primaryModelClass, normalizedPayload, id, requestType);
+  }
+}

--- a/ui/app/serializers/azure/config.js
+++ b/ui/app/serializers/azure/config.js
@@ -27,14 +27,4 @@ export default class AzureConfigSerializer extends ApplicationSerializer {
     };
     return super.normalizeResponse(store, primaryModelClass, normalizedPayload, id, requestType);
   }
-
-  serialize() {
-    const json = super.serialize(...arguments);
-    // if the environment variable was initially set and then deleted we do not want to send an empty string
-    // the backend see this and throw an error.
-    if (json.environment === '') {
-      delete json.environment;
-    }
-    return json;
-  }
 }

--- a/ui/app/serializers/azure/config.js
+++ b/ui/app/serializers/azure/config.js
@@ -27,4 +27,14 @@ export default class AzureConfigSerializer extends ApplicationSerializer {
     };
     return super.normalizeResponse(store, primaryModelClass, normalizedPayload, id, requestType);
   }
+
+  serialize() {
+    const json = super.serialize(...arguments);
+    // if the environment variable was initially set and then deleted we do not want to send an empty string
+    // the backend see this and throw an error.
+    if (json.environment === '') {
+      delete json.environment;
+    }
+    return json;
+  }
 }

--- a/ui/app/templates/vault/cluster/secrets/backend/configuration/index.hbs
+++ b/ui/app/templates/vault/cluster/secrets/backend/configuration/index.hbs
@@ -25,7 +25,6 @@
     @configModels={{this.model.configModels}}
     @typeDisplay={{this.typeDisplay}}
     @id={{this.modelId}}
-    @formatTtl={{this.formatTtl}}
   />
 
   <SecretsEngineMountConfig

--- a/ui/app/templates/vault/cluster/secrets/backend/configuration/index.hbs
+++ b/ui/app/templates/vault/cluster/secrets/backend/configuration/index.hbs
@@ -6,22 +6,25 @@
 <SecretListHeader @model={{this.model.secretEngineModel}} @isConfigure={{true}} />
 
 {{#if this.isConfigurable}}
-  <Toolbar>
-    <ToolbarActions>
-      <ToolbarLink
-        @route="vault.cluster.secrets.backend.configuration.edit"
-        @model={{this.model.secretEngineModel.id}}
-        data-test-secret-backend-configure
-      >
-        Configure
-      </ToolbarLink>
-    </ToolbarActions>
-  </Toolbar>
+  {{#unless (eq this.typeDisplay "Azure")}}
+    <Toolbar>
+      <ToolbarActions>
+        <ToolbarLink
+          @route="vault.cluster.secrets.backend.configuration.edit"
+          @model={{this.model.secretEngineModel.id}}
+          data-test-secret-backend-configure
+        >
+          Configure
+        </ToolbarLink>
+      </ToolbarActions>
+    </Toolbar>
+  {{/unless}}
 
   <SecretEngine::ConfigurationDetails
     @configModels={{this.model.configModels}}
     @typeDisplay={{this.typeDisplay}}
     @id={{this.modelId}}
+    @formatTtl={{this.formatTtl}}
   />
 
   <SecretsEngineMountConfig

--- a/ui/app/templates/vault/cluster/secrets/backend/configuration/index.hbs
+++ b/ui/app/templates/vault/cluster/secrets/backend/configuration/index.hbs
@@ -6,6 +6,7 @@
 <SecretListHeader @model={{this.model.secretEngineModel}} @isConfigure={{true}} />
 
 {{#if this.isConfigurable}}
+  {{! TODO: short-term conditional to be removed once configuration for azure is merged. }}
   {{#unless (eq this.typeDisplay "Azure")}}
     <Toolbar>
       <ToolbarActions>

--- a/ui/lib/core/addon/components/secret-list-header.hbs
+++ b/ui/lib/core/addon/components/secret-list-header.hbs
@@ -72,7 +72,7 @@
     <div class="tabs-container box is-bottomless is-marginless is-fullwidth is-paddingless">
       <nav class="tabs" aria-label="tabs">
         <ul>
-          {{#if (includes @model.engineType (supported-secret-backends))}}
+          {{#if this.showListTab}}
             <li>
               <LinkTo
                 @route="vault.cluster.secrets.backend.list-root"

--- a/ui/lib/core/addon/components/secret-list-header.js
+++ b/ui/lib/core/addon/components/secret-list-header.js
@@ -4,6 +4,8 @@
  */
 
 import Component from '@glimmer/component';
+import { supportedSecretBackends } from 'vault/helpers/supported-secret-backends';
+import { CONFIGURATION_ONLY } from 'vault/helpers/mountable-secret-engines';
 
 /**
  * @module SecretListHeader
@@ -22,5 +24,11 @@ import Component from '@glimmer/component';
 export default class SecretListHeader extends Component {
   get isKV() {
     return ['kv', 'generic'].includes(this.args.model.engineType);
+  }
+
+  get showListTab() {
+    // only show the list tab if the engine is not a configuration only engine and the UI supports it
+    const { engineType } = this.args.model;
+    return supportedSecretBackends().includes(engineType) && !CONFIGURATION_ONLY.includes(engineType);
   }
 }

--- a/ui/tests/acceptance/secrets/backend/aws/aws-configuration-test.js
+++ b/ui/tests/acceptance/secrets/backend/aws/aws-configuration-test.js
@@ -113,7 +113,7 @@ module('Acceptance | aws | configuration', function (hooks) {
         .hasText('foo-audience', 'Identity token audience has been set.');
       assert
         .dom(GENERAL.infoRowValue('Identity token TTL'))
-        .hasText('7200', 'Identity token TTL has been set.');
+        .hasText('2 hours', 'Identity token TTL has been set.');
       assert.dom(GENERAL.infoRowValue('Access key')).doesNotExist('Access key—a non-wif attr is not shown.');
       // cleanup
       await runCmd(`delete sys/mounts/${path}`);
@@ -210,8 +210,10 @@ module('Acceptance | aws | configuration', function (hooks) {
         'Success flash message is rendered showing the lease configuration was saved.'
       );
 
-      assert.dom(GENERAL.infoRowValue('Default Lease TTL')).hasText('33s', `Default TTL has been set.`);
-      assert.dom(GENERAL.infoRowValue('Max Lease TTL')).hasText('44s', `Max lease TTL has been set.`);
+      assert
+        .dom(GENERAL.infoRowValue('Default Lease TTL'))
+        .hasText('33 seconds', `Default TTL has been set.`);
+      assert.dom(GENERAL.infoRowValue('Max Lease TTL')).hasText('44 seconds', `Max lease TTL has been set.`);
       // cleanup
       await runCmd(`delete sys/mounts/${path}`);
     });
@@ -272,8 +274,8 @@ module('Acceptance | aws | configuration', function (hooks) {
       assert.dom(GENERAL.infoRowValue('Region')).hasText('ap-southeast-2', 'Region has been added');
       assert
         .dom(GENERAL.infoRowValue('Default Lease TTL'))
-        .hasText('33s', 'Default Lease TTL has been added');
-      assert.dom(GENERAL.infoRowValue('Max Lease TTL')).hasText('44s', 'Max Lease TTL has been added');
+        .hasText('33 seconds', 'Default Lease TTL has been added');
+      assert.dom(GENERAL.infoRowValue('Max Lease TTL')).hasText('44 seconds', 'Max Lease TTL has been added');
       // cleanup
       await runCmd(`delete sys/mounts/${path}`);
     });

--- a/ui/tests/acceptance/secrets/backend/azure/azure-configuration-test.js
+++ b/ui/tests/acceptance/secrets/backend/azure/azure-configuration-test.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { click, fillIn, visit, currentURL } from '@ember/test-helpers';
+import { click, visit, currentURL } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { v4 as uuidv4 } from 'uuid';
@@ -129,30 +129,7 @@ module('Acceptance | Azure | configuration', function (hooks) {
       await runCmd(`delete sys/mounts/${path}`);
     });
 
-    test('it should not show identityTokenTtl or maxRetries if they have not been set', async function (assert) {
-      const path = `aws-${this.uid}`;
-      await enablePage.enable('aws', path);
-
-      await click(SES.configTab);
-      await click(SES.configure);
-      // manually fill in attrs without using helper so we can exclude identityTokenTtl and maxRetries.
-      await click(SES.wif.accessType('wif')); // toggle to wif
-      await fillIn(GENERAL.inputByAttr('roleArn'), 'foo-role');
-      await fillIn(GENERAL.inputByAttr('identityTokenAudience'), 'foo-audience');
-      // manually fill in non-access type specific fields on root config so we can exclude Max Retries.
-      await click(GENERAL.toggleGroup('Root config options'));
-      await fillIn(GENERAL.inputByAttr('region'), 'eu-central-1');
-      await click(GENERAL.saveButton);
-      // the Serializer removes these two from the payload if the API returns their default value.
-      assert
-        .dom(GENERAL.infoRowValue('Identity token TTL'))
-        .doesNotExist('Identity token TTL does not show.');
-      assert.dom(GENERAL.infoRowValue('Maximum retries')).doesNotExist('Maximum retries does not show.');
-      // cleanup
-      await runCmd(`delete sys/mounts/${path}`);
-    });
-
-    test('it should show API error when Azure configuration read fails', async function (assert) {
+    test('it should show API error when configuration read fails', async function (assert) {
       assert.expect(1);
       const path = `azure-${this.uid}`;
       const type = 'azure';

--- a/ui/tests/acceptance/secrets/backend/azure/azure-configuration-test.js
+++ b/ui/tests/acceptance/secrets/backend/azure/azure-configuration-test.js
@@ -1,0 +1,167 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import { click, fillIn, visit, currentURL } from '@ember/test-helpers';
+import { module, test } from 'qunit';
+import { setupApplicationTest } from 'ember-qunit';
+import { v4 as uuidv4 } from 'uuid';
+import { spy } from 'sinon';
+
+import authPage from 'vault/tests/pages/auth';
+import enablePage from 'vault/tests/pages/settings/mount-secret-backend';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { runCmd } from 'vault/tests/helpers/commands';
+import { GENERAL } from 'vault/tests/helpers/general-selectors';
+import { overrideResponse } from 'vault/tests/helpers/stubs';
+import { SECRET_ENGINE_SELECTORS as SES } from 'vault/tests/helpers/secret-engine/secret-engine-selectors';
+import { mountBackend } from 'vault/tests/helpers/components/mount-backend-form-helpers';
+import {
+  expectedConfigKeys,
+  expectedValueOfConfigKeys,
+  configUrl,
+} from 'vault/tests/helpers/secret-engine/secret-engine-helpers';
+
+module('Acceptance | Azure | configuration', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(function () {
+    const flash = this.owner.lookup('service:flash-messages');
+    this.store = this.owner.lookup('service:store');
+    this.flashSuccessSpy = spy(flash, 'success');
+    this.flashInfoSpy = spy(flash, 'info');
+    this.version = this.owner.lookup('service:version');
+    this.uid = uuidv4();
+    return authPage.login();
+  });
+  module('isEnterprise', function (hooks) {
+    hooks.beforeEach(function () {
+      this.version.type = 'enterprise';
+    });
+
+    test('it should show empty state and navigate to configuration view after mounting the azure engine', async function (assert) {
+      const path = `azure-${this.uid}`;
+      await visit('/vault/settings/mount-secret-backend');
+      await mountBackend('azure', path);
+
+      assert.dom(GENERAL.emptyStateTitle).hasText('Azure not configured');
+      assert.dom(GENERAL.emptyStateActions).doesNotContainText('Configure Azure');
+      // cleanup
+      await runCmd(`delete sys/mounts/${path}`);
+    });
+
+    test('it should not show "Configure" from toolbar', async function (assert) {
+      const path = `azure-${this.uid}`;
+      await enablePage.enable('azure', path);
+      assert.dom(SES.configure).doesNotExist('Configure button does not exist.');
+      assert.strictEqual(
+        currentURL(),
+        `/vault/secrets/${path}/configuration`,
+        'navigated to configuration view'
+      );
+      // cleanup
+      await runCmd(`delete sys/mounts/${path}`);
+    });
+
+    test('it should show configuration with WIF options configured', async function (assert) {
+      const path = `azure-${this.uid}`;
+      const type = 'azure';
+      const wifAttrs = {
+        subscription_id: 'subscription-id',
+        tenant_id: 'tenant-id',
+        client_id: 'client-id',
+        identity_token_audience: 'audience',
+        identity_token_ttl: 720000,
+        environment: 'AZUREPUBLICCLOUD',
+      };
+      this.server.get(`${path}/config`, () => {
+        assert.ok(true, 'request made to config when navigating to the configuration page.');
+        return { data: { id: path, type, ...wifAttrs } };
+      });
+      await enablePage.enable(type, path);
+      for (const key of expectedConfigKeys('azure-wif')) {
+        assert.dom(GENERAL.infoRowLabel(key)).exists(`${key} on the ${type} config details exists.`);
+        const responseKeyAndValue = expectedValueOfConfigKeys(type, key);
+        assert
+          .dom(GENERAL.infoRowValue(key))
+          .hasText(responseKeyAndValue, `value for ${key} on the ${type} config details exists.`);
+      }
+      // check mount configuration details are present and accurate.
+      await click(SES.configurationToggle);
+      assert
+        .dom(GENERAL.infoRowValue('Path'))
+        .hasText(`${path}/`, 'mount path is displayed in the configuration details');
+      // cleanup
+      await runCmd(`delete sys/mounts/${path}`);
+    });
+
+    test('it should show configuration with Azure account options configured', async function (assert) {
+      const path = `azure-${this.uid}`;
+      const type = 'azure';
+      const azureAccountAttrs = {
+        client_secret: 'client-secret',
+        subscription_id: 'subscription-id',
+        tenant_id: 'tenant-id',
+        client_id: 'client-id',
+        root_password_ttl: '20 days 20 hours',
+        environment: 'AZUREPUBLICCLOUD',
+      };
+      this.server.get(`${path}/config`, () => {
+        assert.ok(true, 'request made to config when navigating to the configuration page.');
+        return { data: { id: path, type, ...azureAccountAttrs } };
+      });
+      await enablePage.enable(type, path);
+      for (const key of expectedConfigKeys('azure')) {
+        assert.dom(GENERAL.infoRowLabel(key)).exists(`${key} on the ${type} config details exists.`);
+        const responseKeyAndValue = expectedValueOfConfigKeys(type, key);
+        assert
+          .dom(GENERAL.infoRowValue(key))
+          .hasText(responseKeyAndValue, `value for ${key} on the ${type} config details exists.`);
+      }
+      // check mount configuration details are present and accurate.
+      await click(SES.configurationToggle);
+      assert
+        .dom(GENERAL.infoRowValue('Path'))
+        .hasText(`${path}/`, 'mount path is displayed in the configuration details');
+      // cleanup
+      await runCmd(`delete sys/mounts/${path}`);
+    });
+
+    test('it should not show identityTokenTtl or maxRetries if they have not been set', async function (assert) {
+      const path = `aws-${this.uid}`;
+      await enablePage.enable('aws', path);
+
+      await click(SES.configTab);
+      await click(SES.configure);
+      // manually fill in attrs without using helper so we can exclude identityTokenTtl and maxRetries.
+      await click(SES.wif.accessType('wif')); // toggle to wif
+      await fillIn(GENERAL.inputByAttr('roleArn'), 'foo-role');
+      await fillIn(GENERAL.inputByAttr('identityTokenAudience'), 'foo-audience');
+      // manually fill in non-access type specific fields on root config so we can exclude Max Retries.
+      await click(GENERAL.toggleGroup('Root config options'));
+      await fillIn(GENERAL.inputByAttr('region'), 'eu-central-1');
+      await click(GENERAL.saveButton);
+      // the Serializer removes these two from the payload if the API returns their default value.
+      assert
+        .dom(GENERAL.infoRowValue('Identity token TTL'))
+        .doesNotExist('Identity token TTL does not show.');
+      assert.dom(GENERAL.infoRowValue('Maximum retries')).doesNotExist('Maximum retries does not show.');
+      // cleanup
+      await runCmd(`delete sys/mounts/${path}`);
+    });
+
+    test('it should show API error when Azure configuration read fails', async function (assert) {
+      assert.expect(1);
+      const path = `azure-${this.uid}`;
+      const type = 'azure';
+      // interrupt get and return API error
+      this.server.get(configUrl(type, path), () => {
+        return overrideResponse(400, { errors: ['bad request'] });
+      });
+      await enablePage.enable(type, path);
+      assert.dom(SES.error.title).hasText('Error', 'shows the secrets backend error route');
+    });
+  });
+});

--- a/ui/tests/acceptance/secrets/backend/azure/azure-configuration-test.js
+++ b/ui/tests/acceptance/secrets/backend/azure/azure-configuration-test.js
@@ -46,6 +46,11 @@ module('Acceptance | Azure | configuration', function (hooks) {
       await visit('/vault/settings/mount-secret-backend');
       await mountBackend('azure', path);
 
+      assert.strictEqual(
+        currentURL(),
+        `/vault/secrets/${path}/configuration`,
+        'navigated to configuration view'
+      );
       assert.dom(GENERAL.emptyStateTitle).hasText('Azure not configured');
       assert.dom(GENERAL.emptyStateActions).doesNotContainText('Configure Azure');
       // cleanup
@@ -56,11 +61,6 @@ module('Acceptance | Azure | configuration', function (hooks) {
       const path = `azure-${this.uid}`;
       await enablePage.enable('azure', path);
       assert.dom(SES.configure).doesNotExist('Configure button does not exist.');
-      assert.strictEqual(
-        currentURL(),
-        `/vault/secrets/${path}/configuration`,
-        'navigated to configuration view'
-      );
       // cleanup
       await runCmd(`delete sys/mounts/${path}`);
     });
@@ -82,7 +82,6 @@ module('Acceptance | Azure | configuration', function (hooks) {
       });
       await enablePage.enable(type, path);
       for (const key of expectedConfigKeys('azure-wif')) {
-        assert.dom(GENERAL.infoRowLabel(key)).exists(`${key} on the ${type} config details exists.`);
         const responseKeyAndValue = expectedValueOfConfigKeys(type, key);
         assert
           .dom(GENERAL.infoRowValue(key))

--- a/ui/tests/acceptance/secrets/backend/engines-test.js
+++ b/ui/tests/acceptance/secrets/backend/engines-test.js
@@ -12,7 +12,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { GENERAL } from 'vault/tests/helpers/general-selectors';
 import { deleteEngineCmd, mountEngineCmd, runCmd } from 'vault/tests/helpers/commands';
 import { login } from 'vault/tests/helpers/auth/auth-helpers';
-import { UN_SUPPORTED_ENGINES, mountableEngines } from 'vault/helpers/mountable-secret-engines';
+import { UNSUPPORTED_ENGINES, mountableEngines } from 'vault/helpers/mountable-secret-engines';
 import { PAGE } from 'vault/tests/helpers/kv/kv-selectors';
 
 const SELECTORS = {
@@ -56,7 +56,7 @@ module('Acceptance | secret-engine list view', function (hooks) {
       await visit('/vault/cluster/dashboard');
       await visit('/vault/secrets');
 
-      if (UN_SUPPORTED_ENGINES.includes(engine)) {
+      if (UNSUPPORTED_ENGINES.includes(engine)) {
         assert
           .dom(PAGE.backends.link(enginePath))
           .doesNotHaveClass(

--- a/ui/tests/acceptance/secrets/backend/engines-test.js
+++ b/ui/tests/acceptance/secrets/backend/engines-test.js
@@ -54,7 +54,6 @@ module('Acceptance | secret-engine list view', function (hooks) {
       const engine = engineObject.type;
       const enginePath = `${engine}-${this.uid}`;
       await runCmd(mountEngineCmd(engine, enginePath));
-      // TODO: fix, the list view does not refresh after mounting an engine through the console. Toggle to another page and back to refresh model.
       await visit('/vault/cluster/dashboard');
       await visit('/vault/secrets');
 

--- a/ui/tests/acceptance/secrets/backend/engines-test.js
+++ b/ui/tests/acceptance/secrets/backend/engines-test.js
@@ -12,6 +12,8 @@ import { v4 as uuidv4 } from 'uuid';
 import { GENERAL } from 'vault/tests/helpers/general-selectors';
 import { deleteEngineCmd, mountEngineCmd, runCmd } from 'vault/tests/helpers/commands';
 import { login } from 'vault/tests/helpers/auth/auth-helpers';
+import { UN_SUPPORTED_ENGINES, allEngines } from 'vault/helpers/mountable-secret-engines';
+import { PAGE } from 'vault/tests/helpers/kv/kv-selectors';
 
 const SELECTORS = {
   backendLink: (path) =>
@@ -45,25 +47,32 @@ module('Acceptance | secret-engine list view', function (hooks) {
   });
 
   test('it adds disabled css styling to unsupported secret engines', async function (assert) {
-    assert.expect(2);
-    // first mount engine that is not supported
-    const enginePath = `nomad-${this.uid}`;
-    await runCmd(mountEngineCmd('nomad', enginePath));
-    await visit('/vault/secrets');
+    assert.expect(19);
+    const allEnginesArray = allEngines();
 
-    const rows = findAll(SELECTORS.backendLink());
-    const rowUnsupported = Array.from(rows).filter((row) => row.innerText.includes('nomad'));
-    const rowSupported = Array.from(rows).filter((row) => row.innerText.includes('cubbyhole'));
-    assert
-      .dom(rowUnsupported[0])
-      .doesNotHaveClass(
-        'linked-block',
-        `the linked-block class is not added to unsupported engines, which effectively disables it.`
-      );
-    assert.dom(rowSupported[0]).hasClass('linked-block', `linked-block class is added to supported engines.`);
+    for (const engineObject of allEnginesArray) {
+      const engine = engineObject.type;
+      const enginePath = `${engine}-${this.uid}`;
+      await runCmd(mountEngineCmd(engine, enginePath));
+      // TODO: fix, the list view does not refresh after mounting an engine through the console. Toggle to another page and back to refresh model.
+      await visit('/vault/cluster/dashboard');
+      await visit('/vault/secrets');
 
-    // cleanup
-    await runCmd(deleteEngineCmd(enginePath));
+      if (UN_SUPPORTED_ENGINES.includes(engine)) {
+        assert
+          .dom(PAGE.backends.link(enginePath))
+          .doesNotHaveClass(
+            'linked-block',
+            `the linked-block class is not added to the unsupported ${engine}, which effectively disables it.`
+          );
+      } else {
+        assert
+          .dom(PAGE.backends.link(enginePath))
+          .hasClass('linked-block', `linked-block class is added to supported ${engine} engines.`);
+      }
+      // cleanup
+      await runCmd(deleteEngineCmd(enginePath));
+    }
   });
 
   test('it filters by name and engine type', async function (assert) {

--- a/ui/tests/acceptance/secrets/backend/engines-test.js
+++ b/ui/tests/acceptance/secrets/backend/engines-test.js
@@ -12,7 +12,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { GENERAL } from 'vault/tests/helpers/general-selectors';
 import { deleteEngineCmd, mountEngineCmd, runCmd } from 'vault/tests/helpers/commands';
 import { login } from 'vault/tests/helpers/auth/auth-helpers';
-import { UN_SUPPORTED_ENGINES, allEngines } from 'vault/helpers/mountable-secret-engines';
+import { UN_SUPPORTED_ENGINES, mountableEngines } from 'vault/helpers/mountable-secret-engines';
 import { PAGE } from 'vault/tests/helpers/kv/kv-selectors';
 
 const SELECTORS = {
@@ -47,9 +47,8 @@ module('Acceptance | secret-engine list view', function (hooks) {
   });
 
   test('it adds disabled css styling to unsupported secret engines', async function (assert) {
-    assert.expect(19);
-    const allEnginesArray = allEngines();
-
+    assert.expect(16);
+    const allEnginesArray = mountableEngines();
     for (const engineObject of allEnginesArray) {
       const engine = engineObject.type;
       const enginePath = `${engine}-${this.uid}`;

--- a/ui/tests/acceptance/settings/mount-secret-backend-test.js
+++ b/ui/tests/acceptance/settings/mount-secret-backend-test.js
@@ -26,7 +26,7 @@ import authPage from 'vault/tests/pages/auth';
 import consoleClass from 'vault/tests/pages/components/console/ui-panel';
 import logout from 'vault/tests/pages/logout';
 import mountSecrets from 'vault/tests/pages/settings/mount-secret-backend';
-import { mountableEngines } from 'vault/helpers/mountable-secret-engines'; // allEngines() includes enterprise engines, those are tested elsewhere
+import { CONFIGURATION_ONLY, mountableEngines } from 'vault/helpers/mountable-secret-engines';
 import { supportedSecretBackends } from 'vault/helpers/supported-secret-backends';
 import { GENERAL } from 'vault/tests/helpers/general-selectors';
 import { SECRET_ENGINE_SELECTORS as SES } from 'vault/tests/helpers/secret-engine/secret-engine-selectors';
@@ -250,11 +250,13 @@ module('Acceptance | settings/mount-secret-backend', function (hooks) {
       }
       await click(GENERAL.saveButton);
 
+      const route = CONFIGURATION_ONLY.includes(engine.type) ? 'configuration.index' : 'list-root';
       assert.strictEqual(
         currentRouteName(),
-        `vault.cluster.secrets.backend.list-root`,
-        `${engine.type} navigates to list view`
+        `vault.cluster.secrets.backend.${route}`,
+        `${engine.type} navigates to the correct view (either list if not configuration only or configuration if it is).`
       );
+
       await consoleComponent.runCommands([
         // cleanup after
         `delete sys/mounts/${engine.type}`,

--- a/ui/tests/helpers/secret-engine/secret-engine-helpers.js
+++ b/ui/tests/helpers/secret-engine/secret-engine-helpers.js
@@ -99,8 +99,9 @@ const createSshCaConfig = (store, backend) => {
   return store.peekRecord('ssh/ca-config', backend);
 };
 
-const createAzureConfig = (store, backend, accessType = 'generic') => {
+const createAzureConfig = (store, backend, accessType) => {
   // clear any records first
+  // note: allowed "environment" params for testing https://github.com/hashicorp/vault-plugin-secrets-azure/blob/main/client.go#L35-L37
   store.unloadAll('azure/config');
   if (accessType === 'azure') {
     store.pushPayload('azure/config', {
@@ -116,20 +117,6 @@ const createAzureConfig = (store, backend, accessType = 'generic') => {
         environment: 'AZUREPUBLICCLOUD',
       },
     });
-  } else if (accessType === 'wif') {
-    store.pushPayload('azure/config', {
-      id: backend,
-      modelName: 'azure/config',
-      data: {
-        backend,
-        subscription_id: 'subscription-id',
-        tenant_id: 'tenant-id',
-        client_id: 'client-id',
-        identity_token_audience: 'audience',
-        identity_token_ttl: 720000,
-        environment: 'AZUREPUBLICCLOUD',
-      },
-    });
   } else {
     store.pushPayload('azure/config', {
       id: backend,
@@ -139,7 +126,7 @@ const createAzureConfig = (store, backend, accessType = 'generic') => {
         subscription_id: 'subscription-id-2',
         tenant_id: 'tenant-id-2',
         client_id: 'client-id-2',
-        environment: 'AZUREPUBLICCLOUD', // allowed environment vars for testing https://github.com/hashicorp/vault-plugin-secrets-azure/blob/main/client.go#L35-L37
+        environment: 'AZUREPUBLICCLOUD',
       },
     });
   }
@@ -175,10 +162,6 @@ export const createConfig = (store, backend, type) => {
       return createSshCaConfig(store, backend);
     case 'azure':
       return createAzureConfig(store, backend, 'azure');
-    case 'azure-wif':
-      return createAzureConfig(store, backend, 'wif');
-    case 'azure-generic':
-      return createAzureConfig(store, backend, 'generic');
   }
 };
 // Used in tests to assert the expected keys in the config details of configurable secret engines

--- a/ui/tests/helpers/secret-engine/secret-engine-helpers.js
+++ b/ui/tests/helpers/secret-engine/secret-engine-helpers.js
@@ -99,6 +99,53 @@ const createSshCaConfig = (store, backend) => {
   return store.peekRecord('ssh/ca-config', backend);
 };
 
+const createAzureConfig = (store, backend, accessType = 'generic') => {
+  // clear any records first
+  store.unloadAll('azure/config');
+  if (accessType === 'azure') {
+    store.pushPayload('azure/config', {
+      id: backend,
+      modelName: 'azure/config',
+      data: {
+        backend,
+        client_secret: 'client-secret',
+        subscription_id: 'subscription-id',
+        tenant_id: 'tenant-id',
+        client_id: 'client-id',
+        root_password_ttl: '20 days 20 hours',
+        environment: 'AZUREPUBLICCLOUD',
+      },
+    });
+  } else if (accessType === 'wif') {
+    store.pushPayload('azure/config', {
+      id: backend,
+      modelName: 'azure/config',
+      data: {
+        backend,
+        subscription_id: 'subscription-id',
+        tenant_id: 'tenant-id',
+        client_id: 'client-id',
+        identity_token_audience: 'audience',
+        identity_token_ttl: 720000,
+        environment: 'AZUREPUBLICCLOUD',
+      },
+    });
+  } else {
+    store.pushPayload('azure/config', {
+      id: backend,
+      modelName: 'azure/config',
+      data: {
+        backend,
+        subscription_id: 'subscription-id-2',
+        tenant_id: 'tenant-id-2',
+        client_id: 'client-id-2',
+        environment: 'AZUREPUBLICCLOUD', // allowed environment vars for testing https://github.com/hashicorp/vault-plugin-secrets-azure/blob/main/client.go#L35-L37
+      },
+    });
+  }
+  return store.peekRecord('azure/config', backend);
+};
+
 export function configUrl(type, backend) {
   switch (type) {
     case 'aws':
@@ -126,6 +173,12 @@ export const createConfig = (store, backend, type) => {
       return createAwsLeaseConfig(store, backend);
     case 'ssh':
       return createSshCaConfig(store, backend);
+    case 'azure':
+      return createAzureConfig(store, backend, 'azure');
+    case 'azure-wif':
+      return createAzureConfig(store, backend, 'wif');
+    case 'azure-generic':
+      return createAzureConfig(store, backend, 'generic');
   }
 };
 // Used in tests to assert the expected keys in the config details of configurable secret engines
@@ -143,6 +196,28 @@ export const expectedConfigKeys = (type) => {
       return ['accessKey', 'secretKey'];
     case 'ssh':
       return ['Public key', 'Generate signing key'];
+    case 'azure':
+      return ['Subscription ID', 'Tenant ID', 'Client ID', 'Root password TTL', 'Environment'];
+    case 'azure-camelCase':
+      return ['subscriptionId', 'tenantId', 'clientId', 'rootPasswordTtl', 'environment'];
+    case 'azure-wif':
+      return [
+        'Subscription ID',
+        'Tenant ID',
+        'Client ID',
+        'Environment',
+        'Identity token audience',
+        'Identity token TTL',
+      ];
+    case 'azure-wif-camelCase':
+      return [
+        'subscriptionId',
+        'tenantId',
+        'clientId',
+        'environment',
+        'identityTokenAudience',
+        'Identity token TTL',
+      ];
   }
 };
 
@@ -161,6 +236,25 @@ const valueOfAwsKeys = (string) => {
   }
 };
 
+const valueOfAzureKeys = (string) => {
+  switch (string) {
+    case 'Subscription ID':
+      return 'subscription-id';
+    case 'Tenant ID':
+      return 'tenant-id';
+    case 'Client ID':
+      return 'client-id';
+    case 'Environment':
+      return 'AZUREPUBLICCLOUD';
+    case 'Root password TTL':
+      return '20 days 20 hours';
+    case 'Identity token audience':
+      return 'audience';
+    case 'Identity token TTL':
+      return '8 days 8 hours';
+  }
+};
+
 const valueOfSshKeys = (string) => {
   switch (string) {
     case 'Public key':
@@ -174,6 +268,8 @@ export const expectedValueOfConfigKeys = (type, string) => {
   switch (type) {
     case 'aws':
       return valueOfAwsKeys(string);
+    case 'azure':
+      return valueOfAzureKeys(string);
     case 'ssh':
       return valueOfSshKeys(string);
   }

--- a/ui/tests/integration/components/secret-engine/configuration-details-test.js
+++ b/ui/tests/integration/components/secret-engine/configuration-details-test.js
@@ -30,11 +30,13 @@ module('Integration | Component | SecretEngine/ConfigurationDetails', function (
       <SecretEngine::ConfigurationDetails @typeDisplay="Display Name" />
     `);
     assert.dom(GENERAL.emptyStateTitle).hasText(`Display Name not configured`);
-    assert.dom(GENERAL.emptyStateMessage).hasText(`Get started by configuring your Display Name engine.`);
+    assert
+      .dom(GENERAL.emptyStateMessage)
+      .hasText(`Get started by configuring your Display Name secrets engine.`);
   });
 
   test('it shows config details if configModel(s) are passed in', async function (assert) {
-    assert.expect(21);
+    assert.expect(36);
     const allEnginesArray = allEngines(); // saving as const so we don't invoke the method multiple times via the for loop
     for (const type of CONFIGURABLE_SECRET_ENGINES) {
       const backend = `test-${type}`;
@@ -44,6 +46,7 @@ module('Integration | Component | SecretEngine/ConfigurationDetails', function (
       await render(
         hbs`<SecretEngine::ConfigurationDetails @configModels={{array this.configModels}} @typeDisplay={{this.typeDisplay}}/>`
       );
+
       for (const key of expectedConfigKeys(type)) {
         assert.dom(GENERAL.infoRowLabel(key)).exists(`${key} on the ${type} config details exists.`);
         const responseKeyAndValue = expectedValueOfConfigKeys(type, key);

--- a/ui/types/vault/models/azure/config.d.ts
+++ b/ui/types/vault/models/azure/config.d.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import type Model from '@ember-data/model';
+import type { ModelValidations } from 'vault/app-types';
+
+export default class AzureConfig extends Model {
+  backend: string;
+  subscriptionId: string | undefined;
+  tenantId: string | undefined;
+  clientId: string | undefined;
+  clientSecret: string | undefined;
+  identityTokenAudience: string | undefined;
+  identityTokenTtl: any;
+  environment: string | undefined;
+  rootPasswordTtl: string | undefined;
+
+  get attrs(): any;
+  changedAttributes(): {
+    [key: string]: unknown[];
+  };
+  isNew: boolean;
+  save(): void;
+  unloadRecord(): void;
+}


### PR DESCRIPTION
- [x] ent test pass

### Description
Breaking up the Azure WIF configuration work by separating out configuration details changes into a separate pr. This PR can merge into main with a small amount of short-term conditionals. 
note: no changelog as the final PR will have a changelog for the full feature.

1. Allows Azure to be a "supported secret engine".
2. Shows a Configuration details view, separating out the mount config details from the secret engine details.
3. Shows an empty state for when an engine is not configured.

![image](https://github.com/user-attachments/assets/9c974df1-5e36-4364-a429-4951e3c553a4)
![image](https://github.com/user-attachments/assets/847e21fc-ed49-4ce5-8494-a301ea08aa73)
