### PR TITLE
Fix bug when writing auto tidy config field tidy_cmpv2_nonce_store

### DIFF
--- a/builtin/logical/pki/path_tidy.go
+++ b/builtin/logical/pki/path_tidy.go
@@ -116,7 +116,7 @@ func (tc *tidyConfig) IsAnyTidyEnabled() bool {
 }
 
 func (tc *tidyConfig) AnyTidyConfig() string {
-	return "tidy_cert_store / tidy_revoked_certs / tidy_revoked_cert_issuer_associations / tidy_expired_issuers / tidy_move_legacy_ca_bundle / tidy_revocation_queue / tidy_cross_cluster_revoked_certs / tidy_acme"
+	return "tidy_cert_store / tidy_revoked_certs / tidy_revoked_cert_issuer_associations / tidy_expired_issuers / tidy_move_legacy_ca_bundle / tidy_acme / tidy_cross_cluster_revoked_certs / tidy_revocation_queue / tidy_cert_metadata / tidy_cmpv2_nonce_store"
 }
 
 func (tc *tidyConfig) CalculateStartupBackoff(mountStartup time.Time) time.Time {
@@ -1776,6 +1776,13 @@ func (b *backend) pathConfigAutoTidyWrite(ctx context.Context, req *logical.Requ
 
 		if config.CertMetadata && !constants.IsEnterprise {
 			return logical.ErrorResponse("certificate metadata is only supported on Vault Enterprise"), nil
+		}
+	}
+
+	if tidyCmpv2NonceStoreRaw, ok := d.GetOk("tidy_cmpv2_nonce_store"); ok {
+		config.CMPV2NonceStore = tidyCmpv2NonceStoreRaw.(bool)
+		if config.CMPV2NonceStore && !constants.IsEnterprise {
+			return logical.ErrorResponse("CMPv2 is only supported on Vault Enterprise"), nil
 		}
 	}
 

--- a/builtin/logical/pki/path_tidy.go
+++ b/builtin/logical/pki/path_tidy.go
@@ -1836,6 +1836,7 @@ func (b *backend) tidyStatusStart(config *tidyConfig) {
 		tidyCrossRevokedCerts:   config.CrossRevokedCerts,
 		tidyAcme:                config.TidyAcme,
 		tidyCertMetadata:        config.CertMetadata,
+		tidyCMPV2NonceStore:     config.CMPV2NonceStore,
 		pauseDuration:           config.PauseDuration.String(),
 
 		state:       tidyStatusStarted,

--- a/builtin/logical/pki/path_tidy_test.go
+++ b/builtin/logical/pki/path_tidy_test.go
@@ -614,7 +614,7 @@ func TestCertStorageMetrics(t *testing.T) {
 
 	// We set up a metrics accumulator
 	inmemSink := metrics.NewInmemSink(
-		2*newPeriod, // A short time period is ideal here to test metrics are emitted every periodic func
+		2*newPeriod,  // A short time period is ideal here to test metrics are emitted every periodic func
 		10*newPeriod) // Do not keep a huge amount of metrics in the sink forever, clear them out to save memory usage.
 
 	metricsConf := metrics.DefaultConfig("")

--- a/builtin/logical/pki/path_tidy_test.go
+++ b/builtin/logical/pki/path_tidy_test.go
@@ -39,9 +39,13 @@ func TestTidyConfigs(t *testing.T) {
 	require.Greater(t, len(operations), 1, "expected more than one operation")
 	t.Logf("Got tidy operations: %v", operations)
 
-	lastOp := operations[len(operations)-1]
+	lastOp := "tidy_acme"
 
 	for _, operation := range operations {
+		if operation == "tidy_cmpv2_nonce_store" || operation == "tidy_cert_metadata" {
+			// Skip, since these require ENT
+			continue
+		}
 		b, s := CreateBackendWithStorage(t)
 
 		resp, err := CBWrite(b, s, "config/auto-tidy", map[string]interface{}{
@@ -610,7 +614,7 @@ func TestCertStorageMetrics(t *testing.T) {
 
 	// We set up a metrics accumulator
 	inmemSink := metrics.NewInmemSink(
-		2*newPeriod,  // A short time period is ideal here to test metrics are emitted every periodic func
+		2*newPeriod, // A short time period is ideal here to test metrics are emitted every periodic func
 		10*newPeriod) // Do not keep a huge amount of metrics in the sink forever, clear them out to save memory usage.
 
 	metricsConf := metrics.DefaultConfig("")

--- a/changelog/29852.txt
+++ b/changelog/29852.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+secrets/pki: Fix a bug that prevents enabling automatic tidying of the CMPv2 nonce store.
+```


### PR DESCRIPTION
### Description
Fix a bug when writing auto tidy config field that prevents field tidy_cmpv2_nonce_store from being set.

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
