### PR TITLE
identity: fix a racy deduplication test assertion

### DIFF
--- a/vault/identity_store_test.go
+++ b/vault/identity_store_test.go
@@ -1643,9 +1643,10 @@ func identityStoreLoadingIsDeterministic(t *testing.T, flags *determinismTestFla
 		c.FeatureActivationFlags.ActivateInMem(activationflags.IdentityDeduplication, true)
 		require.NoError(t, err)
 
-		c.identityStore.activateDeduplicationDone = make(chan struct{})
+		c.identityStore.MakeDeduplicationDoneChan()
 		err := c.systemBackend.activateIdentityDeduplication(ctx, nil)
-		<-c.identityStore.activateDeduplicationDone
+		require.NoError(t, err)
+		err = c.identityStore.WaitForActivateDeduplicationDone(ctx)
 		require.NoError(t, err)
 		require.IsType(t, &renameResolver{}, c.identityStore.conflictResolver)
 		require.False(t, c.identityStore.disableLowerCasedNames)

--- a/vault/identity_store_util.go
+++ b/vault/identity_store_util.go
@@ -2947,3 +2947,23 @@ func makeLocalAliasWithName(t *testing.T, name, entityID string, bucketKey strin
 		},
 	}
 }
+
+// MakeDeduplicationDoneChan creates a new done channel for synchronization
+// with tests outside of the vault package (e.g. in external_tests).
+func (i *IdentityStore) MakeDeduplicationDoneChan() {
+	i.activateDeduplicationDone = make(chan struct{})
+}
+
+// WaitForActivateDeduplicationDone is a test helper to wait for the identity
+// deduplication activation to finish.
+func (i *IdentityStore) WaitForActivateDeduplicationDone(ctx context.Context) error {
+	timeoutCtx, cancel := context.WithTimeout(ctx, 90*time.Second)
+	defer cancel()
+	select {
+	case <-i.activateDeduplicationDone:
+		return nil
+	case <-timeoutCtx.Done():
+		return fmt.Errorf("timed out waiting for deduplication")
+
+	}
+}


### PR DESCRIPTION
### Description

This test adds some synchronization for a goroutine in test assertions.

Enterprise PR: https://github.com/hashicorp/vault-enterprise/pull/7591

- [x] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [x] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
