### PR TITLE
UI: Fix open API failures for pki name constraint params

### DIFF
--- a/ui/tests/acceptance/open-api-path-help-test.js
+++ b/ui/tests/acceptance/open-api-path-help-test.js
@@ -80,7 +80,7 @@ function secretEngineHelper(test, secretEngine) {
       assert.deepEqual(
         Object.keys(result).sort(),
         Object.keys(expected).sort(),
-        `getProps returns expected attributes for ${modelName}`
+        `getProps returns expected attributes for ${modelName} (help url: "${helpUrl}")`
       );
       Object.keys(expected).forEach((attrName) => {
         assert.deepEqual(result[attrName], expected[attrName], `${attrName} attribute details match`);

--- a/ui/tests/helpers/openapi/expected-secret-attrs.js
+++ b/ui/tests/helpers/openapi/expected-secret-attrs.js
@@ -1234,6 +1234,34 @@ const pki = {
       label: 'Exclude Common Name from Subject Alternative Names (SANs)',
       type: 'boolean',
     },
+    excludedDnsDomains: {
+      editType: 'stringArray',
+      fieldGroup: 'default',
+      helpText:
+        'Domains for which this certificate is not allowed to sign or issue child certificates (see https://tools.ietf.org/html/rfc5280#section-4.2.1.10).',
+      label: 'Excluded DNS Domains',
+    },
+    excludedEmailAddresses: {
+      editType: 'stringArray',
+      fieldGroup: 'default',
+      helpText:
+        'Email addresses for which this certificate is not allowed to sign or issue child certificates (see https://tools.ietf.org/html/rfc5280#section-4.2.1.10).',
+      label: 'Excluded email addresses',
+    },
+    excludedIpRanges: {
+      editType: 'stringArray',
+      fieldGroup: 'default',
+      helpText:
+        'IP ranges for which this certificate is not allowed to sign or issue child certificates (see https://tools.ietf.org/html/rfc5280#section-4.2.1.10). Ranges must be specified in the notation of IP address and prefix length, like "192.0.2.0/24" or "2001:db8::/32", as defined in RFC 4632 and RFC 4291.',
+      label: 'Excluded IP ranges',
+    },
+    excludedUriDomains: {
+      editType: 'stringArray',
+      fieldGroup: 'default',
+      helpText:
+        'URI domains for which this certificate is not allowed to sign or issue child certificates (see https://tools.ietf.org/html/rfc5280#section-4.2.1.10).',
+      label: 'Excluded URI domains',
+    },
     format: {
       editType: 'string',
       helpText:
@@ -1311,6 +1339,27 @@ const pki = {
         'Domains for which this certificate is allowed to sign or issue child certificates. If set, all DNS names (subject and alt) on child certs must be exact matches or subsets of the given domains (see https://tools.ietf.org/html/rfc5280#section-4.2.1.10).',
       fieldGroup: 'default',
       label: 'Permitted DNS Domains',
+    },
+    permittedEmailAddresses: {
+      editType: 'stringArray',
+      fieldGroup: 'default',
+      helpText:
+        'Email addresses for which this certificate is allowed to sign or issue child certificates (see https://tools.ietf.org/html/rfc5280#section-4.2.1.10).',
+      label: 'Permitted email adresses',
+    },
+    permittedIpRanges: {
+      editType: 'stringArray',
+      fieldGroup: 'default',
+      helpText:
+        'IP ranges for which this certificate is allowed to sign or issue child certificates (see https://tools.ietf.org/html/rfc5280#section-4.2.1.10). Ranges must be specified in the notation of IP address and prefix length, like "192.0.2.0/24" or "2001:db8::/32", as defined in RFC 4632 and RFC 4291.',
+      label: 'Permitted IP ranges',
+    },
+    permittedUriDomains: {
+      editType: 'stringArray',
+      fieldGroup: 'default',
+      helpText:
+        'URI domains for which this certificate is allowed to sign or issue child certificates (see https://tools.ietf.org/html/rfc5280#section-4.2.1.10).',
+      label: 'Permitted URI domains',
     },
     postalCode: {
       editType: 'stringArray',


### PR DESCRIPTION
### Description
Fixes open API failures for params added by https://github.com/hashicorp/vault/pull/29245

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
