### PR TITLE
Add LIST endpoint to AWS Secrets static roles

### DIFF
--- a/builtin/logical/aws/backend.go
+++ b/builtin/logical/aws/backend.go
@@ -57,6 +57,7 @@ func Backend(_ *logical.BackendConfig) *backend {
 			pathRoles(&b),
 			pathListRoles(&b),
 			pathStaticRoles(&b),
+			pathListStaticRoles(&b),
 			pathStaticCredentials(&b),
 			pathUser(&b),
 		},

--- a/changelog/29842.txt
+++ b/changelog/29842.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+secrets/aws: Add LIST endpoint to the AWS secrets engine static roles.
+```

--- a/website/content/api-docs/secret/aws.mdx
+++ b/website/content/api-docs/secret/aws.mdx
@@ -752,7 +752,7 @@ $ curl \
 
 ## List static roles
 
-This endpoint lists all existing static roles in the secrets engine.
+Use the list static roles endpoint to fetch all existing static roles in the secrets engine.
 
 | Method | Path                |
 | :----- | :------------------ |

--- a/website/content/api-docs/secret/aws.mdx
+++ b/website/content/api-docs/secret/aws.mdx
@@ -750,6 +750,33 @@ $ curl \
 }
 ```
 
+## List static role
+
+This endpoint lists all existing static roles in the secrets engine.
+
+| Method | Path                |
+| :----- | :------------------ |
+| `LIST` | `/aws/static-roles` |
+
+### Sample request
+
+```shell-session
+$ curl
+    --header "X-Vault-Token: ..." \
+    --request LIST \
+    http://127.0.0.1:8200/v1/aws/static-roles
+```
+
+### Sample response
+
+```json
+{
+  "data": {
+    "keys": ["example-role"]
+  }
+}
+```
+
 ## Delete static role
 
 This endpoint deletes the static role definition. The user, having been defined externally,

--- a/website/content/api-docs/secret/aws.mdx
+++ b/website/content/api-docs/secret/aws.mdx
@@ -750,7 +750,7 @@ $ curl \
 }
 ```
 
-## List static role
+## List static roles
 
 This endpoint lists all existing static roles in the secrets engine.
 


### PR DESCRIPTION
### Description
What does this PR do?

This PR adds a LIST endpoint to aws/static-roles/


### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
