### PR TITLE
VAULT-34477: Add s390x multilib compiler to build-vault action

### DIFF
--- a/.github/actions/build-vault/action.yml
+++ b/.github/actions/build-vault/action.yml
@@ -87,6 +87,16 @@ runs:
       with:
         github-token: ${{ inputs.github-token }}
     - uses: ./.github/actions/install-external-tools
+    - if: inputs.goarch == 's390x' && inputs.vault-edition == 'ent.hsm'
+      name: Configure CGO compiler for HSM edition on s390x
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y gcc-multilib-s390x-linux-gnu
+        {
+          echo "CC=s390x-linux-gnu-gcc"
+          echo "CC_FOR_TARGET=s390x-linux-gnu-gcc"
+        } | tee -a "$GITHUB_ENV"
     - if: inputs.vault-edition != 'ce'
       name: Configure Git
       shell: bash

--- a/scripts/ci-helper.sh
+++ b/scripts/ci-helper.sh
@@ -2,7 +2,6 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-
 # The ci-helper is used to determine build metadata, build Vault binaries,
 # package those binaries into artifacts, and execute tests with those artifacts.
 
@@ -92,7 +91,14 @@ function build() {
   : "${GO_TAGS:=""}"
   : "${REMOVE_SYMBOLS:=""}"
 
-  (unset GOOS; unset GOARCH; go generate ./...)
+  # Generate code but make sure we don't slurp in cross compilation env vars
+  (
+    unset GOOS
+    unset GOARCH
+    unset CC
+    unset CC_FOR_TARGET
+    go generate ./...
+  )
 
   # Build our ldflags
   msg="--> Building Vault revision $revision, built $build_date..."
@@ -155,7 +161,7 @@ function prepare_ce_legal() {
 # Package version converts a vault version string into a compatible representation for system
 # packages.
 function version_package() {
-  awk '{ gsub("-","~",$1); print $1 }' <<< "$VAULT_VERSION"
+  awk '{ gsub("-","~",$1); print $1 }' <<<"$VAULT_VERSION"
 }
 
 # Run the CI Helper
@@ -163,35 +169,35 @@ function main() {
   case $1 in
   artifact-basename)
     artifact_basename
-  ;;
+    ;;
   build)
     build
-  ;;
+    ;;
   build-ui)
     build_ui
-  ;;
+    ;;
   bundle)
     bundle
-  ;;
+    ;;
   date)
     build_date
-  ;;
+    ;;
   prepare-ent-legal)
     prepare_ent_legal
-  ;;
+    ;;
   prepare-ce-legal)
     prepare_ce_legal
-  ;;
+    ;;
   revision)
     build_revision
-  ;;
+    ;;
   version-package)
     version_package
-  ;;
+    ;;
   *)
     echo "unknown sub-command" >&2
     exit 1
-  ;;
+    ;;
   esac
 }
 


### PR DESCRIPTION
### Description
Install and configure an s390x C toolchain when building Vault editions that need CGO on s390x. x86_64 and aarch64 need no special handling as it is assumed that those binaries are compiled on runners with matching architecture.

CE counterpart to https://github.com/hashicorp/vault-enterprise/pull/7586

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [x] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
