### PR TITLE
sync: document new allowlist fields and disable field for SSRF-strict networking

### DIFF
--- a/website/content/api-docs/system/activation-flags.mdx
+++ b/website/content/api-docs/system/activation-flags.mdx
@@ -6,6 +6,8 @@ description: The `/sys/activation-flags` endpoints are used to enable features t
 
 # `/sys/activation-flags`
 
+@include 'alerts/enterprise-only.mdx'
+
 @include 'alerts/restricted-root.mdx'
 
 Use the `/sys/activation-flags` endpoints to read and manage Vault

--- a/website/content/api-docs/system/secrets-sync.mdx
+++ b/website/content/api-docs/system/secrets-sync.mdx
@@ -267,12 +267,24 @@ Custom tags are merged with internal built-in tags.
 - `granularity` `(string: "secret-path")` - Determines what level of information is synced as a distinct resource at the
 destination. See [this documentation](/vault/docs/sync#granularity) for more details.
 
+- `disable_strict_networking` `(bool: false)` - Disables both the IP address and port number restrictions used by the SSRF-safe sync clients.
+
+- `allowed_ipv4_addresses` `(list<string>: nil)` - List of IPv4 addresses in CIDR-notation that the sync client is allowed to connect to.
+
+- `allowed_ipv6_addresses` `(list<string>: nil)` - List of IPv6 addresses in CIDR-notation that the sync client is allowed to connect to.
+
+- `allowed_ports` `(list<int>: nil)` - List of port numbers that the sync client is allowed to connect to.
+
 ### Sample payload
 ```json
 {
     "access_key_id": "AKI***",
     "secret_access_key": "ktri****",
-    "region": "us-west-1"
+    "region": "us-west-1",
+    "allowed_ipv4_addresses": [
+        "10.0.100.1/24",
+        "10.0.200.1/16"
+    ]
 }
 ```
 
@@ -345,6 +357,13 @@ Custom tags are merged with internal built-in tags.
 - `granularity` `(string: "secret-path")` - Determines what level of information is synced as a distinct resource at the
 destination. See [this documentation](/vault/docs/sync#granularity) for more details.
 
+- `disable_strict_networking` `(bool: false)` - Disables both the IP address and port number restrictions used by the SSRF-safe sync clients.
+
+- `allowed_ipv4_addresses` `(list<string>: nil)` - List of IPv4 addresses in CIDR-notation that the sync client is allowed to connect to.
+
+- `allowed_ipv6_addresses` `(list<string>: nil)` - List of IPv6 addresses in CIDR-notation that the sync client is allowed to connect to.
+
+- `allowed_ports` `(list<int>: nil)` - List of port numbers that the sync client is allowed to connect to.
 
 ### Sample payload
 ```json
@@ -352,7 +371,11 @@ destination. See [this documentation](/vault/docs/sync#granularity) for more det
     "key_vault_uri": "https://keyvault-1234abcd.vault.azure.net",
     "tenant_id": "uuid",
     "client_id": "uuid",
-    "client_secret": "90y8Q***"
+    "client_secret": "90y8Q***",
+    "allowed_ipv6_addresses": [
+        "fe80::0/120",
+        "fe80::100/120"
+    ]
 }
 ```
 
@@ -379,7 +402,7 @@ This endpoint creates a destination to synchronize secrets with the GCP Secret M
 - `name` `(string: <required>)` - Specifies the name for this destination. This is specified as part of the URL.
 
 - `credentials` `(string: <required>)` - JSON credentials (either file contents or '@path/to/file')
-See docs for [alternative ways](/vault/docs/secrets/gcp#authentication) to pass in to this parameter
+  See docs for [alternative ways](/vault/docs/secrets/gcp#authentication) to pass in to this parameter
 
 - `project_id` `(string: "")` - The target project to manage secrets in. If set,
   overrides the project ID derived from the service account JSON credentials or application
@@ -387,25 +410,63 @@ See docs for [alternative ways](/vault/docs/secrets/gcp#authentication) to pass 
   to perform Secret Manager actions in the target project.
 
 - `replication_locations` `(list: nil)` - A list of GCP location names the destination can use to
-store replicated secrets. Note that secrets remain globally readable regardless of the selected locations.
+  store replicated secrets. Note that secrets remain globally readable regardless of the selected locations.
+
+- `locational_kms_keys` `(map<string|string>: nil)` - A map of location names to KMS key names to leverage customer-managed encryption for
+  encryption at rest. Each pair follows the format `location_name=encryption_key_resource_ID`. Refer to the
+  [sample payloads](#sample-payload-3) for more details.
 
 - `secret_name_template` `(string: "")` - Template to use when generating the secret names on the external system.
 The default template yields names like `vault/kv_1234/my-secret`. See [this documentation](/vault/docs/sync#name-template) for more details.
 
 - `custom_tags` `(map<string|string>: nil)` - List of custom tags or labels to set on the synced secrets at the destination.
-Custom tags are merged with internal built-in tags.
+  Custom tags are merged with internal built-in tags.
 
 - `granularity` `(string: "secret-path")` - Determines what level of information is synced as a distinct resource at the
-destination. See [this documentation](/vault/docs/sync#granularity) for more details.
+  destination. See [this documentation](/vault/docs/sync#granularity) for more details.
 
-### Sample payload
+- `disable_strict_networking` `(bool: false)` - Disables both the IP address and port number restrictions used by the SSRF-safe sync clients.
+
+- `allowed_ipv4_addresses` `(list<string>: nil)` - List of IPv4 addresses in CIDR-notation that the sync client is allowed to connect to.
+
+- `allowed_ipv6_addresses` `(list<string>: nil)` - List of IPv6 addresses in CIDR-notation that the sync client is allowed to connect to.
+
+- `allowed_ports` `(list<int>: nil)` - List of port numbers that the sync client is allowed to connect to.
+
+### Sample payloads
+
+#### Sync secrets to GCP without SSRF-safe networking:
 ```json
 {
     "credentials": "<private key string>",
     "replication_locations": [
         "us-east1",
         "us-west1"
-    ]
+    ],
+    "disable_strict_networking": true
+}
+```
+
+#### Sync secrets to GCP with a global KMS key:
+```json
+{
+    "credentials": "<private key string>",
+    "global_kms_key": "projects/my-project/locations/global/keyRings/my-global-keyring/cryptoKeys/my-global-key"
+}
+```
+
+#### Sync secrets to GCP with locational KMS keys:
+```json
+{
+    "credentials": "<private key string>",
+    "replication_locations": [
+        "us-east1",
+        "us-west1"
+    ],
+    "locational_kms_keys": {
+        "us-east1": "projects/my-project/locations/us-east1/keyRings/my-east-keyring/cryptoKeys/my-east-key",
+        "us-west1": "projects/my-project/locations/us-west1/keyRings/my-west-keyring/cryptoKeys/my-west-key"
+    }
 }
 ```
 
@@ -482,9 +543,17 @@ The default template yields names like `VAULT_KV_1234_MY_SECRET`. See [this docu
 - `granularity` `(string: "secret-key")` - Determines what level of information is synced as a distinct resource at the
 destination. See [this documentation](/vault/docs/sync#granularity) for more details.
 
-## Example requests
+- `disable_strict_networking` `(bool: false)` - Disables both the IP address and port number restrictions used by the SSRF-safe sync clients.
 
-### Sync secrets to a GitHub repository
+- `allowed_ipv4_addresses` `(list<string>: nil)` - List of IPv4 addresses in CIDR-notation that the sync client is allowed to connect to.
+
+- `allowed_ipv6_addresses` `(list<string>: nil)` - List of IPv6 addresses in CIDR-notation that the sync client is allowed to connect to.
+
+- `allowed_ports` `(list<int>: nil)` - List of port numbers that the sync client is allowed to connect to.
+
+### Sample paylods
+
+#### Sync secrets to a GitHub repository
 ```json
 {
     "access_token": "github_pat_12345",
@@ -494,7 +563,7 @@ destination. See [this documentation](/vault/docs/sync#granularity) for more det
 }
 ```
 
-### Sync secrets to a GitHub environment
+#### Sync secrets to a GitHub environment
 ```json
 {
     "access_token": "github_pat_12345",
@@ -505,7 +574,7 @@ destination. See [this documentation](/vault/docs/sync#granularity) for more det
 }
 ```
 
-### Sync secrets to a GitHub organization
+#### Sync secrets to a GitHub organization
 ```json
 {
     "access_token": "github_pat_12345",
@@ -551,6 +620,14 @@ The default template yields names like `vault/kv_1234/my-secret`. See [this docu
 
 - `granularity` `(string: "secret-key")` - Determines what level of information is synced as a distinct resource at the
 destination. See [this documentation](/vault/docs/sync#granularity) for more details.
+
+- `disable_strict_networking` `(bool: false)` - Disables both the IP address and port number restrictions used by the SSRF-safe sync clients.
+
+- `allowed_ipv4_addresses` `(list<string>: nil)` - List of IPv4 addresses in CIDR-notation that the sync client is allowed to connect to.
+
+- `allowed_ipv6_addresses` `(list<string>: nil)` - List of IPv6 addresses in CIDR-notation that the sync client is allowed to connect to.
+
+- `allowed_ports` `(list<int>: nil)` - List of port numbers that the sync client is allowed to connect to.
 
 ### Sample payload
 ```json

--- a/website/content/api-docs/system/secrets-sync.mdx
+++ b/website/content/api-docs/system/secrets-sync.mdx
@@ -6,6 +6,8 @@ description: The `/sys/sync` endpoints are used to configure destinations and as
 
 # `/sys/sync`
 
+@include 'alerts/enterprise-only.mdx'
+
 The `/sys/sync` endpoints are used to configure destinations and associate secrets to sync with these destinations.
 
 Each destination type has its own endpoint for creation & update operations, but share the same endpoints for read &
@@ -267,13 +269,7 @@ Custom tags are merged with internal built-in tags.
 - `granularity` `(string: "secret-path")` - Determines what level of information is synced as a distinct resource at the
 destination. See [this documentation](/vault/docs/sync#granularity) for more details.
 
-- `disable_strict_networking` `(bool: false)` - Disables both the IP address and port number restrictions used by the SSRF-safe sync clients.
-
-- `allowed_ipv4_addresses` `(list<string>: nil)` - List of IPv4 addresses in CIDR-notation that the sync client is allowed to connect to.
-
-- `allowed_ipv6_addresses` `(list<string>: nil)` - List of IPv6 addresses in CIDR-notation that the sync client is allowed to connect to.
-
-- `allowed_ports` `(list<int>: nil)` - List of port numbers that the sync client is allowed to connect to.
+@include 'sync-ssrf-fields.mdx'
 
 ### Sample payload
 ```json
@@ -357,13 +353,7 @@ Custom tags are merged with internal built-in tags.
 - `granularity` `(string: "secret-path")` - Determines what level of information is synced as a distinct resource at the
 destination. See [this documentation](/vault/docs/sync#granularity) for more details.
 
-- `disable_strict_networking` `(bool: false)` - Disables both the IP address and port number restrictions used by the SSRF-safe sync clients.
-
-- `allowed_ipv4_addresses` `(list<string>: nil)` - List of IPv4 addresses in CIDR-notation that the sync client is allowed to connect to.
-
-- `allowed_ipv6_addresses` `(list<string>: nil)` - List of IPv6 addresses in CIDR-notation that the sync client is allowed to connect to.
-
-- `allowed_ports` `(list<int>: nil)` - List of port numbers that the sync client is allowed to connect to.
+@include 'sync-ssrf-fields.mdx'
 
 ### Sample payload
 ```json
@@ -425,13 +415,7 @@ The default template yields names like `vault/kv_1234/my-secret`. See [this docu
 - `granularity` `(string: "secret-path")` - Determines what level of information is synced as a distinct resource at the
   destination. See [this documentation](/vault/docs/sync#granularity) for more details.
 
-- `disable_strict_networking` `(bool: false)` - Disables both the IP address and port number restrictions used by the SSRF-safe sync clients.
-
-- `allowed_ipv4_addresses` `(list<string>: nil)` - List of IPv4 addresses in CIDR-notation that the sync client is allowed to connect to.
-
-- `allowed_ipv6_addresses` `(list<string>: nil)` - List of IPv6 addresses in CIDR-notation that the sync client is allowed to connect to.
-
-- `allowed_ports` `(list<int>: nil)` - List of port numbers that the sync client is allowed to connect to.
+@include 'sync-ssrf-fields.mdx'
 
 ### Sample payloads
 
@@ -543,13 +527,7 @@ The default template yields names like `VAULT_KV_1234_MY_SECRET`. See [this docu
 - `granularity` `(string: "secret-key")` - Determines what level of information is synced as a distinct resource at the
 destination. See [this documentation](/vault/docs/sync#granularity) for more details.
 
-- `disable_strict_networking` `(bool: false)` - Disables both the IP address and port number restrictions used by the SSRF-safe sync clients.
-
-- `allowed_ipv4_addresses` `(list<string>: nil)` - List of IPv4 addresses in CIDR-notation that the sync client is allowed to connect to.
-
-- `allowed_ipv6_addresses` `(list<string>: nil)` - List of IPv6 addresses in CIDR-notation that the sync client is allowed to connect to.
-
-- `allowed_ports` `(list<int>: nil)` - List of port numbers that the sync client is allowed to connect to.
+@include 'sync-ssrf-fields.mdx'
 
 ### Sample paylods
 
@@ -621,13 +599,7 @@ The default template yields names like `vault/kv_1234/my-secret`. See [this docu
 - `granularity` `(string: "secret-key")` - Determines what level of information is synced as a distinct resource at the
 destination. See [this documentation](/vault/docs/sync#granularity) for more details.
 
-- `disable_strict_networking` `(bool: false)` - Disables both the IP address and port number restrictions used by the SSRF-safe sync clients.
-
-- `allowed_ipv4_addresses` `(list<string>: nil)` - List of IPv4 addresses in CIDR-notation that the sync client is allowed to connect to.
-
-- `allowed_ipv6_addresses` `(list<string>: nil)` - List of IPv6 addresses in CIDR-notation that the sync client is allowed to connect to.
-
-- `allowed_ports` `(list<int>: nil)` - List of port numbers that the sync client is allowed to connect to.
+@include 'sync-ssrf-fields.mdx'
 
 ### Sample payload
 ```json

--- a/website/content/docs/sync/azurekv.mdx
+++ b/website/content/docs/sync/azurekv.mdx
@@ -22,7 +22,7 @@ Prerequisites:
 1. If you do not already have an Azure Key Vault instance, navigate to the Azure Portal to create a new
   [Key Vault](https://learn.microsoft.com/en-us/azure/key-vault/general/quick-create-portal).
 
-1. A service principal with a client id and client secret will be needed to configure Azure Key Vault as a
+1. A service principal with a client ID and client secret will be needed to configure Azure Key Vault as a
   sync destination. This [guide](https://learn.microsoft.com/en-us/azure/active-directory/develop/howto-create-service-principal-portal)
   will walk you through creating the service principal.
 
@@ -134,7 +134,7 @@ or the association in Vault will delete the secret in your Azure Key Vault as we
 
 For a more minimal set of permissions, you can create a
 [custom role](https://learn.microsoft.com/en-us/azure/role-based-access-control/custom-roles#steps-to-create-a-custom-role)
-using the following JSON role definition. Be sure to replace the subscription id placeholder.
+using the following JSON role definition. Be sure to replace the subscription ID placeholder.
 
 ```json
 {

--- a/website/content/docs/sync/index.mdx
+++ b/website/content/docs/sync/index.mdx
@@ -259,7 +259,7 @@ server-side request forgery (SSRF). All special purpose IPs defined at the IANA 
 [IPv6](https://www.iana.org/assignments/iana-ipv6-special-registry/iana-ipv6-special-registry.xhtml) are blocked, while the only
 two allowed ports are 80 and 443.
 
-Both IP addresses and port numbers can be customized to fit the specific needs of the environment. This is useful in environments such
+Both IP addresses and port numbers can be customized to fit the specific needs of the environment. This is useful in environments
 where the destination service is behind things such as a private endpoint, a load balancer, or a proxy. This strict networking policy
 can also be entirely disabled in environments where IP addresses or port numbers are not static values.
 Refer to the [API](#api) section for more information on these parameters.

--- a/website/content/docs/sync/index.mdx
+++ b/website/content/docs/sync/index.mdx
@@ -254,13 +254,13 @@ for each destination type below:
 ### Endpoint security
 
 By default, Vault restricts the allowed IP addresses and port numbers used by the sync clients to safeguard against
-server-side request forgery (SSRF). All special purpose IP's defined at the IANA special-purpose registry for 
+server-side request forgery (SSRF). All special purpose IPs defined at the IANA special-purpose registry for 
 [IPv4](https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml) and
 [IPv6](https://www.iana.org/assignments/iana-ipv6-special-registry/iana-ipv6-special-registry.xhtml) are blocked, while the only
 two allowed ports are 80 and 443.
 
 Both IP addresses and port numbers can be customized to fit the specific needs of the environment. This is useful in environments such
-as when the destination service is behind things such as a private endpoint, a load balancer, or a proxy. This strict networking policy
+where the destination service is behind things such as a private endpoint, a load balancer, or a proxy. This strict networking policy
 can also be entirely disabled in environments where IP addresses or port numbers are not static values.
 Refer to the [API](#api) section for more information on these parameters.
 

--- a/website/content/docs/sync/index.mdx
+++ b/website/content/docs/sync/index.mdx
@@ -251,6 +251,20 @@ for each destination type below:
 * [AWS Access Management](/vault/docs/sync/awssm#access-management)
 * [GCP Access Management](/vault/docs/sync/gcpsm#access-management)
 
+### Endpoint security
+
+By default, Vault restricts the allowed IP addresses and port numbers used by the sync clients to safeguard against
+server-side request forgery (SSRF). All special purpose IP's defined at the IANA special-purpose registry for 
+[IPv4](https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml) and
+[IPv6](https://www.iana.org/assignments/iana-ipv6-special-registry/iana-ipv6-special-registry.xhtml) are blocked, while the only
+two allowed ports are 80 and 443.
+
+Both IP addresses and port numbers can be customized to fit the specific needs of the environment. This is useful in environments such
+as when the destination service is behind things such as a private endpoint, a load balancer, or a proxy. This strict networking policy
+can also be entirely disabled in environments where IP addresses or port numbers are not static values.
+Refer to the [API](#api) section for more information on these parameters.
+
+
 ## Reconciliation
 
 Vault Secrets Sync is designed to automatically recover from transient failures

--- a/website/content/partials/sync-ssrf-fields.mdx
+++ b/website/content/partials/sync-ssrf-fields.mdx
@@ -1,0 +1,7 @@
+- `disable_strict_networking` `(bool: false)` - Disables both the IP address and port number restrictions used by the SSRF-safe sync clients.
+
+- `allowed_ipv4_addresses` `(list<string>: nil)` - List of IPv4 addresses in CIDR-notation that the sync client is allowed to connect to.
+
+- `allowed_ipv6_addresses` `(list<string>: nil)` - List of IPv6 addresses in CIDR-notation that the sync client is allowed to connect to.
+
+- `allowed_ports` `(list<int>: nil)` - List of port numbers that the sync client is allowed to connect to.


### PR DESCRIPTION
### Description
Documents 4 new fields for all secrets sync destinations:
`disable_strict_networking`
`allowed_ipv4_addresses`
`allowed_ipv6_addresses`
`allowed_ports`

Adds doc text to describe when and why to set these

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
