### PR TITLE
UI: Add KV view for wrap tool

### DIFF
--- a/changelog/29677.txt
+++ b/changelog/29677.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-ui: add KV view for wrap tool
+ui: adds key value pair string inputs as optional form for wrap tool
 ```

--- a/changelog/29677.txt
+++ b/changelog/29677.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: add KV view for wrap tool
+```

--- a/ui/app/components/tools/wrap.hbs
+++ b/ui/app/components/tools/wrap.hbs
@@ -40,16 +40,29 @@
     <div class="box is-sideless is-fullwidth is-marginless">
       <NamespaceReminder @mode="perform" @noun="wrap" />
       <MessageError @errorMessage={{this.errorMessage}} />
-      <div class="field">
-        <div class="control">
-          <JsonEditor
-            @title="Data to wrap"
-            @subTitle="json-formatted"
-            @value={{this.wrapData}}
-            @valueUpdated={{this.codemirrorUpdated}}
-          />
+      <Toggle @name="KV view" @checked={{this.showKvObject}} @onChange={{fn (mut this.showKvObject)}}>
+        <span class="has-text-grey">KV view</span>
+      </Toggle>
+      {{#if this.showKvObject}}
+        <KvObjectEditor
+          class="has-top-margin-m"
+          @label="Data to Wrap"
+          @value={{this.wrapData}}
+          @onChange={{fn (mut this.wrapData)}}
+          @warnNonStringValues={{true}}
+        />
+      {{else}}
+        <div class="field">
+          <div class="control">
+            <JsonEditor
+              @title="Data to wrap"
+              @subTitle="json-formatted"
+              @value={{this.stringifiedWrapData}}
+              @valueUpdated={{this.codemirrorUpdated}}
+            />
+          </div>
         </div>
-      </div>
+      {{/if}}
       <TtlPicker
         @label="Wrap TTL"
         @initialValue="30m"

--- a/ui/app/components/tools/wrap.hbs
+++ b/ui/app/components/tools/wrap.hbs
@@ -42,26 +42,23 @@
       <MessageError @errorMessage={{this.errorMessage}} />
       <Toolbar>
         <ToolbarFilters>
-          <Toggle @name="json" @checked={{this.showJson}} @onChange={{fn (mut this.showJson)}}>
+          <Toggle @name="json" @checked={{this.showJson}} @onChange={{action "handleToggle"}}>
             <span class="has-text-grey">JSON</span>
           </Toggle>
         </ToolbarFilters>
       </Toolbar>
       {{#if this.showJson}}
-        <div class="field">
-          <div class="control">
-            <JsonEditor
-              @title="Data to wrap"
-              @subTitle="json-formatted"
-              @value={{this.stringifiedWrapData}}
-              @valueUpdated={{this.codemirrorUpdated}}
-            />
-          </div>
-        </div>
+        <JsonEditor
+          class="has-top-margin-s"
+          @title="Data to wrap"
+          @subTitle="json-formatted"
+          @value={{this.stringifiedWrapData}}
+          @valueUpdated={{this.codemirrorUpdated}}
+        />
       {{else}}
         <KvObjectEditor
-          class="has-top-margin-m"
-          @label="Data to Wrap"
+          class="has-top-margin-l"
+          @label="Data to wrap"
           @value={{this.wrapData}}
           @onChange={{fn (mut this.wrapData)}}
           @warnNonStringValues={{true}}

--- a/ui/app/components/tools/wrap.hbs
+++ b/ui/app/components/tools/wrap.hbs
@@ -72,10 +72,17 @@
         @helperTextEnabled="Wrap will expire after"
         @changeOnInit={{true}}
       />
+      {{#if this.hasLintingErrors}}
+        <AlertInline
+          @color="warning"
+          class="has-top-padding-s"
+          @message="JSON is unparsable. Fix linting errors to avoid data discrepancies."
+        />
+      {{/if}}
     </div>
     <div class="field is-grouped box is-fullwidth is-bottomless">
       <div class="control">
-        <Hds::Button @text="Wrap data" type="submit" disabled={{this.buttonDisabled}} data-test-tools-submit />
+        <Hds::Button @text="Wrap data" type="submit" data-test-tools-submit />
       </div>
     </div>
   </form>

--- a/ui/app/components/tools/wrap.hbs
+++ b/ui/app/components/tools/wrap.hbs
@@ -42,7 +42,7 @@
       <MessageError @errorMessage={{this.errorMessage}} />
       <Toolbar>
         <ToolbarFilters>
-          <Toggle @name="json" @checked={{this.showJson}} @onChange={{action "handleToggle"}}>
+          <Toggle @name="json" @checked={{this.showJson}} @onChange={{this.handleToggle}}>
             <span class="has-text-grey">JSON</span>
           </Toggle>
         </ToolbarFilters>

--- a/ui/app/components/tools/wrap.hbs
+++ b/ui/app/components/tools/wrap.hbs
@@ -40,18 +40,14 @@
     <div class="box is-sideless is-fullwidth is-marginless">
       <NamespaceReminder @mode="perform" @noun="wrap" />
       <MessageError @errorMessage={{this.errorMessage}} />
-      <Toggle @name="KV view" @checked={{this.showKvObject}} @onChange={{fn (mut this.showKvObject)}}>
-        <span class="has-text-grey">KV view</span>
-      </Toggle>
-      {{#if this.showKvObject}}
-        <KvObjectEditor
-          class="has-top-margin-m"
-          @label="Data to Wrap"
-          @value={{this.wrapData}}
-          @onChange={{fn (mut this.wrapData)}}
-          @warnNonStringValues={{true}}
-        />
-      {{else}}
+      <Toolbar>
+        <ToolbarFilters>
+          <Toggle @name="json" @checked={{this.showJson}} @onChange={{fn (mut this.showJson)}}>
+            <span class="has-text-grey">JSON</span>
+          </Toggle>
+        </ToolbarFilters>
+      </Toolbar>
+      {{#if this.showJson}}
         <div class="field">
           <div class="control">
             <JsonEditor
@@ -62,6 +58,14 @@
             />
           </div>
         </div>
+      {{else}}
+        <KvObjectEditor
+          class="has-top-margin-m"
+          @label="Data to Wrap"
+          @value={{this.wrapData}}
+          @onChange={{fn (mut this.wrapData)}}
+          @warnNonStringValues={{true}}
+        />
       {{/if}}
       <TtlPicker
         @label="Wrap TTL"

--- a/ui/app/components/tools/wrap.js
+++ b/ui/app/components/tools/wrap.js
@@ -22,7 +22,7 @@ export default class ToolsWrap extends Component {
   @service store;
   @service flashMessages;
 
-  @tracked buttonDisabled = false;
+  @tracked hasLintingErrors = false;
   @tracked token = '';
   @tracked wrapTTL = null;
   @tracked wrapData = null;
@@ -44,7 +44,7 @@ export default class ToolsWrap extends Component {
   @action
   handleToggle() {
     this.showJson = !this.showJson;
-    this.buttonDisabled = false;
+    this.hasLintingErrors = false;
   }
 
   @action
@@ -64,14 +64,16 @@ export default class ToolsWrap extends Component {
   @action
   codemirrorUpdated(val, codemirror) {
     codemirror.performLint();
-    const hasErrors = codemirror?.state.lint.marked?.length > 0;
-    this.buttonDisabled = hasErrors;
-    if (!hasErrors) this.wrapData = JSON.parse(val);
+    this.hasLintingErrors = codemirror?.state.lint.marked?.length > 0;
+    if (!this.hasLintingErrors) this.wrapData = JSON.parse(val);
   }
 
   @action
   async handleSubmit(evt) {
     evt.preventDefault();
+
+    if (this.hasLintingErrors) return;
+
     const data = this.wrapData;
     const wrapTTL = this.wrapTTL || null;
 

--- a/ui/app/components/tools/wrap.js
+++ b/ui/app/components/tools/wrap.js
@@ -41,7 +41,8 @@ export default class ToolsWrap extends Component {
     return this?.wrapData ? stringify([this.wrapData], {}) : this.startingValue;
   }
 
-  @action handleToggle() {
+  @action
+  handleToggle() {
     this.showJson = !this.showJson;
     this.buttonDisabled = false;
   }

--- a/ui/app/components/tools/wrap.js
+++ b/ui/app/components/tools/wrap.js
@@ -25,12 +25,9 @@ export default class ToolsWrap extends Component {
   @tracked buttonDisabled = false;
   @tracked token = '';
   @tracked wrapTTL = null;
-  @tracked wrapData;
+  @tracked wrapData = null;
   @tracked errorMessage = '';
   @tracked showJson = true;
-  get jsonWrapStartValue() {
-    return '{\n}';
-  }
 
   get startingValue() {
     // must pass the third param called "space" in JSON.stringify to structure object with whitespace
@@ -41,7 +38,12 @@ export default class ToolsWrap extends Component {
   }
 
   get stringifiedWrapData() {
-    return this?.wrapData ? stringify([this.wrapData], {}) : this.jsonWrapStartValue;
+    return this?.wrapData ? stringify([this.wrapData], {}) : this.startingValue;
+  }
+
+  @action handleToggle() {
+    this.showJson = !this.showJson;
+    this.buttonDisabled = false;
   }
 
   @action
@@ -49,7 +51,9 @@ export default class ToolsWrap extends Component {
     this.token = '';
     this.errorMessage = '';
     this.wrapTTL = null;
-    if (clearData) this.wrapData = '';
+    if (clearData) {
+      this.wrapData = null;
+    }
   }
 
   @action

--- a/ui/app/components/tools/wrap.js
+++ b/ui/app/components/tools/wrap.js
@@ -51,9 +51,7 @@ export default class ToolsWrap extends Component {
     this.token = '';
     this.errorMessage = '';
     this.wrapTTL = null;
-    if (clearData) {
-      this.wrapData = null;
-    }
+    if (clearData) this.wrapData = null;
   }
 
   @action

--- a/ui/app/components/tools/wrap.js
+++ b/ui/app/components/tools/wrap.js
@@ -27,7 +27,7 @@ export default class ToolsWrap extends Component {
   @tracked wrapTTL = null;
   @tracked wrapData;
   @tracked errorMessage = '';
-  @tracked showKvObject = false;
+  @tracked showJson = true;
   get jsonWrapStartValue() {
     return '{\n}';
   }

--- a/ui/app/components/tools/wrap.js
+++ b/ui/app/components/tools/wrap.js
@@ -52,6 +52,7 @@ export default class ToolsWrap extends Component {
     this.token = '';
     this.errorMessage = '';
     this.wrapTTL = null;
+    this.hasLintingErrors = false;
     if (clearData) this.wrapData = null;
   }
 
@@ -71,8 +72,6 @@ export default class ToolsWrap extends Component {
   @action
   async handleSubmit(evt) {
     evt.preventDefault();
-
-    if (this.hasLintingErrors) return;
 
     const data = this.wrapData;
     const wrapTTL = this.wrapTTL || null;

--- a/ui/tests/integration/components/tools/wrap-test.js
+++ b/ui/tests/integration/components/tools/wrap-test.js
@@ -204,12 +204,31 @@ module('Integration | Component | tools/wrap', function (hooks) {
     assert.dom(TTL.toggleByLabel('Wrap TTL')).isNotChecked('Wrap TTL defaults to unchecked');
   });
 
-  test('it disables/enables submit based on json linting', async function (assert) {
+  test('it renders/hides warning based on json linting', async function (assert) {
     await this.renderComponent();
     await codemirror().setValue(`{bad json}`);
-    assert.dom(TS.submit).isDisabled('submit disables if json editor has linting errors');
-
+    assert
+      .dom('[data-test-inline-alert]')
+      .hasText(
+        'JSON is unparsable. Fix linting errors to avoid data discrepancies.',
+        'Linting error message is shown for json view'
+      );
     await codemirror().setValue(this.wrapData);
-    assert.dom(TS.submit).isEnabled('submit reenables if json editor has no linting errors');
+    assert.dom('[data-test-inline-alert]').doesNotExist();
+  });
+
+  test('it hides json warning on done', async function (assert) {
+    await this.renderComponent();
+    await codemirror().setValue(`{bad json}`);
+    assert
+      .dom('[data-test-inline-alert]')
+      .hasText(
+        'JSON is unparsable. Fix linting errors to avoid data discrepancies.',
+        'Linting error message is shown for json view'
+      );
+    await click(TS.submit);
+    await waitUntil(() => find(TS.button('Done')));
+    await click(TS.button('Done'));
+    assert.dom('[data-test-inline-alert]').doesNotExist();
   });
 });

--- a/ui/tests/integration/components/tools/wrap-test.js
+++ b/ui/tests/integration/components/tools/wrap-test.js
@@ -217,7 +217,7 @@ module('Integration | Component | tools/wrap', function (hooks) {
     assert.dom('[data-test-inline-alert]').doesNotExist();
   });
 
-  test('it hides json warning on done', async function (assert) {
+  test('it hides json warning on back and on done', async function (assert) {
     await this.renderComponent();
     await codemirror().setValue(`{bad json}`);
     assert
@@ -229,6 +229,18 @@ module('Integration | Component | tools/wrap', function (hooks) {
     await click(TS.submit);
     await waitUntil(() => find(TS.button('Done')));
     await click(TS.button('Done'));
+    assert.dom('[data-test-inline-alert]').doesNotExist();
+
+    await codemirror().setValue(`{bad json}`);
+    assert
+      .dom('[data-test-inline-alert]')
+      .hasText(
+        'JSON is unparsable. Fix linting errors to avoid data discrepancies.',
+        'Linting error message is shown for json view'
+      );
+    await click(TS.submit);
+    await waitUntil(() => find(TS.button('Back')));
+    await click(TS.button('Back'));
     assert.dom('[data-test-inline-alert]').doesNotExist();
   });
 });

--- a/ui/tests/integration/components/tools/wrap-test.js
+++ b/ui/tests/integration/components/tools/wrap-test.js
@@ -37,7 +37,7 @@ module('Integration | Component | tools/wrap', function (hooks) {
     await this.renderComponent();
 
     assert.dom('h1').hasText('Wrap Data', 'Title renders');
-    assert.dom('[data-test-toggle-label="KV view"]').hasText('KV view');
+    assert.dom('[data-test-toggle-label="json"]').hasText('JSON');
     assert.dom('[data-test-component="json-editor-title"]').hasText('Data to wrap (json-formatted)');
     assert.strictEqual(codemirror().getValue(' '), '{ }', 'json editor initializes with empty object');
     assert.dom(TTL.toggleByLabel('Wrap TTL')).isNotChecked('Wrap TTL defaults to unchecked');
@@ -110,9 +110,9 @@ module('Integration | Component | tools/wrap', function (hooks) {
     await this.renderComponent();
     await codemirror().setValue(this.wrapData);
     assert.dom('[data-test-component="json-editor-title"]').hasText('Data to wrap (json-formatted)');
-    await click('[data-test-toggle-input="KV view"]');
+    await click('[data-test-toggle-input="json"]');
     assert.dom('[data-test-component="json-editor-title"]').doesNotExist();
-    await click('[data-test-toggle-input="KV view"]');
+    await click('[data-test-toggle-input="json"]');
     assert.dom('[data-test-component="json-editor-title"]').exists();
     assert.strictEqual(
       codemirror().getValue(' '),
@@ -143,7 +143,7 @@ module('Integration | Component | tools/wrap', function (hooks) {
 
     await this.renderComponent();
     await codemirror().setValue(this.wrapData);
-    await click('[data-test-toggle-input="KV view"]');
+    await click('[data-test-toggle-input="json"]');
     await click(TS.submit);
     await waitUntil(() => find(TS.toolsInput('wrapping-token')));
     assert.true(flashSpy.calledWith('Wrap was successful.'), 'it renders success flash');

--- a/ui/tests/integration/components/tools/wrap-test.js
+++ b/ui/tests/integration/components/tools/wrap-test.js
@@ -110,12 +110,14 @@ module('Integration | Component | tools/wrap', function (hooks) {
   });
 
   test('it toggles between views and preserves input data', async function (assert) {
-    assert.expect(4);
+    assert.expect(6);
     await this.renderComponent();
     await codemirror().setValue(this.wrapData);
     assert.dom('[data-test-component="json-editor-title"]').hasText('Data to wrap (json-formatted)');
     await click('[data-test-toggle-input="json"]');
     assert.dom('[data-test-component="json-editor-title"]').doesNotExist();
+    assert.dom('[data-test-kv-key="0"]').hasValue('foo');
+    assert.dom('[data-test-kv-value="0"]').hasValue('bar');
     await click('[data-test-toggle-input="json"]');
     assert.dom('[data-test-component="json-editor-title"]').exists();
     assert.strictEqual(
@@ -126,7 +128,7 @@ module('Integration | Component | tools/wrap', function (hooks) {
   });
 
   test('it submits from kv view', async function (assert) {
-    assert.expect(8);
+    assert.expect(6);
 
     const multilineData = `this is a multi-line secret
       that contains
@@ -157,8 +159,6 @@ module('Integration | Component | tools/wrap', function (hooks) {
     await click('[data-test-toggle-input="json"]');
     await fillIn('[data-test-kv-key="0"]', 'foo');
     await fillIn('[data-test-kv-value="0"]', 'bar');
-    assert.dom('[data-test-kv-key="0"]').hasValue('foo');
-    assert.dom('[data-test-kv-value="0"]').hasValue('bar');
     await click('[data-test-kv-add-row="0"]');
     await fillIn('[data-test-kv-key="1"]', 'foo2');
     await fillIn('[data-test-kv-value="1"]', multilineData);

--- a/ui/tests/integration/components/tools/wrap-test.js
+++ b/ui/tests/integration/components/tools/wrap-test.js
@@ -126,10 +126,14 @@ module('Integration | Component | tools/wrap', function (hooks) {
   });
 
   test('it submits from kv view', async function (assert) {
-    assert.expect(8);
+    assert.expect(6);
 
     const flashSpy = sinon.spy(this.owner.lookup('service:flash-messages'), 'success');
-    const updatedWrapData = JSON.stringify({ ...JSON.parse(this.wrapData), foo2: 'bar2' });
+    const updatedWrapData = JSON.stringify({
+      ...JSON.parse(this.wrapData),
+      foo2: 'bar2',
+      foo3: 'foo\nbar\nbaz',
+    });
 
     this.server.post('sys/wrapping/wrap', (schema, { requestBody, requestHeaders }) => {
       const payload = JSON.parse(requestBody);
@@ -149,15 +153,11 @@ module('Integration | Component | tools/wrap', function (hooks) {
     await this.renderComponent();
     await codemirror().setValue(this.wrapData);
     await click('[data-test-toggle-input="json"]');
-
-    const keyInput = find('[data-test-kv-key="1"]');
-    assert.ok(keyInput, 'Key input exists');
-
-    const valueInput = find('[data-test-kv-value="1"]');
-    assert.ok(keyInput, 'Value input exists');
-
-    await fillIn(keyInput, 'foo2');
-    await fillIn(valueInput, 'bar2');
+    await fillIn('[data-test-kv-key="1"]', 'foo2');
+    await fillIn('[data-test-kv-value="1"]', 'bar2');
+    await click('[data-test-kv-add-row="1"]');
+    await fillIn('[data-test-kv-key="2"]', 'foo3');
+    await fillIn('[data-test-kv-value="2"]', 'foo\nbar\nbaz');
     await click(TS.submit);
     await waitUntil(() => find(TS.toolsInput('wrapping-token')));
     assert.true(flashSpy.calledWith('Wrap was successful.'), 'it renders success flash');


### PR DESCRIPTION
### Description
This PR adds a KV view to the wrap tool based off the existing pattern when creating KV secrets. This resolves #28579. The default view is the still the JSON editor, but can be toggled between the two views while retaining input.

This also shifts from disabling the wrap button when there are errors to displaying a warning message while leaving the button enabled. 

Previous:
<img width="1091" alt="image" src="https://github.com/user-attachments/assets/329a3ca2-85b8-4a5a-93d8-07d05041f957" />

Current:
<img width="1074" alt="image" src="https://github.com/user-attachments/assets/43972fcb-05bf-4f98-8f35-3866655ff4c6" />
<img width="1140" alt="image" src="https://github.com/user-attachments/assets/679deba8-5174-4a91-8a17-381ce1ebda35" />
Current with Warning:
<img width="1114" alt="image" src="https://github.com/user-attachments/assets/f654e75c-485e-4262-85c4-ad78b37ecdca" />



### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
