### PR TITLE
Undo additions to the barrier encryption count if persisting those encryptions fails

### DIFF
--- a/changelog/29506.txt
+++ b/changelog/29506.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core: Fix bug when if failing to persist the barrier keyring to track encryption counts, the number of outstanding encryptions remains added to the count, overcounting encryptions.
+```

--- a/vault/barrier_aes_gcm.go
+++ b/vault/barrier_aes_gcm.go
@@ -1281,6 +1281,8 @@ func (b *AESGCMBarrier) persistEncryptions(ctx context.Context) error {
 			newKeyring := b.keyring.Clone()
 			err := b.persistKeyringBestEffort(ctx, newKeyring)
 			if err != nil {
+				// because Keys are pointer addressed, we need to undo the update to the Encryption count here
+				activeKey.Encryptions -= uint64(newEncs)
 				return err
 			}
 			b.UnaccountedEncryptions.Sub(newEncs)


### PR DESCRIPTION
Fixes VAULT-33823

### Description
What does this PR do?

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.