### PR TITLE
[DOCS] Manual cherry pick PR 28746 to 1.18.x doc

### DIFF
--- a/website/content/docs/upgrading/upgrade-to-1.17.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.17.x.mdx
@@ -200,10 +200,4 @@ more details, and information about opt-out.
 
 @include 'known-issues/manual-entity-merge-does-not-persist.mdx'
 
-@include 'known-issues/aws-auth-external-id.mdx'
-
-@include 'known-issues/sync-activation-flags-cache-not-updated.mdx'
-
 @include 'known-issues/1_17_secrets-sync-ssrf-private-endpoints.mdx'
-
-@include 'known-issues/duplicate-hsm-key.mdx'

--- a/website/content/docs/upgrading/upgrade-to-1.17.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.17.x.mdx
@@ -199,3 +199,11 @@ more details, and information about opt-out.
 @include 'known-issues/duplicate-identity-groups.mdx'
 
 @include 'known-issues/manual-entity-merge-does-not-persist.mdx'
+
+@include 'known-issues/aws-auth-external-id.mdx'
+
+@include 'known-issues/sync-activation-flags-cache-not-updated.mdx'
+
+@include 'known-issues/1_17_secrets-sync-ssrf-private-endpoints.mdx'
+
+@include 'known-issues/duplicate-hsm-key.mdx'

--- a/website/content/partials/known-issues/1_17_secrets-sync-ssrf-private-endpoints.mdx
+++ b/website/content/partials/known-issues/1_17_secrets-sync-ssrf-private-endpoints.mdx
@@ -1,0 +1,21 @@
+### Secrets Sync SSRF Protection May Block Private Endpoints
+
+As of version 1.17.3, Vault's Secrets Sync includes additional Server-Side Request Forgery (SSRF) protection measures. This security enhancement prevents sync operations to certain IP ranges by introducing a new SSRF-safe HTTP client. The client specifically blocks requests to private IP ranges (such as 10.0.0.0/8), which affects users accessing cloud provider secret stores through private endpoints.
+
+**Impact:**
+- Secrets Sync operations to private IP ranges will be blocked
+- Affects all destinations when accessed via private endpoints
+
+**Example error message:**
+
+<CodeBlockConfig hideClipboard>
+
+```plaintext
+couldn't sync secret with store: failed to publish event: dial tcp [IP]: prohibited IP address: [IP] is not a permitted destination (denied by: 10.0.0.0/8)
+```
+
+</CodeBlockConfig>
+
+**Current Workaround:**
+1. Remain on Vault version 1.17.2 or earlier if you require Secrets Sync with private endpoints
+2. Use public endpoints for your secret store services


### PR DESCRIPTION
Manual backport of https://github.com/hashicorp/vault/pull/28746

* docs: add Secrets Sync SSRF protection breaking change to 1.17 upgrade guide

The Secrets Sync feature in 1.17.3 introduced SSRF protection that blocks private IP ranges, affecting users accessing secret stores through private endpoints. This adds documentation about the change and available options.

* renamed issue

* referenced secret sync ssrf known issue

* re-ordered secret sync known issue in page

* Hide copy-to-clipboard button on the output example codeblock

---------

### Description
What does this PR do?

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
