### PR TITLE
OpenAPI LDAP config update: Add enableSamaccountnameLogin param

### DIFF
--- a/ui/tests/helpers/openapi/expected-auth-attrs.js
+++ b/ui/tests/helpers/openapi/expected-auth-attrs.js
@@ -849,6 +849,13 @@ const ldap = {
       label: 'Discover DN',
       type: 'boolean',
     },
+    enableSamaccountnameLogin: {
+      editType: 'boolean',
+      fieldGroup: 'default',
+      helpText:
+        'If true, matching sAMAccountName attribute values will be allowed to login when upndomain is defined.',
+      type: 'boolean',
+    },
     groupattr: {
       editType: 'string',
       helpText:


### PR DESCRIPTION
### Description
Adds `enableSamaccountnameLogin` param to the openAPI tests, also double check the field displayed in the UI (no code changes necessary for this as it's a purely openAPI derived model).

<img width="1080" alt="Screenshot 2025-01-24 at 11 46 56 AM" src="https://github.com/user-attachments/assets/3e7104a9-a7c0-487d-897d-0bf400f7b9ae" />


### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
