### PR TITLE
Encapsulate handling rotation job register/deregister for plugins

### DIFF
--- a/builtin/logical/aws/backend.go
+++ b/builtin/logical/aws/backend.go
@@ -10,8 +10,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/aws/aws-sdk-go/service/iam/iamiface"
 	"github.com/aws/aws-sdk-go/service/sts/stsiface"
 	"github.com/hashicorp/vault/sdk/framework"
@@ -76,92 +74,8 @@ func Backend(_ *logical.BackendConfig) *backend {
 			}
 			return nil
 		},
-		RotateCredential: func(ctx context.Context, req *logical.Request) error {
-			// the following code is a modified version of the rotate-root method
-			client, err := b.clientIAM(ctx, req.Storage)
-			if err != nil {
-				return err
-			}
-			if client == nil {
-				return fmt.Errorf("nil IAM client")
-			}
-
-			b.clientMutex.Lock()
-			defer b.clientMutex.Unlock()
-
-			rawRootConfig, err := req.Storage.Get(ctx, "config/root")
-			if err != nil {
-				return err
-			}
-			if rawRootConfig == nil {
-				return fmt.Errorf("no configuration found for config/root")
-			}
-			var config rootConfig
-			if err := rawRootConfig.DecodeJSON(&config); err != nil {
-				return fmt.Errorf("error reading root configuration: %w", err)
-			}
-
-			if config.AccessKey == "" || config.SecretKey == "" {
-				return fmt.Errorf("cannot call config/rotate-root when either access_key or secret_key is empty")
-			}
-
-			var getUserInput iam.GetUserInput // empty input means get current user
-			getUserRes, err := client.GetUserWithContext(ctx, &getUserInput)
-			if err != nil {
-				return fmt.Errorf("error calling GetUser: %w", err)
-			}
-			if getUserRes == nil {
-				return fmt.Errorf("nil response from GetUser")
-			}
-			if getUserRes.User == nil {
-				return fmt.Errorf("nil user returned from GetUser")
-			}
-			if getUserRes.User.UserName == nil {
-				return fmt.Errorf("nil UserName returned from GetUser")
-			}
-
-			createAccessKeyInput := iam.CreateAccessKeyInput{
-				UserName: getUserRes.User.UserName,
-			}
-			createAccessKeyRes, err := client.CreateAccessKeyWithContext(ctx, &createAccessKeyInput)
-			if err != nil {
-				return fmt.Errorf("error calling CreateAccessKey: %w", err)
-			}
-			if createAccessKeyRes.AccessKey == nil {
-				return fmt.Errorf("nil response from CreateAccessKey")
-			}
-			if createAccessKeyRes.AccessKey.AccessKeyId == nil || createAccessKeyRes.AccessKey.SecretAccessKey == nil {
-				return fmt.Errorf("nil AccessKeyId or SecretAccessKey returned from CreateAccessKey")
-			}
-
-			oldAccessKey := config.AccessKey
-
-			config.AccessKey = *createAccessKeyRes.AccessKey.AccessKeyId
-			config.SecretKey = *createAccessKeyRes.AccessKey.SecretAccessKey
-
-			newEntry, err := logical.StorageEntryJSON("config/root", config)
-			if err != nil {
-				return fmt.Errorf("error generating new config/root JSON: %w", err)
-			}
-			if err := req.Storage.Put(ctx, newEntry); err != nil {
-				return fmt.Errorf("error saving new config/root: %w", err)
-			}
-
-			b.iamClient = nil
-			b.stsClient = nil
-
-			deleteAccessKeyInput := iam.DeleteAccessKeyInput{
-				AccessKeyId: aws.String(oldAccessKey),
-				UserName:    getUserRes.User.UserName,
-			}
-			_, err = client.DeleteAccessKeyWithContext(ctx, &deleteAccessKeyInput)
-			if err != nil {
-				return fmt.Errorf("error deleting old access key: %w", err)
-			}
-
-			return nil
-		},
-		BackendType: logical.TypeLogical,
+		RotateCredential: b.rotateRootCredential,
+		BackendType:      logical.TypeLogical,
 	}
 
 	return &b


### PR DESCRIPTION
### Description
Adds helper methods for easier development when adding automated root rotation support to plugins.

Also updates AWS secrets to use these new helpers and moves the RotateCredential handler into a separate method.

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
