### PR TITLE
🧹 Transform Template value on Transformation Details

### DIFF
--- a/ui/app/models/transform.js
+++ b/ui/app/models/transform.js
@@ -77,10 +77,10 @@ export default class TransformModel extends Model {
   })
   masking_character;
 
-  @attr('string', {
+  @attr('array', {
     editType: 'searchSelect',
     isSectionHeader: true,
-    fallbackComponent: 'string-list',
+    fallbackComponent: 'input-list',
     label: 'Template', // CBS TODO: make this required for making a transformation
     models: ['transform/template'],
     selectLimit: 1,

--- a/ui/app/models/transform.js
+++ b/ui/app/models/transform.js
@@ -77,11 +77,11 @@ export default class TransformModel extends Model {
   })
   masking_character;
 
-  @attr('array', {
+  // TODO: add presence required validation for template
+  @attr('string', {
     editType: 'searchSelect',
     isSectionHeader: true,
-    fallbackComponent: 'input-list',
-    label: 'Template', // CBS TODO: make this required for making a transformation
+    fallbackComponent: 'input-search',
     models: ['transform/template'],
     selectLimit: 1,
     onlyAllowExisting: true,

--- a/ui/app/templates/components/transform-edit-form.hbs
+++ b/ui/app/templates/components/transform-edit-form.hbs
@@ -44,7 +44,7 @@
   </div>
   <div class="field is-grouped-split box is-fullwidth is-bottomless">
     <Hds::ButtonSet>
-      <Hds::Button @text="Save" type="submit" data-test-transformation-save-button />
+      <Hds::Button @text="Save" type="submit" data-test-transform-edit />
       <Hds::Button
         @text="Cancel"
         @color="secondary"

--- a/ui/app/templates/components/transform-show-transformation.hbs
+++ b/ui/app/templates/components/transform-show-transformation.hbs
@@ -26,7 +26,6 @@
       <InfoTableRow
         @label={{capitalize (or attr.options.label (humanize (dasherize attr.name)))}}
         @value={{get this.model attr.name}}
-        @type={{attr.type}}
       />
     {{/if}}
   {{/each}}

--- a/ui/app/templates/components/transform-show-transformation.hbs
+++ b/ui/app/templates/components/transform-show-transformation.hbs
@@ -10,8 +10,7 @@
         @label={{capitalize (or attr.options.label (humanize (dasherize attr.name)))}}
         @value={{stringify (get this.model attr.name)}}
       />
-      {{! allowed_roles are passed as an array. If the list exceeds 5, it will be truncated, and the user will be redirected to the roles list view. }}
-    {{else if (eq attr.name "allowed_roles")}}
+    {{else if (eq attr.type "array")}}
       <InfoTableRow
         @label={{capitalize (or attr.options.label (humanize (dasherize attr.name)))}}
         @value={{get this.model attr.name}}
@@ -26,6 +25,7 @@
       <InfoTableRow
         @label={{capitalize (or attr.options.label (humanize (dasherize attr.name)))}}
         @value={{get this.model attr.name}}
+        @type={{attr.type}}
       />
     {{/if}}
   {{/each}}

--- a/ui/app/templates/components/transform-show-transformation.hbs
+++ b/ui/app/templates/components/transform-show-transformation.hbs
@@ -26,6 +26,7 @@
       <InfoTableRow
         @label={{capitalize (or attr.options.label (humanize (dasherize attr.name)))}}
         @value={{get this.model attr.name}}
+        @type={{attr.type}}
       />
     {{/if}}
   {{/each}}

--- a/ui/app/templates/components/transform-show-transformation.hbs
+++ b/ui/app/templates/components/transform-show-transformation.hbs
@@ -10,7 +10,8 @@
         @label={{capitalize (or attr.options.label (humanize (dasherize attr.name)))}}
         @value={{stringify (get this.model attr.name)}}
       />
-    {{else if (eq attr.type "array")}}
+      {{! allowed_roles are passed as an array. If the list exceeds 5, it will be truncated, and the user will be redirected to the roles list view. }}
+    {{else if (eq attr.name "allowed_roles")}}
       <InfoTableRow
         @label={{capitalize (or attr.options.label (humanize (dasherize attr.name)))}}
         @value={{get this.model attr.name}}
@@ -25,7 +26,6 @@
       <InfoTableRow
         @label={{capitalize (or attr.options.label (humanize (dasherize attr.name)))}}
         @value={{get this.model attr.name}}
-        @type={{attr.type}}
       />
     {{/if}}
   {{/each}}

--- a/ui/lib/core/addon/components/search-select.hbs
+++ b/ui/lib/core/addon/components/search-select.hbs
@@ -36,6 +36,7 @@
     {{/if}}
     {{#unless this.hidePowerSelect}}
       <PowerSelect
+        data-test-power-select
         @eventType="click"
         @placeholder={{@placeholder}}
         @searchEnabled={{this.searchEnabled}}

--- a/ui/lib/core/addon/components/search-select.js
+++ b/ui/lib/core/addon/components/search-select.js
@@ -110,9 +110,9 @@ export default class SearchSelect extends Component {
   }
 
   formatInputAndUpdateDropdown(inputValues) {
-    // for model attrs that use editType: 'searchSelect', and the API returns them as a string
-    // we need to wrap them in an array to match the format of the dropdownOptions
-    // ex: model/transform.js -> template
+    // For model attributes using editType: 'searchSelect' where the API returns a string,
+    // we need to wrap the value in an array to match the format expected by the dropdownOptions.
+    // Example: model/transform.js -> template
     inputValues = Array.isArray(inputValues) ? inputValues : [inputValues];
     // inputValues are initially an array of strings from @inputValue
     // map over so selectedOptions are objects

--- a/ui/lib/core/addon/components/search-select.js
+++ b/ui/lib/core/addon/components/search-select.js
@@ -110,6 +110,10 @@ export default class SearchSelect extends Component {
   }
 
   formatInputAndUpdateDropdown(inputValues) {
+    // for model attrs that use editType: 'searchSelect', and the API returns them as a string
+    // we need to wrap them in an array to match the format of the dropdownOptions
+    // ex: model/transform.js -> template
+    inputValues = Array.isArray(inputValues) ? inputValues : [inputValues];
     // inputValues are initially an array of strings from @inputValue
     // map over so selectedOptions are objects
     return inputValues.map((option) => {

--- a/ui/tests/acceptance/enterprise-transform-test.js
+++ b/ui/tests/acceptance/enterprise-transform-test.js
@@ -230,7 +230,7 @@ module('Acceptance | Enterprise | Transform secrets', function (hooks) {
     await settled();
     await click('#allowed_roles [data-test-selected-list-button="delete"]');
 
-    await transformationsPage.save();
+    await transformationsPage.edit();
     await settled();
     assert.dom('.flash-message.is-info').exists('Shows info message since role could not be updated');
     assert.strictEqual(
@@ -241,6 +241,36 @@ module('Acceptance | Enterprise | Transform secrets', function (hooks) {
     assert
       .dom('[data-test-row-value="Allowed roles"]')
       .doesNotExist('Allowed roles are no longer on the transformation');
+  });
+
+  test('it allows user to add and then edit template on a transformation', async function (assert) {
+    const transformationName = 'my-transformation';
+    await visit('/vault/settings/mount-secret-backend');
+    const backend = `transform-${uuidv4()}`;
+    await mountBackend('transform', backend);
+    await templatesPage.createLink();
+
+    await transformationsPage.name(transformationName);
+    await clickTrigger('#template');
+    await selectChoose('#template', '.ember-power-select-option', 0);
+    await transformationsPage.submit();
+    await settled();
+    assert.dom('[data-test-row-value="Template"]').hasText('builtin/creditcardnumber');
+
+    await templatesPage.editLink();
+    await settled();
+    assert
+      .dom('[data-test-selected-option="0"]')
+      .hasText('builtin/creditcardnumber', 'renders the saved template on edit');
+    assert
+      .dom('#template .ember-power-select-trigger')
+      .doesNotExist('No option to select new template because one is already selected');
+
+    await click('#template [data-test-selected-list-button="delete"]');
+    await clickTrigger('#template');
+    await selectChoose('#template', '.ember-power-select-option', 0);
+    await transformationsPage.edit();
+    assert.dom('[data-test-row-value="Template"]').hasText('builtin/socialsecuritynumber');
   });
 
   test('it allows creation and edit of a template', async function (assert) {

--- a/ui/tests/integration/components/search-select-test.js
+++ b/ui/tests/integration/components/search-select-test.js
@@ -52,6 +52,9 @@ const storeService = Service.extend({
             { id: 'barfoo1', name: 'different' },
           ]);
           break;
+        case 'transform/template':
+          resolve([{ id: 'some-string', name: 'some-string', searchText: 'some-string', addToolTip: false }]);
+          break;
         case 'some/model':
           resolve([
             { id: 'model-a-id', name: 'model-a', uuid: 'a123', type: 'a' },
@@ -171,6 +174,34 @@ module('Integration | Component | search select', function (hooks) {
     // verify overflow styling on input field exists
     assert.dom('.list-item-text').exists('selected option field has width set');
     assert.dom('.text-overflow-ellipsis').exists('selected option text has overflow class');
+  });
+
+  test('it shows passed in string when trigger is clicked', async function (assert) {
+    const models = ['transform/template'];
+    this.set('models', models);
+    this.set('onChange', sinon.spy());
+    await render(hbs`
+      <SearchSelect
+        @label="stringtest"
+        @models={{this.models}}
+        @backend="transform"
+        @inputValue="some-string"
+        @onChange={{this.onChange}}
+        @disallowNewItems={{true}}
+        @selectLimit={{1}}
+      />
+    `);
+
+    assert.strictEqual(
+      component.selectedOptions.objectAt(0).text,
+      'some-string',
+      'the selected text is correct'
+    );
+    assert.strictEqual(component.selectedOptions.length, 1, 'there is one selected option');
+    assert.false(component.hasTrigger, 'does not render power select');
+
+    await component.deleteButtons.objectAt(0).click();
+    assert.true(component.hasTrigger, 'power select shows after deleting selected option');
   });
 
   test('it filters options and adds option to create new item when text is entered', async function (assert) {

--- a/ui/tests/pages/secrets/backend/transform/transformations.js
+++ b/ui/tests/pages/secrets/backend/transform/transformations.js
@@ -14,8 +14,8 @@ export default create({
   createLink: clickable('[data-test-secret-create]'),
   name: fillable('[data-test-input="name"]'),
   submit: clickable('[data-test-transform-create]'),
+  edit: clickable('[data-test-transform-edit]'),
   type: fillable('[data-test-input="type"'),
   tweakSource: fillable('[data-test-input="tweak_source"'),
   maskingChar: fillable('[data-test-input="masking_character"'),
-  save: clickable('[data-test-transformation-save-button]'),
 });


### PR DESCRIPTION
- [x] ent test pass

### Description

What was originally intended as a simple CSS cleanup revealed an issue with how we were using model attributes `editType: searchSelect` with `type: string`. These two attributes were incompatible during an edit scenario. There is [one other case ](https://github.com/hashicorp/vault/blob/main/ui/app/models/oidc/client.js#L50) where these two attributes are used together, but in that case, the `editDisabled: true` flag prevented any issues from surfacing during editing.

In the `model/transform.js` the `template` attribute was incorrectly labeled as `type="array"`. According to the API [here](https://developer.hashicorp.com/vault/api-docs/secret/transform#template-1), `template` should be type "string". Updating the model type fixed the styling issue, but it broke the edit functionality.

To resolve the edit issue, I modified the method responsible for reading the attribute’s value in the `searchSelect` component. If the value wasn't already an array, I converted it into an array so the function could process it correctly. This approach seemed to be the least disruptive solution.

**Before:**
![image](https://github.com/user-attachments/assets/10431119-95ca-4143-9c5a-c9f8b2e67187)

**After:**
![image](https://github.com/user-attachments/assets/f6fd9a32-3113-45e7-978b-6a726950d511)
