### PR TITLE
Updating docs to include new assume role fields

### DIFF
--- a/website/content/api-docs/secret/aws.mdx
+++ b/website/content/api-docs/secret/aws.mdx
@@ -703,7 +703,7 @@ specified in either `24h` or `86400` format (see [duration format strings](/vaul
 Updating the rotation period will 'reset' the next rotation to occur at `now` + `rotation_period`.
 
 - `assume_role_arn` `(string)` – <EnterpriseAlert product="vault" inline /> Specifies the ARN of the IAM role in the target AWS account that Vault should assume.
-When provided, Vault will use STS to assume this role and generate temporary credentials.
+When provided, Vault uses the assumed IAM role to generate temporary credentials.
 When set, `assume_role_session_name` must also be provided.
 
 - `assume_role_session_name` `(string)` – <EnterpriseAlert product="vault" inline /> Specifies the session name to use when assuming the role.

--- a/website/content/api-docs/secret/aws.mdx
+++ b/website/content/api-docs/secret/aws.mdx
@@ -670,7 +670,7 @@ This endpoint creates or updates static role definitions. A static role is a 1-t
 with an AWS IAM User, which will be adopted and managed by Vault, including rotating it according
 to the configured `rotation_period`.
 
-In addition, this endpoint (Requires Vault Enterprise 1.19+) now supports cross account management.
+In addition, this endpoint supports cross account management.
 Vault will use the credentials obtained by assuming roles in another AWS account to perform AWS operations.
 Make sure that the IAM user or role configured in Vault has the necessary permissions to assume those roles.
 

--- a/website/content/api-docs/secret/aws.mdx
+++ b/website/content/api-docs/secret/aws.mdx
@@ -670,6 +670,10 @@ This endpoint creates or updates static role definitions. A static role is a 1-t
 with an AWS IAM User, which will be adopted and managed by Vault, including rotating it according
 to the configured `rotation_period`.
 
+In addition, this endpoint (Requires Vault Enterprise 1.19+) now supports cross account management.
+Vault will use the credentials obtained by assuming roles in another AWS account to perform AWS operations.
+Make sure that the IAM user or role configured in Vault has the necessary permissions to assume those roles.
+
 <Note>
 
   Vault will create a new credential upon configuration, and if the maximum number of access keys already exist,
@@ -727,6 +731,20 @@ $ curl \
 ```
 
 ### Sample response
+
+```json
+{
+  "data": {
+    "assume_role_arn": "",
+    "assume_role_session_name": "",
+    "external_id": "",
+    "id": "AIDA..",
+    "name": "my-static-role",
+    "rotation_period": 41400,
+    "username": "example-user"
+  }
+}
+```
 
 ## Read static role
 

--- a/website/content/api-docs/secret/aws.mdx
+++ b/website/content/api-docs/secret/aws.mdx
@@ -702,14 +702,14 @@ Vault should wait before rotating the password. The minimum is 1 minute. Can be
 specified in either `24h` or `86400` format (see [duration format strings](/vault/docs/concepts/duration-format)).
 Updating the rotation period will 'reset' the next rotation to occur at `now` + `rotation_period`.
 
-- `assume_role_arn` `(string)` – Specifies the ARN of the role that Vault should assume.
-When provided, Vault will use AWS STS to assume this role and generate temporary credentials.
-If `assume_role_arn` is provided, `assume_role_session_name` must also be provided.
+- `assume_role_arn` `(string)` – <EnterpriseAlert product="vault" inline /> Specifies the ARN of the IAM role in the target AWS account that Vault should assume.
+When provided, Vault will use STS to assume this role and generate temporary credentials.
+When set, `assume_role_session_name` must also be provided.
 
-- `assume_role_session_name` `(string)` – Specifies the session name to use when assuming the role.
-If `assume_role_session_name` is provided, `assume_role_arn` must also be provided.
+- `assume_role_session_name` `(string)` – <EnterpriseAlert product="vault" inline /> Specifies the session name to use when assuming the role.
+When set, `assume_role_arn` must also be provided.
 
-- `external_id` `(string)` – Specifies the external ID to use when assuming the role.
+- `external_id` `(string)` – <EnterpriseAlert product="vault" inline /> Specifies the external ID to use when assuming the role, if one was set on the IAM role.
 
 ### Sample payload
 

--- a/website/content/api-docs/secret/aws.mdx
+++ b/website/content/api-docs/secret/aws.mdx
@@ -670,8 +670,8 @@ This endpoint creates or updates static role definitions. A static role is a 1-t
 with an AWS IAM User, which will be adopted and managed by Vault, including rotating it according
 to the configured `rotation_period`.
 
-In addition, this endpoint supports cross account management.
-Vault will use the credentials obtained by assuming roles in another AWS account to perform AWS operations.
+In addition, this endpoint supports cross-account management.
+Vault will use the credentials obtained by assuming a role in another AWS account to perform AWS operations.
 Make sure that the IAM user or role configured in Vault has the necessary permissions to assume those roles.
 
 <Note>

--- a/website/content/api-docs/secret/aws.mdx
+++ b/website/content/api-docs/secret/aws.mdx
@@ -695,7 +695,7 @@ Make sure that the IAM user or role configured in Vault has the necessary permis
 - `name` `(string: <required>)` – Specifies the name of the role to create. This
 is specified as part of the URL.
 
-- `username` `(string: <required>)` – Specifies the username of the IAM user.
+- `username` `(string: <required>)` – Specifies the username of the IAM user to be managed.
 
 - `rotation_period` `(string/int: <required>)` – Specifies the amount of time
 Vault should wait before rotating the password. The minimum is 1 minute. Can be

--- a/website/content/api-docs/secret/aws.mdx
+++ b/website/content/api-docs/secret/aws.mdx
@@ -672,7 +672,7 @@ to the configured `rotation_period`.
 
 In addition, this endpoint supports cross-account management.
 Vault will use the credentials obtained by assuming a role in another AWS account to perform AWS operations.
-Make sure that the IAM user or role configured in Vault has the necessary permissions to assume those roles.
+Make sure that the IAM role configured in Vault has the necessary permissions to manage the IAM user within the target account.
 
 <Note>
 

--- a/website/content/api-docs/secret/aws.mdx
+++ b/website/content/api-docs/secret/aws.mdx
@@ -698,6 +698,15 @@ Vault should wait before rotating the password. The minimum is 1 minute. Can be
 specified in either `24h` or `86400` format (see [duration format strings](/vault/docs/concepts/duration-format)).
 Updating the rotation period will 'reset' the next rotation to occur at `now` + `rotation_period`.
 
+- `assume_role_arn` `(string)` – Specifies the ARN of the role that Vault should assume.
+When provided, Vault will use AWS STS to assume this role and generate temporary credentials.
+If `assume_role_arn` is provided, `assume_role_session_name` must also be provided.
+
+- `assume_role_session_name` `(string)` – Specifies the session name to use when assuming the role.
+If `assume_role_session_name` is provided, `assume_role_arn` must also be provided.
+
+- `external_id` `(string)` – Specifies the external ID to use when assuming the role.
+
 ### Sample payload
 
 ```json

--- a/website/content/api-docs/secret/aws.mdx
+++ b/website/content/api-docs/secret/aws.mdx
@@ -738,7 +738,7 @@ $ curl \
     "assume_role_arn": "",
     "assume_role_session_name": "",
     "external_id": "",
-    "id": "AIDA..",
+    "id": "AIDA...",
     "name": "my-static-role",
     "rotation_period": 41400,
     "username": "example-user"

--- a/website/content/docs/secrets/aws.mdx
+++ b/website/content/docs/secrets/aws.mdx
@@ -484,11 +484,11 @@ To configure a cross-account static role:
 
 1. Ensure Vault has access to AWS STS and IAM endpoints.
 1. Create an IAM role in the target AWS account that allows Vault to assume it.
-  1. The role must trust the Vault AWS account to assume it and have the necessary IAM permissions to manage IAM users.
-  1. Use an external ID for enhanced security (optional but recommended).
-1. Create a static role in Vault.
-  1. Set the target account's ARN with the `assume_role_arn` field.
-  1. Set the target account's session name with the `assume_role_session_name` field.
+  The role must trust the Vault AWS account to assume it and have the necessary IAM
+  permissions to manage IAM users.
+1. (Optional, but recommended) Set an external ID for enhanced security.
+1. Create a static role in Vault with the target account's role ARN and session name,
+  using the `assume_role_arn` and `assume_role_session_name` fields respectively.
 
 ```shell-session
 $ vault write aws/static-roles/<role-name> \

--- a/website/content/docs/secrets/aws.mdx
+++ b/website/content/docs/secrets/aws.mdx
@@ -476,7 +476,7 @@ for more details on the fields associated with plugin WIF.
 
 ## Cross-account static role management
 
-<EnterpriseAlert product="vault" />
+@include 'alerts/enterprise-only.mdx'
 
 Vault supports cross-account access for AWS static roles. You can configure credential management for IAM users across multiple AWS accounts by assuming roles in the other accounts.
 

--- a/website/content/docs/secrets/aws.mdx
+++ b/website/content/docs/secrets/aws.mdx
@@ -505,7 +505,8 @@ Once configured, Vault will:
 1. Manage and rotate the IAM user's credentials according to the specified `rotation_period`.
 1. Return the IAM user's access key and secret key when requested via `aws/static-creds/<role-name>`.
 
-Please see the [API documentation](/vault/api-docs/secret/aws#create-update-static-role)
+Refer to the
+[create and update static role endpoint documentation](/vault/api-docs/secret/aws#create-update-static-role)
 for more details on the fields associated with the cross-account management of static roles.
 
 ## STS credentials

--- a/website/content/docs/secrets/aws.mdx
+++ b/website/content/docs/secrets/aws.mdx
@@ -486,6 +486,9 @@ To configure a cross-account static role:
 1. Create an IAM role in the target AWS account that allows Vault to assume it.
   1. The role must trust the Vault AWS account to assume it and have the necessary IAM permissions to manage IAM users.
   1. Use an external ID for enhanced security (optional but recommended).
+1. Create a static role in Vault.
+  1. Set the target account's ARN with the `assume_role_arn` field.
+  1. Set the target account's session name with the `assume_role_session_name` field.
 
 ```shell-session
 $ vault write aws/static-roles/<role-name> \

--- a/website/content/docs/secrets/aws.mdx
+++ b/website/content/docs/secrets/aws.mdx
@@ -474,6 +474,38 @@ have a time-to-live of 1 hour and automatically refresh when they expire.
 Please see the [API documentation](/vault/api-docs/secret/aws#configure-root-credentials)
 for more details on the fields associated with plugin WIF.
 
+## Cross-Account Management of Static Roles
+
+<EnterpriseAlert product="vault" />
+
+Vault now supports cross-account access for AWS static roles,
+allowing credential management for IAM users across multiple AWS accounts via AWS Security Token Service (STS).
+
+To configure a cross-account static role:
+
+1. Ensure Vault has access to AWS STS and IAM endpoints.
+1. Create an IAM role in the target AWS account that allows Vault to assume it.
+  1. The role must trust the Vault AWS account to assume it and have the necessary IAM permissions to manage IAM users.
+  1. Use an external ID for enhanced security (optional but recommended).
+
+```shell-session
+$ vault write aws/static-roles/<role-name> \
+    username="<iam-user>" \
+    assume_role_arn="arn:aws:iam::<account-id>:role/<role-name>" \
+    assume_role_session_name="<session-name>" \
+    external_id="<unique-id>" \
+    rotation_period="1h"
+```
+
+Once configured, Vault will:
+
+1. Assume the specified role in the target AWS account.
+1. Manage and rotate the IAM user's credentials according to the specified `rotation_period`.
+1. Return the IAM user's access key and secret key when requested via `aws/static-creds/<role-name>`.
+
+Please see the [API documentation](/vault/api-docs/secret/aws#create-update-static-role)
+for more details on the fields associated with the cross-account management of static roles.
+
 ## STS credentials
 
 The above demonstrated usage with `iam_user` credential types. As mentioned,

--- a/website/content/docs/secrets/aws.mdx
+++ b/website/content/docs/secrets/aws.mdx
@@ -492,8 +492,8 @@ To configure a cross-account static role:
 
 ```shell-session
 $ vault write aws/static-roles/<role-name> \
-    username="<iam-user>" \
-    assume_role_arn="arn:aws:iam::<account-id>:role/<role-name>" \
+    username="<iam-user-to-manage>" \
+    assume_role_arn="arn:aws:iam::<account-id>:role/<role-name-in-target-account>" \
     assume_role_session_name="<session-name>" \
     external_id="<unique-id>" \
     rotation_period="1h"

--- a/website/content/docs/secrets/aws.mdx
+++ b/website/content/docs/secrets/aws.mdx
@@ -487,8 +487,9 @@ To configure a cross-account static role:
   The role must trust the Vault AWS account to assume it and have the necessary IAM
   permissions to manage IAM users.
 1. (Optional, but recommended) Set an external ID for enhanced security.
-1. Create a static role in Vault with the target account's role ARN and session name,
-  using the `assume_role_arn` and `assume_role_session_name` fields respectively.
+1. Create a static role in Vault.
+   1. Use the `assume_role_arn` field to set the target account ARN.
+   1. Use the `assume_role_session_name` field to set the target account session name.
 
 ```shell-session
 $ vault write aws/static-roles/<role-name> \

--- a/website/content/docs/secrets/aws.mdx
+++ b/website/content/docs/secrets/aws.mdx
@@ -474,7 +474,7 @@ have a time-to-live of 1 hour and automatically refresh when they expire.
 Please see the [API documentation](/vault/api-docs/secret/aws#configure-root-credentials)
 for more details on the fields associated with plugin WIF.
 
-## Cross-Account Management of Static Roles
+## Cross-account management of static roles
 
 <EnterpriseAlert product="vault" />
 

--- a/website/content/docs/secrets/aws.mdx
+++ b/website/content/docs/secrets/aws.mdx
@@ -474,7 +474,7 @@ have a time-to-live of 1 hour and automatically refresh when they expire.
 Please see the [API documentation](/vault/api-docs/secret/aws#configure-root-credentials)
 for more details on the fields associated with plugin WIF.
 
-## Cross-account management of static roles
+## Cross-account static role management
 
 <EnterpriseAlert product="vault" />
 

--- a/website/content/docs/secrets/aws.mdx
+++ b/website/content/docs/secrets/aws.mdx
@@ -478,8 +478,7 @@ for more details on the fields associated with plugin WIF.
 
 <EnterpriseAlert product="vault" />
 
-Vault now supports cross-account access for AWS static roles,
-allowing credential management for IAM users across multiple AWS accounts via AWS Security Token Service (STS).
+Vault supports cross-account access for AWS static roles. You can configure credential management for IAM users across multiple AWS accounts by assuming roles in the other accounts.
 
 To configure a cross-account static role:
 


### PR DESCRIPTION
### Description
What does this PR do?

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
