### PR TITLE
UI - Convert mustache component invocations to angle brackets in tests

### DIFF
--- a/ui/tests/integration/components/b64-toggle-test.js
+++ b/ui/tests/integration/components/b64-toggle-test.js
@@ -12,13 +12,13 @@ module('Integration | Component | b64 toggle', function (hooks) {
   setupRenderingTest(hooks);
 
   test('it renders', async function (assert) {
-    await render(hbs`{{b64-toggle}}`);
+    await render(hbs`<B64Toggle />`);
     assert.dom('button').exists({ count: 1 });
   });
 
   test('it toggles encoding on the passed string', async function (assert) {
     this.set('value', 'value');
-    await render(hbs`{{b64-toggle value=this.value}}`);
+    await render(hbs`<B64Toggle @value={{this.value}} />`);
     await click('button');
     assert.strictEqual(this.value, btoa('value'), 'encodes to base64');
     await click('button');
@@ -27,7 +27,7 @@ module('Integration | Component | b64 toggle', function (hooks) {
 
   test('it toggles encoding starting with base64', async function (assert) {
     this.set('value', btoa('value'));
-    await render(hbs`{{b64-toggle value=this.value initialEncoding='base64'}}`);
+    await render(hbs`<B64Toggle @value={{this.value}} @initialEncoding="base64"/>`);
     assert.ok(find('button').textContent.includes('Decode'), 'renders as on when in b64 mode');
     await click('button');
     assert.strictEqual(this.value, 'value', 'decodes from base64');
@@ -35,7 +35,7 @@ module('Integration | Component | b64 toggle', function (hooks) {
 
   test('it detects changes to value after encoding', async function (assert) {
     this.set('value', btoa('value'));
-    await render(hbs`{{b64-toggle value=this.value initialEncoding='base64'}}`);
+    await render(hbs`<B64Toggle @value={{this.value}} @initialEncoding="base64" />`);
     assert.ok(find('button').textContent.includes('Decode'), 'renders as on when in b64 mode');
     this.set('value', btoa('value') + '=');
     assert.ok(find('button').textContent.includes('Encode'), 'toggles off since value has changed');
@@ -48,7 +48,7 @@ module('Integration | Component | b64 toggle', function (hooks) {
 
   test('it does not toggle when the value is empty', async function (assert) {
     this.set('value', '');
-    await render(hbs`{{b64-toggle value=this.value}}`);
+    await render(hbs`<B64Toggle @value={{this.value}} />`);
     await click('button');
     assert.ok(find('button').textContent.includes('Encode'));
   });

--- a/ui/tests/integration/components/console/log-error-test.js
+++ b/ui/tests/integration/components/console/log-error-test.js
@@ -14,7 +14,7 @@ module('Integration | Component | console/log error', function (hooks) {
   test('it renders', async function (assert) {
     const errorText = 'Error deleting at: sys/foo. URL: v1/sys/foo Code: 404';
     this.set('content', errorText);
-    await render(hbs`{{console/log-error content=this.content}}`);
+    await render(hbs`<Console::LogError @content={{this.content}} />`);
     assert.dom('pre').includesText(errorText);
   });
 });

--- a/ui/tests/integration/components/console/log-list-test.js
+++ b/ui/tests/integration/components/console/log-list-test.js
@@ -19,7 +19,7 @@ module('Integration | Component | console/log list', function (hooks) {
 
     this.set('content', listContent);
 
-    await render(hbs`{{console/log-list content=this.content}}`);
+    await render(hbs`<Console::LogList @content={{this.content}} />`);
 
     assert.dom('pre').includesText(`${expectedText}`);
   });

--- a/ui/tests/integration/components/console/log-object-test.js
+++ b/ui/tests/integration/components/console/log-object-test.js
@@ -19,7 +19,7 @@ module('Integration | Component | console/log object', function (hooks) {
     const expectedText = 'Key Value one two three four seven {"five":"six"} eight [5,6]';
     this.set('content', objectContent);
 
-    await render(hbs`{{console/log-object content=this.content}}`);
+    await render(hbs`<Console::LogObject @content={{this.content}} />`);
     assert.dom('pre').includesText(expectedText);
   });
 });

--- a/ui/tests/integration/components/console/log-text-test.js
+++ b/ui/tests/integration/components/console/log-text-test.js
@@ -17,7 +17,7 @@ module('Integration | Component | console/log text', function (hooks) {
     const text = 'Success! You did a thing!';
     this.set('content', text);
 
-    await render(hbs`{{console/log-text content=this.content}}`);
+    await render(hbs`<Console::LogText @content={{this.content}} />`);
 
     assert.dom('pre').includesText(text);
   });

--- a/ui/tests/integration/components/console/ui-panel-test.js
+++ b/ui/tests/integration/components/console/ui-panel-test.js
@@ -16,20 +16,20 @@ module('Integration | Component | console/ui panel', function (hooks) {
   setupRenderingTest(hooks);
 
   test('it renders', async function (assert) {
-    await render(hbs`{{console/ui-panel}}`);
+    await render(hbs`<Console::UiPanel />`);
 
     assert.ok(component.hasInput);
   });
 
   test('it clears console input on enter', async function (assert) {
-    await render(hbs`{{console/ui-panel}}`);
+    await render(hbs`<Console::UiPanel />`);
     await component.runCommands('list this/thing/here', false);
     await settled();
     assert.strictEqual(component.consoleInputValue, '', 'empties input field on enter');
   });
 
   test('it clears the log when using clear command', async function (assert) {
-    await render(hbs`{{console/ui-panel}}`);
+    await render(hbs`<Console::UiPanel />`);
     await component.runCommands(
       ['list this/thing/here', 'list this/other/thing', 'read another/thing'],
       false
@@ -50,7 +50,7 @@ module('Integration | Component | console/ui panel', function (hooks) {
   });
 
   test('it adds command to history on enter', async function (assert) {
-    await render(hbs`{{console/ui-panel}}`);
+    await render(hbs`<Console::UiPanel />`);
 
     await component.runCommands('list this/thing/here', false);
     await settled();
@@ -67,7 +67,7 @@ module('Integration | Component | console/ui panel', function (hooks) {
   });
 
   test('it cycles through history with more than one command', async function (assert) {
-    await render(hbs`{{console/ui-panel}}`);
+    await render(hbs`<Console::UiPanel />`);
     await component.runCommands(['list this/thing/here', 'read that/thing/there', 'qwerty'], false);
     await settled();
     await component.up();

--- a/ui/tests/integration/components/control-group-test.js
+++ b/ui/tests/integration/components/control-group-test.js
@@ -62,7 +62,7 @@ module('Integration | Component | control group', function (hooks) {
     const { model, authData } = setup();
     this.set('model', model);
     this.set('auth.authData', authData);
-    await render(hbs`{{control-group model=this.model}}`);
+    await render(hbs`<ControlGroup @model={{this.model}} />`);
     assert.ok(component.showsAccessorCallout, 'shows accessor callout');
     assert.strictEqual(component.bannerPrefix, 'Locked');
     assert.strictEqual(component.bannerText, 'The path you requested is locked by a Control Group');
@@ -77,7 +77,7 @@ module('Integration | Component | control group', function (hooks) {
     this.set('model', model);
     this.set('auth.authData', authData);
     this.set('controlGroup.wrapInfo', { token: 'token' });
-    await render(hbs`{{control-group model=this.model}}`);
+    await render(hbs`<ControlGroup @model={{this.model}} />`);
     assert.true(component.showsTokenText, 'shows token message');
     assert.strictEqual(component.token, 'token', 'shows token value');
   });
@@ -86,7 +86,7 @@ module('Integration | Component | control group', function (hooks) {
     const { model, authData } = setup({ authorizations: [{ name: 'manager 1' }, { name: 'manager 2' }] });
     this.set('model', model);
     this.set('auth.authData', authData);
-    await render(hbs`{{control-group model=this.model}}`);
+    await render(hbs`<ControlGroup @model={{this.model}} />`);
     assert.ok(component.authorizationText, 'Already approved by manager 1, manager 2');
   });
 
@@ -94,7 +94,7 @@ module('Integration | Component | control group', function (hooks) {
     const { model, authData } = setup({ approved: true });
     this.set('model', model);
     this.set('auth.authData', authData);
-    await render(hbs`{{control-group model=this.model}}`);
+    await render(hbs`<ControlGroup @model={{this.model}} />`);
 
     assert.strictEqual(component.bannerPrefix, 'Success!');
     assert.strictEqual(component.bannerText, 'You have been given authorization');
@@ -108,7 +108,7 @@ module('Integration | Component | control group', function (hooks) {
     this.set('model', model);
     this.set('auth.authData', authData);
     this.set('controlGroup.wrapInfo', { token: 'token' });
-    await render(hbs`{{control-group model=this.model}}`);
+    await render(hbs`<ControlGroup @model={{this.model}} />`);
     assert.true(component.showsTokenText, 'shows token');
     assert.notOk(component.showsRefresh, 'does not shows refresh button');
     assert.ok(component.showsSuccessComponent, 'renders control group success');
@@ -119,7 +119,7 @@ module('Integration | Component | control group', function (hooks) {
 
     this.set('model', model);
     this.set('auth.authData', authData);
-    await render(hbs`{{control-group model=this.model}}`);
+    await render(hbs`<ControlGroup @model={{this.model}} />`);
 
     assert.strictEqual(component.bannerPrefix, 'Locked');
     assert.strictEqual(
@@ -143,7 +143,7 @@ module('Integration | Component | control group', function (hooks) {
 
     this.set('model', model);
     this.set('auth.authData', authData);
-    await render(hbs`{{control-group model=this.model}}`);
+    await render(hbs`<ControlGroup @model={{this.model}} />`);
 
     assert.strictEqual(component.bannerPrefix, 'Thanks!');
     assert.strictEqual(component.bannerText, 'You have given authorization');
@@ -158,7 +158,7 @@ module('Integration | Component | control group', function (hooks) {
 
     this.set('model', model);
     this.set('auth.authData', authData);
-    await render(hbs`{{control-group model=this.model}}`);
+    await render(hbs`<ControlGroup @model={{this.model}} />`);
 
     assert.strictEqual(component.bannerPrefix, 'Thanks!');
     assert.strictEqual(component.bannerText, 'You have given authorization');
@@ -178,7 +178,7 @@ module('Integration | Component | control group', function (hooks) {
 
     this.set('model', model);
     this.set('auth.authData', authData);
-    await render(hbs`{{control-group model=this.model}}`);
+    await render(hbs`<ControlGroup @model={{this.model}} />`);
     assert.strictEqual(component.bannerPrefix, 'Success!');
     assert.strictEqual(component.bannerText, 'This Control Group has been authorized');
     assert.ok(component.showsBackLink, 'back link is visible');

--- a/ui/tests/integration/components/empty-state-test.js
+++ b/ui/tests/integration/components/empty-state-test.js
@@ -15,7 +15,7 @@ module('Integration | Component | empty-state', function (hooks) {
     // Set any properties with this.set('myProperty', 'value');
     // Handle any actions with this.set('myAction', function(val) { ... });
 
-    await render(hbs`{{empty-state}}`);
+    await render(hbs`<EmptyState />`);
 
     assert.dom(this.element).hasText('');
 

--- a/ui/tests/integration/components/form-error-test.js
+++ b/ui/tests/integration/components/form-error-test.js
@@ -15,7 +15,7 @@ module('Integration | Component | form-error', function (hooks) {
     // Set any properties with this.set('myProperty', 'value');
     // Handle any actions with this.set('myAction', function(val) { ... });
 
-    await render(hbs`{{form-error}}`);
+    await render(hbs`<FormError />`);
 
     assert.dom(this.element).hasText('');
 

--- a/ui/tests/integration/components/identity/item-details-test.js
+++ b/ui/tests/integration/components/identity/item-details-test.js
@@ -32,7 +32,7 @@ module('Integration | Component | identity/item details', function (hooks) {
     });
     sinon.spy(model, 'save');
     this.set('model', model);
-    await render(hbs`{{identity/item-details model=this.model}}`);
+    await render(hbs`<Identity::ItemDetails @model={{this.model}} />`);
     assert.dom('[data-test-disabled-warning]').exists();
     await component.enable();
 
@@ -45,7 +45,7 @@ module('Integration | Component | identity/item details', function (hooks) {
     });
 
     this.set('model', model);
-    await render(hbs`{{identity/item-details model=this.model}}`);
+    await render(hbs`<Identity::ItemDetails @model={{this.model}} />`);
     assert.dom('[data-test-disabled-warning]').exists('shows the warning banner');
     assert.dom('[data-test-enable-identity]').doesNotExist('does not show the enable button');
   });
@@ -54,7 +54,7 @@ module('Integration | Component | identity/item details', function (hooks) {
     const model = EmberObject.create();
     this.set('model', model);
 
-    await render(hbs`{{identity/item-details model=this.model}}`);
+    await render(hbs`<Identity::ItemDetails @model={{this.model}} />`);
     assert.dom('[data-test-disabled-warning]').doesNotExist('does not show the warning banner');
   });
 });

--- a/ui/tests/integration/components/radial-progress-test.js
+++ b/ui/tests/integration/components/radial-progress-test.js
@@ -19,7 +19,7 @@ module('Integration | Component | radial progress', function (hooks) {
     // We have to manually round the circumference, strokeDash, and strokeDashOffset because
     // ie11 truncates decimals differently than other browsers.
     const circumference = ((19 / 2) * Math.PI * 2).toFixed(2);
-    await render(hbs`{{radial-progress progressDecimal=0.5}}`);
+    await render(hbs`<RadialProgress @progressDecimal={{0.5}} />`);
 
     assert.strictEqual(component.viewBox, '0 0 20 20');
     assert.strictEqual(component.height, '20');

--- a/ui/tests/integration/components/transform-edit-base-test.js
+++ b/ui/tests/integration/components/transform-edit-base-test.js
@@ -15,7 +15,7 @@ module('Integration | Component | transform-edit-base', function (hooks) {
     // Set any properties with this.set('myProperty', 'value');
     // Handle any actions with this.set('myAction', function(val) { ... });
 
-    await render(hbs`{{transform-edit-base}}`);
+    await render(hbs`<TransformEditBase />`);
 
     assert.dom(this.element).hasText('');
 

--- a/ui/tests/integration/components/upgrade-page-test.js
+++ b/ui/tests/integration/components/upgrade-page-test.js
@@ -31,7 +31,7 @@ module('Integration | Component | upgrade page', function (hooks) {
 
   test('it renders with custom attributes', async function (assert) {
     await render(hbs`
-      {{upgrade-page title="Test Feature Title" minimumEdition="Vault Enterprise Premium"}}
+      <UpgradePage @title="Test Feature Title" @minimumEdition="Vault Enterprise Premium" />
           `);
 
     assert.dom('.page-header .title').hasText('Test Feature Title', 'renders custom page title');


### PR DESCRIPTION
### Description
This PR does the chore of updating some test formatting to the the more modern component invocation style. 

#### What changes
For the most part, I just ran the [codemod](https://github.com/ember-codemods/ember-angle-brackets-codemod):

```
npx ember-angle-brackets-codemod <path-to-test-file>
```

So of these files confused the codemod, though. So I just updated by hand. 

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
