### PR TITLE
OSS Changes Patch

### DIFF
--- a/vault/activity_log.go
+++ b/vault/activity_log.go
@@ -336,6 +336,9 @@ type ActivityLogExportRecord struct {
 	// MountPath is the path of the auth mount associated with the token used
 	MountPath string `json:"mount_path" mapstructure:"mount_path"`
 
+	// LocalMount indicates if the mount only belongs to the current cluster
+	LocalMount bool `json:"local_mount" mapstructure:"local_mount"`
+
 	// Timestamp denotes the time at which the activity occurred formatted using RFC3339
 	Timestamp string `json:"timestamp" mapstructure:"timestamp"`
 
@@ -916,7 +919,7 @@ func (a *ActivityLog) getLastSegmentNumberByEntityPath(ctx context.Context, enti
 }
 
 // WalkEntitySegments loads each of the entity segments for a particular start time
-func (a *ActivityLog) WalkEntitySegments(ctx context.Context, startTime time.Time, hll *hyperloglog.Sketch, walkFn func(*activity.EntityActivityLog, time.Time, *hyperloglog.Sketch) error) error {
+func (a *ActivityLog) WalkEntitySegments(ctx context.Context, startTime time.Time, hll *hyperloglog.Sketch, walkFn func(*activity.EntityActivityLog, time.Time, bool) error) error {
 	baseGlobalPath := activityGlobalPathPrefix + activityEntityBasePath + fmt.Sprint(startTime.Unix()) + "/"
 	baseLocalPath := activityLocalPathPrefix + activityEntityBasePath + fmt.Sprint(startTime.Unix()) + "/"
 
@@ -940,7 +943,7 @@ func (a *ActivityLog) WalkEntitySegments(ctx context.Context, startTime time.Tim
 			if err != nil {
 				return fmt.Errorf("unable to parse segment %v%v: %w", basePath, path, err)
 			}
-			err = walkFn(out, startTime, hll)
+			err = walkFn(out, startTime, basePath == baseLocalPath)
 			if err != nil {
 				return fmt.Errorf("unable to walk entities: %w", err)
 			}
@@ -3834,7 +3837,7 @@ func (a *ActivityLog) writeExport(ctx context.Context, rw http.ResponseWriter, f
 		return err
 	}
 
-	walkEntities := func(l *activity.EntityActivityLog, startTime time.Time, hll *hyperloglog.Sketch) error {
+	walkEntities := func(l *activity.EntityActivityLog, startTime time.Time, isLocal bool) error {
 		for _, e := range l.Clients {
 			if _, ok := dedupIDs[e.ClientID]; ok {
 				continue
@@ -3866,6 +3869,7 @@ func (a *ActivityLog) writeExport(ctx context.Context, rw http.ResponseWriter, f
 				NamespacePath: nsDisplayPath,
 				Timestamp:     ts.UTC().Format(time.RFC3339),
 				MountAccessor: e.MountAccessor,
+				LocalMount:    isLocal,
 
 				// Default following to empty versus nil, will be overwritten if necessary
 				Policies:                  []string{},
@@ -4261,6 +4265,7 @@ func baseActivityExportCSVHeader() []string {
 		"client_id",
 		"client_type",
 		"local_entity_alias",
+		"local_mount",
 		"namespace_id",
 		"namespace_path",
 		"mount_accessor",

--- a/vault/external_tests/activity_testonly/activity_testonly_test.go
+++ b/vault/external_tests/activity_testonly/activity_testonly_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: BUSL-1.1
 
-////go:build testonly
+//go:build testonly
 
 package activity_testonly
 
@@ -549,6 +549,7 @@ func getCSVExport(t *testing.T, client *api.Client, monthsPreviousTo int, now ti
 
 	boolFields := map[string]struct{}{
 		"local_entity_alias": {},
+		"local_mount":        {},
 	}
 
 	mapFields := map[string]struct{}{


### PR DESCRIPTION
### Description
Added LocalMount field to Export API output
ENT PR: https://github.com/hashicorp/vault-enterprise/pull/7131

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
