### PR TITLE
identity: Introduce ActivationFunc for managing feature state

### DIFF
--- a/helper/activationflags/activation_flags.go
+++ b/helper/activationflags/activation_flags.go
@@ -30,7 +30,7 @@ type FeatureActivationFlags struct {
 // feature activation flags.
 type ActivationManager interface {
 	IsActivationFlagEnabled(featureName string) bool
-	Write(ctx context.Context, featureName string, activate bool) error
+	SetActivationFlagEnabled(ctx context.Context, featureName string, activate bool) error
 }
 
 // NewFeatureActivationFlags is a constructor for FeatureActivationFlags.
@@ -155,10 +155,11 @@ func (f *FeatureActivationFlags) ReloadFlagsFromStorage(ctx context.Context) (ma
 	return changedFlags, nil
 }
 
-// Write is the helper function called by the activation-flags API write endpoint. This stores
-// the boolean value for the activation-flag feature name into Vault storage across the cluster
-// and updates the in-memory cache upon success.
-func (f *FeatureActivationFlags) Write(ctx context.Context, featureName string, activate bool) (err error) {
+// SetActivationFlagEnabled is the helper function called by the
+// activation-flags API write endpoint. This stores the boolean value for the
+// activation-flag feature name into Vault storage across the cluster and
+// updates the in-memory cache upon success.
+func (f *FeatureActivationFlags) SetActivationFlagEnabled(ctx context.Context, featureName string, activate bool) (err error) {
 	f.activationFlagsLock.Lock()
 	defer f.activationFlagsLock.Unlock()
 
@@ -200,8 +201,9 @@ func (f *FeatureActivationFlags) IsActivationFlagEnabled(featureName string) boo
 	return ok && activated
 }
 
-// Set is used to set the activation flag for a feature in tests
-func (f *FeatureActivationFlags) Set(featureName string, activate bool) {
+// ActivateInMem is used to set the activation flag in-memory only for a feature
+// in tests
+func (f *FeatureActivationFlags) ActivateInMem(featureName string, activate bool) {
 	f.activationFlagsLock.Lock()
 	defer f.activationFlagsLock.Unlock()
 

--- a/sdk/framework/backend.go
+++ b/sdk/framework/backend.go
@@ -112,6 +112,10 @@ type Backend struct {
 	// to communicate with a plugin on when to rotate a credential
 	RotateCredential func(context.Context, *logical.Request) error
 
+	// ActivationFunc is the callback function used by ActivationFlags to
+	// communicate with a plugin to activate a feature.
+	ActivationFunc func(context.Context, *logical.Request) error
+
 	logger  log.Logger
 	system  logical.SystemView
 	events  logical.EventSender

--- a/vault/core.go
+++ b/vault/core.go
@@ -1474,7 +1474,10 @@ func (c *Core) configureLogicalBackends(backends map[string]logical.Factory, log
 		}
 
 		// Wire up the idStoreBackend to support the activation flag
-		c.systemBackend.idStoreBackend = idStore.Backend
+		if c.systemBackend != nil {
+			c.systemBackend.idStoreBackend = idStore.Backend
+		}
+
 		return idStore, nil
 	}
 

--- a/vault/core.go
+++ b/vault/core.go
@@ -1467,7 +1467,15 @@ func (c *Core) configureLogicalBackends(backends map[string]logical.Factory, log
 	logicalBackends[mountTypeIdentity] = func(ctx context.Context, config *logical.BackendConfig) (logical.Backend, error) {
 		identityLogger := logger.Named("identity")
 		c.AddLogger(identityLogger)
-		return NewIdentityStore(ctx, c, config, identityLogger)
+
+		idStore, err := NewIdentityStore(ctx, c, config, identityLogger)
+		if err != nil {
+			return nil, fmt.Errorf("error creating identity store: %w", err)
+		}
+
+		// Wire up the idStoreBackend to support the activation flag
+		c.systemBackend.idStoreBackend = idStore.Backend
+		return idStore, nil
 	}
 
 	c.logicalBackends = logicalBackends
@@ -2628,7 +2636,12 @@ func buildUnsealSetupFunctionSlice(c *Core) []func(context.Context) error {
 		setupFunctions = append(setupFunctions, c.loadAudits)
 		setupFunctions = append(setupFunctions, c.setupAuditedHeadersConfig)
 		setupFunctions = append(setupFunctions, c.setupAudits)
-		setupFunctions = append(setupFunctions, c.loadIdentityStoreArtifacts)
+		setupFunctions = append(setupFunctions, func(ctx context.Context) error {
+			if c.identityStore == nil {
+				return nil
+			}
+			return c.identityStore.loadArtifacts(ctx)
+		})
 		setupFunctions = append(setupFunctions, func(ctx context.Context) error {
 			return loadPolicyMFAConfigs(ctx, c)
 		})

--- a/vault/identity_store.go
+++ b/vault/identity_store.go
@@ -58,20 +58,21 @@ func (i *IdentityStore) resetDB() error {
 
 func NewIdentityStore(ctx context.Context, core *Core, config *logical.BackendConfig, logger log.Logger) (*IdentityStore, error) {
 	iStore := &IdentityStore{
-		view:          config.StorageView,
-		logger:        logger,
-		router:        core.router,
-		redirectAddr:  core.redirectAddr,
-		localNode:     core,
-		namespacer:    core,
-		metrics:       core.MetricSink(),
-		totpPersister: core,
-		groupUpdater:  core,
-		tokenStorer:   core,
-		entityCreator: core,
-		mountLister:   core,
-		mfaBackend:    core.loginMFABackend,
-		aliasLocks:    locksutil.CreateLocks(),
+		view:             config.StorageView,
+		logger:           logger,
+		router:           core.router,
+		redirectAddr:     core.redirectAddr,
+		localNode:        core,
+		namespacer:       core,
+		metrics:          core.MetricSink(),
+		totpPersister:    core,
+		groupUpdater:     core,
+		tokenStorer:      core,
+		entityCreator:    core,
+		mountLister:      core,
+		mfaBackend:       core.loginMFABackend,
+		aliasLocks:       locksutil.CreateLocks(),
+		renameDuplicates: core.FeatureActivationFlags,
 	}
 
 	// Create a memdb instance, which by default, operates on lower cased
@@ -108,6 +109,7 @@ func NewIdentityStore(ctx context.Context, core *Core, config *logical.BackendCo
 		Paths:          iStore.paths(),
 		Invalidate:     iStore.Invalidate,
 		InitializeFunc: iStore.initialize,
+		ActivationFunc: iStore.activateDeduplication,
 		PathsSpecial: &logical.Paths{
 			Unauthenticated: []string{
 				"oidc/.well-known/*",

--- a/vault/identity_store_conflicts.go
+++ b/vault/identity_store_conflicts.go
@@ -390,7 +390,7 @@ func (r *renameResolver) ResolveEntities(ctx context.Context, existing, duplicat
 		"namespace_id", duplicate.NamespaceID,
 		"entity_id", duplicate.ID,
 		"duplicate_of_canonical_id", existing.ID,
-		"renamed_from", duplicate.Name,
+		"renamed_from", existing.Name,
 		"renamed_to", duplicate.Name,
 	)
 
@@ -417,7 +417,8 @@ func (r *renameResolver) ResolveGroups(ctx context.Context, existing, duplicate 
 		"namespace_id", duplicate.NamespaceID,
 		"group_id", duplicate.ID,
 		"duplicate_of_canonical_id", existing.ID,
-		"new_name", duplicate.Name,
+		"renamed_from", existing.Name,
+		"renamed_to", duplicate.Name,
 	)
 	return nil
 }

--- a/vault/identity_store_structs.go
+++ b/vault/identity_store_structs.go
@@ -10,6 +10,7 @@ import (
 
 	log "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-memdb"
+	"github.com/hashicorp/vault/helper/activationflags"
 	"github.com/hashicorp/vault/helper/identity"
 	"github.com/hashicorp/vault/helper/metricsutil"
 	"github.com/hashicorp/vault/helper/namespace"
@@ -57,12 +58,17 @@ type IdentityStore struct {
 	// to enable richer queries based on multiple indexes.
 	db *memdb.MemDB
 
-	// locks to make sure things are consistent
-	lock             sync.RWMutex
+	// lock is the high-level IdentityStore lock, which protects underlying
+	// state against concurrent modification/access. If needed, callers should
+	// be sure to take this lock **before** (and never after) taking out any of
+	// the lower-level locks to prevent deadlocks.
+	lock sync.RWMutex
+
+	// oidcLock is used to provide atomic updates to OIDC identity objects.
 	oidcLock         sync.RWMutex
 	generateJWKSLock sync.Mutex
 
-	// groupLock is used to protect modifications to group entries
+	// groupLock is used to provide atomic updates to group identity objects.
 	groupLock sync.RWMutex
 
 	// oidcCache stores common response data as well as when the periodic func needs
@@ -112,6 +118,7 @@ type IdentityStore struct {
 	aliasLocks []*locksutil.LockEntry
 
 	conflictResolver ConflictResolver
+	renameDuplicates activationflags.ActivationManager
 }
 
 type groupDiff struct {

--- a/vault/identity_store_structs.go
+++ b/vault/identity_store_structs.go
@@ -64,11 +64,14 @@ type IdentityStore struct {
 	// the lower-level locks to prevent deadlocks.
 	lock sync.RWMutex
 
-	// oidcLock is used to provide atomic updates to OIDC identity objects.
-	oidcLock         sync.RWMutex
+	// oidcLock is used to protect against concurrent changes to OIDC identity
+	// objects.
+	oidcLock sync.RWMutex
+
 	generateJWKSLock sync.Mutex
 
-	// groupLock is used to provide atomic updates to group identity objects.
+	// groupLock is used to protect against concurrent changes to the group
+	// table and storagepacker.
 	groupLock sync.RWMutex
 
 	// oidcCache stores common response data as well as when the periodic func needs
@@ -118,6 +121,9 @@ type IdentityStore struct {
 	aliasLocks []*locksutil.LockEntry
 
 	conflictResolver ConflictResolver
+
+	// renameDuplicates holds the Core reference to feature activation flags, so
+	// we can set and query enablement of the deduplication feature.
 	renameDuplicates activationflags.ActivationManager
 }
 

--- a/vault/identity_store_test.go
+++ b/vault/identity_store_test.go
@@ -1581,7 +1581,7 @@ func identityStoreLoadingIsDeterministic(t *testing.T, identityDeduplication boo
 		require.False(t, c.Sealed())
 
 		// Test out the system backend ActivationFunc wiring
-		c.FeatureActivationFlags.Set(activationflags.IdentityDeduplication, true)
+		c.FeatureActivationFlags.ActivateInMem(activationflags.IdentityDeduplication, true)
 		require.NoError(t, err)
 
 		err := c.systemBackend.activateIdentityDeduplication(ctx, nil)

--- a/vault/identity_store_test.go
+++ b/vault/identity_store_test.go
@@ -1416,10 +1416,10 @@ func TestIdentityStoreInvalidate_TemporaryEntity(t *testing.T) {
 // the identity cleanup rename resolver to ensure that loading is deterministic
 // for both.
 func TestIdentityStoreLoadingIsDeterministic(t *testing.T) {
-	t.Run(t.Name()+"error-resolver", func(t *testing.T) {
+	t.Run(t.Name()+"-error-resolver", func(t *testing.T) {
 		identityStoreLoadingIsDeterministic(t, false)
 	})
-	t.Run(t.Name()+"identity-cleanup", func(t *testing.T) {
+	t.Run(t.Name()+"-identity-cleanup", func(t *testing.T) {
 		identityStoreLoadingIsDeterministic(t, true)
 	})
 }
@@ -1469,11 +1469,6 @@ func identityStoreLoadingIsDeterministic(t *testing.T, identityDeduplication boo
 	require.NoError(t, err)
 
 	ctx := context.Background()
-
-	if identityDeduplication {
-		err = c.FeatureActivationFlags.Write(ctx, activationflags.IdentityDeduplication, true)
-		require.NoError(t, err)
-	}
 
 	// We create 100 entities each with 1 non-local alias and 1 local alias. We
 	// then randomly create duplicate alias or local alias entries with a
@@ -1571,22 +1566,44 @@ func identityStoreLoadingIsDeterministic(t *testing.T, identityDeduplication boo
 
 	// Storage is now primed for the test.
 
-	// To test that this is deterministic we need to load from storage a bunch of
-	// times and make sure we get the same result. For easier debugging we'll
-	// build a list of human readable ids that we can compare.
-	prevLoadedNames := []string{}
-	for i := 0; i < 10; i++ {
-		// Seal and unseal to reload the identity store
+	if identityDeduplication {
+		// Perform an initial Seal/Unseal with duplicates injected to assert
+		// initial state.
 		require.NoError(t, c.Seal(rootToken))
 		require.True(t, c.Sealed())
 		for _, key := range sealKeys {
 			unsealed, err := c.Unseal(key)
-			require.NoError(t, err, "failed unseal on attempt %d", i)
+			require.NoError(t, err, "failed unseal on initial assertions")
 			if unsealed {
 				break
 			}
 		}
 		require.False(t, c.Sealed())
+
+		// Test out the system backend ActivationFunc wiring
+		c.FeatureActivationFlags.Set(activationflags.IdentityDeduplication, true)
+		require.NoError(t, err)
+
+		err := c.systemBackend.activateIdentityDeduplication(ctx, nil)
+		require.NoError(t, err)
+		require.IsType(t, &renameResolver{}, c.identityStore.conflictResolver)
+		require.False(t, c.identityStore.disableLowerCasedNames)
+	}
+
+	// To test that this is deterministic we need to load from storage a bunch of
+	// times and make sure we get the same result. For easier debugging we'll
+	// build a list of human readable ids that we can compare.
+	prevLoadedNames := []string{}
+	var prevErr error
+	for i := 0; i < 10; i++ {
+		err := c.identityStore.resetDB()
+		require.NoError(t, err)
+
+		err = c.identityStore.loadArtifacts(ctx)
+		if i > 0 {
+			require.Equal(t, prevErr, err)
+		}
+		prevErr = err
 
 		// Identity store should be loaded now. Check it's contents.
 		loadedNames := []string{}
@@ -1626,14 +1643,15 @@ func identityStoreLoadingIsDeterministic(t *testing.T, identityDeduplication boo
 				loadedNames = append(loadedNames, g.Alias.Name)
 			}
 		}
+
 		// This is a non-triviality check to make sure we actually loaded stuff and
 		// are not just passing because of a bug in the test.
 		groupsLoaded := len(loadedNames) - numLoaded
 		require.Greater(t, groupsLoaded, 140, "not enough groups and aliases loaded on attempt %d", i)
 
-		// note `lastIDs` argument is not needed any more but we can't change the
-		// signature without breaking enterprise. It's simpler to keep it unused for
-		// now until both parts of this merge.
+		// note `lastIDs` argument is not needed anymore but we can't change the
+		// signature without breaking enterprise. It's simpler to keep it unused
+		// for now until both parts of this merge.
 		entIdentityStoreDeterminismAssert(t, i, loadedNames, nil)
 
 		if i > 0 {
@@ -1662,7 +1680,7 @@ func TestIdentityStoreLoadingDuplicateReporting(t *testing.T) {
 		},
 	}
 
-	c, sealKeys, rootToken := TestCoreUnsealedWithConfig(t, cfg)
+	c, _, rootToken := TestCoreUnsealedWithConfig(t, cfg)
 
 	// Inject values into storage
 	upme, err := TestUserpassMount(c, false)
@@ -1678,10 +1696,6 @@ func TestIdentityStoreLoadingDuplicateReporting(t *testing.T) {
 
 	// Storage is now primed for the test.
 
-	// Seal and unseal to reload the identity store
-	require.NoError(t, c.Seal(rootToken))
-	require.True(t, c.Sealed())
-
 	// Setup a logger we can use to capture unseal logs
 	var unsealLogs []string
 	unsealLogger := &logFn{
@@ -1695,16 +1709,10 @@ func TestIdentityStoreLoadingDuplicateReporting(t *testing.T) {
 			unsealLogs = append(unsealLogs, fmt.Sprintf("%s: %s", msg, strings.Join(pairs, " ")))
 		},
 	}
-	logger.RegisterSink(unsealLogger)
 
-	for _, key := range sealKeys {
-		unsealed, err := c.Unseal(key)
-		require.NoError(t, err)
-		if unsealed {
-			break
-		}
-	}
-	require.False(t, c.Sealed())
+	logger.RegisterSink(unsealLogger)
+	err = c.identityStore.loadArtifacts(ctx)
+	require.NoError(t, err)
 	logger.DeregisterSink(unsealLogger)
 
 	// Identity store should be loaded now. Check it's contents.

--- a/vault/identity_store_util.go
+++ b/vault/identity_store_util.go
@@ -137,15 +137,18 @@ func (i *IdentityStore) activateDeduplication(ctx context.Context, req *logical.
 	i.groupLock.Lock()
 	defer i.groupLock.Unlock()
 
+	i.logger.Info("activating identity deduplication, reloading identity store")
+
 	i.disableLowerCasedNames = false
 	if err := i.resetDB(); err != nil {
 		return fmt.Errorf("failed to reset existing identity state: %w", err)
 	}
 
 	if err := i.loadArtifacts(ctx); err != nil {
-		return fmt.Errorf("failed to activate identity deduplication; %w", err)
+		return fmt.Errorf("failed to activate identity deduplication: %w", err)
 	}
 
+	i.logger.Info("identity deduplication activated, identity store reload complete")
 	return nil
 }
 

--- a/vault/identity_store_util.go
+++ b/vault/identity_store_util.go
@@ -36,24 +36,28 @@ var (
 	entityLoadingTxMaxSize = 1024
 )
 
-// loadIdentityStoreArtifacts is responsible for loading entities, groups, and aliases from storage into MemDB.
-func (c *Core) loadIdentityStoreArtifacts(ctx context.Context) error {
-	if c.identityStore == nil {
-		c.logger.Warn("identity store is not setup, skipping loading")
+// loadArtifacts is responsible for loading entities, groups, and aliases from
+// storage into MemDB.
+func (i *IdentityStore) loadArtifacts(ctx context.Context) error {
+	if i == nil {
 		return nil
 	}
 
 	loadFunc := func(context.Context) error {
-		if err := c.identityStore.loadEntities(ctx); err != nil {
+		i.logger.Debug("loading identity store artifacts with",
+			"case_sensitive", !i.disableLowerCasedNames,
+			"conflict_resolver", i.conflictResolver)
+
+		if err := i.loadEntities(ctx); err != nil {
 			return fmt.Errorf("failed to load entities: %w", err)
 		}
-		if err := c.identityStore.loadGroups(ctx); err != nil {
+		if err := i.loadGroups(ctx); err != nil {
 			return fmt.Errorf("failed to load groups: %w", err)
 		}
-		if err := c.identityStore.loadOIDCClients(ctx); err != nil {
+		if err := i.loadOIDCClients(ctx); err != nil {
 			return fmt.Errorf("failed to load OIDC clients: %w", err)
 		}
-		if err := c.identityStore.loadCachedEntitiesOfLocalAliases(ctx); err != nil {
+		if err := i.loadCachedEntitiesOfLocalAliases(ctx); err != nil {
 			return fmt.Errorf("failed to load cached local alias entities: %w", err)
 		}
 
@@ -65,13 +69,13 @@ func (c *Core) loadIdentityStoreArtifacts(ctx context.Context) error {
 	// identityStore into case-sensitive mode by switching the underlying
 	// schema to one with a relaxed lowerCase constraint and reload all
 	// artifacts into MemDB.
-	c.identityStore.conflictResolver = &errorResolver{c.identityStore.logger}
+	i.conflictResolver = &errorResolver{i.logger}
 
 	// If the identity deduplication cleanup flag is activated, instead
 	// deal with duplicate entities and groups by renaming with a -UUID
 	// suffix. N.B. *entity alias* duplicates will still be merged as before.
-	if c.FeatureActivationFlags.IsActivationFlagEnabled(activationflags.IdentityDeduplication) {
-		c.identityStore.conflictResolver = &renameResolver{c.identityStore.logger}
+	if i.renameDuplicates.IsActivationFlagEnabled(activationflags.IdentityDeduplication) {
+		i.conflictResolver = &renameResolver{i.logger}
 	}
 
 	// Load everything when MemDB is set to operate on lower cased names.
@@ -95,30 +99,54 @@ func (c *Core) loadIdentityStoreArtifacts(ctx context.Context) error {
 
 	// If we're here, it means we've encountered duplicates while loading
 	// with the errorResolver.
-	c.identityStore.logger.Warn("enabling case sensitive identity names")
+	i.logger.Warn("enabling case sensitive identity names")
 
 	// Set identity store to operate on case sensitive identity names
-	c.identityStore.disableLowerCasedNames = true
+	i.disableLowerCasedNames = true
 
 	// Swap out the MemDB instance and reload artifacts with the
 	// new schema.
-	if err := c.identityStore.resetDB(); err != nil {
+	if err := i.resetDB(); err != nil {
 		return err
 	}
 
 	// Also reset the conflict resolver so that we report potential duplicates to
 	// be resolved before it's safe to return to case-insensitive mode.
-	reporterResolver := newDuplicateReportingErrorResolver(c.identityStore.logger)
-	c.identityStore.conflictResolver = reporterResolver
+	reporterResolver := newDuplicateReportingErrorResolver(i.logger)
+	i.conflictResolver = reporterResolver
 
 	// Attempt to load identity artifacts once more after memdb is reset to
 	// accept case sensitive names
 	err = loadFunc(ctx)
 
 	// Log reported duplicates if any found whether or not we end up erroring.
-	reporterResolver.LogReport(c.identityStore.logger)
+	reporterResolver.LogReport(i.logger)
 
 	return err
+}
+
+// activateDeduplication is called when the identity deduplication feature is
+// enabled via the Activation Flag API. This method holds two high-level locks
+// ([*IdentityStore].lock and [*IdentityStore].groupLock) to prevent concurrent
+// requests from updating MemDB state while we're modifying the underlying
+// schema and reloading from storage.
+func (i *IdentityStore) activateDeduplication(ctx context.Context, req *logical.Request) error {
+	i.lock.Lock()
+	defer i.lock.Unlock()
+
+	i.groupLock.Lock()
+	defer i.groupLock.Unlock()
+
+	i.disableLowerCasedNames = false
+	if err := i.resetDB(); err != nil {
+		return fmt.Errorf("failed to reset existing identity state: %w", err)
+	}
+
+	if err := i.loadArtifacts(ctx); err != nil {
+		return fmt.Errorf("failed to activate identity deduplication; %w", err)
+	}
+
+	return nil
 }
 
 func (i *IdentityStore) sanitizeName(name string) string {

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -33,6 +33,7 @@ import (
 	"github.com/hashicorp/go-secure-stdlib/strutil"
 	semver "github.com/hashicorp/go-version"
 	"github.com/hashicorp/vault/audit"
+	"github.com/hashicorp/vault/helper/activationflags"
 	"github.com/hashicorp/vault/helper/experiments"
 	"github.com/hashicorp/vault/helper/hostutil"
 	"github.com/hashicorp/vault/helper/identity"
@@ -278,7 +279,9 @@ type SystemBackend struct {
 	logger               log.Logger
 	mfaBackend           *PolicyMFABackend
 	syncBackend          *SecretsSyncBackend
+	idStoreBackend       *framework.Backend
 	raftChallengeLimiter *rate.Limiter
+	activationFlags      *activationflags.FeatureActivationFlags
 }
 
 // handleConfigStateSanitized returns the current configuration state. The configuration

--- a/vault/logical_system_activation_flags.go
+++ b/vault/logical_system_activation_flags.go
@@ -157,11 +157,3 @@ func (b *SystemBackend) activationFlagsToResponse(activationFlags []string) *log
 		},
 	}
 }
-
-// activateIdentityDeduplication activates the identity deduplication feature.
-func (b *SystemBackend) activateIdentityDeduplication(ctx context.Context, _ *logical.Request) error {
-	if err := b.idStoreBackend.ActivationFunc(ctx, nil); err != nil {
-		return fmt.Errorf("failed to activate identity deduplication: %w", err)
-	}
-	return nil
-}

--- a/vault/logical_system_activation_flags.go
+++ b/vault/logical_system_activation_flags.go
@@ -157,3 +157,11 @@ func (b *SystemBackend) activationFlagsToResponse(activationFlags []string) *log
 		},
 	}
 }
+
+// activateIdentityDeduplication activates the identity deduplication feature.
+func (b *SystemBackend) activateIdentityDeduplication(ctx context.Context, _ *logical.Request) error {
+	if err := b.idStoreBackend.ActivationFunc(ctx, nil); err != nil {
+		return fmt.Errorf("failed to activate identity deduplication: %w", err)
+	}
+	return nil
+}

--- a/vault/logical_system_activation_flags.go
+++ b/vault/logical_system_activation_flags.go
@@ -160,6 +160,10 @@ func (b *SystemBackend) activationFlagsToResponse(activationFlags []string) *log
 
 // activateIdentityDeduplication activates the identity deduplication feature.
 func (b *SystemBackend) activateIdentityDeduplication(ctx context.Context, _ *logical.Request) error {
+	if b.idStoreBackend == nil || b.idStoreBackend.ActivationFunc == nil {
+		return nil
+	}
+
 	if err := b.idStoreBackend.ActivationFunc(ctx, nil); err != nil {
 		return fmt.Errorf("failed to activate identity deduplication: %w", err)
 	}

--- a/vault/logical_system_activation_flags.go
+++ b/vault/logical_system_activation_flags.go
@@ -131,7 +131,7 @@ func (b *SystemBackend) writeActivationFlagWrite(ctx context.Context, req *logic
 	// Removes /verb from the path
 	featureName := trimPrefix[:strings.LastIndex(trimPrefix, "/")]
 
-	err := b.Core.FeatureActivationFlags.Write(ctx, featureName, isActivate)
+	err := b.Core.FeatureActivationFlags.SetActivationFlagEnabled(ctx, featureName, isActivate)
 	if err != nil {
 		return nil, fmt.Errorf("failed to write new activation flags: %w", err)
 	}


### PR DESCRIPTION
### Description

This PR introduces some changes to the way activation flags are
processed in Vault.

Rather than reaching into subsystems and modifying
state from the activationflags package, each plugin can now register its
own ActivationFunc. Updates to activation flags now trigger the the
feature's ActivationFunc, which can encapsulate the associated
subsystem state.

We include a few bugfixes and minor cosmetic changes, like updates to
log lines and godocs.

Enterprise PR: hashicorp/vault-enterprise#7359
Resolves VAULT-33427, VAULT-33615

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [x] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
