### PR TITLE
Docs: Automatic cluster upgrades Autopilot note

### DIFF
--- a/website/content/docs/enterprise/automated-upgrades.mdx
+++ b/website/content/docs/enterprise/automated-upgrades.mdx
@@ -31,7 +31,7 @@ Autopilot subsystem within Vault will promote the new version nodes to voters wh
 running the latest Vault version equals or exceeds the number of pre-existing nodes. Vault then demotes
 the previous version's nodes to non-voters. Finally, leadership transfers from the prior leader to a
 randomly selected node running the newest Vault version and waits for the user to remove the previous
-nodes from the cluster.
+nodes from the cluster. Be aware that Autopilot [dead server cleanup](https://developer.hashicorp.com/vault/docs/concepts/integrated-storage/autopilot#dead-server-cleanup) automatically removes nodes deemed unhealthy from the Raft cluster when enabled.
 
 Below is a flowchart depicting Autopilot's automated upgrade state machine.
 

--- a/website/content/docs/enterprise/automated-upgrades.mdx
+++ b/website/content/docs/enterprise/automated-upgrades.mdx
@@ -31,7 +31,7 @@ Autopilot subsystem within Vault will promote the new version nodes to voters wh
 running the latest Vault version equals or exceeds the number of pre-existing nodes. Vault then demotes
 the previous version's nodes to non-voters. Finally, leadership transfers from the prior leader to a
 randomly selected node running the newest Vault version and waits for the user to remove the previous
-nodes from the cluster. Be aware that Autopilot [dead server cleanup](https://developer.hashicorp.com/vault/docs/concepts/integrated-storage/autopilot#dead-server-cleanup) automatically removes nodes deemed unhealthy from the Raft cluster when enabled.
+nodes from the cluster. Be aware that Autopilot [dead server cleanup](/vault/docs/concepts/integrated-storage/autopilot#dead-server-cleanup) automatically removes nodes deemed unhealthy from the Raft cluster when enabled.
 
 Below is a flowchart depicting Autopilot's automated upgrade state machine.
 


### PR DESCRIPTION

### Description
Adds a note about Autopilot server cleanup for [SPE-27](https://hashicorp.atlassian.net/browse/SPE-27)

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.


[SPE-27]: https://hashicorp.atlassian.net/browse/SPE-27?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ