### PR TITLE
[DOCS] Match the page_title with H1 header

### DIFF
--- a/website/content/docs/platform/mssql/configuration.mdx
+++ b/website/content/docs/platform/mssql/configuration.mdx
@@ -1,10 +1,10 @@
 ---
 layout: docs
-page_title: Configure the Vault EKM Provider
+page_title: Configure the Vault EKM provider
 description: Configuration options for the Vault EKM Provider for Microsoft SQL Server.
 ---
 
-# Configuring the Vault EKM provider
+# Configure the Vault EKM provider
 
 Configuration is stored in a `config.json` file under ProgramData in a path that
 mirrors the installation folder. This defaults to

--- a/website/content/docs/platform/mssql/installation.mdx
+++ b/website/content/docs/platform/mssql/installation.mdx
@@ -1,10 +1,10 @@
 ---
 layout: docs
-page_title: Install the Vault EKM Provider
-description: Installation steps for the Vault EKM Provider for Microsoft SQL Server.
+page_title: Install the Vault EKM provider
+description: Installation steps for the Vault EKM provider for Microsoft SQL Server.
 ---
 
-# Installing the Vault EKM provider
+# Install the Vault EKM provider
 
 This guide assumes you are installing the Vault EKM Provider for the first time.
 For upgrade instructions, see [upgrading](/vault/docs/platform/mssql/upgrading).

--- a/website/content/docs/platform/mssql/rotation.mdx
+++ b/website/content/docs/platform/mssql/rotation.mdx
@@ -1,10 +1,11 @@
 ---
 layout: docs
-page_title: Rotating encryption keys with the Vault EKM Provider
-description: Steps to rotate the symmetric Database Encryption Key (DEK) and the asymmetric Key Encryption Key (KEK) when using the Vault EKM Provider for Microsoft SQL Server.
+page_title: Rote encryption keys with the Vault EKM provider
+description: >-
+    Steps to rotate the symmetric Database Encryption Key (DEK) and the asymmetric Key Encryption Key (KEK) when using the Vault EKM provider for Microsoft SQL Server.
 ---
 
-# Key rotation
+# Rote encryption keys with the Vault EKM provider
 
 Both the database encryption key and Vault Transit's asymmetric key can be rotated independently.
 

--- a/website/content/docs/platform/mssql/rotation.mdx
+++ b/website/content/docs/platform/mssql/rotation.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: Rote encryption keys with the Vault EKM provider
+page_title: Rotate encryption keys with the Vault EKM provider
 description: >-
     Steps to rotate the symmetric Database Encryption Key (DEK) and the asymmetric Key Encryption Key (KEK) when using the Vault EKM provider for Microsoft SQL Server.
 ---
 
-# Rote encryption keys with the Vault EKM provider
+# Rotate encryption keys with the Vault EKM provider
 
 Both the database encryption key and Vault Transit's asymmetric key can be rotated independently.
 

--- a/website/content/docs/platform/mssql/troubleshooting.mdx
+++ b/website/content/docs/platform/mssql/troubleshooting.mdx
@@ -1,10 +1,10 @@
 ---
 layout: docs
-page_title: Troubleshoot the Vault EKM Provider
-description: Troubleshooting steps for the Vault EKM Provider for Microsoft SQL Server.
+page_title: Troubleshoot the Vault EKM provider
+description: Troubleshooting steps for the Vault EKM provider for Microsoft SQL Server.
 ---
 
-# Troubleshooting the Vault EKM provider
+# Troubleshoot the Vault EKM provider
 
 ## Check windows event logs
 

--- a/website/content/docs/platform/mssql/upgrading.mdx
+++ b/website/content/docs/platform/mssql/upgrading.mdx
@@ -1,10 +1,10 @@
 ---
 layout: docs
-page_title: Upgrade the Vault EKM Provider
-description: Upgrade steps for the Vault EKM Provider for Microsoft SQL Server.
+page_title: Upgrade the Vault EKM provider
+description: Upgrade steps for the Vault EKM provider for Microsoft SQL Server.
 ---
 
-# Upgrading the Vault EKM provider
+# Upgrade the Vault EKM provider
 
 ~> **Note:** The upgrade process will put the database into maintenance mode and
     require a restart. It is highly recommended to test this procedure in a

--- a/website/content/docs/platform/servicenow/configuration.mdx
+++ b/website/content/docs/platform/servicenow/configuration.mdx
@@ -1,10 +1,10 @@
 ---
 layout: docs
-page_title: Configure Vault ServiceNow Credential Resolver
-description: This section documents the configurables for the Vault ServiceNow Credential Resolver.
+page_title: Configure the Vault ServiceNow Credential Resolver
+description: Configurable properties for the Vault ServiceNow Credential Resolver.
 ---
 
-# Configuring the Vault credential resolver
+# Configure the Vault ServiceNow Credential Resolver
 
 ## MID server properties
 

--- a/website/content/docs/platform/servicenow/index.mdx
+++ b/website/content/docs/platform/servicenow/index.mdx
@@ -5,7 +5,7 @@ description: >-
   The Vault Credential Resolver allows ServiceNow MID servers to use Vault as an enterprise-grade external secret store.
 ---
 
-# Vault credential resolver
+# Vault Credential Resolver
 
 ServiceNow® MID servers can use the Vault Credential Resolver to consume secrets
 directly from Vault for the purpose of performing discovery. See

--- a/website/content/docs/platform/servicenow/installation.mdx
+++ b/website/content/docs/platform/servicenow/installation.mdx
@@ -4,7 +4,7 @@ page_title: Install Vault ServiceNow Credential Resolver
 description: Installation steps for the Vault ServiceNow Credential Resolver.
 ---
 
-# Installing the Vault credential resolver
+# Install Vault ServiceNow Credential Resolver
 
 ## Prerequisites
 

--- a/website/content/docs/platform/servicenow/troubleshooting.mdx
+++ b/website/content/docs/platform/servicenow/troubleshooting.mdx
@@ -1,10 +1,10 @@
 ---
 layout: docs
-page_title: Troubleshooting the Vault ServiceNow Credential Resolver
+page_title: Troubleshoot the Vault ServiceNow Credential Resolver
 description: Troubleshooting tips for the Vault ServiceNow Credential Resolver.
 ---
 
-# Troubleshooting
+# Troubleshoot the Vault ServiceNow Credential Resolver
 
 ## Check the logs
 


### PR DESCRIPTION
### Description
What does this PR do?

- Check the `description` matches the content of the doc
- Match the `page_title` and the H1 header for consistency
- Capitalization for consistency
   - `ServiceNow credential resolver` should be `ServiceNow Credential Resolver` ([ServiceNow docs](https://store.servicenow.com/sn_appstore_store.do#!/store/application/3ee1c80c1b257010c216ebd56e4bcb33))

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
