### PR TITLE
Fix anchor text in LDAP release note heading

### DIFF
--- a/website/content/docs/release-notes/1.19.0.mdx
+++ b/website/content/docs/release-notes/1.19.0.mdx
@@ -18,7 +18,7 @@ description: |-
 | Support change (1.16.x)                       | 1.16.x moves to long term support and 1.19 becomes the current LTS version.
 | New behavior (1.19.0)                         | [Changed behavior for Ed25519 signatures in Transit plugin](/vault/docs/upgrading/upgrade-to-1.19.x#ed25519)
 | New behavior (1.19.0)                         | [Duplicate identity cleanup and forced deduplication](/vault/docs/upgrading/upgrade-to-1.19.x#dedupe)
-| Breaking change (1.19)                        | [LDAP security improvement impacting user DN search with `upndomain`](/vault/docs/upgrading/upgrade-to-1.19.x#ldap)
+| Breaking change (1.19)                        | [LDAP security improvement impacting user DN search with `upndomain`](/vault/docs/upgrading/upgrade-to-1.19.x#ldap-user-dn-search-with-upndomain)
 | New behavior (1.19.0)                         | [Anonymized cluster data returned with license utilization](/vault/docs/upgrading/upgrade-to-1.19.x#anon-data)
 | Known issue (1.19.x, 1.18.x, 1.17.x, 1.16.x)  | [Duplicate HSM keys creation when migrating to HSM from Shamir](/vault/docs/upgrading/upgrade-to-1.19.x#hsm-keys)
 | New behavior (1.19.0)                         | [Uppercase values are no longer forced to lower case](/vault/docs/upgrading/upgrade-to-1.19.x#case-sensitive)

--- a/website/content/docs/upgrading/upgrade-to-1.19.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.19.x.mdx
@@ -60,7 +60,7 @@ To understand if you need to take action, consult
 demonstrates the log lines to watch for and how to ensure your resolve
 duplicates safely.
 
-### LDAP user DN search with `upndomain` ((#ldap))
+### LDAP user DN search with `upndomain`
 
 The github.com/hashicorp/cap/ldap dependency has been upgraded to include a security improvement
 which may be a breaking change for users. The enhancement ensures that user DN searches with


### PR DESCRIPTION
### Description
What does this PR do?
- remove anchor text from ldap heading (not rendering properly, thus link not working) - I could not figure out how to make this work with the code syntax in the heading and didnt want to change the heading.

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
