### PR TITLE
Add support for cert auth method in UI

### DIFF
--- a/ui/app/adapters/cluster.js
+++ b/ui/app/adapters/cluster.js
@@ -136,6 +136,8 @@ export default ApplicationAdapter.extend({
       options.data = { role, jwt };
     } else if (backend === 'okta') {
       options.data = { password, nonce };
+    } else if (backend === 'cert') {
+      options.data = { name: role };
     } else {
       options.data = token ? { token, password } : { password };
     }
@@ -186,6 +188,7 @@ export default ApplicationAdapter.extend({
       okta: `login/${encodeURIComponent(username)}`,
       radius: `login/${encodeURIComponent(username)}`,
       token: 'lookup-self',
+      cert: 'login',
     };
     const urlSuffix = authURLs[authBackend];
     const urlPrefix = path && authBackend !== 'token' ? path : authBackend;

--- a/ui/app/helpers/supported-auth-backends.js
+++ b/ui/app/helpers/supported-auth-backends.js
@@ -76,6 +76,14 @@ const SUPPORTED_AUTH_BACKENDS = [
     displayNamePath: ['metadata.org', 'metadata.username'],
     formAttributes: ['token'],
   },
+  {
+    type: 'cert',
+    typeDisplay: 'TLS Certificates',
+    description: 'Authenticate using certificates.',
+    tokenPath: 'client_token',
+    displayNamePath: ['metadata.cert_name', 'metadata.common_name'],
+    formAttributes: ['role'],
+  },
 ];
 
 const ENTERPRISE_AUTH_METHODS = [

--- a/ui/app/templates/components/auth-form.hbs
+++ b/ui/app/templates/components/auth-form.hbs
@@ -134,6 +134,27 @@
               />
             </div>
           </div>
+        {{else if (eq this.selectedAuthBackend.type "cert")}}
+          <div class="field">
+            <label for="role" class="is-label">Role</label>
+            <div class="control">
+              <Input
+                @type="text"
+                @value={{this.role}}
+                autocomplete="off"
+                spellcheck="false"
+                name="role"
+                id="role"
+                class="input"
+                data-test-role
+              />
+            </div>
+            <AlertInline
+              class="has-top-padding-s"
+              @type="info"
+              @message="Leave blank to sign in with any role matching your certificate"
+            />
+          </div>
         {{else}}
           <div class="field">
             <label for="username" class="is-label">Username</label>

--- a/ui/tests/acceptance/auth-test.js
+++ b/ui/tests/acceptance/auth-test.js
@@ -128,6 +128,12 @@ module('Acceptance | auth', function (hooks) {
             role: 'some-role',
           },
         },
+        cert: {
+          url: '/v1/auth/custom-cert/login',
+          payload: {
+            name: 'some-role',
+          },
+        },
       };
     });
 


### PR DESCRIPTION
This allow to connect yourself with a client certificate in a web browser.

This doesn't work with the command `yarn start` because of Ember proxy. So, build with `make static-dist dev-ui` to test locally.

Closes https://github.com/hashicorp/vault/issues/4689

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
