### PR TITLE
Fix misleading comments about namespaces in docs

### DIFF
--- a/website/content/partials/telemetry-metrics/vault/identity/entity/active/monthly.mdx
+++ b/website/content/partials/telemetry-metrics/vault/identity/entity/active/monthly.mdx
@@ -1,8 +1,8 @@
 ### vault.identity.entity.active.monthly ((#vault-identity-entity-active-monthly))
 
-Metric type | Value    | Description
------------ | -------- | -----------
-gauge       | entities | The number of distinct entities (per namespace) that created a token during the past month
+| Metric type | Value    | Description                                                                                         |
+|-------------|----------|-----------------------------------------------------------------------------------------------------|
+| gauge       | entities | The number of distinct entities (across all namespaces) that created a token during the past month. |
 
 Vault reports `vault.identity.entity.active.monthly` at the start of each month
 when client counting is enabled.

--- a/website/content/partials/telemetry-metrics/vault/identity/entity/active/partial_month.mdx
+++ b/website/content/partials/telemetry-metrics/vault/identity/entity/active/partial_month.mdx
@@ -1,8 +1,8 @@
 ### vault.identity.entity.active.partial_month ((#vault-identity-entity-active-partial_month))
 
-Metric type | Value    | Description
------------ | -------- | -----------
-gauge       | entities | The number of distinct entities (per namespace) that created a token during the current month
+| Metric type | Value    | Description                                                                                            |
+|-------------|----------|--------------------------------------------------------------------------------------------------------|
+| gauge       | entities | The number of distinct entities (across all namespaces) that created a token during the current month. |
 
 Vault reports `vault.identity.entity.active.partial_month` periodically during
 the month when client counting is enabled.

--- a/website/content/partials/telemetry-metrics/vault/identity/entity/active/reporting_period.mdx
+++ b/website/content/partials/telemetry-metrics/vault/identity/entity/active/reporting_period.mdx
@@ -1,8 +1,8 @@
 ### vault.identity.entity.active.reporting_period ((#vault-identity-entity-active-reporting_period))
 
-Metric type | Value    | Description
------------ | -------- | -----------
-gauge       | entities | The number of distinct entities (per namespace) that created a token during the configured reporting period
+| Metric type | Value    | Description                                                                                                          |
+|-------------|----------|----------------------------------------------------------------------------------------------------------------------|
+| gauge       | entities | The number of distinct entities (across all namespaces) that created a token during the configured reporting period. |
 
 Vault reports `vault.identity.entity.active.reporting_period` at the start of
 each month when client counting is enabled.

--- a/website/content/partials/telemetry-metrics/vault/identity/entity/count.mdx
+++ b/website/content/partials/telemetry-metrics/vault/identity/entity/count.mdx
@@ -1,5 +1,5 @@
 ### vault.identity.entity.count ((#vault-identity-entity-count))
 
-Metric type | Value    | Description
------------ | -------- | -----------
-gauge       | entities | The number of identity entity aliases (per namespace) currently stored in Vault
+| Metric type | Value    | Description                                                                              |
+|-------------|----------|------------------------------------------------------------------------------------------|
+| gauge       | entities | The number of identity entity aliases (across all namespaces) currently stored in Vault. |

--- a/website/content/partials/telemetry-metrics/vault/identity/entity/creation.mdx
+++ b/website/content/partials/telemetry-metrics/vault/identity/entity/creation.mdx
@@ -1,5 +1,5 @@
 ### vault.identity.entity.creation ((#vault-identity-entity-creation))
 
-Metric type | Value   | Description
------------ | ------- | -----------
-counter     | number  | The number of identity entities created per namespace
+| Metric type | Value  | Description                                                    |
+|-------------|--------|----------------------------------------------------------------|
+| counter     | number | The number of identity entities created across all namespaces. |


### PR DESCRIPTION
### Description

As reported in https://github.com/hashicorp/vault/issues/29330, these metrics are not per namespace, and in general that's not a pattern that we think is good for metrics (if they were namespace cardinality, we'd want to fix it so they weren't).

This fixes the language suggesting they're per namespace, and also some of the tables were incorrectly formatted, so I autoformatted them.

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [x] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
