### PR TITLE
db: fix skip-import-rotation/rootless integration

### DIFF
--- a/builtin/logical/database/backend.go
+++ b/builtin/logical/database/backend.go
@@ -28,6 +28,7 @@ import (
 	"github.com/hashicorp/vault/sdk/helper/locksutil"
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/hashicorp/vault/sdk/queue"
+	"github.com/mitchellh/mapstructure"
 )
 
 const (
@@ -203,6 +204,19 @@ func (b *databaseBackend) DatabaseConfig(ctx context.Context, s logical.Storage,
 	}
 
 	return &config, nil
+}
+
+// ConnectionDetails decodes the DatabaseConfig.ConnectionDetails map into a
+// struct
+func (b *databaseBackend) ConnectionDetails(ctx context.Context, config *DatabaseConfig) (*ConnectionDetails, error) {
+	cd := &ConnectionDetails{}
+
+	err := mapstructure.WeakDecode(config.ConnectionDetails, &cd)
+	if err != nil {
+		return nil, err
+	}
+
+	return cd, nil
 }
 
 type upgradeStatements struct {

--- a/builtin/logical/database/path_config_connection.go
+++ b/builtin/logical/database/path_config_connection.go
@@ -51,6 +51,12 @@ type DatabaseConfig struct {
 	SkipStaticRoleImportRotation bool `json:"skip_static_role_import_rotation" structs:"skip_static_role_import_rotation" mapstructure:"skip_static_role_import_rotation"`
 }
 
+// ConnectionDetails represents the DatabaseConfig.ConnectionDetails map as a
+// struct
+type ConnectionDetails struct {
+	SelfManaged bool `json:"self_managed" structs:"self_managed" mapstructure:"self_managed"`
+}
+
 func (c *DatabaseConfig) SupportsCredentialType(credentialType v5.CredentialType) bool {
 	credTypes, ok := c.ConnectionDetails[v5.SupportedCredentialTypesKey].([]interface{})
 	if !ok {

--- a/builtin/logical/database/path_roles.go
+++ b/builtin/logical/database/path_roles.go
@@ -648,11 +648,6 @@ func (b *databaseBackend) pathStaticRoleCreateUpdate(ctx context.Context, req *l
 		return nil, err
 	}
 
-	connDetails, err := b.ConnectionDetails(ctx, dbConfig)
-	if err != nil {
-		return nil, err
-	}
-
 	lastVaultRotation := role.StaticAccount.LastVaultRotation
 	if passwordRaw, ok := data.GetOk("password"); ok {
 		// We will allow users to update the password until the point where
@@ -661,6 +656,12 @@ func (b *databaseBackend) pathStaticRoleCreateUpdate(ctx context.Context, req *l
 		updateAllowed := lastVaultRotation.IsZero()
 		if updateAllowed {
 			role.StaticAccount.Password = passwordRaw.(string)
+
+			connDetails, err := b.ConnectionDetails(ctx, dbConfig)
+			if err != nil {
+				return nil, err
+			}
+
 			if connDetails != nil && connDetails.SelfManaged {
 				// Password and SelfManagedPassword should map to the same value
 				role.StaticAccount.SelfManagedPassword = passwordRaw.(string)
@@ -686,6 +687,7 @@ func (b *databaseBackend) pathStaticRoleCreateUpdate(ctx context.Context, req *l
 			role.SkipImportRotation = skipImportRotationRaw.(bool)
 		}
 	} else if createRole {
+		// default to the config-level setting
 		role.SkipImportRotation = dbConfig.SkipStaticRoleImportRotation
 	}
 


### PR DESCRIPTION
### Description
Fix a bug where the `self_managed` field was not being evaluated correctly. We use WeakDecode to read the DB config's `connection_details` map and coerce the `self_managed` field to a boolean.

Related to https://github.com/hashicorp/vault/pull/29093

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
