### PR TITLE
[UI] Display Camelized Operation ID in API Explorer

### DIFF
--- a/ui/app/styles/utils/swagger.scss
+++ b/ui/app/styles/utils/swagger.scss
@@ -8,4 +8,9 @@
 /* align list items with container */
 .swagger-ember .swagger-ui .wrapper {
   padding: 0;
+
+  .opblock-summary-path-description-wrapper {
+    width: min-content;
+    flex-grow: 1;
+  }
 }

--- a/ui/lib/open-api-explorer/addon/components/swagger-ui.js
+++ b/ui/lib/open-api-explorer/addon/components/swagger-ui.js
@@ -15,7 +15,6 @@ import SwaggerUIBundle from 'swagger-ui-dist/swagger-ui-bundle.js';
 import { camelize } from '@ember/string';
 
 const { APP } = openApiExplorerConfig;
-const { environment } = config;
 
 export default class SwaggerUiComponent extends Component {
   @service auth;
@@ -86,7 +85,7 @@ export default class SwaggerUiComponent extends Component {
       // 'list' expands tags, but not operations
       docExpansion: 'list',
       operationsSorter: 'alpha',
-      displayOperationId: environment === 'development',
+      displayOperationId: config.environment === 'development',
       filter: true,
       // this makes sure we show the x-vault- options
       showExtensions: true,

--- a/ui/lib/open-api-explorer/addon/components/swagger-ui.js
+++ b/ui/lib/open-api-explorer/addon/components/swagger-ui.js
@@ -8,11 +8,14 @@ import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import parseURL from 'core/utils/parse-url';
-import config from 'open-api-explorer/config/environment';
+import config from 'vault/config/environment';
+import openApiExplorerConfig from 'open-api-explorer/config/environment';
 import { guidFor } from '@ember/object/internals';
 import SwaggerUIBundle from 'swagger-ui-dist/swagger-ui-bundle.js';
+import { camelize } from '@ember/string';
 
-const { APP } = config;
+const { APP } = openApiExplorerConfig;
+const { environment } = config;
 
 export default class SwaggerUiComponent extends Component {
   @service auth;
@@ -49,16 +52,41 @@ export default class SwaggerUiComponent extends Component {
     };
   }
 
+  // the operationId values in the spec are dasherized
+  // camelize the values so they match the function names in the generated API client SDK
+  CamelizeOperationIdPlugin() {
+    return {
+      wrapComponents: {
+        operation:
+          (Original, { React }) =>
+          (props) => {
+            const { operation } = props;
+            const operationId = operation.get('operationId');
+
+            if (operationId) {
+              return React.createElement(Original, {
+                ...props,
+                operation: operation.set('operationId', camelize(operationId)),
+              });
+            }
+
+            return React.createElement(Original, props);
+          },
+      },
+    };
+  }
+
   CONFIG = (SwaggerUIBundle, componentInstance) => {
     return {
       dom_id: `#${componentInstance.inputId}`,
       url: '/v1/sys/internal/specs/openapi',
       deepLinking: false,
       presets: [SwaggerUIBundle.presets.apis],
-      plugins: [SwaggerUIBundle.plugins.DownloadUrl, this.SearchFilterPlugin],
+      plugins: [SwaggerUIBundle.plugins.DownloadUrl, this.SearchFilterPlugin, this.CamelizeOperationIdPlugin],
       // 'list' expands tags, but not operations
       docExpansion: 'list',
       operationsSorter: 'alpha',
+      displayOperationId: environment === 'development',
       filter: true,
       // this makes sure we show the x-vault- options
       showExtensions: true,

--- a/ui/mirage/factories/open-api-explorer.js
+++ b/ui/mirage/factories/open-api-explorer.js
@@ -4,42 +4,51 @@
  */
 
 import { Factory } from 'miragejs';
-/* eslint-disable ember/avoid-leaking-state-in-ember-objects */
+
 export default Factory.extend({
   openapi: '3.0.2',
-  info: {
-    title: 'HashiCorp Vault API',
-    description: 'HTTP API that gives you full access to Vault. All API routes are prefixed with `/v1/`.',
-    version: '1.0.0',
-    license: {
-      name: 'Mozilla Public License 2.0',
-      url: 'https://www.mozilla.org/en-US/MPL/2.0',
-    },
-  },
-  paths: {
-    '/auth/token/create': {
-      description: 'The token create path is used to create new tokens.',
-      post: {
-        summary: 'The token create path is used to create new tokens.',
-        tags: ['auth'],
-        responses: {
-          200: {
-            description: 'OK',
+  // set in afterCreate to avoid leaking state lint error
+  info: null,
+  paths: null,
+
+  afterCreate(spec) {
+    spec.info = {
+      title: 'HashiCorp Vault API',
+      description: 'HTTP API that gives you full access to Vault. All API routes are prefixed with `/v1/`.',
+      version: '1.0.0',
+      license: {
+        name: 'Mozilla Public License 2.0',
+        url: 'https://www.mozilla.org/en-US/MPL/2.0',
+      },
+    };
+
+    spec.paths = {
+      '/auth/token/create': {
+        description: 'The token create path is used to create new tokens.',
+        post: {
+          summary: 'The token create path is used to create new tokens.',
+          tags: ['auth'],
+          operationId: 'token-create',
+          responses: {
+            200: {
+              description: 'OK',
+            },
           },
         },
       },
-    },
-    '/secret/data/{path}': {
-      description: 'Location of a secret.',
-      post: {
-        summary: 'Location of a secret.',
-        tags: ['secret'],
-        responses: {
-          200: {
-            description: 'OK',
+      '/secret/data/{path}': {
+        description: 'Location of a secret.',
+        post: {
+          summary: 'Location of a secret.',
+          tags: ['secret'],
+          operationId: 'kv-v2-write',
+          responses: {
+            200: {
+              description: 'OK',
+            },
           },
         },
       },
-    },
+    };
   },
 });

--- a/ui/tests/integration/components/open-api-explorer/swagger-ui-test.js
+++ b/ui/tests/integration/components/open-api-explorer/swagger-ui-test.js
@@ -61,7 +61,7 @@ module('Integration | Component | open-api-explorer | swagger-ui', function (hoo
     sinon.stub(config, 'environment').value('development');
 
     await this.renderComponent();
-    await waitFor(SELECTORS.container);
+    await waitFor(SELECTORS.operationId);
 
     const id = this.openApiResponse.paths['/auth/token/create'].post.operationId;
     assert.dom(SELECTORS.operationId).hasText(camelize(id), 'renders camelized operation id');

--- a/ui/tests/integration/components/open-api-explorer/swagger-ui-test.js
+++ b/ui/tests/integration/components/open-api-explorer/swagger-ui-test.js
@@ -9,46 +9,45 @@ import { fillIn, render, typeIn, waitFor } from '@ember/test-helpers';
 import { setupEngine } from 'ember-engines/test-support';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { hbs } from 'ember-cli-htmlbars';
+import sinon from 'sinon';
+import config from 'vault/config/environment';
+import { camelize } from '@ember/string';
 
 const SELECTORS = {
   container: '[data-test-swagger-ui]',
   searchInput: 'input.operation-filter-input',
   apiPathBlock: '.opblock-post',
+  operationId: '.opblock-summary-operation-id',
 };
 
 module('Integration | Component | open-api-explorer | swagger-ui', function (hooks) {
   setupRenderingTest(hooks);
   setupEngine(hooks, 'open-api-explorer');
   setupMirage(hooks);
+
   hooks.beforeEach(function () {
     this.store = this.owner.lookup('service:store');
 
-    const openApiResponse = this.server.create('open-api-explorer');
+    this.openApiResponse = this.server.create('open-api-explorer');
     this.server.get('sys/internal/specs/openapi', () => {
-      return openApiResponse;
+      return this.openApiResponse;
     });
 
-    this.totalApiPaths = Object.keys(openApiResponse.paths).length;
+    this.totalApiPaths = Object.keys(this.openApiResponse.paths).length;
 
-    this.renderComponent = async () => {
-      await render(hbs`<SwaggerUi/>`, {
-        owner: this.engine,
-      });
-    };
+    this.renderComponent = () => render(hbs`<SwaggerUi/>`, { owner: this.engine });
   });
 
-  test(`it renders`, async function (assert) {
+  test('it renders', async function (assert) {
     await this.renderComponent();
-
     await waitFor(SELECTORS.container);
 
     assert.dom(SELECTORS.container).exists('renders component');
     assert.dom(SELECTORS.apiPathBlock).exists({ count: this.totalApiPaths }, 'renders all api paths');
   });
 
-  test(`it can search`, async function (assert) {
+  test('it can search', async function (assert) {
     await this.renderComponent();
-
     // in testing only the input is not filling correctly except after the second time
     await fillIn(SELECTORS.searchInput, 'moot');
     await typeIn(SELECTORS.searchInput, 'token');
@@ -56,5 +55,15 @@ module('Integration | Component | open-api-explorer | swagger-ui', function (hoo
     // so asserting that the search input has the value we expect is the best we can do here
     // if the search fn breaks, this test will fail
     assert.dom(SELECTORS.searchInput).hasValue('token', 'search input has value');
+  });
+
+  test('it should render camelized operation ids', async function (assert) {
+    sinon.stub(config, 'environment').value('development');
+
+    await this.renderComponent();
+    await waitFor(SELECTORS.container);
+
+    const id = this.openApiResponse.paths['/auth/token/create'].post.operationId;
+    assert.dom(SELECTORS.operationId).hasText(camelize(id), 'renders camelized operation id');
   });
 });

--- a/ui/tests/integration/components/open-api-explorer/swagger-ui-test.js
+++ b/ui/tests/integration/components/open-api-explorer/swagger-ui-test.js
@@ -5,7 +5,7 @@
 
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'vault/tests/helpers';
-import { fillIn, render, typeIn, waitFor } from '@ember/test-helpers';
+import { fillIn, render, typeIn } from '@ember/test-helpers';
 import { setupEngine } from 'ember-engines/test-support';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { hbs } from 'ember-cli-htmlbars';
@@ -40,7 +40,6 @@ module('Integration | Component | open-api-explorer | swagger-ui', function (hoo
 
   test('it renders', async function (assert) {
     await this.renderComponent();
-    await waitFor(SELECTORS.container);
 
     assert.dom(SELECTORS.container).exists('renders component');
     assert.dom(SELECTORS.apiPathBlock).exists({ count: this.totalApiPaths }, 'renders all api paths');
@@ -58,12 +57,13 @@ module('Integration | Component | open-api-explorer | swagger-ui', function (hoo
   });
 
   test('it should render camelized operation ids', async function (assert) {
-    sinon.stub(config, 'environment').value('development');
+    const envStub = sinon.stub(config, 'environment').value('development');
 
     await this.renderComponent();
-    await waitFor(SELECTORS.operationId);
 
     const id = this.openApiResponse.paths['/auth/token/create'].post.operationId;
     assert.dom(SELECTORS.operationId).hasText(camelize(id), 'renders camelized operation id');
+
+    envStub.restore();
   });
 });

--- a/ui/tests/integration/components/open-api-explorer/swagger-ui-test.js
+++ b/ui/tests/integration/components/open-api-explorer/swagger-ui-test.js
@@ -66,4 +66,14 @@ module('Integration | Component | open-api-explorer | swagger-ui', function (hoo
 
     envStub.restore();
   });
+
+  test('it should not render operation ids in production', async function (assert) {
+    const envStub = sinon.stub(config, 'environment').value('production');
+
+    await this.renderComponent();
+
+    assert.dom(SELECTORS.operationId).doesNotExist('operation ids are hidden in production environment');
+
+    envStub.restore();
+  });
 });


### PR DESCRIPTION
### Description
In preparation for use of the OpenAPI generated client, this PR adds the `operationId` from the spec to the API Explorer when viewed in the development environment. A plugin was added to the swagger UI config to camelize the value so that it matches the method names in the generated client since the value is dasherized in the spec.

![image](https://github.com/user-attachments/assets/6c07e8e4-0e27-4227-84e7-742836910c86)


### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
