### PR TITLE
add EntStaticSystemView to StaticSystemView and its ce stubs

### DIFF
--- a/sdk/logical/system_view.go
+++ b/sdk/logical/system_view.go
@@ -146,6 +146,7 @@ type ExtendedSystemView interface {
 type PasswordGenerator func() (password string, err error)
 
 type StaticSystemView struct {
+	EntStaticSystemView
 	DefaultLeaseTTLVal           time.Duration
 	MaxLeaseTTLVal               time.Duration
 	SudoPrivilegeVal             bool

--- a/sdk/logical/system_view_stubs_oss.go
+++ b/sdk/logical/system_view_stubs_oss.go
@@ -1,0 +1,8 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build !enterprise
+
+package logical
+
+type EntStaticSystemView struct{}


### PR DESCRIPTION
### Description
What does this PR do?
This PR adds EntStaticSystemView to StaticSystemView and its CE stubs

Related ENT PR: https://github.com/hashicorp/vault-enterprise/pull/7269
Ticket: [VAULT-33300](https://hashicorp.atlassian.net/browse/VAULT-33300)
RFC: https://go.hashi.co/rfc/vlt-337

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.


[VAULT-33300]: https://hashicorp.atlassian.net/browse/VAULT-33300?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ