### PR TITLE
Add test to demo loop of death and fix

### DIFF
--- a/changelog/29485.txt
+++ b/changelog/29485.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+core: Config reloading on SIGHUP now includes some Raft settings, which are now also present in `/sys/config/state/sanitized` output.
+```

--- a/command/server.go
+++ b/command/server.go
@@ -37,6 +37,7 @@ import (
 	"github.com/hashicorp/go-secure-stdlib/mlock"
 	"github.com/hashicorp/go-secure-stdlib/parseutil"
 	"github.com/hashicorp/go-secure-stdlib/reloadutil"
+	raftlib "github.com/hashicorp/raft"
 	"github.com/hashicorp/vault/audit"
 	config2 "github.com/hashicorp/vault/command/config"
 	"github.com/hashicorp/vault/command/server"
@@ -50,6 +51,7 @@ import (
 	vaulthttp "github.com/hashicorp/vault/http"
 	"github.com/hashicorp/vault/internalshared/configutil"
 	"github.com/hashicorp/vault/internalshared/listenerutil"
+	"github.com/hashicorp/vault/physical/raft"
 	"github.com/hashicorp/vault/sdk/helper/consts"
 	"github.com/hashicorp/vault/sdk/helper/jsonutil"
 	"github.com/hashicorp/vault/sdk/helper/strutil"
@@ -1605,6 +1607,7 @@ func (c *ServerCommand) Run(args []string) int {
 	// Wait for shutdown
 	shutdownTriggered := false
 	retCode := 0
+	raftConfig := raftlib.DefaultConfig()
 
 	for !shutdownTriggered {
 		select {
@@ -1637,6 +1640,21 @@ func (c *ServerCommand) Run(args []string) int {
 			// reporting Errors found in the config
 			for _, cErr := range configErrors {
 				c.logger.Warn(cErr.String())
+			}
+
+			if err := raft.ApplyConfigSettings(c.logger, config.Storage.Config, raftConfig); err != nil {
+				c.logger.Warn("error reloading raft config", "error", err.Error())
+			} else {
+				rlconfig := raftlib.ReloadableConfig{
+					TrailingLogs:      raftConfig.TrailingLogs,
+					SnapshotInterval:  raftConfig.SnapshotInterval,
+					SnapshotThreshold: raftConfig.SnapshotThreshold,
+					HeartbeatTimeout:  raftConfig.HeartbeatTimeout,
+					ElectionTimeout:   raftConfig.ElectionTimeout,
+				}
+				if err := core.ReloadRaftConfig(rlconfig); err != nil {
+					c.logger.Warn("error reloading raft config", "error", err.Error())
+				}
 			}
 
 			// Note that seal reloading can also be triggered via Core.TriggerSealReload.

--- a/command/server/config.go
+++ b/command/server/config.go
@@ -1338,6 +1338,9 @@ func (c *Config) Sanitized() map[string]interface{} {
 			sanitizedStorage["raft"] = map[string]interface{}{
 				"max_entry_size": c.Storage.Config["max_entry_size"],
 			}
+			for k, v := range c.Storage.Config {
+				sanitizedStorage["raft"].(map[string]interface{})[k] = v
+			}
 		}
 
 		result["storage"] = sanitizedStorage

--- a/http/sys_config_state_test.go
+++ b/http/sys_config_state_test.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/go-test/deep"
+	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/vault/command/server"
 	"github.com/hashicorp/vault/internalshared/configutil"
 	"github.com/hashicorp/vault/vault"
@@ -42,6 +42,8 @@ func TestSysConfigState_Sanitized(t *testing.T) {
 				"cluster_addr":       "http://127.0.0.1:8201",
 				"disable_clustering": false,
 				"raft": map[string]interface{}{
+					"path":           "/storage/path/raft",
+					"node_id":        "raft1",
 					"max_entry_size": "2097152",
 				},
 			},
@@ -199,7 +201,7 @@ func TestSysConfigState_Sanitized(t *testing.T) {
 			testResponseBody(t, resp, &actual)
 			expected["request_id"] = actual["request_id"]
 
-			if diff := deep.Equal(actual, expected); len(diff) > 0 {
+			if diff := cmp.Diff(actual, expected); len(diff) > 0 {
 				t.Fatalf("bad mismatch response body: diff: %v", diff)
 			}
 		})

--- a/physical/raft/chunking_test.go
+++ b/physical/raft/chunking_test.go
@@ -34,7 +34,7 @@ func TestRaft_Chunking_Lifecycle(t *testing.T) {
 
 	t.Log("applying configuration")
 
-	b.applyConfigSettings(raft.DefaultConfig())
+	ApplyConfigSettings(b.logger, b.conf, raft.DefaultConfig())
 
 	t.Log("chunking")
 
@@ -119,7 +119,7 @@ func TestFSM_Chunking_TermChange(t *testing.T) {
 
 	t.Log("applying configuration")
 
-	b.applyConfigSettings(raft.DefaultConfig())
+	ApplyConfigSettings(b.logger, b.conf, raft.DefaultConfig())
 
 	t.Log("chunking")
 

--- a/physical/raft/raft.go
+++ b/physical/raft/raft.go
@@ -2326,7 +2326,11 @@ func isRaftLogVerifyCheckpoint(l *raft.Log) bool {
 
 func (r *RaftBackend) ReloadConfig(config raft.ReloadableConfig) error {
 	if r.raft != nil {
-		return r.raft.ReloadConfig(config)
+		if err := r.raft.ReloadConfig(config); err != nil {
+			return err
+		} else {
+			r.logger.Info("reloaded raft config", "settings", config)
+		}
 	}
 	return nil
 }

--- a/physical/raft/raft.go
+++ b/physical/raft/raft.go
@@ -2325,5 +2325,8 @@ func isRaftLogVerifyCheckpoint(l *raft.Log) bool {
 }
 
 func (r *RaftBackend) ReloadConfig(config raft.ReloadableConfig) error {
-	return r.raft.ReloadConfig(config)
+	if r.raft != nil {
+		return r.raft.ReloadConfig(config)
+	}
+	return nil
 }

--- a/physical/raft/raft_test.go
+++ b/physical/raft/raft_test.go
@@ -894,7 +894,7 @@ func TestRaft_Backend_Performance(t *testing.T) {
 
 		defaultConfig := raft.DefaultConfig()
 		localConfig := raft.DefaultConfig()
-		err := b.applyConfigSettings(localConfig)
+		err := ApplyConfigSettings(b.logger, b.conf, localConfig)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -915,7 +915,7 @@ func TestRaft_Backend_Performance(t *testing.T) {
 		}
 
 		localConfig = raft.DefaultConfig()
-		err = b.applyConfigSettings(localConfig)
+		err = ApplyConfigSettings(b.logger, b.conf, localConfig)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -936,7 +936,7 @@ func TestRaft_Backend_Performance(t *testing.T) {
 		}
 
 		localConfig = raft.DefaultConfig()
-		err = b.applyConfigSettings(localConfig)
+		err = ApplyConfigSettings(b.logger, b.conf, localConfig)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/sdk/helper/testcluster/types.go
+++ b/sdk/helper/testcluster/types.go
@@ -54,8 +54,8 @@ type VaultNodeConfig struct {
 	//   ServiceRegistrationType        string
 	//   ServiceRegistrationOptions    map[string]string
 
-	StorageOptions      map[string]string
-	AdditionalListeners []VaultNodeListenerConfig
+	StorageOptions      map[string]string         `json:"-"`
+	AdditionalListeners []VaultNodeListenerConfig `json:"-"`
 
 	DefaultMaxRequestDuration      time.Duration `json:"default_max_request_duration"`
 	LogFormat                      string        `json:"log_format"`

--- a/vault/raft.go
+++ b/vault/raft.go
@@ -1322,12 +1322,23 @@ func NewDelegateForCore(c *Core) *raft.Delegate {
 	return raft.NewDelegate(c.getRaftBackend(), persistedState, c.saveAutopilotPersistedState)
 }
 
-func (c *Core) ReloadRaftConfig(config raftlib.ReloadableConfig) error {
+func (c *Core) ReloadRaftConfig(config map[string]string) error {
 	rb := c.getRaftBackend()
 	if rb == nil {
 		return nil
 	}
-	return rb.ReloadConfig(config)
+	raftConfig := raftlib.DefaultConfig()
+	if err := raft.ApplyConfigSettings(c.logger, config, raftConfig); err != nil {
+		return err
+	}
+	rlconfig := raftlib.ReloadableConfig{
+		TrailingLogs:      raftConfig.TrailingLogs,
+		SnapshotInterval:  raftConfig.SnapshotInterval,
+		SnapshotThreshold: raftConfig.SnapshotThreshold,
+		HeartbeatTimeout:  raftConfig.HeartbeatTimeout,
+		ElectionTimeout:   raftConfig.ElectionTimeout,
+	}
+	return rb.ReloadConfig(rlconfig)
 }
 
 // getRaftBackend returns the RaftBackend from the HA or physical backend,

--- a/vault/raft.go
+++ b/vault/raft.go
@@ -24,6 +24,7 @@ import (
 	"github.com/hashicorp/go-uuid"
 	goversion "github.com/hashicorp/go-version"
 	lru "github.com/hashicorp/golang-lru/v2"
+	raftlib "github.com/hashicorp/raft"
 	"github.com/hashicorp/vault/api"
 	httpPriority "github.com/hashicorp/vault/http/priority"
 	"github.com/hashicorp/vault/physical/raft"
@@ -1319,6 +1320,14 @@ func NewDelegateForCore(c *Core) *raft.Delegate {
 		c.logger.Error("failed to load autopilot persisted state from storage", "error", err)
 	}
 	return raft.NewDelegate(c.getRaftBackend(), persistedState, c.saveAutopilotPersistedState)
+}
+
+func (c *Core) ReloadRaftConfig(config raftlib.ReloadableConfig) error {
+	rb := c.getRaftBackend()
+	if rb == nil {
+		return nil
+	}
+	return rb.ReloadConfig(config)
 }
 
 // getRaftBackend returns the RaftBackend from the HA or physical backend,

--- a/vault/request_forwarding_rpc.go
+++ b/vault/request_forwarding_rpc.go
@@ -102,14 +102,14 @@ func (s *forwardedRequestRPCServer) Echo(ctx context.Context, in *EchoRequest) (
 	}
 
 	if in.RaftAppliedIndex > 0 && len(in.RaftNodeID) > 0 && s.raftFollowerStates != nil {
-		s.core.logger.Trace("forwarding RPC: echo received",
-			"node_id", in.RaftNodeID,
-			"applied_index", in.RaftAppliedIndex,
-			"term", in.RaftTerm,
-			"desired_suffrage", in.RaftDesiredSuffrage,
-			"sdk_version", in.SdkVersion,
-			"upgrade_version", in.RaftUpgradeVersion,
-			"redundancy_zone", in.RaftRedundancyZone)
+		// s.core.logger.Trace("forwarding RPC: echo received",
+		//	"node_id", in.RaftNodeID,
+		//	"applied_index", in.RaftAppliedIndex,
+		//	"term", in.RaftTerm,
+		//	"desired_suffrage", in.RaftDesiredSuffrage,
+		//	"sdk_version", in.SdkVersion,
+		//	"upgrade_version", in.RaftUpgradeVersion,
+		//	"redundancy_zone", in.RaftRedundancyZone)
 
 		s.raftFollowerStates.Update(&raft.EchoRequestUpdate{
 			NodeID:          in.RaftNodeID,


### PR DESCRIPTION
### Description
I'm probably not going to merge this PR unless I can find a way to rework the test that I'm confident won't be flaky.  For now, it's a way to show that how the loop of death manifests and how it can be fixed by increasing the trailing log retention and reloading config.

In the test, we setup a 3-node cluster, then throttle the network connectivity between the leader and one follower, adding 1s of delay.  We then write a KV every 1ms, and poll the autopilot snapshot state, extracing the LastIndex of the leader and that follower.  The initial config is setup in a very broken way to make the problem manifest quickly: trailing logs is 10, snapshot interval is every 1s, and snapshot threshold is 10 logs.  Within a couple of seconds the follower is in trouble, as it's already far enough behind that the log it needs from the leader core-0 has been compacted away.  When a snapshot is pulled, that doesn't solve the problem, because fetching and applying the snapshot takes long enough that more logs have been written than we have log retention for.  Eventually we increase the retention and reload config and things stabilize.



### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
