### PR TITLE
UI: dependency bump for dompurify

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -88,7 +88,7 @@
     "date-fns-tz": "^1.2.2",
     "deepmerge": "^4.0.0",
     "doctoc": "^2.2.0",
-    "dompurify": "^3.0.2",
+    "dompurify": "^3.2.4",
     "ember-a11y-testing": "^7.0.1",
     "ember-basic-dropdown": "^8.0.4",
     "ember-cli": "~5.8.0",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -3576,6 +3576,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/trusted-types@npm:^2.0.7":
+  version: 2.0.7
+  resolution: "@types/trusted-types@npm:2.0.7"
+  checksum: 8e4202766a65877efcf5d5a41b7dd458480b36195e580a3b1085ad21e948bc417d55d6f8af1fd2a7ad008015d4117d5fdfe432731157da3c68678487174e4ba3
+  languageName: node
+  linkType: hard
+
 "@types/unist@npm:^2, @types/unist@npm:^2.0.0, @types/unist@npm:^2.0.2, @types/unist@npm:^2.0.3":
   version: 2.0.11
   resolution: "@types/unist@npm:2.0.11"
@@ -7399,10 +7406,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dompurify@npm:^3.0.2":
-  version: 3.1.7
-  resolution: "dompurify@npm:3.1.7"
-  checksum: 0a9b811bbc94f3dba60cf6486962362b0f1a5b4ab789f5e1cbd4749b6ba1a1fad190a677a962dc8850ce28764424765fe425e9d6508e4e93ba648ef15d54bc24
+"dompurify@npm:^3.2.4":
+  version: 3.2.4
+  resolution: "dompurify@npm:3.2.4"
+  dependencies:
+    "@types/trusted-types": ^2.0.7
+  dependenciesMeta:
+    "@types/trusted-types":
+      optional: true
+  checksum: 7a299cbbfe3b3d189e5fc77ab94ad312807e37fda1e24a927548b76a58a9c98137e612ce8d94a2f6cd3d3db59844f14fca477676b5eae6103568a82142771df6
   languageName: node
   linkType: hard
 
@@ -18394,7 +18406,7 @@ __metadata:
     date-fns-tz: ^1.2.2
     deepmerge: ^4.0.0
     doctoc: ^2.2.0
-    dompurify: ^3.0.2
+    dompurify: ^3.2.4
     ember-a11y-testing: ^7.0.1
     ember-auto-import: ^2.7.2
     ember-basic-dropdown: ^8.0.4


### PR DESCRIPTION
### Description
Bumps the `devDependency` `dompurify` up a minor version from 3.0.3 to 3.2.4. This dependency was first added in pr #20235. And while that PR didn't specify backporting, we did later in pr #26369.

Note: the backport for 1.18.x is probably only an ent backport, but label has not yet been created, stay tuned.

- [x] enterprise tests pass

