### PR TITLE
identity (CE): Persist conflict resolution after rename

### DIFF
--- a/vault/core.go
+++ b/vault/core.go
@@ -2482,7 +2482,7 @@ func (s standardUnsealStrategy) unseal(ctx context.Context, logger log.Logger, c
 	}
 
 	// Run setup-like functions
-	if err := runUnsealSetupFunctions(ctx, buildUnsealSetupFunctionSlice(c)); err != nil {
+	if err := runUnsealSetupFunctions(ctx, buildUnsealSetupFunctionSlice(c, true)); err != nil {
 		return err
 	}
 
@@ -2583,7 +2583,7 @@ func (c *Core) setupPluginCatalog(ctx context.Context) error {
 // buildUnsealSetupFunctionSlice returns a slice of functions, tailored for this
 // Core's replication state, that can be passed to the runUnsealSetupFunctions
 // function.
-func buildUnsealSetupFunctionSlice(c *Core) []func(context.Context) error {
+func buildUnsealSetupFunctionSlice(c *Core, isActive bool) []func(context.Context) error {
 	// setupFunctions is a slice of functions that need to be called in order,
 	// that if any return an error, processing should immediately cease.
 	setupFunctions := []func(context.Context) error{
@@ -2643,7 +2643,7 @@ func buildUnsealSetupFunctionSlice(c *Core) []func(context.Context) error {
 			if c.identityStore == nil {
 				return nil
 			}
-			return c.identityStore.loadArtifacts(ctx)
+			return c.identityStore.loadArtifacts(ctx, isActive)
 		})
 		setupFunctions = append(setupFunctions, func(ctx context.Context) error {
 			return loadPolicyMFAConfigs(ctx, c)

--- a/vault/core_test.go
+++ b/vault/core_test.go
@@ -3674,7 +3674,7 @@ func TestBuildUnsealSetupFunctionSlice(t *testing.T) {
 			expectedLength: 14,
 		},
 	} {
-		funcs := buildUnsealSetupFunctionSlice(testcase.core)
+		funcs := buildUnsealSetupFunctionSlice(testcase.core, true)
 		assert.Equal(t, testcase.expectedLength, len(funcs), testcase.name)
 	}
 }

--- a/vault/identity_store_conflicts_test.go
+++ b/vault/identity_store_conflicts_test.go
@@ -119,7 +119,7 @@ end of identity duplicate report, refer to https://developer.hashicorp.com/vault
 		// Call ResolveEntities, assume existing is nil for now. In real life we
 		// should be passed the existing entity for the exact match dupes but we
 		// don't depend on that so it's fine to omit.
-		_ = r.ResolveEntities(context.Background(), nil, entity)
+		_, _ = r.ResolveEntities(context.Background(), nil, entity)
 		// Don't care about the actual error here since it would be ignored in
 		// case-sensitive mode anyway.
 
@@ -129,7 +129,7 @@ end of identity duplicate report, refer to https://developer.hashicorp.com/vault
 			Name:        pair[1],
 			NamespaceID: pair[0],
 		}
-		_ = r.ResolveGroups(context.Background(), nil, group)
+		_, _ = r.ResolveGroups(context.Background(), nil, group)
 	}
 
 	// Load aliases second because that is realistic and yet we want to report on
@@ -148,7 +148,7 @@ end of identity duplicate report, refer to https://developer.hashicorp.com/vault
 			// Parse our hacky DSL to define some alias mounts as local
 			Local: strings.HasPrefix(pair[0], "local-"),
 		}
-		_ = r.ResolveAliases(context.Background(), entity, nil, alias)
+		_, _ = r.ResolveAliases(context.Background(), entity, nil, alias)
 	}
 
 	// "log" the report and check it matches expected report below.
@@ -220,7 +220,7 @@ func TestDuplicateRenameResolver(t *testing.T) {
 
 			// Simulate a MemDB lookup
 			existingEntity := seenEntities[name]
-			err := r.ResolveEntities(context.Background(), existingEntity, entity)
+			_, err := r.ResolveEntities(context.Background(), existingEntity, entity)
 			require.NoError(t, err)
 
 			if existingEntity != nil {
@@ -239,7 +239,7 @@ func TestDuplicateRenameResolver(t *testing.T) {
 
 			// More MemDB mocking
 			existingGroup := seenGroups[name]
-			err = r.ResolveGroups(context.Background(), existingGroup, group)
+			_, err = r.ResolveGroups(context.Background(), existingGroup, group)
 			require.NoError(t, err)
 
 			if existingGroup != nil {

--- a/vault/identity_store_conflicts_test.go
+++ b/vault/identity_store_conflicts_test.go
@@ -220,13 +220,15 @@ func TestDuplicateRenameResolver(t *testing.T) {
 
 			// Simulate a MemDB lookup
 			existingEntity := seenEntities[name]
-			_, err := r.ResolveEntities(context.Background(), existingEntity, entity)
+			renamed, err := r.ResolveEntities(context.Background(), existingEntity, entity)
 			require.NoError(t, err)
 
 			if existingEntity != nil {
+				require.True(t, renamed)
 				require.Equal(t, name+"-"+id, entity.Name)
 				require.Equal(t, existingEntity.ID, entity.Metadata["duplicate_of_canonical_id"])
 			} else {
+				require.False(t, renamed)
 				seenEntities[name] = entity
 			}
 
@@ -239,13 +241,15 @@ func TestDuplicateRenameResolver(t *testing.T) {
 
 			// More MemDB mocking
 			existingGroup := seenGroups[name]
-			_, err = r.ResolveGroups(context.Background(), existingGroup, group)
+			renamed, err = r.ResolveGroups(context.Background(), existingGroup, group)
 			require.NoError(t, err)
 
 			if existingGroup != nil {
+				require.True(t, renamed)
 				require.Equal(t, name+"-"+id, group.Name)
 				require.Equal(t, existingGroup.ID, group.Metadata["duplicate_of_canonical_id"])
 			} else {
+				require.False(t, renamed)
 				seenGroups[name] = group
 			}
 		}

--- a/vault/identity_store_test.go
+++ b/vault/identity_store_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"os"
 	"regexp"
 	"slices"
 	"strconv"
@@ -18,8 +19,12 @@ import (
 	"github.com/go-test/deep"
 	"github.com/hashicorp/go-hclog"
 	uuid "github.com/hashicorp/go-uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
+
 	credGithub "github.com/hashicorp/vault/builtin/credential/github"
-	"github.com/hashicorp/vault/builtin/credential/userpass"
 	credUserpass "github.com/hashicorp/vault/builtin/credential/userpass"
 	"github.com/hashicorp/vault/helper/activationflags"
 	"github.com/hashicorp/vault/helper/identity"
@@ -29,10 +34,6 @@ import (
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/hashicorp/vault/sdk/physical"
 	"github.com/hashicorp/vault/sdk/physical/inmem"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"google.golang.org/protobuf/proto"
-	"google.golang.org/protobuf/types/known/anypb"
 )
 
 func TestIdentityStore_DeleteEntityAlias(t *testing.T) {
@@ -1416,12 +1417,65 @@ func TestIdentityStoreInvalidate_TemporaryEntity(t *testing.T) {
 // the identity cleanup rename resolver to ensure that loading is deterministic
 // for both.
 func TestIdentityStoreLoadingIsDeterministic(t *testing.T) {
-	t.Run(t.Name()+"-error-resolver", func(t *testing.T) {
-		identityStoreLoadingIsDeterministic(t, false)
-	})
-	t.Run(t.Name()+"-identity-cleanup", func(t *testing.T) {
-		identityStoreLoadingIsDeterministic(t, true)
-	})
+	seedval := rand.Int63()
+	if os.Getenv("VAULT_TEST_IDENTITY_STORE_SEED") != "" {
+		var err error
+		seedval, err = strconv.ParseInt(os.Getenv("VAULT_TEST_IDENTITY_STORE_SEED"), 10, 64)
+		require.NoError(t, err)
+	}
+	seed := rand.New(rand.NewSource(seedval)) // Seed for deterministic test
+	defer t.Logf("Test generated with seed: %d", seedval)
+
+	tests := []struct {
+		name  string
+		flags *determinismTestFlags
+	}{
+		{
+			name: "error-resolver-primary",
+			flags: &determinismTestFlags{
+				identityDeduplication: false,
+				secondary:             false,
+				seed:                  seed,
+			},
+		},
+		{
+			name: "identity-cleanup-primary",
+			flags: &determinismTestFlags{
+				identityDeduplication: true,
+				secondary:             false,
+				seed:                  seed,
+			},
+		},
+
+		{
+			name: "error-resolver-secondary",
+			flags: &determinismTestFlags{
+				identityDeduplication: false,
+				secondary:             true,
+				seed:                  seed,
+			},
+		},
+		{
+			name: "identity-cleanup-secondary",
+			flags: &determinismTestFlags{
+				identityDeduplication: true,
+				secondary:             true,
+				seed:                  seed,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(t.Name()+"-"+test.name, func(t *testing.T) {
+			identityStoreLoadingIsDeterministic(t, test.flags)
+		})
+	}
+}
+
+type determinismTestFlags struct {
+	identityDeduplication bool
+	secondary             bool
+	seed                  *rand.Rand
 }
 
 // identityStoreLoadingIsDeterministic is a property-based test helper that
@@ -1432,7 +1486,7 @@ func TestIdentityStoreLoadingIsDeterministic(t *testing.T) {
 // deterministic anyway if all data in storage was correct see comments inline
 // for examples of ways storage can be corrupt with respect to the expected
 // schema invariants.
-func identityStoreLoadingIsDeterministic(t *testing.T, identityDeduplication bool) {
+func identityStoreLoadingIsDeterministic(t *testing.T, flags *determinismTestFlags) {
 	// Create some state in store that could trigger non-deterministic behavior.
 	// The nature of the identity store schema is such that the order of loading
 	// entities etc shouldn't matter even if it was non-deterministic, however due
@@ -1456,7 +1510,7 @@ func identityStoreLoadingIsDeterministic(t *testing.T, identityDeduplication boo
 		Logger:          logger,
 		BuiltinRegistry: corehelpers.NewMockBuiltinRegistry(),
 		CredentialBackends: map[string]logical.Factory{
-			"userpass": userpass.Factory,
+			"userpass": credUserpass.Factory,
 		},
 	}
 
@@ -1470,6 +1524,10 @@ func identityStoreLoadingIsDeterministic(t *testing.T, identityDeduplication boo
 
 	ctx := context.Background()
 
+	seed := flags.seed
+	identityDeduplication := flags.identityDeduplication
+	secondary := flags.secondary
+
 	// We create 100 entities each with 1 non-local alias and 1 local alias. We
 	// then randomly create duplicate alias or local alias entries with a
 	// probability that is unrealistic but ensures we have duplicates on every
@@ -1478,9 +1536,9 @@ func identityStoreLoadingIsDeterministic(t *testing.T, identityDeduplication boo
 		name := fmt.Sprintf("entity-%d", i)
 		alias := fmt.Sprintf("alias-%d", i)
 		localAlias := fmt.Sprintf("localalias-%d", i)
-		e := makeEntityForPacker(t, name, c.identityStore.entityPacker)
-		attachAlias(t, e, alias, upme)
-		attachAlias(t, e, localAlias, localMe)
+		e := makeEntityForPacker(t, name, c.identityStore.entityPacker, seed)
+		attachAlias(t, e, alias, upme, seed)
+		attachAlias(t, e, localAlias, localMe, seed)
 		err = TestHelperWriteToStoragePacker(ctx, c.identityStore.entityPacker, e.ID, e)
 		require.NoError(t, err)
 
@@ -1489,35 +1547,35 @@ func identityStoreLoadingIsDeterministic(t *testing.T, identityDeduplication boo
 		// few double and maybe triple duplicates of each type every few test runs
 		// and may have duplicates of both types or neither etc.
 		pDup := 0.3
-		rnd := rand.Float64()
+		rnd := seed.Float64()
 		dupeNum := 1
 		for rnd < pDup && dupeNum < 10 {
-			e := makeEntityForPacker(t, fmt.Sprintf("entity-%d-dup-%d", i, dupeNum), c.identityStore.entityPacker)
-			attachAlias(t, e, alias, upme)
+			e := makeEntityForPacker(t, fmt.Sprintf("entity-%d-dup-%d", i, dupeNum), c.identityStore.entityPacker, seed)
+			attachAlias(t, e, alias, upme, seed)
 			err = TestHelperWriteToStoragePacker(ctx, c.identityStore.entityPacker, e.ID, e)
 			require.NoError(t, err)
 			// Toss again to see if we continue
-			rnd = rand.Float64()
+			rnd = seed.Float64()
 			dupeNum++
 		}
 		// Toss the coin again to see if there are any local dupes
 		dupeNum = 1
-		rnd = rand.Float64()
+		rnd = seed.Float64()
 		for rnd < pDup && dupeNum < 10 {
-			e := makeEntityForPacker(t, fmt.Sprintf("entity-%d-localdup-%d", i, dupeNum), c.identityStore.entityPacker)
-			attachAlias(t, e, localAlias, localMe)
+			e := makeEntityForPacker(t, fmt.Sprintf("entity-%d-localdup-%d", i, dupeNum), c.identityStore.entityPacker, seed)
+			attachAlias(t, e, localAlias, localMe, seed)
 			err = TestHelperWriteToStoragePacker(ctx, c.identityStore.entityPacker, e.ID, e)
 			require.NoError(t, err)
-			rnd = rand.Float64()
+			rnd = seed.Float64()
 			dupeNum++
 		}
 		// See if we should add entity _name_ duplicates too (with no aliases)
-		rnd = rand.Float64()
+		rnd = seed.Float64()
 		for rnd < pDup {
-			e := makeEntityForPacker(t, name, c.identityStore.entityPacker)
+			e := makeEntityForPacker(t, name, c.identityStore.entityPacker, seed)
 			err = TestHelperWriteToStoragePacker(ctx, c.identityStore.entityPacker, e.ID, e)
 			require.NoError(t, err)
-			rnd = rand.Float64()
+			rnd = seed.Float64()
 		}
 		// One more edge case is that it's currently possible as of the time of
 		// writing for a failure during entity invalidation to result in a permanent
@@ -1543,7 +1601,7 @@ func identityStoreLoadingIsDeterministic(t *testing.T, identityDeduplication boo
 		if i%2 == 0 {
 			alias = fmt.Sprintf("groupalias-%d", i)
 		}
-		e := makeGroupWithNameAndAlias(t, name, alias, c.identityStore.groupPacker, upme)
+		e := makeGroupWithNameAndAlias(t, name, alias, c.identityStore.groupPacker, upme, seed)
 		err = TestHelperWriteToStoragePacker(ctx, c.identityStore.groupPacker, e.ID, e)
 		require.NoError(t, err)
 	}
@@ -1551,18 +1609,20 @@ func identityStoreLoadingIsDeterministic(t *testing.T, identityDeduplication boo
 	// non-deterministic behavior.
 	for i := 0; i <= 10; i++ {
 		name := fmt.Sprintf("group-dup-%d", i)
-		e := makeGroupWithNameAndAlias(t, name, "groupalias-dup", c.identityStore.groupPacker, upme)
+		e := makeGroupWithNameAndAlias(t, name, "groupalias-dup", c.identityStore.groupPacker, upme, seed)
 		err = TestHelperWriteToStoragePacker(ctx, c.identityStore.groupPacker, e.ID, e)
 		require.NoError(t, err)
 	}
 	// Add a second and third groups with duplicate names too.
 	for _, name := range []string{"group-0", "group-1", "group-1"} {
-		e := makeGroupWithNameAndAlias(t, name, "", c.identityStore.groupPacker, upme)
+		e := makeGroupWithNameAndAlias(t, name, "", c.identityStore.groupPacker, upme, seed)
 		err = TestHelperWriteToStoragePacker(ctx, c.identityStore.groupPacker, e.ID, e)
 		require.NoError(t, err)
 	}
 
-	entIdentityStoreDeterminismTestSetup(t, ctx, c, upme, localMe)
+	if secondary {
+		entIdentityStoreDeterminismSecondaryTestSetup(t, ctx, c, upme, localMe, seed)
+	}
 
 	// Storage is now primed for the test.
 
@@ -1652,7 +1712,9 @@ func identityStoreLoadingIsDeterministic(t *testing.T, identityDeduplication boo
 		// note `lastIDs` argument is not needed anymore but we can't change the
 		// signature without breaking enterprise. It's simpler to keep it unused
 		// for now until both parts of this merge.
-		entIdentityStoreDeterminismAssert(t, i, loadedNames, nil)
+		if secondary {
+			entIdentityStoreDeterminismSecondaryAssert(t, i, loadedNames, nil)
+		}
 
 		if i > 0 {
 			// Should be in the same order if we are deterministic since MemDB has strong ordering.
@@ -1676,7 +1738,7 @@ func TestIdentityStoreLoadingDuplicateReporting(t *testing.T) {
 		Logger:          logger,
 		BuiltinRegistry: corehelpers.NewMockBuiltinRegistry(),
 		CredentialBackends: map[string]logical.Factory{
-			"userpass": userpass.Factory,
+			"userpass": credUserpass.Factory,
 		},
 	}
 
@@ -1690,9 +1752,16 @@ func TestIdentityStoreLoadingDuplicateReporting(t *testing.T) {
 
 	ctx := namespace.RootContext(nil)
 
-	identityCreateCaseDuplicates(t, ctx, c, upme, localMe)
+	seedval := rand.Int63()
+	if os.Getenv("VAULT_TEST_IDENTITY_STORE_DETERMINISTIC_SEED") != "" {
+		seedval, err = strconv.ParseInt(os.Getenv("VAULT_TEST_IDENTITY_STORE_DETERMINISTIC_SEED"), 10, 64)
+		require.NoError(t, err)
+	}
+	seed := rand.New(rand.NewSource(seedval)) // Seed for deterministic test
+	defer t.Logf("Test generated with seed %d", seedval)
+	identityCreateCaseDuplicates(t, ctx, c, upme, localMe, seed)
 
-	entIdentityStoreDuplicateReportTestSetup(t, ctx, c, rootToken)
+	entIdentityStoreDuplicateReportTestSetup(t, ctx, c, rootToken, seed)
 
 	// Storage is now primed for the test.
 

--- a/vault/identity_store_test.go
+++ b/vault/identity_store_test.go
@@ -1752,8 +1752,8 @@ func TestIdentityStoreLoadingDuplicateReporting(t *testing.T) {
 	ctx := namespace.RootContext(nil)
 
 	seedval := rand.Int63()
-	if os.Getenv("VAULT_TEST_IDENTITY_STORE_DETERMINISTIC_SEED") != "" {
-		seedval, err = strconv.ParseInt(os.Getenv("VAULT_TEST_IDENTITY_STORE_DETERMINISTIC_SEED"), 10, 64)
+	if os.Getenv("VAULT_TEST_IDENTITY_STORE_SEED") != "" {
+		seedval, err = strconv.ParseInt(os.Getenv("VAULT_TEST_IDENTITY_STORE_SEED"), 10, 64)
 		require.NoError(t, err)
 	}
 	seed := rand.New(rand.NewSource(seedval)) // Seed for deterministic test

--- a/vault/identity_store_test.go
+++ b/vault/identity_store_test.go
@@ -1599,7 +1599,7 @@ func identityStoreLoadingIsDeterministic(t *testing.T, identityDeduplication boo
 		err := c.identityStore.resetDB()
 		require.NoError(t, err)
 
-		err = c.identityStore.loadArtifacts(ctx)
+		err = c.identityStore.loadArtifacts(ctx, true)
 		if i > 0 {
 			require.Equal(t, prevErr, err)
 		}
@@ -1711,7 +1711,7 @@ func TestIdentityStoreLoadingDuplicateReporting(t *testing.T) {
 	}
 
 	logger.RegisterSink(unsealLogger)
-	err = c.identityStore.loadArtifacts(ctx)
+	err = c.identityStore.loadArtifacts(ctx, true)
 	require.NoError(t, err)
 	logger.DeregisterSink(unsealLogger)
 

--- a/vault/identity_store_test.go
+++ b/vault/identity_store_test.go
@@ -19,11 +19,6 @@ import (
 	"github.com/go-test/deep"
 	"github.com/hashicorp/go-hclog"
 	uuid "github.com/hashicorp/go-uuid"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"google.golang.org/protobuf/proto"
-	"google.golang.org/protobuf/types/known/anypb"
-
 	credGithub "github.com/hashicorp/vault/builtin/credential/github"
 	credUserpass "github.com/hashicorp/vault/builtin/credential/userpass"
 	"github.com/hashicorp/vault/helper/activationflags"
@@ -34,6 +29,10 @@ import (
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/hashicorp/vault/sdk/physical"
 	"github.com/hashicorp/vault/sdk/physical/inmem"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
 )
 
 func TestIdentityStore_DeleteEntityAlias(t *testing.T) {

--- a/vault/identity_store_test_stubs_oss.go
+++ b/vault/identity_store_test_stubs_oss.go
@@ -7,20 +7,21 @@ package vault
 
 import (
 	"context"
+	"math/rand"
 	"testing"
 )
 
 //go:generate go run github.com/hashicorp/vault/tools/stubmaker
 
-func entIdentityStoreDeterminismTestSetup(t *testing.T, ctx context.Context, c *Core, me, localme *MountEntry) {
+func entIdentityStoreDeterminismSecondaryTestSetup(t *testing.T, ctx context.Context, c *Core, me, localme *MountEntry, seed *rand.Rand) {
 	// no op
 }
 
-func entIdentityStoreDeterminismAssert(t *testing.T, i int, loadedIDs, lastIDs []string) {
+func entIdentityStoreDeterminismSecondaryAssert(t *testing.T, i int, loadedIDs, lastIDs []string) {
 	// no op
 }
 
-func entIdentityStoreDuplicateReportTestSetup(t *testing.T, ctx context.Context, c *Core, rootToken string) {
+func entIdentityStoreDuplicateReportTestSetup(t *testing.T, ctx context.Context, c *Core, rootToken string, seed *rand.Rand) {
 	// no op
 }
 

--- a/vault/identity_store_util.go
+++ b/vault/identity_store_util.go
@@ -19,10 +19,6 @@ import (
 	memdb "github.com/hashicorp/go-memdb"
 	"github.com/hashicorp/go-secure-stdlib/strutil"
 	uuid "github.com/hashicorp/go-uuid"
-	"github.com/stretchr/testify/require"
-	"google.golang.org/protobuf/types/known/anypb"
-	"google.golang.org/protobuf/types/known/timestamppb"
-
 	"github.com/hashicorp/vault/helper/activationflags"
 	"github.com/hashicorp/vault/helper/identity"
 	"github.com/hashicorp/vault/helper/identity/mfa"
@@ -30,6 +26,9 @@ import (
 	"github.com/hashicorp/vault/helper/storagepacker"
 	"github.com/hashicorp/vault/sdk/helper/consts"
 	"github.com/hashicorp/vault/sdk/logical"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 var (


### PR DESCRIPTION
### Description

This PR ensures that automatic de-duplication is consistent across all
nodes in an Enterprise cluster by persisting conflict resolution on the
active node. 

This logic to prevents Enterprise clusters from accidentally reverting
any conflict resolution after it's performed.

The PR includes some modifications to deterministic reload testing,
since they now have the side-effect of persistence on active nodes, as
well as tests for consistency in the face of storagePacker bucket
invalidation.

Enterprise PR: https://github.com/hashicorp/vault-enterprise/pull/7343
Resolves: VAULT-33555, VAULT-33504

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [x] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
