### PR TITLE
[VAULT-33207] Update Policy Modal to add isHrefExternal to External Links

### DIFF
--- a/ui/lib/core/addon/components/policy-example.hbs
+++ b/ui/lib/core/addon/components/policy-example.hbs
@@ -8,7 +8,7 @@
     <p data-test-example-modal-text="acl">
       <Hds::Link::Inline @href={{doc-link "/vault/tutorials/get-started/introduction-policies"}}>ACL Policies</Hds::Link::Inline>
       are written in Hashicorp Configuration Language (
-      <Hds::Link::Inline @href="https://github.com/hashicorp/hcl">HCL</Hds::Link::Inline>
+      <Hds::Link::Inline @isHrefExternal={{true}} @href="https://github.com/hashicorp/hcl">HCL</Hds::Link::Inline>
       ) or JSON and describe which paths in Vault a user or machine is allowed to access. Here is an example policy:
     </p>
   {{else if (eq @policyType "rgp")}}
@@ -32,7 +32,10 @@
       Endpoint Governing Policies (EGPs) are tied to particular paths (e.g.
       <code class="tag is-marginless is-paddingless">aws/creds/</code>
       ) instead of tokens. They use
-      <Hds::Link::Inline @href="https://docs.hashicorp.com/sentinel/language">Sentinel</Hds::Link::Inline>
+      <Hds::Link::Inline
+        @isHrefExternal={{true}}
+        @href="https://docs.hashicorp.com/sentinel/language"
+      >Sentinel</Hds::Link::Inline>
       as a language to access
       <Hds::Link::Inline @href={{doc-link "/vault/docs/enterprise/sentinel/properties"}}>properties</Hds::Link::Inline>
       of the incoming requests.

--- a/ui/lib/core/addon/components/policy-example.hbs
+++ b/ui/lib/core/addon/components/policy-example.hbs
@@ -6,7 +6,8 @@
 <div class="has-bottom-margin-s">
   {{#if (eq @policyType "acl")}}
     <p data-test-example-modal-text="acl">
-      <Hds::Link::Inline @href={{doc-link "/vault/tutorials/get-started/introduction-policies"}}>ACL Policies</Hds::Link::Inline>
+      <Hds::Link::Inline @isHrefExternal={{true}} @href={{doc-link "/vault/tutorials/get-started/introduction-policies"}}>ACL
+        Policies</Hds::Link::Inline>
       are written in Hashicorp Configuration Language (
       <Hds::Link::Inline @isHrefExternal={{true}} @href="https://github.com/hashicorp/hcl">HCL</Hds::Link::Inline>
       ) or JSON and describe which paths in Vault a user or machine is allowed to access. Here is an example policy:
@@ -14,8 +15,12 @@
   {{else if (eq @policyType "rgp")}}
     <p class="has-bottom-margin-s" data-test-example-modal-text="rgp">
       Role Governing Policies (RGPs) are tied to client tokens or identities which is similar to
-      <Hds::Link::Inline @href={{doc-link "/vault/tutorials/policies/policies"}}>ACL policies</Hds::Link::Inline>. They use
-      <Hds::Link::Inline @href={{doc-link "/vault/docs/enterprise/sentinel"}}>Sentinel</Hds::Link::Inline>
+      <Hds::Link::Inline @isHrefExternal={{true}} @href={{doc-link "/vault/tutorials/policies/policies"}}>ACL policies</Hds::Link::Inline>.
+      They use
+      <Hds::Link::Inline
+        @isHrefExternal={{true}}
+        @href={{doc-link "/vault/docs/enterprise/sentinel"}}
+      >Sentinel</Hds::Link::Inline>
       as a language framework to enable fine-grained policy decisions.
     </p>
     <p>
@@ -37,7 +42,10 @@
         @href="https://docs.hashicorp.com/sentinel/language"
       >Sentinel</Hds::Link::Inline>
       as a language to access
-      <Hds::Link::Inline @href={{doc-link "/vault/docs/enterprise/sentinel/properties"}}>properties</Hds::Link::Inline>
+      <Hds::Link::Inline
+        @isHrefExternal={{true}}
+        @href={{doc-link "/vault/docs/enterprise/sentinel/properties"}}
+      >properties</Hds::Link::Inline>
       of the incoming requests.
     </p>
     <p>
@@ -60,6 +68,7 @@
     {{uppercase @policyType}}
     policies can be found
     <Hds::Link::Inline
+      @isHrefExternal={{true}}
       @href={{doc-link (get this.moreInformationLinks @policyType)}}
       data-test-example-modal-information-link
     >


### PR DESCRIPTION
### Description
What does this PR do? This is a followup PR to add `isHrefExternal` attribute to external HDS links in the Policy Modal
Original PR: https://github.com/hashicorp/vault/pull/29254

### Screenshots
ACL Policies: HCL Link
<img width="1728" alt="Screenshot 2024-12-26 at 3 24 58 PM" src="https://github.com/user-attachments/assets/2b49386a-e781-462b-ae7e-1904668b2228" />

Endpoint Governing Policies: Sentinel Link
<img width="1728" alt="Screenshot 2024-12-26 at 3 28 52 PM" src="https://github.com/user-attachments/assets/8623740a-cf73-426d-bd8d-6a66472c2137" />



### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
