### PR TITLE
Add known issue for Azure credential failure

### DIFF
--- a/website/content/docs/release-notes/1.16.1.mdx
+++ b/website/content/docs/release-notes/1.16.1.mdx
@@ -30,6 +30,7 @@ description: |-
 | Known Issue (1.16.7-1.16.8) | [Some values in the audit logs not hmac'd properly](/vault/docs/upgrading/upgrade-to-1.16.x#client-tokens-and-token-accessors-audited-in-plaintext)                                          |
 | New default (1.16.13)       | [Vault product usage metrics reporting](/vault/docs/upgrading/upgrade-to-1.6.x#product-usage-reporting)                                                                                      |
 | Deprecation (1.16.13)       | [`default_report_months` is deprecated for the `sys/internal/counters` API](/vault/docs/upgrading/upgrade-to-1.16.x#activity-log-changes)                                                    |
+| Known Issue (1.16.16)       | [Authorization failures using Azure federated identity credentials](/vault/docs/upgrading/upgrade-to-1.16.x#authorization-failures-using-azure-federated-identity-credentials) |
 
 
 ## Vault companion updates

--- a/website/content/docs/release-notes/1.17.0.mdx
+++ b/website/content/docs/release-notes/1.17.0.mdx
@@ -30,6 +30,7 @@ description: |-
 | Known Issue (1.17.0-1.17.5)                    | [Cached activation flags for secrets sync on follower nodes are not updated](/vault/docs/upgrading/upgrade-to-1.17.x#cached-activation-flags-for-secrets-sync-on-follower-nodes-are-not-updated) |
 | New default (1.17.9)                           | [Vault product usage metrics reporting](/vault/docs/upgrading/upgrade-to-1.17.x#product-usage-reporting)                                                                                         |
 | Deprecation (1.17.9)                           | [`default_report_months` is deprecated for the `sys/internal/counters` API](/vault/docs/upgrading/upgrade-to-1.17.x#activity-log-changes)                                                        |
+| Known Issue (1.17.12)                          | [Authorization failures using Azure federated identity credentials](/vault/docs/upgrading/upgrade-to-1.17.x#authorization-failures-using-azure-federated-identity-credentials) |
 
 ## Vault companion updates
 

--- a/website/content/docs/release-notes/1.18.0.mdx
+++ b/website/content/docs/release-notes/1.18.0.mdx
@@ -19,6 +19,7 @@ description: |-
 | New default (1.18.0)        | [Docker image no longer contains curl](/vault/docs/upgrading/upgrade-to-1.18.x#docker-image-no-longer-contains-curl) |
 | Beta feature removed (1.18) | [Request limiter removed](/vault/docs/upgrading/upgrade-to-1.18.x#request-limiter-configuration-removal)             |
 | New default (1.18.2)        | [Vault product usage metrics reporting](/vault/docs/upgrading/upgrade-to-1.18.x#product-usage-reporting)             |
+| Known Issue (1.18.5)        | [Authorization failures using Azure federated identity credentials](/vault/docs/upgrading/upgrade-to-1.18.x#authorization-failures-using-azure-federated-identity-credentials) |
 
 ## Vault companion updates
 

--- a/website/content/docs/upgrading/upgrade-to-1.16.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.16.x.mdx
@@ -238,3 +238,5 @@ more details, and information about opt-out.
 @include 'known-issues/duplicate-hsm-key.mdx'
 
 @include 'known-issues/database-skip-static-role-rotation.mdx'
+
+@include 'known-issues/azure-unseal-regression.mdx'

--- a/website/content/docs/upgrading/upgrade-to-1.17.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.17.x.mdx
@@ -209,3 +209,5 @@ more details, and information about opt-out.
 @include 'known-issues/duplicate-hsm-key.mdx'
 
 @include 'known-issues/database-skip-static-role-rotation.mdx'
+
+@include 'known-issues/azure-unseal-regression.mdx'

--- a/website/content/docs/upgrading/upgrade-to-1.18.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.18.x.mdx
@@ -144,3 +144,5 @@ more details, and information about opt-out.
 @include 'known-issues/duplicate-hsm-key.mdx'
 
 @include 'known-issues/database-skip-static-role-rotation.mdx'
+
+@include 'known-issues/azure-unseal-regression.mdx'

--- a/website/content/partials/known-issues/azure-unseal-regression.mdx
+++ b/website/content/partials/known-issues/azure-unseal-regression.mdx
@@ -1,0 +1,18 @@
+### Authorization failures using Azure federated identity credentials
+
+A regression was introduced when attempting to fix automated unsealing
+using managed identity based credentials. The regression occurs when
+using Azure federated identity credentials supplying the client ID
+via an environment variable or through configuration while not
+supplying the tenant id and client secret.
+
+The regression causes authorization failures within auto-unseal,
+managed keys and seal wrapping.
+
+#### Workaround
+
+None at this time.
+
+#### Impacted versions
+
+Affects 1.19.0-rc1, 1.18.5, 1.17.12, 1.16.16


### PR DESCRIPTION
### Description

Add known issue for Azure credential failure regression in the most recent versions of Vault.

### TODO only if you're a HashiCorp employee
- [X] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
