### PR TITLE
Fix tech preview typo in export API docs

### DIFF
--- a/website/content/api-docs/system/internal-counters.mdx
+++ b/website/content/api-docs/system/internal-counters.mdx
@@ -846,7 +846,7 @@ $ curl \
 
 </CodeBlockConfig>
 
-### Sample request 
+### Sample request
 
 The following example retrieves the client count for a single month.
 
@@ -1039,13 +1039,13 @@ The `/sys/internal/counters/config` endpoint is used to configure logging of act
   discard any data recorded for that month, but does not delete previous months.
   <Note>
 
-  <EnterpriseAlert product="vault" inline /> 
-  
-  License utilization cannot be reported if client counting is disabled. 
-  
+  <EnterpriseAlert product="vault" inline />
+
+  License utilization cannot be reported if client counting is disabled.
+
   As of 1.16.0, 1.15.6 and 1.14.10, client counting cannot be disabled as manual license utilization reporting is always enabled.
-  
-  As of 1.14.0, 1.13.4, 1.12.8 and 1.11.12, client counting cannot be disabled when automated license utilization reporting is enabled. 
+
+  As of 1.14.0, 1.13.4, 1.12.8 and 1.11.12, client counting cannot be disabled when automated license utilization reporting is enabled.
   </Note>
 - `retention_months` `(integer: 48)` - The number of months of history to retain. The minimum is 48 months and the maximum is 60 months.
 
@@ -1133,7 +1133,7 @@ provided start and end times. The returned set of client information will be
 deduplicated over the time window and will show the earliest activity logged for
 each client. The output will be ordered chronologically by month of activity.
 
-<Note title="Techn preview">
+<Note title="Tech preview">
 
 This endpoint is currently in tech preview status.
 
@@ -1155,8 +1155,8 @@ it may be up to 20 minutes delayed.
 - **`sudo` required** – This endpoint requires `sudo` capability in addition to
   any path-specific capabilities.
 
-| Method | Path                                      |
-| :----- | :---------------------------------------- |
+| Method | Path                                     |
+|:-------|:-----------------------------------------|
 | `GET`  | `/sys/internal/counters/activity/export` |
 
 ### Parameters


### PR DESCRIPTION
### Description

"Techn preview" should be "tech preview"

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [x] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
