### PR TITLE
Add non-API docs for the root rotation plugins

### DIFF
--- a/website/content/docs/secrets/azure.mdx
+++ b/website/content/docs/secrets/azure.mdx
@@ -161,6 +161,8 @@ vault write -f azure/rotate-root
 
 ### Schedule-based credential rotation
 
+<EnterpriseAlert product="vault" />
+
 The azure secrets engine supports configuring schedule-based automatic
 credential rotation for static roles with the
 [rotation_schedule](/vault/api-docs/secret/azure#rotation_schedule) field.

--- a/website/content/docs/secrets/azure.mdx
+++ b/website/content/docs/secrets/azure.mdx
@@ -159,6 +159,39 @@ manipulate dynamic & static credentials.
 vault write -f azure/rotate-root
 ```
 
+### Schedule-based credential rotation
+
+The azure secrets engine supports configuring schedule-based automatic
+credential rotation for static roles with the
+[rotation_schedule](/vault/api-docs/secret/azure#rotation_schedule) field.
+For example:
+
+```shell-session
+$ vault write azure/config \
+    rotation_schedule="0 * * * SAT"
+```
+
+This configuration will set the role's credential rotation to occur on Saturday
+at 00:00.
+
+Additionally, this schedule-based approach allows for optionally configuring a
+[rotation_window](/vault/api-docs/secret/azure#rotation_window) in which
+the automatic rotation is allowed to occur. For example:
+
+```shell-session
+$ vault write database/static-roles/my-role \
+    rotation_window="1h" \
+    rotation_schedule="0 * * * SAT"
+```
+
+This configuration will set rotations to occur on Saturday at 00:00. The 1
+hour `rotation_window` will prevent the rotation from occuring after 01:00. If
+the static role's credential is not rotated during this window, due to a failure
+or otherwise, it will not be rotated until the next scheduled rotation.
+
+!> The `rotation_period` and `rotation_schedule` fields are
+mutually exclusive. One of them must be set but not both.
+
 For more details on this operation, please see the
 [Root Credential Rotation](/vault/api-docs/secret/azure#rotate-root) API docs.
 


### PR DESCRIPTION
### Description
Adds documentation to a couple of the plugins that gained Scheduled Root Rotation

### TODO only if you're a HashiCorp employee
- [X] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
