### PR TITLE
db: honor static role TTL across restarts when skip import rotation i…

### DIFF
--- a/builtin/logical/database/path_creds_create.go
+++ b/builtin/logical/database/path_creds_create.go
@@ -256,9 +256,11 @@ func (b *databaseBackend) pathStaticCredsRead() framework.OperationFunc {
 		}
 
 		respData := map[string]interface{}{
-			"username":            role.StaticAccount.Username,
-			"ttl":                 role.StaticAccount.CredentialTTL().Seconds(),
-			"last_vault_rotation": role.StaticAccount.LastVaultRotation,
+			"username": role.StaticAccount.Username,
+			"ttl":      role.StaticAccount.CredentialTTL().Seconds(),
+		}
+		if !role.StaticAccount.LastVaultRotation.IsZero() {
+			respData["last_vault_rotation"] = role.StaticAccount.LastVaultRotation
 		}
 
 		if role.StaticAccount.UsesRotationPeriod() {

--- a/builtin/logical/database/path_roles_test.go
+++ b/builtin/logical/database/path_roles_test.go
@@ -1388,6 +1388,22 @@ func createRoleWithData(t *testing.T, b *databaseBackend, s logical.Storage, moc
 	}
 }
 
+func readStaticCred(t *testing.T, b *databaseBackend, s logical.Storage, mockDB *mockNewDatabase, roleName string) *logical.Response {
+	t.Helper()
+	mockDB.On("UpdateUser", mock.Anything, mock.Anything).
+		Return(v5.UpdateUserResponse{}, nil).
+		Once()
+	resp, err := b.HandleRequest(context.Background(), &logical.Request{
+		Operation: logical.ReadOperation,
+		Path:      "static-creds/" + roleName,
+		Storage:   s,
+	})
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatal(resp, err)
+	}
+	return resp
+}
+
 const testRoleStaticCreate = `
 CREATE ROLE "{{name}}" WITH
   LOGIN

--- a/builtin/logical/database/rotation_test.go
+++ b/builtin/logical/database/rotation_test.go
@@ -1664,6 +1664,29 @@ func requireWALs(t *testing.T, storage logical.Storage, expectedCount int) []str
 	return wals
 }
 
+// getBackendWithConfig returns an initialized test backend for the given
+// BackendConfig
+func getBackendInitQueue(t *testing.T, c *logical.BackendConfig, tickInterval string) (*databaseBackend, *logical.BackendConfig, *mockNewDatabase) {
+	t.Helper()
+	// make queue ticks more frequent for tests
+	c.Config[queueTickIntervalKey] = tickInterval
+	c.StorageView = &logical.InmemStorage{}
+	// Create and init the backend ourselves instead of using a Factory because
+	// the factory function kicks off threads that cause racy tests.
+	b := Backend(c)
+	ctx := context.Background()
+	if err := b.Setup(ctx, c); err != nil {
+		t.Fatal(err)
+	}
+	b.schedule = &TestSchedule{}
+	b.credRotationQueue = queue.New()
+	b.initQueue(ctx, c)
+
+	mockDB := setupMockDB(b)
+
+	return b, c, mockDB
+}
+
 func getBackend(t *testing.T) (*databaseBackend, logical.Storage, *mockNewDatabase) {
 	t.Helper()
 	config := logical.TestBackendConfig()
@@ -1671,7 +1694,8 @@ func getBackend(t *testing.T) (*databaseBackend, logical.Storage, *mockNewDataba
 	// Create and init the backend ourselves instead of using a Factory because
 	// the factory function kicks off threads that cause racy tests.
 	b := Backend(config)
-	if err := b.Setup(context.Background(), config); err != nil {
+	ctx := context.Background()
+	if err := b.Setup(ctx, config); err != nil {
 		t.Fatal(err)
 	}
 	b.schedule = &TestSchedule{}

--- a/changelog/29537.txt
+++ b/changelog/29537.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+database: Fix a bug where static role passwords are erroneously rotated across backend restarts when using skip import rotation.
+```


### PR DESCRIPTION
## Description
The associated Enterprise PR is here: https://github.com/hashicorp/vault-enterprise/pull/7426

Fix a bug where passwords are rotated across backend restarts when they should not be.

## Solution
Use a the field `NextVaultRotation` which is Now + RotationPeriod (or next schedule) to calculate the queue priority in across backend reloads and calculate the TTL on GET /static-cred requests.

## Background
When skipping auto import rotation is enabled, vault does not rotate the password, leaving role.StaticAccount.LastVaultRotation as a zero value. This is problematic because Vault determines when to rotate a credential using LastVaultRotation + rotationPeriod. If LastVaultRotation is the zero value, adding rotationPeriod causes the credential to be placed at the front of the priority queue, triggering an immediate rotation on unseal.

We currently handle this in memory by setting LastVaultRotation to the current timestamp, ensuring that the credential doesn’t get pushed to the front of the queue. However, this is only done in memory (priority queue) and is not persisted to storage.  If the secrets engine gets reinitialized, Vault reloads static roles from storage with LastVaultRotation as the zero value. Vault again adds rotationPeriod, pushing the credential to the front of the queue and immediately rotating it.  This unexpected rotation can cause issues for customers who are not expecting their credentials to change.


### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
