### PR TITLE
[DOCS] Update the doc title and description for SEO improvements

### DIFF
--- a/website/content/docs/sync/awssm.mdx
+++ b/website/content/docs/sync/awssm.mdx
@@ -1,10 +1,11 @@
 ---
 layout: docs
-page_title: AWS Secrets Manager - Secrets Sync Destination
-description: The AWS Secrets Manager destination syncs secrets from Vault to AWS.
+page_title: Sync secrets from Vault to AWS Secrets Manager
+description: >-
+  Automatically sync and unsync the secrets from Vault to AWS Secrets Manager to centralize visibility and control of secrets lifecycle management.
 ---
 
-# AWS Secrets Manager
+# Sync secrets from Vault to AWS Secrets Manager
 
 The AWS Secrets Manager destination enables Vault to sync and unsync secrets of your choosing into
 an external AWS account. When configured, Vault will actively maintain the state of each externally-synced

--- a/website/content/docs/sync/azurekv.mdx
+++ b/website/content/docs/sync/azurekv.mdx
@@ -1,10 +1,11 @@
 ---
 layout: docs
-page_title: Azure Key Vault - Secrets Sync Destination
-description: The Azure Key Vault destination syncs secrets from Vault to Azure.
+page_title: Sync secrets from Vault to Azure Key Vault
+description: >-
+  Automatically sync and unsync the secrets from Vault to Azure Key Vault to centralize visibility and control of secrets lifecycle management.
 ---
 
-# Azure Key Vault
+# Sync secrets from Vault to Azure Key Vault
 
 The Azure Key Vault destination enables Vault to sync and unsync secrets of your choosing into
 an external Azure account. When configured, Vault will actively maintain the state of each externally-synced

--- a/website/content/docs/sync/gcpsm.mdx
+++ b/website/content/docs/sync/gcpsm.mdx
@@ -1,10 +1,11 @@
 ---
 layout: docs
-page_title: Google Cloud Platform Secret Manager - Secrets Sync Destination
-description: The Google Cloud Platform Secret Manager destination syncs secrets from Vault to GCP.
+page_title: Sync secrets from Vault to GCP Secret Manager
+description: >-
+  Automatically sync and unsync the secrets from Vault to GCP Secret Manager to centralize visibility and control of secrets lifecycle management.
 ---
 
-# Google Cloud Platform Secret Manager
+# Sync secrets from Vault to GCP Secret Manager
 
 The Google Cloud Platform (GCP) Secret Manager sync destination allows Vault to safely synchronize secrets to your GCP projects.
 This is a low footprint option that enables your applications to benefit from Vault-managed secrets without requiring them

--- a/website/content/docs/sync/github.mdx
+++ b/website/content/docs/sync/github.mdx
@@ -1,10 +1,11 @@
 ---
 layout: docs
-page_title: GitHub - Secrets Sync Destination
-description: The GitHub destination syncs secrets from Vault to GitHub.
+page_title: Sync secrets from Vault to GitHub
+description: >-
+  Automatically sync and unsync the secrets from Vault to GitHub to centralize visibility and control of secrets lifecycle management.
 ---
 
-# GitHub actions secrets
+# Sync secrets from Vault to GitHub
 
 The GitHub actions sync destination allows Vault to safely synchronize secrets as GitHub organization, repository, or environment secrets.
 This is a low footprint option that enables your applications to benefit from Vault-managed secrets without requiring them
@@ -23,8 +24,10 @@ Prerequisites:
 
 
 <Warning title="Pitfalls of using an access token">
+
   Access tokens are tied to a user account and can be revoked at any time, causing disruptions to the sync process.
   GitHub applications are long-lived and do not expire. Using a GitHub application for authentication is preferred over using a personal access token.
+  
 </Warning>
 
 ### Repositories

--- a/website/content/docs/sync/index.mdx
+++ b/website/content/docs/sync/index.mdx
@@ -1,9 +1,9 @@
 ---
 layout: docs
 page_title: Secrets sync
-description: Secrets sync allows you to safely sync Vault-managed secrets with external destinations.
+description: >-
+  Use secrets sync feature to automatically sync Vault-managed secrets with external destinations to centralize secrets lifecycle management.
 ---
-
 
 # Secrets sync
 

--- a/website/content/docs/sync/vercelproject.mdx
+++ b/website/content/docs/sync/vercelproject.mdx
@@ -1,10 +1,11 @@
 ---
 layout: docs
-page_title: Vercel Project - Secrets Sync Destination
-description: The Vercel Project destination syncs secrets from Vault to Vercel.
+page_title: Sync secrets from Vault to Vercel Project
+description: >-
+  Automatically sync and unsync the secrets from Vault to a Vercel project to centralize visibility and control of secrets lifecycle management.
 ---
 
-# Vercel Project environment variables
+# Sync secrets from Vault to Vercel Project
 
 The Vercel Project sync destination allows Vault to safely synchronize secrets as Vercel environment variables.
 This is a low footprint option that enables your applications to benefit from Vault-managed secrets without requiring them

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -1581,8 +1581,7 @@
           },
           {
             "title": "KV version  2",
-            "routes":
-            [
+            "routes": [
               {
                 "title": "Overview",
                 "path": "secrets/kv/kv-v2"
@@ -1823,23 +1822,23 @@
         "path": "sync"
       },
       {
-        "title": "AWS Secrets Manager",
+        "title": "Sync to AWS Secrets Manager",
         "path": "sync/awssm"
       },
       {
-        "title": "Azure Key Vault",
+        "title": "Sync to Azure Key Vault",
         "path": "sync/azurekv"
       },
       {
-        "title": "GCP Secret Manager",
+        "title": "Sync to GCP Secret Manager",
         "path": "sync/gcpsm"
       },
       {
-        "title": "GitHub",
+        "title": "Sync to GitHub",
         "path": "sync/github"
       },
       {
-        "title": "Vercel Project",
+        "title": "Sync to Vercel Project",
         "path": "sync/vercelproject"
       }
     ]


### PR DESCRIPTION
### Description

This PR updates the doc page title and description for secrets sync. The intent is to improve the clarity and discoverability of these doc pages.

🔍 [Deploy preview](https://vault-git-docs-update-sync-docs-seo-hashicorp.vercel.app/vault/docs/sync)

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
