### PR TITLE
Remove rootless docker build step

### DIFF
--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -357,30 +357,6 @@ jobs:
           }
           EOF
           sudo systemctl reload docker
-      - name: Install rootless Docker
-        # Enterprise repo runners do not allow sudo, so can't system packages there yet.
-        if: github.repository != 'hashicorp/vault-enterprise'
-        run: |
-          sudo apt-get install -y uidmap dbus-user-session
-          export FORCE_ROOTLESS_INSTALL=1
-          curl -fsSL https://get.docker.com/rootless | sh
-          mkdir -p ~/.config/docker/
-          tee ~/.config/docker/daemon.json  <<EOF
-          {
-            "runtimes": {
-              "runsc": {
-                "path": "/usr/local/bin/runsc",
-                "runtimeArgs": [
-                  "--host-uds=create",
-                  "--ignore-cgroups"
-                ]
-              }
-            }
-          }
-          EOF
-          systemctl --user restart docker
-          # Ensure the original rootful Docker install is still the default.
-          docker context use default
       - id: run-go-tests
         name: Run Go tests
         timeout-minutes: ${{ fromJSON(env.TIMEOUT_IN_MINUTES) }}


### PR DESCRIPTION
### Description

This is failing community PRs, and it also seems to make sense to me to keep CE + Ent building the same way.

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [x] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
