### PR TITLE
[VAULT-33207] Update Policy Modal links to use HDS, add ACL Policies "get started" link

### DIFF
--- a/ui/lib/core/addon/components/policy-example.hbs
+++ b/ui/lib/core/addon/components/policy-example.hbs
@@ -6,15 +6,16 @@
 <div class="has-bottom-margin-s">
   {{#if (eq @policyType "acl")}}
     <p data-test-example-modal-text="acl">
-      ACL Policies are written in Hashicorp Configuration Language (
-      <ExternalLink @href="https://github.com/hashicorp/hcl">HCL</ExternalLink>
+      <Hds::Link::Inline @href={{doc-link "/vault/tutorials/get-started/introduction-policies"}}>ACL Policies</Hds::Link::Inline>
+      are written in Hashicorp Configuration Language (
+      <Hds::Link::Inline @href="https://github.com/hashicorp/hcl">HCL</Hds::Link::Inline>
       ) or JSON and describe which paths in Vault a user or machine is allowed to access. Here is an example policy:
     </p>
   {{else if (eq @policyType "rgp")}}
     <p class="has-bottom-margin-s" data-test-example-modal-text="rgp">
       Role Governing Policies (RGPs) are tied to client tokens or identities which is similar to
-      <DocLink @path="/vault/tutorials/policies/policies">ACL policies</DocLink>. They use
-      <DocLink @path="/vault/docs/enterprise/sentinel">Sentinel</DocLink>
+      <Hds::Link::Inline @href={{doc-link "/vault/tutorials/policies/policies"}}>ACL policies</Hds::Link::Inline>. They use
+      <Hds::Link::Inline @href={{doc-link "/vault/docs/enterprise/sentinel"}}>Sentinel</Hds::Link::Inline>
       as a language framework to enable fine-grained policy decisions.
     </p>
     <p>
@@ -31,9 +32,9 @@
       Endpoint Governing Policies (EGPs) are tied to particular paths (e.g.
       <code class="tag is-marginless is-paddingless">aws/creds/</code>
       ) instead of tokens. They use
-      <ExternalLink @href="https://docs.hashicorp.com/sentinel/language">Sentinel</ExternalLink>
+      <Hds::Link::Inline @href="https://docs.hashicorp.com/sentinel/language">Sentinel</Hds::Link::Inline>
       as a language to access
-      <DocLink @path="/vault/docs/enterprise/sentinel/properties">properties</DocLink>
+      <Hds::Link::Inline @href={{doc-link "/vault/docs/enterprise/sentinel/properties"}}>properties</Hds::Link::Inline>
       of the incoming requests.
     </p>
     <p>
@@ -55,8 +56,11 @@
     More information about
     {{uppercase @policyType}}
     policies can be found
-    <DocLink @path={{get this.moreInformationLinks @policyType}} data-test-example-modal-information-link>
+    <Hds::Link::Inline
+      @href={{doc-link (get this.moreInformationLinks @policyType)}}
+      data-test-example-modal-information-link
+    >
       here.
-    </DocLink>
+    </Hds::Link::Inline>
   </p>
 </div>

--- a/ui/tests/integration/components/policy-example-test.js
+++ b/ui/tests/integration/components/policy-example-test.js
@@ -50,7 +50,7 @@ module('Integration | Component | policy-example', function (hooks) {
     assert
       .dom(SELECTORS.policyDescription('rgp'))
       .hasText(
-        'Role Governing Policies (RGPs) are tied to client tokens or identities which is similar to ACL policies . They use Sentinel as a language framework to enable fine-grained policy decisions.'
+        'Role Governing Policies (RGPs) are tied to client tokens or identities which is similar to ACL policies. They use Sentinel as a language framework to enable fine-grained policy decisions.'
       );
   });
 


### PR DESCRIPTION
### Description
What does this PR do? Updates to Policy Modal:
* Update all links to use HDS (Helios Design System) links
* Add link to "get started" with ACL Policies

### Screenshots: 

ACL Policy Modal: NEW Link: "ACL Policies"
<img width="1728" alt="Screenshot 2024-12-23 at 9 54 58 AM" src="https://github.com/user-attachments/assets/d9da6867-69d5-43a5-bd98-0cfe6071cbe7" />

ACL Policy Modal: UPDATED (to HDS) Link: "HCL"
<img width="1728" alt="Screenshot 2024-12-23 at 9 55 04 AM" src="https://github.com/user-attachments/assets/375b7e40-6164-4095-9c15-5389bb036ed0" />

ACL Policy Modal: UPDATED (to HDS) Link: "here" (policy capabilities)
<img width="1728" alt="Screenshot 2024-12-23 at 9 55 11 AM" src="https://github.com/user-attachments/assets/cb1eebda-115c-4f2e-a715-18c90059fa37" />

Role-Governing Policy Modal: UPDATED (to HDS) Link: "ACL Policies"
<img width="1728" alt="Screenshot 2024-12-23 at 9 55 22 AM" src="https://github.com/user-attachments/assets/c39a978d-42ca-49d4-9cad-0b4ca84f1a34" />

Role-Governing Policy Modal: UPDATED (to HDS) Link: "Sentinel"
<img width="1728" alt="Screenshot 2024-12-23 at 9 55 29 AM" src="https://github.com/user-attachments/assets/c2793494-250d-40d2-a8ce-d1d106b70caf" />

Role-Governing Policy Modal: UPDATED (to HDS) Link: "here" (sentinel role governing policies)
<img width="1728" alt="Screenshot 2024-12-23 at 9 55 35 AM" src="https://github.com/user-attachments/assets/11f3b46b-2cf4-4ac5-a538-1876ab7fdc6e" />

Endpoint Governing Policy Modal: UPDATED (to HDS) Link: "Sentinel"
<img width="1728" alt="Screenshot 2024-12-23 at 9 55 48 AM" src="https://github.com/user-attachments/assets/4241b36f-9b34-4643-a3e7-3fa8a249c58f" />

Endpoint Governing Policy Modal: UPDATED (to HDS) Link: "properties"
<img width="1728" alt="Screenshot 2024-12-23 at 9 55 54 AM" src="https://github.com/user-attachments/assets/da3cffd3-b17f-488f-aa1a-5f3d670007c0" />

Endpoint Governing Policy Modal: UPDATED (to HDS) Link: "here" (sentinel endpoint governing policies)
<img width="1728" alt="Screenshot 2024-12-23 at 9 56 01 AM" src="https://github.com/user-attachments/assets/64f2e01a-2428-4e85-8a1b-2daa8609b649" />


### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
