### PR TITLE
Fix typo: compatability => compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -228,7 +228,7 @@ proto: check-tools-external
 
 	# No additional sed expressions should be added to this list. Going forward
 	# we should just use the variable names choosen by protobuf. These are left
-	# here for backwards compatability, namely for SDK compilation.
+	# here for backwards compatibility, namely for SDK compilation.
 	$(SED) -i -e 's/Id/ID/' -e 's/SPDX-License-IDentifier/SPDX-License-Identifier/' vault/request_forwarding_service.pb.go
 	$(SED) -i -e 's/Idp/IDP/' -e 's/Url/URL/' -e 's/Id/ID/' -e 's/IDentity/Identity/' -e 's/EntityId/EntityID/' -e 's/Api/API/' -e 's/Qr/QR/' -e 's/Totp/TOTP/' -e 's/Mfa/MFA/' -e 's/Pingid/PingID/' -e 's/namespaceId/namespaceID/' -e 's/Ttl/TTL/' -e 's/BoundCidrs/BoundCIDRs/' -e 's/SPDX-License-IDentifier/SPDX-License-Identifier/' helper/identity/types.pb.go helper/identity/mfa/types.pb.go helper/storagepacker/types.pb.go sdk/plugin/pb/backend.pb.go sdk/logical/identity.pb.go vault/activity/activity_log.pb.go
 

--- a/website/content/docs/secrets/key-management/awskms.mdx
+++ b/website/content/docs/secrets/key-management/awskms.mdx
@@ -76,7 +76,7 @@ within AWS KMS. As such, key rotations performed by the secrets engine use the
 process. Applications should refer to the [alias](https://docs.aws.amazon.com/kms/latest/developerguide/kms-alias.html)
 associated with imported keys. Aliases will always have the form: `hashicorp/<key_name>-<unix_timestamp>`.
 
-## Key purpose compatability
+## Key purpose compatibility
 
 The following table defines which key [purposes](/vault/api-docs/secret/key-management#purpose) can be used
 for each key type supported by AWS KMS.

--- a/website/content/docs/secrets/key-management/gcpkms/index.mdx
+++ b/website/content/docs/secrets/key-management/gcpkms/index.mdx
@@ -48,7 +48,7 @@ target [key ring](https://cloud.google.com/kms/docs/resource-hierarchy#key_rings
 Keys are securely transferred from the secrets engine to GCP Cloud KMS in accordance
 with the [key import](https://cloud.google.com/kms/docs/key-import) specification.
 
-## Key purpose compatability
+## Key purpose compatibility
 
 The following table defines which key [purposes](/vault/api-docs/secret/key-management#purpose) can be used
 for each key type supported by GCP Cloud KMS.


### PR DESCRIPTION
### Description

Fix typo occurring in several files: compatability => compatibility
