### PR TITLE
Update GRPC functions to send rotation window and period as seconds explicitly

### DIFF
--- a/sdk/plugin/grpc_system.go
+++ b/sdk/plugin/grpc_system.go
@@ -234,8 +234,8 @@ func (s *gRPCSystemViewClient) RegisterRotationJob(ctx context.Context, req *rot
 			MountPoint:       req.MountPoint,
 			Path:             req.ReqPath,
 			RotationSchedule: req.RotationSchedule,
-			RotationWindow:   int64(req.RotationWindow),
-			RotationPeriod:   int64(req.RotationPeriod),
+			RotationWindow:   int64(req.RotationWindow.Seconds()),
+			RotationPeriod:   int64(req.RotationPeriod.Seconds()),
 		},
 	}
 	resp, err := s.client.RegisterRotationJob(ctx, cfgReq)

--- a/sdk/plugin/grpc_system.go
+++ b/sdk/plugin/grpc_system.go
@@ -234,8 +234,10 @@ func (s *gRPCSystemViewClient) RegisterRotationJob(ctx context.Context, req *rot
 			MountPoint:       req.MountPoint,
 			Path:             req.ReqPath,
 			RotationSchedule: req.RotationSchedule,
-			RotationWindow:   int64(req.RotationWindow.Seconds()),
-			RotationPeriod:   int64(req.RotationPeriod.Seconds()),
+
+			// on the side outbound from the plugin, we convert duration to seconds, so seconds get sent over the wire
+			RotationWindow: int64(req.RotationWindow.Seconds()),
+			RotationPeriod: int64(req.RotationPeriod.Seconds()),
 		},
 	}
 	resp, err := s.client.RegisterRotationJob(ctx, cfgReq)
@@ -472,8 +474,11 @@ func (s *gRPCSystemViewServer) RegisterRotationJob(ctx context.Context, req *pb.
 		MountPoint:       req.Job.MountPoint,
 		ReqPath:          req.Job.Path,
 		RotationSchedule: req.Job.RotationSchedule,
-		RotationWindow:   time.Duration(req.Job.RotationWindow) * time.Second,
-		RotationPeriod:   time.Duration(req.Job.RotationPeriod) * time.Second,
+		// on the side inbound to vault, we convert seconds back to time.Duration
+		// Note: this value is seconds (as per the outbound client call, despite being int64)
+		// The field is int64 because of gRPC reasons, not time.Duration reasons
+		RotationWindow: time.Duration(req.Job.RotationWindow) * time.Second,
+		RotationPeriod: time.Duration(req.Job.RotationPeriod) * time.Second,
 	}
 
 	rotationID, err := s.impl.RegisterRotationJob(ctx, cfgReq)


### PR DESCRIPTION
Resolve a conflict between when we handle durations as nanoseconds vs. seconds.