### PR TITLE
docs: db and ldap secrets engine known issues

### DIFF
--- a/website/content/docs/upgrading/upgrade-to-1.16.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.16.x.mdx
@@ -236,3 +236,4 @@ more details, and information about opt-out.
 @include 'known-issues/manual-entity-merge-does-not-persist.mdx'
 
 
+@include 'known-issues/database-skip-static-role-rotation.mdx

--- a/website/content/docs/upgrading/upgrade-to-1.17.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.17.x.mdx
@@ -200,4 +200,13 @@ more details, and information about opt-out.
 
 @include 'known-issues/manual-entity-merge-does-not-persist.mdx'
 
+@include 'known-issues/aws-auth-external-id.mdx'
+
+@include 'known-issues/sync-activation-flags-cache-not-updated.mdx'
+
 @include 'known-issues/1_17_secrets-sync-ssrf-private-endpoints.mdx'
+
+@include 'known-issues/duplicate-hsm-key.mdx'
+
+@include 'known-issues/database-skip-static-role-rotation.mdx
+

--- a/website/content/docs/upgrading/upgrade-to-1.18.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.18.x.mdx
@@ -138,3 +138,9 @@ reports if manual reporting is preferred.
 
 See the main page for [Vault product usage metrics reporting](/vault/docs/enterprise/license/product-usage-reporting) for
 more details, and information about opt-out.
+
+## Known issues and workarounds
+
+@include 'known-issues/duplicate-hsm-key.mdx'
+
+@include 'known-issues/database-skip-static-role-rotation.mdx

--- a/website/content/partials/known-issues/database-skip-static-role-rotation.mdx
+++ b/website/content/partials/known-issues/database-skip-static-role-rotation.mdx
@@ -1,0 +1,17 @@
+### Database and LDAP Secrets Engine - Unwanted secret rotation on backend restart
+
+#### Affected Versions
+- All versions that support skipping automatic import rotation of static roles.
+
+#### Issue
+The Database secrets engine and the LDAP secrets engine both support skipping
+automatic import rotation of static roles with the config-level field
+`skip_static_role_import_rotation` and the static role-level field
+`skip_import_rotation`.
+
+Any static roles configured with either of these fields set to true will have
+their passwords rotated when Vault is restarted. The password rotation will not
+occur on restart if the static role has already had its password rotated.
+
+#### Workaround
+Currently, there is no workaround except to avoid a restart of the backend.


### PR DESCRIPTION
### Description
Manual backport of https://github.com/hashicorp/vault/pull/29449

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
