### PR TITLE
Update add-a-containerized-plugin.mdx

### DIFF
--- a/website/content/docs/plugins/containerized-plugins/add-a-containerized-plugin.mdx
+++ b/website/content/docs/plugins/containerized-plugins/add-a-containerized-plugin.mdx
@@ -158,7 +158,7 @@ secrets plugin for Docker:
    ```
 1. Build the container image and assign an identifiable tag.
    ```shell-session
-   $ docker build -t hashicorp/vault-plugin-secrets-kv:mycontainer .
+   $ docker build -t hashicorp/vault-plugin-secrets-kv:1.0.0 .
    ```
 
 ## Step 5: Register the plugin
@@ -181,7 +181,7 @@ other external plugin that is available locally to Vault.
    $ export SHA256=$(docker images \
        --no-trunc \
        --format="{{ .ID }}" \
-       hashicorp/vault-plugin-secrets-kv:mycontainer | cut -d: -f2)
+       hashicorp/vault-plugin-secrets-kv:1.0.0 | cut -d: -f2)
    ```
    
    </CodeBlockConfig>
@@ -201,7 +201,7 @@ other external plugin that is available locally to Vault.
    ```shell-session
    $ vault plugin register \
        -sha256="${SHA256}" \
-       -oci_image=hashicorp/vault-plugin-secrets-kv:mycontainer \
+       -oci_image=hashicorp/vault-plugin-secrets-kv:1.0.0 \
        secret my-kv-container
    ```
    
@@ -303,7 +303,7 @@ To use an alternative runtime:
    $ vault plugin register \
       -runtime=docker-rt   \
       -sha256="${SHA256}"  \
-      -oci_image=hashicorp/vault-plugin-secrets-kv:mycontainer \
+      -oci_image=hashicorp/vault-plugin-secrets-kv:1.0.0 \
       secret my-kv-container
    ```
 


### PR DESCRIPTION
Changing from `mycontainer` tag to semantic versioning, which is a requirement.

### Description
Updates documentation to ensure the example works.

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
