### PR TITLE
[UI] Generate API Client Script

### DIFF
--- a/ui/scripts/generate-api-client.sh
+++ b/ui/scripts/generate-api-client.sh
@@ -54,6 +54,8 @@ mv "$SCRIPTS_DIR/openapi.json" "$API_CLIENT_DIR/openapi.json"
 echo "Generating API client..."
 echo
 cd "$API_CLIENT_DIR"
-npx @openapitools/openapi-generator-cli generate -i openapi.json -g typescript-fetch -o . --skip-validate-spec
+# config args specific to typescript-fetch generator
+GEN_CONFIG="prefixParameterInterfaces=true,useSingleRequestParameter=false,useSquareBracketsInArrayNames=true"
+npx @openapitools/openapi-generator-cli generate -i openapi.json -g typescript-fetch -o . --skip-validate-spec --additional-properties=${GEN_CONFIG}
 echo
 echo "API client generated successfully!"

--- a/ui/scripts/generate-api-client.sh
+++ b/ui/scripts/generate-api-client.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+# Generate the API client for Vault UI using the OpenAPI spec
+# Vault Enterprise binary required to generate complete API client
+# Run 'make entdev' in vault-enterprise directory prior to running this script or an error will occur
+
+# exit if a command fails
+set -e
+
+# check if vault version contains +ent
+VERSION=$(vault version)
+if [[ ! "$VERSION" == *"+ent"* ]]; then
+  echo "Vault Enterprise binary not found and is required to generate the complete API client"
+  echo $VERSION
+  echo "Run 'make entdev' in vault-enterprise directory to build the binary and try again"
+  exit 1
+fi
+
+echo "Generating OpenAPI spec..."
+echo
+
+# directory where this script is located
+SOURCE_DIR=$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")
+# parent vault directory
+VAULT_DIR="$( cd -P "$SOURCE_DIR/../../" && pwd )"
+# scripts directory
+SCRIPTS_DIR="$VAULT_DIR/scripts"
+# api client directory
+API_CLIENT_DIR="$VAULT_DIR/ui/api-client"
+
+# cleanup to remove the generated openapi.json file on exit
+cleanup() {
+  rm -f "$SCRIPTS_DIR/openapi.json"
+  rm -f "$API_CLIENT_DIR/openapi.json"
+}
+trap 'cleanup' INT TERM EXIT
+
+# change into scripts directory and execute gen_openapi.sh
+cd "$SCRIPTS_DIR"
+./gen_openapi.sh
+echo
+echo "OpenAPI spec generated successfully!"
+
+# create the api client directory
+echo "Creating API client directory..."
+mkdir "$API_CLIENT_DIR" || echo
+
+# move the generated openapi spec to the api-client directory
+mv "$SCRIPTS_DIR/openapi.json" "$API_CLIENT_DIR/openapi.json"
+
+# generate the typescript-fetch API client
+echo "Generating API client..."
+echo
+cd "$API_CLIENT_DIR"
+npx @openapitools/openapi-generator-cli generate -i openapi.json -g typescript-fetch -o . --skip-validate-spec
+echo
+echo "API client generated successfully!"


### PR DESCRIPTION
### Description
To help generate the api client locally, this PR adds a script that will generate the OpenAPI spec (via gen_openapi.sh) and then generate the typescript-fetch api client. This process may be automated in the future but for now as we generate the client on an ad-hoc basis this script will help with that and keep things consistent.

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
