### PR TITLE
Docs: API: Manual backport of API docs raft auto snapshot updates

### DIFF
--- a/website/content/api-docs/system/storage/raftautosnapshots.mdx
+++ b/website/content/api-docs/system/storage/raftautosnapshots.mdx
@@ -140,12 +140,15 @@ parameters in the context of AWS EKS & S3 configuration.
 
 - `azure_account_name` `(string)` - Azure account name.
 
-- `azure_account_key` `(string)` - Azure account key.
+- `azure_auth_mode` `(string)` - One of `shared` or `managed`.
+
+- `azure_account_key` `(string)` - Azure account key. Used for `shared` authentication.
+
+- `azure_client_id` `(string)` - Azure Client ID. Used for `managed` authentication.
 
 - `azure_blob_environment` `(string)` - Azure blob environment.
 
-- `azure_endpoint` `(string)` - Azure blob storage endpoint. This is typically
-  only set when using a non-Azure implementation like Azurite.
+- `azure_endpoint` `(string)` - Azure blob storage endpoint. Set this when using a non-Azure implementation like Azurite.
 
 ### Sample payload
 
@@ -169,7 +172,7 @@ $ curl \
     http://127.0.0.1:8200/v1/sys/storage/raft/snapshot-auto/config/config1
 ```
 
-## List automated snapshots configs
+## List automated snapshots configuration
 
 **This endpoint requires sudo capability.**
 


### PR DESCRIPTION
### Description

This is manual backport of #29508 for [SPE-998](https://hashicorp.atlassian.net/browse/SPE-998) to the release/1.18.x branch since the backport assistant failed.

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.


[SPE-998]: https://hashicorp.atlassian.net/browse/SPE-998?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ