### PR TITLE
release/1.16.x: update codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,31 +5,31 @@
 # More on CODEOWNERS files: https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
 
 # Select Auth engines are owned by Ecosystem
-/builtin/credential/aws/      @hashicorp/vault-ecosystem-applications
-/builtin/credential/github/   @hashicorp/vault-ecosystem-applications
-/builtin/credential/ldap/     @hashicorp/vault-ecosystem-applications
-/builtin/credential/okta/     @hashicorp/vault-ecosystem-applications
+/builtin/credential/aws/      @hashicorp/vault-ecosystem
+/builtin/credential/github/   @hashicorp/vault-ecosystem
+/builtin/credential/ldap/     @hashicorp/vault-ecosystem
+/builtin/credential/okta/     @hashicorp/vault-ecosystem
 
 # Secrets engines (pki, ssh, totp and transit omitted)
-/builtin/logical/aws/         @hashicorp/vault-ecosystem-applications
-/builtin/logical/cassandra/   @hashicorp/vault-ecosystem-applications
-/builtin/logical/consul/      @hashicorp/vault-ecosystem-applications
-/builtin/logical/database/    @hashicorp/vault-ecosystem-applications
-/builtin/logical/mongodb/     @hashicorp/vault-ecosystem-applications
-/builtin/logical/mssql/       @hashicorp/vault-ecosystem-applications
-/builtin/logical/mysql/       @hashicorp/vault-ecosystem-applications
-/builtin/logical/nomad/       @hashicorp/vault-ecosystem-applications
-/builtin/logical/postgresql/  @hashicorp/vault-ecosystem-applications
-/builtin/logical/rabbitmq/    @hashicorp/vault-ecosystem-applications
+/builtin/logical/aws/         @hashicorp/vault-ecosystem
+/builtin/logical/cassandra/   @hashicorp/vault-ecosystem
+/builtin/logical/consul/      @hashicorp/vault-ecosystem
+/builtin/logical/database/    @hashicorp/vault-ecosystem
+/builtin/logical/mongodb/     @hashicorp/vault-ecosystem
+/builtin/logical/mssql/       @hashicorp/vault-ecosystem
+/builtin/logical/mysql/       @hashicorp/vault-ecosystem
+/builtin/logical/nomad/       @hashicorp/vault-ecosystem
+/builtin/logical/postgresql/  @hashicorp/vault-ecosystem
+/builtin/logical/rabbitmq/    @hashicorp/vault-ecosystem
 
 # Identity Integrations (OIDC, tokens)
-/vault/identity_store_oidc*   @hashicorp/vault-ecosystem-applications
+/vault/identity_store_oidc*   @hashicorp/vault-ecosystem
 
 /plugins/                     @hashicorp/vault-ecosystem
 /vault/plugin_catalog.go      @hashicorp/vault-ecosystem
 
-/website/content/ @hashicorp/vault-education-approvers
-/website/content/docs/plugin-portal.mdx   @acahn @hashicorp/vault-education-approvers
+# Content on developer.hashicorp.com
+/website/ @hashicorp/vault-education-approvers
 
 # Plugin docs
 /website/content/docs/plugins/              @hashicorp/vault-ecosystem @hashicorp/vault-education-approvers
@@ -38,8 +38,8 @@
 # UI code related to Vault's JWT/OIDC auth method and OIDC provider.
 # Changes to these files often require coordination with backend code,
 # so stewards of the backend code are added below for notification.
-/ui/app/components/auth-jwt.js         @hashicorp/vault-ecosystem-applications
-/ui/app/routes/vault/cluster/oidc-*.js @hashicorp/vault-ecosystem-applications
+/ui/app/components/auth-jwt.js         @hashicorp/vault-ecosystem
+/ui/app/routes/vault/cluster/oidc-*.js @hashicorp/vault-ecosystem
 
 # Release config; service account is required for automation tooling.
 /.release/                     @hashicorp/github-secure-vault-core @hashicorp/quality-team


### PR DESCRIPTION
### Description
update codeowners on `release/1.16.x` branch

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
