### PR TITLE
identity: Introduce ConflictResolver interface

### DIFF
--- a/vault/identity_store_conflicts.go
+++ b/vault/identity_store_conflicts.go
@@ -1,0 +1,85 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package vault
+
+import (
+	"context"
+	"errors"
+
+	log "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/vault/helper/identity"
+)
+
+var errDuplicateIdentityName = errors.New("duplicate identity name")
+
+// ConflictResolver defines the interface for resolving conflicts between
+// entities, groups, and aliases. All methods should implement a check for
+// existing=nil. This is an intentional design choice to allow the caller to
+// search for extra information if necessary.
+type ConflictResolver interface {
+	ResolveEntities(ctx context.Context, existing, duplicate *identity.Entity) error
+	ResolveGroups(ctx context.Context, existing, duplicate *identity.Group) error
+	ResolveAliases(ctx context.Context, parent *identity.Entity, existing, duplicate *identity.Alias) error
+}
+
+// The errorResolver is a ConflictResolver that logs a warning message when a
+// pre-existing Identity artifact is found with the same factors as a new one.
+type errorResolver struct {
+	logger log.Logger
+}
+
+// ResolveEntities logs a warning message when a pre-existing Entity is found
+// and returns a duplicate name error, which should be handled by the caller by
+// putting the system in case-sensitive mode.
+func (r *errorResolver) ResolveEntities(ctx context.Context, existing, duplicate *identity.Entity) error {
+	if existing == nil {
+		return nil
+	}
+
+	r.logger.Warn(errDuplicateIdentityName.Error(),
+		"entity_name", duplicate.Name,
+		"duplicate_of_name", existing.Name,
+		"duplicate_of_id", existing.ID,
+		"action", "merge the duplicate entities into one")
+
+	return errDuplicateIdentityName
+}
+
+// Resolveidentity.Groups logs a warning message when a pre-existing identity.Group is found and
+// returns a duplicate name error, which should be handled by the caller by
+// putting the system in case-sensitive mode.
+func (r *errorResolver) ResolveGroups(ctx context.Context, existing, duplicate *identity.Group) error {
+	if existing == nil {
+		return nil
+	}
+
+	r.logger.Warn(errDuplicateIdentityName.Error(),
+		"group_name", duplicate.Name,
+		"duplicate_of_name", existing.Name,
+		"duplicate_of_id", existing.ID,
+		"action", "merge the contents of duplicated groups into one and delete the other")
+
+	return errDuplicateIdentityName
+}
+
+// ResolveAliases logs a warning message when a pre-existing Alias is found and
+// returns a duplicate name error, which should be handled by the caller by
+// putting the system in case-sensitive mode.
+func (r *errorResolver) ResolveAliases(ctx context.Context, parent *identity.Entity, existing, duplicate *identity.Alias) error {
+	if existing == nil {
+		return nil
+	}
+
+	r.logger.Warn(errDuplicateIdentityName.Error(),
+		"alias_name", duplicate.Name,
+		"mount_accessor", duplicate.MountAccessor,
+		"local", duplicate.Local,
+		"entity_name", parent.Name,
+		"alias_canonical_id", duplicate.CanonicalID,
+		"duplicate_of_name", existing.Name,
+		"duplicate_of_canonical_id", existing.CanonicalID,
+		"action", "merge the canonical entity IDs into one")
+
+	return errDuplicateIdentityName
+}

--- a/vault/identity_store_conflicts.go
+++ b/vault/identity_store_conflicts.go
@@ -46,7 +46,7 @@ func (r *errorResolver) ResolveEntities(ctx context.Context, existing, duplicate
 	return errDuplicateIdentityName
 }
 
-// ResolveGroups logs a warning message when a pre-existing identity.Group is found and
+// ResolveGroups logs a warning message when a pre-existing Group is found and
 // returns a duplicate name error, which should be handled by the caller by
 // putting the system in case-sensitive mode.
 func (r *errorResolver) ResolveGroups(ctx context.Context, existing, duplicate *identity.Group) error {

--- a/vault/identity_store_conflicts.go
+++ b/vault/identity_store_conflicts.go
@@ -46,7 +46,7 @@ func (r *errorResolver) ResolveEntities(ctx context.Context, existing, duplicate
 	return errDuplicateIdentityName
 }
 
-// Resolveidentity.Groups logs a warning message when a pre-existing identity.Group is found and
+// ResolveGroups logs a warning message when a pre-existing identity.Group is found and
 // returns a duplicate name error, which should be handled by the caller by
 // putting the system in case-sensitive mode.
 func (r *errorResolver) ResolveGroups(ctx context.Context, existing, duplicate *identity.Group) error {

--- a/vault/identity_store_structs.go
+++ b/vault/identity_store_structs.go
@@ -110,6 +110,8 @@ type IdentityStore struct {
 	// aliasLocks is used to protect modifications to alias entries based on the uniqueness factor
 	// which is name + accessor
 	aliasLocks []*locksutil.LockEntry
+
+	conflictResolver identity.ConflictResolver
 }
 
 type groupDiff struct {

--- a/vault/identity_store_structs.go
+++ b/vault/identity_store_structs.go
@@ -111,7 +111,7 @@ type IdentityStore struct {
 	// which is name + accessor
 	aliasLocks []*locksutil.LockEntry
 
-	conflictResolver identity.ConflictResolver
+	conflictResolver ConflictResolver
 }
 
 type groupDiff struct {

--- a/vault/identity_store_util.go
+++ b/vault/identity_store_util.go
@@ -42,7 +42,7 @@ func (c *Core) loadIdentityStoreArtifacts(ctx context.Context) error {
 	// errDuplicateIdentityName. The error will flip the identityStore into
 	// case-sensitive mode by switching the underlying schema to one with a
 	// relaxed lowerCase constraint and reload all artifacts into MemDB.
-	c.identityStore.conflictResolver = &identity.ErrorResolver{c.identityStore.logger}
+	c.identityStore.conflictResolver = &errorResolver{c.identityStore.logger}
 
 	loadFunc := func(context.Context) error {
 		if err := c.identityStore.loadEntities(ctx); err != nil {
@@ -67,7 +67,7 @@ func (c *Core) loadIdentityStoreArtifacts(ctx context.Context) error {
 	case err == nil:
 		// If it succeeds, all is well
 		return nil
-	case !errwrap.Contains(err, identity.ErrDuplicateName.Error()):
+	case !errwrap.Contains(err, errDuplicateIdentityName.Error()):
 		return err
 	}
 
@@ -142,7 +142,7 @@ func (i *IdentityStore) loadGroups(ctx context.Context) error {
 			nsCtx := namespace.ContextWithNamespace(ctx, ns)
 
 			// Ensure that there are no groups with duplicate names
-			groupByName, err := i.MemDBGroupByName(nsCtx, group.Name, true)
+			groupByName, err := i.MemDBGroupByName(nsCtx, group.Name, false)
 			if err != nil {
 				return err
 			}

--- a/vault/identity_store_util.go
+++ b/vault/identity_store_util.go
@@ -28,9 +28,8 @@ import (
 )
 
 var (
-	errDuplicateIdentityName = errors.New("duplicate identity name")
-	errCycleDetectedPrefix   = "cyclic relationship detected for member group ID"
-	tmpSuffix                = ".tmp"
+	errCycleDetectedPrefix = "cyclic relationship detected for member group ID"
+	tmpSuffix              = ".tmp"
 )
 
 func (c *Core) loadIdentityStoreArtifacts(ctx context.Context) error {


### PR DESCRIPTION
### Description

This PR introduces a new interface for conflict resolution of duplicate Identity artifacts. The initial implementation just reorganizes the code to use the interface with no behavior change.

The interface is intended to provide a minimal touchpoint for implementing new conflict resolution behavior. Since those changes will also introduce significant testcases, the aim here is to merge the new interface and ensure the current code works as intended (according to existing tests).

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [x] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
