### PR TITLE
identity: Perform runtime cleanup in goroutine

### DIFF
--- a/vault/identity_store.go
+++ b/vault/identity_store.go
@@ -58,20 +58,21 @@ func (i *IdentityStore) resetDB() error {
 
 func NewIdentityStore(ctx context.Context, core *Core, config *logical.BackendConfig, logger log.Logger) (*IdentityStore, error) {
 	iStore := &IdentityStore{
-		view:             config.StorageView,
-		logger:           logger,
-		router:           core.router,
-		redirectAddr:     core.redirectAddr,
-		localNode:        core,
-		namespacer:       core,
-		metrics:          core.MetricSink(),
-		totpPersister:    core,
-		tokenStorer:      core,
-		entityCreator:    core,
-		mountLister:      core,
-		mfaBackend:       core.loginMFABackend,
-		aliasLocks:       locksutil.CreateLocks(),
-		renameDuplicates: core.FeatureActivationFlags,
+		view:                   config.StorageView,
+		logger:                 logger,
+		router:                 core.router,
+		redirectAddr:           core.redirectAddr,
+		localNode:              core,
+		namespacer:             core,
+		metrics:                core.MetricSink(),
+		totpPersister:          core,
+		tokenStorer:            core,
+		entityCreator:          core,
+		mountLister:            core,
+		mfaBackend:             core.loginMFABackend,
+		aliasLocks:             locksutil.CreateLocks(),
+		renameDuplicates:       core.FeatureActivationFlags,
+		activationErrorHandler: core,
 	}
 
 	// Create a memdb instance, which by default, operates on lower cased

--- a/vault/identity_store_structs.go
+++ b/vault/identity_store_structs.go
@@ -123,7 +123,11 @@ type IdentityStore struct {
 
 	// renameDuplicates holds the Core reference to feature activation flags, so
 	// we can set and query enablement of the deduplication feature.
-	renameDuplicates activationflags.ActivationManager
+	renameDuplicates       activationflags.ActivationManager
+	activationErrorHandler Sealer
+
+	// activateDeduplicationDone is a channel used for synchronization in testing
+	activateDeduplicationDone chan struct{}
 }
 
 type groupDiff struct {
@@ -175,3 +179,9 @@ type MountLister interface {
 }
 
 var _ MountLister = &Core{}
+
+type Sealer interface {
+	Shutdown() error
+}
+
+var _ Sealer = &Core{}

--- a/vault/identity_store_test.go
+++ b/vault/identity_store_test.go
@@ -1645,8 +1645,10 @@ func identityStoreLoadingIsDeterministic(t *testing.T, flags *determinismTestFla
 
 		err := c.systemBackend.activateIdentityDeduplication(ctx, nil)
 		require.NoError(t, err)
-		require.IsType(t, &renameResolver{}, c.identityStore.conflictResolver)
-		require.False(t, c.identityStore.disableLowerCasedNames)
+		require.EventuallyWithT(t, func(collect *assert.CollectT) {
+			require.IsType(t, &renameResolver{}, c.identityStore.conflictResolver)
+			require.False(t, c.identityStore.disableLowerCasedNames)
+		}, 30*time.Second, 100*time.Millisecond, "timed out waiting for rename resolver")
 	}
 
 	// To test that this is deterministic we need to load from storage a bunch of

--- a/vault/identity_store_util.go
+++ b/vault/identity_store_util.go
@@ -150,7 +150,7 @@ func (i *IdentityStore) activateDeduplication(ctx context.Context, req *logical.
 		// IdentityStore, so we're better of just sealing and letting another node
 		// take over!
 		if err := i.loadArtifacts(ctx, i.localNode.HAState() == consts.Active); err != nil {
-			i.logger.Error("failed to activate identity deduplication, shutting down", "error", err)
+			i.logger.Error("failed to activate identity deduplication, shutting down")
 			i.activationErrorHandler.Shutdown()
 			return
 		}

--- a/vault/logical_system_activation_flags.go
+++ b/vault/logical_system_activation_flags.go
@@ -159,13 +159,16 @@ func (b *SystemBackend) activationFlagsToResponse(activationFlags []string) *log
 }
 
 // activateIdentityDeduplication activates the identity deduplication feature.
-func (b *SystemBackend) activateIdentityDeduplication(ctx context.Context, _ *logical.Request) error {
+func (b *SystemBackend) activateIdentityDeduplication(_ context.Context, _ *logical.Request) error {
 	if b.idStoreBackend == nil || b.idStoreBackend.ActivationFunc == nil {
 		return nil
 	}
 
-	if err := b.idStoreBackend.ActivationFunc(ctx, nil); err != nil {
-		return fmt.Errorf("failed to activate identity deduplication: %w", err)
-	}
+	go func() {
+		if err := b.idStoreBackend.ActivationFunc(context.Background(), nil); err != nil {
+			b.logger.Error("activation flag error", "error", err)
+		}
+	}()
+
 	return nil
 }

--- a/vault/logical_system_activation_flags.go
+++ b/vault/logical_system_activation_flags.go
@@ -159,16 +159,14 @@ func (b *SystemBackend) activationFlagsToResponse(activationFlags []string) *log
 }
 
 // activateIdentityDeduplication activates the identity deduplication feature.
-func (b *SystemBackend) activateIdentityDeduplication(_ context.Context, _ *logical.Request) error {
+func (b *SystemBackend) activateIdentityDeduplication(ctx context.Context, _ *logical.Request) error {
 	if b.idStoreBackend == nil || b.idStoreBackend.ActivationFunc == nil {
 		return nil
 	}
 
-	go func() {
-		if err := b.idStoreBackend.ActivationFunc(context.Background(), nil); err != nil {
-			b.logger.Error("activation flag error", "error", err)
-		}
-	}()
+	if err := b.idStoreBackend.ActivationFunc(ctx, nil); err != nil {
+		b.logger.Error("activation flag error", "error", err)
+	}
 
 	return nil
 }


### PR DESCRIPTION
### Description

Previously identity cleanup was running with the context of the activation request, which would time out for large workloads, resulting in bad failure states. This PR moves the ActivationFunc call to its own goroutine/background Context, so it can proceed uninterrupted. 

Enterprise PR: hashicorp/vault-enterprise#7551
Resolves: VAULT-34330

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [x] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
