### PR TITLE
VAULT-32598: add docs for azure autosnapshot auth modes

### DIFF
--- a/website/content/api-docs/system/storage/raftautosnapshots.mdx
+++ b/website/content/api-docs/system/storage/raftautosnapshots.mdx
@@ -61,7 +61,7 @@ environment variables or files on disk in predefined locations.
 #### storage_type=local
 
 - `local_max_space` `(integer: <required>)` - For `storage_type=local`, the maximum
-  space, in bytes, to use for all snapshots with the given `file_prefix` in the `path_prefix` directory. 
+  space, in bytes, to use for all snapshots with the given `file_prefix` in the `path_prefix` directory.
   Snapshot attempts will fail if there is not enough
   space left in this allowance.
 
@@ -140,7 +140,11 @@ parameters in the context of AWS EKS & S3 configuration.
 
 - `azure_account_name` `(string)` - Azure account name.
 
-- `azure_account_key` `(string)` - Azure account key.
+- `azure_account_key` `(string)` - Azure account key. Used for `shared` authentication.
+
+- `azure_client_id` `(string)` - Azure Client ID. Used for `managed` authentication.
+
+- `azure_auth_mode` `(string)` - One of `shared` or `managed`.
 
 - `azure_blob_environment` `(string)` - Azure blob environment.
 

--- a/website/content/api-docs/system/storage/raftautosnapshots.mdx
+++ b/website/content/api-docs/system/storage/raftautosnapshots.mdx
@@ -61,7 +61,7 @@ environment variables or files on disk in predefined locations.
 #### storage_type=local
 
 - `local_max_space` `(integer: <required>)` - For `storage_type=local`, the maximum
-  space, in bytes, to use for all snapshots with the given `file_prefix` in the `path_prefix` directory.
+  space, in bytes, to use for all snapshots with the given `file_prefix` in the `path_prefix` directory. 
   Snapshot attempts will fail if there is not enough
   space left in this allowance.
 


### PR DESCRIPTION
This PR adds the missing documentation for azure autosnapshot auth modes.