### PR TITLE
add stubs oss for entSetExternalPluginConfig()

### DIFF
--- a/vault/auth.go
+++ b/vault/auth.go
@@ -962,6 +962,9 @@ func (c *Core) newCredentialBackend(ctx context.Context, entry *MountEntry, sysV
 	if err != nil {
 		return nil, err
 	}
+
+	// Set up conf to pass in plugin_name
+	conf := make(map[string]string)
 	var runningSha string
 	factory, ok := c.credentialBackends[t]
 	if !ok {
@@ -984,9 +987,10 @@ func (c *Core) newCredentialBackend(ctx context.Context, entry *MountEntry, sysV
 		if !plug.Builtin {
 			factory = wrapFactoryCheckPerms(c, plugin.Factory)
 		}
+
+		entSetExternalPluginConfig(plug, conf)
 	}
-	// Set up conf to pass in plugin_name
-	conf := make(map[string]string)
+
 	for k, v := range entry.Options {
 		conf[k] = v
 	}

--- a/vault/auth.go
+++ b/vault/auth.go
@@ -963,7 +963,6 @@ func (c *Core) newCredentialBackend(ctx context.Context, entry *MountEntry, sysV
 		return nil, err
 	}
 
-	// Set up conf to pass in plugin_name
 	conf := make(map[string]string)
 	var runningSha string
 	factory, ok := c.credentialBackends[t]
@@ -991,6 +990,7 @@ func (c *Core) newCredentialBackend(ctx context.Context, entry *MountEntry, sysV
 		entSetExternalPluginConfig(plug, conf)
 	}
 
+	// Set up conf to pass in plugin_name
 	for k, v := range entry.Options {
 		conf[k] = v
 	}

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -1692,7 +1692,6 @@ func (c *Core) newLogicalBackend(ctx context.Context, entry *MountEntry, sysView
 		return nil, err
 	}
 
-	// Set up conf to pass in plugin_name
 	conf := make(map[string]string)
 	var runningSha string
 	factory, ok := c.logicalBackends[t]
@@ -1720,6 +1719,7 @@ func (c *Core) newLogicalBackend(ctx context.Context, entry *MountEntry, sysView
 		entSetExternalPluginConfig(plug, conf)
 	}
 
+	// Set up conf to pass in plugin_name
 	for k, v := range entry.Options {
 		conf[k] = v
 	}

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -1691,6 +1691,9 @@ func (c *Core) newLogicalBackend(ctx context.Context, entry *MountEntry, sysView
 	if err != nil {
 		return nil, err
 	}
+
+	// Set up conf to pass in plugin_name
+	conf := make(map[string]string)
 	var runningSha string
 	factory, ok := c.logicalBackends[t]
 	if !ok {
@@ -1713,9 +1716,10 @@ func (c *Core) newLogicalBackend(ctx context.Context, entry *MountEntry, sysView
 		if !plug.Builtin {
 			factory = wrapFactoryCheckPerms(c, factory)
 		}
+
+		entSetExternalPluginConfig(plug, conf)
 	}
-	// Set up conf to pass in plugin_name
-	conf := make(map[string]string)
+
 	for k, v := range entry.Options {
 		conf[k] = v
 	}

--- a/vault/mount_util.go
+++ b/vault/mount_util.go
@@ -10,6 +10,7 @@ import (
 	"path"
 
 	"github.com/hashicorp/vault/helper/namespace"
+	"github.com/hashicorp/vault/sdk/helper/pluginutil"
 	"github.com/hashicorp/vault/sdk/logical"
 )
 
@@ -75,4 +76,9 @@ func (c *Core) mountEntrySysView(entry *MountEntry) extendedSystemView {
 
 func (c *Core) entBuiltinPluginMetrics(ctx context.Context, entry *MountEntry, val float32) error {
 	return nil
+}
+
+// entSetExternalPluginConfig (Vault Community edition) makes no changes to config for external plugins.
+func entSetExternalPluginConfig(_ *pluginutil.PluginRunner, _ map[string]string) {
+	// No-op
 }


### PR DESCRIPTION
### Description
What does this PR do?
This PRs allows Enterprise Vault to set external plugin config

Related ENT PR: https://github.com/hashicorp/vault-enterprise/pull/7269
Ticket: [VAULT-33300](https://hashicorp.atlassian.net/browse/VAULT-33300)
RFC: https://go.hashi.co/rfc/vlt-337

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.


[VAULT-33300]: https://hashicorp.atlassian.net/browse/VAULT-33300?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ