### PR TITLE
Fix rotation manager plugin logs in case of storage errors

### DIFF
--- a/builtin/credential/aws/path_config_client.go
+++ b/builtin/credential/aws/path_config_client.go
@@ -435,11 +435,10 @@ func (b *backend) pathConfigClientCreateUpdate(ctx context.Context, req *logical
 
 	if changedCreds || changedOtherConfig || req.Operation == logical.CreateOperation {
 		if err := req.Storage.Put(ctx, entry); err != nil {
-			b.Logger().Error("write to storage failed but the rotation manager still succeeded.",
-				"operation", performedRotationManagerOpern, "mount", req.MountPoint, "path", req.Path)
-
 			wrappedError := err
 			if performedRotationManagerOpern != "" {
+				b.Logger().Error("write to storage failed but the rotation manager still succeeded.",
+					"operation", performedRotationManagerOpern, "mount", req.MountPoint, "path", req.Path)
 				wrappedError = fmt.Errorf("write to storage failed but the rotation manager still succeeded; "+
 					"operation=%s, mount=%s, path=%s, storageError=%s", performedRotationManagerOpern, req.MountPoint, req.Path, err)
 			}

--- a/builtin/logical/aws/path_config_root.go
+++ b/builtin/logical/aws/path_config_root.go
@@ -283,11 +283,10 @@ func (b *backend) pathConfigRootWrite(ctx context.Context, req *logical.Request,
 
 	// Save the config
 	if err := putConfigToStorage(ctx, req, rc); err != nil {
-		b.Logger().Error("write to storage failed but the rotation manager still succeeded.",
-			"operation", performedRotationManagerOpern, "mount", req.MountPoint, "path", req.Path)
-
 		wrappedError := err
 		if performedRotationManagerOpern != "" {
+			b.Logger().Error("write to storage failed but the rotation manager still succeeded.",
+				"operation", performedRotationManagerOpern, "mount", req.MountPoint, "path", req.Path)
 			wrappedError = fmt.Errorf("write to storage failed but the rotation manager still succeeded; "+
 				"operation=%s, mount=%s, path=%s, storageError=%s", performedRotationManagerOpern, req.MountPoint, req.Path, err)
 		}

--- a/builtin/logical/database/path_config_connection.go
+++ b/builtin/logical/database/path_config_connection.go
@@ -611,11 +611,10 @@ func (b *databaseBackend) connectionWriteHandler() framework.OperationFunc {
 		}
 		err = storeConfig(ctx, req.Storage, name, config)
 		if err != nil {
-			b.Logger().Error("write to storage failed but the rotation manager still succeeded.",
-				"operation", performedRotationManagerOpern, "mount", req.MountPoint, "path", req.Path)
-
 			wrappedError := err
 			if performedRotationManagerOpern != "" {
+				b.Logger().Error("write to storage failed but the rotation manager still succeeded.",
+					"operation", performedRotationManagerOpern, "mount", req.MountPoint, "path", req.Path)
 				wrappedError = fmt.Errorf("write to storage failed but the rotation manager still succeeded; "+
 					"operation=%s, mount=%s, path=%s, storageError=%s", performedRotationManagerOpern, req.MountPoint, req.Path, err)
 			}


### PR DESCRIPTION
### Description
Only logs a certain error if Rotation Manager operations were performed. Moves the log into the if block as it was incorrectly placed before.
