### PR TITLE
Fix return certificate expiry time from NearExpiration

### DIFF
--- a/changelog/29128.txt
+++ b/changelog/29128.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+vault/diagnose: Fix time to expiration reporting within the TLS verification to not be a month off.
+```

--- a/vault/diagnose/tls_verification.go
+++ b/vault/diagnose/tls_verification.go
@@ -270,15 +270,17 @@ func TLSFileWarningChecks(leafCerts, interCerts, rootCerts []*x509.Certificate) 
 	return warnings, nil
 }
 
-// NearExpiration returns a true if a certficate will expire in a month and false otherwise
+// NearExpiration returns a true if a certificate will expire in a month
+// and false otherwise, along with the duration until the certificate expires
+// which can be a negative duration if the certificate has already expired.
 func NearExpiration(c *x509.Certificate) (bool, time.Duration) {
-	oneMonthFromNow := time.Now().Add(30 * 24 * time.Hour)
-	var timeToExpiry time.Duration
-	if oneMonthFromNow.After(c.NotAfter) {
-		timeToExpiry := oneMonthFromNow.Sub(c.NotAfter)
-		return true, timeToExpiry
-	}
-	return false, timeToExpiry
+	now := time.Now()
+	timeToExpiry := c.NotAfter.Sub(now)
+
+	oneMonthFromNow := now.Add(30 * 24 * time.Hour)
+	hasExpired := oneMonthFromNow.After(c.NotAfter)
+
+	return hasExpired, timeToExpiry
 }
 
 // TLSMutualExclusionCertCheck returns error if both TLSDisableClientCerts and TLSRequireAndVerifyClientCert are set

--- a/vault/diagnose/tls_verification.go
+++ b/vault/diagnose/tls_verification.go
@@ -278,9 +278,9 @@ func NearExpiration(c *x509.Certificate) (bool, time.Duration) {
 	timeToExpiry := c.NotAfter.Sub(now)
 
 	oneMonthFromNow := now.Add(30 * 24 * time.Hour)
-	hasExpired := oneMonthFromNow.After(c.NotAfter)
+	isNearExpiration := oneMonthFromNow.After(c.NotAfter)
 
-	return hasExpired, timeToExpiry
+	return isNearExpiration, timeToExpiry
 }
 
 // TLSMutualExclusionCertCheck returns error if both TLSDisableClientCerts and TLSRequireAndVerifyClientCert are set


### PR DESCRIPTION
### Description

 - The duration returned from the `NearExpiration` is supposed to represent the time till expiry from now and not the calculated time a month from now.
 - Also flip the returned value to be a duration value that can be added to time.Now() to get to the expiration value, instead of a negative value that was previously returned.

### TODO only if you're a HashiCorp employee
- [X] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
