### PR TITLE
[Enos] Update descriptions for dev scenarios

### DIFF
--- a/enos/enos-dev-scenario-pr-replication.hcl
+++ b/enos/enos-dev-scenario-pr-replication.hcl
@@ -10,7 +10,7 @@ scenario "dev_pr_replication" {
     non-dev scenario.
 
     For a full tutorial for this scenario, see here:
-    https://eng-handbook.hashicorp.services/internal-tools/enos/tutorial-vault-dev-scenario-pr-replication
+    https://eng-handbook.hashicorp.services/internal-tools/enos/tutorial-vault-dev-scenario-pr-replication/
   EOF
 
   // The matrix is where we define all the baseline combinations that enos can utilize to customize

--- a/enos/enos-dev-scenario-pr-replication.hcl
+++ b/enos/enos-dev-scenario-pr-replication.hcl
@@ -3,71 +3,14 @@
 
 scenario "dev_pr_replication" {
   description = <<-EOF
-    This scenario spins up a two Vault clusters with either an external Consul cluster or
+    This scenario spins up two Vault clusters with either an external Consul cluster or
     integrated Raft for storage. The secondary cluster is configured with performance replication
     from the primary cluster. None of our test verification is included in this scenario in order
     to improve end-to-end speed. If you wish to perform such verification you'll need to use a
     non-dev scenario.
 
-    The scenario supports finding and installing any released 'linux/amd64' or 'linux/arm64' Vault
-    artifact as long as its version is >= 1.8. You can also use the 'artifact:local' variant to
-    build and deploy the current branch!
-
-    In order to execute this scenario you'll need to install the enos CLI:
-      - $ brew tap hashicorp/tap && brew update && brew install hashicorp/tap/enos
-    
-    You'll also need access to an AWS account via Doormat, follow the guide here:
-      https://eng-handbook.hashicorp.services/internal-tools/enos/getting-started/#authenticate-to-aws-with-doormat
-
-    Follow this guide to get an SSH keypair set up in the AWS account:
-      https://eng-handbook.hashicorp.services/internal-tools/enos/getting-started/#set-your-aws-key-pair-name-and-private-key
-
-    Please note that this scenario requires several inputs variables to be set in order to function
-    properly. While not all variants will require all variables, it's suggested that you look over
-    the scenario outline to determine which variables affect which steps and which have inputs that
-    you should set. You can use the following command to get a textual outline of the entire
-    scenario:
-      enos scenario outline dev_pr_replication
-
-    You can also create an HTML version that is suitable for viewing in web browsers:
-      enos scenario outline dev_pr_replication --format html > index.html
-      open index.html
-
-    To configure the required variables you have a couple of choices. You can create an
-    'enos-local.vars' file in the same 'enos' directory where this scenario is defined. In it you
-    declare your desired variable values. For example, you could copy the following content and
-    then set the values as necessary:
-
-    artifactory_username      = "username@hashicorp.com"
-    artifactory_token         = "<ARTIFACTORY TOKEN VALUE>
-    aws_region                = "us-west-2"
-    aws_ssh_keypair_name      = "<YOUR REGION SPECIFIC KEYPAIR NAME>"
-    aws_ssh_keypair_key_path  = "/path/to/your/private/key.pem"
-    dev_build_local_ui        = false
-    dev_consul_version        = "1.18.1"
-    vault_license_path        = "./support/vault.hclic"
-    vault_product_version     = "1.16.2"
-
-    Alternatively, you can set them in your environment:
-    export ENOS_VAR_aws_region="us-west-2"
-    export ENOS_VAR_vault_license_path="./support/vault.hclic"
-
-    After you've configured your inputs you can list and filter the available scenarios and then
-    subsequently launch and destroy them.
-      enos scenario list --help
-      enos scenario launch --help
-      enos scenario list dev_pr_replication
-      enos scenario launch dev_pr_replication arch:amd64 artifact:deb distro:ubuntu edition:ent.hsm primary_backend:raft primary_seal:awskms secondary_backend:raft secondary_seal:pkcs11
-
-    When the scenario is finished launching you refer to the scenario outputs to see information
-    related to your cluster. You can use this information to SSH into nodes and/or to interact
-    with vault.
-      enos scenario output dev_pr_replication arch:amd64 artifact:deb distro:ubuntu edition:ent.hsm primary_backend:raft primary_seal:awskms secondary_backend:raft secondary_seal:pkcs11
-      ssh -i /path/to/your/private/key.pem <PUBLIC_IP>
-      vault status
-
-    After you've finished you can tear down the cluster
-      enos scenario destroy dev_pr_replication arch:amd64 artifact:deb distro:ubuntu edition:ent.hsm primary_backend:raft primary_seal:awskms secondary_backend:raft secondary_seal:pkcs11
+    For a full tutorial for this scenario, see here:
+    https://eng-handbook.hashicorp.services/internal-tools/enos/tutorial-vault-dev-scenario-pr-replication
   EOF
 
   // The matrix is where we define all the baseline combinations that enos can utilize to customize

--- a/enos/enos-dev-scenario-single-cluster.hcl
+++ b/enos/enos-dev-scenario-single-cluster.hcl
@@ -9,7 +9,7 @@ scenario "dev_single_cluster" {
     non-dev scenario instead.
 
     For a full tutorial for this scenario, see here:
-    https://eng-handbook.hashicorp.services/internal-tools/enos/tutorial-vault-dev-scenario-single-cluster
+    https://eng-handbook.hashicorp.services/internal-tools/enos/tutorial-vault-dev-scenario-single-cluster/
   EOF
 
   // The matrix is where we define all the baseline combinations that enos can utilize to customize

--- a/enos/enos-dev-scenario-single-cluster.hcl
+++ b/enos/enos-dev-scenario-single-cluster.hcl
@@ -8,73 +8,13 @@ scenario "dev_single_cluster" {
     to improve end-to-end speed. If you wish to perform such verification you'll need to use a
     non-dev scenario instead.
 
-    The scenario supports finding and installing any released 'linux/amd64' or 'linux/arm64' Vault
-    artifact as long as its version is >= 1.8. You can also use the 'artifact:local' variant to
-    build and deploy the current branch!
-
-    In order to execute this scenario you'll need to install the enos CLI:
-      brew tap hashicorp/tap && brew update && brew install hashicorp/tap/enos
-
-    You'll also need access to an AWS account via Doormat, follow the guide here:
-      https://eng-handbook.hashicorp.services/internal-tools/enos/getting-started/#authenticate-to-aws-with-doormat
-
-    Follow this guide to get an SSH keypair set up in the AWS account:
-      https://eng-handbook.hashicorp.services/internal-tools/enos/getting-started/#set-your-aws-key-pair-name-and-private-key
-
-    Please note that this scenario requires several inputs variables to be set in order to function
-    properly. While not all variants will require all variables, it's suggested that you look over
-    the scenario outline to determine which variables affect which steps and which have inputs that
-    you should set. You can use the following command to get a textual outline of the entire
-    scenario:
-      enos scenario outline dev_single_cluster
-
-    You can also create an HTML version that is suitable for viewing in web browsers:
-      enos scenario outline dev_single_cluster --format html > index.html
-      open index.html
-
-    To configure the required variables you have a couple of choices. You can create an
-    'enos-local.vars' file in the same 'enos' directory where this scenario is defined. In it you
-    declare your desired variable values. For example, you could copy the following content and
-    then set the values as necessary:
-
-    artifactory_username      = "username@hashicorp.com"
-    artifactory_token         = "<ARTIFACTORY TOKEN VALUE>
-    aws_region                = "us-west-2"
-    aws_ssh_keypair_name      = "<YOUR REGION SPECIFIC KEYPAIR NAME>"
-    aws_ssh_keypair_key_path  = "/path/to/your/private/key.pem"
-    dev_build_local_ui        = false
-    dev_consul_version        = "1.18.1"
-    vault_license_path        = "./support/vault.hclic"
-    vault_product_version     = "1.16.2"
-    Alternatively, you can set them in your environment:
-    export ENOS_VAR_aws_region="us-west-2"
-    export ENOS_VAR_vault_license_path="./support/vault.hclic"
-
-    Alternatively, you can set them in your environment:
-    export ENOS_VAR_aws_region="us-west-2"
-    export ENOS_VAR_vault_license_path="./support/vault.hclic"
-
-    After you've configured your inputs you can list and filter the available scenarios and then
-    subsequently launch and destroy them.
-      enos scenario list --help
-      enos scenario launch --help
-      enos scenario list dev_single_cluster
-      enos scenario launch dev_single_cluster arch:arm64 artifact:local backend:raft distro:ubuntu edition:ce seal:awskms
-
-    When the scenario is finished launching you refer to the scenario outputs to see information
-    related to your cluster. You can use this information to SSH into nodes and/or to interact
-    with vault.
-      enos scenario output dev_single_cluster arch:arm64 artifact:local backend:raft distro:ubuntu edition:ce seal:awskms
-      ssh -i /path/to/your/private/key.pem <PUBLIC_IP>
-      vault status
-
-    After you've finished you can tear down the cluster
-      enos scenario destroy dev_single_cluster arch:arm64 artifact:local backend:raft distro:ubuntu edition:ce seal:awskms
+    For a full tutorial for this scenario, see here:
+    https://eng-handbook.hashicorp.services/internal-tools/enos/tutorial-vault-dev-scenario-single-cluster
   EOF
 
   // The matrix is where we define all the baseline combinations that enos can utilize to customize
-  // your scenario. By default enos attempts to perform your command on the entire product of these
-  // possible comginations! Most of the time you'll want to reduce that by passing in a filter.
+  // your scenario. By default, Enos attempts to perform your command on the entire product of these
+  // possible combinations! Most of the time you'll want to reduce that by passing in a filter.
   // Run 'enos scenario list --help' to see more about how filtering scenarios works in enos.
   matrix {
     arch     = ["amd64", "arm64"]


### PR DESCRIPTION
### Description
Now that we have full tutorials for the [single cluster](https://eng-handbook.hashicorp.services/internal-tools/enos/tutorial-vault-dev-scenario-single-cluster/) and [PR replication](https://eng-handbook.hashicorp.services/internal-tools/enos/tutorial-vault-dev-scenario-pr-replication/) dev scenarios, we can remove the extended instructions for how to run the scenario from the scenario `description`.

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
