### PR TITLE
Disallow querying of activity APIs during upgrade

### DIFF
--- a/vault/logical_system_activity.go
+++ b/vault/logical_system_activity.go
@@ -29,6 +29,8 @@ const (
 
 	// WarningCurrentMonthIsAnEstimate is a warning string that is used to let the customer know that for this query, the current month's data is estimated.
 	WarningCurrentMonthIsAnEstimate = "Since this usage period includes both the current month and at least one historical month, counts returned in this usage period are an estimate. Client counts for this period will no longer be estimated at the start of the next month."
+
+	ErrorUpgradeInProgress = "Upgrade to 1.19+ is in progress; the activity log is not queryable until the upgrade is complete"
 )
 
 // activityQueryPath is available in every namespace
@@ -293,6 +295,9 @@ func (b *SystemBackend) handleClientExport(ctx context.Context, req *logical.Req
 	if a == nil {
 		return logical.ErrorResponse("no activity log present"), nil
 	}
+	if !a.hasDedupClientsUpgrade(ctx) {
+		return logical.ErrorResponse(ErrorUpgradeInProgress), nil
+	}
 
 	startTime, endTime, err := parseStartEndTimes(d, b.Core.BillingStart())
 	if err != nil {
@@ -338,6 +343,9 @@ func (b *SystemBackend) handleClientMetricQuery(ctx context.Context, req *logica
 	b.Core.activityLogLock.RUnlock()
 	if a == nil {
 		return logical.ErrorResponse("no activity log present"), nil
+	}
+	if !a.hasDedupClientsUpgrade(ctx) {
+		return logical.ErrorResponse(ErrorUpgradeInProgress), nil
 	}
 
 	warnings := make([]string, 0)
@@ -385,6 +393,9 @@ func (b *SystemBackend) handleMonthlyActivityCount(ctx context.Context, req *log
 	if a == nil {
 		return logical.ErrorResponse("no activity log present"), nil
 	}
+	if !a.hasDedupClientsUpgrade(ctx) {
+		return logical.ErrorResponse(ErrorUpgradeInProgress), nil
+	}
 
 	results, err := a.partialMonthClientCount(ctx)
 	if err != nil {
@@ -405,6 +416,9 @@ func (b *SystemBackend) handleActivityConfigRead(ctx context.Context, req *logic
 	b.Core.activityLogLock.RUnlock()
 	if a == nil {
 		return logical.ErrorResponse("no activity log present"), nil
+	}
+	if !a.hasDedupClientsUpgrade(ctx) {
+		return logical.ErrorResponse(ErrorUpgradeInProgress), nil
 	}
 
 	config, err := a.loadConfigOrDefault(ctx)
@@ -439,6 +453,9 @@ func (b *SystemBackend) handleActivityConfigUpdate(ctx context.Context, req *log
 	b.Core.activityLogLock.RUnlock()
 	if a == nil {
 		return logical.ErrorResponse("no activity log present"), nil
+	}
+	if !a.hasDedupClientsUpgrade(ctx) {
+		return logical.ErrorResponse(ErrorUpgradeInProgress), nil
 	}
 
 	warnings := make([]string, 0)


### PR DESCRIPTION
### Description
- Disallows querying activity API during upgrade
- Ent PR: https://github.com/hashicorp/vault-enterprise/pull/7148

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
