### PR TITLE
🧹 on policy upload file view

### DIFF
--- a/ui/app/components/policy-form.hbs
+++ b/ui/app/components/policy-form.hbs
@@ -84,11 +84,9 @@
         />
       {{/if}}
       {{#unless this.showFileUpload}}
-        <div class="has-top-margin-xs">
-          <span class="is-size-9 has-text-grey has-bottom-margin-l">
-            You can use Alt+Tab (Option+Tab on MacOS) in the code editor to skip to the next field.
-          </span>
-        </div>
+        <span class="is-size-9 has-text-grey has-bottom-margin-l has-top-margin-xs" data-test-alt-tab-message>
+          You can use Alt+Tab (Option+Tab on MacOS) in the code editor to skip to the next field.
+        </span>
       {{/unless}}
     </div>
     {{#each @model.additionalAttrs as |attr|}}

--- a/ui/app/components/policy-form.hbs
+++ b/ui/app/components/policy-form.hbs
@@ -69,7 +69,9 @@
         </ToolbarActions>
       </Toolbar>
       {{#if this.showFileUpload}}
-        <TextFile @uploadOnly={{true}} @onChange={{this.setPolicyFromFile}} />
+        <div class="has-top-margin-xs">
+          <TextFile @uploadOnly={{true}} @onChange={{this.setPolicyFromFile}} />
+        </div>
       {{else}}
         <JsonEditor
           @title="Policy"
@@ -81,11 +83,13 @@
           data-test-policy-editor
         />
       {{/if}}
-      <div class="has-top-margin-xs">
-        <span class="is-size-9 has-text-grey has-bottom-margin-l">
-          You can use Alt+Tab (Option+Tab on MacOS) in the code editor to skip to the next field.
-        </span>
-      </div>
+      {{#unless this.showFileUpload}}
+        <div class="has-top-margin-xs">
+          <span class="is-size-9 has-text-grey has-bottom-margin-l">
+            You can use Alt+Tab (Option+Tab on MacOS) in the code editor to skip to the next field.
+          </span>
+        </div>
+      {{/unless}}
     </div>
     {{#each @model.additionalAttrs as |attr|}}
       <FormField data-test-field={{true}} @attr={{attr}} @model={{@model}} />

--- a/ui/tests/integration/components/policy-form-test.js
+++ b/ui/tests/integration/components/policy-form-test.js
@@ -16,6 +16,7 @@ const SELECTORS = {
   uploadFileToggle: '[data-test-policy-edit-toggle]',
   policyEditor: '[data-test-policy-editor]',
   policyUpload: '[data-test-text-file-input]',
+  altTabMessage: '[data-test-alt-tab-message]',
   saveButton: '[data-test-policy-save]',
   cancelButton: '[data-test-policy-cancel]',
   error: '[data-test-message-error]',
@@ -156,6 +157,22 @@ module('Integration | Component | policy-form', function (hooks) {
     assert.dom(SELECTORS.nameInput).hasValue('test-policy', 'it fills in policy name');
     await click(SELECTORS.saveButton);
     assert.propEqual(this.onSave.lastCall.args[0].policy, policy, 'policy content saves in correct format');
+  });
+
+  test('it shows alt + tab message only when json editor is visible', async function (assert) {
+    await render(hbs`
+    <PolicyForm
+      @model={{this.model}}
+      @onCancel={{this.onCancel}}
+      @onSave={{this.onSave}}
+    />
+    `);
+    assert.dom(SELECTORS.altTabMessage).exists({ count: 1 }, 'Alt tab message shows');
+    assert.dom(SELECTORS.policyEditor).exists({ count: 1 }, 'Policy editor is shown');
+
+    await click(SELECTORS.uploadFileToggle);
+    assert.dom(SELECTORS.policyUpload).exists({ count: 1 }, 'Policy upload is shown after toggle');
+    assert.dom(SELECTORS.altTabMessage).doesNotExist('Alt tab message is not shown');
   });
 
   test('it renders the form to edit existing ACL policy', async function (assert) {


### PR DESCRIPTION
### Description
Noticed that the json specific message `You can use Alt+Tab (Option+Tab on MacOS) in the code editor to skip to the next field.` showed when I was not on the json editor view.

BEFORE
![image](https://github.com/user-attachments/assets/f0b6fdf5-70b8-4d1e-a178-3ca18d16af74)

AFTER
* The message about using Alt+tab is only relevant if you're viewing the code editor.
![image](https://github.com/user-attachments/assets/1d675b77-dc27-4607-9b3f-09dc96e93458)

