### PR TITLE
Add information about an enterprise feature related to validating iss…

### DIFF
--- a/website/content/api-docs/secret/pki/index.mdx
+++ b/website/content/api-docs/secret/pki/index.mdx
@@ -2758,28 +2758,24 @@ do so, import a new issuer and a new `issuer_id` will be assigned.
 ~> **Note**: If no cluster-local address is present and templating is used,
    issuance will fail.
 
-- `disable_critical_extension_checks` `(bool: false)`
-  <EnterpriseAlert inline="true"/> - This determines whether this issuer is able
+- `disable_critical_extension_checks` `(bool: false)` <EnterpriseAlert inline="true"/> - This determines whether this issuer is able
   to issue certificates where the chain of trust (including the issued
   certificate) contain critical extensions not processed by vault, breaking the
   behavior required by [RFC 5280 Section 6.1](https://www.rfc-editor.org/rfc/rfc5280#section-6.1).
 
-- `disable_path_length_checks` `(bool: false)`
-  <EnterpriseAlert inline="true"/> - This determines whether this issuer is able
+- `disable_path_length_checks` `(bool: false)` <EnterpriseAlert inline="true"/> - This determines whether this issuer is able
   to issue certificates where the chain of trust (including the final issued
   certificate) is longer than allowed by a certificate authority in that chain,
   breaking the behavior required by
  [RFC 5280 Section 4.2.1.9](https://www.rfc-editor.org/rfc/rfc5280#section-4.2.1.9).
 
-- `disable_name_checks` `(bool: false)`
-  <EnterpriseAlert inline="true"/> - This determines whether this issuer is able
+- `disable_name_checks` `(bool: false)` <EnterpriseAlert inline="true"/> - This determines whether this issuer is able
   to issue certificates where the chain of trust (including the final issued
   certificate) contains a link in which the subject of the issuing certificate
   does not match the named issuer of the certificate it signed, breaking the
   behavior required by [RFC 5280 Section 4.1.2.4](https://www.rfc-editor.org/rfc/rfc5280#section-4.1.2.4).
 
-- `disable_name_constraint_checks` `(bool: false)`
-  <EnterpriseAlert inline="true"/> - This determines whether this issuer is able
+- `disable_name_constraint_checks` `(bool: false)` <EnterpriseAlert inline="true"/> - This determines whether this issuer is able
   to issue certificates where the chain of trust (including the final issued
   certificate) violates the name constraints critical extension of one of the
   issuer certificates in the chain, breaking the behavior required by

--- a/website/content/api-docs/secret/pki/index.mdx
+++ b/website/content/api-docs/secret/pki/index.mdx
@@ -2762,7 +2762,7 @@ do so, import a new issuer and a new `issuer_id` will be assigned.
   <EnterpriseAlert inline="true"/> - This determines whether this issuer is able
   to issue certificates where the chain of trust (including the issued
   certificate) contain critical extensions not processed by vault, breaking the
-  behavior required by https://www.rfc-editor.org/rfc/rfc5280#section-6.1 .
+  behavior required by [RFC 5280 Section 6.1](https://www.rfc-editor.org/rfc/rfc5280#section-6.1).
 
 - `disable_path_length_checks` `(bool: false)`
   <EnterpriseAlert inline="true"/> - This determines whether this issuer is able

--- a/website/content/api-docs/secret/pki/index.mdx
+++ b/website/content/api-docs/secret/pki/index.mdx
@@ -2758,6 +2758,33 @@ do so, import a new issuer and a new `issuer_id` will be assigned.
 ~> **Note**: If no cluster-local address is present and templating is used,
    issuance will fail.
 
+- `disable_critical_extension_checks` `(bool: false)`
+  <EnterpriseAlert inline="true"/> - This determines whether this issuer is able
+  to issue certificates where the chain of trust (including the issued
+  certificate) contain critical extensions not processed by vault, breaking the
+  behavior required by https://www.rfc-editor.org/rfc/rfc5280#section-6.1 .
+
+- `disable_path_length_checks` `(bool: false)`
+  <EnterpriseAlert inline="true"/> - This determines whether this issuer is able
+  to issue certificates where the chain of trust (including the final issued
+  certificate) is longer than allowed by a certificate authority in that chain,
+  breaking the behavior required by
+  https://www.rfc-editor.org/rfc/rfc5280#section-4.2.1.9 .
+
+- `disable_name_checks` `(bool: false)`
+  <EnterpriseAlert inline="true"/> - This determines whether this issuer is able
+  to issue certificates where the chain of trust (including the final issued
+  certificate) contains a link in which the subject of the issuing certificate
+  does not match the named issuer of the certificate it signed, breaking the
+  behavior required by https://www.rfc-editor.org/rfc/rfc5280#section-4.1.2.4 .
+
+- `disable_name_constraint_checks` `(bool: false)`
+  <EnterpriseAlert inline="true"/> - This determines whether this issuer is able
+  to issue certificates where the chain of trust (including the final issued
+  certificate) violates the name constraints critical extension of one of the
+  issuer certificates in the chain, breaking the behavior required by
+  https://www.rfc-editor.org/rfc/rfc5280#section-4.2.1.10 .
+
 #### Sample payload
 
 ```json

--- a/website/content/api-docs/secret/pki/index.mdx
+++ b/website/content/api-docs/secret/pki/index.mdx
@@ -2783,7 +2783,7 @@ do so, import a new issuer and a new `issuer_id` will be assigned.
   to issue certificates where the chain of trust (including the final issued
   certificate) violates the name constraints critical extension of one of the
   issuer certificates in the chain, breaking the behavior required by
-  https://www.rfc-editor.org/rfc/rfc5280#section-4.2.1.10 .
+  [RFC 5280 Section 4.2.1.10](https://www.rfc-editor.org/rfc/rfc5280#section-4.2.1.10).
 
 #### Sample payload
 

--- a/website/content/api-docs/secret/pki/index.mdx
+++ b/website/content/api-docs/secret/pki/index.mdx
@@ -2769,7 +2769,7 @@ do so, import a new issuer and a new `issuer_id` will be assigned.
   to issue certificates where the chain of trust (including the final issued
   certificate) is longer than allowed by a certificate authority in that chain,
   breaking the behavior required by
-  https://www.rfc-editor.org/rfc/rfc5280#section-4.2.1.9 .
+ [RFC 5280 Section 4.2.1.9](https://www.rfc-editor.org/rfc/rfc5280#section-4.2.1.9).
 
 - `disable_name_checks` `(bool: false)`
   <EnterpriseAlert inline="true"/> - This determines whether this issuer is able

--- a/website/content/api-docs/secret/pki/index.mdx
+++ b/website/content/api-docs/secret/pki/index.mdx
@@ -2776,7 +2776,7 @@ do so, import a new issuer and a new `issuer_id` will be assigned.
   to issue certificates where the chain of trust (including the final issued
   certificate) contains a link in which the subject of the issuing certificate
   does not match the named issuer of the certificate it signed, breaking the
-  behavior required by https://www.rfc-editor.org/rfc/rfc5280#section-4.1.2.4 .
+  behavior required by [RFC 5280 Section 4.1.2.4](https://www.rfc-editor.org/rfc/rfc5280#section-4.1.2.4).
 
 - `disable_name_constraint_checks` `(bool: false)`
   <EnterpriseAlert inline="true"/> - This determines whether this issuer is able


### PR DESCRIPTION
This is the documentation half to the enterprise feature which added four issuer configurations related to chain validation.

JIRA of this task: https://hashicorp.atlassian.net/browse/VAULT-32535
JIRA of the original task: https://hashicorp.atlassian.net/browse/VAULT-32137
PR of the original (ENT) feature: https://github.com/hashicorp/vault-enterprise/pull/6924
RFC of the overall feature: https://hermes.hashicorp.services/document/1MmCXGZ6dioQ7q7id9ZBUdBK0zUHiobtD3OWGrV8hq4E?draft=true

This doesn't need to be backported.