### PR TITLE
Add ops quick start, update nav

### DIFF
--- a/website/content/docs/get-started/operations-qs.mdx
+++ b/website/content/docs/get-started/operations-qs.mdx
@@ -175,7 +175,6 @@ Vault policies allow you to control access to secrets, and which operations are 
        policies=kv-access-policy
    ```
 
-   The `opsuser` user is updated with the `kv-access-policy` policy.
 
 ## Authenticate to Vault
 

--- a/website/content/docs/get-started/operations-qs.mdx
+++ b/website/content/docs/get-started/operations-qs.mdx
@@ -72,8 +72,7 @@ Vault supports multiple [authentication methods](/vault/docs/auth). Authenticati
 plugins control access to Vault for humans and machine based workloads. 
 The `userpass` plugin uses basic authentication with usernames and passwords.
 
-1. Enable the `userpass` auth method. This method allows users to authenticate to
-   Vault.
+1. Use `vault auth enable` to enable the `userpass` authentication method for human clients:
 
    ```shell-session
    $ vault auth enable userpass

--- a/website/content/docs/get-started/operations-qs.mdx
+++ b/website/content/docs/get-started/operations-qs.mdx
@@ -164,7 +164,7 @@ the operations allowed on plugin data.
 
    ```shell-session
    $ vault policy write kv-access-policy - << EOF
-   path "kv/creds" {
+   path "shared/data/kv/creds/*" {
       capabilities = ["read", "create", "update", "delete"]
    }
    EOF

--- a/website/content/docs/get-started/operations-qs.mdx
+++ b/website/content/docs/get-started/operations-qs.mdx
@@ -25,7 +25,7 @@ For a complete Vault learning experience, refer to the [Vault foundations tutori
 
 ## Before you start
 
-- A local installation of the [Vault binary](/vault/install).
+- **You must have [Vault installed](/vault/install) locally**.
 
 ## Start Vault
 

--- a/website/content/docs/get-started/operations-qs.mdx
+++ b/website/content/docs/get-started/operations-qs.mdx
@@ -185,7 +185,7 @@ password `p@ssw0rd`.
 $ vault login -method=userpass username=opsuser
 ```
 
-You are now authenticated to Vault.
+You are now authenticated to Vault with the `opsuser` and the `kv-access-policy` access policy instead of the root token.
 
 
 

--- a/website/content/docs/get-started/operations-qs.mdx
+++ b/website/content/docs/get-started/operations-qs.mdx
@@ -23,7 +23,7 @@ For help managing a production Vault installation, refer to the
 
 For a complete Vault learning experience, refer to the [Vault foundations tutorials](/vault/tutorials/get-started).
 
-## Prerequisites
+## Before you start
 
 - A local installation of the [Vault binary](/vault/install).
 

--- a/website/content/docs/get-started/operations-qs.mdx
+++ b/website/content/docs/get-started/operations-qs.mdx
@@ -140,7 +140,8 @@ secrets are written: The `username` key with a value of `opsuser` and the key
 In the previous step, you wrote a password to the `kv` secrets engine using the
 root token. The use of the root token, and root policy, is not recommended for production environments.
 
-Vault policies allow you to control access to secrets, and which operations are allowed.
+You can use Vault policies to control and limit access to plugin data and
+the operations allowed on plugin data.
 
 1. Write a policy that permits access to the `kv` secrets engine.
 

--- a/website/content/docs/get-started/operations-qs.mdx
+++ b/website/content/docs/get-started/operations-qs.mdx
@@ -188,13 +188,21 @@ $ vault login -method=userpass username=opsuser
 You are now authenticated to Vault.
 
 
-You authenticated to Vault as the `opsuser` user. Retrieve the secrets from the
-path `kv/creds`. The `opsuser` user has access to the `kv/creds` path from the
-`kv-access-policy`.
+
+Try retrieving the secrets stored on the `kv/creds` path:
 
 ```shell-session
 $ vault kv get kv/creds
 ```
+
+Now try retrieving the secrets stored on the `kv/api-keys` path:
+
+```shell-session
+$ vault kv get kv/api-keys
+```
+
+The second command fails because the policy for `opsuser` does
+not grant access to the `/api-keys` path.
 
 You have successfully stored and retrieved your first secret value with a user
 from the `userpass` auth method.

--- a/website/content/docs/get-started/operations-qs.mdx
+++ b/website/content/docs/get-started/operations-qs.mdx
@@ -8,8 +8,18 @@ description: >-
 
 # Operations quick start
 
-This quick start will explore how to set up Vault to authenticate
-entities, store and retrieve your first secret value.
+Start Vault in developer mode to authenticate entities, store and retrieve
+your first key/value secret.
+
+<Warning>
+
+Running Vault in-memory with `dev` mode is insecure but useful for
+practicing locally. **Do not use `dev` mode in production**.
+
+For help managing a production Vault installation, refer to the
+[Production hardening tutorial](/vault/tutorials/operations/production-hardening).
+
+</Warning>
 
 For a complete Vault learning experience, refer to the [Vault foundations tutorials](/vault/tutorials/get-started).
 

--- a/website/content/docs/get-started/operations-qs.mdx
+++ b/website/content/docs/get-started/operations-qs.mdx
@@ -9,7 +9,7 @@ description: Learn how to store and retrieve your first secret.
 This quick start will explore how to set up Vault to authenticate
 entities, store and retrieve your first secret value.
 
-For in-depth Vault learning experience, see the [Vault foundations tutorials](/vault/tutorials/get-started).
+For a complete Vault learning experience, refer to the [Vault foundations tutorials](/vault/tutorials/get-started).
 
 ## Prerequisites
 

--- a/website/content/docs/get-started/operations-qs.mdx
+++ b/website/content/docs/get-started/operations-qs.mdx
@@ -125,7 +125,14 @@ $ vault secrets enable -version=2 kv
 ## Store a secret
 
 
-Write a secret to the `kv` secrets engine.
+
+<Tip>
+
+The `kv` plugin is a core Vault plugin and has dedicated commands in the Vault CLI. Most plugins use the `vault read` and `vault write` commands.
+
+</Tip>
+
+Use the `kv put` command to store the demo user credentials in the `kv` plugin as the secrets `username` and `password`:
 
 ```shell-session
 $ vault kv put kv/creds username=opsuser password=p@ssw0rd

--- a/website/content/docs/get-started/operations-qs.mdx
+++ b/website/content/docs/get-started/operations-qs.mdx
@@ -80,7 +80,8 @@ The `userpass` plugin uses basic authentication with usernames and passwords.
 
    The `userpass` auth method is enabled.
 
-1. To authenticate users with Vault, you must create a user and password.
+1. Use the `userpass` plugin to create a demo user called `opsuser` with the
+    password `p@ssw0rd`:
 
    ```shell-session
    $ vault write auth/userpass/users/opsuser \

--- a/website/content/docs/get-started/operations-qs.mdx
+++ b/website/content/docs/get-started/operations-qs.mdx
@@ -160,7 +160,8 @@ root token. The use of the root token, and root policy, is not recommended for p
 You can use Vault policies to control and limit access to plugin data and
 the operations allowed on plugin data.
 
-1. Write a policy that permits access to the `kv` secrets engine.
+1. Create a policy file that permits `read`, `create`, `update`, and `delete`
+   operations on the `/creds` path for your `kv` plugin:
 
    ```shell-session
    $ vault policy write kv-access-policy - << EOF

--- a/website/content/docs/get-started/operations-qs.mdx
+++ b/website/content/docs/get-started/operations-qs.mdx
@@ -1,0 +1,190 @@
+---
+layout: docs
+page_title: Operations quick start
+description: Learn how to store and retrieve your first secret.
+---
+
+# Operations quick start
+
+This quick start will explore how to set up Vault to authenticate
+entities, store and retrieve your first secret value.
+
+For in-depth Vault learning experience, see the [Vault foundations tutorials](/vault/tutorials/get-started).
+
+## Prerequisites
+
+- A local installation of the [Vault binary](/vault/install).
+
+## Start Vault
+
+<Warning>
+
+This in-memory “dev” server is useful for practicing with Vault locally for the
+first time, but is insecure and should never be used in production. For
+developers who need to manage their own production Vault installations, this
+[page](/vault/tutorials/operations/production-hardening) provides some guidance
+on how to make your setup more production-ready.
+
+</Warning>
+
+1. Start the Vault server in development mode.
+
+   ```shell-session
+   $ vault server -dev -dev-root-token-id="dev-only-token"
+   ```
+
+   The `-dev-root-token-id` flag for dev servers defines the initial root token.
+   The root token allows full access to any entity that presents the token (in this
+   case "dev-only-token").
+
+   <Warning>
+
+   The [root token](/vault/docs/concepts/tokens#root-tokens) is useful for
+   testing as the associate `root` policy allows full access to all data and functionality of Vault. The
+   root token must be carefully guarded in production. Ideally, even an administrator of
+   Vault would use their own token with limited privileges instead of the root token.
+
+   </Warning>
+
+   Vault is now listening over HTTP on port `8200`.
+
+1. Open a new terminal and export environment variables to interact with the
+   Vault server.
+
+   ```shell-session
+   $ export VAULT_ADDR='http://127.0.0.1:8200'
+   ```
+
+1. Log into the Vault server using the root token.
+
+   ```shell-session
+   $ vault login dev-only-token
+   ```
+
+   You are now authenticated to Vault with the root token.
+
+## Enable auth methods
+
+Vault supports multiple [authentication methods](/vault/docs/auth). These
+plugins authenticate both human and machine based workloads to Vault. In this
+quick start, you will use the `userpass` auth method.
+
+1. Enable the `userpass` auth method. This method allows users to authenticate to
+   Vault.
+
+   ```shell-session
+   $ vault auth enable userpass
+   ```
+
+   The `userpass` auth method is enabled.
+
+1. To authenticate users with Vault, you must create a user and password.
+
+   ```shell-session
+   $ vault write auth/userpass/users/opsuser \
+       password=p@ssw0rd
+   ```
+
+   The user `opsuser` is created. The password is `p@ssw0rd`.
+
+1. (Optional) Enable the `approle` auth method. This is a general purpose plugin that
+   allows machines or apps to authenticate to Vault.
+
+   ```shell-session
+   $ vault auth enable approle
+   ```
+
+   The `approle` auth method is enabled.
+
+1. (Optional) To authenticate workloads with Vault, you must create a role.
+
+   ```shell-session
+   $ vault write auth/approle/role/my-app-role \
+       secret_id_ttl=10m \
+       token_ttl=20m \
+       token_max_ttl=30m
+   ```
+
+   The role `my-app-role` is created. The role has a secret ID TTL of 10 minutes, a
+   token TTL of 20 minutes, and a token max TTL of 30 minutes.
+
+## Enable secrets engines
+
+Vault supports multiple [secrets engines](/vault/docs/secrets). These
+plugins support various use cases like storing static secrets, dynamic secrets,
+and managing PKI certificates.
+
+Enable the `kv` secrets engine. This engine stores arbitrary secrets.
+
+```shell-session
+$ vault secrets enable -version=2 kv
+```
+
+The `kv` secrets engine is enabled.
+
+## Store a secret
+
+Vault securely stores secrets static for a configured `kv` secrets engine.
+
+Write a secret to the `kv` secrets engine.
+
+```shell-session
+$ vault kv put kv/creds username=opsuser password=p@ssw0rd
+```
+
+The `kv put` command writes the secret to the `kv` secrets engine. In this example, two
+secrets are written: The `username` key with a value of `opsuser` and the key
+`password` with a value of `p@ssw0rd`.
+
+## Protect secrets
+
+In the previous step, you wrote a password to the `kv` secrets engine using the
+root token. Using the root token, and root policy, is not recommended for production environments.
+
+Vault policies allow you to control access to secrets, and which operations are allowed.
+
+1. Write a policy that permits access to the `kv` secrets engine.
+
+   ```shell-session
+   $ vault policy write kv-access-policy - << EOF
+   path "kv/creds" {
+      capabilities = ["read", "create", "update", "delete"]
+   }
+   EOF
+   ```
+
+   This policy supports the `read`, `create`, `update`, and `delete` operations on
+   the path `kv/creds`.
+
+1. Attach the policy to the `opsuser` user.
+
+   ```shell-session
+   $ vault write auth/userpass/users/opsuser \
+       policies=kv-access-policy
+   ```
+
+   The `opsuser` user is updated with the `kv-access-policy` policy.
+
+## Authenticate to Vault
+
+Authenticate to Vault using the `opsuser` user. When prompted, enter the
+password `p@ssw0rd`.
+
+```shell-session
+$ vault login -method=userpass username=opsuser
+```
+
+You are now authenticated to Vault.
+
+## Retrieve a secret
+
+You authenticated to Vault as the `opsuser` user. Retrieve the secrets from the
+path `kv/creds`. The `opsuser` user has access to the `kv/creds` path from the
+`kv-access-policy`.
+
+```shell-session
+$ vault kv get kv/creds
+```
+
+You have successfully stored and retrieved your first secret value with a user
+from the `userpass` auth method.

--- a/website/content/docs/get-started/operations-qs.mdx
+++ b/website/content/docs/get-started/operations-qs.mdx
@@ -89,8 +89,8 @@ The `userpass` plugin uses basic authentication with usernames and passwords.
    ```
 
 
-1. (Optional) Enable the `approle` auth method. This is a general purpose plugin that
-   allows machines or apps to authenticate to Vault.
+1. Use `vault auth enable` to enable the `approle` authentication method
+    for machines and application clients:
 
    ```shell-session
    $ vault auth enable approle

--- a/website/content/docs/get-started/operations-qs.mdx
+++ b/website/content/docs/get-started/operations-qs.mdx
@@ -160,8 +160,6 @@ the operations allowed on plugin data.
    EOF
    ```
 
-   This policy supports the `read`, `create`, `update`, and `delete` operations on
-   the path `kv/creds`.
 
 1. Attach the policy to the `opsuser` user.
 

--- a/website/content/docs/get-started/operations-qs.mdx
+++ b/website/content/docs/get-started/operations-qs.mdx
@@ -69,8 +69,8 @@ For a complete Vault learning experience, refer to the [Vault foundations tutori
 ## Enable auth methods
 
 Vault supports multiple [authentication methods](/vault/docs/auth). Authentication
-plugins authenticate both human and machine based workloads to Vault. In this
-quick start, you will use the `userpass` auth method.
+plugins control access to Vault for humans and machine based workloads. 
+The `userpass` plugin uses basic authentication with usernames and passwords.
 
 1. Enable the `userpass` auth method. This method allows users to authenticate to
    Vault.

--- a/website/content/docs/get-started/operations-qs.mdx
+++ b/website/content/docs/get-started/operations-qs.mdx
@@ -106,8 +106,8 @@ The `userpass` plugin uses basic authentication with usernames and passwords.
        token_max_ttl=30m
    ```
 
-   The role `my-app-role` is created. The role has a secret ID TTL of 10 minutes, a
-   token TTL of 20 minutes, and a token max TTL of 30 minutes.
+   The `my-app-role` role has a secret ID TTL of 10 minutes, a token TTL
+   of 20 minutes, and a token max TTL of 30 minutes.
 
 ## Enable secrets engines
 

--- a/website/content/docs/get-started/operations-qs.mdx
+++ b/website/content/docs/get-started/operations-qs.mdx
@@ -1,7 +1,9 @@
 ---
 layout: docs
 page_title: Operations quick start
-description: Learn how to store and retrieve your first secret.
+description: >-
+  Bring Vault up in developer mode with a basic configuration file
+  then store and retrieve a key/value secret.
 ---
 
 # Operations quick start

--- a/website/content/docs/get-started/operations-qs.mdx
+++ b/website/content/docs/get-started/operations-qs.mdx
@@ -88,7 +88,6 @@ The `userpass` plugin uses basic authentication with usernames and passwords.
        password=p@ssw0rd
    ```
 
-   The user `opsuser` is created. The password is `p@ssw0rd`.
 
 1. (Optional) Enable the `approle` auth method. This is a general purpose plugin that
    allows machines or apps to authenticate to Vault.

--- a/website/content/docs/get-started/operations-qs.mdx
+++ b/website/content/docs/get-started/operations-qs.mdx
@@ -97,7 +97,7 @@ The `userpass` plugin uses basic authentication with usernames and passwords.
    ```
 
 
-1. (Optional) To authenticate workloads with Vault, you must create a role.
+1.  Use the `approle` plugin to create a demo role called `my-app-role` :
 
    ```shell-session
    $ vault write auth/approle/role/my-app-role \

--- a/website/content/docs/get-started/operations-qs.mdx
+++ b/website/content/docs/get-started/operations-qs.mdx
@@ -42,10 +42,10 @@ For a complete Vault learning experience, refer to the [Vault foundations tutori
 
    <Warning>
 
-   The [root token](/vault/docs/concepts/tokens#root-tokens) is useful for
-   testing as the associate `root` policy allows full access to all data and functionality of Vault. The
-   root token must be carefully guarded in production. Ideally, even an administrator of
-   Vault would use their own token with limited privileges instead of the root token.
+   [Root tokens](/vault/docs/concepts/tokens#root-tokens) grant full
+   access to all data and functionality in your Vault server. Do not share
+   your root token. For production deployments, we recommend creating
+   individual administrator tokens  with explicit privileges.
 
    </Warning>
 

--- a/website/content/docs/get-started/operations-qs.mdx
+++ b/website/content/docs/get-started/operations-qs.mdx
@@ -135,7 +135,10 @@ The `kv` plugin is a core Vault plugin and has dedicated commands in the Vault C
 Use the `kv put` command to store the demo user credentials in the `kv` plugin as the secrets `username` and `password`:
 
 ```shell-session
-$ vault kv put kv/creds username=opsuser password=p@ssw0rd
+$ vault kv put   \
+  -mount shared  \
+  kv/creds       \
+  username=opsuser password=p@ssw0rd
 ```
 
 The `kv put` command writes the secret to the `kv` secrets engine. In this example, two

--- a/website/content/docs/get-started/operations-qs.mdx
+++ b/website/content/docs/get-started/operations-qs.mdx
@@ -2,14 +2,13 @@
 layout: docs
 page_title: Operations quick start
 description: >-
-  Bring Vault up in developer mode with a basic configuration file
-  then store and retrieve a key/value secret.
+  Bring Vault up in developer mode then store and retrieve a key/value secret.
 ---
 
 # Operations quick start
 
-Start Vault in developer mode to authenticate entities, store and retrieve
-your first key/value secret.
+Start Vault in developer mode and authenticate entities, store and retrieve
+your first key/value secret, and test access control with policies.
 
 <Warning>
 
@@ -25,12 +24,11 @@ For a complete Vault learning experience, refer to the [Vault foundations tutori
 
 ## Before you start
 
-- **You must have [Vault installed](/vault/install) locally**.
+- You must have [Vault installed](/vault/install) locally.
 
-## Start Vault
+## Start Vault in `dev` mode
 
-
-1. Start the Vault server in development mode.
+Use the `-dev` and `-dev-root-token` flags to start the Vault server in development mode:
 
    ```shell-session
    $ vault server -dev -dev-root-token-id="dev-only-token"
@@ -49,7 +47,7 @@ For a complete Vault learning experience, refer to the [Vault foundations tutori
 
    </Warning>
 
-   Vault is now listening over HTTP on port `8200`.
+## Authenticate to Vault
 
 1. Open a new terminal and export environment variables to interact with the
    Vault server.
@@ -66,10 +64,10 @@ For a complete Vault learning experience, refer to the [Vault foundations tutori
 
    You are now authenticated to Vault with the root token.
 
-## Enable auth methods
+## Enable authentication plugins
 
 Vault supports multiple [authentication methods](/vault/docs/auth). Authentication
-plugins control access to Vault for humans and machine based workloads. 
+plugins control access to Vault for humans and machine based workloads.
 The `userpass` plugin uses basic authentication with usernames and passwords.
 
 1. Use `vault auth enable` to enable the `userpass` authentication method for human clients:
@@ -78,7 +76,7 @@ The `userpass` plugin uses basic authentication with usernames and passwords.
    $ vault auth enable userpass
    ```
 
-   The `userpass` auth method is enabled.
+   The `userpass` auth method plugin is enabled.
 
 1. Use the `userpass` plugin to create a demo user called `opsuser` with the
     password `p@ssw0rd`:
@@ -88,7 +86,6 @@ The `userpass` plugin uses basic authentication with usernames and passwords.
        password=p@ssw0rd
    ```
 
-
 1. Use `vault auth enable` to enable the `approle` authentication method
     for machines and application clients:
 
@@ -96,8 +93,7 @@ The `userpass` plugin uses basic authentication with usernames and passwords.
    $ vault auth enable approle
    ```
 
-
-1.  Use the `approle` plugin to create a demo role called `my-app-role` :
+1. Use the `approle` plugin to create a demo role called `my-app-role` :
 
    ```shell-session
    $ vault write auth/approle/role/my-app-role \
@@ -109,7 +105,7 @@ The `userpass` plugin uses basic authentication with usernames and passwords.
    The `my-app-role` role has a secret ID TTL of 10 minutes, a token TTL
    of 20 minutes, and a token max TTL of 30 minutes.
 
-## Enable secrets engines
+## Enable the key/value secret plugin
 
 Vault supports multiple [secrets engine plugins](/vault/docs/secrets).
 You can use secret engine plugins to manage critical information like
@@ -121,10 +117,7 @@ The key/value plugin (`kv`) stores and versions arbitrary secrets. Use `vault se
 $ vault secrets enable -path shared -version 2 kv
 ```
 
-
 ## Store a secret
-
-
 
 <Tip>
 
@@ -132,27 +125,28 @@ The `kv` plugin is a core Vault plugin and has dedicated commands in the Vault C
 
 </Tip>
 
-Use the `kv put` command to store the demo user credentials in the `kv` plugin as the secrets `username` and `password`:
+1. Use the `kv put` command to store the demo user credentials in the `kv` plugin as the secrets `username` and `password`:
 
-```shell-session
-$ vault kv put   \
-  -mount shared  \
-  kv/creds       \
-  username=opsuser password=p@ssw0rd
-```
+   ```shell-session
+   $ vault kv put \
+     -mount shared \
+     kv/creds \
+     username=opsuser password=p@ssw0rd
+   ```
 
-`kv put` writes the keys `username` and `password` and their values to
-the `/creds` path for the key/value plugin called `kv`. 
+   `kv put` writes the keys `username` and `password` and their values to
+   the `/creds` path for the key/value plugin called `kv`.
 
-Now write a third key to a separate path called `api-keys`:
-```shell-session
-$ vault kv put   \
-  -mount shared  \
-  kv/api-keys       \
-  square=1234
-```
+1. Write a third key to a separate path called `api-keys`:
 
-## Protect secrets
+   ```shell-session
+   $ vault kv put \
+     -mount shared \
+     kv/api-keys \
+     square=1234
+   ```
+
+## Create a policy to protect secrets
 
 In the previous step, you wrote a password to the `kv` secrets engine using the
 root token. The use of the root token, and root policy, is not recommended for production environments.
@@ -171,7 +165,6 @@ the operations allowed on plugin data.
    EOF
    ```
 
-
 1. Use `vault write` to attach the policy to your `userpass` authentication
    plugin policy for the `opsuser` user:
 
@@ -180,34 +173,33 @@ the operations allowed on plugin data.
        policies=kv-access-policy
    ```
 
+## Test the policy
 
-## Authenticate to Vault
+1. Use `vault login` to authenticate to Vault using the `opsuser` user. When prompted, enter the
+   password `p@ssw0rd`:
 
-Use `vault login` to authenticate to Vault using the `opsuser` user. When prompted, enter the
-password `p@ssw0rd`:
+   ```shell-session
+   $ vault login -method=userpass username=opsuser
+   ```
 
-```shell-session
-$ vault login -method=userpass username=opsuser
-```
+   You are now authenticated to Vault with the `opsuser` and the `kv-access-policy` access policy instead of the root token.
 
-You are now authenticated to Vault with the `opsuser` and the `kv-access-policy` access policy instead of the root token.
+1. Try retrieving the secrets stored on the `kv/creds` path:
 
+   ```shell-session
+   $ vault kv get kv/creds
+   ```
 
+   The command retrieves the secrets stored on the `kv/creds` path.
 
-Try retrieving the secrets stored on the `kv/creds` path:
+1. Try retrieving the secrets stored on the `kv/api-keys` path:
 
-```shell-session
-$ vault kv get kv/creds
-```
+   ```shell-session
+   $ vault kv get kv/api-keys
+   ```
 
-Now try retrieving the secrets stored on the `kv/api-keys` path:
-
-```shell-session
-$ vault kv get kv/api-keys
-```
-
-The second command fails because the policy for `opsuser` does
-not grant access to the `/api-keys` path.
+   The second command fails because the policy for `opsuser` does
+   not grant access to the `/api-keys` path.
 
 You have successfully stored and retrieved your first secret value with a user
 from the `userpass` auth method.

--- a/website/content/docs/get-started/operations-qs.mdx
+++ b/website/content/docs/get-started/operations-qs.mdx
@@ -111,9 +111,9 @@ The `userpass` plugin uses basic authentication with usernames and passwords.
 
 ## Enable secrets engines
 
-Vault supports multiple [secrets engines](/vault/docs/secrets). These
-plugins support various use cases like storing static secrets, dynamic secrets,
-and managing PKI certificates.
+Vault supports multiple [secrets engine plugins](/vault/docs/secrets).
+You can use secret engine plugins to manage critical information like
+static secrets, dynamic secrets, and PKI certificates.
 
 Enable the `kv` secrets engine. This engine stores arbitrary secrets.
 

--- a/website/content/docs/get-started/operations-qs.mdx
+++ b/website/content/docs/get-started/operations-qs.mdx
@@ -178,7 +178,7 @@ Vault policies allow you to control access to secrets, and which operations are 
 
 ## Authenticate to Vault
 
-Authenticate to Vault using the `opsuser` user. When prompted, enter the
+Use `vault login` to authenticate to Vault using the `opsuser` user. When prompted, enter the
 password `p@ssw0rd`.
 
 ```shell-session

--- a/website/content/docs/get-started/operations-qs.mdx
+++ b/website/content/docs/get-started/operations-qs.mdx
@@ -77,7 +77,7 @@ on how to make your setup more production-ready.
 
 ## Enable auth methods
 
-Vault supports multiple [authentication methods](/vault/docs/auth). These
+Vault supports multiple [authentication methods](/vault/docs/auth). Authentication
 plugins authenticate both human and machine based workloads to Vault. In this
 quick start, you will use the `userpass` auth method.
 

--- a/website/content/docs/get-started/operations-qs.mdx
+++ b/website/content/docs/get-started/operations-qs.mdx
@@ -124,7 +124,6 @@ $ vault secrets enable -version=2 kv
 
 ## Store a secret
 
-Vault securely stores secrets static for a configured `kv` secrets engine.
 
 Write a secret to the `kv` secrets engine.
 

--- a/website/content/docs/get-started/operations-qs.mdx
+++ b/website/content/docs/get-started/operations-qs.mdx
@@ -139,7 +139,7 @@ secrets are written: The `username` key with a value of `opsuser` and the key
 ## Protect secrets
 
 In the previous step, you wrote a password to the `kv` secrets engine using the
-root token. Using the root token, and root policy, is not recommended for production environments.
+root token. The use of the root token, and root policy, is not recommended for production environments.
 
 Vault policies allow you to control access to secrets, and which operations are allowed.
 

--- a/website/content/docs/get-started/operations-qs.mdx
+++ b/website/content/docs/get-started/operations-qs.mdx
@@ -29,15 +29,6 @@ For a complete Vault learning experience, refer to the [Vault foundations tutori
 
 ## Start Vault
 
-<Warning>
-
-This in-memory “dev” server is useful for practicing with Vault locally for the
-first time, but is insecure and should never be used in production. For
-developers who need to manage their own production Vault installations, this
-[page](/vault/tutorials/operations/production-hardening) provides some guidance
-on how to make your setup more production-ready.
-
-</Warning>
 
 1. Start the Vault server in development mode.
 

--- a/website/content/docs/get-started/operations-qs.mdx
+++ b/website/content/docs/get-started/operations-qs.mdx
@@ -118,7 +118,7 @@ static secrets, dynamic secrets, and PKI certificates.
 The key/value plugin (`kv`) stores and versions arbitrary secrets. Use `vault secrets enable` to enable the key/value plugin:
 
 ```shell-session
-$ vault secrets enable -version=2 kv
+$ vault secrets enable -path shared -version 2 kv
 ```
 
 

--- a/website/content/docs/get-started/operations-qs.mdx
+++ b/website/content/docs/get-started/operations-qs.mdx
@@ -115,7 +115,7 @@ Vault supports multiple [secrets engine plugins](/vault/docs/secrets).
 You can use secret engine plugins to manage critical information like
 static secrets, dynamic secrets, and PKI certificates.
 
-Enable the `kv` secrets engine. This engine stores arbitrary secrets.
+The key/value plugin (`kv`) stores and versions arbitrary secrets. Use `vault secrets enable` to enable the key/value plugin:
 
 ```shell-session
 $ vault secrets enable -version=2 kv

--- a/website/content/docs/get-started/operations-qs.mdx
+++ b/website/content/docs/get-started/operations-qs.mdx
@@ -121,7 +121,6 @@ Enable the `kv` secrets engine. This engine stores arbitrary secrets.
 $ vault secrets enable -version=2 kv
 ```
 
-The `kv` secrets engine is enabled.
 
 ## Store a secret
 

--- a/website/content/docs/get-started/operations-qs.mdx
+++ b/website/content/docs/get-started/operations-qs.mdx
@@ -172,7 +172,8 @@ the operations allowed on plugin data.
    ```
 
 
-1. Attach the policy to the `opsuser` user.
+1. Use `vault write` to attach the policy to your `userpass` authentication
+   plugin policy for the `opsuser` user:
 
    ```shell-session
    $ vault write auth/userpass/users/opsuser \

--- a/website/content/docs/get-started/operations-qs.mdx
+++ b/website/content/docs/get-started/operations-qs.mdx
@@ -141,9 +141,16 @@ $ vault kv put   \
   username=opsuser password=p@ssw0rd
 ```
 
-The `kv put` command writes the secret to the `kv` secrets engine. In this example, two
-secrets are written: The `username` key with a value of `opsuser` and the key
-`password` with a value of `p@ssw0rd`.
+`kv put` writes the keys `username` and `password` and their values to
+the `/creds` path for the key/value plugin called `kv`. 
+
+Now write a third key to a separate path called `api-keys`:
+```shell-session
+$ vault kv put   \
+  -mount shared  \
+  kv/api-keys       \
+  square=1234
+```
 
 ## Protect secrets
 

--- a/website/content/docs/get-started/operations-qs.mdx
+++ b/website/content/docs/get-started/operations-qs.mdx
@@ -96,7 +96,6 @@ The `userpass` plugin uses basic authentication with usernames and passwords.
    $ vault auth enable approle
    ```
 
-   The `approle` auth method is enabled.
 
 1. (Optional) To authenticate workloads with Vault, you must create a role.
 

--- a/website/content/docs/get-started/operations-qs.mdx
+++ b/website/content/docs/get-started/operations-qs.mdx
@@ -187,7 +187,6 @@ $ vault login -method=userpass username=opsuser
 
 You are now authenticated to Vault.
 
-## Retrieve a secret
 
 You authenticated to Vault as the `opsuser` user. Retrieve the secrets from the
 path `kv/creds`. The `opsuser` user has access to the `kv/creds` path from the

--- a/website/content/docs/get-started/operations-qs.mdx
+++ b/website/content/docs/get-started/operations-qs.mdx
@@ -172,7 +172,7 @@ the operations allowed on plugin data.
 ## Authenticate to Vault
 
 Use `vault login` to authenticate to Vault using the `opsuser` user. When prompted, enter the
-password `p@ssw0rd`.
+password `p@ssw0rd`:
 
 ```shell-session
 $ vault login -method=userpass username=opsuser

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -11,16 +11,20 @@
     "title": "Get Started",
     "routes": [
       {
-        "title": "CLI Quick Start",
-        "href": "https://learn.hashicorp.com/collections/vault/getting-started"
+        "title": "Operations quick start",
+        "path": "get-started/operations-qs"
       },
       {
-        "title": "HCP Quick Start",
-        "href": "https://learn.hashicorp.com/collections/vault/cloud"
-      },
-      {
-        "title": "Developer Quick Start",
+        "title": "Developer quick start",
         "path": "get-started/developer-qs"
+      },
+      {
+        "title": "Vault foundations tutorials",
+        "href": "/vault/tutorials/get-started"
+      },
+      {
+        "title": "HCP Vault Dedicated tutorials",
+        "href": "/vault/tutorials/get-started-hcp-vault-dedicated"
       }
     ]
   },

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -11,12 +11,12 @@
     "title": "Get Started",
     "routes": [
       {
-        "title": "Operations quick start",
-        "path": "get-started/operations-qs"
-      },
-      {
         "title": "Developer quick start",
         "path": "get-started/developer-qs"
+      },
+      {
+        "title": "Operations quick start",
+        "path": "get-started/operations-qs"
       },
       {
         "title": "Vault foundations tutorials",


### PR DESCRIPTION
### Description
What does this PR do?

- Migrate basic steps from CLI quick start tutorial to ops quick start doc (not all steps were migrated).
- Tried to match flow/language to developer quick start doc
- Update nav to point to foundations tutorial (with tutorial in nav label to be clear)

🔍 [Deploy preview](https://vault-git-vault-retire-cli-quickstart-hashicorp.vercel.app/vault/docs/get-started/operations-qs)


### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
