### PR TITLE
Docs: add a note for quorum size scaling

### DIFF
--- a/website/content/docs/internals/integrated-storage.mdx
+++ b/website/content/docs/internals/integrated-storage.mdx
@@ -302,6 +302,12 @@ For example, if you start with a 5-node cluster:
 You should always maintain quorum to limit the impact on failure tolerance when
 changing or scaling your Vault instance.
 
+<Note>
+
+Be aware that you need to adjust peers as needed during scaling events, as purposeful scaling events to increase or reduce cluster size can transpire in a minimal time window. Consider this if you use Autopilot for automatic server cleanup because your scaling time window can be shorter than the default [dead_server_last_contract_threshold](/vault/docs/concepts/integrated-storage/autopilot#dead_server_last_contact_threshold), and you need to adjust this value in such cases.
+
+</Note>
+
 ### Redundancy Zones
 
 If you are using autopilot with [redundancy zones](/vault/docs/enterprise/redundancy-zones),


### PR DESCRIPTION
### Description

Mention scaling window and Autopilot wrt dead_server_last_contract_threshold for [SPE-994](https://hashicorp.atlassian.net/browse/SPE-994)

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.


[SPE-994]: https://hashicorp.atlassian.net/browse/SPE-994?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ