### PR TITLE
ignore system view service ent in buf linter

### DIFF
--- a/buf.yaml
+++ b/buf.yaml
@@ -47,6 +47,7 @@ lint:
       - sdk/logical/plugin.proto
       - sdk/logical/version.proto
       - sdk/plugin/pb/backend.proto
+      - sdk/plugin/pb/system_view_service_ent.proto
       - vault/activity/activity_log.proto
       - sdk/helper/clientcountutil/generation/generate_data.proto
       - vault/hcp_link/proto/link_control/link_control.proto
@@ -79,6 +80,7 @@ lint:
       - sdk/logical/plugin.proto
       - sdk/logical/version.proto
       - sdk/plugin/pb/backend.proto
+      - sdk/plugin/pb/system_view_service_ent.proto
       - vault/activity/activity_log.proto
       - sdk/helper/clientcountutil/generation/generate_data.proto
       - vault/hcp_link/proto/link_control/link_control.proto
@@ -93,6 +95,7 @@ lint:
       - sdk/database/dbplugin/database.proto
       - sdk/database/dbplugin/v5/proto/database.proto
       - sdk/plugin/pb/backend.proto
+      - sdk/plugin/pb/system_view_service_ent.proto
       - vault/replication_services_ent.proto
       - vault/request_forwarding_service.proto
     RPC_REQUEST_STANDARD_NAME:
@@ -100,6 +103,7 @@ lint:
       - sdk/database/dbplugin/v5/proto/database.proto
       - sdk/logical/version.proto
       - sdk/plugin/pb/backend.proto
+      - sdk/plugin/pb/system_view_service_ent.proto
       - vault/replication/replication_resolver_ent.proto
       - vault/replication_services_ent.proto
       - vault/request_forwarding_service.proto
@@ -118,6 +122,7 @@ lint:
       - sdk/helper/pluginutil/multiplexing.proto
       - sdk/logical/version.proto
       - sdk/plugin/pb/backend.proto
+      - sdk/plugin/pb/system_view_service_ent.proto
       - vault/hcp_link/proto/link_control/link_control.proto
       - vault/hcp_link/proto/meta/meta.proto
       - vault/replication/replication_resolver_ent.proto


### PR DESCRIPTION
### Description
What does this PR do?
This PR ignores  `sdk/plugin/pb/system_view_service_ent.proto` in `buf.yaml` to fix protobuf linter

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
