### PR TITLE
VAULT-31907: Entity loading speedup

### DIFF
--- a/changelog/29326.txt
+++ b/changelog/29326.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+core/identity: Improve performance of loading entities when unsealing by batching updates, caching local alias storage reads, and doing more work in parallel. 
+```

--- a/vault/identity_store_util.go
+++ b/vault/identity_store_util.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	metrics "github.com/armon/go-metrics"
+	"github.com/golang/protobuf/ptypes"
 	"github.com/hashicorp/errwrap"
 	memdb "github.com/hashicorp/go-memdb"
 	"github.com/hashicorp/go-secure-stdlib/strutil"
@@ -393,10 +394,10 @@ func (i *IdentityStore) loadEntities(ctx context.Context) error {
 	// create a slice of result channels, one for each bucket. We need each result
 	// and err chan to be 1 buffered so we can leave a result there even if the
 	// processing loop is blocking on an earlier bucket still.
-	results := make([]chan *storagepacker.Bucket, len(existing))
+	results := make([]chan []*identity.Entity, len(existing))
 	errs := make([]chan error, len(existing))
 	for j := range existing {
-		results[j] = make(chan *storagepacker.Bucket, 1)
+		results[j] = make(chan []*identity.Entity, 1)
 		errs[j] = make(chan error, 1)
 	}
 
@@ -424,8 +425,18 @@ func (i *IdentityStore) loadEntities(ctx context.Context) error {
 						continue
 					}
 
+					items := make([]*identity.Entity, len(bucket.Items))
+					for j, item := range bucket.Items {
+						entity, err := i.parseEntityFromBucketItem(ctx, item)
+						if err != nil {
+							errs[idx] <- err
+							continue
+						}
+						items[j] = entity
+					}
+
 					// Write results out to the result channel
-					results[idx] <- bucket
+					results[idx] <- items
 
 				// quit early
 				case <-quit:
@@ -453,6 +464,8 @@ func (i *IdentityStore) loadEntities(ctx context.Context) error {
 		close(broker)
 	}()
 
+	localAliasBuckets := make(map[string]*storagepacker.Bucket)
+
 	// Restore each key by pulling from the result chan
 LOOP:
 	for j := range existing {
@@ -462,17 +475,15 @@ LOOP:
 			close(quit)
 			break LOOP
 
-		case bucket := <-results[j]:
+		case entities := <-results[j]:
 			// If there is no entry, nothing to restore
-			if bucket == nil {
+			if entities == nil {
 				continue
 			}
 
-			for _, item := range bucket.Items {
-				entity, err := i.parseEntityFromBucketItem(ctx, item)
-				if err != nil {
-					return err
-				}
+			tx := i.db.Txn(true)
+			upsertedItems := 0
+			for _, entity := range entities {
 				if entity == nil {
 					continue
 				}
@@ -517,22 +528,28 @@ LOOP:
 					}
 				}
 
-				localAliases, err := i.parseLocalAliases(entity.ID)
+				err = i.loadLocalAliasesForEntity(ctx, entity, localAliasBuckets)
 				if err != nil {
 					return fmt.Errorf("failed to load local aliases from storage: %v", err)
 				}
-				if localAliases != nil {
-					for _, alias := range localAliases.Aliases {
-						entity.UpsertAlias(alias)
-					}
-				}
 
+				toBeUpserted := 1 + len(entity.Aliases)
+				if upsertedItems+toBeUpserted > 1024 {
+					tx.Commit()
+					upsertedItems = 0
+					tx = i.db.Txn(true)
+				}
 				// Only update MemDB and don't hit the storage again
-				err = i.upsertEntity(nsCtx, entity, nil, false)
+				err = i.upsertEntityInTxn(nsCtx, tx, entity, nil, false)
 				if err != nil {
 					return fmt.Errorf("failed to update entity in MemDB: %w", err)
 				}
+				upsertedItems += toBeUpserted
 			}
+			if upsertedItems > 0 {
+				tx.Commit()
+			}
+			tx.Abort()
 		}
 	}
 
@@ -554,6 +571,40 @@ LOOP:
 		i.logger.Info("entities restored")
 	}
 
+	return nil
+}
+
+// loadLocalAliasesForEntity upserts local aliases into the entity by retrieving
+// the local aliases from the cache (if present) or storage
+func (i *IdentityStore) loadLocalAliasesForEntity(ctx context.Context, entity *identity.Entity, localAliasCache map[string]*storagepacker.Bucket) error {
+	bucketKey := i.localAliasPacker.BucketKey(entity.ID)
+	if len(bucketKey) == 0 {
+		return fmt.Errorf("no bucket key for ID %s", entity.ID)
+	}
+	bucket, ok := localAliasCache[bucketKey]
+	if !ok {
+		var err error
+		bucket, err = i.localAliasPacker.GetBucket(ctx, bucketKey)
+		if err != nil {
+			return fmt.Errorf("failed to load local alias bucket from storage: %v", err)
+		}
+		localAliasCache[bucketKey] = bucket
+	}
+	if bucket == nil {
+		return nil
+	}
+	for _, item := range bucket.Items {
+		if item.ID == entity.ID {
+			var localAliases identity.LocalAliases
+			err := ptypes.UnmarshalAny(item.Message, &localAliases)
+			if err != nil {
+				return fmt.Errorf("failed to unmarshal local alias: %v", err)
+			}
+			for _, alias := range localAliases.Aliases {
+				entity.UpsertAlias(alias)
+			}
+		}
+	}
 	return nil
 }
 

--- a/vault/identity_store_util.go
+++ b/vault/identity_store_util.go
@@ -34,6 +34,7 @@ import (
 var (
 	errCycleDetectedPrefix = "cyclic relationship detected for member group ID"
 	tmpSuffix              = ".tmp"
+	entityLoadingTxMaxSize = 1024
 )
 
 // loadIdentityStoreArtifacts is responsible for loading entities, groups, and aliases from storage into MemDB.
@@ -534,7 +535,7 @@ LOOP:
 				}
 
 				toBeUpserted := 1 + len(entity.Aliases)
-				if upsertedItems+toBeUpserted > 1024 {
+				if upsertedItems+toBeUpserted > entityLoadingTxMaxSize {
 					tx.Commit()
 					upsertedItems = 0
 					tx = i.db.Txn(true)


### PR DESCRIPTION
### Description
This PR has 3 performance improvements in the `loadEntities` function:
1. Batch memDB operations into groups of 1024. Previously, we were creating a new transaction per entity.
2. Cache the bucket reads from the local alias storage packer and use those when loading entities
3. Deserialize the entities concurrently 

I ran [benchmarks](https://github.com/hashicorp/vault-enterprise/compare/miagilepner/exp-faster-identity-load?expand=1) using:
* 200k total entities
* Each entity had 1 local alias and 1 non-local alias

I got the number 1024 by batching entities together across buckets (which this branch **does not** implement, but I used for benchmarking so that I wouldn't need to create millions of entities). These batches are counted by adding the number of entities and the number of aliases per entity (note: this is different than what I posted on slack earlier today. I was incorrectly only counting the number of entities per batch). 

```
Benchmark_loadEntities/tx_size_2048-10         	       5	22934412175 ns/op
Benchmark_loadEntities/tx_size_1024-10         	       5	6821009883 ns/op
Benchmark_loadEntities/tx_size_512-10          	       5	6938667308 ns/op
Benchmark_loadEntities/tx_size_256-10          	       5	6962929416 ns/op
Benchmark_loadEntities/tx_size_1-10            	       5	10874873183 ns/op
```

I also benchmarked the other 2 performance improvements; `cache_aliases_{true|false}` being optimization number 2, and `unmarshal_parallel_{true|false}` being optimization number 3. 

The results of the benchmarks are:
```
Benchmark_loadEntities/tx_size_1024_cache_aliases_true_unmarshal_parallel_true_-10         	       3	5570892945 ns/op
Benchmark_loadEntities/tx_size_1024_cache_aliases_true_unmarshal_parallel_false_-10        	       3	6047840347 ns/op
Benchmark_loadEntities/tx_size_1024_cache_aliases_false_unmarshal_parallel_true_-10        	       3	5858072153 ns/op
Benchmark_loadEntities/tx_size_1024_cache_aliases_false_unmarshal_parallel_false_-10       	       3	6072485403 ns/op
Benchmark_loadEntities/tx_size_1_cache_aliases_true_unmarshal_parallel_true_-10            	       3	9174082680 ns/op
Benchmark_loadEntities/tx_size_1_cache_aliases_true_unmarshal_parallel_false_-10           	       3	9550873292 ns/op
Benchmark_loadEntities/tx_size_1_cache_aliases_false_unmarshal_parallel_true_-10           	       3	9403697055 ns/op
Benchmark_loadEntities/tx_size_1_cache_aliases_false_unmarshal_parallel_false_-10          	       3	9821321805 ns/op
```


### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
