### PR TITLE
docs/events: update note about client redirect for 1.19

### DIFF
--- a/website/content/docs/concepts/events.mdx
+++ b/website/content/docs/concepts/events.mdx
@@ -139,8 +139,9 @@ Here is an example event notification in JSON format:
 
 <Note title="Note">
 
-For multi-node Vault deployments, Vault only accepts subscriptions on the active node. If a client attempts to subscribe to events on a standby node,
-Vault will respond with a redirect to the active node. Vault uses the [`api_addr`](/vault/docs/configuration#api_addr) of the active node's configuration to route the redirect.
+For multi-node Vault deployments, Vault only accepts subscriptions on the active node and performance standbys.
+If a client attempts to subscribe to events on a [non-performance standby node](/vault/docs/enterprise/performance-standby#disabling-performance-standbys), Vault will respond with a redirect to the active node.
+Vault uses the [`api_addr`](/vault/docs/configuration#api_addr) of the active node's configuration to route the redirect.
 
 Vault deployments with performance replication must subscribe to events on the
 primary performance cluster. Vault ignores subscriptions made from secondary

--- a/website/content/docs/concepts/events.mdx
+++ b/website/content/docs/concepts/events.mdx
@@ -140,8 +140,7 @@ Here is an example event notification in JSON format:
 <Note title="Note">
 
 For multi-node Vault deployments, Vault only accepts subscriptions on the active node and performance standbys.
-If a client attempts to subscribe to events on a [non-performance standby node](/vault/docs/enterprise/performance-standby#disabling-performance-standbys), Vault will respond with a redirect to the active node.
-Vault uses the [`api_addr`](/vault/docs/configuration#api_addr) of the active node's configuration to route the redirect.
+Vault reroutes subscription requests made to [non-performance standby nodes](/vault/docs/enterprise/performance-standby#disabling-performance-standbys) to the active node based on the [`api_addr`](/vault/docs/configuration#api_addr) configuration setting on the active node.
 
 Vault deployments with performance replication must subscribe to events on the
 primary performance cluster. Vault ignores subscriptions made from secondary


### PR DESCRIPTION
### Description
Updates the note about client redirect for event subscriptions, since as of Vault 1.19.0-rc1+ent, the redirect is no longer necessary in a cluster with performance standby nodes.

Preview link:
* https://vault-git-docs-vault-33453update-119-event-docs-hashicorp.vercel.app/vault/docs/concepts/events#subscribing-to-event-notifications

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [-] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [-] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [-] **RFC:** If this change has an associated RFC, please link it in the description.
- [-] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
