### PR TITLE
Fix missing locking in mount tests

### DIFF
--- a/vault/mount_test.go
+++ b/vault/mount_test.go
@@ -144,6 +144,8 @@ func TestCore_DefaultMountTable(t *testing.T) {
 
 	c.mountsLock.Lock()
 	defer c.mountsLock.Unlock()
+	c2.mountsLock.Lock()
+	defer c2.mountsLock.Unlock()
 	if diff := deep.Equal(c.mounts.sortEntriesByPath(), c2.mounts.sortEntriesByPath()); len(diff) > 0 {
 		t.Fatalf("mismatch: %v", diff)
 	}
@@ -192,6 +194,8 @@ func TestCore_Mount(t *testing.T) {
 	// Verify matching mount tables
 	c.mountsLock.Lock()
 	defer c.mountsLock.Unlock()
+	c2.mountsLock.Lock()
+	defer c2.mountsLock.Unlock()
 	if diff := deep.Equal(c.mounts.sortEntriesByPath(), c2.mounts.sortEntriesByPath()); len(diff) > 0 {
 		t.Fatalf("mismatch: %v", diff)
 	}
@@ -266,6 +270,8 @@ func TestCore_Mount_kv_generic(t *testing.T) {
 	// Verify matching mount tables
 	c.mountsLock.Lock()
 	defer c.mountsLock.Unlock()
+	c2.mountsLock.Lock()
+	defer c2.mountsLock.Unlock()
 	if diff := deep.Equal(c.mounts.sortEntriesByPath(), c2.mounts.sortEntriesByPath()); len(diff) > 0 {
 		t.Fatalf("mismatch: %v", diff)
 	}


### PR DESCRIPTION
### Description

Looks like `c2` was just missed by accident. This is causing races when other processes read the mount table.

See: https://github.com/hashicorp/vault-enterprise/actions/runs/12187321355/job/33999445396#step:7:223

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [x] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
