### PR TITLE
Fix small typo/anchor link in GCP sync API docs section

### DIFF
--- a/website/content/api-docs/system/secrets-sync.mdx
+++ b/website/content/api-docs/system/secrets-sync.mdx
@@ -402,7 +402,7 @@ This endpoint creates a destination to synchronize secrets with the GCP Secret M
 - `replication_locations` `(list: nil)` - A list of GCP location names the destination can use to
   store replicated secrets. Note that secrets remain globally readable regardless of the selected locations.
 
-- `locational_kms_keys` `(map<string|string>: nil)` - A map of location names to KMS key names to leverage customer-managed encryption for
+- `locational_kms_keys` `(map<string|string>: nil)` - A map of location names to KMS key names to leverage customer-managed encryption keys for
   encryption at rest. Each pair follows the format `location_name=encryption_key_resource_ID`. Refer to the
   [sample payloads](#sample-payload-3) for more details.
 
@@ -529,7 +529,7 @@ destination. See [this documentation](/vault/docs/sync#granularity) for more det
 
 @include 'sync-ssrf-fields.mdx'
 
-### Sample paylods
+### Sample payloads
 
 #### Sync secrets to a GitHub repository
 ```json

--- a/website/content/api-docs/system/secrets-sync.mdx
+++ b/website/content/api-docs/system/secrets-sync.mdx
@@ -404,7 +404,7 @@ This endpoint creates a destination to synchronize secrets with the GCP Secret M
 
 - `locational_kms_keys` `(map<string|string>: nil)` - A map of location names to KMS key names to leverage customer-managed encryption keys for
   encryption at rest. Each pair follows the format `location_name=encryption_key_resource_ID`. Refer to the
-  [sample payloads](#sample-payload-3) for more details.
+  [sample payloads](#sample-payloads) for more details.
 
 - `secret_name_template` `(string: "")` - Template to use when generating the secret names on the external system.
 The default template yields names like `vault/kv_1234/my-secret`. See [this documentation](/vault/docs/sync#name-template) for more details.


### PR DESCRIPTION
### Description
Fix a typo and anchor link

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
