### PR TITLE
[BACKPORT] Add EDU as approvers for more granular targets

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -32,8 +32,8 @@
 /website/ @hashicorp/vault-education-approvers
 
 # Plugin docs
-/website/content/docs/plugins/              @hashicorp/vault-ecosystem
-/website/content/docs/upgrading/plugins.mdx @hashicorp/vault-ecosystem
+/website/content/docs/plugins/              @hashicorp/vault-ecosystem @hashicorp/vault-education-approvers
+/website/content/docs/upgrading/plugins.mdx @hashicorp/vault-ecosystem @hashicorp/vault-education-approvers
 
 /ui/  @hashicorp/vault-ui
 # UI code related to Vault's JWT/OIDC auth method and OIDC provider.
@@ -53,17 +53,17 @@
 # Cryptosec
 /builtin/logical/pki/                                @hashicorp/vault-crypto
 /builtin/logical/pkiext/                             @hashicorp/vault-crypto
-/website/content/docs/secrets/pki/                   @hashicorp/vault-crypto
-/website/content/api-docs/secret/pki.mdx             @hashicorp/vault-crypto
+/website/content/docs/secrets/pki/                   @hashicorp/vault-crypto @hashicorp/vault-education-approvers
+/website/content/api-docs/secret/pki.mdx             @hashicorp/vault-crypto @hashicorp/vault-education-approvers
 /builtin/credential/cert/                            @hashicorp/vault-crypto
-/website/content/docs/auth/cert.mdx                  @hashicorp/vault-crypto
-/website/content/api-docs/auth/cert.mdx              @hashicorp/vault-crypto
+/website/content/docs/auth/cert.mdx                  @hashicorp/vault-crypto @hashicorp/vault-education-approvers
+/website/content/api-docs/auth/cert.mdx              @hashicorp/vault-crypto @hashicorp/vault-education-approvers
 /builtin/logical/ssh/                                @hashicorp/vault-crypto
-/website/content/docs/secrets/ssh/                   @hashicorp/vault-crypto
-/website/content/api-docs/secret/ssh.mdx             @hashicorp/vault-crypto
+/website/content/docs/secrets/ssh/                   @hashicorp/vault-crypto @hashicorp/vault-education-approvers
+/website/content/api-docs/secret/ssh.mdx             @hashicorp/vault-crypto @hashicorp/vault-education-approvers
 /builtin/logical/transit/                            @hashicorp/vault-crypto
-/website/content/docs/secrets/transit/               @hashicorp/vault-crypto
-/website/content/api-docs/secret/transit.mdx         @hashicorp/vault-crypto
+/website/content/docs/secrets/transit/               @hashicorp/vault-crypto @hashicorp/vault-education-approvers
+/website/content/api-docs/secret/transit.mdx         @hashicorp/vault-crypto @hashicorp/vault-education-approvers
 /helper/random/                                      @hashicorp/vault-crypto
 /sdk/helper/certutil/                                @hashicorp/vault-crypto
 /sdk/helper/cryptoutil/                              @hashicorp/vault-crypto
@@ -77,13 +77,13 @@
 /vault/managed_key*                                  @hashicorp/vault-crypto
 /vault/seal*                                         @hashicorp/vault-crypto
 /vault/seal/                                         @hashicorp/vault-crypto
-/website/content/docs/configuration/seal/            @hashicorp/vault-crypto
-/website/content/docs/enterprise/sealwrap.mdx        @hashicorp/vault-crypto
-/website/content/api-docs/system/sealwrap-rewrap.mdx @hashicorp/vault-crypto
-/website/content/docs/secrets/transform/             @hashicorp/vault-crypto
-/website/content/api-docs/secret/transform.mdx       @hashicorp/vault-crypto
-/website/content/docs/secrets/kmip-profiles.mdx      @hashicorp/vault-crypto
-/website/content/docs/secrets/kmip.mdx               @hashicorp/vault-crypto
-/website/content/api-docs/secret/kmip.mdx            @hashicorp/vault-crypto
-/website/content/docs/enterprise/fips/               @hashicorp/vault-crypto
-/website/content/docs/platform/k8s                   @hashicorp/vault-ecosystem
+/website/content/docs/configuration/seal/            @hashicorp/vault-crypto @hashicorp/vault-education-approvers
+/website/content/docs/enterprise/sealwrap.mdx        @hashicorp/vault-crypto @hashicorp/vault-education-approvers
+/website/content/api-docs/system/sealwrap-rewrap.mdx @hashicorp/vault-crypto @hashicorp/vault-education-approvers
+/website/content/docs/secrets/transform/             @hashicorp/vault-crypto @hashicorp/vault-education-approvers
+/website/content/api-docs/secret/transform.mdx       @hashicorp/vault-crypto @hashicorp/vault-education-approvers
+/website/content/docs/secrets/kmip-profiles.mdx      @hashicorp/vault-crypto @hashicorp/vault-education-approvers
+/website/content/docs/secrets/kmip.mdx               @hashicorp/vault-crypto @hashicorp/vault-education-approvers
+/website/content/api-docs/secret/kmip.mdx            @hashicorp/vault-crypto @hashicorp/vault-education-approvers
+/website/content/docs/enterprise/fips/               @hashicorp/vault-crypto @hashicorp/vault-education-approvers
+/website/content/docs/platform/k8s                   @hashicorp/vault-ecosystem @hashicorp/vault-education-approvers


### PR DESCRIPTION
Manual backport of https://github.com/hashicorp/vault/pull/29124