### PR TITLE
 Update VSO docs for v0.10.0

### DIFF
--- a/website/content/docs/platform/k8s/vso/api-reference.mdx
+++ b/website/content/docs/platform/k8s/vso/api-reference.mdx
@@ -7,7 +7,7 @@ description: >-
 
 <!--
   copied from docs/api/api-reference.md in the vault-secrets-operator repo.
-  commit SHA=08a6e5071ffa4faa486bd4b2c53b27585da4680c
+  commit SHA=2f09afa7eb88776446eff459610d7e45a7293ffb
 -->
 # API Reference
 
@@ -1084,7 +1084,7 @@ _Appears in:_
 | `uriSans` _string array_ | The requested URI SANs. |  |  |
 | `otherSans` _string array_ | Requested other SANs, in an array with the format<br />oid;type:value for each entry. |  |  |
 | `userIDs` _string array_ | User ID (OID 0.9.2342.19200300.100.1.1) Subject values to be placed on the<br />signed certificate. |  |  |
-| `ttl` _string_ | TTL for the certificate; sets the expiration date.<br />If not specified the Vault role's default,<br />backend default, or system default TTL is used, in that order.<br />Cannot be larger than the mount's max TTL.<br />Note: this only has an effect when generating a CA cert or signing a CA cert,<br />not when generating a CSR for an intermediate CA.<br />Should be in duration notation e.g. 120s, 2h, etc. |  | Pattern: `^([0-9]+(\.[0-9]+)?(s|m|h))$` <br />Type: string <br /> |
+| `ttl` _string_ | TTL for the certificate; sets the expiration date.<br />If not specified the Vault role's default,<br />backend default, or system default TTL is used, in that order.<br />Cannot be larger than the mount's max TTL.<br />Note: this only has an effect when generating a CA cert or signing a CA cert,<br />not when generating a CSR for an intermediate CA.<br />Should be in duration notation e.g. 120s, 2h, etc. |  | Pattern: `^([0-9]+(\.[0-9]+)?(s|m|h|d))$` <br />Type: string <br /> |
 | `format` _string_ | Format for the certificate. Choices: "pem", "der", "pem_bundle".<br />If "pem_bundle",<br />any private key and issuing cert will be appended to the certificate pem.<br />If "der", the value will be base64 encoded.<br />Default: pem |  |  |
 | `privateKeyFormat` _string_ | PrivateKeyFormat, generally the default will be controlled by the Format<br />parameter as either base64-encoded DER or PEM-encoded DER.<br />However, this can be set to "pkcs8" to have the returned<br />private key contain base64-encoded pkcs8 or PEM-encoded<br />pkcs8 instead.<br />Default: der |  |  |
 | `notAfter` _string_ | NotAfter field of the certificate with specified date value.<br />The value format should be given in UTC format YYYY-MM-ddTHH:MM:SSZ |  |  |
@@ -1189,6 +1189,6 @@ _Appears in:_
 | `type` _string_ | Type of the Vault static secret |  | Enum: [kv-v1 kv-v2] <br /> |
 | `refreshAfter` _string_ | RefreshAfter a period of time, in duration notation e.g. 30s, 1m, 24h |  | Pattern: `^([0-9]+(\.[0-9]+)?(s|m|h))$` <br />Type: string <br /> |
 | `hmacSecretData` _boolean_ | HMACSecretData determines whether the Operator computes the<br />HMAC of the Secret's data. The MAC value will be stored in<br />the resource's Status.SecretMac field, and will be used for drift detection<br />and during incoming Vault secret comparison.<br />Enabling this feature is recommended to ensure that Secret's data stays consistent with Vault. | true |  |
-| `rolloutRestartTargets` _[RolloutRestartTarget](#rolloutrestarttarget) array_ | RolloutRestartTargets should be configured whenever the application(s) consuming the Vault secret does<br />not support dynamically reloading a rotated secret.<br />In that case one, or more RolloutRestartTarget(s) can be configured here. The Operator will<br />trigger a "rollout-restart" for each target whenever the Vault secret changes between reconciliation events.<br />All configured targets wil be ignored if HMACSecretData is set to false.<br />See RolloutRestartTarget for more details. |  |  |
+| `rolloutRestartTargets` _[RolloutRestartTarget](#rolloutrestarttarget) array_ | RolloutRestartTargets should be configured whenever the application(s) consuming the Vault secret does<br />not support dynamically reloading a rotated secret.<br />In that case one, or more RolloutRestartTarget(s) can be configured here. The Operator will<br />trigger a "rollout-restart" for each target whenever the Vault secret changes between reconciliation events.<br />All configured targets will be ignored if HMACSecretData is set to false.<br />See RolloutRestartTarget for more details. |  |  |
 | `destination` _[Destination](#destination)_ | Destination provides configuration necessary for syncing the Vault secret to Kubernetes. |  |  |
 | `syncConfig` _[SyncConfig](#syncconfig)_ | SyncConfig configures sync behavior from Vault to VSO |  |  |

--- a/website/content/docs/platform/k8s/vso/helm.mdx
+++ b/website/content/docs/platform/k8s/vso/helm.mdx
@@ -179,7 +179,7 @@ Use these links to navigate to a particular top-level stanza.
 
       - `repository` ((#v-controller-manager-image-repository)) (`string: hashicorp/vault-secrets-operator`)
 
-      - `tag` ((#v-controller-manager-image-tag)) (`string: 0.9.1`)
+      - `tag` ((#v-controller-manager-image-tag)) (`string: 0.10.0`)
 
     - `logging` ((#v-controller-manager-logging)) - logging
 
@@ -398,6 +398,18 @@ Use these links to navigate to a particular top-level stanza.
       May also be set via the `VSO_MAX_CONCURRENT_RECONCILES` environment variable.
 
       default: 100
+
+    - `kubeClient` ((#v-controller-manager-kubeclient))
+
+      - `qps` ((#v-controller-manager-kubeclient-qps)) (`float: ""`) - QPS indicates the maximum QPS to the kubernetes API.
+        When the value is 0, the kubernetes client's default is used.
+        May also set via the `VSO_KUBE_CLIENT_QPS` environment variable.
+        Default: 0
+
+      - `burst` ((#v-controller-manager-kubeclient-burst)) (`uint: ""`) - Maximum burst for throttling requests to the kubernetes API.
+        When the value is 0, the kubernetes client's default is used.
+        May also set via the `VSO_KUBE_CLIENT_BURST` environment variable.
+        Default: 0
 
     - `extraEnv` ((#v-controller-manager-extraenv)) (`array<map>`) - Defines additional environment variables to be added to the
       vault-secrets-operator manager container.

--- a/website/content/docs/platform/k8s/vso/installation.mdx
+++ b/website/content/docs/platform/k8s/vso/installation.mdx
@@ -32,13 +32,13 @@ $ helm repo add hashicorp https://helm.releases.hashicorp.com
 ```shell-session
 $ helm search repo hashicorp/vault-secrets-operator
 NAME           	CHART VERSION	APP VERSION	DESCRIPTION
-hashicorp/vault-secrets-operator	0.9.1       	0.9.1     	Official HashiCorp Vault Secrets Operator Chart
+hashicorp/vault-secrets-operator	0.10.0       	0.10.0     	Official HashiCorp Vault Secrets Operator Chart
 ```
 
 Then install the Operator:
 
 ```shell-session
-$ helm install --version 0.9.1 --create-namespace --namespace vault-secrets-operator vault-secrets-operator hashicorp/vault-secrets-operator
+$ helm install --version 0.10.0 --create-namespace --namespace vault-secrets-operator vault-secrets-operator hashicorp/vault-secrets-operator
 ```
 
 ## Updating CRDs when using Helm
@@ -70,9 +70,9 @@ To upgrade your VSO release, replace `<TARGET_VSO_VERSION>` with the VSO version
 $ helm upgrade --version <TARGET_VSO_VERSION> --namespace vault-secrets-operator vault-secrets-operator hashicorp/vault-secrets-operator
 ```
 
-For example, if you are upgrading to VSO 0.9.1:
+For example, if you are upgrading to VSO 0.10.0:
 ```shell-session
-$ helm upgrade --version 0.9.1 --namespace vault-secrets-operator vault-secrets-operator hashicorp/vault-secrets-operator
+$ helm upgrade --version 0.10.0 --namespace vault-secrets-operator vault-secrets-operator hashicorp/vault-secrets-operator
 ```
 
 The VSO Helm chart will automatically upgrade the CRDs to match the VSO version being deployed.
@@ -88,9 +88,9 @@ You can install and update your installation using `kustomize` which allows you 
 
 To install using Kustomize, download and untar/unzip the latest release from the [Releases Page](https://github.com/hashicorp/vault-secrets-operator/releases).
 ```shell-session
-$ wget -q https://github.com/hashicorp/vault-secrets-operator/archive/refs/tags/v0.9.1.tar.gz
-$ tar -zxf v0.9.1.tar.gz
-$ cd vault-secrets-operator-0.9.1/
+$ wget -q https://github.com/hashicorp/vault-secrets-operator/archive/refs/tags/v0.10.0.tar.gz
+$ tar -zxf v0.10.0.tar.gz
+$ cd vault-secrets-operator-0.10.0/
 ```
 
 Next install using `kustomize build`:

--- a/website/content/docs/platform/k8s/vso/openshift.mdx
+++ b/website/content/docs/platform/k8s/vso/openshift.mdx
@@ -32,7 +32,7 @@ The Vault Secrets Operator may also be installed in OpenShift using the Helm cha
 $ helm install vault-secrets-operator hashicorp/vault-secrets-operator \
   --create-namespace \
   --namespace vault-secrets-operator \
-  --version 0.9.1 \
+  --version 0.10.0 \
   --values values.yaml
 ```
 
@@ -65,7 +65,7 @@ controller:
   manager:
     image:
       repository: registry.connect.redhat.com/hashicorp/vault-secrets-operator
-      tag: 0.9.1-ubi
+      tag: 0.10.0-ubi
     resources:
       limits:
         memory: 256Mi


### PR DESCRIPTION
### Description

Update the VSO docs for 0.10.0. All documentation was auto generated from the VSO code.

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
