### PR TITLE
VAULT-32159 docs for pki metrics

### DIFF
--- a/website/content/docs/enterprise/license/product-usage-reporting.mdx
+++ b/website/content/docs/enterprise/license/product-usage-reporting.mdx
@@ -181,7 +181,7 @@ All of these metrics are numerical, and contain no sensitive values or additiona
 | `vault.secretsync.destinations.gitlab.count`         | The total number of GitLab secret destinations configured for secret sync.         |
 | `vault.secretsync.destinations.inmem.count`          | The total number of InMem secret destinations configured for secret sync.          |
 | `vault.pki.roles.count`                              | The total roles in all PKI mounts across all namespaces.                           |
-| `vault.pki.certs.count`                              | The total certs from all PKI mounts across all namespaces.                         |
+| `vault.pki.issuers.count`                            | The total issuers from all PKI mounts across all namespaces.                       |
 
 ## Usage metadata list
 

--- a/website/content/docs/enterprise/license/product-usage-reporting.mdx
+++ b/website/content/docs/enterprise/license/product-usage-reporting.mdx
@@ -130,7 +130,7 @@ All of these metrics are numerical, and contain no sensitive values or additiona
 | `vault.auth.method.gcp.count`                        | The total number of GCP auth mounts in Vault.                                      |
 | `vault.auth.method.jwt.count`                        | The total number of JWT auth mounts in Vault.                                      |
 | `vault.auth.method.kerberos.count`                   | The total number of Kerberos auth mounts in Vault.                                 |
-| `vault.auth.method.kubernetes.count`                 | The total number of kubernetes auth mounts in Vault.                               |
+| `vault.auth.method.kubernetes.count`                 | The total number of Kubernetes auth mounts in Vault.                               |
 | `vault.auth.method.ldap.count`                       | The total number of LDAP auth mounts in Vault.                                     |
 | `vault.auth.method.oci.count`                        | The total number of OCI auth mounts in Vault.                                      |
 | `vault.auth.method.okta.count`                       | The total number of Okta auth mounts in Vault.                                     |
@@ -152,7 +152,7 @@ All of these metrics are numerical, and contain no sensitive values or additiona
 | `vault.secret.engine.kubernetes.count`               | The total number of Kubernetes secret engines in Vault.                            |
 | `vault.secret.engine.cassandra.count`                | The total number of Cassandra secret engines in Vault.                             |
 | `vault.secret.engine.keymgmt.count`                  | The total number of Keymgmt secret engines in Vault.                               |
-| `vault.secret.engine.kv.count`                       | The total number of kv secret engines in Vault.                                    |
+| `vault.secret.engine.kv.count`                       | The total number of KV secret engines in Vault.                                    |
 | `vault.secret.engine.kmip.count`                     | The total number of KMIP secret engines in Vault.                                  |
 | `vault.secret.engine.mongodb.count`                  | The total number of MongoDB secret engines in Vault.                               |
 | `vault.secret.engine.mongodbatlas.count`             | The total number of MongoDBAtlas secret engines in Vault.                          |
@@ -180,6 +180,8 @@ All of these metrics are numerical, and contain no sensitive values or additiona
 | `vault.secretsync.destinations.terraform.count`      | The total number of Terraform secret destinations configured for secret sync.      |
 | `vault.secretsync.destinations.gitlab.count`         | The total number of GitLab secret destinations configured for secret sync.         |
 | `vault.secretsync.destinations.inmem.count`          | The total number of InMem secret destinations configured for secret sync.          |
+| `vault.pki.roles.count`                              | The total roles in all PKI mounts across all namespaces.                           |
+| `vault.pki.certs.count`                              | The total certs from all PKI mounts across all namespaces.                         |
 
 ## Usage metadata list
 


### PR DESCRIPTION
### Description

Docs corresponding to https://github.com/hashicorp/vault-enterprise/pull/7096

Will need manual backport for 1.17 and 1.16.

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [x] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
