### PR TITLE
UI: Fix token renewal breaking policy checks

### DIFF
--- a/changelog/29416.txt
+++ b/changelog/29416.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui (enterprise): Fixes token renewal to ensure capability checks are performed in the relevant namespace, resolving 'Not authorized' errors for resources that users have permission to access.
+```

--- a/ui/tests/helpers/auth/auth-form-selectors.ts
+++ b/ui/tests/helpers/auth/auth-form-selectors.ts
@@ -4,6 +4,7 @@
  */
 
 export const AUTH_FORM = {
+  method: '[data-test-select=auth-method]',
   form: '[data-test-auth-form]',
   login: '[data-test-auth-submit]',
   tabs: (method: string) => (method ? `[data-test-auth-method="${method}"]` : '[data-test-auth-method]'),

--- a/ui/tests/helpers/auth/auth-helpers.ts
+++ b/ui/tests/helpers/auth/auth-helpers.ts
@@ -9,6 +9,7 @@ import { AUTH_FORM } from 'vault/tests/helpers/auth/auth-form-selectors';
 
 const { rootToken } = VAULT_KEYS;
 
+// LOGIN WITH TOKEN
 export const login = async (token = rootToken) => {
   // make sure we're always logged out and logged back in
   await logout();
@@ -23,6 +24,30 @@ export const loginNs = async (ns: string, token = rootToken) => {
   await visit('/vault/auth?with=token');
   await fillIn(AUTH_FORM.namespaceInput, ns);
   await fillIn(AUTH_FORM.input('token'), token);
+  return click(AUTH_FORM.login);
+};
+
+// LOGIN WITH NON-TOKEN methods
+/*
+inputValues are for filling in the form values
+the key completes to the input's test selector and fills it in with the corresponding value
+for example: { username: 'bob', password: 'my-password', 'auth-form-mount-path': 'userpasss1' };
+*/
+export const loginMethod = async (
+  methodType: string,
+  inputValues: object,
+  { toggleOptions = false, ns = '' }
+) => {
+  // make sure we're always logged out and logged back in
+  await logout();
+  await visit(`/vault/auth?with=${methodType}`);
+
+  if (ns) await fillIn(AUTH_FORM.namespaceInput, ns);
+  if (toggleOptions) await click(AUTH_FORM.moreOptions);
+
+  for (const [input, value] of Object.entries(inputValues)) {
+    await fillIn(AUTH_FORM.input(input), value);
+  }
   return click(AUTH_FORM.login);
 };
 


### PR DESCRIPTION
### Description
✅ enterprise tests passed
The UI makes a lot of inferences based on the shape of the auth response we receive. The UI relies on the `namespace_path` from the auth response to set the user's root namespace which is then used to calculate capabilities.
https://github.com/hashicorp/vault/blob/dcdbacd281052a7baf898f1129ce6801ae930d22/ui/app/adapters/capabilities.js#L16-L30

`renew-self` does not return `namespace_path`, so this PR manually adds it in the `renew()` method, if it exists. The auth code is challenging to parse and is prone to regressions. I double checked that this change does not affect the bug the previous PR was solving that introduced these code changes: https://github.com/hashicorp/vault/pull/24168/files

This fixes a bug where clicking `Renew token` would incorrectly gate navigation to resources a user **does** have access to. For example, the database overview page:

## before token renewal
<img width="1100" alt="Screenshot 2025-01-30 at 10 28 19 AM" src="https://github.com/user-attachments/assets/96b79e5e-9655-430b-8073-2e49e7c1505c" />

## after token renewal
<img width="1100" alt="Screenshot 2025-01-30 at 10 27 48 AM" src="https://github.com/user-attachments/assets/e7db9a55-0708-4964-9ee2-21c626470f7b" />


### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
