### PR TITLE
Update vault-plugin-secrets-gcp to v0.21.1

### DIFF
--- a/changelog/29747.txt
+++ b/changelog/29747.txt
@@ -1,0 +1,3 @@
+```release-note:change
+secrets/gcp: Update plugin to v0.21.1
+```

--- a/go.mod
+++ b/go.mod
@@ -154,7 +154,7 @@ require (
 	github.com/hashicorp/vault-plugin-secrets-ad v0.20.1
 	github.com/hashicorp/vault-plugin-secrets-alicloud v0.19.0
 	github.com/hashicorp/vault-plugin-secrets-azure v0.21.1
-	github.com/hashicorp/vault-plugin-secrets-gcp v0.21.0
+	github.com/hashicorp/vault-plugin-secrets-gcp v0.21.1
 	github.com/hashicorp/vault-plugin-secrets-gcpkms v0.20.0
 	github.com/hashicorp/vault-plugin-secrets-kubernetes v0.10.0
 	github.com/hashicorp/vault-plugin-secrets-kv v0.21.0

--- a/go.sum
+++ b/go.sum
@@ -1599,8 +1599,8 @@ github.com/hashicorp/vault-plugin-secrets-alicloud v0.19.0 h1:XH1typO/R5RlyyW5cm
 github.com/hashicorp/vault-plugin-secrets-alicloud v0.19.0/go.mod h1:MxfMowH1VenMCtixd/mDqq9z10CBobzOMZJOXRLi0TA=
 github.com/hashicorp/vault-plugin-secrets-azure v0.21.1 h1:+9iHg7P71vVZ+1muAkao28tl6bf9qWw3VRWZmKSTswI=
 github.com/hashicorp/vault-plugin-secrets-azure v0.21.1/go.mod h1:IwfPcNyzaigu3LFy8yp+f1TVgBNdtJtTMERWhtDrXqw=
-github.com/hashicorp/vault-plugin-secrets-gcp v0.21.0 h1:ZVVVVWLDC/PxmKU92eAvIRQgFjDlnJtqWa8OF+RnK7Y=
-github.com/hashicorp/vault-plugin-secrets-gcp v0.21.0/go.mod h1:GCYpFSIzl00jeub1Yh80fnMLLnV88poCw3+Odpx2u/4=
+github.com/hashicorp/vault-plugin-secrets-gcp v0.21.1 h1:xEXWqoreWz4ZeZOaLbGpkUHDnJdsO7YADfARxoecsJg=
+github.com/hashicorp/vault-plugin-secrets-gcp v0.21.1/go.mod h1:PJwUCF6t95OSpkM15YJZJO8eSPYf/SjvEsrBJZrkzk8=
 github.com/hashicorp/vault-plugin-secrets-gcpkms v0.20.0 h1:gFPxVPaFJjyPUF3GE7LwgGkVkQ+BA7BE775IfdznZ5M=
 github.com/hashicorp/vault-plugin-secrets-gcpkms v0.20.0/go.mod h1:SgKyMgD4+Jj4jDRgFOactHENY7Vov6Hi0UdYWVO9NGY=
 github.com/hashicorp/vault-plugin-secrets-kubernetes v0.10.0 h1:Fw7s2f1WNW1GZgd3jb+7mkx6jPH528AFwWMHg9LarCQ=


### PR DESCRIPTION
This PR was generated by a GitHub Action. Full log: https://github.com/hashicorp/vault/actions/runs/13572852288