### PR TITLE
Add links to the filtering concept page and the audit API page to the audit filtering doc

### DIFF
--- a/website/content/docs/enterprise/audit/filtering.mdx
+++ b/website/content/docs/enterprise/audit/filtering.mdx
@@ -169,7 +169,6 @@ The `/var/kv-audit.log` now includes four entries in total:
 The fallback device captured entries for the other commands. And the
  original audit file, `vault-audit.log`, continues to capture all audit events.
 
-@include "content-footer-title.mdx"
 
 <Tabs>
 

--- a/website/content/docs/enterprise/audit/filtering.mdx
+++ b/website/content/docs/enterprise/audit/filtering.mdx
@@ -173,19 +173,15 @@ The fallback device captured entries for the other commands. And the
 <Tabs>
 
   <Tab heading="Related concepts">
-    <ul>
-      <li>
-        <a href="/vault/docs/concepts/filtering">Filtering</a>
-      </li>
-    </ul>
+    
+    - [Filtering](/vault/docs/concepts/filtering)
+
   </Tab>
 
   <Tab heading="Related API docs">
-    <ul>
-      <li>
-        <a href="/vault/api-docs/system/audit#common-configuration-options">Audit API</a>
-      </li>
-    </ul>
+
+    - [Audit API](/vault/api-docs/system/audit#common-configuration-options)
+
   </Tab>
 
 </Tabs>

--- a/website/content/docs/enterprise/audit/filtering.mdx
+++ b/website/content/docs/enterprise/audit/filtering.mdx
@@ -168,3 +168,25 @@ The `/var/kv-audit.log` now includes four entries in total:
 
 The fallback device captured entries for the other commands. And the
  original audit file, `vault-audit.log`, continues to capture all audit events.
+
+@include "content-footer-title.mdx"
+
+<Tabs>
+
+  <Tab heading="Related concepts">
+    <ul>
+      <li>
+        <a href="/vault/docs/concepts/filtering">Filtering</a>
+      </li>
+    </ul>
+  </Tab>
+
+  <Tab heading="Related API docs">
+    <ul>
+      <li>
+        <a href="/vault/api-docs/system/audit#common-configuration-options">Audit API</a>
+      </li>
+    </ul>
+  </Tab>
+
+</Tabs>


### PR DESCRIPTION
### Description
We've noticed that users often find the audit filtering page, but miss the related page for filtering. This is probably because the two aren't linked to each other. This is an attempt to make this a little bit better. I tried to follow (what I think is) the existing pattern, but I am not sure if I got it right.

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [x] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
