### PR TITLE
Backport 1.18.x - UI: LDAP Hierarchical Library names

### DIFF
--- a/changelog/29293.txt
+++ b/changelog/29293.txt
@@ -1,0 +1,6 @@
+```release-note:improvement
+ui: Adds navigation for LDAP hierarchical libraries
+```
+```release-note:bug
+ui: Fixes navigation for quick actions in LDAP roles' popup menu
+```

--- a/changelog/29376.txt
+++ b/changelog/29376.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+activity: Include activity records from clients created by deleted or disabled auth mounts in Export API response.
+```

--- a/ui/app/adapters/ldap/library.js
+++ b/ui/app/adapters/ldap/library.js
@@ -7,23 +7,28 @@ import NamedPathAdapter from 'vault/adapters/named-path';
 import { encodePath } from 'vault/utils/path-encoding-helpers';
 
 export default class LdapLibraryAdapter extends NamedPathAdapter {
-  getURL(backend, name) {
+  // path could be the library name (full path) or just part of the path i.e. west-account/
+  _getURL(backend, path) {
     const base = `${this.buildURL()}/${encodePath(backend)}/library`;
-    return name ? `${base}/${name}` : base;
+    return path ? `${base}/${path}` : base;
   }
 
   urlForUpdateRecord(name, modelName, snapshot) {
-    return this.getURL(snapshot.attr('backend'), name);
+    // when editing the name IS the full path so we can use "name" instead of "completeLibraryName" here
+    return this._getURL(snapshot.attr('backend'), name);
   }
   urlForDeleteRecord(name, modelName, snapshot) {
-    return this.getURL(snapshot.attr('backend'), name);
+    const { backend, completeLibraryName } = snapshot.record;
+    return this._getURL(backend, completeLibraryName);
   }
 
   query(store, type, query) {
-    const { backend } = query;
-    return this.ajax(this.getURL(backend), 'GET', { data: { list: true } })
+    const { backend, path_to_library } = query;
+    // if we have a path_to_library then we're listing subdirectories at a hierarchical library path (i.e west-account/my-library)
+    const url = this._getURL(backend, path_to_library);
+    return this.ajax(url, 'GET', { data: { list: true } })
       .then((resp) => {
-        return resp.data.keys.map((name) => ({ name, backend }));
+        return resp.data.keys.map((name) => ({ name, backend, path_to_library }));
       })
       .catch((error) => {
         if (error.httpStatus === 404) {
@@ -34,11 +39,11 @@ export default class LdapLibraryAdapter extends NamedPathAdapter {
   }
   queryRecord(store, type, query) {
     const { backend, name } = query;
-    return this.ajax(this.getURL(backend, name), 'GET').then((resp) => ({ ...resp.data, backend, name }));
+    return this.ajax(this._getURL(backend, name), 'GET').then((resp) => ({ ...resp.data, backend, name }));
   }
 
   fetchStatus(backend, name) {
-    const url = `${this.getURL(backend, name)}/status`;
+    const url = `${this._getURL(backend, name)}/status`;
     return this.ajax(url, 'GET').then((resp) => {
       const statuses = [];
       for (const key in resp.data) {
@@ -53,7 +58,7 @@ export default class LdapLibraryAdapter extends NamedPathAdapter {
     });
   }
   checkOutAccount(backend, name, ttl) {
-    const url = `${this.getURL(backend, name)}/check-out`;
+    const url = `${this._getURL(backend, name)}/check-out`;
     return this.ajax(url, 'POST', { data: { ttl } }).then((resp) => {
       const { lease_id, lease_duration, renewable } = resp;
       const { service_account_name: account, password } = resp.data;
@@ -61,7 +66,7 @@ export default class LdapLibraryAdapter extends NamedPathAdapter {
     });
   }
   checkInAccount(backend, name, service_account_names) {
-    const url = `${this.getURL(backend, name)}/check-in`;
+    const url = `${this._getURL(backend, name)}/check-in`;
     return this.ajax(url, 'POST', { data: { service_account_names } }).then((resp) => resp.data);
   }
 }

--- a/ui/app/adapters/ldap/role.js
+++ b/ui/app/adapters/ldap/role.js
@@ -56,8 +56,8 @@ export default class LdapRoleAdapter extends ApplicationAdapter {
   }
 
   urlForDeleteRecord(id, modelName, snapshot) {
-    const { backend, type, name } = snapshot.record;
-    return this._getURL(backend, this._pathForRoleType(type), name);
+    const { backend, type, completeRoleName } = snapshot.record;
+    return this._getURL(backend, this._pathForRoleType(type), completeRoleName);
   }
 
   /* 

--- a/ui/app/models/ldap/library.js
+++ b/ui/app/models/ldap/library.js
@@ -18,6 +18,7 @@ const formFields = ['name', 'service_account_names', 'ttl', 'max_ttl', 'disable_
 @withFormFields(formFields)
 export default class LdapLibraryModel extends Model {
   @attr('string') backend; // dynamic path of secret -- set on response from value passed to queryRecord
+  @attr('string') path_to_library; // ancestral path to the library added in the adapter (only exists for nested libraries)
 
   @attr('string', {
     label: 'Library name',
@@ -63,6 +64,12 @@ export default class LdapLibraryModel extends Model {
     defaultValue: 'Enabled',
   })
   disable_check_in_enforcement;
+
+  get completeLibraryName() {
+    // if there is a path_to_library then the name is hierarchical
+    // and we must concat the ancestors with the leaf name to get the full library path
+    return this.path_to_library ? this.path_to_library + this.name : this.name;
+  }
 
   get displayFields() {
     return this.formFields.filter((field) => field.name !== 'service_account_names');

--- a/ui/app/models/ldap/role.js
+++ b/ui/app/models/ldap/role.js
@@ -163,6 +163,12 @@ export default class LdapRoleModel extends Model {
   })
   rollback_ldif;
 
+  get completeRoleName() {
+    // if there is a path_to_role then the name is hierarchical
+    // and we must concat the ancestors with the leaf name to get the full role path
+    return this.path_to_role ? this.path_to_role + this.name : this.name;
+  }
+
   get isStatic() {
     return this.type === 'static';
   }
@@ -224,9 +230,11 @@ export default class LdapRoleModel extends Model {
   }
 
   fetchCredentials() {
-    return this.store.adapterFor('ldap/role').fetchCredentials(this.backend, this.type, this.name);
+    return this.store
+      .adapterFor('ldap/role')
+      .fetchCredentials(this.backend, this.type, this.completeRoleName);
   }
   rotateStaticPassword() {
-    return this.store.adapterFor('ldap/role').rotateStaticPassword(this.backend, this.name);
+    return this.store.adapterFor('ldap/role').rotateStaticPassword(this.backend, this.completeRoleName);
   }
 }

--- a/ui/lib/ldap/addon/components/page/libraries.hbs
+++ b/ui/lib/ldap/addon/components/page/libraries.hbs
@@ -43,10 +43,10 @@
 {{else}}
   <div class="has-bottom-margin-s">
     {{#each this.filteredLibraries as |library|}}
-      <ListItem @linkPrefix={{this.mountPoint}} @linkParams={{array "libraries.library.details" library.name}} as |Item|>
+      <ListItem @linkPrefix={{this.mountPoint}} @linkParams={{this.linkParams library}} as |Item|>
         <Item.content>
           <Icon @name="folder" />
-          <span data-test-library={{library.name}}>{{library.name}}</span>
+          <span data-test-library={{library.completeLibraryName}}>{{library.name}}</span>
         </Item.content>
         <Item.menu>
           {{#if (or library.canRead library.canEdit library.canDelete)}}
@@ -55,21 +55,40 @@
                 @icon="more-horizontal"
                 @text="More options"
                 @hasChevron={{false}}
-                data-test-popup-menu-trigger
+                data-test-popup-menu-trigger={{library.completeLibraryName}}
               />
-              {{#if library.canEdit}}
-                <dd.Interactive @text="Edit" data-test-edit @route="libraries.library.edit" @model={{library}} />
-              {{/if}}
-              {{#if library.canRead}}
-                <dd.Interactive @text="Details" data-test-details @route="libraries.library.details" @model={{library}} />
-              {{/if}}
-              {{#if library.canDelete}}
+              {{#if (this.isHierarchical library.name)}}
                 <dd.Interactive
-                  @text="Delete"
-                  data-test-delete
-                  @color="critical"
-                  {{on "click" (fn (mut this.libraryToDelete) library)}}
+                  @text="Content"
+                  data-test-subdirectory
+                  @route="libraries.subdirectory"
+                  @model={{library.completeLibraryName}}
                 />
+              {{else}}
+                {{#if library.canEdit}}
+                  <dd.Interactive
+                    @text="Edit"
+                    data-test-edit
+                    @route="libraries.library.edit"
+                    @model={{library.completeLibraryName}}
+                  />
+                {{/if}}
+                {{#if library.canRead}}
+                  <dd.Interactive
+                    @text="Details"
+                    data-test-details
+                    @route="libraries.library.details"
+                    @model={{library.completeLibraryName}}
+                  />
+                {{/if}}
+                {{#if library.canDelete}}
+                  <dd.Interactive
+                    @text="Delete"
+                    data-test-delete
+                    @color="critical"
+                    {{on "click" (fn (mut this.libraryToDelete) library)}}
+                  />
+                {{/if}}
               {{/if}}
             </Hds::Dropdown>
           {{/if}}

--- a/ui/lib/ldap/addon/components/page/libraries.ts
+++ b/ui/lib/ldap/addon/components/page/libraries.ts
@@ -14,6 +14,7 @@ import type LdapLibraryModel from 'vault/models/ldap/library';
 import type SecretEngineModel from 'vault/models/secret-engine';
 import type FlashMessageService from 'vault/services/flash-messages';
 import type { Breadcrumb, EngineOwner } from 'vault/vault/app-types';
+import type RouterService from '@ember/routing/router-service';
 
 interface Args {
   libraries: Array<LdapLibraryModel>;
@@ -24,9 +25,17 @@ interface Args {
 
 export default class LdapLibrariesPageComponent extends Component<Args> {
   @service declare readonly flashMessages: FlashMessageService;
+  @service('app-router') declare readonly router: RouterService;
 
   @tracked filterValue = '';
   @tracked libraryToDelete: LdapLibraryModel | null = null;
+
+  isHierarchical = (name: string) => name.endsWith('/');
+
+  linkParams = (library: LdapLibraryModel) => {
+    const route = this.isHierarchical(library.name) ? 'libraries.subdirectory' : 'libraries.library.details';
+    return [route, library.completeLibraryName];
+  };
 
   get mountPoint(): string {
     const owner = getOwner(this) as EngineOwner;
@@ -43,8 +52,9 @@ export default class LdapLibrariesPageComponent extends Component<Args> {
   @action
   async onDelete(model: LdapLibraryModel) {
     try {
-      const message = `Successfully deleted library ${model.name}.`;
+      const message = `Successfully deleted library ${model.completeLibraryName}.`;
       await model.destroyRecord();
+      this.router.transitionTo('vault.cluster.secrets.backend.ldap.libraries');
       this.flashMessages.success(message);
     } catch (error) {
       this.flashMessages.danger(`Error deleting library \n ${errorMessage(error)}`);

--- a/ui/lib/ldap/addon/components/page/library/details/accounts.ts
+++ b/ui/lib/ldap/addon/components/page/library/details/accounts.ts
@@ -27,7 +27,7 @@ export default class LdapLibraryDetailsAccountsPageComponent extends Component<A
   @tracked checkOutTtl: string | null = null;
 
   get cliCommand() {
-    return `vault lease renew ad/library/${this.args.library.name}/check-out/:lease_id`;
+    return `vault lease renew ${this.args.library.backend}/library/${this.args.library.name}/check-out/:lease_id`;
   }
   @action
   setTtl(data: TtlEvent) {

--- a/ui/lib/ldap/addon/components/page/roles.hbs
+++ b/ui/lib/ldap/addon/components/page/roles.hbs
@@ -62,7 +62,7 @@
                 @text="Content"
                 data-test-subdirectory
                 @route="roles.subdirectory"
-                @models={{array role.type (concat role.path_to_role role.name)}}
+                @models={{array role.type role.completeRoleName}}
               />
             {{else}}
               {{#if role.canEdit}}
@@ -73,7 +73,7 @@
                   @text="Get credentials"
                   data-test-get-creds
                   @route="roles.role.credentials"
-                  @models={{array role.type role.name}}
+                  @models={{array role.type role.completeRoleName}}
                 />
               {{/if}}
               {{#if role.canRotateStaticCreds}}
@@ -89,7 +89,7 @@
                 data-test-details
                 @route="roles.role.details"
                 {{! this will force the roles.role model hook to fire since we may only have a partial model loaded in the list view }}
-                @models={{array role.type role.name}}
+                @models={{array role.type role.completeRoleName}}
               />
               {{#if role.canDelete}}
                 <dd.Interactive

--- a/ui/lib/ldap/addon/components/page/roles.ts
+++ b/ui/lib/ldap/addon/components/page/roles.ts
@@ -36,10 +36,7 @@ export default class LdapRolesPageComponent extends Component<Args> {
 
   linkParams = (role: LdapRoleModel) => {
     const route = this.isHierarchical(role.name) ? 'roles.subdirectory' : 'roles.role.details';
-    // if there is a path_to_role we're in a subdirectory
-    // and must concat the ancestors with the leaf name to get the full role path
-    const roleName = role.path_to_role ? role.path_to_role + role.name : role.name;
-    return [route, role.type, roleName];
+    return [route, role.type, role.completeRoleName];
   };
 
   get mountPoint(): string {
@@ -60,7 +57,7 @@ export default class LdapRolesPageComponent extends Component<Args> {
   @action
   async onRotate(model: LdapRoleModel) {
     try {
-      const message = `Successfully rotated credentials for ${model.name}.`;
+      const message = `Successfully rotated credentials for ${model.completeRoleName}.`;
       await model.rotateStaticPassword();
       this.flashMessages.success(message);
     } catch (error) {
@@ -73,7 +70,7 @@ export default class LdapRolesPageComponent extends Component<Args> {
   @action
   async onDelete(model: LdapRoleModel) {
     try {
-      const message = `Successfully deleted role ${model.name}.`;
+      const message = `Successfully deleted role ${model.completeRoleName}.`;
       await model.destroyRecord();
       this.store.clearDataset('ldap/role');
       this.router.transitionTo('vault.cluster.secrets.backend.ldap.roles');

--- a/ui/lib/ldap/addon/routes.js
+++ b/ui/lib/ldap/addon/routes.js
@@ -19,6 +19,8 @@ export default buildRoutes(function () {
   });
   this.route('libraries', function () {
     this.route('create');
+    // wildcard route so we can traverse hierarchical libraries i.e. prod/admin/my-library
+    this.route('subdirectory', { path: '/subdirectory/*path_to_library' });
     this.route('library', { path: '/:name' }, function () {
       this.route('details', function () {
         this.route('accounts');

--- a/ui/lib/ldap/addon/routes/libraries/library/check-out.ts
+++ b/ui/lib/ldap/addon/routes/libraries/library/check-out.ts
@@ -16,6 +16,7 @@ import type Transition from '@ember/routing/transition';
 import type { Breadcrumb } from 'vault/vault/app-types';
 import { LdapLibraryCheckOutCredentials } from 'vault/vault/adapters/ldap/library';
 import type AdapterError from 'ember-data/adapter'; // eslint-disable-line ember/use-ember-data-rfc-395-imports
+import { ldapBreadcrumbs, libraryRoutes } from 'ldap/utils/ldap-breadcrumbs';
 
 interface LdapLibraryCheckOutController extends Controller {
   breadcrumbs: Array<Breadcrumb>;
@@ -45,13 +46,15 @@ export default class LdapLibraryCheckOutRoute extends Route {
     transition: Transition
   ) {
     super.setupController(controller, resolvedModel, transition);
-
     const library = this.modelFor('libraries.library') as LdapLibraryModel;
+    const routeParams = (childResource: string) => {
+      return [library.backend, childResource];
+    };
     controller.breadcrumbs = [
       { label: library.backend, route: 'overview' },
-      { label: 'libraries', route: 'libraries' },
-      { label: library.name, route: 'libraries.library' },
-      { label: 'check-out' },
+      { label: 'Libraries', route: 'libraries' },
+      ...ldapBreadcrumbs(library.name, routeParams, libraryRoutes),
+      { label: 'Check-Out' },
     ];
   }
 

--- a/ui/lib/ldap/addon/routes/libraries/library/details.ts
+++ b/ui/lib/ldap/addon/routes/libraries/library/details.ts
@@ -9,6 +9,7 @@ import type LdapLibraryModel from 'vault/models/ldap/library';
 import type Controller from '@ember/controller';
 import type Transition from '@ember/routing/transition';
 import type { Breadcrumb } from 'vault/vault/app-types';
+import { ldapBreadcrumbs, libraryRoutes } from 'ldap/utils/ldap-breadcrumbs';
 
 interface LdapLibraryDetailsController extends Controller {
   breadcrumbs: Array<Breadcrumb>;
@@ -23,10 +24,14 @@ export default class LdapLibraryDetailsRoute extends Route {
   ) {
     super.setupController(controller, resolvedModel, transition);
 
+    const routeParams = (childResource: string) => {
+      return [resolvedModel.backend, childResource];
+    };
+
     controller.breadcrumbs = [
       { label: resolvedModel.backend, route: 'overview' },
-      { label: 'libraries', route: 'libraries' },
-      { label: resolvedModel.name },
+      { label: 'Libraries', route: 'libraries' },
+      ...ldapBreadcrumbs(resolvedModel.name, routeParams, libraryRoutes, true),
     ];
   }
 }

--- a/ui/lib/ldap/addon/routes/libraries/library/edit.ts
+++ b/ui/lib/ldap/addon/routes/libraries/library/edit.ts
@@ -9,6 +9,7 @@ import type LdapLibraryModel from 'vault/models/ldap/library';
 import type Controller from '@ember/controller';
 import type Transition from '@ember/routing/transition';
 import type { Breadcrumb } from 'vault/vault/app-types';
+import { ldapBreadcrumbs, libraryRoutes } from 'ldap/utils/ldap-breadcrumbs';
 
 interface LdapLibraryEditController extends Controller {
   breadcrumbs: Array<Breadcrumb>;
@@ -23,11 +24,14 @@ export default class LdapLibraryEditRoute extends Route {
   ) {
     super.setupController(controller, resolvedModel, transition);
 
+    const routeParams = (childResource: string) => {
+      return [resolvedModel.backend, childResource];
+    };
     controller.breadcrumbs = [
       { label: resolvedModel.backend, route: 'overview' },
-      { label: 'libraries', route: 'libraries' },
-      { label: resolvedModel.name, route: 'libraries.library.details' },
-      { label: 'edit' },
+      { label: 'Libraries', route: 'libraries' },
+      ...ldapBreadcrumbs(resolvedModel.name, routeParams, libraryRoutes),
+      { label: 'Edit' },
     ];
   }
 }

--- a/ui/lib/ldap/addon/routes/libraries/subdirectory.ts
+++ b/ui/lib/ldap/addon/routes/libraries/subdirectory.ts
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+import { hash } from 'rsvp';
+
+import type Store from '@ember-data/store';
+import type SecretMountPath from 'vault/services/secret-mount-path';
+import type Transition from '@ember/routing/transition';
+import type LdapLibraryModel from 'vault/models/ldap/library';
+import type SecretEngineModel from 'vault/models/secret-engine';
+import type Controller from '@ember/controller';
+import type { Breadcrumb } from 'vault/vault/app-types';
+import { ldapBreadcrumbs, libraryRoutes } from 'ldap/utils/ldap-breadcrumbs';
+
+interface RouteModel {
+  backendModel: SecretEngineModel;
+  path_to_library: string;
+  libraries: Array<LdapLibraryModel>;
+}
+interface RouteController extends Controller {
+  breadcrumbs: Array<Breadcrumb>;
+  model: RouteModel;
+}
+interface RouteParams {
+  path_to_library?: string;
+}
+
+export default class LdapLibrariesSubdirectoryRoute extends Route {
+  @service declare readonly store: Store;
+  @service declare readonly secretMountPath: SecretMountPath;
+
+  model(params: RouteParams) {
+    const backendModel = this.modelFor('application') as SecretEngineModel;
+    const { path_to_library } = params;
+    return hash({
+      backendModel,
+      path_to_library,
+      libraries: this.store.query('ldap/library', { backend: backendModel.id, path_to_library }),
+    });
+  }
+
+  setupController(controller: RouteController, resolvedModel: RouteModel, transition: Transition) {
+    super.setupController(controller, resolvedModel, transition);
+
+    const routeParams = (childResource: string) => {
+      return [resolvedModel.backendModel.id, childResource];
+    };
+
+    controller.breadcrumbs = [
+      { label: 'Secrets', route: 'secrets', linkExternal: true },
+      { label: resolvedModel.backendModel.id, route: 'overview' },
+      { label: 'Libraries', route: 'libraries' },
+      ...ldapBreadcrumbs(resolvedModel.path_to_library, routeParams, libraryRoutes, true),
+    ];
+  }
+}

--- a/ui/lib/ldap/addon/routes/roles/role/credentials.ts
+++ b/ui/lib/ldap/addon/routes/roles/role/credentials.ts
@@ -5,7 +5,7 @@
 
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
-import { ldapBreadcrumbs } from 'ldap/utils/ldap-breadcrumbs';
+import { ldapBreadcrumbs, roleRoutes } from 'ldap/utils/ldap-breadcrumbs';
 
 import type Store from '@ember-data/store';
 import type LdapRoleModel from 'vault/models/ldap/role';
@@ -58,11 +58,14 @@ export default class LdapRoleCredentialsRoute extends Route {
     super.setupController(controller, resolvedModel, transition);
 
     const role = this.modelFor('roles.role') as LdapRoleModel;
+    const routeParams = (childResource: string) => {
+      return [role.backend, role.type, childResource];
+    };
     controller.breadcrumbs = [
       { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: role.backend, route: 'overview' },
       { label: 'Roles', route: 'roles' },
-      ...ldapBreadcrumbs(role.name, role.type, role.backend),
+      ...ldapBreadcrumbs(role.name, routeParams, roleRoutes),
       { label: 'Credentials' },
     ];
   }

--- a/ui/lib/ldap/addon/routes/roles/role/details.ts
+++ b/ui/lib/ldap/addon/routes/roles/role/details.ts
@@ -5,7 +5,7 @@
 
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
-import { ldapBreadcrumbs } from 'ldap/utils/ldap-breadcrumbs';
+import { ldapBreadcrumbs, roleRoutes } from 'ldap/utils/ldap-breadcrumbs';
 
 import type { Breadcrumb } from 'vault/vault/app-types';
 import type Controller from '@ember/controller';
@@ -24,11 +24,15 @@ export default class LdapRolesRoleDetailsRoute extends Route {
   setupController(controller: RouteController, resolvedModel: LdapRoleModel, transition: Transition) {
     super.setupController(controller, resolvedModel, transition);
 
+    const routeParams = (childResource: string) => {
+      return [this.secretMountPath.currentPath, resolvedModel.type, childResource];
+    };
+
     controller.breadcrumbs = [
       { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: resolvedModel.backend, route: 'overview' },
       { label: 'Roles', route: 'roles' },
-      ...ldapBreadcrumbs(resolvedModel.name, resolvedModel.type, this.secretMountPath.currentPath, true),
+      ...ldapBreadcrumbs(resolvedModel.name, routeParams, roleRoutes, true),
     ];
   }
 }

--- a/ui/lib/ldap/addon/routes/roles/role/edit.ts
+++ b/ui/lib/ldap/addon/routes/roles/role/edit.ts
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { ldapBreadcrumbs } from 'ldap/utils/ldap-breadcrumbs';
+import { ldapBreadcrumbs, roleRoutes } from 'ldap/utils/ldap-breadcrumbs';
 
 import type LdapRoleModel from 'vault/models/ldap/role';
 import type Controller from '@ember/controller';
@@ -20,11 +20,15 @@ export default class LdapRoleEditRoute extends Route {
   setupController(controller: RouteController, resolvedModel: LdapRoleModel, transition: Transition) {
     super.setupController(controller, resolvedModel, transition);
 
+    const routeParams = (childResource: string) => {
+      return [resolvedModel.backend, resolvedModel.type, childResource];
+    };
+
     controller.breadcrumbs = [
       { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: resolvedModel.backend, route: 'overview' },
       { label: 'Roles', route: 'roles' },
-      ...ldapBreadcrumbs(resolvedModel.name, resolvedModel.type, resolvedModel.backend),
+      ...ldapBreadcrumbs(resolvedModel.name, routeParams, roleRoutes),
       { label: 'Edit' },
     ];
   }

--- a/ui/lib/ldap/addon/routes/roles/subdirectory.ts
+++ b/ui/lib/ldap/addon/routes/roles/subdirectory.ts
@@ -5,7 +5,7 @@
 
 import LdapRolesRoute from '../roles';
 import { hash } from 'rsvp';
-import { ldapBreadcrumbs } from 'ldap/utils/ldap-breadcrumbs';
+import { ldapBreadcrumbs, roleRoutes } from 'ldap/utils/ldap-breadcrumbs';
 
 import type { Breadcrumb } from 'vault/vault/app-types';
 import type Controller from '@ember/controller';
@@ -55,11 +55,16 @@ export default class LdapRolesSubdirectoryRoute extends LdapRolesRoute {
   setupController(controller: RouteController, resolvedModel: RouteModel, transition: Transition) {
     super.setupController(controller, resolvedModel, transition);
     const { backendModel, roleAncestry } = resolvedModel;
+
+    const routeParams = (childResource: string) => {
+      return [backendModel.id, roleAncestry.type, childResource];
+    };
+
     const crumbs = [
       { label: 'Secrets', route: 'secrets', linkExternal: true },
       { label: backendModel.id, route: 'overview' },
       { label: 'Roles', route: 'roles' },
-      ...ldapBreadcrumbs(roleAncestry.path_to_role, roleAncestry.type, backendModel.id, true),
+      ...ldapBreadcrumbs(roleAncestry.path_to_role, routeParams, roleRoutes, true),
     ];
 
     // must call 'set' so breadcrumbs update as we navigate through directories

--- a/ui/lib/ldap/addon/templates/libraries/subdirectory.hbs
+++ b/ui/lib/ldap/addon/templates/libraries/subdirectory.hbs
@@ -1,0 +1,11 @@
+{{!
+  Copyright (c) HashiCorp, Inc.
+  SPDX-License-Identifier: BUSL-1.1
+~}}
+
+<Page::Libraries
+  @libraries={{this.model.libraries}}
+  @promptConfig={{false}}
+  @backendModel={{this.model.backendModel}}
+  @breadcrumbs={{this.breadcrumbs}}
+/>

--- a/ui/lib/ldap/addon/utils/ldap-breadcrumbs.ts
+++ b/ui/lib/ldap/addon/utils/ldap-breadcrumbs.ts
@@ -4,10 +4,16 @@
  */
 import type { Breadcrumb } from 'vault/vault/app-types';
 
+export const roleRoutes = { details: 'roles.role.details', subdirectory: 'roles.subdirectory' };
+export const libraryRoutes = {
+  details: 'libraries.library.details',
+  subdirectory: 'libraries.subdirectory',
+};
+
 export const ldapBreadcrumbs = (
   fullPath: string | undefined, // i.e. path/to/item
-  roleType: string,
-  mountPath: string,
+  routeParams: (childResource: string) => string[], // array of route param strings
+  routes: { details: string; subdirectory: string },
   lastItemCurrent = false // this array of objects can be spread anywhere within the crumbs array
 ): Breadcrumb[] => {
   if (!fullPath) return [];
@@ -26,11 +32,10 @@ export const ldapBreadcrumbs = (
     const segment = ancestry.slice(0, idx + 1).join('/');
 
     const itemPath = isLast && !isDirectory ? segment : `${segment}/`;
-    const routeParams = [mountPath, roleType, itemPath];
     return {
       label: name,
-      route: isLast && !isDirectory ? 'roles.role.details' : 'roles.subdirectory',
-      models: routeParams,
+      route: isLast && !isDirectory ? routes.details : routes.subdirectory,
+      models: routeParams(itemPath),
     };
   });
 };

--- a/ui/mirage/handlers/ldap.js
+++ b/ui/mirage/handlers/ldap.js
@@ -10,6 +10,7 @@ export default function (server) {
     const { name, backend } = req.params;
     return name ? { name } : { backend };
   };
+
   const getRecord = (schema, req, dbKey) => {
     const record = schema.db[dbKey].findBy(query(req));
     if (record) {
@@ -21,6 +22,7 @@ export default function (server) {
     }
     return new Response(404, {}, { errors: [] });
   };
+
   const createOrUpdateRecord = (schema, req, dbKey) => {
     const data = JSON.parse(req.requestBody);
     const dbCollection = schema.db[dbKey];
@@ -28,6 +30,7 @@ export default function (server) {
     dbCollection.update(query(req), data);
     return new Response(204);
   };
+
   const listRecords = (schema, dbKey, query = {}) => {
     const records = schema.db[dbKey].where(query);
     const keys = records.map(({ name }) => {
@@ -56,17 +59,6 @@ export default function (server) {
     return getRecord(schema, req, 'ldapRoles', type);
   };
 
-  // mount
-  server.post('/sys/mounts/:path', () => new Response(204));
-  server.get('/sys/internal/ui/mounts/:path', () => ({
-    data: {
-      accessor: 'ldap_ade94329',
-      type: 'ldap',
-      path: 'ldap-test/',
-      uuid: '35e9119d-5708-4b6b-58d2-f913e27f242d',
-      config: {},
-    },
-  }));
   // config
   server.post('/:backend/config', (schema, req) => createOrUpdateRecord(schema, req, 'ldapConfigs'));
   server.get('/:backend/config', (schema, req) => getRecord(schema, req, 'ldapConfigs'));
@@ -90,8 +82,60 @@ export default function (server) {
   server.post('/:backend/library/:name', (schema, req) => createOrUpdateRecord(schema, req, 'ldapLibraries'));
   server.get('/:backend/library/:name', (schema, req) => getRecord(schema, req, 'ldapLibraries'));
   server.get('/:backend/library', (schema) => listRecords(schema, 'ldapLibraries'));
-  server.get('/:backend/library/:name/status', () => ({
-    'bob.johnson': { available: false, borrower_client_token: '8b80c305eb3a7dbd161ef98f10ea60a116ce0910' },
-    'mary.smith': { available: true },
-  }));
+  server.get('/:backend/library/:name/status', (schema) => {
+    const data = schema.db['ldapAccountStatuses'].reduce((prev, curr) => {
+      prev[curr.account] = {
+        available: curr.available,
+        borrower_client_token: curr.borrower_client_token,
+      };
+      return prev;
+    }, {});
+    return { data };
+  });
+  // check-out / check-in
+  server.post('/:backend/library/:set_name/check-in', (schema, req) => {
+    // Check-in makes an unavailable account available again
+    const { service_account_names } = JSON.parse(req.requestBody);
+    const dbCollection = schema.db['ldapAccountStatuses'];
+    const updated = dbCollection.find(service_account_names).map((f) => ({
+      ...f,
+      available: true,
+      borrower_client_token: undefined,
+    }));
+    updated.forEach((u) => {
+      dbCollection.update(u.id, u);
+    });
+    return {
+      data: {
+        check_ins: service_account_names,
+      },
+    };
+  });
+  server.post('/:backend/library/:set_name/check-out', (schema, req) => {
+    const { set_name, backend } = req.params;
+    const dbCollection = schema.db['ldapAccountStatuses'];
+    const available = dbCollection.where({ available: true });
+    if (available) {
+      return Response(404, {}, { errors: ['no accounts available to check out'] });
+    }
+    const checkOut = {
+      ...available[0],
+      available: false,
+      borrower_client_token: crypto.randomUUID(),
+    };
+    dbCollection.update(checkOut.id, checkOut);
+    return {
+      request_id: '364a17d4-e5ab-998b-ceee-b49929229e0c',
+      lease_id: `${backend}/library/${set_name}/check-out/aoBsaBEI4PK96VnukubvYDlZ`,
+      renewable: true,
+      lease_duration: 36000,
+      data: {
+        password: crypto.randomUUID(),
+        service_account_name: checkOut.account,
+      },
+      wrap_info: null,
+      warnings: null,
+      auth: null,
+    };
+  });
 }

--- a/ui/mirage/handlers/ldap.js
+++ b/ui/mirage/handlers/ldap.js
@@ -49,14 +49,16 @@ export default function (server) {
   };
 
   const listOrGetRecord = (schema, req, type) => {
-    // if the param name is admin, we want to LIST admin/ roles
+    const dbKey = type ? 'ldapRoles' : 'ldapLibraries';
+    const query = type ? { type, name: `admin/child-${type}-role` } : { name: 'admin/test-library' };
     if (req.queryParams.list) {
-      // passing a query with specific name is not flexible
-      // but we only seeded the mirage db with one hierarchical role for each type
-      return listRecords(schema, 'ldapRoles', { type, name: `admin/child-${type}-role` });
+      // the mirage database has setup all hierarchical names to be prefixed with "admin/"
+      // while passing a query with specific name is not flexible, for simplicity
+      // we only seeded the mirage db with one hierarchical resource for each role and a library
+      return listRecords(schema, dbKey, query);
     }
-    // otherwise we want to view details for a specific role
-    return getRecord(schema, req, 'ldapRoles', type);
+    // otherwise we want to view details for a specific resource
+    return getRecord(schema, req, dbKey);
   };
 
   // config
@@ -80,9 +82,9 @@ export default function (server) {
   }));
   // libraries
   server.post('/:backend/library/:name', (schema, req) => createOrUpdateRecord(schema, req, 'ldapLibraries'));
-  server.get('/:backend/library/:name', (schema, req) => getRecord(schema, req, 'ldapLibraries'));
+  server.get('/:backend/library/*name', (schema, req) => listOrGetRecord(schema, req));
   server.get('/:backend/library', (schema) => listRecords(schema, 'ldapLibraries'));
-  server.get('/:backend/library/:name/status', (schema) => {
+  server.get('/:backend/library/*name/status', (schema) => {
     const data = schema.db['ldapAccountStatuses'].reduce((prev, curr) => {
       prev[curr.account] = {
         available: curr.available,

--- a/ui/mirage/handlers/ldap.js
+++ b/ui/mirage/handlers/ldap.js
@@ -84,60 +84,8 @@ export default function (server) {
   server.post('/:backend/library/:name', (schema, req) => createOrUpdateRecord(schema, req, 'ldapLibraries'));
   server.get('/:backend/library/*name', (schema, req) => listOrGetRecord(schema, req));
   server.get('/:backend/library', (schema) => listRecords(schema, 'ldapLibraries'));
-  server.get('/:backend/library/*name/status', (schema) => {
-    const data = schema.db['ldapAccountStatuses'].reduce((prev, curr) => {
-      prev[curr.account] = {
-        available: curr.available,
-        borrower_client_token: curr.borrower_client_token,
-      };
-      return prev;
-    }, {});
-    return { data };
-  });
-  // check-out / check-in
-  server.post('/:backend/library/:set_name/check-in', (schema, req) => {
-    // Check-in makes an unavailable account available again
-    const { service_account_names } = JSON.parse(req.requestBody);
-    const dbCollection = schema.db['ldapAccountStatuses'];
-    const updated = dbCollection.find(service_account_names).map((f) => ({
-      ...f,
-      available: true,
-      borrower_client_token: undefined,
-    }));
-    updated.forEach((u) => {
-      dbCollection.update(u.id, u);
-    });
-    return {
-      data: {
-        check_ins: service_account_names,
-      },
-    };
-  });
-  server.post('/:backend/library/:set_name/check-out', (schema, req) => {
-    const { set_name, backend } = req.params;
-    const dbCollection = schema.db['ldapAccountStatuses'];
-    const available = dbCollection.where({ available: true });
-    if (available) {
-      return Response(404, {}, { errors: ['no accounts available to check out'] });
-    }
-    const checkOut = {
-      ...available[0],
-      available: false,
-      borrower_client_token: crypto.randomUUID(),
-    };
-    dbCollection.update(checkOut.id, checkOut);
-    return {
-      request_id: '364a17d4-e5ab-998b-ceee-b49929229e0c',
-      lease_id: `${backend}/library/${set_name}/check-out/aoBsaBEI4PK96VnukubvYDlZ`,
-      renewable: true,
-      lease_duration: 36000,
-      data: {
-        password: crypto.randomUUID(),
-        service_account_name: checkOut.account,
-      },
-      wrap_info: null,
-      warnings: null,
-      auth: null,
-    };
-  });
+  server.get('/:backend/library/*name/status', () => ({
+    'bob.johnson': { available: false, borrower_client_token: '8b80c305eb3a7dbd161ef98f10ea60a116ce0910' },
+    'mary.smith': { available: true },
+  }));
 }

--- a/ui/mirage/models/ldap-account-status.js
+++ b/ui/mirage/models/ldap-account-status.js
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import { Model } from 'miragejs';
+
+export default Model.extend({
+  account: '', // should match ID
+  library: '',
+  available: false,
+  borrower_client_token: undefined,
+});

--- a/ui/mirage/scenarios/ldap.js
+++ b/ui/mirage/scenarios/ldap.js
@@ -14,6 +14,8 @@ export default function (server) {
   server.create('ldap-role', 'static', { name: 'my-role' });
   server.create('ldap-role', 'dynamic', { name: 'my-role' });
   server.create('ldap-library', { name: 'test-library' });
+  // mirage handler is hardcoded to accommodate hierarchical paths starting with 'admin/'
+  server.create('ldap-library', { name: 'admin/test-library' });
   server.create('ldap-account-status', {
     id: 'bob.johnson',
     account: 'bob.johnson',

--- a/ui/mirage/scenarios/ldap.js
+++ b/ui/mirage/scenarios/ldap.js
@@ -4,7 +4,7 @@
  */
 
 export default function (server) {
-  server.create('ldap-config', { path: 'kubernetes' });
+  server.create('ldap-config', { path: 'kubernetes', backend: 'ldap-test' });
   server.create('ldap-role', 'static', { name: 'static-role' });
   server.create('ldap-role', 'dynamic', { name: 'dynamic-role' });
   // hierarchical roles
@@ -14,4 +14,15 @@ export default function (server) {
   server.create('ldap-role', 'static', { name: 'my-role' });
   server.create('ldap-role', 'dynamic', { name: 'my-role' });
   server.create('ldap-library', { name: 'test-library' });
+  server.create('ldap-account-status', {
+    id: 'bob.johnson',
+    account: 'bob.johnson',
+    available: false,
+    borrower_client_token: '8b80c305eb3a7dbd161ef98f10ea60a116ce0910',
+  });
+  server.create('ldap-account-status', {
+    id: 'mary.smith',
+    account: 'mary.smith',
+    available: true,
+  });
 }

--- a/ui/mirage/scenarios/ldap.js
+++ b/ui/mirage/scenarios/ldap.js
@@ -16,15 +16,4 @@ export default function (server) {
   server.create('ldap-library', { name: 'test-library' });
   // mirage handler is hardcoded to accommodate hierarchical paths starting with 'admin/'
   server.create('ldap-library', { name: 'admin/test-library' });
-  server.create('ldap-account-status', {
-    id: 'bob.johnson',
-    account: 'bob.johnson',
-    available: false,
-    borrower_client_token: '8b80c305eb3a7dbd161ef98f10ea60a116ce0910',
-  });
-  server.create('ldap-account-status', {
-    id: 'mary.smith',
-    account: 'mary.smith',
-    available: true,
-  });
 }

--- a/ui/tests/acceptance/secrets/backend/ldap/libraries-test.js
+++ b/ui/tests/acceptance/secrets/backend/ldap/libraries-test.js
@@ -10,9 +10,10 @@ import { v4 as uuidv4 } from 'uuid';
 import ldapMirageScenario from 'vault/mirage/scenarios/ldap';
 import ldapHandlers from 'vault/mirage/handlers/ldap';
 import authPage from 'vault/tests/pages/auth';
-import { click } from '@ember/test-helpers';
+import { click, currentURL } from '@ember/test-helpers';
 import { isURL, visitURL } from 'vault/tests/helpers/ldap/ldap-helpers';
 import { deleteEngineCmd, mountEngineCmd, runCmd } from 'vault/tests/helpers/commands';
+import { LDAP_SELECTORS } from 'vault/tests/helpers/ldap/ldap-selectors';
 
 module('Acceptance | ldap | libraries', function (hooks) {
   setupApplicationTest(hooks);
@@ -37,7 +38,7 @@ module('Acceptance | ldap | libraries', function (hooks) {
 
   test('it should show libraries on overview page', async function (assert) {
     await visitURL('overview', this.backend);
-    assert.dom('[data-test-libraries-count]').hasText('1');
+    assert.dom('[data-test-libraries-count]').hasText('2');
   });
 
   test('it should transition to create library route on toolbar link click', async function (assert) {
@@ -49,10 +50,29 @@ module('Acceptance | ldap | libraries', function (hooks) {
   });
 
   test('it should transition to library details route on list item click', async function (assert) {
-    await click('[data-test-list-item-link] a');
-    assert.true(
-      isURL('libraries/test-library/details/accounts', this.backend),
+    await click(LDAP_SELECTORS.libraryItem('test-library'));
+    assert.strictEqual(
+      currentURL(),
+      `/vault/secrets/${this.backend}/ldap/libraries/test-library/details/accounts`,
       'Transitions to library details accounts route on list item click'
+    );
+    assert.dom('[data-test-account-name]').exists({ count: 2 }, 'lists the accounts');
+    assert.dom('[data-test-checked-out-account]').exists({ count: 1 }, 'lists the checked out accounts');
+  });
+
+  test('it should transition to library details for hierarchical list items', async function (assert) {
+    await click(LDAP_SELECTORS.libraryItem('admin/'));
+    assert.strictEqual(
+      currentURL(),
+      `/vault/secrets/${this.backend}/ldap/libraries/subdirectory/admin/`,
+      'Transitions to subdirectory list view'
+    );
+
+    await click(LDAP_SELECTORS.libraryItem('admin/test-library'));
+    assert.strictEqual(
+      currentURL(),
+      `/vault/secrets/${this.backend}/ldap/libraries/admin%2Ftest-library/details/accounts`,
+      'Transitions to child library details accounts'
     );
     assert.dom('[data-test-account-name]').exists({ count: 2 }, 'lists the accounts');
     assert.dom('[data-test-checked-out-account]').exists({ count: 1 }, 'lists the checked out accounts');

--- a/ui/tests/acceptance/secrets/backend/ldap/libraries-test.js
+++ b/ui/tests/acceptance/secrets/backend/ldap/libraries-test.js
@@ -6,11 +6,13 @@
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
+import { v4 as uuidv4 } from 'uuid';
 import ldapMirageScenario from 'vault/mirage/scenarios/ldap';
 import ldapHandlers from 'vault/mirage/handlers/ldap';
 import authPage from 'vault/tests/pages/auth';
 import { click } from '@ember/test-helpers';
 import { isURL, visitURL } from 'vault/tests/helpers/ldap/ldap-helpers';
+import { deleteEngineCmd, mountEngineCmd, runCmd } from 'vault/tests/helpers/commands';
 
 module('Acceptance | ldap | libraries', function (hooks) {
   setupApplicationTest(hooks);
@@ -19,21 +21,41 @@ module('Acceptance | ldap | libraries', function (hooks) {
   hooks.beforeEach(async function () {
     ldapHandlers(this.server);
     ldapMirageScenario(this.server);
+    this.backend = `ldap-test-${uuidv4()}`;
     await authPage.login();
-    return visitURL('libraries');
+    // mount & configure
+    await runCmd([
+      mountEngineCmd('ldap', this.backend),
+      `write ${this.backend}/config binddn=foo bindpass=bar url=http://localhost:8208`,
+    ]);
+    return visitURL('libraries', this.backend);
+  });
+
+  hooks.afterEach(async function () {
+    await runCmd(deleteEngineCmd(this.backend));
+  });
+
+  test('it should show libraries on overview page', async function (assert) {
+    await visitURL('overview', this.backend);
+    assert.dom('[data-test-libraries-count]').hasText('1');
   });
 
   test('it should transition to create library route on toolbar link click', async function (assert) {
     await click('[data-test-toolbar-action="library"]');
-    assert.true(isURL('libraries/create'), 'Transitions to library create route on toolbar link click');
+    assert.true(
+      isURL('libraries/create', this.backend),
+      'Transitions to library create route on toolbar link click'
+    );
   });
 
   test('it should transition to library details route on list item click', async function (assert) {
     await click('[data-test-list-item-link] a');
     assert.true(
-      isURL('libraries/test-library/details/accounts'),
+      isURL('libraries/test-library/details/accounts', this.backend),
       'Transitions to library details accounts route on list item click'
     );
+    assert.dom('[data-test-account-name]').exists({ count: 2 }, 'lists the accounts');
+    assert.dom('[data-test-checked-out-account]').exists({ count: 1 }, 'lists the checked out accounts');
   });
 
   test('it should transition to routes from list item action menu', async function (assert) {
@@ -44,7 +66,7 @@ module('Acceptance | ldap | libraries', function (hooks) {
       await click(`[data-test-${action}]`);
       const uri = action === 'details' ? 'details/accounts' : action;
       assert.true(
-        isURL(`libraries/test-library/${uri}`),
+        isURL(`libraries/test-library/${uri}`, this.backend),
         `Transitions to ${action} route on list item action menu click`
       );
       await click('[data-test-breadcrumb="libraries"] a');
@@ -55,13 +77,13 @@ module('Acceptance | ldap | libraries', function (hooks) {
     await click('[data-test-list-item-link] a');
     await click('[data-test-tab="config"]');
     assert.true(
-      isURL('libraries/test-library/details/configuration'),
+      isURL('libraries/test-library/details/configuration', this.backend),
       'Transitions to configuration route on tab click'
     );
 
     await click('[data-test-tab="accounts"]');
     assert.true(
-      isURL('libraries/test-library/details/accounts'),
+      isURL('libraries/test-library/details/accounts', this.backend),
       'Transitions to accounts route on tab click'
     );
   });
@@ -69,6 +91,9 @@ module('Acceptance | ldap | libraries', function (hooks) {
   test('it should transition to routes from library details toolbar links', async function (assert) {
     await click('[data-test-list-item-link] a');
     await click('[data-test-edit]');
-    assert.true(isURL('libraries/test-library/edit'), 'Transitions to credentials route from toolbar link');
+    assert.true(
+      isURL('libraries/test-library/edit', this.backend),
+      'Transitions to credentials route from toolbar link'
+    );
   });
 });

--- a/ui/tests/acceptance/secrets/backend/ldap/overview-test.js
+++ b/ui/tests/acceptance/secrets/backend/ldap/overview-test.js
@@ -6,12 +6,14 @@
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
+import { v4 as uuidv4 } from 'uuid';
 import ldapMirageScenario from 'vault/mirage/scenarios/ldap';
 import ldapHandlers from 'vault/mirage/handlers/ldap';
 import authPage from 'vault/tests/pages/auth';
 import { click, fillIn, visit } from '@ember/test-helpers';
 import { selectChoose } from 'ember-power-select/test-support';
 import { isURL, visitURL } from 'vault/tests/helpers/ldap/ldap-helpers';
+import { deleteEngineCmd, mountEngineCmd, runCmd } from 'vault/tests/helpers/commands';
 
 module('Acceptance | ldap | overview', function (hooks) {
   setupApplicationTest(hooks);
@@ -19,77 +21,101 @@ module('Acceptance | ldap | overview', function (hooks) {
 
   hooks.beforeEach(async function () {
     ldapHandlers(this.server);
+    this.backend = `ldap-test-${uuidv4()}`;
+    this.mountAndConfig = (backend) => {
+      return runCmd([
+        mountEngineCmd('ldap', backend),
+        `write ${backend}/config binddn=foo bindpass=bar url=http://localhost:8208`,
+      ]);
+    };
     return authPage.login();
   });
 
   test('it should transition to ldap overview on mount success', async function (assert) {
+    const backend = 'ldap-test-mount';
     await visit('/vault/secrets');
     await click('[data-test-enable-engine]');
     await click('[data-test-mount-type="ldap"]');
-    await fillIn('[data-test-input="path"]', 'ldap-test');
+    await fillIn('[data-test-input="path"]', backend);
     await click('[data-test-mount-submit]');
-    assert.true(isURL('overview'), 'Transitions to ldap overview route on mount success');
+    assert.true(isURL('overview', backend), 'Transitions to ldap overview route on mount success');
+    assert.dom('[data-test-header-title]').hasText(backend);
+    // cleanup mounted engine
+    await visit('/vault/secrets');
+    await runCmd(deleteEngineCmd(backend));
   });
 
   test('it should transition to routes on tab link click', async function (assert) {
     assert.expect(4);
+    await this.mountAndConfig(this.backend);
 
-    await visitURL('overview');
+    await visitURL('overview', this.backend);
 
     for (const tab of ['roles', 'libraries', 'config', 'overview']) {
       await click(`[data-test-tab="${tab}"]`);
       const route = tab === 'config' ? 'configuration' : tab;
-      assert.true(isURL(route), `Transitions to ${route} route on tab link click`);
+      assert.true(isURL(route, this.backend), `Transitions to ${route} route on tab link click`);
     }
   });
 
   test('it should transition to configuration route when engine is not configured', async function (assert) {
-    await visitURL('overview');
+    await runCmd(mountEngineCmd('ldap', this.backend));
+    await visitURL('overview', this.backend);
     await click('[data-test-config-cta] a');
-    assert.true(isURL('configure'), 'Transitions to configure route on cta link click');
+    assert.true(isURL('configure', this.backend), 'Transitions to configure route on cta link click');
 
-    await click('[data-test-breadcrumb="ldap-test"] a');
+    await click(`[data-test-breadcrumb="${this.backend}"] a`);
     await click('[data-test-toolbar-action="config"]');
-    assert.true(isURL('configure'), 'Transitions to configure route on toolbar link click');
+    assert.true(isURL('configure', this.backend), 'Transitions to configure route on toolbar link click');
   });
   // including a test for the configuration route here since it is the only one needed
   test('it should transition to configuration edit on toolbar link click', async function (assert) {
     ldapMirageScenario(this.server);
-    await visitURL('overview');
+    await this.mountAndConfig(this.backend);
+    await visitURL('overview', this.backend);
     await click('[data-test-tab="config"]');
     await click('[data-test-toolbar-config-action]');
-    assert.true(isURL('configure'), 'Transitions to configure route on toolbar link click');
+    assert.true(isURL('configure', this.backend), 'Transitions to configure route on toolbar link click');
   });
 
   test('it should transition to create role route on card action link click', async function (assert) {
     ldapMirageScenario(this.server);
-    await visitURL('overview');
+    await this.mountAndConfig(this.backend);
+    await visitURL('overview', this.backend);
     await click('[data-test-overview-card="Roles"] a');
-    assert.true(isURL('roles/create'), 'Transitions to role create route on card action link click');
+    assert.true(
+      isURL('roles/create', this.backend),
+      'Transitions to role create route on card action link click'
+    );
   });
 
   test('it should transition to create library route on card action link click', async function (assert) {
     ldapMirageScenario(this.server);
-    await visitURL('overview');
+    await this.mountAndConfig(this.backend);
+    await visitURL('overview', this.backend);
     await click('[data-test-overview-card="Libraries"] a');
-    assert.true(isURL('libraries/create'), 'Transitions to library create route on card action link click');
+    assert.true(
+      isURL('libraries/create', this.backend),
+      'Transitions to library create route on card action link click'
+    );
   });
 
   test('it should transition to role credentials route on generate credentials action', async function (assert) {
     ldapMirageScenario(this.server);
-    await visitURL('overview');
+    await this.mountAndConfig(this.backend);
+    await visitURL('overview', this.backend);
     await selectChoose('.search-select', 'static-role');
     await click('[data-test-generate-credential-button]');
     assert.true(
-      isURL('roles/static/static-role/credentials'),
+      isURL('roles/static/static-role/credentials', this.backend),
       'Transitions to role credentials route on generate credentials action'
     );
 
-    await click('[data-test-breadcrumb="ldap-test"] a');
+    await click(`[data-test-breadcrumb="${this.backend}"] a`);
     await selectChoose('.search-select', 'dynamic-role');
     await click('[data-test-generate-credential-button]');
     assert.true(
-      isURL('roles/dynamic/dynamic-role/credentials'),
+      isURL('roles/dynamic/dynamic-role/credentials', this.backend),
       'Transitions to role credentials route on generate credentials action'
     );
   });

--- a/ui/tests/acceptance/secrets/backend/ldap/roles-test.js
+++ b/ui/tests/acceptance/secrets/backend/ldap/roles-test.js
@@ -6,6 +6,7 @@
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
+import { v4 as uuidv4 } from 'uuid';
 import ldapMirageScenario from 'vault/mirage/scenarios/ldap';
 import ldapHandlers from 'vault/mirage/handlers/ldap';
 import authPage from 'vault/tests/pages/auth';
@@ -13,6 +14,7 @@ import { click, fillIn, waitFor } from '@ember/test-helpers';
 import { assertURL, isURL, visitURL } from 'vault/tests/helpers/ldap/ldap-helpers';
 import { GENERAL } from 'vault/tests/helpers/general-selectors';
 import { LDAP_SELECTORS } from 'vault/tests/helpers/ldap/ldap-selectors';
+import { deleteEngineCmd, mountEngineCmd, runCmd } from 'vault/tests/helpers/commands';
 
 module('Acceptance | ldap | roles', function (hooks) {
   setupApplicationTest(hooks);
@@ -21,14 +23,26 @@ module('Acceptance | ldap | roles', function (hooks) {
   hooks.beforeEach(async function () {
     ldapHandlers(this.server);
     ldapMirageScenario(this.server);
-    this.backend = 'ldap-test';
+    this.backend = `ldap-test-${uuidv4()}`;
     await authPage.login();
-    return visitURL('roles');
+    // mount & configure
+    await runCmd([
+      mountEngineCmd('ldap', this.backend),
+      `write ${this.backend}/config binddn=foo bindpass=bar url=http://localhost:8208`,
+    ]);
+    return visitURL('roles', this.backend);
+  });
+
+  hooks.afterEach(async function () {
+    await runCmd(deleteEngineCmd(this.backend));
   });
 
   test('it should transition to create role route on toolbar link click', async function (assert) {
     await click('[data-test-toolbar-action="role"]');
-    assert.true(isURL('roles/create'), 'Transitions to role create route on toolbar link click');
+    assert.true(
+      isURL('roles/create', this.backend),
+      'Transitions to role create route on toolbar link click'
+    );
   });
 
   test('it should transition to role details route on list item click', async function (assert) {
@@ -63,7 +77,7 @@ module('Acceptance | ldap | roles', function (hooks) {
       await click(LDAP_SELECTORS.action(action));
       const uri = action === 'get-creds' ? 'credentials' : action;
       assert.true(
-        isURL(`roles/dynamic/dynamic-role/${uri}`),
+        isURL(`roles/dynamic/dynamic-role/${uri}`, this.backend),
         `Transitions to ${uri} route on list item action menu click`
       );
       await click(GENERAL.breadcrumbLink('Roles'));
@@ -74,13 +88,16 @@ module('Acceptance | ldap | roles', function (hooks) {
     await click(LDAP_SELECTORS.roleItem('dynamic', 'dynamic-role'));
     await click('[data-test-get-credentials]');
     assert.true(
-      isURL('roles/dynamic/dynamic-role/credentials'),
+      isURL('roles/dynamic/dynamic-role/credentials', this.backend),
       'Transitions to credentials route from toolbar link'
     );
 
     await click('[data-test-breadcrumb="dynamic-role"] a');
     await click('[data-test-edit]');
-    assert.true(isURL('roles/dynamic/dynamic-role/edit'), 'Transitions to edit route from toolbar link');
+    assert.true(
+      isURL('roles/dynamic/dynamic-role/edit', this.backend),
+      'Transitions to edit route from toolbar link'
+    );
   });
 
   test('it should clear roles page filter value on route exit', async function (assert) {
@@ -88,6 +105,7 @@ module('Acceptance | ldap | roles', function (hooks) {
     assert
       .dom('[data-test-filter-input]')
       .hasValue('foo', 'Roles page filter value set after model refresh and rerender');
+    await waitFor(GENERAL.emptyStateTitle);
     await click('[data-test-tab="libraries"]');
     await click('[data-test-tab="roles"]');
     assert.dom('[data-test-filter-input]').hasNoValue('Roles page filter value cleared on route exit');

--- a/ui/tests/helpers/ldap/ldap-selectors.ts
+++ b/ui/tests/helpers/ldap/ldap-selectors.ts
@@ -5,6 +5,8 @@
 
 export const LDAP_SELECTORS = {
   roleItem: (type: string, name: string) => `[data-test-role="${type} ${name}"]`,
+  libraryItem: (name: string) => `[data-test-library="${name}"]`,
   roleMenu: (type: string, name: string) => `[data-test-popup-menu-trigger="${type} ${name}"]`,
+  libraryMenu: (name: string) => `[data-test-popup-menu-trigger="${name}"]`,
   action: (action: string) => `[data-test-${action}]`,
 };

--- a/ui/tests/integration/components/ldap/page/libraries-test.js
+++ b/ui/tests/integration/components/ldap/page/libraries-test.js
@@ -12,6 +12,7 @@ import hbs from 'htmlbars-inline-precompile';
 import { allowAllCapabilitiesStub } from 'vault/tests/helpers/stubs';
 import { createSecretsEngine, generateBreadcrumbs } from 'vault/tests/helpers/ldap/ldap-helpers';
 import { setRunOptions } from 'ember-a11y-testing/test-support';
+import { LDAP_SELECTORS } from 'vault/tests/helpers/ldap/ldap-selectors';
 
 module('Integration | Component | ldap | Page::Libraries', function (hooks) {
   setupRenderingTest(hooks);
@@ -25,7 +26,7 @@ module('Integration | Component | ldap | Page::Libraries', function (hooks) {
     this.backend = createSecretsEngine(this.store);
     this.breadcrumbs = generateBreadcrumbs(this.backend.id);
 
-    for (const name of ['foo', 'bar']) {
+    for (const name of ['foo', 'bar', 'foo/']) {
       this.store.pushPayload('ldap/library', {
         modelName: 'ldap/library',
         backend: 'ldap-test',
@@ -92,13 +93,20 @@ module('Integration | Component | ldap | Page::Libraries', function (hooks) {
   test('it should render libraries list', async function (assert) {
     await this.renderComponent();
 
-    assert.dom('[data-test-list-item-content] svg').hasClass('flight-icon-folder', 'List item icon renders');
-    assert.dom('[data-test-library]').hasText(this.libraries[0].name, 'List item name renders');
+    assert.dom('[data-test-list-item-content] svg').hasClass('hds-icon-folder', 'List item icon renders');
+    assert.dom('[data-test-library="foo"]').hasText('foo', 'List item name renders');
 
-    await click('[data-test-popup-menu-trigger]');
+    await click(LDAP_SELECTORS.libraryMenu('foo'));
+    assert.dom('[data-test-subdirectory]').doesNotExist();
     assert.dom('[data-test-edit]').hasText('Edit', 'Edit link renders in menu');
     assert.dom('[data-test-details]').hasText('Details', 'Details link renders in menu');
     assert.dom('[data-test-delete]').hasText('Delete', 'Details link renders in menu');
+
+    await click(LDAP_SELECTORS.libraryMenu('foo/'));
+    assert.dom('[data-test-subdirectory]').hasText('Content', 'Content link renders in menu');
+    assert.dom('[data-test-edit]').doesNotExist();
+    assert.dom('[data-test-details]').doesNotExist();
+    assert.dom('[data-test-delete]').doesNotExist();
   });
 
   test('it should filter libraries', async function (assert) {
@@ -110,11 +118,11 @@ module('Integration | Component | ldap | Page::Libraries', function (hooks) {
       .hasText('There are no libraries matching "baz"', 'Filter message renders');
 
     await fillIn('[data-test-filter-input]', 'foo');
-    assert.dom('[data-test-list-item-content]').exists({ count: 1 }, 'List is filtered with correct results');
+    assert.dom('[data-test-list-item-content]').exists({ count: 2 }, 'List is filtered with correct results');
 
     await fillIn('[data-test-filter-input]', '');
     assert
       .dom('[data-test-list-item-content]')
-      .exists({ count: 2 }, 'All libraries are displayed when filter is cleared');
+      .exists({ count: 3 }, 'All libraries are displayed when filter is cleared');
   });
 });

--- a/ui/tests/integration/components/ldap/page/library/details/accounts-test.js
+++ b/ui/tests/integration/components/ldap/page/library/details/accounts-test.js
@@ -77,6 +77,9 @@ module('Integration | Component | ldap | Page::Library::Details::Accounts', func
 
     assert
       .dom('[data-test-accounts-code-block] code')
-      .hasText('vault lease renew ad/library/test-library/check-out/:lease_id', 'Renew cli command renders');
+      .hasText(
+        'vault lease renew ldap-test/library/test-library/check-out/:lease_id',
+        'Renew cli command renders with backend path'
+      );
   });
 });

--- a/ui/tests/unit/adapters/ldap/role-test.js
+++ b/ui/tests/unit/adapters/ldap/role-test.js
@@ -19,8 +19,8 @@ module('Unit | Adapter | ldap/role', function (hooks) {
     this.adapter = this.store.adapterFor('ldap/role');
     this.path = 'role';
 
-    this.getModel = (type) => {
-      const name = 'test-role';
+    this.getModel = (type, roleName) => {
+      const name = roleName || 'test-role';
       this.store.pushPayload('ldap/role', {
         modelName: 'ldap/role',
         backend: 'ldap-test',
@@ -32,214 +32,296 @@ module('Unit | Adapter | ldap/role', function (hooks) {
     };
   });
 
-  test('it should make request to correct endpoints when listing records', async function (assert) {
-    assert.expect(6);
+  module('happy paths', function () {
+    test('it should make request to correct endpoints when listing records', async function (assert) {
+      assert.expect(6);
 
-    const assertRequest = (schema, req) => {
-      assert.ok(req.queryParams.list, 'list query param sent when listing roles');
-      const name = req.url.includes('static-role') ? 'static-test' : 'dynamic-test';
-      return { data: { keys: [name] } };
-    };
+      const assertRequest = (schema, req) => {
+        assert.ok(req.queryParams.list, 'list query param sent when listing roles');
+        const name = req.url.includes('static-role') ? 'static-test' : 'dynamic-test';
+        return { data: { keys: [name] } };
+      };
 
-    this.server.get('/ldap-test/static-role', assertRequest);
-    this.server.get('/ldap-test/role', assertRequest);
+      this.server.get('/ldap-test/static-role', assertRequest);
+      this.server.get('/ldap-test/role', assertRequest);
 
-    this.models = await this.store.query('ldap/role', { backend: 'ldap-test' });
+      this.models = await this.store.query('ldap/role', { backend: 'ldap-test' });
 
-    const model = this.models[0];
-    assert.strictEqual(this.models.length, 2, 'Returns responses from both endpoints');
-    assert.strictEqual(model.backend, 'ldap-test', 'Backend value is set on records returned from query');
-    // sorted alphabetically by name so dynamic should be first
-    assert.strictEqual(model.type, 'dynamic', 'Type value is set on records returned from query');
-    assert.strictEqual(model.name, 'dynamic-test', 'Name value is set on records returned from query');
-  });
-
-  test('it should conditionally trigger info level flash message for single endpoint error from query', async function (assert) {
-    const flashMessages = this.owner.lookup('service:flashMessages');
-    const flashSpy = sinon.spy(flashMessages, 'info');
-
-    this.server.get('/ldap-test/static-role', () => {
-      return new Response(403, {}, { errors: ['permission denied'] });
-    });
-    this.server.get('/ldap-test/role', () => ({ data: { keys: ['dynamic-test'] } }));
-
-    await this.store.query('ldap/role', { backend: 'ldap-test' });
-    await this.store.query(
-      'ldap/role',
-      { backend: 'ldap-test' },
-      { adapterOptions: { showPartialError: true } }
-    );
-
-    assert.true(
-      flashSpy.calledOnceWith('Error fetching roles from /v1/ldap-test/static-role: permission denied'),
-      'Partial error info only displays when adapter option is passed'
-    );
-  });
-
-  test('it should throw error for query when requests to both endpoints fail', async function (assert) {
-    assert.expect(2);
-
-    this.server.get('/ldap-test/:path', (schema, req) => {
-      const errors = {
-        'static-role': ['permission denied'],
-        role: ['server error'],
-      }[req.params.path];
-      return new Response(req.params.path === 'static-role' ? 403 : 500, {}, { errors });
+      const model = this.models[0];
+      assert.strictEqual(this.models.length, 2, 'Returns responses from both endpoints');
+      assert.strictEqual(model.backend, 'ldap-test', 'Backend value is set on records returned from query');
+      // sorted alphabetically by name so dynamic should be first
+      assert.strictEqual(model.type, 'dynamic', 'Type value is set on records returned from query');
+      assert.strictEqual(model.name, 'dynamic-test', 'Name value is set on records returned from query');
     });
 
-    try {
+    test('it should conditionally trigger info level flash message for single endpoint error from query', async function (assert) {
+      const flashMessages = this.owner.lookup('service:flashMessages');
+      const flashSpy = sinon.spy(flashMessages, 'info');
+
+      this.server.get('/ldap-test/static-role', () => {
+        return new Response(403, {}, { errors: ['permission denied'] });
+      });
+      this.server.get('/ldap-test/role', () => ({ data: { keys: ['dynamic-test'] } }));
+
       await this.store.query('ldap/role', { backend: 'ldap-test' });
-    } catch (error) {
-      assert.deepEqual(
-        error.errors,
-        ['/v1/ldap-test/static-role: permission denied', '/v1/ldap-test/role: server error'],
-        'Error messages is thrown with correct payload from query.'
+      await this.store.query(
+        'ldap/role',
+        { backend: 'ldap-test' },
+        { adapterOptions: { showPartialError: true } }
       );
-      assert.strictEqual(
-        error.message,
-        'Error fetching roles:',
-        'Error message is thrown with correct payload from query.'
-      );
-    }
-  });
 
-  test('it should make request to correct endpoints when querying record', async function (assert) {
-    assert.expect(5);
-
-    this.server.get('/ldap-test/:path/test-role', (schema, req) => {
-      assert.strictEqual(
-        req.params.path,
-        this.path,
-        'GET request made to correct endpoint when querying record'
+      assert.true(
+        flashSpy.calledOnceWith('Error fetching roles from /v1/ldap-test/static-role: permission denied'),
+        'Partial error info only displays when adapter option is passed'
       );
     });
 
-    for (const type of ['dynamic', 'static']) {
-      this.model = await this.store.queryRecord('ldap/role', {
-        backend: 'ldap-test',
-        type,
-        name: 'test-role',
+    test('it should throw error for query when requests to both endpoints fail', async function (assert) {
+      assert.expect(2);
+
+      this.server.get('/ldap-test/:path', (schema, req) => {
+        const errors = {
+          'static-role': ['permission denied'],
+          role: ['server error'],
+        }[req.params.path];
+        return new Response(req.params.path === 'static-role' ? 403 : 500, {}, { errors });
       });
-      this.path = 'static-role';
-    }
 
-    assert.strictEqual(
-      this.model.backend,
-      'ldap-test',
-      'Backend value is set on records returned from query'
-    );
-    assert.strictEqual(this.model.type, 'static', 'Type value is set on records returned from query');
-    assert.strictEqual(this.model.name, 'test-role', 'Name value is set on records returned from query');
-  });
-
-  test('it should make request to correct endpoints when creating new dynamic role record', async function (assert) {
-    assert.expect(1);
-
-    this.server.post('/ldap-test/:path/:name', (schema, req) => {
-      assert.strictEqual(
-        req.params.path,
-        this.path,
-        'POST request made to correct endpoint when creating new record for a dynamic role'
-      );
+      try {
+        await this.store.query('ldap/role', { backend: 'ldap-test' });
+      } catch (error) {
+        assert.deepEqual(
+          error.errors,
+          ['/v1/ldap-test/static-role: permission denied', '/v1/ldap-test/role: server error'],
+          'Error messages is thrown with correct payload from query.'
+        );
+        assert.strictEqual(
+          error.message,
+          'Error fetching roles:',
+          'Error message is thrown with correct payload from query.'
+        );
+      }
     });
 
-    const getModel = (type, name) => {
-      return this.store.createRecord('ldap/role', {
-        backend: 'ldap-test',
-        name,
-        type,
+    test('it should make request to correct endpoints when querying record', async function (assert) {
+      assert.expect(5);
+
+      this.server.get('/ldap-test/:path/test-role', (schema, req) => {
+        assert.strictEqual(
+          req.params.path,
+          this.path,
+          'GET request made to correct endpoint when querying record'
+        );
       });
-    };
 
-    const model = getModel('dynamic-role', 'dynamic-role-name');
-    await model.save();
-  });
+      for (const type of ['dynamic', 'static']) {
+        this.model = await this.store.queryRecord('ldap/role', {
+          backend: 'ldap-test',
+          type,
+          name: 'test-role',
+        });
+        this.path = 'static-role';
+      }
 
-  test('it should make request to correct endpoints when creating new static role record', async function (assert) {
-    assert.expect(1);
-
-    this.server.post('/ldap-test/:path/:name', (schema, req) => {
       assert.strictEqual(
-        req.params.path,
-        this.path,
-        'POST request made to correct endpoint when creating new record for a static role'
+        this.model.backend,
+        'ldap-test',
+        'Backend value is set on records returned from query'
       );
+      assert.strictEqual(this.model.type, 'static', 'Type value is set on records returned from query');
+      assert.strictEqual(this.model.name, 'test-role', 'Name value is set on records returned from query');
     });
 
-    const getModel = (type, name) => {
-      return this.store.createRecord('ldap/role', {
-        backend: 'ldap-test',
-        name,
-        type,
+    test('it should make request to correct endpoints when creating new dynamic role record', async function (assert) {
+      assert.expect(1);
+
+      this.server.post('/ldap-test/:path/:name', (schema, req) => {
+        assert.strictEqual(
+          req.params.path,
+          this.path,
+          'POST request made to correct endpoint when creating new record for a dynamic role'
+        );
       });
-    };
 
-    const model = getModel('static-role', 'static-role-name');
-    await model.save();
+      const getModel = (type, name) => {
+        return this.store.createRecord('ldap/role', {
+          backend: 'ldap-test',
+          name,
+          type,
+        });
+      };
+
+      const model = getModel('dynamic-role', 'dynamic-role-name');
+      await model.save();
+    });
+
+    test('it should make request to correct endpoints when creating new static role record', async function (assert) {
+      assert.expect(1);
+
+      this.server.post('/ldap-test/:path/:name', (schema, req) => {
+        assert.strictEqual(
+          req.params.path,
+          this.path,
+          'POST request made to correct endpoint when creating new record for a static role'
+        );
+      });
+
+      const getModel = (type, name) => {
+        return this.store.createRecord('ldap/role', {
+          backend: 'ldap-test',
+          name,
+          type,
+        });
+      };
+
+      const model = getModel('static-role', 'static-role-name');
+      await model.save();
+    });
+
+    test('it should make request to correct endpoints when updating record', async function (assert) {
+      assert.expect(2);
+
+      this.server.post('/ldap-test/:path/test-role', (schema, req) => {
+        assert.strictEqual(
+          req.params.path,
+          this.path,
+          'POST request made to correct endpoint when updating record'
+        );
+      });
+
+      for (const type of ['dynamic', 'static']) {
+        const record = this.getModel(type);
+        await record.save();
+        this.path = 'static-role';
+      }
+    });
+
+    test('it should make request to correct endpoints when deleting record', async function (assert) {
+      assert.expect(2);
+
+      this.server.delete('/ldap-test/:path/test-role', (schema, req) => {
+        assert.strictEqual(
+          req.params.path,
+          this.path,
+          'DELETE request made to correct endpoint when deleting record'
+        );
+      });
+
+      for (const type of ['dynamic', 'static']) {
+        const record = this.getModel(type);
+        await record.destroyRecord();
+        this.path = 'static-role';
+      }
+    });
+
+    test('it should make request to correct endpoints when fetching credentials', async function (assert) {
+      assert.expect(2);
+
+      this.path = 'creds';
+
+      this.server.get('/ldap-test/:path/test-role', (schema, req) => {
+        assert.strictEqual(
+          req.params.path,
+          this.path,
+          'GET request made to correct endpoint when fetching credentials'
+        );
+      });
+
+      for (const type of ['dynamic', 'static']) {
+        await this.adapter.fetchCredentials('ldap-test', type, 'test-role');
+        this.path = 'static-cred';
+      }
+    });
+
+    test('it should make request to correct endpoint when rotating static role password', async function (assert) {
+      assert.expect(1);
+
+      this.server.post('/ldap-test/rotate-role/test-role', () => {
+        assert.ok('GET request made to correct endpoint when rotating static role password');
+      });
+
+      await this.adapter.rotateStaticPassword('ldap-test', 'test-role');
+    });
   });
 
-  test('it should make request to correct endpoints when updating record', async function (assert) {
-    assert.expect(2);
+  module('hierarchical paths', function () {
+    test('it should make request to correct endpoint when listing hierarchical records', async function (assert) {
+      assert.expect(2);
 
-    this.server.post('/ldap-test/:path/test-role', (schema, req) => {
-      assert.strictEqual(
-        req.params.path,
-        this.path,
-        'POST request made to correct endpoint when updating record'
+      const staticAncestry = { path_to_role: 'static-admin/', type: 'static' };
+      const dynamicAncestry = { path_to_role: 'dynamic-admin/', type: 'dynamic' };
+
+      this.server.get(`/ldap-test/static-role/${staticAncestry.path_to_role}`, (schema, req) => {
+        assert.strictEqual(
+          req.queryParams.list,
+          'true',
+          `query request lists roles of type: ${staticAncestry.type}`
+        );
+        return { data: { keys: ['my-static-role'] } };
+      });
+      this.server.get(`/ldap-test/role/${dynamicAncestry.path_to_role}`, (schema, req) => {
+        assert.strictEqual(
+          req.queryParams.list,
+          'true',
+          `query request lists roles of type: ${dynamicAncestry.type}`
+        );
+        return { data: { keys: ['my-dynamic-role'] } };
+      });
+
+      await this.store.query(
+        'ldap/role',
+        { backend: 'ldap-test' },
+        { adapterOptions: { roleAncestry: staticAncestry } }
+      );
+      await this.store.query(
+        'ldap/role',
+        { backend: 'ldap-test' },
+        { adapterOptions: { roleAncestry: dynamicAncestry } }
       );
     });
 
     for (const type of ['dynamic', 'static']) {
-      const record = this.getModel(type);
-      await record.save();
-      this.path = 'static-role';
+      test(`it should make request to correct endpoint when deleting a role for type: ${type}`, async function (assert) {
+        assert.expect(1);
+
+        const url =
+          type === 'static'
+            ? '/ldap-test/static-role/admin/my-static-role'
+            : '/ldap-test/role/admin/my-dynamic-role';
+
+        this.server.delete(url, () => {
+          assert.true(true, `DELETE request made to delete hierarchical role of type: ${type}`);
+        });
+
+        const record = this.getModel(type, `admin/my-${type}-role`);
+        await record.destroyRecord();
+      });
+
+      test(`it should make request to correct endpoints when fetching credentials for type: ${type}`, async function (assert) {
+        assert.expect(1);
+
+        const url =
+          type === 'static'
+            ? '/ldap-test/static-cred/admin/my-static-role'
+            : '/ldap-test/creds/admin/my-dynamic-role';
+
+        this.server.get(url, () => {
+          assert.true(true, `request made to fetch credentials for role type: ${type}`);
+        });
+
+        await this.adapter.fetchCredentials('ldap-test', type, `admin/my-${type}-role`);
+      });
     }
-  });
 
-  test('it should make request to correct endpoints when deleting record', async function (assert) {
-    assert.expect(2);
+    test('it should make request to correct endpoint when rotating static role password', async function (assert) {
+      assert.expect(1);
 
-    this.server.delete('/ldap-test/:path/test-role', (schema, req) => {
-      assert.strictEqual(
-        req.params.path,
-        this.path,
-        'DELETE request made to correct endpoint when deleting record'
-      );
+      this.server.post('/ldap-test/rotate-role/admin/test-role', () => {
+        assert.ok('GET request made to correct endpoint when rotating static role password');
+      });
+
+      await this.adapter.rotateStaticPassword('ldap-test', 'admin/test-role');
     });
-
-    for (const type of ['dynamic', 'static']) {
-      const record = this.getModel(type);
-      await record.destroyRecord();
-      this.path = 'static-role';
-    }
-  });
-
-  test('it should make request to correct endpoints when fetching credentials', async function (assert) {
-    assert.expect(2);
-
-    this.path = 'creds';
-
-    this.server.get('/ldap-test/:path/test-role', (schema, req) => {
-      assert.strictEqual(
-        req.params.path,
-        this.path,
-        'GET request made to correct endpoint when fetching credentials'
-      );
-    });
-
-    for (const type of ['dynamic', 'static']) {
-      await this.adapter.fetchCredentials('ldap-test', type, 'test-role');
-      this.path = 'static-cred';
-    }
-  });
-
-  test('it should make request to correct endpoint when rotating static role password', async function (assert) {
-    assert.expect(1);
-
-    this.server.post('/ldap-test/rotate-role/test-role', () => {
-      assert.ok('GET request made to correct endpoint when rotating static role password');
-    });
-
-    await this.adapter.rotateStaticPassword('ldap-test', 'test-role');
   });
 });

--- a/ui/tests/unit/utils/ldap-breadcrumbs-test.js
+++ b/ui/tests/unit/utils/ldap-breadcrumbs-test.js
@@ -3,15 +3,18 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { ldapBreadcrumbs } from 'ldap/utils/ldap-breadcrumbs';
+import { ldapBreadcrumbs, roleRoutes } from 'ldap/utils/ldap-breadcrumbs';
 import { module, test } from 'qunit';
 
 module('Unit | Utility | ldap breadcrumbs', function (hooks) {
   hooks.beforeEach(async function () {
     this.mountPath = 'my-engine';
     this.roleType = 'static';
+    const routeParams = (childResource) => {
+      return [this.mountPath, this.roleType, childResource];
+    };
     this.testCrumbs = (path, { lastItemCurrent }) => {
-      return ldapBreadcrumbs(path, this.roleType, this.mountPath, lastItemCurrent);
+      return ldapBreadcrumbs(path, routeParams, roleRoutes, lastItemCurrent);
     };
   });
 

--- a/ui/types/vault/models/ldap/library.d.ts
+++ b/ui/types/vault/models/ldap/library.d.ts
@@ -13,10 +13,12 @@ import type {
 export default interface LdapLibraryModel extends WithFormFieldsAndValidationsModel {
   backend: string;
   name: string;
+  path_to_library: string;
   service_account_names: string;
   default_ttl: number;
   max_ttl: number;
   disable_check_in_enforcement: string;
+  get completeLibraryName(): string;
   get displayFields(): Array<FormField>;
   libraryPath: CapabilitiesModel;
   statusPath: CapabilitiesModel;

--- a/ui/types/vault/models/ldap/role.d.ts
+++ b/ui/types/vault/models/ldap/role.d.ts
@@ -20,6 +20,7 @@ export default interface LdapRoleModel extends WithFormFieldsAndValidationsModel
   username_template: string;
   creation_ldif: string;
   rollback_ldif: string;
+  get completeRoleName(): string;
   get isStatic(): string;
   get isDynamic(): string;
   get fieldsForType(): Array<string>;

--- a/vault/activity_log.go
+++ b/vault/activity_log.go
@@ -3172,16 +3172,6 @@ func (a *ActivityLog) writeExport(ctx context.Context, rw http.ResponseWriter, f
 								return fmt.Errorf("failed to process local entity alias")
 							}
 
-							record.MountType, ok = alias["mount_type"].(string)
-							if !ok {
-								return fmt.Errorf("failed to process mount type")
-							}
-
-							record.MountPath, ok = alias["mount_path"].(string)
-							if !ok {
-								return fmt.Errorf("failed to process mount path")
-							}
-
 							entityAliasMetadata, ok := alias["metadata"].(map[string]string)
 							if !ok {
 								return fmt.Errorf("failed to process entity alias metadata")
@@ -3199,6 +3189,23 @@ func (a *ActivityLog) writeExport(ctx context.Context, rw http.ResponseWriter, f
 							if entityAliasCustomMetadata != nil {
 								record.EntityAliasCustomMetadata = entityAliasCustomMetadata
 							}
+
+							valResp := a.core.router.ValidateMountByAccessor(e.MountAccessor)
+							if valResp == nil {
+								record.MountType = ""
+								record.MountPath = fmt.Sprintf(DeletedMountFmt, e.MountAccessor)
+							} else {
+								record.MountType, ok = alias["mount_type"].(string)
+								if !ok {
+									return fmt.Errorf("failed to process mount type")
+								}
+								record.MountPath, ok = alias["mount_path"].(string)
+								if !ok {
+									return fmt.Errorf("failed to process mount path")
+								}
+
+							}
+
 						}
 					} else {
 						// fetch mount directly to ensure mount type and path are populated

--- a/vault/activity_log_test.go
+++ b/vault/activity_log_test.go
@@ -4110,7 +4110,7 @@ func TestActivityLog_partialMonthClientCountWithMultipleMountPaths(t *testing.T)
 	// these are the paths that are expected and correspond with the entity records created above
 	expectedPaths := []string{
 		noMountAccessor,
-		fmt.Sprintf(deletedMountFmt, "deleted"),
+		fmt.Sprintf(DeletedMountFmt, "deleted"),
 		path,
 	}
 	for _, expectedPath := range expectedPaths {

--- a/vault/activity_log_util_common.go
+++ b/vault/activity_log_util_common.go
@@ -392,7 +392,7 @@ func (a *ActivityLog) sortActivityLogMonthsResponse(months []*ResponseMonth) {
 
 const (
 	noMountAccessor     = "no mount accessor (pre-1.10 upgrade?)"
-	deletedMountFmt     = "deleted mount; accessor %q"
+	DeletedMountFmt     = "deleted mount; accessor %q"
 	DeletedNamespaceFmt = "deleted namespace %q"
 )
 
@@ -405,7 +405,7 @@ func (a *ActivityLog) mountAccessorToMountPath(mountAccessor string) string {
 	} else {
 		valResp := a.core.router.ValidateMountByAccessor(mountAccessor)
 		if valResp == nil {
-			displayPath = fmt.Sprintf(deletedMountFmt, mountAccessor)
+			displayPath = fmt.Sprintf(DeletedMountFmt, mountAccessor)
 		} else {
 			displayPath = valResp.MountPath
 			if !strings.HasSuffix(displayPath, "/") {

--- a/vault/activity_log_util_common_test.go
+++ b/vault/activity_log_util_common_test.go
@@ -978,7 +978,7 @@ func Test_ActivityLog_ComputeCurrentMonth_NamespaceMounts(t *testing.T) {
 			correctMountPaths := func(namespaces []*activity.MonthlyNamespaceRecord) {
 				for _, ns := range namespaces {
 					for _, mount := range ns.Mounts {
-						mount.MountPath = fmt.Sprintf(deletedMountFmt, mount.MountPath)
+						mount.MountPath = fmt.Sprintf(DeletedMountFmt, mount.MountPath)
 					}
 				}
 			}


### PR DESCRIPTION
Manual backport for https://github.com/hashicorp/vault/pull/29293

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
