### PR TITLE
Fix decryption of raft bootstrap challenge in multi-seal scenarios

### DIFF
--- a/changelog/29117.txt
+++ b/changelog/29117.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core/seal (enterprise): Fix decryption of the raft bootstrap challenge when using seal high availability.
+```

--- a/vault/core.go
+++ b/vault/core.go
@@ -234,7 +234,8 @@ type unlockInformation struct {
 }
 
 type raftInformation struct {
-	challenge           *wrapping.BlobInfo
+	// challenge is in ciphertext
+	challenge           []byte
 	leaderClient        *api.Client
 	leaderBarrierConfig *SealConfig
 	nonVoter            bool

--- a/vault/raft.go
+++ b/vault/raft.go
@@ -16,12 +16,10 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/golang/protobuf/proto"
 	"github.com/hashicorp/go-cleanhttp"
 	"github.com/hashicorp/go-discover"
 	discoverk8s "github.com/hashicorp/go-discover/provider/k8s"
 	"github.com/hashicorp/go-hclog"
-	wrapping "github.com/hashicorp/go-kms-wrapping/v2"
 	"github.com/hashicorp/go-secure-stdlib/tlsutil"
 	"github.com/hashicorp/go-uuid"
 	goversion "github.com/hashicorp/go-version"
@@ -1029,13 +1027,8 @@ func (c *Core) getRaftChallenge(leaderInfo *raft.LeaderJoinInfo) (*raftInformati
 		return nil, fmt.Errorf("error decoding raft bootstrap challenge: %w", err)
 	}
 
-	eBlob := &wrapping.BlobInfo{}
-	if err := proto.Unmarshal(challengeRaw, eBlob); err != nil {
-		return nil, fmt.Errorf("error decoding raft bootstrap challenge: %w", err)
-	}
-
 	return &raftInformation{
-		challenge:           eBlob,
+		challenge:           challengeRaw,
 		leaderClient:        apiClient,
 		leaderBarrierConfig: &sealConfig,
 	}, nil
@@ -1353,15 +1346,6 @@ func (c *Core) joinRaftSendAnswer(ctx context.Context, sealAccess seal.Access, r
 		return errors.New("raft is already initialized")
 	}
 
-	multiWrapValue := &seal.MultiWrapValue{
-		Generation: sealAccess.Generation(),
-		Slots:      []*wrapping.BlobInfo{raftInfo.challenge},
-	}
-	plaintext, _, err := sealAccess.Decrypt(ctx, multiWrapValue, nil)
-	if err != nil {
-		return fmt.Errorf("error decrypting challenge: %w", err)
-	}
-
 	parsedClusterAddr, err := url.Parse(c.ClusterAddr())
 	if err != nil {
 		return fmt.Errorf("error parsing cluster address: %w", err)
@@ -1375,6 +1359,12 @@ func (c *Core) joinRaftSendAnswer(ctx context.Context, sealAccess seal.Access, r
 		if err != nil {
 			return err
 		}
+	}
+
+	sealer := NewSealAccessSealer(sealAccess, c.logger, "bootstrap_challenge_read")
+	plaintext, err := sealer.Open(context.Background(), raftInfo.challenge)
+	if err != nil {
+		return fmt.Errorf("error decrypting challenge: %w", err)
 	}
 
 	answerReq := raftInfo.leaderClient.NewRequest("PUT", "/v1/sys/storage/raft/bootstrap/answer")


### PR DESCRIPTION
### Description

Fix decryption of raft bootstrap challenge in multi-seal scenarios (Vault Enterprise).

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
