### PR TITLE
Exit raft removed checker if raft isn't initialized

### DIFF
--- a/physical/raft/raft.go
+++ b/physical/raft/raft.go
@@ -1461,6 +1461,16 @@ func (b *RaftBackend) StartRemovedChecker(ctx context.Context) {
 		for {
 			select {
 			case <-ticker.C:
+				// If the raft cluster has been torn down (which will happen on
+				// seal) the raft backend will be uninitialized. We want to exit
+				// the loop in that case. If the cluster unseals, we'll get a
+				// new backend setup and that will have its own removed checker.
+
+				// There is a ctx.Done() check below that will also exit, but
+				// in most (if not all) places we pass in context.Background()
+				// to this function. Checking initialization will prevent this
+				// loop from continuing to run after the raft backend is stopped
+				// regardless of the context.
 				if !b.Initialized() {
 					return
 				}

--- a/physical/raft/raft.go
+++ b/physical/raft/raft.go
@@ -1461,6 +1461,9 @@ func (b *RaftBackend) StartRemovedChecker(ctx context.Context) {
 		for {
 			select {
 			case <-ticker.C:
+				if !b.Initialized() {
+					return
+				}
 				removed, err := b.IsNodeRemoved(ctx, b.localID)
 				if err != nil {
 					logger.Error("failed to check if node is removed", "node ID", b.localID, "error", err)

--- a/vault/external_tests/raftha/raft_ha_test.go
+++ b/vault/external_tests/raftha/raft_ha_test.go
@@ -364,6 +364,9 @@ func TestRaftHACluster_Removed_ReAdd(t *testing.T) {
 			if !server.Healthy {
 				return fmt.Errorf("server %s is unhealthy", serverID)
 			}
+			if server.NodeType != "voter" {
+				return fmt.Errorf("server %s has type %s", serverID, server.NodeType)
+			}
 		}
 		return nil
 	})


### PR DESCRIPTION
### Description
Exits the checker. This prevents log spamming.

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
