### PR TITLE
Add hook for entreprise support for PKI name constraints extension

### DIFF
--- a/builtin/logical/pki/cert_util.go
+++ b/builtin/logical/pki/cert_util.go
@@ -551,6 +551,8 @@ func (cb CreationBundleInputFromFieldData) GetUserIds() []string {
 	return cb.data.Get("user_ids").([]string)
 }
 
+// GetPathNameConstraints parses and returns the name constraints extension if present (enterprise).
+// ignore-nil-nil-function-check
 func (cb CreationBundleInputFromFieldData) GetPathNameConstraints() (*pkix.Extension, error) {
 	jsonString, exists := cb.data.GetOk("name_constraints")
 	if !exists {

--- a/builtin/logical/pki/cert_util.go
+++ b/builtin/logical/pki/cert_util.go
@@ -551,6 +551,14 @@ func (cb CreationBundleInputFromFieldData) GetUserIds() []string {
 	return cb.data.Get("user_ids").([]string)
 }
 
+func (cb CreationBundleInputFromFieldData) GetPathNameConstraints() (*pkix.Extension, error) {
+	jsonString, exists := cb.data.GetOk("name_constraints")
+	if !exists {
+		return nil, nil
+	}
+	return entParseNameConstraintsJson(jsonString.(string))
+}
+
 // generateCreationBundle is a shared function that reads parameters supplied
 // from the various endpoints and generates a CreationParameters with the
 // parameters that can be used to issue or sign

--- a/builtin/logical/pki/cert_util_oss.go
+++ b/builtin/logical/pki/cert_util_oss.go
@@ -1,0 +1,15 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+//go:build !enterprise
+
+package pki
+
+import (
+	"crypto/x509/pkix"
+	"errors"
+)
+
+func entParseNameConstraintsJson(nameConstraintsString string) (*pkix.Extension, error) {
+	return nil, errors.New("name_constraints is an ent-only field")
+}

--- a/builtin/logical/pki/fields.go
+++ b/builtin/logical/pki/fields.go
@@ -299,6 +299,12 @@ The value format should be given in UTC format YYYY-MM-ddTHH:MM:SSZ`,
 		},
 	}
 
+	fields["name_constraints"] = &framework.FieldSchema{
+		Type:        framework.TypeString,
+		Default:     "",
+		Description: `Names Constraints extension, see https://www.rfc-editor.org/rfc/rfc5280#section-4.2.1.10 ; formatted as a JSON tree of permitted and excluded subtrees.`,
+	}
+
 	return fields
 }
 

--- a/builtin/logical/pki/issuing/cert_verify.go
+++ b/builtin/logical/pki/issuing/cert_verify.go
@@ -65,9 +65,9 @@ func VerifyCertificate(ctx context.Context, storage logical.Storage, issuerId Is
 		DisableTimeChecks:              true,
 		DisableEKUChecks:               true,
 		DisableCriticalExtensionChecks: false,
-		DisableNameChecks:              false,
+		DisableNameChecks:              false, // issuer name check
 		DisablePathLenChecks:           false,
-		DisableNameConstraintChecks:    false,
+		DisableNameConstraintChecks:    false, // path name constraints extension
 	}
 
 	if err := entSetCertVerifyOptions(ctx, storage, issuerId, &options); err != nil {

--- a/builtin/logical/pki/issuing/issue_common.go
+++ b/builtin/logical/pki/issuing/issue_common.go
@@ -92,6 +92,7 @@ type CreationBundleInput interface {
 	IsUserIdInSchema() (interface{}, bool)
 	GetUserIds() []string
 	IgnoreCSRSignature() bool
+	GetPathNameConstraints() (*pkix.Extension, error)
 }
 
 // GenerateCreationBundle is a shared function that reads parameters supplied
@@ -408,6 +409,11 @@ func GenerateCreationBundle(b logical.SystemView, role *RoleEntry, entityInfo En
 		}
 	}
 
+	pathNameConstraints, err := cb.GetPathNameConstraints()
+	if err != nil {
+		return nil, nil, errutil.UserError{Err: fmt.Sprintf("requested name_constraints cannot be populated: %s", err)}
+	}
+
 	creation := &certutil.CreationBundle{
 		Params: &certutil.CreationParameters{
 			Subject:                       subject,
@@ -430,6 +436,7 @@ func GenerateCreationBundle(b logical.SystemView, role *RoleEntry, entityInfo En
 			ForceAppendCaChain:            caSign != nil,
 			SKID:                          skid,
 			IgnoreCSRSignature:            cb.IgnoreCSRSignature(),
+			NameConstraints:               pathNameConstraints,
 		},
 		SigningBundle: caSign,
 		CSR:           csr,

--- a/builtin/logical/pki/issuing/sign_cert.go
+++ b/builtin/logical/pki/issuing/sign_cert.go
@@ -114,6 +114,8 @@ func (b BasicSignCertInput) GetPermittedDomains() []string {
 	return []string{}
 }
 
+// GetPathNameConstraints always returns nil for BasicSignCertInput.
+// ignore-nil-nil-function-check
 func (b BasicSignCertInput) GetPathNameConstraints() (*pkix.Extension, error) {
 	return nil, nil
 }

--- a/builtin/logical/pki/issuing/sign_cert.go
+++ b/builtin/logical/pki/issuing/sign_cert.go
@@ -8,6 +8,7 @@ import (
 	"crypto/ed25519"
 	"crypto/rsa"
 	"crypto/x509"
+	"crypto/x509/pkix"
 	"fmt"
 
 	"github.com/hashicorp/vault/sdk/helper/certutil"
@@ -111,6 +112,10 @@ func (b BasicSignCertInput) UseCSRValues() bool {
 
 func (b BasicSignCertInput) GetPermittedDomains() []string {
 	return []string{}
+}
+
+func (b BasicSignCertInput) GetPathNameConstraints() (*pkix.Extension, error) {
+	return nil, nil
 }
 
 func SignCert(b logical.SystemView, role *RoleEntry, entityInfo EntityInfo, caSign *certutil.CAInfoBundle, signInput SignCertInput) (*certutil.ParsedCertBundle, []string, error) {

--- a/builtin/logical/pki/path_issue_sign.go
+++ b/builtin/logical/pki/path_issue_sign.go
@@ -432,7 +432,7 @@ func (b *backend) pathIssueSignCert(ctx context.Context, req *logical.Request, d
 		}
 	}
 
-	if err := issuing.VerifyCertificate(sc.GetContext(), sc.GetStorage(), issuerId, parsedBundle); err != nil {
+	if err = issuing.VerifyCertificate(sc.GetContext(), sc.GetStorage(), issuerId, parsedBundle); err != nil {
 		return nil, err
 	}
 

--- a/sdk/helper/certutil/types.go
+++ b/sdk/helper/certutil/types.go
@@ -810,6 +810,9 @@ type CreationParameters struct {
 	UseCSRValues        bool
 	PermittedDNSDomains []string
 
+	// The path NameConstraints extension for issued certificates.
+	NameConstraints *pkix.Extension
+
 	// URLs to encode into the certificate
 	URLs *URLEntries
 


### PR DESCRIPTION
### Description

Add hook for entreprise support for PKI name constraints extension.

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
