### PR TITLE
UI OldVersionAlert Override

### DIFF
--- a/ui/lib/kv/addon/components/page/secret/edit.hbs
+++ b/ui/lib/kv/addon/components/page/secret/edit.hbs
@@ -12,7 +12,7 @@
 </KvPageHeader>
 
 {{#if this.showOldVersionAlert}}
-  <Hds::Alert data-test-secret-version-alert @type="inline" @color="warning" class="has-top-bottom-margin" as |A|>
+  <Hds::Alert data-test-secret-version-alert @type="inline" @color="critical" class="has-top-bottom-margin" as |A|>
     <A.Title>Warning</A.Title>
     <A.Description>
       You are creating a new version based on data from Version
@@ -20,6 +20,14 @@
       <code>{{@secret.path}}</code>
       is Version
       {{@currentVersion}}.
+      <div class="field">
+        <Input
+          id="override-check"
+          @type="checkbox"
+          @checked={{mut this.secretVersionOverride}}
+        />
+        <label for="override-check" class="ttl-picker-label">Override current version {{@currentVersion}} with this data</label>
+      </div>
     </A.Description>
   </Hds::Alert>
 {{/if}}
@@ -66,7 +74,7 @@
         @text="Save"
         @icon={{if this.save.isRunning "loading"}}
         type="submit"
-        disabled={{this.save.isRunning}}
+        disabled={{or this.save.isRunning (not this.secretVersionOverride)}}
         data-test-kv-save
       />
       <Hds::Button
@@ -77,6 +85,9 @@
         {{on "click" this.onCancel}}
         data-test-kv-cancel
       />
+      {{#if (not this.secretVersionOverride)}}
+        <InfoTooltip>Click the checkbox in the alert above to enable saving the secret</InfoTooltip>
+      {{/if}}
     </div>
     {{#if this.invalidFormAlert}}
       <AlertInline


### PR DESCRIPTION
### Description
This makes it so that you can't ignore the OldVersionAlert. With a large team, there might be multiple people editing the same secret at the same time. If the page hasn't been reloaded, Vault gives you a 'check-and-set parameter did not match the current version' error by default, but if it is reloaded, it just gives you a warning, and let's you override the latest secret. Often overriding is done by accident since the url will open the version of the secret that was the latest at the time the link was clicked.
This change adds a checkbox that needs to be checked in order to override the current latest version with an older version of the secret.

Previous:
<img width="1127" alt="Screenshot 2025-02-21 at 8 17 53 AM" src="https://github.com/user-attachments/assets/5cee280e-2b10-495c-a283-02640c3c29cb" />
Proposed:
<img width="1139" alt="Screenshot 2025-02-21 at 11 29 30 AM" src="https://github.com/user-attachments/assets/5746fca9-c946-44f7-95f3-17c2074e5b1a" />
<details open>
  <summary>Video Screenshot</summary>



https://github.com/user-attachments/assets/4ad7eceb-4b72-40ad-bfb8-ced665a132d5



</details>

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
