### PR TITLE
Enables a warning if validations (ent-feature) set issuer configurati…

### DIFF
--- a/builtin/logical/pki/path_fetch_issuers.go
+++ b/builtin/logical/pki/path_fetch_issuers.go
@@ -679,8 +679,10 @@ func (b *backend) pathUpdateIssuer(ctx context.Context, req *logical.Request, da
 		}
 	}
 
+	var updatedIssuanceValidations bool
 	if updateEntIssuerFields(issuer, data, false) {
 		modified = true
+		updatedIssuanceValidations = true
 	}
 
 	// Updating the chain should be the last modification as there's a chance
@@ -735,6 +737,8 @@ func (b *backend) pathUpdateIssuer(ctx context.Context, req *logical.Request, da
 					return logical.ErrorResponse("error reverting bad chain update, state unknown: %v, \ninitial error: %v", newErr.Error(), err.Error()), nil
 				}
 				return logical.ErrorResponse("other changes to issuer may be persisted.  Error setting manual chain, issuer would be unusuable with this chain: %v", err), nil
+			} else {
+				updatedIssuanceValidations = false
 			}
 		}
 
@@ -755,6 +759,12 @@ func (b *backend) pathUpdateIssuer(ctx context.Context, req *logical.Request, da
 		_, aiaErr := ToURLEntries(sc, issuer.ID, issuer.AIAURIs)
 		if aiaErr != nil {
 			response.AddWarning(fmt.Sprintf("issuance may fail: %v\n\nConsider setting the cluster-local address if it is not already set.", aiaErr))
+		}
+	}
+	if updatedIssuanceValidations {
+		warning := checkIssuer(issuer, ctx, req, b)
+		if warning != "" {
+			response.AddWarning(warning)
 		}
 	}
 
@@ -959,6 +969,12 @@ func (b *backend) pathPatchIssuer(ctx context.Context, req *logical.Request, dat
 		issuer.AIAURIs = nil
 	}
 
+	updatedIssuanceValidations := false
+	if updateEntIssuerFields(issuer, data, true) {
+		modified = true
+		updatedIssuanceValidations = true
+	}
+
 	// Manual Chain Changes
 	newPathData, ok := data.GetOk("manual_chain")
 	if ok {
@@ -1012,14 +1028,12 @@ func (b *backend) pathPatchIssuer(ctx context.Context, req *logical.Request, dat
 						return logical.ErrorResponse("error reverting bad chain update, state unknown: %v, \ninitial error: %v", newErr.Error(), err.Error()), nil
 					}
 					return logical.ErrorResponse("other changes to issuer may be persisted.  Error setting manual chain, issuer would be unusuable with this chain: %v", err), nil
+				} else {
+					updatedIssuanceValidations = false
 				}
 			}
 
 		}
-	}
-
-	if updateEntIssuerFields(issuer, data, true) {
-		modified = true
 	}
 
 	if modified {
@@ -1033,6 +1047,12 @@ func (b *backend) pathPatchIssuer(ctx context.Context, req *logical.Request, dat
 	if newName != oldName {
 		addWarningOnDereferencing(sc, oldName, response)
 	}
+	if updatedIssuanceValidations {
+		warning := checkIssuer(issuer, ctx, req, b)
+		if warning != "" {
+			response.AddWarning(warning)
+		}
+	}
 	if issuer.AIAURIs != nil && issuer.AIAURIs.EnableTemplating {
 		_, aiaErr := ToURLEntries(sc, issuer.ID, issuer.AIAURIs)
 		if aiaErr != nil {
@@ -1041,6 +1061,17 @@ func (b *backend) pathPatchIssuer(ctx context.Context, req *logical.Request, dat
 	}
 
 	return response, err
+}
+
+// checkIssuer looks at an issuer that has already been written, and returns a warning if it is not functional.
+func checkIssuer(issuer *issuing.IssuerEntry, ctx context.Context, req *logical.Request, b *backend) (warning string) {
+	if issuer.Usage.HasUsage(issuing.IssuanceUsage) {
+		err := b.issueSignEmptyCert(ctx, req, issuer.ID.String())
+		if err != nil {
+			return fmt.Sprintf("warning: issuer with issuance usage %s cannot issue certificates with this configuration: %v", issuer.ID.String(), err)
+		}
+	}
+	return ""
 }
 
 func (b *backend) pathGetRawIssuer(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {


### PR DESCRIPTION
…on so that it isn't usable.

### Description
Enables an ent-feature in case validations are set in such a way that an issuer isn't usable.

This isn't actually used-code in OSS, but it's a convenient function to have available for UX reasons.

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - Not Security Related
   - [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files. : ENT PR is here; https://github.com/hashicorp/vault-enterprise/pull/7462
- [x] **Jira:** In Branch name
