### PR TITLE
Fix failing AWS configuration test

### DIFF
--- a/ui/app/serializers/aws/root-config.js
+++ b/ui/app/serializers/aws/root-config.js
@@ -10,13 +10,6 @@ export default class AwsRootConfigSerializer extends ApplicationSerializer {
     if (!payload.data) {
       return super.normalizeResponse(...arguments);
     }
-    // remove identityTokenTtl and maxRetries if the API's default value of 0 or -1, respectively. We don't want to display this value on configuration details if they haven't changed the default value
-    if (payload.data.identity_token_ttl === 0) {
-      delete payload.data.identity_token_ttl;
-    }
-    if (payload.data.max_retries === -1) {
-      delete payload.data.max_retries;
-    }
     const normalizedPayload = {
       id: payload.id,
       backend: payload.backend,

--- a/ui/tests/acceptance/secrets/backend/aws/aws-configuration-test.js
+++ b/ui/tests/acceptance/secrets/backend/aws/aws-configuration-test.js
@@ -171,8 +171,9 @@ module('Acceptance | aws | configuration', function (hooks) {
       await runCmd(`delete sys/mounts/${path}`);
     });
 
-    test('it should show identityTokenTtl or maxRetries even they have not been set', async function (assert) {
-      // testing this scenario to document the intention that we will show fields that have not been set but are returned by the api due to defaults
+    test('it should show identityTokenTtl or maxRetries even if they have not been set', async function (assert) {
+      // documenting the intention that we show fields that have not been set but are returned by the api due to defaults
+      // this test also documents that maxRetries returns 0 while the API docs indicate -1 is the default value
       const path = `aws-${this.uid}`;
       await enablePage.enable('aws', path);
 

--- a/ui/tests/acceptance/secrets/backend/aws/aws-configuration-test.js
+++ b/ui/tests/acceptance/secrets/backend/aws/aws-configuration-test.js
@@ -171,7 +171,8 @@ module('Acceptance | aws | configuration', function (hooks) {
       await runCmd(`delete sys/mounts/${path}`);
     });
 
-    test('it should not show identityTokenTtl or maxRetries if they have not been set', async function (assert) {
+    test('it should show identityTokenTtl or maxRetries even they have not been set', async function (assert) {
+      // testing this scenario to document the intention that we will show fields that have not been set but are returned by the api due to defaults
       const path = `aws-${this.uid}`;
       await enablePage.enable('aws', path);
 
@@ -188,8 +189,10 @@ module('Acceptance | aws | configuration', function (hooks) {
       // the Serializer removes these two from the payload if the API returns their default value.
       assert
         .dom(GENERAL.infoRowValue('Identity token TTL'))
-        .doesNotExist('Identity token TTL does not show.');
-      assert.dom(GENERAL.infoRowValue('Max retries')).doesNotExist('Max retries does not show.');
+        .hasText('0', 'Identity token TTL shows default.');
+      assert
+        .dom(GENERAL.infoRowValue('Max retries'))
+        .hasText('0', 'Max retries shows 0 indicating the default will be used.');
       // cleanup
       await runCmd(`delete sys/mounts/${path}`);
     });


### PR DESCRIPTION
### Description
When I originally wrote the aws-configuration acceptance test, `maxRetries` would return -1 and be scrubbed from the details view by the adapter. 

1. With [pr #29497 ](https://github.com/hashicorp/vault/pull/29497/files#diff-11906daf04096f16c364abff4761df97c3b879915152cee7f14a03e1f74dc32eR192) maxRetries now returns `0`. The intention of this PR was
>AWS Secrets persists entries between writes. This means that if you had previously set a value, it will remain in the config even if you do not provide it in a following update.

I informed the backend that even on a fresh cluster with no AWS mounts the first AWS mount returns `0` for the `maxRetries` config value. Pushing this fix through to stop test failures, but if this was not their intention then you'll likely see another pr to address the fix if there is one.

3. I removed the scrubbing in the adapter to follow patterns in GCP and Azure.

Here's a screenshot of an AWS configuration if I only amended the Access Key and Secret Key.
![image](https://github.com/user-attachments/assets/85567da1-8d6e-4072-b8a5-574ee79c3bf6)


