### PR TITLE
Revert "fix OSS sealunwrapper adding extra get + put request to all s…

### DIFF
--- a/sdk/physical/inmem/inmem_ha.go
+++ b/sdk/physical/inmem/inmem_ha.go
@@ -83,13 +83,6 @@ func (i *InmemHABackend) HAEnabled() bool {
 	return true
 }
 
-func (i *InmemHABackend) Underlying() *InmemBackend {
-	if txBackend, ok := i.Backend.(*TransactionalInmemBackend); ok {
-		return &txBackend.InmemBackend
-	}
-	return i.Backend.(*InmemBackend)
-}
-
 // InmemLock is an in-memory Lock implementation for the HABackend
 type InmemLock struct {
 	in    *InmemHABackend

--- a/vault/sealunwrapper.go
+++ b/vault/sealunwrapper.go
@@ -18,9 +18,10 @@ import (
 // NewSealUnwrapper creates a new seal unwrapper
 func NewSealUnwrapper(underlying physical.Backend, logger log.Logger) physical.Backend {
 	ret := &sealUnwrapper{
-		underlying: underlying,
-		logger:     logger,
-		locks:      locksutil.CreateLocks(),
+		underlying:   underlying,
+		logger:       logger,
+		locks:        locksutil.CreateLocks(),
+		allowUnwraps: new(uint32),
 	}
 
 	if underTxn, ok := underlying.(physical.Transactional); ok {
@@ -42,7 +43,7 @@ type sealUnwrapper struct {
 	underlying   physical.Backend
 	logger       log.Logger
 	locks        []*locksutil.LockEntry
-	allowUnwraps atomic.Bool
+	allowUnwraps *uint32
 }
 
 // transactionalSealUnwrapper is a seal unwrapper that wraps a physical that is transactional
@@ -62,70 +63,63 @@ func (d *sealUnwrapper) Put(ctx context.Context, entry *physical.Entry) error {
 	return d.underlying.Put(ctx, entry)
 }
 
-// unwrap gets an entry from underlying storage and tries to unwrap it.
-// - If the entry is not wrapped: the entry will be returned unchanged and wasWrapped will be false
-// - If the entry is wrapped and encrypted: an error is returned.
-// - If the entry is wrapped but not encrypted: the entry will be unwrapped and returned. wasWrapped will be true.
-func (d *sealUnwrapper) unwrap(ctx context.Context, key string) (unwrappedEntry *physical.Entry, wasWrapped bool, err error) {
-	entry, err := d.underlying.Get(ctx, key)
+// unwrap gets an entry from underlying storage and tries to unwrap it. If the entry was not wrapped, return
+// value unwrappedEntry will be nil. If the entry is wrapped and encrypted, an error is returned.
+func (d *sealUnwrapper) unwrap(ctx context.Context, key string) (entry, unwrappedEntry *physical.Entry, err error) {
+	entry, err = d.underlying.Get(ctx, key)
 	if err != nil {
-		return nil, false, err
+		return nil, nil, err
 	}
 	if entry == nil {
-		return nil, false, nil
+		return nil, nil, err
 	}
 
 	wrappedEntryValue, unmarshaled := UnmarshalSealWrappedValueWithCanary(entry.Value)
 	switch {
 	case !unmarshaled:
-		// Entry is not wrapped
-		return entry, false, nil
+		unwrappedEntry = entry
 	case wrappedEntryValue.isEncrypted():
-		// Entry is wrapped and encrypted
-		return nil, true, fmt.Errorf("cannot decode sealwrapped storage entry %q", entry.Key)
+		return nil, nil, fmt.Errorf("cannot decode sealwrapped storage entry %q", entry.Key)
 	default:
-		// Entry is wrapped and not encrypted
 		pt, err := wrappedEntryValue.getPlaintextValue()
 		if err != nil {
-			return nil, true, err
+			return nil, nil, err
 		}
-		return &physical.Entry{
+		unwrappedEntry = &physical.Entry{
 			Key:   entry.Key,
 			Value: pt,
-		}, true, nil
+		}
 	}
+
+	return entry, unwrappedEntry, nil
 }
 
 func (d *sealUnwrapper) Get(ctx context.Context, key string) (*physical.Entry, error) {
-	entry, wasWrapped, err := d.unwrap(ctx, key)
+	entry, unwrappedEntry, err := d.unwrap(ctx, key)
 	switch {
-	case err != nil: // Failed to get entry
+	case err != nil:
 		return nil, err
-	case entry == nil: // Entry doesn't exist
+	case entry == nil:
 		return nil, nil
-	case !wasWrapped || !d.allowUnwraps.Load(): // Entry was not wrapped or unwrapping not allowed
-		return entry, nil
+	case atomic.LoadUint32(d.allowUnwraps) != 1:
+		return unwrappedEntry, nil
 	}
 
-	// Entry was wrapped, we need to replace it with the unwrapped value
-
-	// Grab locks because we are performing a write
 	locksutil.LockForKey(d.locks, key).Lock()
 	defer locksutil.LockForKey(d.locks, key).Unlock()
 
-	// Read entry again in case it was changed while we were waiting for the lock
-	entry, wasWrapped, err = d.unwrap(ctx, key)
+	// At this point we need to re-read and re-check
+	entry, unwrappedEntry, err = d.unwrap(ctx, key)
 	switch {
-	case err != nil: // Failed to get entry
+	case err != nil:
 		return nil, err
-	case entry == nil: // Entry doesn't exist
+	case entry == nil:
 		return nil, nil
-	case !wasWrapped || !d.allowUnwraps.Load(): // Entry was not wrapped or unwrapping not allowed
-		return entry, nil
+	case atomic.LoadUint32(d.allowUnwraps) != 1:
+		return unwrappedEntry, nil
 	}
 
-	// Write out the unwrapped value
-	return entry, d.underlying.Put(ctx, entry)
+	return unwrappedEntry, d.underlying.Put(ctx, unwrappedEntry)
 }
 
 func (d *sealUnwrapper) Delete(ctx context.Context, key string) error {
@@ -161,12 +155,12 @@ func (d *transactionalSealUnwrapper) Transaction(ctx context.Context, txns []*ph
 // This should only run during preSeal which ensures that it can't be run
 // concurrently and that it will be run only by the active node
 func (d *sealUnwrapper) stopUnwraps() {
-	d.allowUnwraps.Store(false)
+	atomic.StoreUint32(d.allowUnwraps, 0)
 }
 
 func (d *sealUnwrapper) runUnwraps() {
 	// Allow key unwraps on key gets. This gets set only when running on the
 	// active node to prevent standbys from changing data underneath the
 	// primary
-	d.allowUnwraps.Store(true)
+	atomic.StoreUint32(d.allowUnwraps, 1)
 }

--- a/vault/sealunwrapper_test.go
+++ b/vault/sealunwrapper_test.go
@@ -21,37 +21,31 @@ import (
 func TestSealUnwrapper(t *testing.T) {
 	logger := corehelpers.NewTestLogger(t)
 
-	// Test with both cache enabled and disabled
-	for _, disableCache := range []bool{true, false} {
-		// Test without transactions
-		phys, err := inmem.NewInmemHA(nil, logger)
-		if err != nil {
-			t.Fatal(err)
-		}
-		performTestSealUnwrapper(t, phys, logger, disableCache)
-
-		// Test with transactions
-		tPhys, err := inmem.NewTransactionalInmemHA(nil, logger)
-		if err != nil {
-			t.Fatal(err)
-		}
-		performTestSealUnwrapper(t, tPhys, logger, disableCache)
+	// Test without transactions
+	phys, err := inmem.NewInmemHA(nil, logger)
+	if err != nil {
+		t.Fatal(err)
 	}
+	performTestSealUnwrapper(t, phys, logger)
+
+	// Test with transactions
+	tPhys, err := inmem.NewTransactionalInmemHA(nil, logger)
+	if err != nil {
+		t.Fatal(err)
+	}
+	performTestSealUnwrapper(t, tPhys, logger)
 }
 
-func performTestSealUnwrapper(t *testing.T, phys physical.Backend, logger log.Logger, disableCache bool) {
+func performTestSealUnwrapper(t *testing.T, phys physical.Backend, logger log.Logger) {
 	ctx := context.Background()
 	base := &CoreConfig{
-		Physical:     phys,
-		DisableCache: disableCache,
+		Physical: phys,
 	}
 	cluster := NewTestCluster(t, base, &TestClusterOptions{
 		Logger: logger,
 	})
 	cluster.Start()
 	defer cluster.Cleanup()
-
-	physImem := phys.(interface{ Underlying() *inmem.InmemBackend }).Underlying()
 
 	// Read a value and then save it back in a proto message
 	entry, err := phys.Get(ctx, "core/master")
@@ -84,15 +78,7 @@ func performTestSealUnwrapper(t *testing.T, phys physical.Backend, logger log.Lo
 	// successfully decode it, but be able to unmarshal it when read back from
 	// the underlying physical store. When we read from active, it should both
 	// successfully decode it and persist it back.
-	checkValue := func(core *Core, wrapped bool, ro bool) {
-		if ro {
-			physImem.FailPut(true)
-			physImem.FailDelete(true)
-			defer func() {
-				physImem.FailPut(false)
-				physImem.FailDelete(false)
-			}()
-		}
+	checkValue := func(core *Core, wrapped bool) {
 		entry, err := core.physical.Get(ctx, "core/master")
 		if err != nil {
 			t.Fatal(err)
@@ -120,12 +106,7 @@ func performTestSealUnwrapper(t *testing.T, phys physical.Backend, logger log.Lo
 	}
 
 	TestWaitActive(t, cluster.Cores[0].Core)
-	checkValue(cluster.Cores[2].Core, true, true)
-	checkValue(cluster.Cores[1].Core, true, true)
-	checkValue(cluster.Cores[0].Core, false, false)
-
-	// The storage entry should now be unwrapped, so there should be no more writes to storage when we read it
-	checkValue(cluster.Cores[2].Core, false, true)
-	checkValue(cluster.Cores[1].Core, false, true)
-	checkValue(cluster.Cores[0].Core, false, true)
+	checkValue(cluster.Cores[2].Core, true)
+	checkValue(cluster.Cores[1].Core, true)
+	checkValue(cluster.Cores[0].Core, false)
 }


### PR DESCRIPTION
…torage requests"

This reverts commit 8ee711df92edce1370bf69be2278165e2b28e23a.

### Description
What does this PR do?

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
