### PR TITLE
Update default expected for AWS max retries

### DIFF
--- a/ui/tests/acceptance/secrets/backend/aws/aws-configuration-test.js
+++ b/ui/tests/acceptance/secrets/backend/aws/aws-configuration-test.js
@@ -173,7 +173,6 @@ module('Acceptance | aws | configuration', function (hooks) {
 
     test('it should show identityTokenTtl or maxRetries even if they have not been set', async function (assert) {
       // documenting the intention that we show fields that have not been set but are returned by the api due to defaults
-      // this test also documents that maxRetries returns 0 while the API docs indicate -1 is the default value
       const path = `aws-${this.uid}`;
       await enablePage.enable('aws', path);
 
@@ -187,13 +186,12 @@ module('Acceptance | aws | configuration', function (hooks) {
       await click(GENERAL.toggleGroup('Root config options'));
       await fillIn(GENERAL.inputByAttr('region'), 'eu-central-1');
       await click(GENERAL.saveButton);
-      // the Serializer removes these two from the payload if the API returns their default value.
       assert
         .dom(GENERAL.infoRowValue('Identity token TTL'))
         .hasText('0', 'Identity token TTL shows default.');
       assert
         .dom(GENERAL.infoRowValue('Max retries'))
-        .hasText('0', 'Max retries shows 0 indicating the default will be used.');
+        .hasText('-1', 'Max retries shows -1 indicating the default will be used.');
       // cleanup
       await runCmd(`delete sys/mounts/${path}`);
     });


### PR DESCRIPTION
### Description
In 1.19.0 work, the default value for the AWS root-config parameter `max_retries` changed from -1 to 0. I updated my test to reflect this change, but I was aware of an existing ticket to revert it to the original default. That ticket has been completed, and the default has been restored to its expected value. As a result, I’ve updated my test accordingly.

See PR #29737, which implements the fix

- [x] ent test pass

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
