### PR TITLE
docs: backport: 1.18.x: fix build

### DIFF
--- a/website/content/partials/known-issues/aws-auth-external-id.mdx
+++ b/website/content/partials/known-issues/aws-auth-external-id.mdx
@@ -1,0 +1,19 @@
+### AWS Auth Role configuration requires an external_id
+
+#### Affected Versions
+
+- 1.17.0 - 1.17.3
+
+#### Issue
+
+You must set the `external_id` parameter during role configuration, or the Vault
+AWS authentication plugin returns a validation error.
+
+#### Workaround
+
+To avoid the error during configuration:
+
+1. Set the `external_id` parameter when configuring AWS authentication plugin
+   with a valid ID or any string longer than two characters.
+1. Configure any desired roles. 
+1. If you used an arbitrary string, remove the external ID.

--- a/website/content/partials/known-issues/duplicate-hsm-key.mdx
+++ b/website/content/partials/known-issues/duplicate-hsm-key.mdx
@@ -1,0 +1,13 @@
+### Seal/Seal Wrapped - Duplicate HSM Keys
+
+#### Affected Versions
+- All versions that support migration from Shamir to HSM-backed unseal/seal wrap in HSM-HA configurations.
+
+#### Issue
+During a migration from Shamir to an HSM-backed unseal configuration with HSM - High Availability (HA), duplicate HSM keys may be created.
+These issues can occur even after a seal migration to HSM that initially appeared successful. The root cause is under investigation, with potential links to key handling during HA configuration or migration processes.
+- Unseal failures: Nodes may fail to unseal after a restart, with errors such as CKR_DATA_INVALID.
+- Duplicate HSM keys: These may be created, resulting in intermittent read failures with errors such as CKR_SIGNATURE_INVALID and CKR_KEY_HANDLE_INVALID for any seal wrapped value - see /vault/docs/enterprise/sealwrap#wrapped-parameters.
+
+#### Workaround
+As a workaround, always run Vault with `generate_key = false`, creating the required keys within the HSM manually during the setup process.

--- a/website/content/partials/known-issues/sync-activation-flags-cache-not-updated.mdx
+++ b/website/content/partials/known-issues/sync-activation-flags-cache-not-updated.mdx
@@ -1,0 +1,23 @@
+### Cached activation flags for secrets sync on follower nodes are not updated
+
+#### Affected versions
+
+- 1.16.0 - 1.16.2
+- 1.17.0 - 1.17.5
+
+#### Issue
+
+Vault 1.16 introduced secrets sync with a one-time flag required to activate the
+feature before use. Writing the activation flag to enable secrets sync is forwarded
+to leader nodes for storage and distributed to follower nodes, but the in-memory
+cache for this flag is not updated on the followers. 
+
+This prevents any secrets sync endpoints (those starting with `sys/sync/`) from
+being usable on follower nodes in a cluster.
+
+#### Workaround
+
+The cache is force-updated on all nodes when the leader node steps down and the
+cluster promotes a new leader. First, activate the secrets sync feature as described
+in the [documentation](/vault/docs/sync#activating-the-feature). Then, have the leader node
+step down.


### PR DESCRIPTION
### Description
Fix build, missing 2 files

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
