### PR TITLE
Document new serial_number_source PKI role field

### DIFF
--- a/website/content/api-docs/secret/pki/index.mdx
+++ b/website/content/api-docs/secret/pki/index.mdx
@@ -3437,6 +3437,13 @@ request is denied.
   certificates are stored. If true, metadata is not stored and an error is returned
   if the `metadata` field is specified on issuance APIs
 
+- `serial_number_source` `(string: "json-csr")` - Specifies the source of the subject serial
+  number. Valid values are `json-csr` (default) or `json`.
+  When set to `json-csr`, the subject serial number is taken from the `serial_number` parameter
+  and falls back to the serial number in the CSR. When set to `json`, the subject serial number
+  is taken from the `serial_number` parameter but will ignore any value in the CSR.
+  For backwards compatibility an empty value for this field will default to the `json-csr` behavior.
+
 #### Sample payload
 
 ```json


### PR DESCRIPTION
### Description

Update the PKI role api-docs for the new field `serial_number_source` that was added within https://github.com/hashicorp/vault/pull/29369

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
