### PR TITLE
VAULT-34593 CE changes

### DIFF
--- a/vault/core_metrics.go
+++ b/vault/core_metrics.go
@@ -607,6 +607,17 @@ func (c *Core) GetSecretEngineUsageMetrics() map[string]int {
 
 	for _, entry := range c.mounts.Entries {
 		mountType := entry.Type
+
+		if mountType == mountTypeNSIdentity {
+			mountType = pluginconsts.SecretEngineIdentity
+		}
+		if mountType == mountTypeNSSystem {
+			mountType = pluginconsts.SecretEngineSystem
+		}
+		if mountType == mountTypeNSCubbyhole {
+			mountType = pluginconsts.SecretEngineCubbyhole
+		}
+
 		if _, ok := mounts[mountType]; !ok {
 			mounts[mountType] = 1
 		} else {
@@ -625,6 +636,11 @@ func (c *Core) GetAuthMethodUsageMetrics() map[string]int {
 
 	for _, entry := range c.auth.Entries {
 		authType := entry.Type
+
+		if authType == mountTypeNSToken {
+			authType = pluginconsts.AuthTypeToken
+		}
+
 		if _, ok := mounts[authType]; !ok {
 			mounts[authType] = 1
 		} else {

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -75,6 +75,7 @@ const (
 	mountTypeSystem      = "system"
 	mountTypeNSSystem    = "ns_system"
 	mountTypeIdentity    = "identity"
+	mountTypeNSIdentity  = "ns_identity"
 	mountTypeCubbyhole   = "cubbyhole"
 	mountTypePlugin      = "plugin"
 	mountTypeKV          = "kv"


### PR DESCRIPTION
### Description

CE Changes for https://github.com/hashicorp/vault-enterprise/pull/7608

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [x] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
