### PR TITLE
Prepare code base for Go 1.24 update.

### DIFF
--- a/api/secret.go
+++ b/api/secret.go
@@ -6,6 +6,7 @@ package api
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"reflect"
@@ -380,7 +381,7 @@ func ParseSecret(r io.Reader) (*Secret, error) {
 			if err := json.Unmarshal(errBytes, &errStrArray); err != nil {
 				return nil, err
 			}
-			return nil, fmt.Errorf(strings.Join(errStrArray, " "))
+			return nil, errors.New(strings.Join(errStrArray, " "))
 		}
 
 		// if any raw data is present in resp.Body, add it to secret

--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -2277,7 +2277,7 @@ func runTestSignVerbatim(t *testing.T, keyType string) {
 		t.Fatal(err)
 	}
 	if resp != nil && resp.IsError() {
-		t.Fatalf(resp.Error().Error())
+		t.Fatal(resp.Error().Error())
 	}
 	if resp.Data == nil || resp.Data["certificate"] == nil {
 		t.Fatal("did not get expected data")
@@ -2317,7 +2317,7 @@ func runTestSignVerbatim(t *testing.T, keyType string) {
 		t.Fatal(err)
 	}
 	if resp != nil && resp.IsError() {
-		t.Fatalf(resp.Error().Error())
+		t.Fatal(resp.Error().Error())
 	}
 	if resp.Data == nil || resp.Data["certificate"] == nil {
 		t.Fatal("did not get expected data")

--- a/builtin/logical/pki/chain_util.go
+++ b/builtin/logical/pki/chain_util.go
@@ -6,6 +6,7 @@ package pki
 import (
 	"bytes"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"sort"
 
@@ -439,7 +440,7 @@ func (sc *storageContext) rebuildIssuersChains(referenceCert *issuing.IssuerEntr
 		}
 	}
 	if len(msg) > 0 {
-		return fmt.Errorf(msg)
+		return errors.New(msg)
 	}
 
 	// Finally, write all issuers to disk.

--- a/builtin/logical/transit/path_hmac_test.go
+++ b/builtin/logical/transit/path_hmac_test.go
@@ -108,7 +108,7 @@ func TestTransit_HMAC(t *testing.T) {
 					t.Fatalf("error validating hmac: %s", errStr)
 				}
 				if resp.Data["valid"].(bool) == false {
-					t.Fatalf(fmt.Sprintf("error validating hmac;\nreq:\n%#v\nresp:\n%#v", *req, *resp))
+					t.Fatalf("error validating hmac;\nreq:\n%#v\nresp:\n%#v", *req, *resp)
 				}
 			}
 			req.Path = strings.ReplaceAll(req.Path, "hmac", "verify")

--- a/command/agentproxyshared/cache/cache_test.go
+++ b/command/agentproxyshared/cache/cache_test.go
@@ -226,17 +226,19 @@ func TestCache_ConcurrentRequests(t *testing.T) {
 				"key": key,
 			})
 			if err != nil {
-				t.Fatal(err)
+				t.Error(err.Error())
+				return
 			}
 			secret, err := testClient.Logical().Read(key)
 			if err != nil {
-				t.Fatal(err)
+				t.Error(err.Error())
+				return
 			}
 			if secret == nil || secret.Data["key"].(string) != key {
-				t.Fatal(fmt.Sprintf("failed to read value for key: %q", key))
+				t.Errorf("failed to read value for key: %q", key)
+				return
 			}
 		}(i)
-
 	}
 	wg.Wait()
 }

--- a/command/debug_test.go
+++ b/command/debug_test.go
@@ -742,7 +742,7 @@ func TestDebugCommand_InsecureUmask(t *testing.T) {
 			// check permissions of the parent debug directory
 			err = isValidFilePermissions(fs)
 			if err != nil {
-				t.Fatalf(err.Error())
+				t.Fatal(err.Error())
 			}
 
 			// check permissions of the files within the parent directory
@@ -768,7 +768,7 @@ func TestDebugCommand_InsecureUmask(t *testing.T) {
 				err = filepath.Walk(bundlePath, func(path string, info os.FileInfo, err error) error {
 					err = isValidFilePermissions(info)
 					if err != nil {
-						t.Fatalf(err.Error())
+						t.Fatal(err.Error())
 					}
 					return nil
 				})

--- a/command/operator_diagnose_test.go
+++ b/command/operator_diagnose_test.go
@@ -7,6 +7,7 @@ package command
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -733,7 +734,7 @@ func compareResult(exp *diagnose.Result, act *diagnose.Result) error {
 		for _, c := range act.Children {
 			errStrings = append(errStrings, fmt.Sprintf("%+v", c))
 		}
-		return fmt.Errorf(strings.Join(errStrings, ","))
+		return errors.New(strings.Join(errStrings, ","))
 	}
 
 	if len(exp.Children) > 0 {

--- a/command/server/config_custom_response_headers_test.go
+++ b/command/server/config_custom_response_headers_test.go
@@ -4,7 +4,6 @@
 package server
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/go-test/deep"
@@ -65,7 +64,7 @@ func TestCustomResponseHeadersConfigs(t *testing.T) {
 		t.Fatalf("Error encountered when loading config %+v", err)
 	}
 	if diff := deep.Equal(expectedCustomResponseHeader, config.Listeners[0].CustomResponseHeaders); diff != nil {
-		t.Fatalf(fmt.Sprintf("parsed custom headers do not match the expected ones, difference: %v", diff))
+		t.Fatalf("parsed custom headers do not match the expected ones, difference: %v", diff)
 	}
 }
 
@@ -84,29 +83,29 @@ func TestCustomResponseHeadersConfigsMultipleListeners(t *testing.T) {
 		t.Fatalf("Error encountered when loading config %+v", err)
 	}
 	if diff := deep.Equal(expectedCustomResponseHeader, config.Listeners[0].CustomResponseHeaders); diff != nil {
-		t.Fatalf(fmt.Sprintf("parsed custom headers do not match the expected ones, difference: %v", diff))
+		t.Fatalf("parsed custom headers do not match the expected ones, difference: %v", diff)
 	}
 
 	if diff := deep.Equal(expectedCustomResponseHeader, config.Listeners[1].CustomResponseHeaders); diff == nil {
-		t.Fatalf(fmt.Sprintf("parsed custom headers do not match the expected ones, difference: %v", diff))
+		t.Fatalf("parsed custom headers do not match the expected ones, difference: %v", diff)
 	}
 	if diff := deep.Equal(expectedCustomResponseHeader["default"], config.Listeners[1].CustomResponseHeaders["default"]); diff != nil {
-		t.Fatalf(fmt.Sprintf("parsed custom headers do not match the expected ones, difference: %v", diff))
+		t.Fatalf("parsed custom headers do not match the expected ones, difference: %v", diff)
 	}
 
 	if diff := deep.Equal(expectedCustomResponseHeader, config.Listeners[2].CustomResponseHeaders); diff == nil {
-		t.Fatalf(fmt.Sprintf("parsed custom headers do not match the expected ones, difference: %v", diff))
+		t.Fatalf("parsed custom headers do not match the expected ones, difference: %v", diff)
 	}
 
 	if diff := deep.Equal(defaultSTS, config.Listeners[2].CustomResponseHeaders["default"]); diff != nil {
-		t.Fatalf(fmt.Sprintf("parsed custom headers do not match the expected ones, difference: %v", diff))
+		t.Fatalf("parsed custom headers do not match the expected ones, difference: %v", diff)
 	}
 
 	if diff := deep.Equal(expectedCustomResponseHeader, config.Listeners[3].CustomResponseHeaders); diff == nil {
-		t.Fatalf(fmt.Sprintf("parsed custom headers do not match the expected ones, difference: %v", diff))
+		t.Fatalf("parsed custom headers do not match the expected ones, difference: %v", diff)
 	}
 
 	if diff := deep.Equal(defaultSTS, config.Listeners[3].CustomResponseHeaders["default"]); diff != nil {
-		t.Fatalf(fmt.Sprintf("parsed custom headers do not match the expected ones, difference: %v", diff))
+		t.Fatalf("parsed custom headers do not match the expected ones, difference: %v", diff)
 	}
 }

--- a/helper/osutil/fileinfo_test.go
+++ b/helper/osutil/fileinfo_test.go
@@ -74,10 +74,10 @@ func TestCheckPathInfo(t *testing.T) {
 
 		err = checkPathInfo(info, "testFile", tc.uid, int(tc.permissions))
 		if tc.expectError && err == nil {
-			t.Errorf("invalid result. expected error")
+			t.Error("invalid result. expected error")
 		}
 		if !tc.expectError && err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 
 		err = os.RemoveAll("testFile")

--- a/sdk/database/dbplugin/v5/grpc_server.go
+++ b/sdk/database/dbplugin/v5/grpc_server.go
@@ -171,12 +171,12 @@ func (g *gRPCServer) NewUser(ctx context.Context, req *proto.NewUserRequest) (*p
 
 func (g *gRPCServer) UpdateUser(ctx context.Context, req *proto.UpdateUserRequest) (*proto.UpdateUserResponse, error) {
 	if req.GetUsername() == "" {
-		return &proto.UpdateUserResponse{}, status.Errorf(codes.InvalidArgument, "no username provided")
+		return &proto.UpdateUserResponse{}, status.Error(codes.InvalidArgument, "no username provided")
 	}
 
 	dbReq, err := getUpdateUserRequest(req)
 	if err != nil {
-		return &proto.UpdateUserResponse{}, status.Errorf(codes.InvalidArgument, err.Error())
+		return &proto.UpdateUserResponse{}, status.Error(codes.InvalidArgument, err.Error())
 	}
 
 	impl, err := g.getDatabase(ctx)

--- a/sdk/helper/certutil/certutil_test.go
+++ b/sdk/helper/certutil/certutil_test.go
@@ -16,6 +16,7 @@ import (
 	"encoding/asn1"
 	"encoding/json"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"math/big"
 	mathrand "math/rand"
@@ -58,7 +59,7 @@ func TestCertBundleConversion(t *testing.T) {
 		err = compareCertBundleToParsedCertBundle(cbut, pcbut)
 		if err != nil {
 			t.Logf("Error occurred with bundle %d in test array (index %d).\n", i+1, i)
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 
 		cbut, err := pcbut.ToCertBundle()
@@ -68,7 +69,7 @@ func TestCertBundleConversion(t *testing.T) {
 
 		err = compareCertBundleToParsedCertBundle(cbut, pcbut)
 		if err != nil {
-			t.Fatalf(err.Error())
+			t.Fatal(err.Error())
 		}
 	}
 }
@@ -132,7 +133,7 @@ func TestCertBundleParsing(t *testing.T) {
 		err = compareCertBundleToParsedCertBundle(cbut, pcbut)
 		if err != nil {
 			t.Logf("Error occurred with bundle %d in test array (index %d).\n", i+1, i)
-			t.Fatalf(err.Error())
+			t.Fatal(err.Error())
 		}
 
 		dataMap := structs.New(cbut).Map()
@@ -144,7 +145,7 @@ func TestCertBundleParsing(t *testing.T) {
 		err = compareCertBundleToParsedCertBundle(cbut, pcbut)
 		if err != nil {
 			t.Logf("Error occurred with bundle %d in test array (index %d).\n", i+1, i)
-			t.Fatalf(err.Error())
+			t.Fatal(err.Error())
 		}
 
 		pcbut, err = ParsePEMBundle(cbut.ToPEMBundle())
@@ -155,14 +156,14 @@ func TestCertBundleParsing(t *testing.T) {
 		err = compareCertBundleToParsedCertBundle(cbut, pcbut)
 		if err != nil {
 			t.Logf("Error occurred with bundle %d in test array (index %d).\n", i+1, i)
-			t.Fatalf(err.Error())
+			t.Fatal(err.Error())
 		}
 	}
 }
 
 func compareCertBundleToParsedCertBundle(cbut *CertBundle, pcbut *ParsedCertBundle) error {
 	if cbut == nil {
-		return fmt.Errorf("got nil bundle")
+		return errors.New("got nil bundle")
 	}
 	if pcbut == nil {
 		return fmt.Errorf("got nil parsed bundle")
@@ -281,7 +282,7 @@ func TestCSRBundleConversion(t *testing.T) {
 
 		err = compareCSRBundleToParsedCSRBundle(csrbut, pcsrbut)
 		if err != nil {
-			t.Fatalf(err.Error())
+			t.Fatal(err.Error())
 		}
 
 		csrbut, err = pcsrbut.ToCSRBundle()
@@ -291,7 +292,7 @@ func TestCSRBundleConversion(t *testing.T) {
 
 		err = compareCSRBundleToParsedCSRBundle(csrbut, pcsrbut)
 		if err != nil {
-			t.Fatalf(err.Error())
+			t.Fatal(err.Error())
 		}
 	}
 }

--- a/sdk/helper/certutil/helpers.go
+++ b/sdk/helper/certutil/helpers.go
@@ -112,7 +112,7 @@ func GetHexFormatted(buf []byte, sep string) string {
 	var ret bytes.Buffer
 	for _, cur := range buf {
 		if ret.Len() > 0 {
-			fmt.Fprintf(&ret, sep)
+			fmt.Fprint(&ret, sep)
 		}
 		fmt.Fprintf(&ret, "%02x", cur)
 	}

--- a/sdk/helper/keysutil/lock_manager.go
+++ b/sdk/helper/keysutil/lock_manager.go
@@ -277,12 +277,12 @@ func (lm *LockManager) BackupPolicy(ctx context.Context, storage logical.Storage
 			return "", err
 		}
 		if p == nil {
-			return "", fmt.Errorf(fmt.Sprintf("key %q not found", name))
+			return "", fmt.Errorf("key %q not found", name)
 		}
 	}
 
 	if atomic.LoadUint32(&p.deleted) == 1 {
-		return "", fmt.Errorf(fmt.Sprintf("key %q not found", name))
+		return "", fmt.Errorf("key %q not found", name)
 	}
 
 	backup, err := p.Backup(ctx, storage)

--- a/sdk/plugin/grpc_system.go
+++ b/sdk/plugin/grpc_system.go
@@ -459,8 +459,7 @@ func (s *gRPCSystemViewServer) GenerateIdentityToken(ctx context.Context, req *p
 		TTL:      time.Duration(req.GetTTL()) * time.Second,
 	})
 	if err != nil {
-		return &pb.GenerateIdentityTokenResponse{}, status.Errorf(codes.Internal,
-			err.Error())
+		return &pb.GenerateIdentityTokenResponse{}, status.Error(codes.Internal, err.Error())
 	}
 
 	return &pb.GenerateIdentityTokenResponse{

--- a/vault/activity_log_test.go
+++ b/vault/activity_log_test.go
@@ -1329,7 +1329,7 @@ func TestActivityLog_loadCurrentClientSegment(t *testing.T) {
 	for _, tc := range testCases {
 		data, err := proto.Marshal(tc.entities)
 		if err != nil {
-			t.Fatalf(err.Error())
+			t.Fatal(err.Error())
 		}
 		WriteToStorage(t, core, ActivityLogPrefix+tc.path, data)
 	}
@@ -1442,7 +1442,7 @@ func TestActivityLog_loadPriorEntitySegment(t *testing.T) {
 	for _, tc := range testCases {
 		data, err := proto.Marshal(tc.entities)
 		if err != nil {
-			t.Fatalf(err.Error())
+			t.Fatal(err.Error())
 		}
 		WriteToStorage(t, core, ActivityLogPrefix+tc.path, data)
 	}
@@ -1488,7 +1488,7 @@ func TestActivityLog_loadTokenCount(t *testing.T) {
 
 	data, err := proto.Marshal(tokenCount)
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err.Error())
 	}
 
 	testCases := []struct {
@@ -1622,7 +1622,7 @@ func setupActivityRecordsInStorage(t *testing.T, base time.Time, includeEntities
 				Clients: []*activity.EntityRecord{entityRecord},
 			})
 			if err != nil {
-				t.Fatalf(err.Error())
+				t.Fatal(err.Error())
 			}
 			if i == 0 {
 				WriteToStorage(t, core, ActivityLogPrefix+"entity/"+fmt.Sprint(monthsAgo.Unix())+"/0", entityData)
@@ -1648,7 +1648,7 @@ func setupActivityRecordsInStorage(t *testing.T, base time.Time, includeEntities
 
 		tokenData, err := proto.Marshal(tokenCount)
 		if err != nil {
-			t.Fatalf(err.Error())
+			t.Fatal(err.Error())
 		}
 
 		WriteToStorage(t, core, ActivityLogPrefix+"directtokens/"+fmt.Sprint(base.Unix())+"/0", tokenData)
@@ -4064,7 +4064,7 @@ func TestActivityLog_partialMonthClientCountWithMultipleMountPaths(t *testing.T)
 			Clients: []*activity.EntityRecord{entityRecord},
 		})
 		if err != nil {
-			t.Fatalf(err.Error())
+			t.Fatal(err.Error())
 		}
 		storagePath := fmt.Sprintf("%sentity/%d/%d", ActivityLogPrefix, timeutil.StartOfMonth(now).Unix(), i)
 		WriteToStorage(t, core, storagePath, entityData)

--- a/vault/core_test.go
+++ b/vault/core_test.go
@@ -379,7 +379,7 @@ func TestCore_HasVaultVersion(t *testing.T) {
 	upgradeTime := versionEntry.TimestampInstalled
 
 	if upgradeTime.After(time.Now()) || upgradeTime.Before(time.Now().Add(-1*time.Hour)) {
-		t.Fatalf("upgrade time isn't within reasonable bounds of new core initialization. " +
+		t.Fatal("upgrade time isn't within reasonable bounds of new core initialization. " +
 			fmt.Sprintf("time is: %+v, upgrade time is %+v", time.Now(), upgradeTime))
 	}
 }

--- a/vault/diagnose/output.go
+++ b/vault/diagnose/output.go
@@ -13,7 +13,7 @@ import (
 	"sync"
 	"time"
 
-	wordwrap "github.com/mitchellh/go-wordwrap"
+	"github.com/mitchellh/go-wordwrap"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
@@ -118,7 +118,7 @@ func (t *TelemetryCollector) OnStart(_ context.Context, s sdktrace.ReadWriteSpan
 	defer t.mu.Unlock()
 	t.spans[s.SpanContext().SpanID()] = s
 	if isMainSection(s) {
-		fmt.Fprintf(t.ui, status_unknown+s.Name())
+		fmt.Fprint(t.ui, status_unknown+s.Name())
 	}
 }
 

--- a/vault/diagnose/tls_verification.go
+++ b/vault/diagnose/tls_verification.go
@@ -9,6 +9,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"strings"
@@ -91,7 +92,7 @@ func outputError(ctx context.Context, newWarnings, listenerWarnings []string, ne
 	}
 	if newErr != nil {
 		errMsg := listenerID + ": " + newErr.Error()
-		listenerErrors = append(listenerErrors, fmt.Errorf(errMsg))
+		listenerErrors = append(listenerErrors, errors.New(errMsg))
 		Fail(ctx, errMsg)
 	}
 	return listenerWarnings, listenerErrors
@@ -350,7 +351,7 @@ func TLSCAFileCheck(CAFilePath string) ([]string, error) {
 
 	// Check for TLS Errors
 	if err = TLSErrorChecks(leafCerts, interCerts, rootCerts); err != nil {
-		return warningsSlc, fmt.Errorf(strings.ReplaceAll(err.Error(), "leaf", "root"))
+		return warningsSlc, errors.New(strings.ReplaceAll(err.Error(), "leaf", "root"))
 	}
 
 	return warningsSlc, err

--- a/vault/diagnose/tls_verification_test.go
+++ b/vault/diagnose/tls_verification_test.go
@@ -36,10 +36,10 @@ func TestTLSValidCert(t *testing.T) {
 	warnings, errs := ListenerChecks(context.Background(), listeners)
 	if errs != nil {
 		// The test failed -- we can just return one of the errors
-		t.Fatalf(errs[0].Error())
+		t.Fatal(errs[0].Error())
 	}
 	if warnings != nil {
-		t.Fatalf("warnings returned from good listener")
+		t.Fatal("warnings returned from good listener")
 	}
 }
 

--- a/vault/external_tests/metrics/core_metrics_int_test.go
+++ b/vault/external_tests/metrics/core_metrics_int_test.go
@@ -49,7 +49,7 @@ func TestMountTableMetrics(t *testing.T) {
 
 	nonlocalLogicalMountsize, err := gaugeSearchHelper(data, 3)
 	if err != nil {
-		t.Errorf(err.Error())
+		t.Error(err.Error())
 	}
 
 	// Mount new kv
@@ -69,11 +69,11 @@ func TestMountTableMetrics(t *testing.T) {
 
 	nonlocalLogicalMountsizeAfterMount, err := gaugeSearchHelper(data, 4)
 	if err != nil {
-		t.Errorf(err.Error())
+		t.Error(err.Error())
 	}
 
 	if nonlocalLogicalMountsizeAfterMount <= nonlocalLogicalMountsize {
-		t.Errorf("Mount size does not change after new mount is mounted")
+		t.Error("Mount size does not change after new mount is mounted")
 	}
 }
 

--- a/vault/login_mfa.go
+++ b/vault/login_mfa.go
@@ -1908,9 +1908,9 @@ func (c *Core) validateDuo(ctx context.Context, mfaFactors *MFAFactor, mConfig *
 	case "allow":
 		return nil
 	case "deny":
-		return fmt.Errorf(preauth.Response.Status_Msg)
+		return errors.New(preauth.Response.Status_Msg)
 	case "enroll":
-		return fmt.Errorf(fmt.Sprintf("%q - %q", preauth.Response.Status_Msg, preauth.Response.Enroll_Portal_Url))
+		return fmt.Errorf("%q - %q", preauth.Response.Status_Msg, preauth.Response.Enroll_Portal_Url)
 	case "auth":
 		break
 	default:

--- a/vault/request_forwarding.go
+++ b/vault/request_forwarding.go
@@ -35,7 +35,7 @@ import (
 
 var (
 	NotHAMember       = "node is not in HA cluster membership"
-	StatusNotHAMember = status.Errorf(codes.FailedPrecondition, NotHAMember)
+	StatusNotHAMember = status.Error(codes.FailedPrecondition, NotHAMember)
 )
 
 const haNodeIDKey = "ha_node_id"

--- a/vault/token_store_test.go
+++ b/vault/token_store_test.go
@@ -4126,7 +4126,7 @@ func TestTokenStore_RolePeriod(t *testing.T) {
 			t.Fatal("response was nil")
 		}
 		if resp.Auth == nil {
-			t.Fatalf(fmt.Sprintf("response auth was nil, resp is %#v", *resp))
+			t.Fatalf("response auth was nil, resp is %#v", *resp)
 		}
 		if resp.Auth.ClientToken == "" {
 			t.Fatalf("bad: %#v", resp)
@@ -4283,7 +4283,7 @@ func TestTokenStore_RoleExplicitMaxTTL(t *testing.T) {
 			t.Fatal("response was nil")
 		}
 		if resp.Auth == nil {
-			t.Fatalf(fmt.Sprintf("response auth was nil, resp is %#v", *resp))
+			t.Fatalf("response auth was nil, resp is %#v", *resp)
 		}
 		if resp.Auth.ClientToken == "" {
 			t.Fatalf("bad: %#v", resp)
@@ -4675,7 +4675,7 @@ func TestTokenStore_Periodic(t *testing.T) {
 			t.Fatal("response was nil")
 		}
 		if resp.Auth == nil {
-			t.Fatalf(fmt.Sprintf("response auth was nil, resp is %#v", *resp))
+			t.Fatalf("response auth was nil, resp is %#v", *resp)
 		}
 		if resp.Auth.ClientToken == "" {
 			t.Fatalf("bad: %#v", resp)
@@ -4736,7 +4736,7 @@ func TestTokenStore_Periodic(t *testing.T) {
 			t.Fatal("response was nil")
 		}
 		if resp.Auth == nil {
-			t.Fatalf(fmt.Sprintf("response auth was nil, resp is %#v", *resp))
+			t.Fatalf("response auth was nil, resp is %#v", *resp)
 		}
 		if resp.Auth.ClientToken == "" {
 			t.Fatalf("bad: %#v", resp)
@@ -4788,7 +4788,7 @@ func testTokenStore_NumUses_ErrorCheckHelper(t *testing.T, resp *logical.Respons
 		t.Fatal("response was nil")
 	}
 	if resp.Auth == nil {
-		t.Fatalf(fmt.Sprintf("response auth was nil, resp is %#v", *resp))
+		t.Fatalf("response auth was nil, resp is %#v", *resp)
 	}
 	if resp.Auth.ClientToken == "" {
 		t.Fatalf("bad: %#v", resp)
@@ -4935,7 +4935,7 @@ func TestTokenStore_Periodic_ExplicitMax(t *testing.T) {
 			t.Fatal("response was nil")
 		}
 		if resp.Auth == nil {
-			t.Fatalf(fmt.Sprintf("response auth was nil, resp is %#v", *resp))
+			t.Fatalf("response auth was nil, resp is %#v", *resp)
 		}
 		if resp.Auth.ClientToken == "" {
 			t.Fatalf("bad: %#v", resp)
@@ -5009,7 +5009,7 @@ func TestTokenStore_Periodic_ExplicitMax(t *testing.T) {
 			t.Fatal("response was nil")
 		}
 		if resp.Auth == nil {
-			t.Fatalf(fmt.Sprintf("response auth was nil, resp is %#v", *resp))
+			t.Fatalf("response auth was nil, resp is %#v", *resp)
 		}
 		if resp.Auth.ClientToken == "" {
 			t.Fatalf("bad: %#v", resp)


### PR DESCRIPTION
### Description

Prepare the code base for a future Go 1.24 update when it is released. 

There are a few issues that have become failures in 1.24, mainly passing in constant strings into methods that expect format arguments such as Fatalf, Sprintf. The second being calling t.Fatal from outside the main test go routine.

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [X] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
