### PR TITLE
Prevent barrier term overflow on rotation

### DIFF
--- a/changelog/29176.txt
+++ b/changelog/29176.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core: Prevent integer overflows of the barrier key counter on key rotation requests
+```

--- a/vault/barrier_aes_gcm.go
+++ b/vault/barrier_aes_gcm.go
@@ -621,6 +621,11 @@ func (b *AESGCMBarrier) Rotate(ctx context.Context, randomSource io.Reader) (uin
 	term := b.keyring.ActiveTerm()
 	newTerm := term + 1
 
+	if newTerm < term {
+		// We've rolled over the uint32, don't allow this
+		return 0, errors.New("failed to generate a new term value due to integer overflow")
+	}
+
 	// Add a new encryption key
 	newKeyring, err := b.keyring.AddKey(&Key{
 		Term:    newTerm,


### PR DESCRIPTION
### Description

 - Upon requesting to rotate the barrier key if we overflow the term uint32, fail the rotation.

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [X] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
