### PR TITLE
docs: improve token renewal documentation consistency

### DIFF
--- a/website/content/docs/commands/token/renew.mdx
+++ b/website/content/docs/commands/token/renew.mdx
@@ -17,10 +17,43 @@ revoked, or if the token has already reached its maximum TTL.
 
 ## Examples
 
-Renew a token (this uses the `/auth/token/renew` endpoint and permission):
+Create a token first:
 
 ```shell-session
-$ vault token renew 96ddf4bc-d217-f3ba-f9bd-017055595017
+$ vault token create
+Key                Value
+---                -----
+token              hvs.CAESIJk8P_ieg60yf9c92rl0S5j1mdMh7docAoHVS2q7UQ8bGh4KHGh2cy5uQ3dNQUhvbnFhTWl5cVJpMGxpVDhMZWU
+token_accessor     ntL634hzE0CtQnyCIqkxSa82
+token_duration     768h
+token_renewable    true
+token_policies     [default]
+```
+
+Renew a token using the token value (this uses the `/auth/token/renew` endpoint and permission):
+
+```shell-session
+$ vault token renew hvs.CAESIJk8P_ieg6Oyf9c92rl0S5j1mdMh7docAoHVS2q7UQ8bGh4KHGh2cy5uQ3dNQUhvbnFhTWl5cVJpMGxpVDhMZWU
+Key                Value
+---                -----
+token              n/a
+token_accessor     ntL634hzE0CtQnyCIqkxSa82
+token_duration     768h
+token_renewable    true
+token_policies     [default]
+```
+
+Alternatively, renew a token using its accessor value (this is useful when you don't have the actual token):
+
+```shell-session
+$ vault token renew -accessor ntL634hzE0CtQnyCIqkxSa82
+Key                Value
+---                -----
+token              n/a
+token_accessor     ntL634hzE0CtQnyCIqkxSa82
+token_duration     768h
+token_renewable    true
+token_policies     [default]
 ```
 
 Renew the currently authenticated token (this uses the `/auth/token/renew-self`
@@ -33,14 +66,16 @@ $ vault token renew
 Renew a token requesting a specific increment value:
 
 ```shell-session
-$ vault token renew -increment=30m 96ddf4bc-d217-f3ba-f9bd-017055595017
+$ vault token renew -increment=30m hvs.CAESIJk8P_ieg6Oyf9c92rl0S5j1mdMh7docAoHVS2q7UQ8bGh4KHGh2cy5uQ3dNQUhvbnFhTWl5cVJpMGxpVDhMZWU
 ```
 
 Fail if the requested TTL increment cannot be fully fulfilled:
 
 ```shell-session
-$ vault token renew -increment=30m 96ddf4bc-d217-f3ba-f9bd-017055595017 --fail-if-not-fulfilled || vault login
+$ vault token renew -increment=30m hvs.CAESIJk8P_ieg6Oyf9c92rl0S5j1mdMh7docAoHVS2q7UQ8bGh4KHGh2cy5uQ3dNQUhvbnFhTWl5cVJpMGxpVDhMZWU --fail-if-not-fulfilled || vault login
 ```
+
+**Note:** You can renew a token using either the token itself or its accessor. The token_accessor provides a way to perform certain operations (like renewal) without requiring the actual sensitive token value. This is useful for managing tokens without needing to handle the secret token itself.
 
 ## Usage
 


### PR DESCRIPTION
Fixes #29664

## Problem
The current documentation creates confusion by showing a token creation example with one token_accessor, but then shows a renewal example with a completely different token_accessor without explanation.

## Solution
This PR improves the token renewal documentation by:
- Using the same token_accessor in both creation and renewal examples
- Adding an example showing how to renew using the token_accessor
- Adding a note explaining the relationship between tokens and token_accessors
- Making the workflow clear by showing the complete process from token creation to renewal

This change makes it obvious which token is being renewed, addressing the confusion reported in the issue.

