### PR TITLE
fmt: check gosimports during pre-commit hooks

### DIFF
--- a/builtin/credential/ldap/backend_test.go
+++ b/builtin/credential/ldap/backend_test.go
@@ -11,9 +11,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/vault/sdk/helper/automatedrotationutil"
-	"github.com/hashicorp/vault/sdk/rotation"
-
 	goldap "github.com/go-ldap/ldap/v3"
 	"github.com/go-test/deep"
 	hclog "github.com/hashicorp/go-hclog"
@@ -21,10 +18,12 @@ import (
 	"github.com/hashicorp/vault/helper/namespace"
 	"github.com/hashicorp/vault/helper/testhelpers/ldap"
 	logicaltest "github.com/hashicorp/vault/helper/testhelpers/logical"
+	"github.com/hashicorp/vault/sdk/helper/automatedrotationutil"
 	"github.com/hashicorp/vault/sdk/helper/ldaputil"
 	"github.com/hashicorp/vault/sdk/helper/policyutil"
 	"github.com/hashicorp/vault/sdk/helper/tokenutil"
 	"github.com/hashicorp/vault/sdk/logical"
+	"github.com/hashicorp/vault/sdk/rotation"
 	"github.com/mitchellh/mapstructure"
 )
 

--- a/scripts/go-helper.sh
+++ b/scripts/go-helper.sh
@@ -8,41 +8,67 @@ set -euo pipefail
 check_fmt() {
   echo "==> Checking code formatting..."
 
-  declare -a malformed=()
-  IFS=" " read -r -a files <<< "$(tr '\n' ' ' <<< "$@")"
+  declare -a malformed_imports=()
+  declare -a malformed_formatting=()
+  local failed=0
+  IFS=" " read -r -a files <<<"$(tr '\n' ' ' <<<"$@")"
   if [ -n "${files+set}" ] && [[ "${files[0]}" != "" ]]; then
     echo "--> Checking changed files..."
     for file in "${files[@]}"; do
       if [ ! -f "$file" ]; then
-        echo "--> $file no longer exists ⚠"
+        echo "----> $file no longer exists ⚠"
         continue
       fi
 
-      if echo "$file" | grep -v pb.go | grep -v vendor > /dev/null; then
+      if echo "$file" | grep -v pb.go | grep -v vendor >/dev/null; then
         local output
+        if ! output=$(gosimports -d "$file") || [ "$output" != "" ]; then
+          echo "----> ${file} ✖ (gosimports)"
+          malformed_imports+=("$file")
+          failed=1
+        fi
         if ! output=$(gofumpt -l "$file") || [ "$output" != "" ]; then
-          echo "--> ${file} ✖"
-          malformed+=("$file")
+          echo "----> ${file} ✖ (gofumpt)"
+          malformed_formatting+=("$file")
+          failed=1
+        fi
+
+        if [ "$failed" == 1 ]; then
           continue
         fi
       fi
 
-      echo "--> ${file} ✔"
+      echo "----> ${file} ✔"
     done
   else
     echo "--> Checking all files..."
-    IFS=" " read -r -a malformed <<< "$(find . -name '*.go' | grep -v pb.go | grep -v vendor | xargs gofumpt -l)"
+    IFS=" " read -r -a malformed_imports <<<"$(find . -name '*.go' | grep -v pb.go | grep -v vendor | xargs gosimports -l | tr '\n' ' ')"
+    IFS=" " read -r -a malformed_formatting <<<"$(find . -name '*.go' | grep -v pb.go | grep -v vendor | xargs gofumpt -l)"
   fi
 
-  if [ "${#malformed[@]}" -ne 0 ] && [ -n "${malformed[0]}" ] ; then
-    echo "--> The following files need to be reformatted with gofumpt"
-    printf '%s\n' "${malformed[@]}"
+  if [ "${#malformed_imports[@]}" -ne 0 ] && [ -n "${malformed_imports[0]}" ]; then
+    failed=1
+    echo "--> The following files need to be reformatted with gosimports"
+    printf '%s\n' "${malformed_imports[*]}"
     echo "Run \`make fmt\` to reformat code."
-    for file in "${malformed[@]}"; do
+    for file in "${malformed_imports[@]}"; do
+      gosimports -d "$file"
+    done
+  fi
+
+  if [ "${#malformed_formatting[@]}" -ne 0 ] && [ -n "${malformed_formatting[0]}" ]; then
+    failed=1
+    echo "--> The following files need to be reformatted with gofumpt"
+    printf '%s\n' "${malformed_formatting[@]}"
+    echo "Run \`make fmt\` to reformat code."
+    for file in "${malformed_formatting[@]}"; do
       gofumpt -w "$file"
       git diff --no-color "$file"
     done
-    exit 1
+  fi
+
+  if [ $failed == 1 ]; then
+    return 1
   fi
 }
 
@@ -58,14 +84,14 @@ check_version() {
   else
     GO_VERSION=$($GO_CMD version | grep -o 'go[0-9]\+\.[0-9]\+\(\.[0-9]\+\)\?' | tr -d 'go')
 
-    IFS="." read -r -a GO_VERSION_ARR <<< "$GO_VERSION"
-    IFS="." read -r -a GO_VERSION_REQ <<< "$GO_VERSION_MIN"
+    IFS="." read -r -a GO_VERSION_ARR <<<"$GO_VERSION"
+    IFS="." read -r -a GO_VERSION_REQ <<<"$GO_VERSION_MIN"
 
     if [[ ${GO_VERSION_ARR[0]} -lt ${GO_VERSION_REQ[0]} ||
-      ( ${GO_VERSION_ARR[0]} -eq ${GO_VERSION_REQ[0]} &&
-      ( ${GO_VERSION_ARR[1]} -lt ${GO_VERSION_REQ[1]} ||
-      ( ${GO_VERSION_ARR[1]} -eq ${GO_VERSION_REQ[1]} && ${GO_VERSION_ARR[2]} -lt ${GO_VERSION_REQ[2]} )))
-    ]]; then
+      (${GO_VERSION_ARR[0]} -eq ${GO_VERSION_REQ[0]} &&
+      (${GO_VERSION_ARR[1]} -lt ${GO_VERSION_REQ[1]} ||
+      (${GO_VERSION_ARR[1]} -eq ${GO_VERSION_REQ[1]} && ${GO_VERSION_ARR[2]} -lt ${GO_VERSION_REQ[2]}))) ]] \
+      ; then
       echo "Vault requires go $GO_VERSION_MIN to build; found $GO_VERSION."
       exit 1
     fi
@@ -78,19 +104,19 @@ check_version() {
 mod_download() {
   while IFS= read -r -d '' mod; do
     echo "==> Downloading Go modules for $mod to $(go env GOMODCACHE)..."
-    pushd "$(dirname "$mod")" > /dev/null || (echo "failed to push into module dir" && exit 1)
-      GOOS=linux GOARCH=amd64 GOPRIVATE=github.com/hashicorp go mod download -x
-    popd > /dev/null || (echo "failed to pop out of module dir" && exit 1)
-  done < <(find . -type f -name go.mod -not -path "./tools/pipeline/*" -print0 )
+    pushd "$(dirname "$mod")" >/dev/null || (echo "failed to push into module dir" && exit 1)
+    GOOS=linux GOARCH=amd64 GOPRIVATE=github.com/hashicorp go mod download -x
+    popd >/dev/null || (echo "failed to pop out of module dir" && exit 1)
+  done < <(find . -type f -name go.mod -not -path "./tools/pipeline/*" -print0)
 }
 
 # Tidy all the go.mod's defined in the project.
 mod_tidy() {
   while IFS= read -r -d '' mod; do
     echo "==> Tidying $mod..."
-    pushd "$(dirname "$mod")" > /dev/null || (echo "failed to push into module dir" && exit 1)
-      GOOS=linux GOARCH=amd64 GOPRIVATE=github.com/hashicorp go mod tidy
-    popd > /dev/null || (echo "failed to pop out of module dir" && exit 1)
+    pushd "$(dirname "$mod")" >/dev/null || (echo "failed to push into module dir" && exit 1)
+    GOOS=linux GOARCH=amd64 GOPRIVATE=github.com/hashicorp go mod tidy
+    popd >/dev/null || (echo "failed to pop out of module dir" && exit 1)
   done < <(find . -type f -name go.mod -print0)
 }
 
@@ -98,20 +124,20 @@ main() {
   case $1 in
   mod-download)
     mod_download
-  ;;
+    ;;
   mod-tidy)
     mod_tidy
-  ;;
+    ;;
   check-fmt)
     check_fmt "${@:2}"
-  ;;
+    ;;
   check-version)
     check_version "$2"
-  ;;
+    ;;
   *)
     echo "unknown sub-command" >&2
     exit 1
-  ;;
+    ;;
   esac
 }
 

--- a/sdk/database/dbplugin/plugin.go
+++ b/sdk/database/dbplugin/plugin.go
@@ -8,13 +8,12 @@ import (
 	"fmt"
 	"time"
 
-	"google.golang.org/grpc"
-
 	"github.com/hashicorp/errwrap"
 	log "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-plugin"
 	"github.com/hashicorp/vault/sdk/helper/consts"
 	"github.com/hashicorp/vault/sdk/helper/pluginutil"
+	"google.golang.org/grpc"
 )
 
 // Database is the interface that all database objects must implement.

--- a/sdk/database/dbplugin/v5/grpc_client.go
+++ b/sdk/database/dbplugin/v5/grpc_client.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/golang/protobuf/ptypes"
-
 	"github.com/hashicorp/vault/sdk/database/dbplugin/v5/proto"
 	"github.com/hashicorp/vault/sdk/helper/pluginutil"
 	"github.com/hashicorp/vault/sdk/logical"

--- a/sdk/database/dbplugin/v5/grpc_database_plugin_oss.go
+++ b/sdk/database/dbplugin/v5/grpc_database_plugin_oss.go
@@ -8,12 +8,11 @@ package dbplugin
 import (
 	"context"
 
-	"google.golang.org/grpc"
-
 	"github.com/hashicorp/go-plugin"
 	"github.com/hashicorp/vault/sdk/database/dbplugin/v5/proto"
 	"github.com/hashicorp/vault/sdk/helper/pluginutil"
 	"github.com/hashicorp/vault/sdk/logical"
+	"google.golang.org/grpc"
 )
 
 // GRPCClient (Vault CE edition) initializes and returns a gRPCClient with Database and

--- a/tools/pipeline/internal/cmd/github_list_runs.go
+++ b/tools/pipeline/internal/cmd/github_list_runs.go
@@ -12,9 +12,8 @@ import (
 	"time"
 
 	ghclient "github.com/google/go-github/v68/github"
-	"github.com/spf13/cobra"
-
 	"github.com/hashicorp/vault/tools/pipeline/internal/pkg/github"
+	"github.com/spf13/cobra"
 )
 
 var listGithubWorkflowRuns = &github.ListWorkflowRunsReq{}

--- a/tools/pipeline/internal/pkg/generate/enos_dynamic_config_test.go
+++ b/tools/pipeline/internal/pkg/generate/enos_dynamic_config_test.go
@@ -10,9 +10,8 @@ import (
 	"slices"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/hashicorp/vault/tools/pipeline/internal/pkg/releases"
+	"github.com/stretchr/testify/require"
 )
 
 var testAPIVersions = []string{


### PR DESCRIPTION
### Description

`gosimports` is the preferred style for module imports and it is enforced via CI. I've found that things often manage to drift so I've taken the liberty to update our pre-commit hook to verify our imports formatting before a change is committed.

Along with updating the formatting helper I've also run `make fmt` to resolve any formatting drift that managed to make it into the codebase.

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [x] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
