### PR TITLE
Pin CI tool versions

### DIFF
--- a/.github/actions/install-external-tools/action.yml
+++ b/.github/actions/install-external-tools/action.yml
@@ -23,15 +23,16 @@ runs:
     - uses: ./.github/actions/set-up-staticcheck
       # We assume that the Go toolchain will be managed by the caller workflow so we don't set one
       # up here.
-    - run: ./.github/scripts/retry-command.sh go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
+      # Protobuf tool versions should match what's in Vault's go.mod.
+    - run: ./.github/scripts/retry-command.sh go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.36.3
       shell: bash
-    - run: ./.github/scripts/retry-command.sh go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
+    - run: ./.github/scripts/retry-command.sh go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.36.3
       shell: bash
-    - run: ./.github/scripts/retry-command.sh go install github.com/favadi/protoc-go-inject-tag@latest
+    - run: ./.github/scripts/retry-command.sh go install github.com/favadi/protoc-go-inject-tag@v1.4.0
       shell: bash
-    - run: ./.github/scripts/retry-command.sh go install golang.org/x/tools/cmd/goimports@latest
+    - run: ./.github/scripts/retry-command.sh go install golang.org/x/tools/cmd/goimports@v0.30.0
       shell: bash
-    - run: ./.github/scripts/retry-command.sh go install github.com/golangci/revgrep/cmd/revgrep@latest
+    - run: ./.github/scripts/retry-command.sh go install github.com/golangci/revgrep/cmd/revgrep@v0.8.0
       shell: bash
-    - run: ./.github/scripts/retry-command.sh go install github.com/loggerhead/enumer@latest
+    - run: ./.github/scripts/retry-command.sh go install github.com/loggerhead/enumer@v1.5.11
       shell: bash

--- a/tools/tools.sh
+++ b/tools/tools.sh
@@ -36,20 +36,21 @@ install_external() {
   # If you update this please update check_external below as well as our external tools
   # install action .github/actions/install-external-tools/action.yml
   #
+  # Protobuf tool versions should match what's in Vault's go.mod.
   tools=(
-    honnef.co/go/tools/cmd/staticcheck@latest
+    honnef.co/go/tools/cmd/staticcheck@v0.6.0
     github.com/bufbuild/buf/cmd/buf@v1.45.0
-    github.com/favadi/protoc-go-inject-tag@latest
-    github.com/golangci/misspell/cmd/misspell@latest
-    github.com/golangci/revgrep/cmd/revgrep@latest
-    github.com/loggerhead/enumer@latest
-    github.com/rinchsan/gosimports/cmd/gosimports@latest
-    golang.org/x/tools/cmd/goimports@latest
-    google.golang.org/protobuf/cmd/protoc-gen-go@latest
-    google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
-    gotest.tools/gotestsum@latest
-    mvdan.cc/gofumpt@latest
-    mvdan.cc/sh/v3/cmd/shfmt@latest
+    github.com/favadi/protoc-go-inject-tag@v1.4.0
+    github.com/golangci/misspell/cmd/misspell@v0.3.4
+    github.com/golangci/revgrep/cmd/revgrep@v0.8.0
+    github.com/loggerhead/enumer@v1.5.11
+    github.com/rinchsan/gosimports/cmd/gosimports@v0.3.8
+    golang.org/x/tools/cmd/goimports@v0.30.0
+    google.golang.org/protobuf/cmd/protoc-gen-go@v1.36.3
+    google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.36.3
+    gotest.tools/gotestsum@v1.12.0
+    mvdan.cc/gofumpt@v0.7.0
+    mvdan.cc/sh/v3/cmd/shfmt@v3.10.0
   )
 
   echo "==> Installing external tools..."


### PR DESCRIPTION
### Description

This pins CI tool versions. For protobuf, the same version as is in the go.mod is chosen (i.e. they are kept the same). For the rest, I chose the latest version.

This makes our CI more reproducible (i.e. the same build re-ran should not get different results). It also means that, like with GHAs, we don't automatically roll to the latest version (there may be a vulnerability or a reason we don't want to upgrade), and are pinned to known good versions.

This should reduce noise, and hopefully remove 'alert fatigue' with the linter being red all the time.

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
