### PR TITLE
physical: use permitpool from go-secure-stdlib

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -114,6 +114,7 @@ require (
 	github.com/hashicorp/go-secure-stdlib/nonceutil v0.1.0
 	github.com/hashicorp/go-secure-stdlib/parseutil v0.1.8
 	github.com/hashicorp/go-secure-stdlib/password v0.1.1
+	github.com/hashicorp/go-secure-stdlib/permitpool v1.0.0
 	github.com/hashicorp/go-secure-stdlib/reloadutil v0.1.1
 	github.com/hashicorp/go-secure-stdlib/strutil v0.1.2
 	github.com/hashicorp/go-secure-stdlib/tlsutil v0.1.3
@@ -204,7 +205,7 @@ require (
 	github.com/sasha-s/go-deadlock v0.3.5
 	github.com/sethvargo/go-limiter v0.7.1
 	github.com/shirou/gopsutil/v3 v3.22.6
-	github.com/stretchr/testify v1.9.0
+	github.com/stretchr/testify v1.10.0
 	github.com/tink-crypto/tink-go/v2 v2.2.0
 	go.etcd.io/bbolt v1.4.0-beta.0
 	go.etcd.io/etcd/client/pkg/v3 v3.5.17

--- a/go.sum
+++ b/go.sum
@@ -1478,6 +1478,8 @@ github.com/hashicorp/go-secure-stdlib/parseutil v0.1.8 h1:iBt4Ew4XEGLfh6/bPk4rSY
 github.com/hashicorp/go-secure-stdlib/parseutil v0.1.8/go.mod h1:aiJI+PIApBRQG7FZTEBx5GiiX+HbOHilUdNxUZi4eV0=
 github.com/hashicorp/go-secure-stdlib/password v0.1.1 h1:6JzmBqXprakgFEHwBgdchsjaA9x3GyjdI568bXKxa60=
 github.com/hashicorp/go-secure-stdlib/password v0.1.1/go.mod h1:9hH302QllNwu1o2TGYtSk8I8kTAN0ca1EHpwhm5Mmzo=
+github.com/hashicorp/go-secure-stdlib/permitpool v1.0.0 h1:U6y5MXGiDVOOtkWJ6o/tu1TxABnI0yKTQWJr7z6BpNk=
+github.com/hashicorp/go-secure-stdlib/permitpool v1.0.0/go.mod h1:ecDb3o+8D4xtP0nTCufJaAVawHavy5M2eZ64Nq/8/LM=
 github.com/hashicorp/go-secure-stdlib/plugincontainer v0.4.1 h1:JY+zGg8gOmslwif1fiCqT5Hu1SikLZQcHkmQhCoA9gY=
 github.com/hashicorp/go-secure-stdlib/plugincontainer v0.4.1/go.mod h1:jW3KCTvdPyAdVecOUwiiO2XaYgUJ/isigt++ISkszkY=
 github.com/hashicorp/go-secure-stdlib/reloadutil v0.1.1 h1:SMGUnbpAcat8rIKHkBPjfv81yC46a8eCNZ2hsR2l1EI=
@@ -2159,8 +2161,9 @@ github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.3/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
-github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/tencentcloud/tencentcloud-sdk-go v1.0.162 h1:8fDzz4GuVg4skjY2B0nMN7h6uN61EDVkuLyI2+qGHhI=
 github.com/tencentcloud/tencentcloud-sdk-go v1.0.162/go.mod h1:asUz5BPXxgoPGaRgZaVm1iGcUAuHyYUo1nXqKa83cvI=
 github.com/tilinna/clock v1.0.2/go.mod h1:ZsP7BcY7sEEz7ktc0IVy8Us6boDrK8VradlKRUGfOao=

--- a/physical/azure/azure.go
+++ b/physical/azure/azure.go
@@ -21,6 +21,7 @@ import (
 	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/armon/go-metrics"
 	log "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-secure-stdlib/permitpool"
 	"github.com/hashicorp/go-secure-stdlib/strutil"
 	"github.com/hashicorp/vault/sdk/physical"
 )
@@ -37,7 +38,7 @@ const (
 type AzureBackend struct {
 	container  *azblob.ContainerURL
 	logger     log.Logger
-	permitPool *physical.PermitPool
+	permitPool *permitpool.Pool
 }
 
 // Verify AzureBackend satisfies the correct interfaces
@@ -191,7 +192,7 @@ func NewAzureBackend(conf map[string]string, logger log.Logger) (physical.Backen
 	a := &AzureBackend{
 		container:  &containerURL,
 		logger:     logger,
-		permitPool: physical.NewPermitPool(maxParInt),
+		permitPool: permitpool.New(maxParInt),
 	}
 	return a, nil
 }
@@ -233,7 +234,9 @@ func (a *AzureBackend) Put(ctx context.Context, entry *physical.Entry) error {
 		return fmt.Errorf("value is bigger than the current supported limit of 4MBytes")
 	}
 
-	a.permitPool.Acquire()
+	if err := a.permitPool.Acquire(ctx); err != nil {
+		return err
+	}
 	defer a.permitPool.Release()
 
 	blobURL := a.container.NewBlockBlobURL(entry.Key)
@@ -248,7 +251,9 @@ func (a *AzureBackend) Put(ctx context.Context, entry *physical.Entry) error {
 func (a *AzureBackend) Get(ctx context.Context, key string) (*physical.Entry, error) {
 	defer metrics.MeasureSince([]string{"azure", "get"}, time.Now())
 
-	a.permitPool.Acquire()
+	if err := a.permitPool.Acquire(ctx); err != nil {
+		return nil, err
+	}
 	defer a.permitPool.Release()
 
 	blobURL := a.container.NewBlockBlobURL(key)
@@ -285,7 +290,9 @@ func (a *AzureBackend) Get(ctx context.Context, key string) (*physical.Entry, er
 func (a *AzureBackend) Delete(ctx context.Context, key string) error {
 	defer metrics.MeasureSince([]string{"azure", "delete"}, time.Now())
 
-	a.permitPool.Acquire()
+	if err := a.permitPool.Acquire(ctx); err != nil {
+		return err
+	}
 	defer a.permitPool.Release()
 
 	blobURL := a.container.NewBlockBlobURL(key)
@@ -310,7 +317,9 @@ func (a *AzureBackend) Delete(ctx context.Context, key string) error {
 func (a *AzureBackend) List(ctx context.Context, prefix string) ([]string, error) {
 	defer metrics.MeasureSince([]string{"azure", "list"}, time.Now())
 
-	a.permitPool.Acquire()
+	if err := a.permitPool.Acquire(ctx); err != nil {
+		return nil, err
+	}
 	defer a.permitPool.Release()
 
 	var keys []string

--- a/physical/cockroachdb/cockroachdb.go
+++ b/physical/cockroachdb/cockroachdb.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach-go/v2/crdb"
 	log "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-secure-stdlib/permitpool"
 	"github.com/hashicorp/go-secure-stdlib/strutil"
 	"github.com/hashicorp/vault/sdk/physical"
 	_ "github.com/jackc/pgx/v4/stdlib"
@@ -44,7 +45,7 @@ type CockroachDBBackend struct {
 	rawHAStatements map[string]string
 	haStatements    map[string]*sql.Stmt
 	logger          log.Logger
-	permitPool      *physical.PermitPool
+	permitPool      *permitpool.Pool
 	haEnabled       bool
 }
 
@@ -142,7 +143,7 @@ func NewCockroachDBBackend(conf map[string]string, logger log.Logger) (physical.
 		},
 		haStatements: make(map[string]*sql.Stmt),
 		logger:       logger,
-		permitPool:   physical.NewPermitPool(maxParInt),
+		permitPool:   permitpool.New(maxParInt),
 		haEnabled:    haEnabled,
 	}
 
@@ -176,7 +177,9 @@ func (c *CockroachDBBackend) prepare(statementMap map[string]*sql.Stmt, name, qu
 func (c *CockroachDBBackend) Put(ctx context.Context, entry *physical.Entry) error {
 	defer metrics.MeasureSince([]string{"cockroachdb", "put"}, time.Now())
 
-	c.permitPool.Acquire()
+	if err := c.permitPool.Acquire(ctx); err != nil {
+		return err
+	}
 	defer c.permitPool.Release()
 
 	_, err := c.statements["put"].Exec(entry.Key, entry.Value)
@@ -190,7 +193,9 @@ func (c *CockroachDBBackend) Put(ctx context.Context, entry *physical.Entry) err
 func (c *CockroachDBBackend) Get(ctx context.Context, key string) (*physical.Entry, error) {
 	defer metrics.MeasureSince([]string{"cockroachdb", "get"}, time.Now())
 
-	c.permitPool.Acquire()
+	if err := c.permitPool.Acquire(ctx); err != nil {
+		return nil, err
+	}
 	defer c.permitPool.Release()
 
 	var result []byte
@@ -213,7 +218,9 @@ func (c *CockroachDBBackend) Get(ctx context.Context, key string) (*physical.Ent
 func (c *CockroachDBBackend) Delete(ctx context.Context, key string) error {
 	defer metrics.MeasureSince([]string{"cockroachdb", "delete"}, time.Now())
 
-	c.permitPool.Acquire()
+	if err := c.permitPool.Acquire(ctx); err != nil {
+		return err
+	}
 	defer c.permitPool.Release()
 
 	_, err := c.statements["delete"].Exec(key)
@@ -228,7 +235,9 @@ func (c *CockroachDBBackend) Delete(ctx context.Context, key string) error {
 func (c *CockroachDBBackend) List(ctx context.Context, prefix string) ([]string, error) {
 	defer metrics.MeasureSince([]string{"cockroachdb", "list"}, time.Now())
 
-	c.permitPool.Acquire()
+	if err := c.permitPool.Acquire(ctx); err != nil {
+		return nil, err
+	}
 	defer c.permitPool.Release()
 
 	likePrefix := prefix + "%"
@@ -267,7 +276,9 @@ func (c *CockroachDBBackend) Transaction(ctx context.Context, txns []*physical.T
 		return nil
 	}
 
-	c.permitPool.Acquire()
+	if err := c.permitPool.Acquire(ctx); err != nil {
+		return err
+	}
 	defer c.permitPool.Release()
 
 	return crdb.ExecuteTx(context.Background(), c.client, nil, func(tx *sql.Tx) error {

--- a/physical/cockroachdb/cockroachdb_ha.go
+++ b/physical/cockroachdb/cockroachdb_ha.go
@@ -4,6 +4,7 @@
 package cockroachdb
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"sync"
@@ -106,7 +107,9 @@ func (l *CockroachDBLock) Lock(stopCh <-chan struct{}) (<-chan struct{}, error) 
 // CockroachDB table.
 func (l *CockroachDBLock) Unlock() error {
 	c := l.backend
-	c.permitPool.Acquire()
+	if err := c.permitPool.Acquire(context.Background()); err != nil {
+		return err
+	}
 	defer c.permitPool.Release()
 
 	if l.renewTicker != nil {
@@ -121,7 +124,9 @@ func (l *CockroachDBLock) Unlock() error {
 // including this one, and returns the current value.
 func (l *CockroachDBLock) Value() (bool, string, error) {
 	c := l.backend
-	c.permitPool.Acquire()
+	if err := c.permitPool.Acquire(context.Background()); err != nil {
+		return false, "", err
+	}
 	defer c.permitPool.Release()
 	var result string
 	err := c.haStatements["get"].QueryRow(l.key).Scan(&result)
@@ -185,7 +190,9 @@ func (l *CockroachDBLock) periodicallyRenewLock(done chan struct{}) {
 // else has the lock, whereas non-nil means that something unexpected happened.
 func (l *CockroachDBLock) writeItem() (bool, error) {
 	c := l.backend
-	c.permitPool.Acquire()
+	if err := c.permitPool.Acquire(context.Background()); err != nil {
+		return false, err
+	}
 	defer c.permitPool.Release()
 
 	sqlResult, err := c.haStatements["upsert"].Exec(l.identity, l.key, l.value, fmt.Sprintf("%d seconds", l.ttlSeconds))

--- a/physical/couchdb/couchdb.go
+++ b/physical/couchdb/couchdb.go
@@ -19,6 +19,7 @@ import (
 	metrics "github.com/armon/go-metrics"
 	cleanhttp "github.com/hashicorp/go-cleanhttp"
 	log "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-secure-stdlib/permitpool"
 	"github.com/hashicorp/vault/sdk/physical"
 )
 
@@ -26,7 +27,7 @@ import (
 type CouchDBBackend struct {
 	logger     log.Logger
 	client     *couchDBClient
-	permitPool *physical.PermitPool
+	permitPool *permitpool.Pool
 }
 
 // Verify CouchDBBackend satisfies the correct interfaces
@@ -196,7 +197,7 @@ func buildCouchDBBackend(conf map[string]string, logger log.Logger) (*CouchDBBac
 			Client:   cleanhttp.DefaultPooledClient(),
 		},
 		logger:     logger,
-		permitPool: physical.NewPermitPool(maxParInt),
+		permitPool: permitpool.New(maxParInt),
 	}, nil
 }
 
@@ -213,7 +214,9 @@ type couchDBEntry struct {
 
 // Put is used to insert or update an entry
 func (m *CouchDBBackend) Put(ctx context.Context, entry *physical.Entry) error {
-	m.permitPool.Acquire()
+	if err := m.permitPool.Acquire(ctx); err != nil {
+		return err
+	}
 	defer m.permitPool.Release()
 
 	return m.PutInternal(ctx, entry)
@@ -221,7 +224,9 @@ func (m *CouchDBBackend) Put(ctx context.Context, entry *physical.Entry) error {
 
 // Get is used to fetch an entry
 func (m *CouchDBBackend) Get(ctx context.Context, key string) (*physical.Entry, error) {
-	m.permitPool.Acquire()
+	if err := m.permitPool.Acquire(ctx); err != nil {
+		return nil, err
+	}
 	defer m.permitPool.Release()
 
 	return m.GetInternal(ctx, key)
@@ -229,7 +234,9 @@ func (m *CouchDBBackend) Get(ctx context.Context, key string) (*physical.Entry, 
 
 // Delete is used to permanently delete an entry
 func (m *CouchDBBackend) Delete(ctx context.Context, key string) error {
-	m.permitPool.Acquire()
+	if err := m.permitPool.Acquire(ctx); err != nil {
+		return err
+	}
 	defer m.permitPool.Release()
 
 	return m.DeleteInternal(ctx, key)
@@ -239,7 +246,9 @@ func (m *CouchDBBackend) Delete(ctx context.Context, key string) error {
 func (m *CouchDBBackend) List(ctx context.Context, prefix string) ([]string, error) {
 	defer metrics.MeasureSince([]string{"couchdb", "list"}, time.Now())
 
-	m.permitPool.Acquire()
+	if err := m.permitPool.Acquire(ctx); err != nil {
+		return nil, err
+	}
 	defer m.permitPool.Release()
 
 	items, err := m.client.list(prefix)
@@ -276,7 +285,7 @@ func NewTransactionalCouchDBBackend(conf map[string]string, logger log.Logger) (
 	if err != nil {
 		return nil, err
 	}
-	backend.permitPool = physical.NewPermitPool(1)
+	backend.permitPool = permitpool.New(1)
 
 	return &TransactionalCouchDBBackend{
 		CouchDBBackend: *backend,

--- a/physical/gcs/gcs.go
+++ b/physical/gcs/gcs.go
@@ -19,6 +19,7 @@ import (
 	metrics "github.com/armon/go-metrics"
 	log "github.com/hashicorp/go-hclog"
 	multierror "github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-secure-stdlib/permitpool"
 	"github.com/hashicorp/vault/helper/useragent"
 	"github.com/hashicorp/vault/sdk/physical"
 	"google.golang.org/api/iterator"
@@ -75,7 +76,7 @@ type Backend struct {
 	// client is the API client and permitPool is the allowed concurrent uses of
 	// the client.
 	client     *storage.Client
-	permitPool *physical.PermitPool
+	permitPool *permitpool.Pool
 
 	// haEnabled indicates if HA is enabled.
 	haEnabled bool
@@ -171,7 +172,7 @@ func NewBackend(c map[string]string, logger log.Logger) (physical.Backend, error
 		bucket:     bucket,
 		chunkSize:  chunkSize,
 		client:     client,
-		permitPool: physical.NewPermitPool(maxParallel),
+		permitPool: permitpool.New(maxParallel),
 
 		haEnabled: haEnabled,
 		haClient:  haClient,
@@ -185,7 +186,9 @@ func (b *Backend) Put(ctx context.Context, entry *physical.Entry) (retErr error)
 	defer metrics.MeasureSince(metricPut, time.Now())
 
 	// Pooling
-	b.permitPool.Acquire()
+	if err := b.permitPool.Acquire(ctx); err != nil {
+		return err
+	}
 	defer b.permitPool.Release()
 
 	// Insert
@@ -211,7 +214,9 @@ func (b *Backend) Get(ctx context.Context, key string) (retEntry *physical.Entry
 	defer metrics.MeasureSince(metricGet, time.Now())
 
 	// Pooling
-	b.permitPool.Acquire()
+	if err := b.permitPool.Acquire(ctx); err != nil {
+		return nil, err
+	}
 	defer b.permitPool.Release()
 
 	// Read
@@ -246,7 +251,9 @@ func (b *Backend) Delete(ctx context.Context, key string) error {
 	defer metrics.MeasureSince(metricDelete, time.Now())
 
 	// Pooling
-	b.permitPool.Acquire()
+	if err := b.permitPool.Acquire(ctx); err != nil {
+		return err
+	}
 	defer b.permitPool.Release()
 
 	// Delete
@@ -263,7 +270,9 @@ func (b *Backend) List(ctx context.Context, prefix string) ([]string, error) {
 	defer metrics.MeasureSince(metricList, time.Now())
 
 	// Pooling
-	b.permitPool.Acquire()
+	if err := b.permitPool.Acquire(ctx); err != nil {
+		return nil, err
+	}
 	defer b.permitPool.Release()
 
 	iter := b.client.Bucket(b.bucket).Objects(ctx, &storage.Query{

--- a/physical/manta/manta.go
+++ b/physical/manta/manta.go
@@ -17,6 +17,7 @@ import (
 
 	metrics "github.com/armon/go-metrics"
 	log "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-secure-stdlib/permitpool"
 	"github.com/hashicorp/vault/sdk/physical"
 	triton "github.com/joyent/triton-go"
 	"github.com/joyent/triton-go/authentication"
@@ -28,7 +29,7 @@ const mantaDefaultRootStore = "/stor"
 
 type MantaBackend struct {
 	logger     log.Logger
-	permitPool *physical.PermitPool
+	permitPool *permitpool.Pool
 	client     *storage.StorageClient
 	directory  string
 }
@@ -95,7 +96,7 @@ func NewMantaBackend(conf map[string]string, logger log.Logger) (physical.Backen
 		client:     client,
 		directory:  conf["directory"],
 		logger:     logger,
-		permitPool: physical.NewPermitPool(maxParInt),
+		permitPool: permitpool.New(maxParInt),
 	}, nil
 }
 
@@ -103,7 +104,9 @@ func NewMantaBackend(conf map[string]string, logger log.Logger) (physical.Backen
 func (m *MantaBackend) Put(ctx context.Context, entry *physical.Entry) error {
 	defer metrics.MeasureSince([]string{"manta", "put"}, time.Now())
 
-	m.permitPool.Acquire()
+	if err := m.permitPool.Acquire(ctx); err != nil {
+		return err
+	}
 	defer m.permitPool.Release()
 
 	r := bytes.NewReader(entry.Value)
@@ -121,7 +124,9 @@ func (m *MantaBackend) Put(ctx context.Context, entry *physical.Entry) error {
 func (m *MantaBackend) Get(ctx context.Context, key string) (*physical.Entry, error) {
 	defer metrics.MeasureSince([]string{"manta", "get"}, time.Now())
 
-	m.permitPool.Acquire()
+	if err := m.permitPool.Acquire(ctx); err != nil {
+		return nil, err
+	}
 	defer m.permitPool.Release()
 
 	output, err := m.client.Objects().Get(ctx, &storage.GetObjectInput{
@@ -154,7 +159,9 @@ func (m *MantaBackend) Get(ctx context.Context, key string) (*physical.Entry, er
 func (m *MantaBackend) Delete(ctx context.Context, key string) error {
 	defer metrics.MeasureSince([]string{"manta", "delete"}, time.Now())
 
-	m.permitPool.Acquire()
+	if err := m.permitPool.Acquire(ctx); err != nil {
+		return err
+	}
 	defer m.permitPool.Release()
 
 	if strings.HasSuffix(key, "/") {
@@ -210,7 +217,9 @@ func tryDeleteDirectory(ctx context.Context, m *MantaBackend, directoryPath stri
 func (m *MantaBackend) List(ctx context.Context, prefix string) ([]string, error) {
 	defer metrics.MeasureSince([]string{"manta", "list"}, time.Now())
 
-	m.permitPool.Acquire()
+	if err := m.permitPool.Acquire(ctx); err != nil {
+		return nil, err
+	}
 	defer m.permitPool.Release()
 
 	objs, err := m.client.Dir().List(ctx, &storage.ListDirectoryInput{

--- a/physical/manta/manta_test.go
+++ b/physical/manta/manta_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	log "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-secure-stdlib/permitpool"
 	"github.com/hashicorp/vault/sdk/helper/logging"
 	"github.com/hashicorp/vault/sdk/physical"
 	triton "github.com/joyent/triton-go"
@@ -57,7 +58,7 @@ func TestMantaBackend(t *testing.T) {
 		client:     client,
 		directory:  testHarnessBucket,
 		logger:     logger.Named("storage.mantabackend"),
-		permitPool: physical.NewPermitPool(128),
+		permitPool: permitpool.New(128),
 	}
 
 	err = mb.client.Dir().Put(context.Background(), &storage.PutDirectoryInput{

--- a/physical/mssql/mssql.go
+++ b/physical/mssql/mssql.go
@@ -16,6 +16,7 @@ import (
 	metrics "github.com/armon/go-metrics"
 	_ "github.com/denisenkom/go-mssqldb"
 	log "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-secure-stdlib/permitpool"
 	"github.com/hashicorp/go-secure-stdlib/strutil"
 	"github.com/hashicorp/vault/sdk/physical"
 )
@@ -31,7 +32,7 @@ type MSSQLBackend struct {
 	client     *sql.DB
 	statements map[string]*sql.Stmt
 	logger     log.Logger
-	permitPool *physical.PermitPool
+	permitPool *permitpool.Pool
 }
 
 func isInvalidIdentifier(name string) bool {
@@ -171,7 +172,7 @@ func NewMSSQLBackend(conf map[string]string, logger log.Logger) (physical.Backen
 		client:     db,
 		statements: make(map[string]*sql.Stmt),
 		logger:     logger,
-		permitPool: physical.NewPermitPool(maxParInt),
+		permitPool: permitpool.New(maxParInt),
 	}
 
 	statements := map[string]string{
@@ -205,7 +206,9 @@ func (m *MSSQLBackend) prepare(name, query string) error {
 func (m *MSSQLBackend) Put(ctx context.Context, entry *physical.Entry) error {
 	defer metrics.MeasureSince([]string{"mssql", "put"}, time.Now())
 
-	m.permitPool.Acquire()
+	if err := m.permitPool.Acquire(ctx); err != nil {
+		return err
+	}
 	defer m.permitPool.Release()
 
 	_, err := m.statements["put"].Exec(entry.Key, entry.Value, entry.Key, entry.Key, entry.Value)
@@ -219,7 +222,9 @@ func (m *MSSQLBackend) Put(ctx context.Context, entry *physical.Entry) error {
 func (m *MSSQLBackend) Get(ctx context.Context, key string) (*physical.Entry, error) {
 	defer metrics.MeasureSince([]string{"mssql", "get"}, time.Now())
 
-	m.permitPool.Acquire()
+	if err := m.permitPool.Acquire(ctx); err != nil {
+		return nil, err
+	}
 	defer m.permitPool.Release()
 
 	var result []byte
@@ -243,7 +248,9 @@ func (m *MSSQLBackend) Get(ctx context.Context, key string) (*physical.Entry, er
 func (m *MSSQLBackend) Delete(ctx context.Context, key string) error {
 	defer metrics.MeasureSince([]string{"mssql", "delete"}, time.Now())
 
-	m.permitPool.Acquire()
+	if err := m.permitPool.Acquire(ctx); err != nil {
+		return err
+	}
 	defer m.permitPool.Release()
 
 	_, err := m.statements["delete"].Exec(key)
@@ -257,7 +264,9 @@ func (m *MSSQLBackend) Delete(ctx context.Context, key string) error {
 func (m *MSSQLBackend) List(ctx context.Context, prefix string) ([]string, error) {
 	defer metrics.MeasureSince([]string{"mssql", "list"}, time.Now())
 
-	m.permitPool.Acquire()
+	if err := m.permitPool.Acquire(ctx); err != nil {
+		return nil, err
+	}
 	defer m.permitPool.Release()
 
 	likePrefix := prefix + "%"

--- a/physical/raft/raft.go
+++ b/physical/raft/raft.go
@@ -25,6 +25,7 @@ import (
 	log "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-raftchunking"
 	"github.com/hashicorp/go-secure-stdlib/parseutil"
+	"github.com/hashicorp/go-secure-stdlib/permitpool"
 	"github.com/hashicorp/go-secure-stdlib/tlsutil"
 	"github.com/hashicorp/raft"
 	autopilot "github.com/hashicorp/raft-autopilot"
@@ -175,7 +176,7 @@ type RaftBackend struct {
 	serverAddressProvider raft.ServerAddressProvider
 
 	// permitPool is used to limit the number of concurrent storage calls.
-	permitPool *physical.PermitPool
+	permitPool *permitpool.Pool
 
 	// maxEntrySize imposes a size limit (in bytes) on a raft entry (put or transaction).
 	// It is suggested to use a value of 2x the Raft chunking size for optimal
@@ -632,7 +633,7 @@ func NewRaftBackend(conf map[string]string, logger log.Logger) (physical.Backend
 		closers:                       closers,
 		dataDir:                       backendConfig.Path,
 		localID:                       backendConfig.NodeId,
-		permitPool:                    physical.NewPermitPool(physical.DefaultParallelOperations),
+		permitPool:                    permitpool.New(physical.DefaultParallelOperations),
 		maxEntrySize:                  backendConfig.MaxEntrySize,
 		maxMountAndNamespaceEntrySize: backendConfig.MaxMountAndNamespaceTableEntrySize,
 		maxBatchEntries:               backendConfig.MaxBatchEntries,
@@ -819,7 +820,9 @@ func (b *RaftBackend) applyVerifierCheckpoint() error {
 	data := make([]byte, 1)
 	data[0] = byte(verifierCheckpointOp)
 
-	b.permitPool.Acquire()
+	if err := b.permitPool.Acquire(context.Background()); err != nil {
+		return err
+	}
 	b.l.RLock()
 
 	var err error
@@ -1823,7 +1826,9 @@ func (b *RaftBackend) Delete(ctx context.Context, path string) error {
 			},
 		},
 	}
-	b.permitPool.Acquire()
+	if err := b.permitPool.Acquire(ctx); err != nil {
+		return err
+	}
 	defer b.permitPool.Release()
 
 	b.l.RLock()
@@ -1843,7 +1848,9 @@ func (b *RaftBackend) Get(ctx context.Context, path string) (*physical.Entry, er
 		return nil, err
 	}
 
-	b.permitPool.Acquire()
+	if err := b.permitPool.Acquire(ctx); err != nil {
+		return nil, err
+	}
 	defer b.permitPool.Release()
 
 	if err := ctx.Err(); err != nil {
@@ -1886,7 +1893,9 @@ func (b *RaftBackend) Put(ctx context.Context, entry *physical.Entry) error {
 		},
 	}
 
-	b.permitPool.Acquire()
+	if err := b.permitPool.Acquire(ctx); err != nil {
+		return err
+	}
 	defer b.permitPool.Release()
 
 	b.l.RLock()
@@ -1906,7 +1915,9 @@ func (b *RaftBackend) List(ctx context.Context, prefix string) ([]string, error)
 		return nil, err
 	}
 
-	b.permitPool.Acquire()
+	if err := b.permitPool.Acquire(ctx); err != nil {
+		return nil, err
+	}
 	defer b.permitPool.Release()
 
 	if err := ctx.Err(); err != nil {
@@ -1961,7 +1972,9 @@ func (b *RaftBackend) Transaction(ctx context.Context, txns []*physical.TxnEntry
 		command.Operations[i] = op
 	}
 
-	b.permitPool.Acquire()
+	if err := b.permitPool.Acquire(ctx); err != nil {
+		return err
+	}
 	defer b.permitPool.Release()
 
 	b.l.RLock()

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/hashicorp/go-secure-stdlib/mlock v0.1.3
 	github.com/hashicorp/go-secure-stdlib/parseutil v0.1.8
 	github.com/hashicorp/go-secure-stdlib/password v0.1.1
+	github.com/hashicorp/go-secure-stdlib/permitpool v0.0.0-20250109173936-1ecdd6ad783f
 	github.com/hashicorp/go-secure-stdlib/plugincontainer v0.4.1
 	github.com/hashicorp/go-secure-stdlib/strutil v0.1.2
 	github.com/hashicorp/go-secure-stdlib/tlsutil v0.1.3
@@ -44,7 +45,7 @@ require (
 	github.com/pierrec/lz4 v2.6.1+incompatible
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/ryanuber/go-glob v1.0.0
-	github.com/stretchr/testify v1.9.0
+	github.com/stretchr/testify v1.10.0
 	github.com/tink-crypto/tink-go/v2 v2.2.0
 	go.uber.org/atomic v1.11.0
 	golang.org/x/crypto v0.31.0

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/hashicorp/go-secure-stdlib/mlock v0.1.3
 	github.com/hashicorp/go-secure-stdlib/parseutil v0.1.8
 	github.com/hashicorp/go-secure-stdlib/password v0.1.1
-	github.com/hashicorp/go-secure-stdlib/permitpool v0.0.0-20250109173936-1ecdd6ad783f
+	github.com/hashicorp/go-secure-stdlib/permitpool v1.0.0
 	github.com/hashicorp/go-secure-stdlib/plugincontainer v0.4.1
 	github.com/hashicorp/go-secure-stdlib/strutil v0.1.2
 	github.com/hashicorp/go-secure-stdlib/tlsutil v0.1.3

--- a/sdk/go.sum
+++ b/sdk/go.sum
@@ -202,6 +202,8 @@ github.com/hashicorp/go-secure-stdlib/password v0.1.1 h1:6JzmBqXprakgFEHwBgdchsj
 github.com/hashicorp/go-secure-stdlib/password v0.1.1/go.mod h1:9hH302QllNwu1o2TGYtSk8I8kTAN0ca1EHpwhm5Mmzo=
 github.com/hashicorp/go-secure-stdlib/permitpool v0.0.0-20250109173936-1ecdd6ad783f h1:FC0HhfmXKlQh/21KJFhGsvrOyNY1JEKRobE93wP5cKQ=
 github.com/hashicorp/go-secure-stdlib/permitpool v0.0.0-20250109173936-1ecdd6ad783f/go.mod h1:ecDb3o+8D4xtP0nTCufJaAVawHavy5M2eZ64Nq/8/LM=
+github.com/hashicorp/go-secure-stdlib/permitpool v1.0.0 h1:U6y5MXGiDVOOtkWJ6o/tu1TxABnI0yKTQWJr7z6BpNk=
+github.com/hashicorp/go-secure-stdlib/permitpool v1.0.0/go.mod h1:ecDb3o+8D4xtP0nTCufJaAVawHavy5M2eZ64Nq/8/LM=
 github.com/hashicorp/go-secure-stdlib/plugincontainer v0.4.1 h1:JY+zGg8gOmslwif1fiCqT5Hu1SikLZQcHkmQhCoA9gY=
 github.com/hashicorp/go-secure-stdlib/plugincontainer v0.4.1/go.mod h1:jW3KCTvdPyAdVecOUwiiO2XaYgUJ/isigt++ISkszkY=
 github.com/hashicorp/go-secure-stdlib/strutil v0.1.2 h1:kes8mmyCpxJsI7FTwtzRqEy9CdjCtrXrXGuOpxEA7Ts=

--- a/sdk/go.sum
+++ b/sdk/go.sum
@@ -200,6 +200,8 @@ github.com/hashicorp/go-secure-stdlib/parseutil v0.1.8 h1:iBt4Ew4XEGLfh6/bPk4rSY
 github.com/hashicorp/go-secure-stdlib/parseutil v0.1.8/go.mod h1:aiJI+PIApBRQG7FZTEBx5GiiX+HbOHilUdNxUZi4eV0=
 github.com/hashicorp/go-secure-stdlib/password v0.1.1 h1:6JzmBqXprakgFEHwBgdchsjaA9x3GyjdI568bXKxa60=
 github.com/hashicorp/go-secure-stdlib/password v0.1.1/go.mod h1:9hH302QllNwu1o2TGYtSk8I8kTAN0ca1EHpwhm5Mmzo=
+github.com/hashicorp/go-secure-stdlib/permitpool v0.0.0-20250109173936-1ecdd6ad783f h1:FC0HhfmXKlQh/21KJFhGsvrOyNY1JEKRobE93wP5cKQ=
+github.com/hashicorp/go-secure-stdlib/permitpool v0.0.0-20250109173936-1ecdd6ad783f/go.mod h1:ecDb3o+8D4xtP0nTCufJaAVawHavy5M2eZ64Nq/8/LM=
 github.com/hashicorp/go-secure-stdlib/plugincontainer v0.4.1 h1:JY+zGg8gOmslwif1fiCqT5Hu1SikLZQcHkmQhCoA9gY=
 github.com/hashicorp/go-secure-stdlib/plugincontainer v0.4.1/go.mod h1:jW3KCTvdPyAdVecOUwiiO2XaYgUJ/isigt++ISkszkY=
 github.com/hashicorp/go-secure-stdlib/strutil v0.1.2 h1:kes8mmyCpxJsI7FTwtzRqEy9CdjCtrXrXGuOpxEA7Ts=
@@ -444,8 +446,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
-github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/tink-crypto/tink-go/v2 v2.2.0 h1:L2Da0F2Udh2agtKztdr69mV/KpnY3/lGTkMgLTVIXlA=
 github.com/tink-crypto/tink-go/v2 v2.2.0/go.mod h1:JJ6PomeNPF3cJpfWC0lgyTES6zpJILkAX0cJNwlS3xU=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=

--- a/sdk/physical/file/file.go
+++ b/sdk/physical/file/file.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/hashicorp/errwrap"
 	log "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-secure-stdlib/permitpool"
 	"github.com/hashicorp/vault/sdk/helper/consts"
 	"github.com/hashicorp/vault/sdk/helper/jsonutil"
 	"github.com/hashicorp/vault/sdk/physical"
@@ -40,7 +41,7 @@ type FileBackend struct {
 	sync.RWMutex
 	path       string
 	logger     log.Logger
-	permitPool *physical.PermitPool
+	permitPool *permitpool.Pool
 }
 
 type TransactionalFileBackend struct {
@@ -61,7 +62,7 @@ func NewFileBackend(conf map[string]string, logger log.Logger) (physical.Backend
 	return &FileBackend{
 		path:       path,
 		logger:     logger,
-		permitPool: physical.NewPermitPool(physical.DefaultParallelOperations),
+		permitPool: permitpool.New(physical.DefaultParallelOperations),
 	}, nil
 }
 
@@ -76,7 +77,7 @@ func NewTransactionalFileBackend(conf map[string]string, logger log.Logger) (phy
 		FileBackend: FileBackend{
 			path:       path,
 			logger:     logger,
-			permitPool: physical.NewPermitPool(1),
+			permitPool: permitpool.New(1),
 		},
 	}, nil
 }

--- a/sdk/physical/file/file.go
+++ b/sdk/physical/file/file.go
@@ -83,7 +83,9 @@ func NewTransactionalFileBackend(conf map[string]string, logger log.Logger) (phy
 }
 
 func (b *FileBackend) Delete(ctx context.Context, path string) error {
-	b.permitPool.Acquire()
+	if err := b.permitPool.Acquire(ctx); err != nil {
+		return err
+	}
 	defer b.permitPool.Release()
 
 	b.Lock()
@@ -158,7 +160,9 @@ func (b *FileBackend) cleanupLogicalPath(path string) error {
 }
 
 func (b *FileBackend) Get(ctx context.Context, k string) (*physical.Entry, error) {
-	b.permitPool.Acquire()
+	if err := b.permitPool.Acquire(ctx); err != nil {
+		return nil, err
+	}
 	defer b.permitPool.Release()
 
 	b.RLock()
@@ -217,7 +221,9 @@ func (b *FileBackend) GetInternal(ctx context.Context, k string) (*physical.Entr
 }
 
 func (b *FileBackend) Put(ctx context.Context, entry *physical.Entry) error {
-	b.permitPool.Acquire()
+	if err := b.permitPool.Acquire(ctx); err != nil {
+		return err
+	}
 	defer b.permitPool.Release()
 
 	b.Lock()
@@ -296,7 +302,9 @@ func (b *FileBackend) PutInternal(ctx context.Context, entry *physical.Entry) er
 }
 
 func (b *FileBackend) List(ctx context.Context, prefix string) ([]string, error) {
-	b.permitPool.Acquire()
+	if err := b.permitPool.Acquire(ctx); err != nil {
+		return nil, err
+	}
 	defer b.permitPool.Release()
 
 	b.RLock()
@@ -377,7 +385,9 @@ func (b *FileBackend) validatePath(path string) error {
 }
 
 func (b *TransactionalFileBackend) Transaction(ctx context.Context, txns []*physical.TxnEntry) error {
-	b.permitPool.Acquire()
+	if err := b.permitPool.Acquire(ctx); err != nil {
+		return err
+	}
 	defer b.permitPool.Release()
 
 	b.Lock()

--- a/sdk/physical/inmem/inmem.go
+++ b/sdk/physical/inmem/inmem.go
@@ -150,7 +150,9 @@ func (i *InmemBackend) SetWriteLatency(latency time.Duration) {
 
 // Put is used to insert or update an entry
 func (i *InmemBackend) Put(ctx context.Context, entry *physical.Entry) error {
-	i.permitPool.Acquire()
+	if err := i.permitPool.Acquire(ctx); err != nil {
+		return err
+	}
 	defer i.permitPool.Release()
 
 	i.Lock()
@@ -194,7 +196,9 @@ func (i *InmemBackend) FailPut(fail bool) {
 
 // Get is used to fetch an entry
 func (i *InmemBackend) Get(ctx context.Context, key string) (*physical.Entry, error) {
-	i.permitPool.Acquire()
+	if err := i.permitPool.Acquire(ctx); err != nil {
+		return nil, err
+	}
 	defer i.permitPool.Release()
 
 	i.RLock()
@@ -244,7 +248,9 @@ func (i *InmemBackend) FailGetInTxn(fail bool) {
 
 // Delete is used to permanently delete an entry
 func (i *InmemBackend) Delete(ctx context.Context, key string) error {
-	i.permitPool.Acquire()
+	if err := i.permitPool.Acquire(ctx); err != nil {
+		return err
+	}
 	defer i.permitPool.Release()
 
 	i.Lock()
@@ -284,7 +290,9 @@ func (i *InmemBackend) FailDelete(fail bool) {
 // List is used to list all the keys under a given
 // prefix, up to the next prefix.
 func (i *InmemBackend) List(ctx context.Context, prefix string) ([]string, error) {
-	i.permitPool.Acquire()
+	if err := i.permitPool.Acquire(ctx); err != nil {
+		return nil, err
+	}
 	defer i.permitPool.Release()
 
 	i.RLock()
@@ -356,7 +364,9 @@ func (i *InmemBackend) GetMountTablePaths() []string {
 
 // Transaction implements the transaction interface
 func (t *TransactionalInmemBackend) Transaction(ctx context.Context, txns []*physical.TxnEntry) error {
-	t.permitPool.Acquire()
+	if err := t.permitPool.Acquire(ctx); err != nil {
+		return err
+	}
 	defer t.permitPool.Release()
 
 	t.Lock()

--- a/sdk/physical/inmem/inmem.go
+++ b/sdk/physical/inmem/inmem.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/armon/go-radix"
 	log "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-secure-stdlib/permitpool"
 	"github.com/hashicorp/vault/sdk/physical"
 	uberAtomic "go.uber.org/atomic"
 )
@@ -46,7 +47,7 @@ var (
 type InmemBackend struct {
 	sync.RWMutex
 	root         *radix.Tree
-	permitPool   *physical.PermitPool
+	permitPool   *permitpool.Pool
 	logger       log.Logger
 	failGet      *uint32
 	failPut      *uint32
@@ -90,7 +91,7 @@ func NewInmem(conf map[string]string, logger log.Logger) (physical.Backend, erro
 
 	return &InmemBackend{
 		root:         radix.New(),
-		permitPool:   physical.NewPermitPool(physical.DefaultParallelOperations),
+		permitPool:   permitpool.New(physical.DefaultParallelOperations),
 		logger:       logger,
 		failGet:      new(uint32),
 		failPut:      new(uint32),
@@ -118,7 +119,7 @@ func NewTransactionalInmem(conf map[string]string, logger log.Logger) (physical.
 	return &TransactionalInmemBackend{
 		InmemBackend: InmemBackend{
 			root:         radix.New(),
-			permitPool:   physical.NewPermitPool(1),
+			permitPool:   permitpool.New(1),
 			logger:       logger,
 			failGet:      new(uint32),
 			failPut:      new(uint32),

--- a/sdk/physical/inmem/transactions_test.go
+++ b/sdk/physical/inmem/transactions_test.go
@@ -60,7 +60,9 @@ func (f *faultyPseudo) List(ctx context.Context, prefix string) ([]string, error
 }
 
 func (f *faultyPseudo) Transaction(ctx context.Context, txns []*physical.TxnEntry) error {
-	f.underlying.permitPool.Acquire()
+	if err := f.underlying.permitPool.Acquire(ctx); err != nil {
+		return err
+	}
 	defer f.underlying.permitPool.Release()
 
 	f.underlying.Lock()

--- a/sdk/physical/inmem/transactions_test.go
+++ b/sdk/physical/inmem/transactions_test.go
@@ -12,6 +12,7 @@ import (
 
 	radix "github.com/armon/go-radix"
 	log "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-secure-stdlib/permitpool"
 	"github.com/hashicorp/vault/sdk/helper/logging"
 	"github.com/hashicorp/vault/sdk/physical"
 )
@@ -72,7 +73,7 @@ func newFaultyPseudo(logger log.Logger, faultyPaths []string) *faultyPseudo {
 	out := &faultyPseudo{
 		underlying: InmemBackend{
 			root:       radix.New(),
-			permitPool: physical.NewPermitPool(1),
+			permitPool: permitpool.New(1),
 			logger:     logger.Named("storage.inmembackend"),
 			failGet:    new(uint32),
 			failPut:    new(uint32),

--- a/sdk/physical/physical.go
+++ b/sdk/physical/physical.go
@@ -185,37 +185,6 @@ type Lock interface {
 // Factory is the factory function to create a physical backend.
 type Factory func(config map[string]string, logger log.Logger) (Backend, error)
 
-// PermitPool is used to limit maximum outstanding requests
-type PermitPool struct {
-	sem chan int
-}
-
-// NewPermitPool returns a new permit pool with the provided
-// number of permits
-func NewPermitPool(permits int) *PermitPool {
-	if permits < 1 {
-		permits = DefaultParallelOperations
-	}
-	return &PermitPool{
-		sem: make(chan int, permits),
-	}
-}
-
-// Acquire returns when a permit has been acquired
-func (c *PermitPool) Acquire() {
-	c.sem <- 1
-}
-
-// Release returns a permit to the pool
-func (c *PermitPool) Release() {
-	<-c.sem
-}
-
-// Get number of requests in the permit pool
-func (c *PermitPool) CurrentPermits() int {
-	return len(c.sem)
-}
-
 // Prefixes is a shared helper function returns all parent 'folders' for a
 // given vault key.
 // e.g. for 'foo/bar/baz', it returns ['foo', 'foo/bar']

--- a/sdk/physical/physical.go
+++ b/sdk/physical/physical.go
@@ -11,6 +11,8 @@ import (
 	"github.com/hashicorp/go-secure-stdlib/permitpool"
 )
 
+const DefaultParallelOperations = 128
+
 // The operation type
 type Operation string
 

--- a/sdk/physical/physical.go
+++ b/sdk/physical/physical.go
@@ -8,9 +8,8 @@ import (
 	"strings"
 
 	log "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-secure-stdlib/permitpool"
 )
-
-const DefaultParallelOperations = 128
 
 // The operation type
 type Operation string
@@ -184,6 +183,27 @@ type Lock interface {
 
 // Factory is the factory function to create a physical backend.
 type Factory func(config map[string]string, logger log.Logger) (Backend, error)
+
+// PermitPool is used to limit maximum outstanding requests
+// Deprecated: use permitpool.Pool from go-secure-stdlib.
+type PermitPool struct {
+	*permitpool.Pool
+}
+
+// NewPermitPool returns a new permit pool with the provided
+// number of permits.
+// Deprecated: use permitpool.New from go-secure-stdlib.
+func NewPermitPool(permits int) *PermitPool {
+	return &PermitPool{
+		Pool: permitpool.New(permits),
+	}
+}
+
+// Acquire returns when a permit has been acquired
+// Deprecated: use permitpool.Acquire from go-secure-stdlib.
+func (c *PermitPool) Acquire() {
+	_ = c.Pool.Acquire(context.Background())
+}
 
 // Prefixes is a shared helper function returns all parent 'folders' for a
 // given vault key.


### PR DESCRIPTION
The `PermitPool` type is being moved to go-secure-stdlib to be shared with Boundary.

### [sdk/physical: use permitpool from go-secure-stdlib](https://github.com/hashicorp/vault/pull/29331/commits/148daa150e12f9cb1ce9a745d8ff6be308968642)

### [physical: use permitpool from go-secure-stdlib](https://github.com/hashicorp/vault/pull/29331/commits/29e9c88f1911ff364d842f2cc4e49153e37ee84e)