### PR TITLE
Add missing parameter signature_bits to the generate root PKI API docs

### DIFF
--- a/website/content/api-docs/secret/pki/index.mdx
+++ b/website/content/api-docs/secret/pki/index.mdx
@@ -2252,6 +2252,12 @@ use the values set via `config/urls`.
   `alt_names` map using OID 2.5.4.5. Note that this has no impact on the
   Certificate's serial number field, which Vault randomly generates.
 
+- `signature_bits` `(int: 0)` - Specifies the number of bits to use in
+  the signature algorithm; accepts 256 for SHA-2-256, 384 for SHA-2-384,
+  and 512 for SHA-2-512. Defaults to 0 to automatically detect based
+  on issuer's key length (SHA-2-256 for RSA keys, and matching the curve size
+  for NIST P-Curves).
+
 - `not_before_duration` `(duration: "30s")` - Specifies the duration by which to
   backdate the NotBefore property. This value has no impact in the validity period
   of the requested certificate, specified in the `ttl` field.


### PR DESCRIPTION
### Description

Add a missing parameter `signature_bits` to the Generate Root PKI API documentation.  

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
