### PR TITLE
Remove potentially misleading part of automated reporting docs

### DIFF
--- a/website/content/docs/enterprise/license/utilization-reporting.mdx
+++ b/website/content/docs/enterprise/license/utilization-reporting.mdx
@@ -10,12 +10,7 @@ description: >-
 @include 'alerts/enterprise-only.mdx'
 
 Automated license utilization reporting sends license utilization data to
-HashiCorp without requiring you to manually collect and report them. It also
-lets you review your license usage with the monitoring solution you already use
-(for example Splunk, Datadog, or others) so you can optimize and manage your
-deployments. Use these reports to understand how much more you can deploy under
-your current contract, protect against overutilization, and budget for predicted
-consumption.
+HashiCorp without requiring you to manually collect and report them.
 
 Automated reporting shares the minimum data required to validate license
 utilization as defined in our contracts. They consist of mostly computed metrics
@@ -228,20 +223,20 @@ HashiCorp collects the following utilization data as JSON payloads:
          - `nonentity` - The sum of tokens without an entity attached
 - `metadata` - Optional product-specific metadata
    - `billing_start` - The billing start date associated with the reporting cluster (license start date if not configured).
-   
+
    <Note title="Important change to supported versions">
-      
-      As of 1.16.7, 1.17.3 and later, 
-      the <a href="/vault/docs/concepts/billing-start-date">billing start date</a> automatically 
+
+      As of 1.16.7, 1.17.3 and later,
+      the <a href="/vault/docs/concepts/billing-start-date">billing start date</a> automatically
       rolls over to the latest billing year at the end of the last cycle.
-        
+
       For more information, refer to the upgrade guide for your Vault version:
 
       [Vault v1.16.x](/vault/docs/upgrading/upgrade-to-1.16.x#auto-rolled-billing-start-date),
       [Vault v1.17.x](/vault/docs/upgrading/upgrade-to-1.17.x#auto-rolled-billing-start-date)
 
-    </Note> 
-    
+    </Note>
+
    - `cluster_id` - The cluster UUID as shown by `vault status` on the reporting
      cluster
 


### PR DESCRIPTION
### Description

This section of the docs implies a way for customers to use and ingest the automated reporting, which has confused customers. I think it's clearer if we simply remove it.

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [x] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
