### PR TITLE
CE changes for VAULT-33452

### DIFF
--- a/changelog/29618.txt
+++ b/changelog/29618.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+events (enterprise): Send events downstream to a performance standby node only when there is a subscriber on the standby node with a filter matching the events.
+```

--- a/vault/eventbus/bus_test.go
+++ b/vault/eventbus/bus_test.go
@@ -818,8 +818,9 @@ func TestSubscribeGlobal_WithApply(t *testing.T) {
 	}
 }
 
-// TestSubscribeCluster tests that the cluster filter subscription mechanism works.
-func TestSubscribeCluster(t *testing.T) {
+// TestSubscribeClusterNode tests that the cluster node filter subscription
+// mechanism works.
+func TestSubscribeClusterNode(t *testing.T) {
 	bus, err := NewEventBus("", nil)
 	if err != nil {
 		t.Fatal(err)
@@ -830,7 +831,7 @@ func TestSubscribeCluster(t *testing.T) {
 	bus.filters.addPattern("somecluster", []string{""}, "abc*")
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	t.Cleanup(cancelFunc)
-	ch, cancel2, err := bus.NewClusterSubscription(ctx, "somecluster")
+	ch, cancel2, err := bus.NewClusterNodeSubscription(ctx, "somecluster")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -854,8 +855,9 @@ func TestSubscribeCluster(t *testing.T) {
 	}
 }
 
-// TestSubscribeCluster_WithApply tests that the cluster filter subscription mechanism works when using ApplyClusterFilterChanges.
-func TestSubscribeCluster_WithApply(t *testing.T) {
+// TestSubscribeClusterNode_WithApply tests that the cluster node filter
+// subscription mechanism works when using ApplyClusterNodeFilterChanges.
+func TestSubscribeClusterNode_WithApply(t *testing.T) {
 	bus, err := NewEventBus("", nil)
 	if err != nil {
 		t.Fatal(err)
@@ -865,14 +867,14 @@ func TestSubscribeCluster_WithApply(t *testing.T) {
 
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	t.Cleanup(cancelFunc)
-	bus.ApplyClusterFilterChanges("somecluster", []FilterChange{
+	bus.ApplyClusterNodeFilterChanges("somecluster", []FilterChange{
 		{
 			Operation:         FilterChangeAdd,
 			NamespacePatterns: []string{""},
 			EventTypePattern:  "abc*",
 		},
 	})
-	ch, cancel2, err := bus.NewClusterSubscription(ctx, "somecluster")
+	ch, cancel2, err := bus.NewClusterNodeSubscription(ctx, "somecluster")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -937,8 +939,9 @@ func TestClearGlobalFilter(t *testing.T) {
 	}
 }
 
-// TestClearClusterFilter tests that clearing a cluster filter means no messages get through.
-func TestClearClusterFilter(t *testing.T) {
+// TestClearClusterNodeFilter tests that clearing a cluster node filter means no
+// messages get through.
+func TestClearClusterNodeFilter(t *testing.T) {
 	bus, err := NewEventBus("", nil)
 	if err != nil {
 		t.Fatal(err)
@@ -948,15 +951,15 @@ func TestClearClusterFilter(t *testing.T) {
 
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	t.Cleanup(cancelFunc)
-	bus.ApplyClusterFilterChanges("somecluster", []FilterChange{
+	bus.ApplyClusterNodeFilterChanges("somecluster", []FilterChange{
 		{
 			Operation:         FilterChangeAdd,
 			NamespacePatterns: []string{""},
 			EventTypePattern:  "abc*",
 		},
 	})
-	bus.ClearClusterFilter("somecluster")
-	ch, cancel2, err := bus.NewClusterSubscription(ctx, "somecluster")
+	bus.ClearClusterNodeFilter("somecluster")
+	ch, cancel2, err := bus.NewClusterNodeSubscription(ctx, "somecluster")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1020,7 +1023,8 @@ func TestNotifyOnGlobalFilterChanges(t *testing.T) {
 	}
 }
 
-// TestNotifyOnLocalFilterChanges tests that notifications on local cluster filter changes are sent.
+// TestNotifyOnLocalFilterChanges tests that notifications on local cluster node
+// filter changes are sent.
 func TestNotifyOnLocalFilterChanges(t *testing.T) {
 	bus, err := NewEventBus("somecluster", nil)
 	if err != nil {
@@ -1037,7 +1041,7 @@ func TestNotifyOnLocalFilterChanges(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Cleanup(cancel2)
-	bus.ApplyClusterFilterChanges("somecluster", []FilterChange{
+	bus.ApplyClusterNodeFilterChanges("somecluster", []FilterChange{
 		{
 			Operation:         FilterChangeAdd,
 			NamespacePatterns: []string{""},

--- a/vault/eventbus/filter_test.go
+++ b/vault/eventbus/filter_test.go
@@ -45,7 +45,8 @@ func TestFilters_AddRemoveMatchLocal(t *testing.T) {
 	assert.False(t, f.anyMatch(ns, "abc"))
 }
 
-// TestFilters_Watch checks that adding a watch for a cluster will send a notification when the patterns are modified.
+// TestFilters_Watch checks that adding a watch for a cluster node will send a
+// notification when the patterns are modified.
 func TestFilters_Watch(t *testing.T) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	t.Cleanup(cancelFunc)
@@ -135,7 +136,7 @@ func TestFilters_AddRemoveClear(t *testing.T) {
 	f.removePattern("somecluster", []string{"ns1"}, "abc")
 	assert.Equal(t, "", f.filters["somecluster"].String())
 	f.addPattern("somecluster", []string{"ns1"}, "abc")
-	f.clearClusterPatterns("somecluster")
+	f.clearClusterNodePatterns("somecluster")
 	assert.NotContains(t, f.filters, "somecluster")
 
 	f.addGlobalPattern([]string{"ns1"}, "abc")


### PR DESCRIPTION
### Description
CE changes and changelog for https://github.com/hashicorp/vault-enterprise/pull/7400

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [-] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [-] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [-] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
