### PR TITLE
fix db test data race for queue tick interval

### DIFF
--- a/builtin/logical/database/rotation_test.go
+++ b/builtin/logical/database/rotation_test.go
@@ -1032,25 +1032,20 @@ func TestQueueTickIntervalKeyConfig(t *testing.T) {
 	cluster, sys := getClusterPostgresDB(t)
 	defer cluster.Cleanup()
 
-	config := logical.TestBackendConfig()
-	config.StorageView = &logical.InmemStorage{}
-	config.System = sys
-	config.Config[queueTickIntervalKey] = "1"
+	values := []string{"1", "0", "-1"}
+	for _, v := range values {
+		t.Run("test"+v, func(t *testing.T) {
+			config := logical.TestBackendConfig()
+			config.StorageView = &logical.InmemStorage{}
+			config.System = sys
+			config.Config[queueTickIntervalKey] = v
 
-	// Rotation ticker starts running in Factory call
-	b, err := Factory(context.Background(), config)
-	require.Nil(t, err)
-	b.Cleanup(context.Background())
-
-	config.Config[queueTickIntervalKey] = "0"
-	b, err = Factory(context.Background(), config)
-	require.Nil(t, err)
-	b.Cleanup(context.Background())
-
-	config.Config[queueTickIntervalKey] = "-1"
-	b, err = Factory(context.Background(), config)
-	require.Nil(t, err)
-	b.Cleanup(context.Background())
+			// Rotation ticker starts running in Factory call
+			b, err := Factory(context.Background(), config)
+			require.Nil(t, err)
+			b.Cleanup(context.Background())
+		})
+	}
 }
 
 func testBackend_StaticRole_Rotations(t *testing.T, createUser userCreator, opts map[string]interface{}) {


### PR DESCRIPTION
### Description
Attempt to fix a data race for the queue tick interval on the logical.BackendConfig map. I was unable to repro the data race locally, but I think reinitializing the BackendConfig for each value under test should fix the issue.

Failure: https://github.com/hashicorp/vault-enterprise/actions/runs/12584472353/job/35075729417

Test data race output:
```
WARNING: DATA RACE
Write at 0x00c00cedad80 by goroutine 29135:
  runtime.mapassign_faststr()
      /home/runner/actions-runner/_work/_tool/go/1.23.3/x64/src/runtime/map_faststr.go:223 +0x0
  github.com/hashicorp/vault/builtin/logical/database.TestQueueTickIntervalKeyConfig()
      /home/runner/actions-runner/_work/vault-enterprise/vault-enterprise/builtin/logical/database/rotation_test.go:1045 +0x308
  testing.tRunner()
      /home/runner/actions-runner/_work/_tool/go/1.23.3/x64/src/testing/testing.go:1690 +0x226
  testing.(*T).Run.gowrap1()
      /home/runner/actions-runner/_work/_tool/go/1.23.3/x64/src/testing/testing.go:1743 +0x44

Previous read at 0x00c00cedad80 by goroutine 37721:
  runtime.mapaccess2_faststr()
      /home/runner/actions-runner/_work/_tool/go/1.23.3/x64/src/runtime/map_faststr.go:117 +0x0
  github.com/hashicorp/vault/builtin/logical/database.(*databaseBackend).initQueue()
      /home/runner/actions-runner/_work/vault-enterprise/vault-enterprise/builtin/logical/database/rotation.go:622 +0x6c8
  github.com/hashicorp/vault/builtin/logical/database.Factory.gowrap1()
      /home/runner/actions-runner/_work/vault-enterprise/vault-enterprise/builtin/logical/database/backend.go:76 +0x5d
```


### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
