### PR TITLE
use elevated github token in plugin-update gha ent step

### DIFF
--- a/.github/workflows/plugin-update.yml
+++ b/.github/workflows/plugin-update.yml
@@ -47,7 +47,11 @@ jobs:
 
       - name: Update Enterprise-only plugin
         if: github.repository == 'hashicorp/vault-enterprise'
+        env:
+          # Use elevated token to read private repos.
+          GITHUB_TOKEN: ${{secrets.ELEVATED_GITHUB_TOKEN}}
         run: |
+          git config --global url."https://${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
           (cd vault_ent && go get "github.com/hashicorp/${{ inputs.plugin }}@v${{ inputs.version }}" && go mod tidy)
           go mod tidy
 


### PR DESCRIPTION
### Description

This PR updates the `plugin-update` GHA to  use the elevated GitHub token in the `Update Enterprise-only plugin` step to `go get` dependencies from private repos.

<details><summary>Local testing</summary>

Tested the `plugin-update` GHA on `vault-enterprise` with these changes https://github.com/hashicorp/vault-enterprise/pull/7299 and manually triggering the GHA at https://github.com/hashicorp/vault-enterprise/actions/workflows/plugin-update.yml.

Before this change: https://github.com/hashicorp/vault-enterprise/actions/runs/12919423225/job/36029907171. `plugin-update` workflow against `main` was failing on the `Update Enterprise-only plugin` step with the following error:
```
go: github.com/hashicorp/go-census/v2@v2.1.0: reading github.com/hashicorp/go-census/go.mod at revision v2.1.0: git ls-remote -q origin in /home/runner/go/pkg/mod/cache/vcs/61d801bed7b30f94c264d9b709cb1bfb65b26a18822673f655a4ba6888c46285: exit status 128:
	fatal: could not read Username for 'https://github.com/': terminal prompts disabled
Confirm the import path was entered correctly.
If this is a private repository, see https://golang.org/doc/faq#git_https for additional information.
Error: Process completed with exit code 1.
```

After this change: https://github.com/hashicorp/vault-enterprise/actions/runs/12920729956/job/36033542584. `plugin-update` workflow against this branch passes the `Update Enterprise-only plugin` step, but fails on `Detect changes` with
```
Error: no updates were made for vault-plugin-auth-saml with tag v0.4.0
Error: Process completed with exit code 1.
```
which is expected (because the plugin is already on v0.4.0) and safe to ignore.
</details>

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
