### PR TITLE
go: don't download pipeline modules when caching build modules

### DIFF
--- a/scripts/go-helper.sh
+++ b/scripts/go-helper.sh
@@ -81,7 +81,7 @@ mod_download() {
     pushd "$(dirname "$mod")" > /dev/null || (echo "failed to push into module dir" && exit 1)
       GOOS=linux GOARCH=amd64 GOPRIVATE=github.com/hashicorp go mod download -x
     popd > /dev/null || (echo "failed to pop out of module dir" && exit 1)
-  done < <(find . -type f -name go.mod -print0)
+  done < <(find . -type f -name go.mod -not -path "./tools/pipeline/*" -print0 )
 }
 
 # Tidy all the go.mod's defined in the project.


### PR DESCRIPTION
### Description

Various different CI jobs need Go modules in order to build or test
Vault. To speed this up in CI we cache them in Github Actions.
The caching requires downloading all modules first in order to upload
them to the actions cache, which is performed by calling the
`go-mod-download` Make target. This target will iterate over the
directory tree and download Go modules in all directories that include
a `go.mod` file.

There are two small problems with this approach that we resolved with
this PR:
* Our `go-mod-download` target would download modules for all
  `go.mod`'s present in the directory tree, regardless of whether or not
  they are required to build or test Vault. Only downloading those
  required results in slightly smaller caches.
* `tools/pipeline` is intentionally a separate Go module so as to not
  require its modules in order to build Vault, however, our
  `go-mod-download` downloading all modules requires the workflow
  environment to include auth credentials for internal modules. If a
  community contributed PRs modifies a `go.mod`, which in turn requires
  a new cache, the PR will always fail because it cannot download
  modules that require secrets.

Now we avoid installing our `tools/pipeline` modules when generating our
module cache which should allow community contributed PRs to execute
build and Go tests, while skipping enos workflows which already required
secrets and were thus skipped.

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
