### PR TITLE
VAULT-34126 CE part

### DIFF
--- a/api/sys_utilization_report.go
+++ b/api/sys_utilization_report.go
@@ -1,0 +1,91 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package api
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"github.com/mitchellh/mapstructure"
+)
+
+func (c *Sys) UtilizationReport() (*UtilizationReportOutput, error) {
+	return c.UtilizationReportWithContext(context.Background())
+}
+
+func (c *Sys) UtilizationReportWithContext(ctx context.Context) (*UtilizationReportOutput, error) {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
+	r := c.c.NewRequest(http.MethodGet, "/v1/sys/utilization-report")
+
+	resp, err := c.c.rawRequestWithContext(ctx, r)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	secret, err := ParseSecret(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if secret == nil || secret.Data == nil {
+		return nil, errors.New("data from server response is empty")
+	}
+
+	var result UtilizationReportOutput
+	err = mapstructure.Decode(secret.Data, &result)
+	if err != nil {
+		return nil, err
+	}
+
+	return &result, err
+}
+
+type UtilizationReportOutput struct {
+	Namespaces int `json:"namespaces,omitempty" structs:"namespaces" mapstructure:"namespaces"`
+
+	KVV1Secrets int `json:"kvv1_secrets,omitempty" structs:"kvv1_secrets" mapstructure:"kvv1_secrets"`
+	KVV2Secrets int `json:"kvv2_secrets,omitempty" structs:"kvv2_secrets" mapstructure:"kvv2_secrets"`
+
+	AuthMethods   map[string]int `json:"auth_methods,omitempty" structs:"auth_methods" mapstructure:"auth_methods"`
+	SecretEngines map[string]int `json:"secret_engines,omitempty" structs:"secret_engines" mapstructure:"secret_engines"`
+
+	ReplicationStatus *UtilizationReportReplicationStatusInformation `json:"replication_status,omitempty" structs:"replication_status" mapstructure:"replication_status"`
+
+	PKI *UtilizationReportPKIInformation `json:"pki,omitempty" structs:"pki" mapstructure:"pki"`
+
+	SecretSync *UtilizationReportSecretSyncInformation `json:"secret_sync,omitempty" structs:"secret_sync" mapstructure:"secret_sync"`
+
+	LeaseCountQuotas *UtilizationReportLeaseCountQuotaInformation `json:"lease_count_quotas,omitempty" structs:"lease_count_quotas" mapstructure:"lease_count_quotas"`
+}
+
+type UtilizationReportReplicationStatusInformation struct {
+	DRPrimary bool   `json:"dr_primary,omitempty" structs:"dr_primary" mapstructure:"dr_primary"`
+	DRState   string `json:"dr_state,omitempty" structs:"dr_state" mapstructure:"dr_state"`
+	PRPrimary bool   `json:"pr_primary,omitempty" structs:"pr_primary" mapstructure:"pr_primary"`
+	PRState   string `json:"pr_state,omitempty" structs:"pr_state" mapstructure:"pr_state"`
+}
+
+type UtilizationReportPKIInformation struct {
+	TotalRoles   int `json:"total_roles,omitempty" structs:"total_roles" mapstructure:"total_roles"`
+	TotalIssuers int `json:"total_issuers,omitempty" structs:"total_issuers" mapstructure:"total_issuers"`
+}
+
+type UtilizationReportSecretSyncInformation struct {
+	TotalSources      int `json:"total_sources,omitempty" structs:"total_sources" mapstructure:"total_sources"`
+	TotalDestinations int `json:"total_destinations,omitempty" structs:"total_destinations" mapstructure:"total_destinations"`
+}
+
+type UtilizationReportLeaseCountQuotaInformation struct {
+	TotalLeaseCountQuotas            int                                                `json:"total_lease_count_quotas,omitempty" structs:"total_lease_count_quotas" mapstructure:"total_lease_count_quotas"`
+	GlobalLeaseCountQuotaInformation *UtilizationReportGlobalLeaseCountQuotaInformation `json:"global_lease_count_quota,omitempty" structs:"global_lease_count_quota" mapstructure:"global_lease_count_quota"`
+}
+
+type UtilizationReportGlobalLeaseCountQuotaInformation struct {
+	Name     string `json:"name,omitempty" structs:"name" mapstructure:"name"`
+	Capacity int    `json:"capacity,omitempty" structs:"capacity" mapstructure:"capacity"`
+	Count    int    `json:"count,omitempty" structs:"count" mapstructure:"count"`
+}


### PR DESCRIPTION
### Description

This just has the API changes. CE component of https://github.com/hashicorp/vault-enterprise/pull/7585

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [x] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
