### PR TITLE
Add identity cleanup activation flag

### DIFF
--- a/vault/logical_system_activation_flags.go
+++ b/vault/logical_system_activation_flags.go
@@ -34,6 +34,9 @@ This path responds to the following HTTP methods.
 
 	PUT|POST /<feature-name>/activate
 		Activates the specified feature. Cannot be undone.`
+
+	activationFlagIdentityCleanup = "identity-cleanup"
+	activationFlagTest            = "activation-test"
 )
 
 // These variables should only be mutated during initialization or server construction.
@@ -66,7 +69,24 @@ func (b *SystemBackend) activationFlagsPaths() []*framework.Path {
 			HelpDescription: helpDescription,
 		},
 		{
-			Pattern: fmt.Sprintf("%s/%s/%s", prefixActivationFlags, "activation-test", verbActivationFlagsActivate),
+			Pattern: fmt.Sprintf("%s/%s/%s", prefixActivationFlags, activationFlagTest, verbActivationFlagsActivate),
+			DisplayAttrs: &framework.DisplayAttributes{
+				OperationPrefix: prefixActivationFlags,
+				OperationVerb:   verbActivationFlagsActivate,
+			},
+			Operations: map[logical.Operation]framework.OperationHandler{
+				logical.UpdateOperation: &framework.PathOperation{
+					Callback:                    b.handleActivationFlagsActivate,
+					ForwardPerformanceSecondary: true,
+					ForwardPerformanceStandby:   true,
+					Summary:                     summaryUpdate,
+				},
+			},
+			HelpSynopsis:    helpSynopsis,
+			HelpDescription: helpDescription,
+		},
+		{
+			Pattern: fmt.Sprintf("%s/%s/%s", prefixActivationFlags, activationFlagIdentityCleanup, verbActivationFlagsActivate),
 			DisplayAttrs: &framework.DisplayAttributes{
 				OperationPrefix: prefixActivationFlags,
 				OperationVerb:   verbActivationFlagsActivate,

--- a/vault/logical_system_activation_flags.go
+++ b/vault/logical_system_activation_flags.go
@@ -35,7 +35,7 @@ This path responds to the following HTTP methods.
 	PUT|POST /<feature-name>/activate
 		Activates the specified feature. Cannot be undone.`
 
-	activationFlagIdentityCleanup = "identity-cleanup"
+	activationFlagIdentityCleanup = "force-identity-deduplication"
 	activationFlagTest            = "activation-test"
 )
 

--- a/vault/logical_system_activation_flags.go
+++ b/vault/logical_system_activation_flags.go
@@ -36,7 +36,6 @@ This path responds to the following HTTP methods.
 		Activates the specified feature. Cannot be undone.`
 )
 
-// Register CRUD functions dynamically.
 // These variables should only be mutated during initialization or server construction.
 // It is unsafe to modify them once the Vault core is running.
 var (

--- a/vault/logical_system_activation_flags_test.go
+++ b/vault/logical_system_activation_flags_test.go
@@ -70,18 +70,37 @@ func TestActivationFlags_BadFeatureName(t *testing.T) {
 
 // TestActivationFlags_Write tests the write operations for the activation flags
 func TestActivationFlags_Write(t *testing.T) {
-	t.Run("given an initial state then read flags and expect all to be unactivated", func(t *testing.T) {
+	t.Run("given an initial state then write an activation test flag and expect no errors", func(t *testing.T) {
 		core, _, _ := TestCoreUnsealedWithConfig(t, &CoreConfig{})
 
 		_, err := core.systemBackend.HandleRequest(
 			context.Background(),
 			&logical.Request{
 				Operation: logical.UpdateOperation,
-				Path:      fmt.Sprintf("%s/%s/%s", prefixActivationFlags, "activation-test", verbActivationFlagsActivate),
+				Path:      fmt.Sprintf("%s/%s/%s", prefixActivationFlags, activationFlagTest, verbActivationFlagsActivate),
 				Storage:   core.systemBarrierView,
 			},
 		)
 
 		require.NoError(t, err)
+	})
+
+	t.Run("activate identity cleanup flag", func(t *testing.T) {
+		core, _, _ := TestCoreUnsealedWithConfig(t, &CoreConfig{})
+
+		resp, err := core.systemBackend.HandleRequest(
+			context.Background(),
+			&logical.Request{
+				Operation: logical.UpdateOperation,
+				Path:      fmt.Sprintf("%s/%s/%s", prefixActivationFlags, activationFlagIdentityCleanup, verbActivationFlagsActivate),
+				Storage:   core.systemBarrierView,
+			},
+		)
+
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.NotEmpty(t, resp.Data)
+		require.NotNil(t, resp.Data["activated"])
+		require.Contains(t, resp.Data["activated"], activationFlagIdentityCleanup)
 	})
 }

--- a/vault/logical_system_activation_flags_test.go
+++ b/vault/logical_system_activation_flags_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/hashicorp/vault/helper/namespace"
 	"github.com/hashicorp/vault/sdk/logical"
-
 	"github.com/stretchr/testify/require"
 )
 

--- a/vault/logical_system_activation_flags_test.go
+++ b/vault/logical_system_activation_flags_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/hashicorp/vault/helper/namespace"
 	"github.com/hashicorp/vault/sdk/logical"
+
 	"github.com/stretchr/testify/require"
 )
 


### PR DESCRIPTION
### Description
Add identity cleanup activation flag. 

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
