### PR TITLE
Reverting Dedup Until Local Mount

### DIFF
--- a/changelog/29145.txt
+++ b/changelog/29145.txt
@@ -1,4 +1,0 @@
-```release-note:improvement
-activity: Add a "local_mount" field to the Export API response. This field is true if the client is a token or created on a
-local mount.
-```

--- a/vault/activity_log_util_common.go
+++ b/vault/activity_log_util_common.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/axiomhq/hyperloglog"
+	semver "github.com/hashicorp/go-version"
 	"github.com/hashicorp/vault/helper/timeutil"
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/hashicorp/vault/vault/activity"
@@ -637,6 +638,28 @@ func (a *ActivityLog) getAllEntitySegmentsForMonth(ctx context.Context, path str
 		}
 	}
 	return segments, nil
+}
+
+// OldestVersionHasDeduplicatedClients returns whether this cluster is 1.19+, and
+// hence supports deduplicated clients
+func (a *ActivityLog) OldestVersionHasDeduplicatedClients(ctx context.Context) bool {
+	oldestVersionIsDedupClients := a.core.IsNewInstall(ctx)
+	if !oldestVersionIsDedupClients {
+		if v, _, err := a.core.FindOldestVersionTimestamp(); err == nil {
+			oldestVersion, err := semver.NewSemver(v)
+			if err != nil {
+				a.core.logger.Debug("could not extract version instance", "version", v)
+				return false
+			}
+			dedupChangeVersion, err := semver.NewSemver(DeduplicatedClientMinimumVersion)
+			if err != nil {
+				a.core.logger.Debug("could not extract version instance", "version", DeduplicatedClientMinimumVersion)
+				return false
+			}
+			oldestVersionIsDedupClients = oldestVersionIsDedupClients || oldestVersion.GreaterThanOrEqual(dedupChangeVersion)
+		}
+	}
+	return oldestVersionIsDedupClients
 }
 
 func (a *ActivityLog) loadClientDataIntoSegment(ctx context.Context, pathPrefix string, startTime time.Time, seqNum uint64, currentSegment *segmentInfo) ([]*activity.EntityRecord, error) {

--- a/vault/external_tests/activity_testonly/activity_testonly_test.go
+++ b/vault/external_tests/activity_testonly/activity_testonly_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: BUSL-1.1
 
-//go:build testonly
+////go:build testonly
 
 package activity_testonly
 
@@ -549,7 +549,6 @@ func getCSVExport(t *testing.T, client *api.Client, monthsPreviousTo int, now ti
 
 	boolFields := map[string]struct{}{
 		"local_entity_alias": {},
-		"local_mount":        {},
 	}
 
 	mapFields := map[string]struct{}{

--- a/vault/logical_system_activity.go
+++ b/vault/logical_system_activity.go
@@ -29,8 +29,6 @@ const (
 
 	// WarningCurrentMonthIsAnEstimate is a warning string that is used to let the customer know that for this query, the current month's data is estimated.
 	WarningCurrentMonthIsAnEstimate = "Since this usage period includes both the current month and at least one historical month, counts returned in this usage period are an estimate. Client counts for this period will no longer be estimated at the start of the next month."
-
-	ErrorUpgradeInProgress = "Upgrade to 1.19+ is in progress; the activity log is not queryable until the upgrade is complete"
 )
 
 // activityQueryPath is available in every namespace
@@ -295,9 +293,6 @@ func (b *SystemBackend) handleClientExport(ctx context.Context, req *logical.Req
 	if a == nil {
 		return logical.ErrorResponse("no activity log present"), nil
 	}
-	if !a.hasDedupClientsUpgrade(ctx) {
-		return logical.ErrorResponse(ErrorUpgradeInProgress), nil
-	}
 
 	startTime, endTime, err := parseStartEndTimes(d, b.Core.BillingStart())
 	if err != nil {
@@ -343,9 +338,6 @@ func (b *SystemBackend) handleClientMetricQuery(ctx context.Context, req *logica
 	b.Core.activityLogLock.RUnlock()
 	if a == nil {
 		return logical.ErrorResponse("no activity log present"), nil
-	}
-	if !a.hasDedupClientsUpgrade(ctx) {
-		return logical.ErrorResponse(ErrorUpgradeInProgress), nil
 	}
 
 	warnings := make([]string, 0)
@@ -393,9 +385,6 @@ func (b *SystemBackend) handleMonthlyActivityCount(ctx context.Context, req *log
 	if a == nil {
 		return logical.ErrorResponse("no activity log present"), nil
 	}
-	if !a.hasDedupClientsUpgrade(ctx) {
-		return logical.ErrorResponse(ErrorUpgradeInProgress), nil
-	}
 
 	results, err := a.partialMonthClientCount(ctx)
 	if err != nil {
@@ -416,9 +405,6 @@ func (b *SystemBackend) handleActivityConfigRead(ctx context.Context, req *logic
 	b.Core.activityLogLock.RUnlock()
 	if a == nil {
 		return logical.ErrorResponse("no activity log present"), nil
-	}
-	if !a.hasDedupClientsUpgrade(ctx) {
-		return logical.ErrorResponse(ErrorUpgradeInProgress), nil
 	}
 
 	config, err := a.loadConfigOrDefault(ctx)
@@ -453,9 +439,6 @@ func (b *SystemBackend) handleActivityConfigUpdate(ctx context.Context, req *log
 	b.Core.activityLogLock.RUnlock()
 	if a == nil {
 		return logical.ErrorResponse("no activity log present"), nil
-	}
-	if !a.hasDedupClientsUpgrade(ctx) {
-		return logical.ErrorResponse(ErrorUpgradeInProgress), nil
 	}
 
 	warnings := make([]string, 0)


### PR DESCRIPTION
### Description
Reverts three commits.
We will create an ENT PR for this. 


### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
