### PR TITLE
fixes for flakes in raft removed tests

### DIFF
--- a/helper/testhelpers/testhelpers.go
+++ b/helper/testhelpers/testhelpers.go
@@ -1003,3 +1003,15 @@ func WaitForNodesExcludingSelectedStandbys(t testing.TB, cluster *vault.TestClus
 func IsLocalOrRegressionTests() bool {
 	return os.Getenv("CI") == "" || os.Getenv("VAULT_REGRESSION_TESTS") == "true"
 }
+
+func RaftDataDir(t testing.TB, core *vault.TestClusterCore) string {
+	t.Helper()
+	r, ok := core.UnderlyingStorage.(*raft.RaftBackend)
+	if !ok {
+		r, ok = core.UnderlyingHAStorage.(*raft.RaftBackend)
+		if !ok {
+			t.Fatal("no raft backend")
+		}
+	}
+	return r.DataDir(t)
+}

--- a/physical/raft/testing.go
+++ b/physical/raft/testing.go
@@ -13,6 +13,11 @@ import (
 	"github.com/hashicorp/go-uuid"
 )
 
+func (b *RaftBackend) DataDir(t testing.TB) string {
+	t.Helper()
+	return b.dataDir
+}
+
 func GetRaft(t testing.TB, bootstrap bool, noStoreState bool) (*RaftBackend, string) {
 	return getRaftInternal(t, bootstrap, defaultRaftConfig(t, bootstrap, noStoreState), nil, nil, nil)
 }

--- a/vault/external_tests/raft/raft_test.go
+++ b/vault/external_tests/raft/raft_test.go
@@ -1378,14 +1378,26 @@ func TestRaftCluster_Removed(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	_, err = cluster.Cores[0].Client.Logical().Write("/sys/storage/raft/remove-peer", map[string]interface{}{
+	leaderClient := cluster.Cores[0].Client
+	_, err = leaderClient.Logical().Write("/sys/storage/raft/remove-peer", map[string]interface{}{
 		"server_id": follower.NodeID,
 	})
+	require.NoError(t, err)
 	followerClient.SetCheckRedirect(func(request *http.Request, requests []*http.Request) error {
 		require.Fail(t, "request caused a redirect", request.URL.Path)
 		return fmt.Errorf("no redirects allowed")
 	})
-	require.NoError(t, err)
+	configChanged := func() bool {
+		config, err := leaderClient.Logical().Read("sys/storage/raft/configuration")
+		require.NoError(t, err)
+		cfg := config.Data["config"].(map[string]interface{})
+		servers := cfg["servers"].([]interface{})
+		return len(servers) == 2
+	}
+	// raft config changes happen async, so block until the config change is
+	// applied
+	require.Eventually(t, configChanged, 3*time.Second, 50*time.Millisecond)
+
 	_, err = followerClient.Logical().Write("secret/foo", map[string]interface{}{
 		"test": "other_data",
 	})
@@ -1555,7 +1567,7 @@ func TestRaftCluster_Removed_ReAdd(t *testing.T) {
 		"server_id": follower.NodeID,
 	})
 	require.NoError(t, err)
-	require.Eventually(t, follower.Sealed, 3*time.Second, 250*time.Millisecond)
+	require.Eventually(t, follower.Sealed, 10*time.Second, 250*time.Millisecond)
 
 	joinReq := &api.RaftJoinRequest{LeaderAPIAddr: leader.Address.String()}
 	_, err = follower.Client.Sys().RaftJoin(joinReq)

--- a/vault/external_tests/raftha/raft_ha_test.go
+++ b/vault/external_tests/raftha/raft_ha_test.go
@@ -371,7 +371,7 @@ func TestRaftHACluster_Removed_ReAdd(t *testing.T) {
 		"server_id": follower.NodeID,
 	})
 	require.NoError(t, err)
-	require.Eventually(t, follower.Sealed, 3*time.Second, 250*time.Millisecond)
+	require.Eventually(t, follower.Sealed, 10*time.Second, 250*time.Millisecond)
 
 	_, err = follower.Client.Sys().RaftJoin(joinReq)
 	require.Error(t, err)


### PR DESCRIPTION
### Description
Updates the tests to fix occasional flakes.

Adds a helper method for an enterprise test. Enterprise PR: https://github.com/hashicorp/vault-enterprise/pull/7199

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
