### PR TITLE
Fix bug with merging vault agent configs that set template_config

### DIFF
--- a/changelog/29680.txt
+++ b/changelog/29680.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+agent: Fixed an issue where giving the agent multiple config files could cause the merged config to be incorrect
+when `template_config` is set in one of the config files.
+```

--- a/command/agent/config/config.go
+++ b/command/agent/config/config.go
@@ -181,6 +181,9 @@ type ExecConfig struct {
 func NewConfig() *Config {
 	return &Config{
 		SharedConfig: new(configutil.SharedConfig),
+		TemplateConfig: &TemplateConfig{
+			MaxConnectionsPerHost: DefaultTemplateConfigMaxConnsPerHost,
+		},
 	}
 }
 
@@ -248,8 +251,13 @@ func (c *Config) Merge(c2 *Config) *Config {
 		result.DisableKeepAlivesTemplating = c2.DisableKeepAlivesTemplating
 	}
 
+	// Instead of checking if TemplateConfig is not nil, we compare against the default value
+	// that is set in NewConfig to determine if a TemplateConfig was specified in the config
+	defaultConfig := TemplateConfig{
+		MaxConnectionsPerHost: DefaultTemplateConfigMaxConnsPerHost,
+	}
 	result.TemplateConfig = c.TemplateConfig
-	if c2.TemplateConfig != nil {
+	if *c2.TemplateConfig != defaultConfig {
 		result.TemplateConfig = c2.TemplateConfig
 	}
 
@@ -1104,9 +1112,6 @@ func parseTemplateConfig(result *Config, list *ast.ObjectList) error {
 
 	templateConfigList := list.Filter(name)
 	if len(templateConfigList.Items) == 0 {
-		result.TemplateConfig = &TemplateConfig{
-			MaxConnectionsPerHost: DefaultTemplateConfigMaxConnsPerHost,
-		}
 		return nil
 	}
 

--- a/command/agent/config/test-fixtures/config-template-min-no-auth.hcl
+++ b/command/agent/config/test-fixtures/config-template-min-no-auth.hcl
@@ -1,0 +1,7 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+template {
+  source      = "/path/on/disk/to/template2.ctmpl"
+  destination = "/path/on/disk/where/template/will/render2.txt"
+}


### PR DESCRIPTION
### Description
This change fixes https://github.com/hashicorp/vault/issues/29654, where giving the vault agent multiple config files can cause the resulting merged config to be incorrect when `template_config` is set in one of the config files. Specifically, when the first config file provided to the vault agent has a `template_config` stanza, and the second one doesn't, the merged config only has default `template_config` values. This is because we started creating a `TemplateConfig` struct even for configs that didn't specify it, to ensure that the `MaxConnectionsPerHost` default was being honored (https://github.com/hashicorp/vault/pull/24989). But we were still doing a nil check for `TemplateConfig` during the merge process to determine if it needed to be updated, so we were overwriting it with the defaults if the config being processed didn't specify it. 

I changed the nil check to checking against the default `TemplateConfig` value, and also moved setting that default from within `parseTemplateConfig` into `NewConfig()` to make sure the default continues to be set when no `template_config` is specified. 

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
