### PR TITLE
Add OCI annotations to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,10 @@ LABEL name="Vault" \
       release=${PRODUCT_REVISION} \
       revision=${PRODUCT_REVISION} \
       summary="Vault is a tool for securely accessing secrets." \
-      description="Vault is a tool for securely accessing secrets. A secret is anything that you want to tightly control access to, such as API keys, passwords, certificates, and more. Vault provides a unified interface to any secret, while providing tight access control and recording a detailed audit log."
+      description="Vault is a tool for securely accessing secrets. A secret is anything that you want to tightly control access to, such as API keys, passwords, certificates, and more. Vault provides a unified interface to any secret, while providing tight access control and recording a detailed audit log." \
+      org.opencontainers.image.source="https://github.com/hashicorp/vault" \
+      org.opencontainers.image.version=${PRODUCT_VERSION} \
+      org.opencontainers.image.revision=${PRODUCT_REVISION}
 
 # Copy the license file as per Legal requirement
 COPY LICENSE /usr/share/doc/$NAME/LICENSE.txt


### PR DESCRIPTION
### Description

Solve #24393.

> Make the distributed docker image contain org.opencontainers.image.source label for easy reference back to this repository when the [hashicorp/vault](https://hub.docker.com/r/hashicorp/vault) image gets updates. This is useful for tools like Renovate that makes updates to repositories when this image gets updates. OCI has standardized a few labels for adding metadata to images: https://github.com/opencontainers/image-spec/blob/main/annotations.md