### PR TITLE
[Enos] VAULT-30196: SSH Secrets Engine

### DIFF
--- a/enos/modules/verify_secrets_engines/modules/create/main.tf
+++ b/enos/modules/verify_secrets_engines/modules/create/main.tf
@@ -50,5 +50,6 @@ output "state" {
     identity = local.identity_output
     kv       = local.kv_output
     pki      = local.pki_output
+    ssh      = local.ssh_output
   }
 }

--- a/enos/modules/verify_secrets_engines/modules/create/ssh.tf
+++ b/enos/modules/verify_secrets_engines/modules/create/ssh.tf
@@ -1,0 +1,130 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+locals {
+  ssh_role_name     = "ssh_role"
+  ssh_mount         = "ssh"
+  ssh_key_types  = ["otp", "ca"]
+  ssh_key_type   = local.ssh_key_types[random_integer.ssh_key_type_idx.result]
+  ssh_test_ip       = "192.168.1.1"
+  ssh_test_user     = "testuser"
+  ssh_public_key    = "ssh-rsa AAAAB3..."
+
+  ssh_output = {
+    role_name    = local.ssh_role_name
+    mount        = local.ssh_mount
+    ca_key_type  = local.ssh_key_type
+    test = {
+      ip   = local.ssh_test_ip
+      user = local.ssh_test_user
+    }
+  }
+}
+
+resource "random_integer" "ssh_key_type_idx" {
+  min = 0
+  max = length(local.ssh_key_types) - 1
+}
+
+output "ssh" {
+  value = local.ssh_output
+}
+
+# Enable SSH secrets engine
+resource "enos_remote_exec" "secrets_enable_ssh" {
+  environment = {
+    ENGINE            = "ssh"
+    MOUNT             = local.ssh_mount
+    VAULT_ADDR        = var.vault_addr
+    VAULT_TOKEN       = var.vault_root_token
+    VAULT_INSTALL_DIR = var.vault_install_dir
+  }
+
+  scripts = [abspath("${path.module}/../../scripts/secrets-enable.sh")]
+
+  transport = {
+    ssh = {
+      host = var.leader_host.public_ip
+    }
+  }
+}
+
+# Configure SSH CA
+resource "enos_remote_exec" "ssh_configure_ca" {
+  depends_on = [enos_remote_exec.secrets_enable_ssh]
+  environment = {
+    REQPATH      = "ssh/config/ca"
+    PAYLOAD      = jsonencode({ key_type = local.ssh_ca_key_type })
+    VAULT_ADDR   = var.vault_addr
+    VAULT_TOKEN  = var.vault_root_token
+    VAULT_INSTALL_DIR = var.vault_install_dir
+  }
+
+  scripts = [abspath("${path.module}/../../scripts/write-payload.sh")]
+
+  transport = {
+    ssh = {
+      host = var.leader_host.public_ip
+    }
+  }
+}
+
+# Create SSH role
+resource "enos_remote_exec" "ssh_create_role" {
+  depends_on = [enos_remote_exec.ssh_configure_ca]
+  environment = {
+    REQPATH      = "ssh/roles/${local.ssh_role_name}"
+    PAYLOAD      = jsonencode({ key_type = "ca", default_user = local.ssh_test_user, port = 22 })
+    VAULT_ADDR   = var.vault_addr
+    VAULT_TOKEN  = var.vault_root_token
+    VAULT_INSTALL_DIR = var.vault_install_dir
+  }
+
+  scripts = [abspath("${path.module}/../../scripts/write-payload.sh")]
+
+  transport = {
+    ssh = {
+      host = var.leader_host.public_ip
+    }
+  }
+}
+
+# Sign SSH key
+resource "enos_remote_exec" "ssh_sign_key" {
+  depends_on = [enos_remote_exec.ssh_create_role]
+  environment = {
+    REQPATH      = "ssh/sign/${local.ssh_role_name}"
+    PAYLOAD      = jsonencode({ public_key = local.ssh_public_key })
+    VAULT_ADDR   = var.vault_addr
+    VAULT_TOKEN  = var.vault_root_token
+    VAULT_INSTALL_DIR = var.vault_install_dir
+  }
+
+  scripts = [abspath("${path.module}/../../scripts/write-payload.sh")]
+
+  transport = {
+    ssh = {
+      host = var.leader_host.public_ip
+    }
+  }
+}
+
+# Generate SSH OTP credential
+resource "enos_remote_exec" "ssh_generate_otp" {
+  depends_on = [enos_remote_exec.ssh_create_role]
+  environment = {
+    REQPATH      = "ssh/creds/${local.ssh_role_name}"
+    PAYLOAD      = jsonencode({ ip = local.ssh_test_ip, username = local.ssh_test_user })
+    VAULT_ADDR   = var.vault_addr
+    VAULT_TOKEN  = var.vault_root_token
+    VAULT_INSTALL_DIR = var.vault_install_dir
+  }
+
+  scripts = [abspath("${path.module}/../../scripts/write-payload.sh")]
+
+  transport = {
+    ssh = {
+      host = var.leader_host.public_ip
+    }
+  }
+}

--- a/enos/modules/verify_secrets_engines/modules/read/ssh.tf
+++ b/enos/modules/verify_secrets_engines/modules/read/ssh.tf
@@ -1,0 +1,87 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+# Read and Verify SSH role configuration
+resource "enos_remote_exec" "ssh_verify_role" {
+  for_each = var.hosts
+
+  environment = {
+    ROLE_NAME          = var.create_state.ssh.role.name
+    KEY_TYPE           = var.create_state.ssh.role.key_type
+    DEFAULT_USER       = var.create_state.ssh.role.default_user
+    PORT               = var.create_state.ssh.role.port
+    VAULT_ADDR         = var.vault_addr
+    VAULT_TOKEN        = local.user_login_data.auth.client_token
+    VAULT_INSTALL_DIR  = var.vault_install_dir
+  }
+
+  scripts = [abspath("${path.module}/../../scripts/ssh-verify-role.sh")]
+
+  transport = {
+    ssh = {
+      host = each.value.public_ip
+    }
+  }
+}
+
+# Read and Verify SSH CA configuration
+resource "enos_remote_exec" "ssh_verify_ca" {
+  for_each = var.hosts
+
+  environment = {
+    CA_KEY_TYPE = var.create_state.ssh.ca.key_type
+    VAULT_ADDR           = var.vault_addr
+    VAULT_TOKEN          = local.user_login_data.auth.client_token
+    VAULT_INSTALL_DIR    = var.vault_install_dir
+  }
+
+  scripts = [abspath("${path.module}/../../scripts/ssh-verify-ca.sh")]
+
+  transport = {
+    ssh = {
+      host = each.value.public_ip
+    }
+  }
+}
+
+// Read and Verify Signed SSH Key
+resource "enos_remote_exec" "ssh_verify_signed_key" {
+  for_each = var.hosts
+
+  environment = {
+    ROLE_NAME       = var.create_state.ssh.role.name
+    PUBLIC_KEY_PATH = var.public_key_path
+    VAULT_ADDR      = var.vault_addr
+    VAULT_TOKEN     = local.user_login_data.auth.client_token
+    VAULT_INSTALL_DIR = var.vault_install_dir
+  }
+
+  scripts = [abspath("${path.module}/../../scripts/ssh-verify-signed-key.sh")]
+
+  transport = {
+    ssh = {
+      host = each.value.public_ip
+    }
+  }
+}
+
+// Read and Verify OTP Credential
+resource "enos_remote_exec" "ssh_verify_otp" {
+  for_each = var.hosts
+
+  environment = {
+    OTP_ROLE_NAME = var.create_state.ssh.otp_role.name
+    TARGET_IP     = each.value.public_ip
+    VAULT_ADDR    = var.vault_addr
+    VAULT_TOKEN   = local.user_login_data.auth.client_token
+    VAULT_INSTALL_DIR = var.vault_install_dir
+  }
+
+  scripts = [abspath("${path.module}/../../scripts/ssh-verify-otp.sh")]
+
+  transport = {
+    ssh = {
+      host = each.value.public_ip
+    }
+  }
+}

--- a/enos/modules/verify_secrets_engines/scripts/ssh-verify-ca.sh
+++ b/enos/modules/verify_secrets_engines/scripts/ssh-verify-ca.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+set -e
+
+fail() {
+  echo "$1" 1>&2
+  exit 1
+}
+
+[[ -z "$EXPECTED_CA_KEY_TYPE" ]] && fail "EXPECTED_CA_KEY_TYPE env variable has not been set"
+[[ -z "$VAULT_ADDR" ]] && fail "VAULT_ADDR env variable has not been set"
+[[ -z "$VAULT_TOKEN" ]] && fail "VAULT_TOKEN env variable has not been set"
+[[ -z "$VAULT_INSTALL_DIR" ]] && fail "VAULT_INSTALL_DIR env variable has not been set"
+
+binpath=${VAULT_INSTALL_DIR}/vault
+test -x "$binpath" || fail "unable to locate vault binary at $binpath"
+
+export VAULT_FORMAT=json
+
+# Read the SSH CA configuration from Vault
+if ! ca_output=$("$binpath" read "ssh/config/ca" 2>&1); then
+  fail "failed to read ssh/config/ca: $ca_output"
+fi
+
+# Extract actual key_type
+actual_ca_key_type=$(echo "$ca_output" | jq -r '.data.key_type')
+
+# Verify the key_type
+[[ "$actual_ca_key_type" != "$EXPECTED_CA_KEY_TYPE" ]] && fail "CA key_type mismatch: expected $EXPECTED_CA_KEY_TYPE, got $actual_ca_key_type"
+
+echo "SSH CA verification successful."

--- a/enos/modules/verify_secrets_engines/scripts/ssh-verify-otp.sh
+++ b/enos/modules/verify_secrets_engines/scripts/ssh-verify-otp.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+set -e
+
+fail() {
+  echo "$1" 1>&2
+  exit 1
+}
+
+[[ -z "$OTP_ROLE_NAME" ]] && fail "OTP_ROLE_NAME env variable has not been set"
+[[ -z "$TARGET_IP" ]] && fail "TARGET_IP env variable has not been set"
+[[ -z "$VAULT_ADDR" ]] && fail "VAULT_ADDR env variable has not been set"
+[[ -z "$VAULT_TOKEN" ]] && fail "VAULT_TOKEN env variable has not been set"
+[[ -z "$VAULT_INSTALL_DIR" ]] && fail "VAULT_INSTALL_DIR env variable has not been set"
+
+binpath=${VAULT_INSTALL_DIR}/vault
+test -x "$binpath" || fail "unable to locate vault binary at $binpath"
+
+export VAULT_FORMAT=json
+if ! otp_output=$("$binpath" write ssh/creds/$OTP_ROLE_NAME ip=$TARGET_IP 2>&1); then
+  fail "failed to generate OTP credential: $otp_output"
+fi
+
+otp_key=$(echo "$otp_output" | jq -r '.data.key')
+otp_user=$(echo "$otp_output" | jq -r '.data.username')
+
+echo "OTP credential generated successfully for user $otp_user with OTP: $otp_key"

--- a/enos/modules/verify_secrets_engines/scripts/ssh-verify-role.sh
+++ b/enos/modules/verify_secrets_engines/scripts/ssh-verify-role.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+set -e
+
+fail() {
+  echo "$1" 1>&2
+  exit 1
+}
+
+# Check required environment variables
+[[ -z "$ROLE_NAME" ]] && fail "ROLE_NAME env variable has not been set"
+[[ -z "$KEY_TYPE" ]] && fail "KEY_TYPE env variable has not been set"
+[[ -z "$DEFAULT_USER" ]] && fail "DEFAULTUSER env variable has not been set"
+[[ -z "$PORT" ]] && fail "PORT env variable has not been set"
+[[ -z "$VAULT_ADDR" ]] && fail "VAULT_ADDR env variable has not been set"
+[[ -z "$VAULT_TOKEN" ]] && fail "VAULT_TOKEN env variable has not been set"
+[[ -z "$VAULT_INSTALL_DIR" ]] && fail "VAULT_INSTALL_DIR env variable has not been set"
+
+binpath=${VAULT_INSTALL_DIR}/vault
+test -x "$binpath" || fail "unable to locate vault binary at $binpath"
+
+export VAULT_FORMAT=json
+if ! output=$("$binpath" read "ssh/roles/$ROLE_NAME" 2>&1); then
+  fail "failed to read ssh/roles/$ROLE_NAME: $output"
+fi
+
+# Extract actual values
+actual_key_type=$(echo "$output" | jq -r '.data.key_type')
+actual_user=$(echo "$output" | jq -r '.data.default_user')
+actual_port=$(echo "$output" | jq -r '.data.port')
+
+# Verify the values
+[[ "$actual_key_type" != "$KEY_TYPE" ]] && fail "key_type mismatch: expected $KEY_TYPE, got $actual_key_type"
+[[ "$actual_user" != "$DEFAULT_USER" ]] && fail "default_user mismatch: expected $DEFAULT_USER, got $actual_user"
+[[ "$actual_port" != "$PORT" ]] && fail "port mismatch: expected $PORT, got $actual_port"
+
+echo "SSH role verification successful."

--- a/enos/modules/verify_secrets_engines/scripts/ssh-verify-signed-key.sh
+++ b/enos/modules/verify_secrets_engines/scripts/ssh-verify-signed-key.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+set -e
+
+fail() {
+  echo "$1" 1>&2
+  exit 1
+}
+
+[[ -z "$ROLE_NAME" ]] && fail "ROLE_NAME env variable has not been set"
+[[ -z "$PUBLIC_KEY_PATH" ]] && fail "PUBLIC_KEY_PATH env variable has not been set"
+[[ -z "$VAULT_ADDR" ]] && fail "VAULT_ADDR env variable has not been set"
+[[ -z "$VAULT_TOKEN" ]] && fail "VAULT_TOKEN env variable has not been set"
+[[ -z "$VAULT_INSTALL_DIR" ]] && fail "VAULT_INSTALL_DIR env variable has not been set"
+
+binpath=${VAULT_INSTALL_DIR}/vault
+test -x "$binpath" || fail "unable to locate vault binary at $binpath"
+
+export VAULT_FORMAT=json
+if ! signed_key_output=$("$binpath" write -field=signed_key ssh/sign/$ROLE_NAME public_key=@$PUBLIC_KEY_PATH 2>&1); then
+  fail "failed to sign SSH key: $signed_key_output"
+fi
+
+echo "Signed SSH key obtained successfully."


### PR DESCRIPTION
### Description
VAULT-30196: Enos Scenarios for the SSH Secrets Engine API

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
