### PR TITLE
CE side changes to key policy engine for ML-DSA/Hybrid support

### DIFF
--- a/builtin/logical/pki/cert_util_test.go
+++ b/builtin/logical/pki/cert_util_test.go
@@ -8,7 +8,6 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"fmt"
-	"github.com/hashicorp/vault/sdk/helper/testhelpers/schema"
 	"net"
 	"net/url"
 	"os"
@@ -23,6 +22,7 @@ import (
 	"github.com/hashicorp/vault/builtin/logical/pki/parsing"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/helper/certutil"
+	"github.com/hashicorp/vault/sdk/helper/testhelpers/schema"
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/stretchr/testify/require"
 )

--- a/builtin/logical/transit/backend_ce.go
+++ b/builtin/logical/transit/backend_ce.go
@@ -24,3 +24,5 @@ func (b *backend) periodicFuncEnt(_ context.Context, _ *logical.Request) error {
 func (b *backend) cleanupEnt(_ context.Context) {}
 
 func (b *backend) setupEnt() {}
+
+func entAugmentAsymKey(p *keysutil.Policy, k string, v keysutil.KeyEntry, key *asymKey) {}

--- a/builtin/logical/transit/backend_ce.go
+++ b/builtin/logical/transit/backend_ce.go
@@ -24,5 +24,3 @@ func (b *backend) periodicFuncEnt(_ context.Context, _ *logical.Request) error {
 func (b *backend) cleanupEnt(_ context.Context) {}
 
 func (b *backend) setupEnt() {}
-
-func entAugmentAsymKey(p *keysutil.Policy, k string, v keysutil.KeyEntry, key *asymKey) {}

--- a/builtin/logical/transit/path_export_ce_test.go
+++ b/builtin/logical/transit/path_export_ce_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
 //go:build !enterprise
 
 package transit

--- a/builtin/logical/transit/path_export_ce_test.go
+++ b/builtin/logical/transit/path_export_ce_test.go
@@ -1,0 +1,7 @@
+//go:build !enterprise
+
+package transit
+
+import "testing"
+
+func entTestExportsCorrectVersion(t *testing.T) {}

--- a/builtin/logical/transit/path_export_test.go
+++ b/builtin/logical/transit/path_export_test.go
@@ -62,37 +62,39 @@ func TestTransit_Export_Unknown_ExportType(t *testing.T) {
 func TestTransit_Export_KeyVersion_ExportsCorrectVersion(t *testing.T) {
 	t.Parallel()
 
-	verifyExportsCorrectVersion(t, "encryption-key", "aes128-gcm96")
-	verifyExportsCorrectVersion(t, "encryption-key", "aes256-gcm96")
-	verifyExportsCorrectVersion(t, "encryption-key", "chacha20-poly1305")
-	verifyExportsCorrectVersion(t, "encryption-key", "rsa-2048")
-	verifyExportsCorrectVersion(t, "encryption-key", "rsa-3072")
-	verifyExportsCorrectVersion(t, "encryption-key", "rsa-4096")
-	verifyExportsCorrectVersion(t, "signing-key", "ecdsa-p256")
-	verifyExportsCorrectVersion(t, "signing-key", "ecdsa-p384")
-	verifyExportsCorrectVersion(t, "signing-key", "ecdsa-p521")
-	verifyExportsCorrectVersion(t, "signing-key", "ed25519")
-	verifyExportsCorrectVersion(t, "signing-key", "rsa-2048")
-	verifyExportsCorrectVersion(t, "signing-key", "rsa-3072")
-	verifyExportsCorrectVersion(t, "signing-key", "rsa-4096")
-	verifyExportsCorrectVersion(t, "hmac-key", "aes128-gcm96")
-	verifyExportsCorrectVersion(t, "hmac-key", "aes256-gcm96")
-	verifyExportsCorrectVersion(t, "hmac-key", "chacha20-poly1305")
-	verifyExportsCorrectVersion(t, "hmac-key", "ecdsa-p256")
-	verifyExportsCorrectVersion(t, "hmac-key", "ecdsa-p384")
-	verifyExportsCorrectVersion(t, "hmac-key", "ecdsa-p521")
-	verifyExportsCorrectVersion(t, "hmac-key", "ed25519")
-	verifyExportsCorrectVersion(t, "hmac-key", "hmac")
-	verifyExportsCorrectVersion(t, "public-key", "rsa-2048")
-	verifyExportsCorrectVersion(t, "public-key", "rsa-3072")
-	verifyExportsCorrectVersion(t, "public-key", "rsa-4096")
-	verifyExportsCorrectVersion(t, "public-key", "ecdsa-p256")
-	verifyExportsCorrectVersion(t, "public-key", "ecdsa-p384")
-	verifyExportsCorrectVersion(t, "public-key", "ecdsa-p521")
-	verifyExportsCorrectVersion(t, "public-key", "ed25519")
+	verifyExportsCorrectVersion(t, "encryption-key", "aes128-gcm96", "", "")
+	verifyExportsCorrectVersion(t, "encryption-key", "aes256-gcm96", "", "")
+	verifyExportsCorrectVersion(t, "encryption-key", "chacha20-poly1305", "", "")
+	verifyExportsCorrectVersion(t, "encryption-key", "rsa-2048", "", "")
+	verifyExportsCorrectVersion(t, "encryption-key", "rsa-3072", "", "")
+	verifyExportsCorrectVersion(t, "encryption-key", "rsa-4096", "", "")
+	verifyExportsCorrectVersion(t, "signing-key", "ecdsa-p256", "", "")
+	verifyExportsCorrectVersion(t, "signing-key", "ecdsa-p384", "", "")
+	verifyExportsCorrectVersion(t, "signing-key", "ecdsa-p521", "", "")
+	verifyExportsCorrectVersion(t, "signing-key", "ed25519", "", "")
+	verifyExportsCorrectVersion(t, "signing-key", "rsa-2048", "", "")
+	verifyExportsCorrectVersion(t, "signing-key", "rsa-3072", "", "")
+	verifyExportsCorrectVersion(t, "signing-key", "rsa-4096", "", "")
+	verifyExportsCorrectVersion(t, "signing-key", "ml-dsa", "44", "")
+	verifyExportsCorrectVersion(t, "signing-key", "hybrid", "44", "ed25519")
+	verifyExportsCorrectVersion(t, "hmac-key", "aes128-gcm96", "", "")
+	verifyExportsCorrectVersion(t, "hmac-key", "aes256-gcm96", "", "")
+	verifyExportsCorrectVersion(t, "hmac-key", "chacha20-poly1305", "", "")
+	verifyExportsCorrectVersion(t, "hmac-key", "ecdsa-p256", "", "")
+	verifyExportsCorrectVersion(t, "hmac-key", "ecdsa-p384", "", "")
+	verifyExportsCorrectVersion(t, "hmac-key", "ecdsa-p521", "", "")
+	verifyExportsCorrectVersion(t, "hmac-key", "ed25519", "", "")
+	verifyExportsCorrectVersion(t, "hmac-key", "hmac", "", "")
+	verifyExportsCorrectVersion(t, "public-key", "rsa-2048", "", "")
+	verifyExportsCorrectVersion(t, "public-key", "rsa-3072", "", "")
+	verifyExportsCorrectVersion(t, "public-key", "rsa-4096", "", "")
+	verifyExportsCorrectVersion(t, "public-key", "ecdsa-p256", "", "")
+	verifyExportsCorrectVersion(t, "public-key", "ecdsa-p384", "", "")
+	verifyExportsCorrectVersion(t, "public-key", "ecdsa-p521", "", "")
+	verifyExportsCorrectVersion(t, "public-key", "ed25519", "", "")
 }
 
-func verifyExportsCorrectVersion(t *testing.T, exportType, keyType string) {
+func verifyExportsCorrectVersion(t *testing.T, exportType, keyType, parameterSet, ecKeyType string) {
 	b, storage := createBackendWithSysView(t)
 
 	// First create a key, v1
@@ -104,6 +106,13 @@ func verifyExportsCorrectVersion(t *testing.T, exportType, keyType string) {
 	req.Data = map[string]interface{}{
 		"exportable": true,
 		"type":       keyType,
+	}
+	if parameterSet != "" {
+		req.Data["parameter_set"] = parameterSet
+	}
+	if ecKeyType != "" {
+		req.Data["hybrid_key_type_pqc"] = "ml-dsa"
+		req.Data["hybrid_key_type_ec"] = ecKeyType
 	}
 	if keyType == "hmac" {
 		req.Data["key_size"] = 32

--- a/builtin/logical/transit/path_export_test.go
+++ b/builtin/logical/transit/path_export_test.go
@@ -75,8 +75,6 @@ func TestTransit_Export_KeyVersion_ExportsCorrectVersion(t *testing.T) {
 	verifyExportsCorrectVersion(t, "signing-key", "rsa-2048", "", "")
 	verifyExportsCorrectVersion(t, "signing-key", "rsa-3072", "", "")
 	verifyExportsCorrectVersion(t, "signing-key", "rsa-4096", "", "")
-	verifyExportsCorrectVersion(t, "signing-key", "ml-dsa", "44", "")
-	verifyExportsCorrectVersion(t, "signing-key", "hybrid", "44", "ed25519")
 	verifyExportsCorrectVersion(t, "hmac-key", "aes128-gcm96", "", "")
 	verifyExportsCorrectVersion(t, "hmac-key", "aes256-gcm96", "", "")
 	verifyExportsCorrectVersion(t, "hmac-key", "chacha20-poly1305", "", "")
@@ -92,106 +90,109 @@ func TestTransit_Export_KeyVersion_ExportsCorrectVersion(t *testing.T) {
 	verifyExportsCorrectVersion(t, "public-key", "ecdsa-p384", "", "")
 	verifyExportsCorrectVersion(t, "public-key", "ecdsa-p521", "", "")
 	verifyExportsCorrectVersion(t, "public-key", "ed25519", "", "")
+	entTestExportsCorrectVersion(t)
 }
 
 func verifyExportsCorrectVersion(t *testing.T, exportType, keyType, parameterSet, ecKeyType string) {
-	b, storage := createBackendWithSysView(t)
+	t.Run(keyType+":"+ecKeyType, func(t *testing.T) {
+		b, storage := createBackendWithSysView(t)
 
-	// First create a key, v1
-	req := &logical.Request{
-		Storage:   storage,
-		Operation: logical.UpdateOperation,
-		Path:      "keys/foo",
-	}
-	req.Data = map[string]interface{}{
-		"exportable": true,
-		"type":       keyType,
-	}
-	if parameterSet != "" {
-		req.Data["parameter_set"] = parameterSet
-	}
-	if ecKeyType != "" {
-		req.Data["hybrid_key_type_pqc"] = "ml-dsa"
-		req.Data["hybrid_key_type_ec"] = ecKeyType
-	}
-	if keyType == "hmac" {
-		req.Data["key_size"] = 32
-	}
-	_, err := b.HandleRequest(context.Background(), req)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	verifyVersion := func(versionRequest string, expectedVersion int) {
+		// First create a key, v1
 		req := &logical.Request{
 			Storage:   storage,
-			Operation: logical.ReadOperation,
-			Path:      fmt.Sprintf("export/%s/foo/%s", exportType, versionRequest),
+			Operation: logical.UpdateOperation,
+			Path:      "keys/foo",
 		}
-		rsp, err := b.HandleRequest(context.Background(), req)
+		req.Data = map[string]interface{}{
+			"exportable": true,
+			"type":       keyType,
+		}
+		if parameterSet != "" {
+			req.Data["parameter_set"] = parameterSet
+		}
+		if ecKeyType != "" {
+			req.Data["hybrid_key_type_pqc"] = "ml-dsa"
+			req.Data["hybrid_key_type_ec"] = ecKeyType
+		}
+		if keyType == "hmac" {
+			req.Data["key_size"] = 32
+		}
+		_, err := b.HandleRequest(context.Background(), req)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		typRaw, ok := rsp.Data["type"]
-		if !ok {
-			t.Fatal("no type returned from export")
-		}
-		typ, ok := typRaw.(string)
-		if !ok {
-			t.Fatalf("could not find key type, resp data is %#v", rsp.Data)
-		}
-		if typ != keyType {
-			t.Fatalf("key type mismatch; %q vs %q", typ, keyType)
-		}
+		verifyVersion := func(versionRequest string, expectedVersion int) {
+			req := &logical.Request{
+				Storage:   storage,
+				Operation: logical.ReadOperation,
+				Path:      fmt.Sprintf("export/%s/foo/%s", exportType, versionRequest),
+			}
+			rsp, err := b.HandleRequest(context.Background(), req)
+			if err != nil {
+				t.Fatal(err)
+			}
 
-		keysRaw, ok := rsp.Data["keys"]
-		if !ok {
-			t.Fatal("could not find keys value")
-		}
-		keys, ok := keysRaw.(map[string]string)
-		if !ok {
-			t.Fatal("could not cast to keys map")
-		}
-		if len(keys) != 1 {
-			t.Fatal("unexpected number of keys found")
-		}
+			typRaw, ok := rsp.Data["type"]
+			if !ok {
+				t.Fatal("no type returned from export")
+			}
+			typ, ok := typRaw.(string)
+			if !ok {
+				t.Fatalf("could not find key type, resp data is %#v", rsp.Data)
+			}
+			if typ != keyType {
+				t.Fatalf("key type mismatch; %q vs %q", typ, keyType)
+			}
 
-		for k := range keys {
-			if k != strconv.Itoa(expectedVersion) {
-				t.Fatalf("expected version %q, received version %q", strconv.Itoa(expectedVersion), k)
+			keysRaw, ok := rsp.Data["keys"]
+			if !ok {
+				t.Fatal("could not find keys value")
+			}
+			keys, ok := keysRaw.(map[string]string)
+			if !ok {
+				t.Fatal("could not cast to keys map")
+			}
+			if len(keys) != 1 {
+				t.Fatal("unexpected number of keys found")
+			}
+
+			for k := range keys {
+				if k != strconv.Itoa(expectedVersion) {
+					t.Fatalf("expected version %q, received version %q", strconv.Itoa(expectedVersion), k)
+				}
 			}
 		}
-	}
 
-	verifyVersion("v1", 1)
-	verifyVersion("1", 1)
-	verifyVersion("latest", 1)
+		verifyVersion("v1", 1)
+		verifyVersion("1", 1)
+		verifyVersion("latest", 1)
 
-	req.Path = "keys/foo/rotate"
-	// v2
-	_, err = b.HandleRequest(context.Background(), req)
-	if err != nil {
-		t.Fatal(err)
-	}
+		req.Path = "keys/foo/rotate"
+		// v2
+		_, err = b.HandleRequest(context.Background(), req)
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	verifyVersion("v1", 1)
-	verifyVersion("1", 1)
-	verifyVersion("v2", 2)
-	verifyVersion("2", 2)
-	verifyVersion("latest", 2)
+		verifyVersion("v1", 1)
+		verifyVersion("1", 1)
+		verifyVersion("v2", 2)
+		verifyVersion("2", 2)
+		verifyVersion("latest", 2)
 
-	// v3
-	_, err = b.HandleRequest(context.Background(), req)
-	if err != nil {
-		t.Fatal(err)
-	}
+		// v3
+		_, err = b.HandleRequest(context.Background(), req)
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	verifyVersion("v1", 1)
-	verifyVersion("1", 1)
-	verifyVersion("v3", 3)
-	verifyVersion("3", 3)
-	verifyVersion("latest", 3)
+		verifyVersion("v1", 1)
+		verifyVersion("1", 1)
+		verifyVersion("v3", 3)
+		verifyVersion("3", 3)
+		verifyVersion("latest", 3)
+	})
 }
 
 func TestTransit_Export_ValidVersionsOnly(t *testing.T) {

--- a/builtin/logical/transit/path_import.go
+++ b/builtin/logical/transit/path_import.go
@@ -46,7 +46,7 @@ func (b *backend) pathImport() *framework.Path {
 				Default: "aes256-gcm96",
 				Description: `The type of key being imported. Currently, "aes128-gcm96" (symmetric), "aes256-gcm96" (symmetric), "ecdsa-p256"
 (asymmetric), "ecdsa-p384" (asymmetric), "ecdsa-p521" (asymmetric), "ed25519" (asymmetric), "rsa-2048" (asymmetric), "rsa-3072"
-(asymmetric), "rsa-4096" (asymmetric), "hmac", "aes128-cmac", "aes256-cmac" are supported.  Defaults to "aes256-gcm96".
+(asymmetric), "rsa-4096" (asymmetric), "ml-dsa-44 (asymmetric)", "ml-dsa-65 (asymmetric)", "ml-dsa-87 (asymmetric)", "hmac", "aes128-cmac", "aes256-cmac" are supported.  Defaults to "aes256-gcm96".
 `,
 			},
 			"hash_function": {

--- a/builtin/logical/transit/path_keys.go
+++ b/builtin/logical/transit/path_keys.go
@@ -143,7 +143,7 @@ Supported types are: ML-DSA.`,
 			"hybrid_key_type_ec": {
 				Type: framework.TypeString,
 				Description: `The key type of the elliptic curve key to use for hybrid signature schemes.
-Supported types are: ecdsa-p256, ecdsa-p384, ecdsa-p521.`,
+Supported types are: ecdsa-p256, ecdsa-p384, ecdsa-p521, and ed25519.`,
 			},
 		},
 
@@ -247,6 +247,7 @@ func (b *backend) pathPolicyWrite(ctx context.Context, req *logical.Request, d *
 		polReq.KeyType = keysutil.KeyType_AES256_CMAC
 	case "ml-dsa":
 		polReq.KeyType = keysutil.KeyType_ML_DSA
+
 		if parameterSet != keysutil.ParameterSet_ML_DSA_44 &&
 			parameterSet != keysutil.ParameterSet_ML_DSA_65 &&
 			parameterSet != keysutil.ParameterSet_ML_DSA_87 {
@@ -322,6 +323,7 @@ type asymKey struct {
 	PublicKey        string    `json:"public_key" structs:"public_key" mapstructure:"public_key"`
 	CertificateChain string    `json:"certificate_chain" structs:"certificate_chain" mapstructure:"certificate_chain"`
 	CreationTime     time.Time `json:"creation_time" structs:"creation_time" mapstructure:"creation_time"`
+	HybridPublicKey  string    `json:"hybrid_public_key" structs:"hybrid_public_key" mapstructure:"hybrid_public_key"`
 }
 
 func (b *backend) pathPolicyRead(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
@@ -538,6 +540,8 @@ func getHybridKeyConfig(pqcKeyType, parameterSet, ecKeyType string) (keysutil.Hy
 		config.ECKeyType = keysutil.KeyType_ECDSA_P384
 	case "ecdsa-p521":
 		config.ECKeyType = keysutil.KeyType_ECDSA_P521
+	case "ed25519":
+		config.ECKeyType = keysutil.KeyType_ED25519
 	default:
 		return keysutil.HybridKeyConfig{}, fmt.Errorf("invalid key type for hybrid key: %s", ecKeyType)
 	}

--- a/sdk/helper/keysutil/policy.go
+++ b/sdk/helper/keysutil/policy.go
@@ -493,8 +493,8 @@ type Policy struct {
 	deleted uint32
 
 	Name    string      `json:"name"`
-	Key     []byte      `json:"key"`      // DEPRECATED
-	KeySize int         `json:"key_size"` // For algorithms with variable key sizes
+	Key     []byte      `json:"key,omitempty"`      // DEPRECATED
+	KeySize int         `json:"key_size,omitempty"` // For algorithms with variable key sizes
 	Keys    keyEntryMap `json:"keys"`
 
 	// Derived keys MUST provide a context and the master underlying key is

--- a/sdk/helper/keysutil/policy.go
+++ b/sdk/helper/keysutil/policy.go
@@ -323,19 +323,19 @@ type KeyEntry struct {
 	// Time of creation
 	CreationTime time.Time `json:"time"`
 
-	EC_X *big.Int `json:"ec_x"`
-	EC_Y *big.Int `json:"ec_y"`
-	EC_D *big.Int `json:"ec_d"`
+	EC_X *big.Int `json:"ec_x,omitempty"`
+	EC_Y *big.Int `json:"ec_y,omitempty"`
+	EC_D *big.Int `json:"ec_d,omitempty"`
 
-	RSAKey       *rsa.PrivateKey `json:"rsa_key"`
-	RSAPublicKey *rsa.PublicKey  `json:"rsa_public_key"`
+	RSAKey       *rsa.PrivateKey `json:"rsa_key,omitempty"`
+	RSAPublicKey *rsa.PublicKey  `json:"rsa_public_key,omitempty"`
 
 	// The public key in an appropriate format for the type of key
-	FormattedPublicKey string `json:"public_key"`
+	FormattedPublicKey string `json:"public_key,omitempty"`
 
 	// If convergent is enabled, the version (falling back to what's in the
 	// policy)
-	ConvergentVersion int `json:"convergent_version"`
+	ConvergentVersion int `json:"convergent_version,omitempty"`
 
 	// This is deprecated (but still filled) in favor of the value above which
 	// is more precise
@@ -345,7 +345,7 @@ type KeyEntry struct {
 
 	// Key entry certificate chain. If set, leaf certificate key matches the
 	// KeyEntry key
-	CertificateChain [][]byte `json:"certificate_chain"`
+	CertificateChain [][]byte `json:"certificate_chain,omitempty"`
 }
 
 func (ke *KeyEntry) IsPrivateKeyMissing() bool {
@@ -493,8 +493,8 @@ type Policy struct {
 	deleted uint32
 
 	Name    string      `json:"name"`
-	Key     []byte      `json:"key,omitempty"`      // DEPRECATED
-	KeySize int         `json:"key_size,omitempty"` // For algorithms with variable key sizes
+	Key     []byte      `json:"key"`      // DEPRECATED
+	KeySize int         `json:"key_size"` // For algorithms with variable key sizes
 	Keys    keyEntryMap `json:"keys"`
 
 	// Derived keys MUST provide a context and the master underlying key is
@@ -977,7 +977,6 @@ func (p *Policy) DeriveKey(context, salt []byte, ver int, numBytes int) ([]byte,
 				return nil, errutil.InternalError{Err: fmt.Sprintf("error generating derived key: %v", err)}
 			}
 			return pri, nil
-
 		default:
 			return nil, errutil.InternalError{Err: "unsupported key type for derivation"}
 		}
@@ -1274,30 +1273,10 @@ func (p *Policy) SignWithOptions(ver int, context, input []byte, options *Signin
 	case KeyType_ECDSA_P256, KeyType_ECDSA_P384, KeyType_ECDSA_P521:
 		sig, err = signWithECDSA(p.Type, keyParams, input, marshaling)
 	case KeyType_ED25519:
-		var key ed25519.PrivateKey
-
-		if p.Derived {
-			// Derive the key that should be used
-			var err error
-			key, err = p.GetKey(context, ver, 32)
-			if err != nil {
-				return nil, errutil.InternalError{Err: fmt.Sprintf("error deriving key: %v", err)}
-			}
-			pubKey = key.Public().(ed25519.PublicKey)
-		} else {
-			key = ed25519.PrivateKey(keyParams.Key)
-		}
-
-		opts, err := genEd25519Options(hashAlgorithm, options.SigContext)
-		if err != nil {
-			return nil, errutil.UserError{Err: fmt.Sprintf("error generating Ed25519 options: %v", err)}
-		}
-
-		sig, err = key.Sign(rand.Reader, input, opts)
+		sig, pubKey, err = p.signWithEd25519(ver, input, context, options, keyParams)
 		if err != nil {
 			return nil, err
 		}
-
 	case KeyType_RSA2048, KeyType_RSA3072, KeyType_RSA4096:
 		key := keyParams.RSAKey
 
@@ -1328,7 +1307,7 @@ func (p *Policy) SignWithOptions(ver int, context, input []byte, options *Signin
 			return nil, errutil.InternalError{Err: fmt.Sprintf("unsupported rsa signature algorithm %s", sigAlgorithm)}
 		}
 	default:
-		sig, err = entSignWithOptions(p, input, ver, options)
+		sig, err = entSignWithOptions(p, input, context, ver, hashAlgorithm, options)
 	}
 
 	// Convert to base64
@@ -1345,6 +1324,33 @@ func (p *Policy) SignWithOptions(ver int, context, input []byte, options *Signin
 	}
 
 	return res, nil
+}
+
+func (p *Policy) signWithEd25519(ver int, input []byte, context []byte, options *SigningOptions, keyParams KeyEntry) ([]byte, []byte, error) {
+	var key ed25519.PrivateKey
+	var pubKey []byte
+	if p.Derived {
+		// Derive the key that should be used
+		var err error
+		key, err = p.GetKey(context, ver, 32)
+		if err != nil {
+			return nil, nil, errutil.InternalError{Err: fmt.Sprintf("error deriving key: %v", err)}
+		}
+		pubKey = key.Public().(ed25519.PublicKey)
+	} else {
+		key = ed25519.PrivateKey(keyParams.Key)
+	}
+
+	opts, err := genEd25519Options(options.HashAlgorithm, options.SigContext)
+	if err != nil {
+		return nil, nil, errutil.UserError{Err: fmt.Sprintf("error generating Ed25519 options: %v", err)}
+	}
+
+	sig, err := key.Sign(rand.Reader, input, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+	return sig, pubKey, nil
 }
 
 func signWithECDSA(keyType KeyType, keyParams KeyEntry, input []byte, marshaling MarshalingType) ([]byte, error) {
@@ -1484,42 +1490,8 @@ func (p *Policy) VerifySignatureWithOptions(context, input []byte, sig string, o
 			return false, err
 		}
 		return verifyWithECDSA(p.Type, key, input, sigBytes, marshaling)
-
 	case KeyType_ED25519:
-		var pub ed25519.PublicKey
-
-		if p.Derived {
-			// Derive the key that should be used
-			key, err := p.GetKey(context, ver, 32)
-			if err != nil {
-				return false, errutil.InternalError{Err: fmt.Sprintf("error deriving key: %v", err)}
-			}
-			pub = ed25519.PrivateKey(key).Public().(ed25519.PublicKey)
-		} else {
-			keyEntry, err := p.safeGetKeyEntry(ver)
-			if err != nil {
-				return false, err
-			}
-
-			raw, err := base64.StdEncoding.DecodeString(keyEntry.FormattedPublicKey)
-			if err != nil {
-				return false, err
-			}
-
-			pub = ed25519.PublicKey(raw)
-		}
-
-		opts, err := genEd25519Options(hashAlgorithm, options.SigContext)
-		if err != nil {
-			return false, errutil.UserError{Err: fmt.Sprintf("error generating Ed25519 options: %v", err)}
-		}
-		if err := stdlibEd25519.VerifyWithOptions(pub, input, sigBytes, opts); err != nil {
-			// We drop the error, just report back that we failed signature verification
-			return false, nil
-		}
-
-		return true, nil
-
+		return p.verifyEd25519WithOptions(ver, input, context, "", options, sigBytes)
 	case KeyType_RSA2048, KeyType_RSA3072, KeyType_RSA4096:
 		keyEntry, err := p.safeGetKeyEntry(ver)
 		if err != nil {
@@ -1558,7 +1530,7 @@ func (p *Policy) VerifySignatureWithOptions(context, input []byte, sig string, o
 		return err == nil, nil
 
 	default:
-		return entVerifySignatureWithOptions(p, input, sigBytes, ver, options)
+		return entVerifySignatureWithOptions(p, context, input, sigBytes, ver, hashAlgorithm, options)
 	}
 }
 
@@ -1604,6 +1576,54 @@ func verifyWithECDSA(keyType KeyType, keyParams KeyEntry, input, sigBytes []byte
 	}
 
 	return ecdsa.Verify(key, input, ecdsaSig.R, ecdsaSig.S), nil
+}
+
+func (p *Policy) verifyEd25519WithOptions(ver int, input []byte, context []byte, publicKey string, options *SigningOptions, sigBytes []byte) (bool, error) {
+	var pub ed25519.PublicKey
+
+	if publicKey == "" {
+		if p.Derived {
+			// Derive the key that should be used
+			key, err := p.GetKey(context, ver, 32)
+			if err != nil {
+				return false, errutil.InternalError{Err: fmt.Sprintf("error deriving key: %v", err)}
+			}
+			pub = ed25519.PrivateKey(key).Public().(ed25519.PublicKey)
+		} else {
+			keyEntry, err := p.safeGetKeyEntry(ver)
+			if err != nil {
+				return false, err
+			}
+
+			raw, err := base64.StdEncoding.DecodeString(keyEntry.FormattedPublicKey)
+			if err != nil {
+				return false, err
+			}
+
+			pub = ed25519.PublicKey(raw)
+		}
+	} else {
+		raw, err := base64.StdEncoding.DecodeString(publicKey)
+		if err != nil {
+			return false, err
+		}
+
+		pub = ed25519.PublicKey(raw)
+	}
+
+	opts, err := genEd25519Options(options.HashAlgorithm, options.SigContext)
+	if err != nil {
+		return false, errutil.UserError{Err: fmt.Sprintf("error generating Ed25519 options: %v", err)}
+	}
+	if pub == nil {
+		return false, errutil.InternalError{Err: "no Ed25519 public key on policy"}
+	}
+	if err := stdlibEd25519.VerifyWithOptions(pub, input, sigBytes, opts); err != nil {
+		// We drop the error, just report back that we failed signature verification
+		return false, nil
+	}
+
+	return true, nil
 }
 
 func (p *Policy) Import(ctx context.Context, storage logical.Storage, key []byte, randReader io.Reader) error {
@@ -1797,19 +1817,10 @@ func (p *Policy) RotateInMemory(randReader io.Reader) (retErr error) {
 		}
 
 	case KeyType_ED25519:
-		// Go uses a 64-byte private key for Ed25519 keys (private+public, each
-		// 32-bytes long). When we do Key derivation, we still generate a 32-byte
-		// random value (and compute the corresponding Ed25519 public key), but
-		// use this entire 64-byte key as if it was an HKDF key. The corresponding
-		// underlying public key is never returned (which is probably good, because
-		// doing so would leak half of our HKDF key...), but means we cannot import
-		// derived-enabled Ed25519 public key components.
-		pub, pri, err := ed25519.GenerateKey(randReader)
+		err := generateEd25519Key(randReader, &entry.Key, &entry.FormattedPublicKey)
 		if err != nil {
 			return err
 		}
-		entry.Key = pri
-		entry.FormattedPublicKey = base64.StdEncoding.EncodeToString(pub)
 	case KeyType_RSA2048, KeyType_RSA3072, KeyType_RSA4096:
 		bitSize := 2048
 		if p.Type == KeyType_RSA3072 {
@@ -1855,6 +1866,23 @@ func (p *Policy) RotateInMemory(randReader io.Reader) (retErr error) {
 		p.MinDecryptionVersion = 1
 	}
 
+	return nil
+}
+
+func generateEd25519Key(randReader io.Reader, private *[]byte, public *string) error {
+	// Go uses a 64-byte private key for Ed25519 keys (private+public, each
+	// 32-bytes long). When we do Key derivation, we still generate a 32-byte
+	// random value (and compute the corresponding Ed25519 public key), but
+	// use this entire 64-byte key as if it was an HKDF key. The corresponding
+	// underlying public key is never returned (which is probably good, because
+	// doing so would leak half of our HKDF key...), but means we cannot import
+	// derived-enabled Ed25519 public key components.
+	pub, pri, err := ed25519.GenerateKey(randReader)
+	if err != nil {
+		return err
+	}
+	*private = pri
+	*public = base64.StdEncoding.EncodeToString(pub)
 	return nil
 }
 

--- a/sdk/helper/keysutil/policy.go
+++ b/sdk/helper/keysutil/policy.go
@@ -1530,7 +1530,7 @@ func (p *Policy) VerifySignatureWithOptions(context, input []byte, sig string, o
 		return err == nil, nil
 
 	default:
-		return entVerifySignatureWithOptions(p, context, input, sigBytes, ver, hashAlgorithm, options)
+		return entVerifySignatureWithOptions(p, input, context, sigBytes, ver, options)
 	}
 }
 

--- a/sdk/helper/keysutil/policy_ce.go
+++ b/sdk/helper/keysutil/policy_ce.go
@@ -18,11 +18,11 @@ func (e entKeyEntry) IsEntPrivateKeyMissing() bool {
 	return true
 }
 
-func entSignWithOptions(p *Policy, input []byte, ver int, options *SigningOptions) ([]byte, error) {
+func entSignWithOptions(p *Policy, input, context []byte, ver int, hashAlgorithm HashType, options *SigningOptions) ([]byte, error) {
 	return nil, fmt.Errorf("unsupported key type %v", p.Type)
 }
 
-func entVerifySignatureWithOptions(p *Policy, input []byte, sigBytes []byte, ver int, options *SigningOptions) (bool, error) {
+func entVerifySignatureWithOptions(p *Policy, input, context []byte, sigBytes []byte, ver int, options *SigningOptions) (bool, error) {
 	return false, errutil.InternalError{Err: fmt.Sprintf("unsupported key type %v", p.Type)}
 }
 

--- a/sdk/helper/keysutil/policy_test.go
+++ b/sdk/helper/keysutil/policy_test.go
@@ -55,7 +55,7 @@ func TestPolicy_KeyTypes(t *testing.T) {
 	}
 }
 
-func TestPolicy_HmacCmacSuported(t *testing.T) {
+func TestPolicy_HmacCmacSupported(t *testing.T) {
 	// Test HMAC supported feature
 	for _, keyType := range allTestKeyTypes {
 		switch keyType {


### PR DESCRIPTION
### Description
Supporting changes for key types for ML-DSA/Hybrid Ed25519.

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.