### PR TITLE
Add serialNumberSource to OpenAPI test (not added to form)

### DIFF
--- a/ui/tests/helpers/openapi/expected-secret-attrs.js
+++ b/ui/tests/helpers/openapi/expected-secret-attrs.js
@@ -1131,6 +1131,15 @@ const pki = {
       label: 'Require Common Name',
       type: 'boolean',
     },
+    serialNumberSource: {
+      defaultValue: 'json-csr',
+      editType: 'string',
+      fieldGroup: 'default',
+      helpText:
+        'Source for the certificate subject serial number. If "json-csr" (default), the value from the JSON serial_number field is used, falling back to the value in the CSR if empty. If "json", the value from the serial_number JSON field is used, ignoring the value in the CSR.',
+      label: 'Serial number source',
+      type: 'string',
+    },
     serverFlag: {
       editType: 'boolean',
       helpText:


### PR DESCRIPTION
For now adding this to stop the backend test from failing. However, waiting to hear Design's thoughts about the best way and where to display this on the ui. 

Backend param was added in PR #29369

- [x] Ent test pass

