### PR TITLE
VAULT-33693 actions: fix push event PR labels

### DIFF
--- a/.github/actions/metadata/action.yml
+++ b/.github/actions/metadata/action.yml
@@ -108,15 +108,32 @@ runs:
 
           labels=$(gh api "/repos/${{ github.repository }}/issues/${{ github.event.number }}/labels" | jq -erc '. | map(.name)')
         else
+          # We can assume we're being triggered for a 'push' (a merge)
           is_draft='false'
 
-          # Look up the labels for the pull request that is associated with the last commit. If
-          # there are none set it as a JSON encoded empty array.
-          if pr_number=$(gh api "/repos/${{ github.repository }}/commits/${{ github.ref }}/pulls" | jq -erc '.[0].number'); then
-            if ! labels=$(gh api "/repos/${{ github.repository }}/issues/${pr_number}/labels" | jq -erc '. | map(.name)'); then
-              labels='[]'
-            fi
-          else
+          # Look up the pull request labels for the PR that is associated with
+          # the commit. If there are none set it as a JSON encoded empty array.
+          repo=$(printf ${{ github.repository }} | cut -d "/" -f2)
+          if ! labels=$(gh api graphql -F repo="$repo" -f query='
+            query prLabels($repo: String!){
+              repository(name: $repo, owner: "hashicorp") {
+                commit: object(expression: "${{ steps.vault-metadata.outputs.vault-revision }}") {
+                  ... on Commit {
+                  associatedPullRequests(first:1){
+                    edges{
+                      node{
+                        labels(first: 10) {
+                          nodes {
+                            name
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }' | jq -erc '.data.repository.commit.associatedPullRequests.edges[0].node.labels.nodes | map(.name)');
+          then
             labels='[]'
           fi
         fi

--- a/.github/actions/metadata/action.yml
+++ b/.github/actions/metadata/action.yml
@@ -114,17 +114,18 @@ runs:
           # Look up the pull request labels for the PR that is associated with
           # the commit. If there are none set it as a JSON encoded empty array.
           repo=$(printf ${{ github.repository }} | cut -d "/" -f2)
-          if ! labels=$(gh api graphql -F repo="$repo" -f query='
-            query prLabels($repo: String!){
+          if ! labels=$(gh api graphql -F repo="$repo" -F sha="${{ steps.vault-metadata.outputs.vault-revision }}" -f query='
+            query($repo: String!, $sha: String!){
               repository(name: $repo, owner: "hashicorp") {
-                commit: object(expression: "${{ steps.vault-metadata.outputs.vault-revision }}") {
+                commit: object(expression: $sha) {
                   ... on Commit {
-                  associatedPullRequests(first:1){
-                    edges{
-                      node{
-                        labels(first: 10) {
-                          nodes {
-                            name
+                    associatedPullRequests(first:1){
+                      edges{
+                        node{
+                          labels(first: 10) {
+                            nodes {
+                              name
+                            }
                           }
                         }
                       }


### PR DESCRIPTION
### Description
Fix pull request label metadata when triggered by `push` event types. We now use Github's `associatedPullRequests()` connection on the `Commit` associated with the SHA to resolve the labels.

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [x] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
