### PR TITLE
sync/gcp: document CMEK and CloudResourceManager API requirement

### DIFF
--- a/website/content/docs/sync/gcpsm.mdx
+++ b/website/content/docs/sync/gcpsm.mdx
@@ -119,7 +119,7 @@ Moving forward, any modification on the Vault secret will be propagated in near 
 counterpart. Creating a new secret version in Vault will create a new version in GCP Secret Manager. Deleting the secret
 or the association in Vault will delete the secret in your GCP project as well.
 
-### Replication policy
+## Replication policy
 
 GCP can target specific geographic regions to provide strict control on where
 your applications store data and sync secrets. You can target specific GCP 
@@ -129,9 +129,23 @@ secrets.
 Regardless of the region limits on writes, synced secrets are always readable 
 globally when the client has the required permissions.
 
+### Encryption keys
+
+Vault can leverage customer-managed encryption keys (CMEK) to encrypt secrets in GCP Secret Manager instead of Google-managed keys
+as part of the replication policy. To use CMEK, you must first create key ring(s) and key(s) as desired, ensuring that the key quantity
+corresponds with the planned replication policy. The key rings and keys must be created before configuring the sync destination.
+
+When using a global KMS key, it must be the only key set on the destination and the replication locations must remain unset, meaning
+it can only be used with using GCP's automatic replication. When specifying regional keys, a key must be set for each region in the
+replication location list. GCP key names are expected in the format of the entire resource ID, e.g. `projects/<project_id>/locations/<location_name>/keyRings/<key_ring_name>/cryptoKeys/<key_name>`. See the [API](#api) section for more details.
+
 ## Permissions
 
-The credentials given to Vault must have the following permissions to synchronize secrets:
+Enabling the Secret Manager API and the Cloud Resource Manager API's are prerequisites to using secrets sync with
+GCP Secret Manager. Once both API's are enabled, it may take several minutes for the changes to take effect within
+the GCP project. 
+
+After the necessary API's are active, the credentials given to Vault must have the following permissions to synchronize secrets:
 
 ```shell-session
 secretmanager.secrets.create

--- a/website/content/docs/sync/gcpsm.mdx
+++ b/website/content/docs/sync/gcpsm.mdx
@@ -131,7 +131,7 @@ globally when the client has the required permissions.
 
 ### Encryption keys
 
-Vault can leverage customer-managed encryption keys (CMEK) to encrypt secrets in GCP Secret Manager instead of Google-managed keys
+Vault can leverage customer-managed encryption keys (CMEK) instead of Google-managed keys to encrypt secrets in GCP Secret Manager 
 as part of the replication policy. To use CMEK, you must first create key ring(s) and key(s) as desired, ensuring that the key quantity
 corresponds with the planned replication policy. The key rings and keys must be created before configuring the sync destination.
 
@@ -142,10 +142,10 @@ replication location list. GCP key names are expected in the format of the entir
 ## Permissions
 
 Enabling the Secret Manager API and the Cloud Resource Manager API's are prerequisites to using secrets sync with
-GCP Secret Manager. Once both API's are enabled, it may take several minutes for the changes to take effect within
+GCP Secret Manager. Once both APIs are enabled, it may take several minutes for the changes to take effect within
 the GCP project. 
 
-After the necessary API's are active, the credentials given to Vault must have the following permissions to synchronize secrets:
+After the necessary APIs are active, the credentials given to Vault must have the following permissions to synchronize secrets:
 
 ```shell-session
 secretmanager.secrets.create


### PR DESCRIPTION
### Description
Document Customer-managed Encryption Keys for GCP secrets sync.

Add note about the two required GCP APIs to be enabled.

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
