### PR TITLE
Api drop dep go rootcerts 26136

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -18,7 +18,6 @@ require (
 	github.com/hashicorp/go-hclog v1.6.3
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-retryablehttp v0.7.7
-	github.com/hashicorp/go-rootcerts v1.0.2
 	github.com/hashicorp/go-secure-stdlib/parseutil v0.1.6
 	github.com/hashicorp/go-secure-stdlib/strutil v0.1.2
 	github.com/hashicorp/hcl v1.0.0

--- a/api/go.sum
+++ b/api/go.sum
@@ -27,8 +27,6 @@ github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+l
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/go-retryablehttp v0.7.7 h1:C8hUCYzor8PIfXHa4UrZkU4VvK8o9ISHxT2Q8+VepXU=
 github.com/hashicorp/go-retryablehttp v0.7.7/go.mod h1:pkQpWZeYWskR+D1tR2O5OcBFOxfA7DoAO6xtkuQnHTk=
-github.com/hashicorp/go-rootcerts v1.0.2 h1:jzhAVGtqPKbwpyCPELlgNWhE1znq+qwJtW5Oi2viEzc=
-github.com/hashicorp/go-rootcerts v1.0.2/go.mod h1:pqUvnprVnM5bf7AOirdbb01K4ccR319Vf4pU3K5EGc8=
 github.com/hashicorp/go-secure-stdlib/parseutil v0.1.6 h1:om4Al8Oy7kCm/B86rLCLah4Dt5Aa0Fr5rYBG60OzwHQ=
 github.com/hashicorp/go-secure-stdlib/parseutil v0.1.6/go.mod h1:QmrqtbKuxxSWTN3ETMPuB+VtEiBJ/A9XhoYGv8E1uD8=
 github.com/hashicorp/go-secure-stdlib/strutil v0.1.1/go.mod h1:gKOamz3EwoIoJq7mlMIRBpVTAUn8qPCrEclOKKWhD3U=

--- a/api/ssh_agent.go
+++ b/api/ssh_agent.go
@@ -15,7 +15,6 @@ import (
 	"github.com/hashicorp/errwrap"
 	cleanhttp "github.com/hashicorp/go-cleanhttp"
 	multierror "github.com/hashicorp/go-multierror"
-	rootcerts "github.com/hashicorp/go-rootcerts"
 	"github.com/hashicorp/hcl"
 	"github.com/hashicorp/hcl/hcl/ast"
 	"github.com/mitchellh/mapstructure"
@@ -108,14 +107,11 @@ func (c *SSHHelperConfig) NewClient() (*Client, error) {
 
 	// Check if certificates are provided via config file.
 	if c.shouldSetTLSParameters() {
-		rootConfig := &rootcerts.Config{
-			CAFile: c.CACert,
-			CAPath: c.CAPath,
-		}
-		certPool, err := rootcerts.LoadCACerts(rootConfig)
+		certPool, err := loadCACerts(c.CACert, nil, c.CAPath)
 		if err != nil {
 			return nil, err
 		}
+
 		// Enable TLS on the HTTP client information
 		c.SetTLSParameters(clientConfig, certPool)
 	}


### PR DESCRIPTION
### Description
Fixes #26136: drop dependency on module [`github.com/hashicorp/go-rootcerts`](https://github.com/hashicorp/go-rootcerts) by inlining the CACert/CAPath loading logic.

See details on the rationale in #26136.