### PR TITLE
update ember-svg-jar

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -187,6 +187,7 @@
     "rollup": "~2.79.2",
     "serialize-javascript": "^3.1.0",
     "underscore": "^1.12.1",
+    "undici": "^6.21.1",
     "xmlhttprequest-ssl": "^1.6.2",
     "@embroider/macros": "^1.15.0",
     "socket.io": "^4.6.2",

--- a/ui/package.json
+++ b/ui/package.json
@@ -125,7 +125,7 @@
     "ember-sinon-qunit": "^7.4.0",
     "ember-source": "~5.8.0",
     "ember-style-modifier": "^4.1.0",
-    "ember-svg-jar": "2.6.0",
+    "ember-svg-jar": "2.6.2",
     "ember-template-lint": "^6.0.0",
     "ember-template-lint-plugin-prettier": "^5.0.0",
     "ember-test-selectors": "6.0.0",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -9058,9 +9058,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ember-svg-jar@npm:2.6.0":
-  version: 2.6.0
-  resolution: "ember-svg-jar@npm:2.6.0"
+"ember-svg-jar@npm:2.6.2":
+  version: 2.6.2
+  resolution: "ember-svg-jar@npm:2.6.2"
   dependencies:
     "@embroider/macros": ^1.12.2
     broccoli-caching-writer: ^3.0.3
@@ -9077,7 +9077,7 @@ __metadata:
     ember-cli-htmlbars: ^5.7.1
     lodash: ^4.17.15
     safe-stable-stringify: ^2.2.0
-  checksum: 2848b112898d37f72593ef4d1319d2a4f883f7a6fc9c4115d13669fb2ff5b42d9b954339ab666cb6bf8f71de71ab5f59df1789ebbb53046e0a5705df744ad3fb
+  checksum: fd7ff13ea35fbe6ca484b8f74017c997c2b910489368ea3bfdc64b2813b47a8fafdc208c70642ea6bd235773770cf4096ea6ed3f30c2a984013ac0702fbb2bf7
   languageName: node
   linkType: hard
 
@@ -18712,7 +18712,7 @@ __metadata:
     ember-sinon-qunit: ^7.4.0
     ember-source: ~5.8.0
     ember-style-modifier: ^4.1.0
-    ember-svg-jar: 2.6.0
+    ember-svg-jar: 2.6.2
     ember-template-lint: ^6.0.0
     ember-template-lint-plugin-prettier: ^5.0.0
     ember-test-selectors: 6.0.0

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -18301,10 +18301,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici@npm:^6.19.5":
-  version: 6.20.1
-  resolution: "undici@npm:6.20.1"
-  checksum: 3bb1405b406fa0e913ff4ec6fd310c9b4d950b7064ba5949b2f616c1f13070d26f5558aefb4b56b2eafb555925443ce44cb801e143d2417ecf12ddf8d5c05cf6
+"undici@npm:^6.21.1":
+  version: 6.21.1
+  resolution: "undici@npm:6.21.1"
+  checksum: 2efc52f77224754a2efa7cb6459829f3c93c8321d17e76f574a904b353783d95073b6116f5b15637c4845d98c9dc5a019b809cb9d63b3529267e7727c49f6996
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description
Unsure if this will work. I'm relying on the `^` to bump `cheerios` use of `undici` `^6.19.5` to `6.21.1`. 

`ember-svg-jar` uses `cheerio` which uses `undici` 6.19.5. On [cheerio's repo](https://github.com/cheeriojs/cheerio/blob/main/package.json#L128), they have bumped their `undici` dependency but they haven't released the new version. 

The pin helped but did not solve the case above. See code in yarn.lock [here](https://github.com/hashicorp/vault/pull/29762/files#diff-3a968206d6de2fecfc5dacd7d94bab7744c9f5d5c999a816164d95cbc135c316L18297).

Thoughts?

- [x] Enterprise test pass

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
