### PR TITLE
UI: backport auth test helpers

### DIFF
--- a/ui/tests/helpers/auth/auth-form-selectors.ts
+++ b/ui/tests/helpers/auth/auth-form-selectors.ts
@@ -13,4 +13,5 @@ export const AUTH_FORM = {
   input: (item: string) => `[data-test-${item}]`, // i.e. jwt, role, token, password or username
   mountPathInput: '[data-test-auth-form-mount-path]',
   moreOptions: '[data-test-auth-form-options-toggle]',
+  namespaceInput: '[data-test-auth-form-ns-input]',
 };

--- a/ui/tests/helpers/auth/auth-helpers.ts
+++ b/ui/tests/helpers/auth/auth-helpers.ts
@@ -15,7 +15,16 @@ export const login = async (token = rootToken) => {
   await logout();
   await visit('/vault/auth?with=token');
   await fillIn(AUTH_FORM.input('token'), token);
-  return await click(AUTH_FORM.login);
+  return click(AUTH_FORM.login);
+};
+
+export const loginNs = async (ns: string, token = rootToken) => {
+  // make sure we're always logged out and logged back in
+  await logout();
+  await visit('/vault/auth?with=token');
+  await fillIn(AUTH_FORM.namespaceInput, ns);
+  await fillIn(AUTH_FORM.input('token'), token);
+  return click(AUTH_FORM.login);
 };
 
 // LOGIN WITH NON-TOKEN methods


### PR DESCRIPTION
### Description
Enterprise tests passed ✅ 
Backports some helpers that were used in tests for https://github.com/hashicorp/vault/pull/29416 

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
