### PR TITLE
vso/docs: restore upgrade instructions

### DIFF
--- a/website/content/docs/platform/k8s/vso/installation.mdx
+++ b/website/content/docs/platform/k8s/vso/installation.mdx
@@ -41,6 +41,16 @@ Then install the Operator:
 $ helm install --version 0.9.1 --create-namespace --namespace vault-secrets-operator vault-secrets-operator hashicorp/vault-secrets-operator
 ```
 
+## Updating CRDs when using Helm
+
+<Note title="Important">
+
+  As of VSO 0.8.0, VSO will automatically update its CRDs.
+  The manual upgrade step [Updating CRDs](#updating-crds-when-using-helm-prior-to-vso-0-8-0) below is no longer
+  required before upgrading to VSO 0.8.0+.
+
+</Note>
+
 ## Upgrading using Helm
 
 You can upgrade an existing installation with the `helm upgrade` command.
@@ -55,15 +65,15 @@ Hang tight while we grab the latest from your chart repositories...
 Update Complete. ⎈Happy Helming!⎈
 ```
 
-## Updating CRDs when using Helm
+To upgrade your VSO release, replace `<TARGET_VSO_VERSION>` with the VSO version you are upgrading to:
+```shell-session
+$ helm upgrade --version <TARGET_VSO_VERSION> --namespace vault-secrets-operator vault-secrets-operator hashicorp/vault-secrets-operator
+```
 
-<Note title="Important">
-
-  As of VSO 0.8.0, VSO will automatically update its CRDs.
-  The manual upgrade step [Updating CRDs](#updating-crds-when-using-helm-prior-to-vso-0-8-0) below is no longer required when
-  upgrading to VSO 0.8.0+.
-
-</Note>
+For example, if you are upgrading to VSO 0.9.1:
+```shell-session
+$ helm upgrade --version 0.9.1 --namespace vault-secrets-operator vault-secrets-operator hashicorp/vault-secrets-operator
+```
 
 The VSO Helm chart will automatically upgrade the CRDs to match the VSO version being deployed.
 There should be no need to manually update the CRDs prior to upgrading VSO using Helm.


### PR DESCRIPTION
### Description
What does this PR do?

### TODO only if you're a HashiCorp employee
- [X] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [-] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [-] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [X] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [-] **RFC:** If this change has an associated RFC, please link it in the description.
- [-] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
