### PR TITLE
Fix OpenAPI test Azure Auth

### DIFF
--- a/ui/tests/helpers/openapi/expected-auth-attrs.js
+++ b/ui/tests/helpers/openapi/expected-auth-attrs.js
@@ -105,6 +105,13 @@ const azure = {
         'The OAuth2 client secret to connection to Azure. This value can also be provided with the AZURE_CLIENT_SECRET environment variable.',
       type: 'string',
     },
+    disableAutomatedRotation: {
+      editType: 'boolean',
+      fieldGroup: 'default',
+      helpText:
+        'If set to true, will deregister all registered rotation jobs from the RotationManager for the plugin.',
+      type: 'boolean',
+    },
     environment: {
       editType: 'string',
       fieldGroup: 'default',
@@ -141,6 +148,27 @@ const azure = {
       fieldGroup: 'default',
       helpText:
         'The TTL of the root password in Azure. This can be either a number of seconds or a time formatted duration (ex: 24h, 48ds)',
+    },
+    rotationPeriod: {
+      editType: 'number',
+      fieldGroup: 'default',
+      helpText:
+        'TTL for automatic credential rotation of the given username. Mutually exclusive with rotation_schedule',
+      type: 'number',
+    },
+    rotationSchedule: {
+      editType: 'string',
+      fieldGroup: 'default',
+      helpText:
+        'CRON-style string that will define the schedule on which rotations should occur. Mutually exclusive with rotation_period',
+      type: 'string',
+    },
+    rotationWindow: {
+      editType: 'number',
+      fieldGroup: 'default',
+      helpText:
+        'Specifies the amount of time in which the rotation is allowed to occur starting from a given rotation_schedule',
+      type: 'number',
     },
     tenantId: {
       editType: 'string',


### PR DESCRIPTION
### Description
Very similar to PR #29610, update OpenAPI params for Azure auth method.

Confirmed new attrs show:
<img width="372" alt="image" src="https://github.com/user-attachments/assets/4db70852-e3de-4ae3-8b7e-ef244336dc64" />
<img width="330" alt="image" src="https://github.com/user-attachments/assets/3764f92c-d9a5-496a-badf-6f5a22f95045" />

Note: Azure does not hit the same config issue that GCP does. 
