### PR TITLE
Fix tutorial typos

### DIFF
--- a/changelog/29798.txt
+++ b/changelog/29798.txt
@@ -1,4 +1,0 @@
-```release-note:bug
-website/content/docs/enterprise/sentinel: fix typo in title of Sentinel docs page
-website/data/docs-nav-data.json: fix typo in title of Sentinel docs route
-```

--- a/changelog/29798.txt
+++ b/changelog/29798.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+website/content/docs/enterprise/sentinel: fix typo in title of Sentinel docs page
+website/data/docs-nav-data.json: fix typo in title of Sentinel docs route
+```

--- a/website/content/docs/enterprise/sentinel/index.mdx
+++ b/website/content/docs/enterprise/sentinel/index.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: Mange Vault policies with Sentinel
+page_title: Manage Vault policies with Sentinel
 description: >-
-  Mange Vault policies programmatically with Sentinel.
+  Manage Vault policies programmatically with Sentinel.
 ---
 
-# Mange Vault policies with Sentinel
+# Manage Vault policies with Sentinel
 
 @include 'alerts/enterprise-and-hcp.mdx'
 

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -3168,7 +3168,7 @@
         "title": "Manage policies as code",
         "routes": [
           {
-            "title": "Mange Vault policies with Sentinel",
+            "title": "Manage Vault policies with Sentinel",
             "path": "enterprise/sentinel"
           },
           {


### PR DESCRIPTION
### Description
Fixes typos in:
- [website/content/docs/enterprise/sentinel/index.mdx](https://github.com/hashicorp/vault/blob/main/website/content/docs/enterprise/sentinel/index.mdx)
- [website/data/docs-nav-data.json](https://github.com/hashicorp/vault/blob/a66bd4ec20e4d7a31d6b8e1233db0bc98cfdbc62/website/data/docs-nav-data.json#L3171)

`Mange -> Manage`