### PR TITLE
Fix issue caused by group-creation forwarding.

### DIFF
--- a/vault/identity_store_conflicts.go
+++ b/vault/identity_store_conflicts.go
@@ -103,7 +103,7 @@ type duplicateReportingErrorResolver struct {
 	// when in case-sensitive mode.
 	//
 	// Since this is only ever called from `load*` methods on IdentityStore during
-	// an unseal we can assume that it's all from a single goroutine and does'nt
+	// an unseal we can assume that it's all from a single goroutine and doesn't
 	// need locking.
 	seenEntities     map[string][]*identity.Entity
 	seenGroups       map[string][]*identity.Group
@@ -316,8 +316,7 @@ type Warner interface {
 	Warn(msg string, args ...interface{})
 }
 
-// TODO set this correctly.
-const identityDuplicateReportUrl = "https://developer.hashicorp.com/vault/docs/upgrading/identity-deduplication"
+const identityDuplicateReportUrl = "https://developer.hashicorp.com/vault/docs/upgrading/deduplication"
 
 func (r *duplicateReportingErrorResolver) LogReport(log Warner) {
 	report := r.Report()

--- a/vault/identity_store_conflicts_test.go
+++ b/vault/identity_store_conflicts_test.go
@@ -65,7 +65,7 @@ func TestDuplicateReportingErrorResolver(t *testing.T) {
 	}
 
 	expectReport := `
-DUPLICATES DETECTED, see following logs for details and refer to https://developer.hashicorp.com/vault/docs/upgrading/identity-deduplication for resolution.:
+DUPLICATES DETECTED, see following logs for details and refer to https://developer.hashicorp.com/vault/docs/upgrading/deduplication for resolution.:
 1 different-case local entity alias duplicates found (potential security risk):
 local entity-alias "DIFFERENT-CASE-ALIAS-1" with mount accessor "local-mount" duplicates 1 others: id="00000000-0000-0000-0000-000000000009" canonical_id="11111111-0000-0000-0000-000000000009" force_deduplication="would merge others into this entity"
 local entity-alias "different-CASE-ALIAS-1" with mount accessor "local-mount" duplicates 1 others: id="00000000-0000-0000-0000-000000000010" canonical_id="11111111-0000-0000-0000-000000000010" force_deduplication="would merge into entity 11111111-0000-0000-0000-000000000009"
@@ -99,7 +99,7 @@ group "DIFFERENT-CASE-DUPE-1" with namespace ID "root" duplicates 1 others: id="
 group "exact-dupe-1" with namespace ID "root" duplicates 1 others: id="00000000-0000-0000-0000-000000000004" force_deduplication="would not rename"
 group "exact-dupe-1" with namespace ID "root" duplicates 1 others: id="00000000-0000-0000-0000-000000000005" force_deduplication="would rename to exact-dupe-1-00000000-0000-0000-0000-000000000005"
 end of group duplicates:
-end of identity duplicate report, refer to https://developer.hashicorp.com/vault/docs/upgrading/identity-deduplication for resolution.:
+end of identity duplicate report, refer to https://developer.hashicorp.com/vault/docs/upgrading/deduplication for resolution.:
 `
 
 	// Create a new errorResolver

--- a/vault/identity_store_group_aliases.go
+++ b/vault/identity_store_group_aliases.go
@@ -45,8 +45,12 @@ func groupAliasPaths(i *IdentityStore) []*framework.Path {
 				},
 			},
 
-			Callbacks: map[logical.Operation]framework.OperationFunc{
-				logical.UpdateOperation: i.pathGroupAliasRegister(),
+			Operations: map[logical.Operation]framework.OperationHandler{
+				logical.UpdateOperation: &framework.PathOperation{
+					Callback:                    i.pathGroupAliasRegister(),
+					ForwardPerformanceStandby:   true,
+					ForwardPerformanceSecondary: true,
+				},
 			},
 
 			HelpSynopsis:    strings.TrimSpace(groupAliasHelp["group-alias"][0]),
@@ -85,6 +89,8 @@ func groupAliasPaths(i *IdentityStore) []*framework.Path {
 					DisplayAttrs: &framework.DisplayAttributes{
 						OperationVerb: "update",
 					},
+					ForwardPerformanceStandby:   true,
+					ForwardPerformanceSecondary: true,
 				},
 				logical.ReadOperation: &framework.PathOperation{
 					Callback: i.pathGroupAliasIDRead(),
@@ -97,6 +103,8 @@ func groupAliasPaths(i *IdentityStore) []*framework.Path {
 					DisplayAttrs: &framework.DisplayAttributes{
 						OperationVerb: "delete",
 					},
+					ForwardPerformanceStandby:   true,
+					ForwardPerformanceSecondary: true,
 				},
 			},
 

--- a/vault/identity_store_util.go
+++ b/vault/identity_store_util.go
@@ -2035,14 +2035,6 @@ func (i *IdentityStore) UpsertGroupInTxn(ctx context.Context, txn *memdb.Txn, gr
 		return fmt.Errorf("group is nil")
 	}
 
-	g, err := i.MemDBGroupByName(ctx, group.Name, true)
-	if err != nil {
-		return err
-	}
-	if g != nil {
-		group.ID = g.ID
-	}
-
 	// Increment the modify index of the group
 	group.ModifyIndex++
 


### PR DESCRIPTION
### Description

Fixes a bug introduced in #29483. That PR included an attempt to prevent duplicate groups with different IDs being created by a race condition, however that fix interferes in a subtle way when duplicate groups (causes by historical bugs, like the one it was trying to fix) are already present in storage. It turns out that that code was not actually necessary for the fix - removing it doesn't make any of the test cases added in https://github.com/hashicorp/vault-enterprise/pull/6990 fail - I ran them over 40 times each locally with no failures.

This PR also fixes up the URL in the reports since the docs were moved around.

Fixes [VAULT-33879](https://hashicorp.atlassian.net/browse/VAULT-33879). This also fixes a bunch of potential new issues in the case that duplicate groups already exist - before this fix they would have loaded the contents of one group but swapped it's ID for another duplicate which is even more confusing and problematic than before!

There is no Enterprise part to this PR exactly, however while working on this I realised we deprecated an RPC and so will make a PR to remove it and make it error to avoid unexpected behavior during mixed version upgrade scenarios.

@biazmoreira The one thing you mentioned that I didn't get to was that we potentially missed some of the `group-alias` endpoints in the original PR. I took a quick look and it certainly does look like there are a couple of code paths there that get to doing an `UpsertGroup` which will no longer forward at the RPC level and are potentially even more broken than before because of that by #29483. Could you take a look? We can include that in this PR if so.

### TODO
 - [ ] Add forwarding to necessary group-alias endpoints too.

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [x] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.


[VAULT-33879]: https://hashicorp.atlassian.net/browse/VAULT-33879?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ