### PR TITLE
UI: Use timestamp.now() in custom messages

### DIFF
--- a/ui/app/models/config-ui/message.js
+++ b/ui/app/models/config-ui/message.js
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 import Model, { attr } from '@ember-data/model';
+import timestamp from 'core/utils/timestamp';
 import lazyCapabilities, { apiPath } from 'vault/macros/lazy-capabilities';
 import { isAfter, addDays, startOfDay, parseISO, isBefore } from 'date-fns';
 import { withModelValidations } from 'vault/decorators/model-validations';
@@ -109,7 +110,9 @@ export default class MessageModel extends Model {
     editType: 'dateTimeLocal',
     label: 'Message starts',
     subText: 'Defaults to 12:00 a.m. the following day (local timezone).',
-    defaultValue: addDays(startOfDay(new Date()), 1).toISOString(),
+    defaultValue() {
+      return addDays(startOfDay(timestamp.now()), 1).toISOString();
+    },
   })
   startTime;
   @attr('dateTimeLocal', { editType: 'yield', label: 'Message expires' }) endTime;
@@ -126,7 +129,7 @@ export default class MessageModel extends Model {
 
   // date helpers
   get isStartTimeAfterToday() {
-    return isAfter(parseISO(this.startTime), new Date());
+    return isAfter(parseISO(this.startTime), timestamp.now());
   }
 
   // capabilities

--- a/ui/lib/config-ui/addon/components/messages/page/create-and-edit.js
+++ b/ui/lib/config-ui/addon/components/messages/page/create-and-edit.js
@@ -11,6 +11,7 @@ import { service } from '@ember/service';
 import { action } from '@ember/object';
 import Ember from 'ember';
 import { isAfter } from 'date-fns';
+import timestamp from 'core/utils/timestamp';
 
 /**
  * @module Page::CreateAndEditMessageForm
@@ -63,7 +64,7 @@ export default class MessagesList extends Component {
       const modalMessages = this.args.messages?.filter((message) => message.type === 'modal') || [];
       const hasExpiredModalMessages = modalMessages.every((message) => {
         if (!message.endTime) return false;
-        return isAfter(new Date(), new Date(message.endTime));
+        return isAfter(timestamp.now(), new Date(message.endTime));
       });
 
       if (!hasExpiredModalMessages && this.args.hasSomeActiveModals && this.args.message.type === 'modal') {

--- a/ui/tests/integration/components/config-ui/messages/page/create-and-edit-test.js
+++ b/ui/tests/integration/components/config-ui/messages/page/create-and-edit-test.js
@@ -30,8 +30,6 @@ module('Integration | Component | messages/page/create-and-edit', function (hook
   });
 
   test('it should display all the create form fields and default radio button values', async function (assert) {
-    assert.expect(17);
-
     await render(hbs`<Messages::Page::CreateAndEdit @message={{this.message}} />`, {
       owner: this.engine,
     });

--- a/ui/tests/integration/components/config-ui/messages/page/create-and-edit-test.js
+++ b/ui/tests/integration/components/config-ui/messages/page/create-and-edit-test.js
@@ -57,7 +57,6 @@ module('Integration | Component | messages/page/create-and-edit', function (hook
           this.message.startTime
         }, now: ${timestamp.now().toISOString()}`
       );
-    assert.dom(CUSTOM_MESSAGES.input('startTime')).hasValue('2023-07-02T00:00'); // Sun Jul 2 midnight PST
     assert.dom(CUSTOM_MESSAGES.input('endTime')).hasValue('');
   });
 

--- a/ui/tests/integration/components/config-ui/messages/page/create-and-edit-test.js
+++ b/ui/tests/integration/components/config-ui/messages/page/create-and-edit-test.js
@@ -22,7 +22,7 @@ module('Integration | Component | messages/page/create-and-edit', function (hook
   setupMirage(hooks);
 
   hooks.beforeEach(function () {
-    const now = new Date('2023-07-02T00:00:00Z'); // Sat Jul 01 2023 17:00:00 GMT-0700 (PST)
+    const now = new Date('2023-07-02T00:00:00Z'); // stub "now" for testing
     sinon.replace(timestamp, 'now', sinon.fake.returns(now));
     this.context = { owner: this.engine };
     this.store = this.owner.lookup('service:store');

--- a/ui/tests/integration/components/config-ui/messages/page/create-and-edit-test.js
+++ b/ui/tests/integration/components/config-ui/messages/page/create-and-edit-test.js
@@ -14,6 +14,7 @@ import { format, addDays, startOfDay } from 'date-fns';
 import { CUSTOM_MESSAGES } from 'vault/tests/helpers/config-ui/message-selectors';
 import timestamp from 'core/utils/timestamp';
 import { GENERAL } from 'vault/tests/helpers/general-selectors';
+import sinon from 'sinon';
 
 module('Integration | Component | messages/page/create-and-edit', function (hooks) {
   setupRenderingTest(hooks);
@@ -21,6 +22,8 @@ module('Integration | Component | messages/page/create-and-edit', function (hook
   setupMirage(hooks);
 
   hooks.beforeEach(function () {
+    const now = new Date('2023-07-02T00:00:00Z'); // Sat Jul 01 2023 17:00:00 GMT-0700 (PST)
+    sinon.replace(timestamp, 'now', sinon.fake.returns(now));
     this.context = { owner: this.engine };
     this.store = this.owner.lookup('service:store');
     this.message = this.store.createRecord('config-ui/message');
@@ -47,9 +50,7 @@ module('Integration | Component | messages/page/create-and-edit', function (hook
     assert.dom('[data-test-kv-key="0"]').exists();
     assert.dom('[data-test-kv-value="0"]').exists();
     assert.dom(CUSTOM_MESSAGES.input('startTime')).exists();
-    assert
-      .dom(CUSTOM_MESSAGES.input('startTime'))
-      .hasValue(format(addDays(startOfDay(timestamp.now()), 1), datetimeLocalStringFormat));
+    assert.dom(CUSTOM_MESSAGES.input('startTime')).hasValue('2023-07-02T00:00'); // Sun Jul 2 midnight PST
     assert.dom(CUSTOM_MESSAGES.input('endTime')).exists();
     assert.dom(CUSTOM_MESSAGES.input('endTime')).hasValue('');
   });

--- a/ui/tests/integration/components/config-ui/messages/page/create-and-edit-test.js
+++ b/ui/tests/integration/components/config-ui/messages/page/create-and-edit-test.js
@@ -49,9 +49,15 @@ module('Integration | Component | messages/page/create-and-edit', function (hook
     assert.dom(CUSTOM_MESSAGES.field('message')).exists();
     assert.dom('[data-test-kv-key="0"]').exists();
     assert.dom('[data-test-kv-value="0"]').exists();
-    assert.dom(CUSTOM_MESSAGES.input('startTime')).exists();
+    assert
+      .dom(CUSTOM_MESSAGES.input('startTime'))
+      .hasValue(
+        format(addDays(startOfDay(timestamp.now()), 1), datetimeLocalStringFormat),
+        `message startTime defaults to midnight of following day. test context startTime: ${
+          this.message.startTime
+        }, now: ${timestamp.now().toISOString()}`
+      );
     assert.dom(CUSTOM_MESSAGES.input('startTime')).hasValue('2023-07-02T00:00'); // Sun Jul 2 midnight PST
-    assert.dom(CUSTOM_MESSAGES.input('endTime')).exists();
     assert.dom(CUSTOM_MESSAGES.input('endTime')).hasValue('');
   });
 


### PR DESCRIPTION
### Description
This replaces `new Date()` with `timestamp.now()` which can be more reliable stubbed in tests. See https://github.com/hashicorp/vault/issues/19521 for more context

✅ enterprise tests (because of timezone weirdness, double checked enterprise tests by [opening a PR to the enterprise](https://github.com/hashicorp/vault-enterprise/actions/runs/13207666265/job/36874612485) repo)

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
