### PR TITLE
[BACKPORT] Make EDU owner for files under website/ under release/1.16

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -28,12 +28,13 @@
 /plugins/                     @hashicorp/vault-ecosystem
 /vault/plugin_catalog.go      @hashicorp/vault-ecosystem
 
-/website/content/ @hashicorp/vault-education-approvers
-/website/content/docs/plugin-portal.mdx   @acahn @hashicorp/vault-education-approvers
+# Content on developer.hashicorp.com
+/website/ @hashicorp/vault-education-approvers
 
 # Plugin docs
-/website/content/docs/plugins/              @hashicorp/vault-ecosystem @hashicorp/vault-education-approvers
-/website/content/docs/upgrading/plugins.mdx @hashicorp/vault-ecosystem @hashicorp/vault-education-approvers
+/website/content/docs/plugins/              @hashicorp/vault-ecosystem
+/website/content/docs/upgrading/plugins.mdx @hashicorp/vault-ecosystem
+
 
 # UI code related to Vault's JWT/OIDC auth method and OIDC provider.
 # Changes to these files often require coordination with backend code,


### PR DESCRIPTION
### Description

Manual backport of [PR #29078](https://github.com/hashicorp/vault/pull/29078)

Updates `CODEOWNER`:

- Makes `@hashicorp/vault-education-approvers` owner for files under the `website` directory.
- Removes explicit `@hashicorp/vault-education-approvers` entries for individual `website/` subdirectories and files.