### PR TITLE
VAULT-34581: retry_join: handle escapes in `auto_join` config

### DIFF
--- a/command/server/config_test_helpers.go
+++ b/command/server/config_test_helpers.go
@@ -35,13 +35,16 @@ func testConfigRaftRetryJoin(t *testing.T) {
 	t.Parallel()
 
 	retryJoinExpected := []map[string]string{
+		// NOTE: Normalization handles IPv6 addresses and returns auto_join with
+		// sorted stable keys.
 		{"leader_api_addr": "http://127.0.0.1:8200"},
 		{"leader_api_addr": "http://[2001:db8::2:1]:8200"},
-		{"auto_join": "provider=mdns service=consul domain=2001:db8::2:1"},
-		{"auto_join": "provider=os tag_key=consul tag_value=server username=foo password=bar auth_url=https://[2001:db8::2:1]/auth"},
-		{"auto_join": "provider=triton account=testaccount url=https://[2001:db8::2:1] key_id=1234 tag_key=consul-role tag_value=server"},
-		{"auto_join": "provider=packet auth_token=token project=uuid url=https://[2001:db8::2:1] address_type=public_v6"},
-		{"auto_join": "provider=vsphere category_name=consul-role tag_name=consul-server host=https://[2001:db8::2:1] user=foo password=bar insecure_ssl=false"},
+		{"auto_join": "provider=mdns domain=2001:db8::2:1 service=consul"},
+		{"auto_join": "provider=os auth_url=https://[2001:db8::2:1]/auth password=bar tag_key=consul tag_value=server username=foo"},
+		{"auto_join": "provider=triton account=testaccount key_id=1234 tag_key=consul-role tag_value=server url=https://[2001:db8::2:1]"},
+		{"auto_join": "provider=packet address_type=public_v6 auth_token=token project=uuid url=https://[2001:db8::2:1]"},
+		{"auto_join": "provider=vsphere category_name=consul-role host=https://[2001:db8::2:1] insecure_ssl=false password=bar tag_name=consul-server user=foo"},
+		{"auto_join": "provider=k8s label_selector=\"app.kubernetes.io/name=vault, component=server\" namespace=vault"},
 	}
 	for _, cfg := range []string{
 		"attr",

--- a/command/server/test-fixtures/raft_retry_join_attr.hcl
+++ b/command/server/test-fixtures/raft_retry_join_attr.hcl
@@ -23,6 +23,9 @@ storage "raft" {
   retry_join = [
     { "auto_join" = "provider=vsphere category_name=consul-role tag_name=consul-server host=https://[2001:db8:0:0:0:0:2:1] user=foo password=bar insecure_ssl=false" }
   ]
+  retry_join = [
+    { "auto_join" = "provider=k8s namespace=vault label_selector=\"app.kubernetes.io/name=vault, component=server\"" }
+  ]
 }
 
 listener "tcp" {

--- a/command/server/test-fixtures/raft_retry_join_block.hcl
+++ b/command/server/test-fixtures/raft_retry_join_block.hcl
@@ -26,6 +26,9 @@ storage "raft" {
   retry_join {
     "auto_join" = "provider=vsphere category_name=consul-role tag_name=consul-server host=https://[2001:db8:0:0:0:0:2:1] user=foo password=bar insecure_ssl=false"
   }
+  retry_join {
+    "auto_join" = "provider=k8s namespace=vault label_selector=\"app.kubernetes.io/name=vault, component=server\""
+  }
 }
 
 listener "tcp" {

--- a/command/server/test-fixtures/raft_retry_join_mixed.hcl
+++ b/command/server/test-fixtures/raft_retry_join_mixed.hcl
@@ -23,6 +23,9 @@ storage "raft" {
   retry_join {
     "auto_join" = "provider=vsphere category_name=consul-role tag_name=consul-server host=https://[2001:db8:0:0:0:0:2:1] user=foo password=bar insecure_ssl=false"
   }
+  retry_join = [
+    { "auto_join" = "provider=k8s namespace=vault label_selector=\"app.kubernetes.io/name=vault, component=server\"" }
+  ]
 }
 
 listener "tcp" {


### PR DESCRIPTION
### Description

`go-discover` supports being configured with some configuration strings that include double-quotes, backslashes and escapes. As such, we now use its own parser when normalizing `auto_join` config that may have addresses.

Fixes: https://github.com/hashicorp/vault/issues/29863

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [x] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
