### PR TITLE
[VAULT-33146] Update tutorial link for creating a policy

### DIFF
--- a/changelog/29226.txt
+++ b/changelog/29226.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-ui: Update vault tutorial link.
+ui: Update tutorial link for creating a policy.
 ```

--- a/changelog/29226.txt
+++ b/changelog/29226.txt
@@ -1,3 +1,0 @@
-```release-note:improvement
-ui: Update tutorial link for creating a policy.
-```

--- a/changelog/29226.txt
+++ b/changelog/29226.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: Update vault tutorial link.
+```

--- a/ui/app/templates/vault/cluster/policies/index.hbs
+++ b/ui/app/templates/vault/cluster/policies/index.hbs
@@ -155,7 +155,7 @@
           @iconPosition="trailing"
           @icon="learn-link"
           @text="Getting started with policies"
-          @href={{doc-link "/vault/tutorials/getting-started/getting-started-policies"}}
+          @href={{doc-link "/vault/tutorials/get-started/introduction-policies"}}
         />
       {{else}}
         <Hds::Link::Standalone


### PR DESCRIPTION
### Description
What does this PR do?
Update tutorial link for creating a policy. 

Note: Had to get a little hacky to test/render screenshots. Hardcoded list & message if/else conditional in order to display empty state w/ link. Default state is not empty & unable to delete/remove default policy, so not sure when/if empty state is actually rendered.

Before:
![Screenshot 2024-12-19 at 12 04 37 PM](https://github.com/user-attachments/assets/245a99b4-7be2-4aad-88ba-c89c2398e934)

After:
"Getting started with policies" link points to new url
![Screenshot 2024-12-19 at 12 05 08 PM](https://github.com/user-attachments/assets/b307a5d9-6170-40f0-86ab-d8148121e414)



### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
