### PR TITLE
UI: update openapi for auth-config/ldap model

### DIFF
--- a/ui/tests/helpers/openapi/expected-auth-attrs.js
+++ b/ui/tests/helpers/openapi/expected-auth-attrs.js
@@ -898,6 +898,13 @@ const ldap = {
       fieldGroup: 'default',
       type: 'string',
     },
+    disableAutomatedRotation: {
+      editType: 'boolean',
+      fieldGroup: 'default',
+      helpText:
+        'If set to true, will deregister all registered rotation jobs from the RotationManager for the plugin.',
+      type: 'boolean',
+    },
     discoverdn: {
       editType: 'boolean',
       helpText: 'Use anonymous bind to discover the bind DN of a user (optional)',
@@ -961,6 +968,27 @@ const ldap = {
       helpText:
         'Timeout, in seconds, for the connection when making requests against the server before returning back an error.',
       fieldGroup: 'default',
+    },
+    rotationPeriod: {
+      editType: 'number',
+      fieldGroup: 'default',
+      helpText:
+        'TTL for automatic credential rotation of the given username. Mutually exclusive with rotation_schedule',
+      type: 'number',
+    },
+    rotationSchedule: {
+      editType: 'string',
+      fieldGroup: 'default',
+      helpText:
+        'CRON-style string that will define the schedule on which rotations should occur. Mutually exclusive with rotation_period',
+      type: 'string',
+    },
+    rotationWindow: {
+      editType: 'number',
+      fieldGroup: 'default',
+      helpText:
+        'Specifies the amount of time in which the rotation is allowed to occur starting from a given rotation_schedule',
+      type: 'number',
     },
     starttls: {
       editType: 'boolean',


### PR DESCRIPTION
### Description

Adds `disableAutomatedRotation`, `rotationPeriod`, `rotationSchedule`, `rotationWindow` to the expected openAPI output and checks auto-generated form renders as expected
<img width="972" alt="Screenshot 2025-02-13 at 4 05 25 PM" src="https://github.com/user-attachments/assets/f8530651-ec6a-4f90-a078-8a8094205ea0" />

✅ openAPI params pass
<img width="892" alt="Screenshot 2025-02-13 at 4 04 25 PM" src="https://github.com/user-attachments/assets/d6091b72-7985-4149-ac36-6f79ca61fdcd" />


### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
