### PR TITLE
use const for  in relation to vault eventing metadata

### DIFF
--- a/sdk/logical/events.go
+++ b/sdk/logical/events.go
@@ -12,6 +12,10 @@ import (
 
 // common event metadata keys
 const (
+	// EventMetadataPath is used in event metadata to show the API path the client must have the `subscribe` capability
+	// on in order consume the event. It is recommended that the event path metadata field uses that api path that was invoked
+	// in order to generate the event
+	EventMetadataPath = "path"
 	// EventMetadataDataPath is used in event metadata to show the API path that can be used to fetch any underlying
 	// data. For example, the KV plugin would set this to `data/mysecret`. The event system will automatically prepend
 	// the plugin mount to this path, if present, so it would become `secret/data/mysecret`, for example.

--- a/sdk/logical/events.go
+++ b/sdk/logical/events.go
@@ -13,15 +13,16 @@ import (
 // common event metadata keys
 const (
 	// EventMetadataPath is used in event metadata to show the API path the client must have the `subscribe` capability
-	// on in order consume the event. It is recommended that the event path metadata field is the API path that was invoked
-	// in order to generate the event.
+	// on in order to consume the event. It is recommended that the event path metadata field is the API path that was
+	// invoked in order to generate the event.
 	//
-	// For example, the KV plugin would set this to `data/mysecret`. The event system will automatically prepend
-	// the plugin mount to this path, if present, so it would become `secret/data/mysecret`, for example.
+	// For example, the KV plugin would set this to `data/mysecret`. The event system will automatically prepend the
+	// plugin mount to this path, if present, so it would become `secret/data/mysecret`, for example.
 	// If this is an auth plugin event, this will additionally be prepended with `auth/`.
 	EventMetadataPath = "path"
 	// EventMetadataDataPath is used in event metadata to show the API path that can be used to fetch any underlying
-	// data. Similar to the `path` event metadata, the event system will automatically prepend the plugin mount to the `data_path`.
+	// data. Similar to the `path` event metadata, the event system will automatically prepend the plugin mount to the
+	// `data_path`.
 	EventMetadataDataPath = "data_path"
 	// EventMetadataOperation is used in event metadata to express what operation was performed that generated the
 	// event, e.g., `read` or `write`.

--- a/sdk/logical/events.go
+++ b/sdk/logical/events.go
@@ -13,13 +13,15 @@ import (
 // common event metadata keys
 const (
 	// EventMetadataPath is used in event metadata to show the API path the client must have the `subscribe` capability
-	// on in order consume the event. It is recommended that the event path metadata field uses that api path that was invoked
-	// in order to generate the event
-	EventMetadataPath = "path"
-	// EventMetadataDataPath is used in event metadata to show the API path that can be used to fetch any underlying
-	// data. For example, the KV plugin would set this to `data/mysecret`. The event system will automatically prepend
+	// on in order consume the event. It is recommended that the event path metadata field is the API path that was invoked
+	// in order to generate the event.
+	//
+	// For example, the KV plugin would set this to `data/mysecret`. The event system will automatically prepend
 	// the plugin mount to this path, if present, so it would become `secret/data/mysecret`, for example.
 	// If this is an auth plugin event, this will additionally be prepended with `auth/`.
+	EventMetadataPath = "path"
+	// EventMetadataDataPath is used in event metadata to show the API path that can be used to fetch any underlying
+	// data. Similar to the `path` event metadata, the event system will automatically prepend the plugin mount to the `data_path`.
 	EventMetadataDataPath = "data_path"
 	// EventMetadataOperation is used in event metadata to express what operation was performed that generated the
 	// event, e.g., `read` or `write`.

--- a/vault/eventbus/bus.go
+++ b/vault/eventbus/bus.go
@@ -40,7 +40,7 @@ var (
 
 	// these metadata fields will have the plugin mount path prepended to them
 	metadataPrependPathFields = []string{
-		"path",
+		logical.EventMetadataPath,
 		logical.EventMetadataDataPath,
 	}
 )


### PR DESCRIPTION
### Description
What does this PR do?

Adds a const `path` for indicating the `path` metadata key used for in eventing


