### PR TITLE
Run Migrations If Migration Worker has not been run #7162

### DIFF
--- a/vault/activity_log.go
+++ b/vault/activity_log.go
@@ -4095,11 +4095,10 @@ func (a *ActivityLog) writeExport(ctx context.Context, rw http.ResponseWriter, f
 func (c *Core) activityLogMigrationTask(ctx context.Context) {
 	manager := c.activityLog
 	if !c.IsPerfSecondary() {
-		// If the oldest version is less than 1.19 and no migrations tasks have been run, kick off the migration task
-		if !manager.OldestVersionHasDeduplicatedClients(ctx) && !manager.hasDedupClientsUpgrade(ctx) {
+		// If no migrations tasks have been run, kick off the migration task
+		if !manager.hasDedupClientsUpgrade(ctx) {
 			go c.primaryDuplicateClientMigrationWorker(ctx)
 		} else {
-			// Store that upgrade processes have already been completed
 			manager.writeDedupClientsUpgrade(ctx)
 		}
 	} else {
@@ -4108,6 +4107,8 @@ func (c *Core) activityLogMigrationTask(ctx context.Context) {
 		// already upgraded primary
 		if !manager.hasDedupClientsUpgrade(ctx) {
 			go c.secondaryDuplicateClientMigrationWorker(ctx)
+		} else {
+			manager.writeDedupClientsUpgrade(ctx)
 		}
 	}
 }
@@ -4118,7 +4119,12 @@ func (c *Core) activityLogMigrationTask(ctx context.Context) {
 // current cluster. This method wil only exit once all connected secondary clusters have
 // upgraded to 1.19, and this cluster receives global data from all of them.
 func (c *Core) primaryDuplicateClientMigrationWorker(ctx context.Context) error {
+	c.activityLogLock.Lock()
 	a := c.activityLog
+	c.activityLogLock.Unlock()
+	if a == nil {
+		return fmt.Errorf("activity log not configured")
+	}
 	a.logger.Trace("started primary activity log migration worker")
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()

--- a/vault/activity_log_util_common.go
+++ b/vault/activity_log_util_common.go
@@ -15,7 +15,6 @@ import (
 	"time"
 
 	"github.com/axiomhq/hyperloglog"
-	semver "github.com/hashicorp/go-version"
 	"github.com/hashicorp/vault/helper/timeutil"
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/hashicorp/vault/vault/activity"
@@ -638,28 +637,6 @@ func (a *ActivityLog) getAllEntitySegmentsForMonth(ctx context.Context, path str
 		}
 	}
 	return segments, nil
-}
-
-// OldestVersionHasDeduplicatedClients returns whether this cluster is 1.19+, and
-// hence supports deduplicated clients
-func (a *ActivityLog) OldestVersionHasDeduplicatedClients(ctx context.Context) bool {
-	oldestVersionIsDedupClients := a.core.IsNewInstall(ctx)
-	if !oldestVersionIsDedupClients {
-		if v, _, err := a.core.FindOldestVersionTimestamp(); err == nil {
-			oldestVersion, err := semver.NewSemver(v)
-			if err != nil {
-				a.core.logger.Debug("could not extract version instance", "version", v)
-				return false
-			}
-			dedupChangeVersion, err := semver.NewSemver(DeduplicatedClientMinimumVersion)
-			if err != nil {
-				a.core.logger.Debug("could not extract version instance", "version", DeduplicatedClientMinimumVersion)
-				return false
-			}
-			oldestVersionIsDedupClients = oldestVersionIsDedupClients || oldestVersion.GreaterThanOrEqual(dedupChangeVersion)
-		}
-	}
-	return oldestVersionIsDedupClients
 }
 
 func (a *ActivityLog) loadClientDataIntoSegment(ctx context.Context, pathPrefix string, startTime time.Time, seqNum uint64, currentSegment *segmentInfo) ([]*activity.EntityRecord, error) {


### PR DESCRIPTION
### Description
ENT PR: https://github.com/hashicorp/vault-enterprise/pull/7162

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
