### PR TITLE
Backport of Update vault-plugin-secrets-openldap to v0.14.4 into release/1.18.x

### DIFF
--- a/changelog/29131.txt
+++ b/changelog/29131.txt
@@ -1,0 +1,3 @@
+```release-note:change
+secrets/openldap: Update plugin to v0.14.4
+```

--- a/go.mod
+++ b/go.mod
@@ -150,7 +150,7 @@ require (
 	github.com/hashicorp/vault-plugin-secrets-kubernetes v0.9.0
 	github.com/hashicorp/vault-plugin-secrets-kv v0.20.0
 	github.com/hashicorp/vault-plugin-secrets-mongodbatlas v0.13.0
-	github.com/hashicorp/vault-plugin-secrets-openldap v0.14.3
+	github.com/hashicorp/vault-plugin-secrets-openldap v0.14.4
 	github.com/hashicorp/vault-plugin-secrets-terraform v0.10.0
 	github.com/hashicorp/vault-testing-stepwise v0.3.1
 	github.com/hashicorp/vault/api v1.15.0

--- a/go.sum
+++ b/go.sum
@@ -1600,8 +1600,8 @@ github.com/hashicorp/vault-plugin-secrets-kv v0.20.0 h1:p1RVmd4x1rgGK0tN8DDu21J2
 github.com/hashicorp/vault-plugin-secrets-kv v0.20.0/go.mod h1:bCpMggD3Z0+H+3dOmTCoQjBHC53jA08lPqOLmFrHBi8=
 github.com/hashicorp/vault-plugin-secrets-mongodbatlas v0.13.0 h1:BeDS7luTeOW0braIbtuyairFF8SEz7k3nvi9e+mJ2Ok=
 github.com/hashicorp/vault-plugin-secrets-mongodbatlas v0.13.0/go.mod h1:sprde+S70PBIbgOLUAKDxR+xNF714ksBBVh77O3hnWc=
-github.com/hashicorp/vault-plugin-secrets-openldap v0.14.3 h1:HY8q7qVmhtBYiNa5K24wws72jPjwzkSuAt7LwkRcT8Q=
-github.com/hashicorp/vault-plugin-secrets-openldap v0.14.3/go.mod h1:wqOf/QJqrrNXjnm0eLUnm5Ju9s/LIZUl6wEKmnFL9Uo=
+github.com/hashicorp/vault-plugin-secrets-openldap v0.14.4 h1:BA5gf+itQ4FtEg4gyXvEZW0ioRCSUNnO3+XBrxDNi9A=
+github.com/hashicorp/vault-plugin-secrets-openldap v0.14.4/go.mod h1:mdECWDLyILokYVpdBgwvHWkPJ+cEnSTxR6yDT0TBS98=
 github.com/hashicorp/vault-plugin-secrets-terraform v0.10.0 h1:YzOJrpuDRNrw5SQ4i7IEjedF40I/7ejupQy+gAyQ6Zg=
 github.com/hashicorp/vault-plugin-secrets-terraform v0.10.0/go.mod h1:j2nbB//xAQMD+5JivVDalwDEyzJY3AWzKIkw6k65xJQ=
 github.com/hashicorp/vault-testing-stepwise v0.3.1 h1:SqItnMWOOknQfJJR49Fps34ZfBMWSqBFFTx6NoTHzNw=


### PR DESCRIPTION
### Description
Backports https://github.com/hashicorp/vault/pull/29131 into `release/1.18.x`