### PR TITLE
Fix log level of when starting a raft node

### DIFF
--- a/physical/raft/raft.go
+++ b/physical/raft/raft.go
@@ -617,7 +617,7 @@ func NewRaftBackend(conf map[string]string, logger log.Logger) (physical.Backend
 	isRemoved := new(atomic.Bool)
 	removedVal, err := stableStore.GetUint64(removedKey)
 	if err != nil {
-		logger.Error("error checking if this node is removed. continuing under the assumption that it's not", "error", err)
+		logger.Debug("error checking if this node is removed. continuing under the assumption that it's not", "error", err)
 	}
 	if removedVal == 1 {
 		isRemoved.Store(true)


### PR DESCRIPTION
### Description
A non-removed raft node would always print this error log line, which could be confusing for users. Switch the log line to debug level.

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
