### PR TITLE
fix: Fix problematic error returns

### DIFF
--- a/builtin/credential/userpass/path_user_password.go
+++ b/builtin/credential/userpass/path_user_password.go
@@ -83,7 +83,7 @@ func (b *backend) pathUserPasswordUpdate(ctx context.Context, req *logical.Reque
 
 	userErr, intErr := b.updateUserPassword(req, d, userEntry)
 	if intErr != nil {
-		return nil, err
+		return nil, intErr
 	}
 	if userErr != nil {
 		return logical.ErrorResponse(userErr.Error()), logical.ErrInvalidRequest


### PR DESCRIPTION
### Description

Because err has been judged before, err here must be nil.

According to the context logic, it should be `intErr`


For https://github.com/hashicorp/vault/issues/29936


### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
