### PR TITLE
UI: MFA methods now display namespace_path instead of namespace_id

### DIFF
--- a/ui/app/models/mfa-method.js
+++ b/ui/app/models/mfa-method.js
@@ -58,7 +58,7 @@ export default class MfaMethod extends Model {
   @attr('string', {
     label: 'Namespace',
   })
-  namespace_id;
+  namespace_path;
   @attr('string') mount_accessor;
 
   // PING ID

--- a/ui/app/templates/components/mfa/method-list-item.hbs
+++ b/ui/app/templates/components/mfa/method-list-item.hbs
@@ -20,7 +20,7 @@
           <div class="has-top-margin-xs">
             <code class="is-size-9">
               Namespace:
-              {{@model.namespace_id}}
+              {{@model.namespace_path}}
             </code>
           </div>
         </div>

--- a/ui/tests/acceptance/mfa-login-enforcement-test.js
+++ b/ui/tests/acceptance/mfa-login-enforcement-test.js
@@ -171,7 +171,7 @@ module('Acceptance | mfa-login-enforcement', function (hooks) {
     assert
       .dom(`[data-test-mfa-method-list-item="${method.id}"]`)
       .includesText(
-        `${method.name} ${method.id} Namespace: ${method.namespace_id}`,
+        `${method.name} ${method.id} Namespace: ${method.namespace_path}`,
         'Method list item renders'
       );
     await click('[data-test-popup-menu-trigger]');

--- a/ui/tests/acceptance/mfa-method-test.js
+++ b/ui/tests/acceptance/mfa-method-test.js
@@ -66,7 +66,7 @@ module('Acceptance | mfa-method', function (hooks) {
     assert
       .dom(`[data-test-mfa-method-list-item="${model.id}"]`)
       .includesText(
-        `${model.name} ${model.id} Namespace: ${model.namespace_id}`,
+        `${model.name} ${model.id} Namespace: ${model.namespace_path}`,
         'Copy renders for list item'
       );
 


### PR DESCRIPTION
### Description
What does this PR do?
The namespace label for MFA method items previously showed the namespace id. This changes it to show the namespace path instead. 

Before: 
<img width="1129" alt="image" src="https://github.com/user-attachments/assets/c7bc287c-f860-47bd-8a21-20087d69aeac" />

After: 
<img width="1091" alt="image" src="https://github.com/user-attachments/assets/fb86e15e-9be3-4804-8c74-9b0beb9053f6" />


### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
