### PR TITLE
Deleted namespace client counts is now shown when queried from admin namespace CE changes

### DIFF
--- a/changelog/29432.txt
+++ b/changelog/29432.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+activity: Show activity records from clients created in deleted namespaces when activity log is queried from admin namespace.
+```

--- a/vault/activity_log.go
+++ b/vault/activity_log.go
@@ -1801,8 +1801,9 @@ func (c *Core) ActivityLogInjectResponse(ctx context.Context, pq *activity.Preco
 
 func (a *ActivityLog) includeInResponse(query *namespace.Namespace, record *namespace.Namespace) bool {
 	if record == nil {
-		// Deleted namespace, only include in root queries
-		return query.ID == namespace.RootNamespaceID
+		// Deleted namespace, only include in root or admin namespace (if configured) queries
+		adminNsPath := namespace.Canonicalize(a.core.administrativeNamespacePath())
+		return query.ID == namespace.RootNamespaceID || (adminNsPath != "" && query.Path == adminNsPath)
 	}
 	return record.HasParent(query)
 }

--- a/vault/activity_log_test.go
+++ b/vault/activity_log_test.go
@@ -1922,7 +1922,8 @@ func (f *fakeResponseWriter) WriteHeader(statusCode int) {
 // their parents.
 func TestActivityLog_IncludeNamespace(t *testing.T) {
 	root := namespace.RootNamespace
-	a := &ActivityLog{}
+	core, _, _ := TestCoreUnsealed(t)
+	a := core.activityLog
 
 	nsA := &namespace.Namespace{
 		ID:   "aaaaa",

--- a/vault/core.go
+++ b/vault/core.go
@@ -3629,6 +3629,15 @@ func (c *Core) LogFormat() string {
 	return conf.(*server.Config).LogFormat
 }
 
+// administrativeNamespacePath returns the configured administrative namespace path.
+func (c *Core) administrativeNamespacePath() string {
+	conf := c.rawConfig.Load()
+	if conf == nil {
+		return ""
+	}
+	return conf.(*server.Config).AdministrativeNamespacePath
+}
+
 // LogLevel returns the log level provided by level provided by config, CLI flag, or env
 func (c *Core) LogLevel() string {
 	return c.logLevel

--- a/vault/core_test.go
+++ b/vault/core_test.go
@@ -3753,3 +3753,16 @@ func TestCore_IsRemovedFromCluster(t *testing.T) {
 		t.Fatalf("expected removed to be false and ok to be true, got removed: %v, ok: %v", removed, ok)
 	}
 }
+
+// Test_administrativeNamespacePath verifies if administrativeNamespacePath function returns the configured administrative namespace path
+func Test_administrativeNamespacePath(t *testing.T) {
+	adminNamespacePath := "admin"
+	coreConfig := &CoreConfig{
+		RawConfig: &server.Config{
+			SharedConfig: &configutil.SharedConfig{AdministrativeNamespacePath: adminNamespacePath},
+		},
+		AdministrativeNamespacePath: adminNamespacePath,
+	}
+	core, _, _ := TestCoreUnsealedWithConfig(t, coreConfig)
+	require.Equal(t, core.administrativeNamespacePath(), adminNamespacePath)
+}


### PR DESCRIPTION
### Description
What does this PR do?
Deleted namespace client counts is now shown when queried from admin namespace.
Jira: https://hashicorp.atlassian.net/browse/VAULT-33413

Admin namespace is set using administrative_namespace_path in configuration file. Included test that reloads config with different administrative_namespace_path and verifies that only the right admin path has deleted namespaces.
Approved ENT: https://github.com/hashicorp/vault-enterprise/pull/7328

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
