### PR TITLE
Expand on import transform docs

### DIFF
--- a/website/content/docs/import/index.mdx
+++ b/website/content/docs/import/index.mdx
@@ -156,7 +156,9 @@ These can be combined using `and`, `or`, and `not`:
 
 #### Transformers
 
-Transform stanzas come in two forms: `exact` and `regexp`.
+Transform stanzas come in two forms: `exact` and `regexp`.  For each secret found in the source,
+the CLI examples each transform in order.  As soon as one applies to the source secret, all subsequent
+transforms are ignored.
 
 An exact transform allows renaming a secret during import, so that the `from` secret name
 is imported into Vault as a secret named `to`.  In the following example it, takes a source secret
@@ -170,8 +172,13 @@ named `foo` and transforms it to `foosball` during import.
 ```
 
 `regexp` transforms rename secrets during import using
-[Go regular expression syntax](https://github.com/google/re2/wiki/Syntax). For
-example, the transform below imports any secret in the source whose name starts
+[Go regular expression syntax](https://github.com/google/re2/wiki/Syntax).
+The `to` attribute of the transform block contains a template describing
+the name to import the secret as, using `$` followed by a capture group number or name
+to reference parenthesized matches in the `from` regular expression.
+To insert a literal `$` in the output, use `$$` in the template.
+
+For example, the transform below imports any secret in the source whose name starts
 with `foo` and replaces the `foo` prefix with `bar`.
 
 ```hcl
@@ -189,3 +196,50 @@ The `from` value supports parentheses to bookend capture groups and named
 capture groups using the syntax `(?P<name>re)`. When you use named capture
 groups, you can reference the named group in the `to` value. For example,
 `$name` instead of `$1`.
+
+Unfortunately `$` has special meaning inside HCL files: it's used to reference
+variables, which aren't used in import configuration, but the HCL parser still
+treats `$` specially if followed by open curly brace (`{`).
+
+Placeholders in a template don't behave as desired if they're followed by a letter or number,
+e.g. `to = "$1abc$2"` will be interpreted as the concatenation of the capture groups
+named `$1abc` and `$2`.  Similarly, with named capture groups, `to = "$namefoo"` won't match
+a capture group named `name`.  The usual fix in such cases is to use curly braces around
+the number or name of the capture group, but that runs afoul of the HCL variable interpolation
+syntax described above.
+
+The solution is to escape the variable interpolation by doubling the `$`, but only in the case
+where braces are used.
+
+Good:
+```hcl
+  transform "regexp" {
+    from = "foo(.*)"
+    to = "$${1}bar"
+  }
+  transform "regexp" {
+    from = "(?P<prefix>.*)foo"
+    to = "$${prefix}bar"
+  }
+```
+
+Bad:
+```hcl
+  transform "regexp" {
+    from = "foo(.*)"
+    to = "$1bar"
+  }
+  transform "regexp" {
+    from = "foo(.*)"
+    to = "${1}bar"
+  }
+  transform "regexp" {
+    from = "foo(.*)"
+    to = "$$1bar"
+  }
+  transform "regexp" {
+    from = "(?P<prefix>.*)foo"
+    to = "${prefix}bar"
+  }
+```
+


### PR DESCRIPTION
### Description
What does this PR do?

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
