### PR TITLE
UI: Adds `serial_number_source` to pki role form

### DIFF
--- a/ui/app/models/pki/role.js
+++ b/ui/app/models/pki/role.js
@@ -72,6 +72,7 @@ export default class PkiRoleModel extends Model {
         'Additional subject fields': [
           'allowedUserIds',
           'allowedSerialNumbers',
+          'serialNumberSource',
           'requireCn',
           'useCsrCommonName',
           'useCsrSans',
@@ -244,12 +245,29 @@ export default class PkiRoleModel extends Model {
 
   /* Overriding OpenApi Additional subject field options */
   @attr({
-    label: 'Allowed serial numbers',
     subText:
       'A list of allowed serial numbers to be requested during certificate issuance. Shell-style globbing is supported. If empty, custom-specified serial numbers will be forbidden.',
     editType: 'stringArray',
   })
   allowedSerialNumbers;
+
+  @attr({
+    editType: 'radio',
+    possibleValues: [
+      {
+        value: 'json-csr',
+        subText:
+          'The subject serial number will be taken from the "serial_number" parameter and fall back to the serial number in the CSR.',
+      },
+      {
+        value: 'json',
+        subText:
+          'The subject serial number will be taken from the "serial_number" parameter but will ignore any value in the CSR.',
+      },
+    ],
+    defaultValue: 'json-csr',
+  })
+  serialNumberSource;
 
   @attr('boolean', {
     label: 'Require common name',

--- a/ui/tests/integration/components/pki/pki-role-form-test.js
+++ b/ui/tests/integration/components/pki/pki-role-form-test.js
@@ -191,6 +191,7 @@ module('Integration | Component | pki-role-form', function (hooks) {
           key_usage: ['DigitalSignature', 'KeyAgreement', 'KeyEncipherment'],
           not_before_duration: '30s',
           require_cn: true,
+          serial_number_source: 'json-csr',
           signature_bits: '384',
           use_csr_common_name: true,
           use_csr_sans: true,


### PR DESCRIPTION
### Description
Adds `serial_number_source` implemented by https://github.com/hashicorp/vault/pull/29369 to the UI "Additional subject fields" section of the PKI role form
<img width="1092" alt="Screenshot 2025-01-30 at 5 05 03 PM" src="https://github.com/user-attachments/assets/101a5987-a488-4802-bf1d-250e402dcdbe" />

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
