### PR TITLE
[DOCS] Match the page_title and H1 header

### DIFF
--- a/website/content/docs/secrets/databases/cassandra.mdx
+++ b/website/content/docs/secrets/databases/cassandra.mdx
@@ -1,7 +1,7 @@
 ---
 layout: docs
-page_title: Cassandra - Database - Secrets Engines
-description: |-
+page_title: Cassandra database secrets engine
+description: >-
   Cassandra is one of the supported plugins for the database secrets engine.
   This plugin generates database credentials dynamically based on configured
   roles for the Cassandra database.

--- a/website/content/docs/secrets/databases/couchbase.mdx
+++ b/website/content/docs/secrets/databases/couchbase.mdx
@@ -1,7 +1,7 @@
 ---
 layout: docs
-page_title: Couchbase - Database - Secrets Engines
-description: |-
+page_title: Couchbase database secrets engine
+description: >-
   Couchbase is one of the supported plugins for the database secrets engine.
   This plugin generates database credentials dynamically based on configured
   roles for the Couchbase database.

--- a/website/content/docs/secrets/databases/custom.mdx
+++ b/website/content/docs/secrets/databases/custom.mdx
@@ -1,12 +1,8 @@
 ---
 layout: docs
-page_title: Custom - Database - Secrets Engines
-description: |-
-  The database secrets engine allows new functionality to be added through a
-  plugin interface without needing to modify Vault's core code. This allows you
-  write your own code to generate credentials in any database you wish. It also
-  allows databases that require dynamically linked libraries to be used as
-  plugins while keeping Vault itself statically linked.
+page_title: Custom database secrets engines
+description: >-
+   Write your own code to generate credentials in any database through a plugin interface without needing to modify Vault's core code.
 ---
 
 # Custom database secrets engines

--- a/website/content/docs/secrets/databases/db2.mdx
+++ b/website/content/docs/secrets/databases/db2.mdx
@@ -1,7 +1,7 @@
 ---
 layout: docs
-page_title: IBM Db2 - Database - Credentials
-description: |-
+page_title: IBM Db2
+description: >-
   Manage credentials for IBM Db2 using Vault's LDAP secrets engine.
 ---
 

--- a/website/content/docs/secrets/databases/hanadb.mdx
+++ b/website/content/docs/secrets/databases/hanadb.mdx
@@ -1,7 +1,7 @@
 ---
 layout: docs
-page_title: HANA - Database - Secrets Engines
-description: |-
+page_title: HANA database secrets engine
+description: >-
   HANA is one of the supported plugins for the database secrets engine. This
   plugin generates database credentials dynamically based on configured roles
   for the HANA database.

--- a/website/content/docs/secrets/databases/index.mdx
+++ b/website/content/docs/secrets/databases/index.mdx
@@ -1,14 +1,11 @@
 ---
 layout: docs
-page_title: Database - Secrets Engines
-description: |-
-  The database secrets engine generates database credentials dynamically based
-  on configured roles. It works with a number of different databases through a
-  plugin interface. There are a number of built-in database types and an exposed
-  framework for running custom database types for extendability.
+page_title: Database secrets engine
+description: >-
+   Dynamically generate database credentials based on configured roles with the database secrets engien. It works with a number of different databases through a plugin interface. 
 ---
 
-# Databases
+# Database secrets engine
 
 The database secrets engine generates database credentials dynamically based on
 configured roles. It works with a number of different databases through a plugin

--- a/website/content/docs/secrets/databases/index.mdx
+++ b/website/content/docs/secrets/databases/index.mdx
@@ -2,7 +2,7 @@
 layout: docs
 page_title: Database secrets engine
 description: >-
-   Dynamically generate database credentials based on configured roles with the database secrets engien. It works with a number of different databases through a plugin interface. 
+   Dynamically generate database credentials based on configured roles with the database secrets engine through a plugin interface to a number of different databases. 
 ---
 
 # Database secrets engine

--- a/website/content/docs/secrets/databases/influxdb.mdx
+++ b/website/content/docs/secrets/databases/influxdb.mdx
@@ -1,7 +1,7 @@
 ---
 layout: docs
-page_title: InfluxDB - Database - Secrets Engines
-description: |-
+page_title: InfluxDB database secrets engine
+description: >-
   InfluxDB is one of the supported plugins for the database secrets engine.
   This plugin generates database credentials dynamically based on configured
   roles for the InfluxDB database.

--- a/website/content/docs/secrets/databases/mongodb.mdx
+++ b/website/content/docs/secrets/databases/mongodb.mdx
@@ -1,7 +1,7 @@
 ---
 layout: docs
-page_title: MongoDB - Database - Secrets Engines
-description: |-
+page_title: MongoDB database secrets engine
+description: >-
   MongoDB is one of the supported plugins for the database secrets engine. This
   plugin generates database credentials dynamically based on configured roles
   for the MongoDB database.

--- a/website/content/docs/secrets/databases/mongodbatlas.mdx
+++ b/website/content/docs/secrets/databases/mongodbatlas.mdx
@@ -1,7 +1,7 @@
 ---
 layout: docs
-page_title: MongoDB Atlas- Database - Secrets Engines
-description: |-
+page_title: MongoDB Atlas database secrets engine
+description: >-
   MongoDB Atlas is one of the supported plugins for the database secrets engine. This
   plugin generates database credentials dynamically based on configured roles
   for MongoDB Atlas databases.

--- a/website/content/docs/secrets/databases/mssql.mdx
+++ b/website/content/docs/secrets/databases/mssql.mdx
@@ -1,8 +1,7 @@
 ---
 layout: docs
-page_title: MSSQL - Database - Secrets Engines
-description: |-
-
+page_title: MSSQL database secrets engine
+description: >-
   MSSQL is one of the supported plugins for the database secrets engine. This
   plugin generates database credentials dynamically based on configured roles
   for the MSSQL database.

--- a/website/content/docs/secrets/databases/mysql-maria.mdx
+++ b/website/content/docs/secrets/databases/mysql-maria.mdx
@@ -1,7 +1,7 @@
 ---
 layout: docs
-page_title: MySQL/MariaDB - Database - Secrets Engines
-description: |-
+page_title: MySQL/MariaDB database secrets engine
+description: >-
   MySQL is one of the supported plugins for the database secrets engine. This
   plugin generates database credentials dynamically based on configured roles
   for the MySQL database.

--- a/website/content/docs/secrets/databases/oracle.mdx
+++ b/website/content/docs/secrets/databases/oracle.mdx
@@ -1,7 +1,7 @@
 ---
 layout: docs
-page_title: Oracle - database - secrets engines
-description: |-
+page_title: Oracle database secrets engine
+description: >-
   Oracle is one of the supported plugins for the database secrets engine. This
   plugin generates database credentials dynamically based on configured roles
   for the Oracle database.

--- a/website/content/docs/secrets/databases/postgresql.mdx
+++ b/website/content/docs/secrets/databases/postgresql.mdx
@@ -1,7 +1,7 @@
 ---
 layout: docs
-page_title: PostgreSQL - Database - Secrets Engines
-description: |-
+page_title: PostgreSQL database secrets engine
+description: >-
   PostgreSQL is one of the supported plugins for the database secrets engine.
   This plugin generates database credentials dynamically based on configured
   roles for the PostgreSQL database.

--- a/website/content/docs/secrets/databases/redis.mdx
+++ b/website/content/docs/secrets/databases/redis.mdx
@@ -1,17 +1,17 @@
 ---
 layout: docs
-page_title: Redis - Database - Secrets Engines
-description: |-
+page_title: Redis database secrets engine
+description: >-
   Redis is one of the supported plugins for the database secrets engine.
   This plugin generates database credentials dynamically based on configured
-  roles for the Redis database, and also supports [Static Roles](/vault/docs/secrets/databases#static-roles).
+  roles for the Redis database.
 ---
 
 # Redis database secrets engine
 
 Redis is one of the supported plugins for the database secrets engine. This
 plugin generates database credentials dynamically based on configured roles for
-the Redis database.
+the Redis database, and also supports [Static Roles](/vault/docs/secrets/databases#static-roles).
 
 See the [database secrets engine](/vault/docs/secrets/databases) docs for
 more information about setting up the database secrets engine.

--- a/website/content/docs/secrets/databases/rediselasticache.mdx
+++ b/website/content/docs/secrets/databases/rediselasticache.mdx
@@ -1,7 +1,7 @@
 ---
 layout: docs
-page_title: Redis ElastiCache - Database - Secrets Engines
-description: |-
+page_title: Redis ElastiCache database secrets engine
+description: >-
   Redis ElastiCache is one of the supported plugins for the database secrets engine.
   This plugin generates static credentials for existing managed roles.
 ---

--- a/website/content/docs/secrets/databases/redshift.mdx
+++ b/website/content/docs/secrets/databases/redshift.mdx
@@ -1,7 +1,7 @@
 ---
 layout: docs
-page_title: Redshift - Database - Secrets Engines
-description: |-
+page_title: Redshift database secrets engine
+description: >-
   Redshift is a supported plugin for the database secrets engine.
   This plugin generates database credentials dynamically based on configured
   roles for the AWS Redshift database service.

--- a/website/content/docs/secrets/databases/snowflake.mdx
+++ b/website/content/docs/secrets/databases/snowflake.mdx
@@ -1,7 +1,7 @@
 ---
 layout: docs
-page_title: Snowflake - Database - Secrets Engines
-description: |-
+page_title: Snowflake database secrets engine
+description: >-
   Snowflake is one of the supported plugins for the database secrets engine.
   This plugin generates database credentials dynamically based on configured
   roles for Snowflake hosted databases.


### PR DESCRIPTION
### Description
What does this PR do?

- Match the `page_title` and the H1 header for consistency
- Use `>-` instead of `|-` for the description so that extra spaces won't be included in the char length


### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
