### PR TITLE
VAULT-32159 CE changes for PKI metrics

### DIFF
--- a/vault/core_metrics.go
+++ b/vault/core_metrics.go
@@ -491,6 +491,69 @@ func (c *Core) walkKvMountSecrets(ctx context.Context, m *kvMount) {
 	}
 }
 
+// GetTotalPkiRoles returns the total roles across all PKI mounts in Vault
+func (c *Core) GetTotalPkiRoles(ctx context.Context) int {
+	c.mountsLock.RLock()
+	defer c.mountsLock.RUnlock()
+
+	numRoles := 0
+
+	for _, entry := range c.mounts.Entries {
+		secretType := entry.Type
+		if secretType == pluginconsts.SecretEnginePki {
+			listRequest := &logical.Request{
+				Operation: logical.ListOperation,
+				Path:      entry.namespace.Path + entry.Path + "roles",
+			}
+			resp, err := c.router.Route(ctx, listRequest)
+			if err != nil || resp == nil {
+				continue
+			}
+			rawKeys, ok := resp.Data["keys"]
+			if !ok {
+				continue
+			}
+			keys, ok := rawKeys.([]string)
+			fmt.Printf("Violet keys: %v\n", keys)
+			if ok {
+				numRoles += len(keys)
+			}
+		}
+	}
+	return numRoles
+}
+
+// GetTotalPkiCerts returns the total certs across all PKI mounts in Vault
+func (c *Core) GetTotalPkiCerts(ctx context.Context) int {
+	c.mountsLock.RLock()
+	defer c.mountsLock.RUnlock()
+
+	numRoles := 0
+
+	for _, entry := range c.mounts.Entries {
+		secretType := entry.Type
+		if secretType == pluginconsts.SecretEnginePki {
+			listRequest := &logical.Request{
+				Operation: logical.ListOperation,
+				Path:      entry.namespace.Path + entry.Path + "certs",
+			}
+			resp, err := c.router.Route(ctx, listRequest)
+			if err != nil || resp == nil {
+				continue
+			}
+			rawKeys, ok := resp.Data["keys"]
+			if !ok {
+				continue
+			}
+			keys, ok := rawKeys.([]string)
+			if ok {
+				numRoles += len(keys)
+			}
+		}
+	}
+	return numRoles
+}
+
 // getMinNamespaceSecrets is expected to be called on the output
 // of GetKvUsageMetrics to get the min number of secrets in a single namespace.
 func getMinNamespaceSecrets(mapOfNamespacesToSecrets map[string]int) int {

--- a/vault/core_metrics.go
+++ b/vault/core_metrics.go
@@ -514,7 +514,6 @@ func (c *Core) GetTotalPkiRoles(ctx context.Context) int {
 				continue
 			}
 			keys, ok := rawKeys.([]string)
-			fmt.Printf("Violet keys: %v\n", keys)
 			if ok {
 				numRoles += len(keys)
 			}


### PR DESCRIPTION
### Description

CE pair PR for https://github.com/hashicorp/vault-enterprise/pull/7096

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [x] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
