### PR TITLE
exclude *_ent_test.go from copywrite-exceptions.sh

### DIFF
--- a/scripts/copywrite-exceptions.sh
+++ b/scripts/copywrite-exceptions.sh
@@ -4,8 +4,7 @@
 # headers in only files intended for public users, and deletes them,
 # then runs the copywrite bot to utilize local subdir config
 # to inject correct headers.
-
-find . -type f -name '*.go' -not -name '*_ent.go' | while read line; do
+find . -type f -name '*.go' -not -name '*_ent.go' -not -name '*_ent_test.go' | while read line; do
   if grep "SPDX-License-Identifier: BUSL-1.1" $line; then
     sed -i '/SPDX-License-Identifier: BUSL-1.1/d' $line
     sed -i '/Copyright (c) HashiCorp, Inc./d' $line

--- a/scripts/copywrite-exceptions.sh
+++ b/scripts/copywrite-exceptions.sh
@@ -4,6 +4,7 @@
 # headers in only files intended for public users, and deletes them,
 # then runs the copywrite bot to utilize local subdir config
 # to inject correct headers.
+
 find . -type f -name '*.go' -not -name '*_ent.go' -not -name '*_ent_test.go' | while read line; do
   if grep "SPDX-License-Identifier: BUSL-1.1" $line; then
     sed -i '/SPDX-License-Identifier: BUSL-1.1/d' $line


### PR DESCRIPTION
### Description
What does this PR do?
This PR updates copywrite-exceptions.sh exclude *_ent_test.go

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
