### PR TITLE
(DOCS) VAULT-31525 Added note for case sensitivity changes in the RADIUS auth plugin

### DIFF
--- a/website/content/docs/release-notes/1.19.0.mdx
+++ b/website/content/docs/release-notes/1.19.0.mdx
@@ -21,6 +21,7 @@ description: |-
 | Breaking change (1.19)                        | [LDAP security improvement impacting user DN search with `upndomain`](/vault/docs/upgrading/upgrade-to-1.19.x#ldap)
 | New behavior (1.19.0)                         | [Anonymized cluster data returned with license utilization](/vault/docs/upgrading/upgrade-to-1.19.x#anon-data)
 | Known issue (1.19.x, 1.18.x, 1.17.x, 1.16.x)  | [Duplicate HSM keys creation when migrating to HSM from Shamir](/vault/docs/upgrading/upgrade-to-1.19.x#hsm-keys)
+| New behavior (1.19.0)                         | [Uppercase values are no longer forced to lower case](/vault/docs/upgrading/upgrade-to-1.19.x#case-sensitive)
 
 ## Vault companion updates
 

--- a/website/content/docs/upgrading/upgrade-to-1.19.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.19.x.mdx
@@ -77,6 +77,10 @@ Vault 1.19.0 collects anonymous usage data about the Vault cluster and
 automatically sends the cluster usage data with the standard utilization data
 reported through automated license reporting.
 
+### RADIUS authentication is no longer case sensitive ((#case-sensitive))
+
+As of Vault 1.19.0 the RADIUS authentication plugin will not force case sensitivity when entered.
+
 
 ## Known issues and workarounds
 


### PR DESCRIPTION
### Description
Adds documentation around case sensitivity changes in the RADIUS auth plugin.


### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
