### PR TITLE
VAULT-31758: Store when a node is removed in the raft stable store

### DIFF
--- a/changelog/29090.txt
+++ b/changelog/29090.txt
@@ -1,0 +1,3 @@
+```release-note:change
+core/raft: Return an error on sys/storage/raft/join if a node that has been removed from raft cluster attempts to re-join when it still has existing raft data on disk.   
+```

--- a/vault/external_tests/raftha/raft_ha_test.go
+++ b/vault/external_tests/raftha/raft_ha_test.go
@@ -5,6 +5,7 @@ package raftha
 
 import (
 	"testing"
+	"time"
 
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/vault/api"
@@ -326,4 +327,42 @@ func TestRaft_HA_ExistingCluster(t *testing.T) {
 	}
 
 	updateCluster(t)
+}
+
+// TestRaftHACluster_Removed_ReAdd creates a raft HA cluster with a file
+// backend. The test adds two standbys to the cluster and then removes one of
+// them. The removed follower tries to re-join, and the test verifies that it
+// errors and cannot join.
+func TestRaftHACluster_Removed_ReAdd(t *testing.T) {
+	t.Parallel()
+	var conf vault.CoreConfig
+	opts := vault.TestClusterOptions{HandlerFunc: vaulthttp.Handler}
+	teststorage.RaftHASetup(&conf, &opts, teststorage.MakeFileBackend)
+	cluster := vault.NewTestCluster(t, &conf, &opts)
+	defer cluster.Cleanup()
+	vault.TestWaitActive(t, cluster.Cores[0].Core)
+
+	leader := cluster.Cores[0]
+	follower := cluster.Cores[2]
+	joinReq := &api.RaftJoinRequest{LeaderCACert: string(cluster.CACertPEM)}
+	_, err := follower.Client.Sys().RaftJoin(joinReq)
+	require.NoError(t, err)
+	_, err = cluster.Cores[1].Client.Sys().RaftJoin(joinReq)
+	require.NoError(t, err)
+
+	testhelpers.RetryUntil(t, 3*time.Second, func() error {
+		return testhelpers.VerifyRaftPeers(t, leader.Client, map[string]bool{
+			"core-0": true,
+			"core-1": true,
+			"core-2": true,
+		})
+	})
+	_, err = leader.Client.Logical().Write("/sys/storage/raft/remove-peer", map[string]interface{}{
+		"server_id": follower.NodeID,
+	})
+	require.NoError(t, err)
+	require.Eventually(t, follower.Sealed, 3*time.Second, 250*time.Millisecond)
+
+	_, err = follower.Client.Sys().RaftJoin(joinReq)
+	require.Error(t, err)
 }

--- a/vault/raft.go
+++ b/vault/raft.go
@@ -1053,6 +1053,13 @@ func (c *Core) JoinRaftCluster(ctx context.Context, leaderInfos []*raft.LeaderJo
 	}
 
 	isRaftHAOnly := c.isRaftHAOnly()
+	if raftBackend.IsRemoved() {
+		if isRaftHAOnly {
+			return false, errors.New("node has been removed from the HA cluster. Raft data for this node must be cleaned up before it can be added back")
+		} else {
+			return false, errors.New("node has been removed from the HA cluster. All vault data for this node must be cleaned up before it can be added back")
+		}
+	}
 	// Prevent join from happening if we're using raft for storage and
 	// it has already been initialized.
 	if init && !isRaftHAOnly {


### PR DESCRIPTION
### Description
This PR has a raft node write to its stable store when it's been removed. When a raft backend is created, the backend reads this value from the stable store to set the removed flag. If you try to add back a raft node that's been removed to a cluster, it will error (instead of returning a successful status without doing anything).  

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
