### PR TITLE
Fix OpenApi test for GCP Auth

### DIFF
--- a/ui/tests/helpers/openapi/expected-auth-attrs.js
+++ b/ui/tests/helpers/openapi/expected-auth-attrs.js
@@ -378,6 +378,13 @@ const gcp = {
       fieldGroup: 'default',
       type: 'object',
     },
+    disableAutomatedRotation: {
+      editType: 'boolean',
+      fieldGroup: 'default',
+      helpText:
+        'If set to true, will deregister all registered rotation jobs from the RotationManager for the plugin.',
+      type: 'boolean',
+    },
     gceAlias: {
       editType: 'string',
       helpText: 'Indicates what value to use when generating an alias for GCE authentications.',
@@ -416,6 +423,27 @@ const gcp = {
       editType: 'ttl',
       fieldGroup: 'default',
       helpText: 'Time-to-live of plugin identity tokens',
+    },
+    rotationPeriod: {
+      editType: 'number',
+      fieldGroup: 'default',
+      helpText:
+        'TTL for automatic credential rotation of the given username. Mutually exclusive with rotation_schedule',
+      type: 'number',
+    },
+    rotationSchedule: {
+      editType: 'string',
+      fieldGroup: 'default',
+      helpText:
+        'CRON-style string that will define the schedule on which rotations should occur. Mutually exclusive with rotation_period',
+      type: 'string',
+    },
+    rotationWindow: {
+      editType: 'number',
+      fieldGroup: 'default',
+      helpText:
+        'Specifies the amount of time in which the rotation is allowed to occur starting from a given rotation_schedule',
+      type: 'number',
     },
     serviceAccountEmail: {
       editType: 'string',


### PR DESCRIPTION
### Description
These fields were added from PR #29401

**Note:** there is a known behavior change where if a user submits a default gcp auth config they hit an API error. This is because the backend sees the default of `0` as a value, and both `rotation_window` and `rotation_period` cannot be set. This is something the backend will be addressing in a different pr. 
![image](https://github.com/user-attachments/assets/405f6b89-2f0c-4f41-86b1-40bb5d6d4435)


Confirmed the fields have been added to the auth form.
![image](https://github.com/user-attachments/assets/8995f939-ded4-4a64-8658-c4232f8ff62d)
![image](https://github.com/user-attachments/assets/2e3f7552-1376-43f8-afeb-4a46c966e0c8)


* Note this form is huge and a literal copy/paste of the openApi so it's not very pretty nor helpful.
![image](https://github.com/user-attachments/assets/f76d2bf8-4b86-4628-a498-4972d3ec0549)

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
