### PR TITLE
Add support for cross account management of static roles in AWS Secrets

### DIFF
--- a/builtin/logical/aws/backend.go
+++ b/builtin/logical/aws/backend.go
@@ -131,8 +131,9 @@ func (b *backend) clearClients() {
 }
 
 // clientIAM returns the configured IAM client. If nil, it constructs a new one
-// and returns it, setting it the internal variable
-func (b *backend) clientIAM(ctx context.Context, s logical.Storage) (iamiface.IAMAPI, error) {
+// and returns it, setting it the internal variable.
+// entry is only needed when configuring the client to use for role assumption.
+func (b *backend) clientIAM(ctx context.Context, s logical.Storage, entry *staticRoleEntry) (iamiface.IAMAPI, error) {
 	b.clientMutex.RLock()
 	if b.iamClient != nil {
 		b.clientMutex.RUnlock()
@@ -150,10 +151,11 @@ func (b *backend) clientIAM(ctx context.Context, s logical.Storage) (iamiface.IA
 		return b.iamClient, nil
 	}
 
-	iamClient, err := b.nonCachedClientIAM(ctx, s, b.Logger())
+	iamClient, err := b.nonCachedClientIAM(ctx, s, b.Logger(), entry)
 	if err != nil {
 		return nil, err
 	}
+
 	b.iamClient = iamClient
 
 	return b.iamClient, nil

--- a/builtin/logical/aws/backend.go
+++ b/builtin/logical/aws/backend.go
@@ -90,7 +90,7 @@ type backend struct {
 
 	// Function pointer used to override the IAM client creation for mocked testing
 	// If set, this function will be called instead of creating real IAM clients
-	nonCachedClientIAMTest func(context.Context, logical.Storage, hclog.Logger, *staticRoleEntry) (iamiface.IAMAPI, error)
+	nonCachedClientIAMFunc func(context.Context, logical.Storage, hclog.Logger, *staticRoleEntry) (iamiface.IAMAPI, error)
 
 	// Mutex to protect access to reading and writing policies
 	roleMutex sync.RWMutex
@@ -257,11 +257,11 @@ func (b *backend) initialize(ctx context.Context, request *logical.Initializatio
 }
 
 // getNonCachedIAMClient returns an IAM client. In a test env, if a mocked client creation
-// function is set (nonCachedClientIAMTest), it will be used instead of the default client creation function.
+// function is set (nonCachedClientIAMFunc), it will be used instead of the default client creation function.
 // This allows us to mock AWS clients in tests.
 func (b *backend) getNonCachedIAMClient(ctx context.Context, storage logical.Storage, cfg staticRoleEntry) (iamiface.IAMAPI, error) {
-	if b.nonCachedClientIAMTest != nil {
-		return b.nonCachedClientIAMTest(ctx, storage, b.Logger(), &cfg)
+	if b.nonCachedClientIAMFunc != nil {
+		return b.nonCachedClientIAMFunc(ctx, storage, b.Logger(), &cfg)
 	}
 	return b.nonCachedClientIAM(ctx, storage, b.Logger(), &cfg)
 }

--- a/builtin/logical/aws/client.go
+++ b/builtin/logical/aws/client.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/iam"
@@ -148,21 +149,33 @@ func (b *backend) getRootConfigs(ctx context.Context, s logical.Storage, clientT
 	return configs, nil
 }
 
-func (b *backend) nonCachedClientIAM(ctx context.Context, s logical.Storage, logger hclog.Logger) (*iam.IAM, error) {
-	awsConfig, err := b.getRootConfigs(ctx, s, "iam", logger)
-	if err != nil {
-		return nil, err
+func (b *backend) nonCachedClientIAM(ctx context.Context, s logical.Storage, logger hclog.Logger, entry *staticRoleEntry) (*iam.IAM, error) {
+	var awsConfig *aws.Config
+	var err error
+
+	if entry != nil && entry.AssumeRoleARN != "" {
+		awsConfig, err = b.assumeRoleStatic(ctx, s, entry)
+		if err != nil {
+			return nil, fmt.Errorf("failed to assume role %q: %w", entry.AssumeRoleARN, err)
+		}
+	} else {
+		configs, err := b.getRootConfigs(ctx, s, "iam", logger)
+		if err != nil {
+			return nil, err
+		}
+		if len(configs) != 1 {
+			return nil, errors.New("could not obtain aws config")
+		}
+		awsConfig = configs[0]
 	}
-	if len(awsConfig) != 1 {
-		return nil, errors.New("could not obtain aws config")
-	}
-	sess, err := session.NewSession(awsConfig[0])
+
+	sess, err := session.NewSession(awsConfig)
 	if err != nil {
 		return nil, err
 	}
 	client := iam.New(sess)
 	if client == nil {
-		return nil, fmt.Errorf("could not obtain iam client")
+		return nil, fmt.Errorf("could not obtain IAM client")
 	}
 	return client, nil
 }
@@ -195,6 +208,62 @@ func (b *backend) nonCachedClientSTS(ctx context.Context, s logical.Storage, log
 	}
 
 	return nil, fmt.Errorf("could not obtain sts client")
+}
+
+// assumeRoleStatic assumes an AWS role for cross-account static role management.
+// It uses the role ARN and session name provided in the staticRoleEntry configuration
+// to generate credentials for the assumed role.
+func (b *backend) assumeRoleStatic(ctx context.Context, s logical.Storage, entry *staticRoleEntry) (*aws.Config, error) {
+	if entry.AssumeRoleARN == "" {
+		return nil, fmt.Errorf("assume_role_arn must be specified for cross-account role management")
+	}
+
+	if entry.AssumeRoleSessionName == "" {
+		return nil, fmt.Errorf("assume_role_session_name must be specified for cross-account role management")
+	}
+
+	assumeRoleInput := &sts.AssumeRoleInput{
+		RoleArn:         aws.String(entry.AssumeRoleARN),
+		RoleSessionName: aws.String(entry.AssumeRoleSessionName),
+	}
+
+	// Add External ID if specified
+	if entry.ExternalID != "" {
+		assumeRoleInput.ExternalId = aws.String(entry.ExternalID)
+	}
+
+	stsClient, err := b.nonCachedClientSTS(ctx, s, b.Logger())
+	if stsClient == nil {
+		return nil, fmt.Errorf("STS client is nil: %w", err)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to create STS client: %w", err)
+	}
+	region := stsClient.Client.Config.Region // extract region from STS client config
+
+	// Assume the role
+	output, err := stsClient.AssumeRoleWithContext(ctx, assumeRoleInput)
+	if err != nil {
+		return nil, fmt.Errorf("failed to assume role %s: %w", entry.AssumeRoleARN, err)
+	}
+	b.Logger().Debug("Successfully assumed role", "role", entry.AssumeRoleARN, "access_key", *output.Credentials.AccessKeyId)
+
+	if output.Credentials == nil {
+		return nil, fmt.Errorf("STS response missing credentials for role %s", entry.AssumeRoleARN)
+	}
+
+	// Create new AWS credentials
+	creds := credentials.NewStaticCredentials(
+		*output.Credentials.AccessKeyId,
+		*output.Credentials.SecretAccessKey,
+		*output.Credentials.SessionToken,
+	)
+	config := &aws.Config{
+		Credentials: creds,
+		Region:      region,
+	}
+
+	return config, nil
 }
 
 // PluginIdentityTokenFetcher fetches plugin identity tokens from Vault. It is provided

--- a/builtin/logical/aws/client_ce.go
+++ b/builtin/logical/aws/client_ce.go
@@ -1,6 +1,8 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: BUSL-1.1
 
+//go:build !enterprise
+
 package aws
 
 import (

--- a/builtin/logical/aws/client_ce.go
+++ b/builtin/logical/aws/client_ce.go
@@ -15,5 +15,5 @@ import (
 // It uses the role ARN and session name provided in the staticRoleEntry configuration
 // to generate credentials for the assumed role.
 func (b *backend) assumeRoleStatic(ctx context.Context, s logical.Storage, entry *staticRoleEntry) (*aws.Config, error) {
-	return nil, fmt.Errorf("assumeRoleStatic is not supported in this version of Vault")
+	return nil, fmt.Errorf("cross-account static roles are only supported in Vault Enterprise")
 }

--- a/builtin/logical/aws/client_ce.go
+++ b/builtin/logical/aws/client_ce.go
@@ -1,0 +1,19 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package aws
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/hashicorp/vault/sdk/logical"
+)
+
+// assumeRoleStatic assumes an AWS role for cross-account static role management.
+// It uses the role ARN and session name provided in the staticRoleEntry configuration
+// to generate credentials for the assumed role.
+func (b *backend) assumeRoleStatic(ctx context.Context, s logical.Storage, entry *staticRoleEntry) (*aws.Config, error) {
+	return nil, fmt.Errorf("assumeRoleStatic is not supported in this version of Vault")
+}

--- a/builtin/logical/aws/iam_policies.go
+++ b/builtin/logical/aws/iam_policies.go
@@ -66,7 +66,7 @@ func (b *backend) getGroupPolicies(ctx context.Context, s logical.Storage, iamGr
 		return nil, nil, nil
 	}
 
-	iamClient, err = b.clientIAM(ctx, s)
+	iamClient, err = b.clientIAM(ctx, s, nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/builtin/logical/aws/path_config_rotate_root.go
+++ b/builtin/logical/aws/path_config_rotate_root.go
@@ -42,7 +42,7 @@ func (b *backend) pathConfigRotateRootUpdate(ctx context.Context, req *logical.R
 
 func (b *backend) rotateRoot(ctx context.Context, req *logical.Request) (*logical.Response, error) {
 	// have to get the client config first because that takes out a read lock
-	client, err := b.clientIAM(ctx, req.Storage)
+	client, err := b.clientIAM(ctx, req.Storage, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/builtin/logical/aws/path_static_roles.go
+++ b/builtin/logical/aws/path_static_roles.go
@@ -299,7 +299,7 @@ func (b *backend) validateRoleName(name string) error {
 // validateIAMUser checks the user information we have for the role against the information on AWS. On a create, it uses the username
 // to retrieve the user information and _sets_ the userID. On update, it validates the userID and username.
 func (b *backend) validateIAMUserExists(ctx context.Context, storage logical.Storage, entry *staticRoleEntry, isCreate bool) error {
-	c, err := b.nonCachedClientIAM(ctx, storage, b.Logger(), entry)
+	c, err := b.getNonCachedIAMClient(ctx, storage, *entry)
 	if err != nil {
 		return fmt.Errorf("unable to get client to validate username %q: %w", entry.Username, err)
 	}

--- a/builtin/logical/aws/path_static_roles_ce.go
+++ b/builtin/logical/aws/path_static_roles_ce.go
@@ -5,9 +5,17 @@
 
 package aws
 
-import "github.com/hashicorp/vault/sdk/framework"
+import (
+	"fmt"
+
+	"github.com/hashicorp/vault/sdk/framework"
+)
 
 // AddStaticAssumeRoleFieldsEnt is a no-op for community edition
 func AddStaticAssumeRoleFieldsEnt(fields map[string]*framework.FieldSchema) {
 	// no-op
+}
+
+func validateAssumeRoleFields(data *framework.FieldData, config *staticRoleEntry) error {
+	return fmt.Errorf("assumeRoleStatic is not supported in this version of Vault")
 }

--- a/builtin/logical/aws/path_static_roles_ce.go
+++ b/builtin/logical/aws/path_static_roles_ce.go
@@ -17,5 +17,13 @@ func AddStaticAssumeRoleFieldsEnt(fields map[string]*framework.FieldSchema) {
 }
 
 func validateAssumeRoleFields(data *framework.FieldData, config *staticRoleEntry) error {
-	return fmt.Errorf("assumeRoleStatic is not supported in this version of Vault")
+	_, hasAssumeRoleARN := data.GetOk(paramAssumeRoleARN)
+	_, hasRoleSessionName := data.GetOk(paramRoleSessionName)
+	_, hasExternalID := data.GetOk(paramExternalID)
+
+	if hasAssumeRoleARN || hasRoleSessionName || hasExternalID {
+		return fmt.Errorf("cross-account static roles are only supported in Vault Enterprise")
+	}
+
+	return nil
 }

--- a/builtin/logical/aws/path_static_roles_ce.go
+++ b/builtin/logical/aws/path_static_roles_ce.go
@@ -1,0 +1,13 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+//go:build !enterprise
+
+package aws
+
+import "github.com/hashicorp/vault/sdk/framework"
+
+// AddStaticAssumeRoleFieldsEnt is a no-op for community edition
+func AddStaticAssumeRoleFieldsEnt(fields map[string]*framework.FieldSchema) {
+	// no-op
+}

--- a/builtin/logical/aws/path_static_roles_test.go
+++ b/builtin/logical/aws/path_static_roles_test.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/aws/aws-sdk-go/service/iam/iamiface"
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-secure-stdlib/awsutil"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/logical"
@@ -97,7 +99,10 @@ func TestStaticRolesValidation(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			b.iamClient = miam
+			// Used to override the real IAM client creation to return the mocked client
+			b.nonCachedClientIAMTest = func(ctx context.Context, s logical.Storage, logger hclog.Logger, entry *staticRoleEntry) (iamiface.IAMAPI, error) {
+				return miam, nil
+			}
 			if err := b.Setup(bgCTX, config); err != nil {
 				t.Fatal(err)
 			}
@@ -241,7 +246,10 @@ func TestStaticRolesWrite(t *testing.T) {
 			}
 
 			b := Backend(config)
-			b.iamClient = miam
+			// Used to override the real IAM client creation to return the mocked client
+			b.nonCachedClientIAMTest = func(ctx context.Context, s logical.Storage, logger hclog.Logger, entry *staticRoleEntry) (iamiface.IAMAPI, error) {
+				return miam, nil
+			}
 			if err := b.Setup(bgCTX, config); err != nil {
 				t.Fatal(err)
 			}
@@ -454,7 +462,10 @@ func TestStaticRoleDelete(t *testing.T) {
 			}
 
 			b := Backend(config)
-			b.iamClient = miam
+			// Used to override the real IAM client creation to return the mocked client
+			b.nonCachedClientIAMTest = func(ctx context.Context, s logical.Storage, logger hclog.Logger, entry *staticRoleEntry) (iamiface.IAMAPI, error) {
+				return miam, nil
+			}
 
 			// put in storage
 			staticRole := staticRoleEntry{

--- a/builtin/logical/aws/path_static_roles_test.go
+++ b/builtin/logical/aws/path_static_roles_test.go
@@ -100,7 +100,7 @@ func TestStaticRolesValidation(t *testing.T) {
 				t.Fatal(err)
 			}
 			// Used to override the real IAM client creation to return the mocked client
-			b.nonCachedClientIAMTest = func(ctx context.Context, s logical.Storage, logger hclog.Logger, entry *staticRoleEntry) (iamiface.IAMAPI, error) {
+			b.nonCachedClientIAMFunc = func(ctx context.Context, s logical.Storage, logger hclog.Logger, entry *staticRoleEntry) (iamiface.IAMAPI, error) {
 				return miam, nil
 			}
 			if err := b.Setup(bgCTX, config); err != nil {
@@ -247,7 +247,7 @@ func TestStaticRolesWrite(t *testing.T) {
 
 			b := Backend(config)
 			// Used to override the real IAM client creation to return the mocked client
-			b.nonCachedClientIAMTest = func(ctx context.Context, s logical.Storage, logger hclog.Logger, entry *staticRoleEntry) (iamiface.IAMAPI, error) {
+			b.nonCachedClientIAMFunc = func(ctx context.Context, s logical.Storage, logger hclog.Logger, entry *staticRoleEntry) (iamiface.IAMAPI, error) {
 				return miam, nil
 			}
 			if err := b.Setup(bgCTX, config); err != nil {
@@ -463,7 +463,7 @@ func TestStaticRoleDelete(t *testing.T) {
 
 			b := Backend(config)
 			// Used to override the real IAM client creation to return the mocked client
-			b.nonCachedClientIAMTest = func(ctx context.Context, s logical.Storage, logger hclog.Logger, entry *staticRoleEntry) (iamiface.IAMAPI, error) {
+			b.nonCachedClientIAMFunc = func(ctx context.Context, s logical.Storage, logger hclog.Logger, entry *staticRoleEntry) (iamiface.IAMAPI, error) {
 				return miam, nil
 			}
 

--- a/builtin/logical/aws/path_user.go
+++ b/builtin/logical/aws/path_user.go
@@ -175,7 +175,7 @@ func (b *backend) pathUserRollback(ctx context.Context, req *logical.Request, _k
 	username := entry.UserName
 
 	// Get the client
-	client, err := b.clientIAM(ctx, req.Storage)
+	client, err := b.clientIAM(ctx, req.Storage, nil)
 	if err != nil {
 		return err
 	}

--- a/builtin/logical/aws/rotation.go
+++ b/builtin/logical/aws/rotation.go
@@ -88,7 +88,7 @@ func (b *backend) rotateCredential(ctx context.Context, storage logical.Storage)
 // createCredential will create a new iam credential, deleting the oldest one if necessary.
 func (b *backend) createCredential(ctx context.Context, storage logical.Storage, cfg staticRoleEntry, shouldLockStorage bool) (*awsCredentials, error) {
 	// Always create a fresh client
-	iamClient, err := b.nonCachedClientIAM(ctx, storage, b.Logger(), &cfg)
+	iamClient, err := b.getNonCachedIAMClient(ctx, storage, cfg)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get IAM client for role %q: %w", cfg.Name, err)
 	}

--- a/builtin/logical/aws/rotation.go
+++ b/builtin/logical/aws/rotation.go
@@ -59,6 +59,7 @@ func (b *backend) rotateCredential(ctx context.Context, storage logical.Storage)
 		return false, nil
 	}
 
+	b.Logger().Debug("rotating credential", "role", item.Key)
 	cfg := item.Value.(staticRoleEntry)
 
 	creds, err := b.createCredential(ctx, storage, cfg, true)
@@ -86,9 +87,10 @@ func (b *backend) rotateCredential(ctx context.Context, storage logical.Storage)
 
 // createCredential will create a new iam credential, deleting the oldest one if necessary.
 func (b *backend) createCredential(ctx context.Context, storage logical.Storage, cfg staticRoleEntry, shouldLockStorage bool) (*awsCredentials, error) {
-	iamClient, err := b.clientIAM(ctx, storage)
+	// Always create a fresh client
+	iamClient, err := b.nonCachedClientIAM(ctx, storage, b.Logger(), &cfg)
 	if err != nil {
-		return nil, fmt.Errorf("unable to get the AWS IAM client: %w", err)
+		return nil, fmt.Errorf("failed to get IAM client for role %q: %w", cfg.Name, err)
 	}
 
 	// IAM users can have a most 2 sets of keys at a time.
@@ -190,8 +192,13 @@ func (b *backend) deleteCredential(ctx context.Context, storage logical.Storage,
 		return fmt.Errorf("couldn't delete from storage: %w", err)
 	}
 
+	iamClient, err := b.nonCachedClientIAM(ctx, storage, b.Logger(), &cfg)
+	if err != nil {
+		return fmt.Errorf("failed to get IAM client for role %q while deleting: %w", cfg.Name, err)
+	}
+
 	// because we have the information, this is the one we created, so it's safe for us to delete.
-	_, err = b.iamClient.DeleteAccessKey(&iam.DeleteAccessKeyInput{
+	_, err = iamClient.DeleteAccessKey(&iam.DeleteAccessKeyInput{
 		AccessKeyId: aws.String(creds.AccessKeyID),
 		UserName:    aws.String(cfg.Username),
 	})

--- a/builtin/logical/aws/rotation_test.go
+++ b/builtin/logical/aws/rotation_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/aws/aws-sdk-go/service/iam/iamiface"
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-secure-stdlib/awsutil"
 	"github.com/hashicorp/vault/api"
 	"github.com/hashicorp/vault/helper/testhelpers"
@@ -146,7 +147,14 @@ func TestRotation(t *testing.T) {
 				if err != nil {
 					t.Fatalf("couldn't initialze mock IAM handler: %s", err)
 				}
-				b.iamClient = miam
+				// b.iamClient = miam
+				// Used to override the IAM client creation to return the mocked client
+				b.nonCachedClientIAMTest = func(ctx context.Context, storage logical.Storage, logger hclog.Logger, entry *staticRoleEntry) (iamiface.IAMAPI, error) {
+					if entry.Username == cred.config.Username && entry.ID == cred.config.ID {
+						return miam, nil
+					}
+					return nil, fmt.Errorf("unexpected IAM client creation for user %q", entry.Username)
+				}
 
 				c, err := b.createCredential(bgCTX, config.StorageView, cred.config, true)
 				if err != nil {
@@ -192,7 +200,11 @@ func TestRotation(t *testing.T) {
 			if err != nil {
 				t.Fatalf("couldn't initialze mock IAM handler: %s", err)
 			}
-			b.iamClient = miam
+			// b.iamClient = miam
+			// Set the IAM mock client to be used in the rotation
+			b.nonCachedClientIAMTest = func(ctx context.Context, storage logical.Storage, logger hclog.Logger, entry *staticRoleEntry) (iamiface.IAMAPI, error) {
+				return miam, nil
+			}
 
 			req := &logical.Request{
 				Storage: config.StorageView,
@@ -340,7 +352,10 @@ func TestCreateCredential(t *testing.T) {
 			}
 
 			b := Backend(config)
-			b.iamClient = fiam
+			// b.iamClient = fiam
+			b.nonCachedClientIAMTest = func(ctx context.Context, s logical.Storage, logger hclog.Logger, entry *staticRoleEntry) (iamiface.IAMAPI, error) {
+				return fiam, nil
+			}
 
 			_, err = b.createCredential(context.Background(), config.StorageView, staticRoleEntry{Username: c.username, ID: c.id}, true)
 			if err != nil {
@@ -403,7 +418,10 @@ func TestRequeueOnError(t *testing.T) {
 		t.Fail()
 	}
 
-	b.iamClient = miam
+	// Used to override the IAM real client creation to return the mocked client
+	b.nonCachedClientIAMTest = func(ctx context.Context, s logical.Storage, logger hclog.Logger, entry *staticRoleEntry) (iamiface.IAMAPI, error) {
+		return miam, nil
+	}
 
 	_, err = b.createCredential(bgCTX, config.StorageView, cred, true)
 	if err != nil {
@@ -428,7 +446,9 @@ func TestRequeueOnError(t *testing.T) {
 	if err != nil {
 		t.Fatalf("couldn't initialize the mock iam: %s", err)
 	}
-	b.iamClient = miam
+	b.nonCachedClientIAMTest = func(ctx context.Context, s logical.Storage, logger hclog.Logger, entry *staticRoleEntry) (iamiface.IAMAPI, error) {
+		return miam, nil
+	}
 
 	// now rotate, but it will fail
 	r, e := b.rotateCredential(bgCTX, config.StorageView)
@@ -501,6 +521,12 @@ func Test_RotationQueueInitialized(t *testing.T) {
 				b := Backend(config)
 				b.iamClient = mockClient
 				b.minAllowableRotationPeriod = 1 * time.Second
+
+				// Used to override the IAM real client creation to return the mocked client
+				b.nonCachedClientIAMTest = func(ctx context.Context, storage logical.Storage, logger hclog.Logger, entry *staticRoleEntry) (iamiface.IAMAPI, error) {
+					return mockClient, nil
+				}
+
 				err := b.Setup(ctx, config)
 				return b, err
 			},

--- a/builtin/logical/aws/rotation_test.go
+++ b/builtin/logical/aws/rotation_test.go
@@ -149,7 +149,7 @@ func TestRotation(t *testing.T) {
 				}
 
 				// Used to override the IAM client creation to return the mocked client
-				b.nonCachedClientIAMTest = func(ctx context.Context, storage logical.Storage, logger hclog.Logger, entry *staticRoleEntry) (iamiface.IAMAPI, error) {
+				b.nonCachedClientIAMFunc = func(ctx context.Context, storage logical.Storage, logger hclog.Logger, entry *staticRoleEntry) (iamiface.IAMAPI, error) {
 					if entry.Username == cred.config.Username && entry.ID == cred.config.ID {
 						return miam, nil
 					}
@@ -202,7 +202,7 @@ func TestRotation(t *testing.T) {
 			}
 
 			// Set the IAM mock client to be used in the rotation
-			b.nonCachedClientIAMTest = func(ctx context.Context, storage logical.Storage, logger hclog.Logger, entry *staticRoleEntry) (iamiface.IAMAPI, error) {
+			b.nonCachedClientIAMFunc = func(ctx context.Context, storage logical.Storage, logger hclog.Logger, entry *staticRoleEntry) (iamiface.IAMAPI, error) {
 				return miam, nil
 			}
 
@@ -353,7 +353,7 @@ func TestCreateCredential(t *testing.T) {
 
 			b := Backend(config)
 
-			b.nonCachedClientIAMTest = func(ctx context.Context, s logical.Storage, logger hclog.Logger, entry *staticRoleEntry) (iamiface.IAMAPI, error) {
+			b.nonCachedClientIAMFunc = func(ctx context.Context, s logical.Storage, logger hclog.Logger, entry *staticRoleEntry) (iamiface.IAMAPI, error) {
 				return fiam, nil
 			}
 
@@ -419,7 +419,7 @@ func TestRequeueOnError(t *testing.T) {
 	}
 
 	// Used to override the IAM real client creation to return the mocked client
-	b.nonCachedClientIAMTest = func(ctx context.Context, s logical.Storage, logger hclog.Logger, entry *staticRoleEntry) (iamiface.IAMAPI, error) {
+	b.nonCachedClientIAMFunc = func(ctx context.Context, s logical.Storage, logger hclog.Logger, entry *staticRoleEntry) (iamiface.IAMAPI, error) {
 		return miam, nil
 	}
 
@@ -446,7 +446,7 @@ func TestRequeueOnError(t *testing.T) {
 	if err != nil {
 		t.Fatalf("couldn't initialize the mock iam: %s", err)
 	}
-	b.nonCachedClientIAMTest = func(ctx context.Context, s logical.Storage, logger hclog.Logger, entry *staticRoleEntry) (iamiface.IAMAPI, error) {
+	b.nonCachedClientIAMFunc = func(ctx context.Context, s logical.Storage, logger hclog.Logger, entry *staticRoleEntry) (iamiface.IAMAPI, error) {
 		return miam, nil
 	}
 
@@ -523,7 +523,7 @@ func Test_RotationQueueInitialized(t *testing.T) {
 				b.minAllowableRotationPeriod = 1 * time.Second
 
 				// Used to override the IAM real client creation to return the mocked client
-				b.nonCachedClientIAMTest = func(ctx context.Context, storage logical.Storage, logger hclog.Logger, entry *staticRoleEntry) (iamiface.IAMAPI, error) {
+				b.nonCachedClientIAMFunc = func(ctx context.Context, storage logical.Storage, logger hclog.Logger, entry *staticRoleEntry) (iamiface.IAMAPI, error) {
 					return mockClient, nil
 				}
 

--- a/builtin/logical/aws/rotation_test.go
+++ b/builtin/logical/aws/rotation_test.go
@@ -147,7 +147,7 @@ func TestRotation(t *testing.T) {
 				if err != nil {
 					t.Fatalf("couldn't initialze mock IAM handler: %s", err)
 				}
-				// b.iamClient = miam
+
 				// Used to override the IAM client creation to return the mocked client
 				b.nonCachedClientIAMTest = func(ctx context.Context, storage logical.Storage, logger hclog.Logger, entry *staticRoleEntry) (iamiface.IAMAPI, error) {
 					if entry.Username == cred.config.Username && entry.ID == cred.config.ID {
@@ -200,7 +200,7 @@ func TestRotation(t *testing.T) {
 			if err != nil {
 				t.Fatalf("couldn't initialze mock IAM handler: %s", err)
 			}
-			// b.iamClient = miam
+
 			// Set the IAM mock client to be used in the rotation
 			b.nonCachedClientIAMTest = func(ctx context.Context, storage logical.Storage, logger hclog.Logger, entry *staticRoleEntry) (iamiface.IAMAPI, error) {
 				return miam, nil
@@ -352,7 +352,7 @@ func TestCreateCredential(t *testing.T) {
 			}
 
 			b := Backend(config)
-			// b.iamClient = fiam
+
 			b.nonCachedClientIAMTest = func(ctx context.Context, s logical.Storage, logger hclog.Logger, entry *staticRoleEntry) (iamiface.IAMAPI, error) {
 				return fiam, nil
 			}

--- a/builtin/logical/aws/secret_access_keys.go
+++ b/builtin/logical/aws/secret_access_keys.go
@@ -361,7 +361,7 @@ func (b *backend) secretAccessKeysCreate(
 	displayName, policyName string,
 	role *awsRoleEntry,
 ) (*logical.Response, error) {
-	iamClient, err := b.clientIAM(ctx, s)
+	iamClient, err := b.clientIAM(ctx, s, nil)
 	if err != nil {
 		return logical.ErrorResponse(err.Error()), nil
 	}

--- a/website/content/api-docs/secret/aws.mdx
+++ b/website/content/api-docs/secret/aws.mdx
@@ -696,6 +696,15 @@ Vault should wait before rotating the password. The minimum is 1 minute. Can be
 specified in either `24h` or `86400` format (see [duration format strings](/vault/docs/concepts/duration-format)).
 Updating the rotation period will 'reset' the next rotation to occur at `now` + `rotation_period`.
 
+- `assume_role_arn` `(string)` – Specifies the ARN of the role that Vault should assume.
+When provided, Vault will use AWS STS to assume this role and generate temporary credentials.
+If `assume_role_arn` is provided, `assume_role_session_name` must also be provided.
+
+- `assume_role_session_name` `(string)` – Specifies the session name to use when assuming the role.
+If `assume_role_session_name` is provided, `assume_role_arn` must also be provided.
+
+- `external_id` `(string)` – Specifies the external ID to use when assuming the role.
+
 ### Sample payload
 
 ```json

--- a/website/content/api-docs/secret/aws.mdx
+++ b/website/content/api-docs/secret/aws.mdx
@@ -696,15 +696,6 @@ Vault should wait before rotating the password. The minimum is 1 minute. Can be
 specified in either `24h` or `86400` format (see [duration format strings](/vault/docs/concepts/duration-format)).
 Updating the rotation period will 'reset' the next rotation to occur at `now` + `rotation_period`.
 
-- `assume_role_arn` `(string)` – Specifies the ARN of the role that Vault should assume.
-When provided, Vault will use AWS STS to assume this role and generate temporary credentials.
-If `assume_role_arn` is provided, `assume_role_session_name` must also be provided.
-
-- `assume_role_session_name` `(string)` – Specifies the session name to use when assuming the role.
-If `assume_role_session_name` is provided, `assume_role_arn` must also be provided.
-
-- `external_id` `(string)` – Specifies the external ID to use when assuming the role.
-
 ### Sample payload
 
 ```json


### PR DESCRIPTION
### Description
What does this PR do?

This is the CE component of adding cross account management of static roles for AWS Secrets. 
ENT PR: https://github.com/hashicorp/vault-enterprise/pull/7353

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
