### PR TITLE
secrets/aws: ensure `max_retries` default value is unchanged

### DIFF
--- a/builtin/logical/aws/path_config_root.go
+++ b/builtin/logical/aws/path_config_root.go
@@ -81,6 +81,8 @@ func pathConfigRoot(b *backend) *framework.Path {
 			},
 		},
 
+		ExistenceCheck: b.pathConfigRootExistenceCheck,
+
 		Operations: map[logical.Operation]framework.OperationHandler{
 			logical.ReadOperation: &framework.PathOperation{
 				Callback: b.pathConfigRootRead,
@@ -89,6 +91,13 @@ func pathConfigRoot(b *backend) *framework.Path {
 				},
 			},
 			logical.UpdateOperation: &framework.PathOperation{
+				Callback: b.pathConfigRootWrite,
+				DisplayAttrs: &framework.DisplayAttributes{
+					OperationVerb:   "configure",
+					OperationSuffix: "root-iam-credentials",
+				},
+			},
+			logical.CreateOperation: &framework.PathOperation{
 				Callback: b.pathConfigRootWrite,
 				DisplayAttrs: &framework.DisplayAttributes{
 					OperationVerb:   "configure",
@@ -104,6 +113,16 @@ func pathConfigRoot(b *backend) *framework.Path {
 	automatedrotationutil.AddAutomatedRotationFields(p.Fields)
 
 	return p
+}
+
+// Establishes dichotomy of request operation between CreateOperation and UpdateOperation.
+// Returning 'true' forces an UpdateOperation, CreateOperation otherwise.
+func (b *backend) pathConfigRootExistenceCheck(ctx context.Context, req *logical.Request, data *framework.FieldData) (bool, error) {
+	entry, err := getConfigFromStorage(ctx, req)
+	if err != nil {
+		return false, err
+	}
+	return entry != nil, nil
 }
 
 func (b *backend) pathConfigRootRead(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {


### PR DESCRIPTION
### Description
In #29497, we added distinction between a create and update operation in AWS Secrets, which was causing default values for `max_retries` to be returned as `0` instead of the previous expected value of `-1`. This was because the `CreateOperation` was not properly supported, and each operation was treated as an update which messed with the defaults.

This PR correctly distinguishes between the Create and Update operations, and also includes a test to ensure the legacy behavior of the `max_retries` parameter is still enforced.