### PR TITLE
[UI] Handlebars Copyright Header Comment Format

### DIFF
--- a/ui/app/components/alphabet-edit.hbs
+++ b/ui/app/components/alphabet-edit.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/app/components/app-footer.hbs
+++ b/ui/app/components/app-footer.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Hds::AppFooter class="has-margin-top-auto" as |AF|>
   <AF.ExtraBefore>

--- a/ui/app/components/auth-config-form/config.hbs
+++ b/ui/app/components/auth-config-form/config.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <form {{on "submit" (perform this.saveModel)}}>
   <div class="box is-sideless is-fullwidth is-marginless">

--- a/ui/app/components/auth-config-form/options.hbs
+++ b/ui/app/components/auth-config-form/options.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <form {{on "submit" (perform this.saveModel)}}>
   <div class="box is-sideless is-fullwidth is-marginless">

--- a/ui/app/components/auth-saml.hbs
+++ b/ui/app/components/auth-saml.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if this.canLoginSaml}}
   <form id="auth-form" {{on "submit" (fn this.startSAMLAuth @onSubmit (hash role=@roleName))}}>

--- a/ui/app/components/auth/login-form.hbs
+++ b/ui/app/components/auth/login-form.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if this.waitingForOktaNumberChallenge}}
   <OktaNumberChallenge

--- a/ui/app/components/auth/page.hbs
+++ b/ui/app/components/auth/page.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if this.mfaErrors}}
   <div class="has-top-margin-xxl" data-test-mfa-error>

--- a/ui/app/components/clients/attribution.hbs
+++ b/ui/app/components/clients/attribution.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="chart-wrapper single-chart-grid" data-test-clients-attribution={{this.noun}}>
   <div class="chart-header has-bottom-margin-m">

--- a/ui/app/components/clients/chart-container.hbs
+++ b/ui/app/components/clients/chart-container.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{! HBS display template for rendering title, description and stat boxes with a chart on the right }}
 

--- a/ui/app/components/clients/charts/vertical-bar-basic.hbs
+++ b/ui/app/components/clients/charts/vertical-bar-basic.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="lineal-chart" data-test-chart={{or @chartTitle "vertical bar chart"}}>
   <Lineal::Fluid as |width|>

--- a/ui/app/components/clients/charts/vertical-bar-grouped.hbs
+++ b/ui/app/components/clients/charts/vertical-bar-grouped.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if (and @data @legend)}}
   <div class="lineal-chart" data-test-chart={{or @chartTitle "grouped vertical bar chart"}}>

--- a/ui/app/components/clients/charts/vertical-bar-stacked.hbs
+++ b/ui/app/components/clients/charts/vertical-bar-stacked.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="lineal-chart" data-test-chart={{or @chartTitle "stacked vertical bar chart"}}>
   <Lineal::Fluid as |width|>

--- a/ui/app/components/clients/config.hbs
+++ b/ui/app/components/clients/config.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if (eq @mode "edit")}}
   <form onsubmit={{action "onSaveChanges"}} data-test-clients-config-form>

--- a/ui/app/components/clients/counts/error.hbs
+++ b/ui/app/components/clients/counts/error.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <EmptyState
   @title={{if (eq @error.httpStatus 403) "You are not authorized" "Error"}}

--- a/ui/app/components/clients/counts/nav-bar.hbs
+++ b/ui/app/components/clients/counts/nav-bar.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <nav class="tabs has-bottom-margin-s" aria-label="navigation for managing client counts">
   <ul>

--- a/ui/app/components/clients/date-range.hbs
+++ b/ui/app/components/clients/date-range.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div ...attributes>
   <Hds::Text::Display @tag="p" class="has-bottom-margin-xs">

--- a/ui/app/components/clients/horizontal-bar-chart.hbs
+++ b/ui/app/components/clients/horizontal-bar-chart.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if @dataset}}
   <svg

--- a/ui/app/components/clients/no-data.hbs
+++ b/ui/app/components/clients/no-data.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if (or @config.reportingEnabled (eq @config.enabled "On"))}}
   <EmptyState

--- a/ui/app/components/clients/page-header.hbs
+++ b/ui/app/components/clients/page-header.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Hds::PageHeader class="has-top-padding-l has-bottom-padding-m" as |PH|>
   <PH.Title>Vault Usage Metrics</PH.Title>

--- a/ui/app/components/clients/page/acme.hbs
+++ b/ui/app/components/clients/page/acme.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{! ACME clients added in 1.17 }}
 

--- a/ui/app/components/clients/page/counts.hbs
+++ b/ui/app/components/clients/page/counts.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Clients::PageHeader
   @startTimestamp={{@startTimestamp}}

--- a/ui/app/components/clients/page/overview.hbs
+++ b/ui/app/components/clients/page/overview.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Clients::RunningTotal
   @isSecretsSyncActivated={{this.flags.secretsSyncIsActivated}}

--- a/ui/app/components/clients/page/sync.hbs
+++ b/ui/app/components/clients/page/sync.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 {{#if this.flags.secretsSyncIsActivated}}
   {{#if (not this.byMonthActivityData)}}
     {{! byMonthActivityData is an empty array if there is no monthly data (monthly breakdown was added in 1.11)

--- a/ui/app/components/clients/page/token.hbs
+++ b/ui/app/components/clients/page/token.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if (and this.byMonthActivityData this.isDateRange)}}
   <Clients::ChartContainer

--- a/ui/app/components/clients/running-total.hbs
+++ b/ui/app/components/clients/running-total.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if (gt @byMonthActivityData.length 1)}}
   <Clients::ChartContainer

--- a/ui/app/components/clients/usage-stats.hbs
+++ b/ui/app/components/clients/usage-stats.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{! Display only template that renders yielded components in columns, beneath a title and description }}
 <Hds::Card::Container

--- a/ui/app/components/dashboard/client-count-card.hbs
+++ b/ui/app/components/dashboard/client-count-card.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Hds::Card::Container @hasBorder={{true}} class="has-padding-l" data-test-card="client-count">
   <div class="is-flex-between">

--- a/ui/app/components/dashboard/learn-more-card.hbs
+++ b/ui/app/components/dashboard/learn-more-card.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Hds::Card::Container @hasBorder={{true}} class="has-padding-l" data-test-card="learn-more">
   <h2 class="title is-4 has-bottom-margin-xxs" data-test-learn-more-title>Learn more</h2>

--- a/ui/app/components/dashboard/overview.hbs
+++ b/ui/app/components/dashboard/overview.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Dashboard::VaultVersionTitle @version={{@version}} />
 

--- a/ui/app/components/dashboard/quick-actions-card.hbs
+++ b/ui/app/components/dashboard/quick-actions-card.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Hds::Card::Container @hasBorder={{true}} class="has-padding-l" data-test-card="quick-actions">
   <h2 class="title is-4">Quick actions</h2>

--- a/ui/app/components/dashboard/replication-card.hbs
+++ b/ui/app/components/dashboard/replication-card.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 <Hds::Card::Container @hasBorder={{true}} class="has-padding-l" data-test-card="replication">
 
   <div class="is-flex-between">

--- a/ui/app/components/dashboard/replication-state-text.hbs
+++ b/ui/app/components/dashboard/replication-state-text.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div>
   <h2 class="is-size-5 has-text-weight-semibold has-bottom-margin-xs" data-test-title={{@title}}>

--- a/ui/app/components/dashboard/secrets-engines-card.hbs
+++ b/ui/app/components/dashboard/secrets-engines-card.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Hds::Card::Container
   @hasBorder={{true}}

--- a/ui/app/components/dashboard/vault-configuration-details-card.hbs
+++ b/ui/app/components/dashboard/vault-configuration-details-card.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Hds::Card::Container @hasBorder={{true}} class="has-padding-l" data-test-card="configuration-details">
   <h3 class="title is-4" data-test-dashboard-card-header="configuration">Configuration details</h3>

--- a/ui/app/components/dashboard/vault-version-title.hbs
+++ b/ui/app/components/dashboard/vault-version-title.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.levelLeft>

--- a/ui/app/components/flash-toast.hbs
+++ b/ui/app/components/flash-toast.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Hds::Toast @color={{this.color}} @onDismiss={{@close}} class="has-bottom-margin-m" data-test-flash-toast as |T|>
   <T.Title data-test-flash-toast-title>{{this.title}}</T.Title>

--- a/ui/app/components/generate-credentials.hbs
+++ b/ui/app/components/generate-credentials.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/app/components/get-credentials-card.hbs
+++ b/ui/app/components/get-credentials-card.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Hds::Card::Container @level="mid" @hasBorder={{true}} class="has-padding-l" ...attributes>
   <form {{on "submit" this.transitionToCredential}}>

--- a/ui/app/components/license-info.hbs
+++ b/ui/app/components/license-info.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.levelLeft>

--- a/ui/app/components/logo-edition.hbs
+++ b/ui/app/components/logo-edition.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <svg width="146" height="51" viewBox="0 0 146 51" xmlns="http://www.w3.org/2000/svg">
   <g id="vault-logo-v" fill-rule="nonzero">

--- a/ui/app/components/modal-form/oidc-assignment-template.hbs
+++ b/ui/app/components/modal-form/oidc-assignment-template.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Oidc::AssignmentForm @onSave={{this.onSave}} @model={{this.assignment}} @onCancel={{@onCancel}} />

--- a/ui/app/components/modal-form/oidc-key-template.hbs
+++ b/ui/app/components/modal-form/oidc-key-template.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Oidc::KeyForm @onSave={{this.onSave}} @model={{this.key}} @onCancel={{@onCancel}} @isModalForm={{true}} />

--- a/ui/app/components/modal-form/policy-template.hbs
+++ b/ui/app/components/modal-form/policy-template.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if this.policy.policyType}}
   <Hds::Tabs as |T|>

--- a/ui/app/components/mount-backend-form.hbs
+++ b/ui/app/components/mount-backend-form.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.levelLeft>

--- a/ui/app/components/mount-backend/type-form.hbs
+++ b/ui/app/components/mount-backend/type-form.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#each (array "generic" "cloud" "infra") as |category|}}
   <Hds::Text::Display class="has-top-padding-m has-bottom-padding-s" @tag="h2" size="400">

--- a/ui/app/components/not-found.hbs
+++ b/ui/app/components/not-found.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="box is-shadowless" data-test-not-found>
   <PageHeader as |p|>

--- a/ui/app/components/page/userpass-reset-password.hbs
+++ b/ui/app/components/page/userpass-reset-password.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.levelLeft>

--- a/ui/app/components/policy-form.hbs
+++ b/ui/app/components/policy-form.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <form {{on "submit" (perform this.save)}} data-test-policy-form>
   <div class="box is-shadowless is-fullwidth is-marginless">

--- a/ui/app/components/regex-validator.hbs
+++ b/ui/app/components/regex-validator.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if @attr}}
   <div class="field" data-test-regex-validator-pattern>

--- a/ui/app/components/resultant-acl-banner.hbs
+++ b/ui/app/components/resultant-acl-banner.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#unless this.hideBanner}}
   <Hds::Alert

--- a/ui/app/components/seal-action.hbs
+++ b/ui/app/components/seal-action.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="box is-sideless is-fullwidth is-marginless">
   {{#if this.error}}

--- a/ui/app/components/secret-engine/configuration-details.hbs
+++ b/ui/app/components/secret-engine/configuration-details.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#each @configModels as |configModel|}}
   {{#each configModel.displayAttrs as |attr|}}

--- a/ui/app/components/secret-engine/configure-ssh.hbs
+++ b/ui/app/components/secret-engine/configure-ssh.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <form {{on "submit" (perform this.save)}} aria-label="save ssh creds" class="has-top-padding-m" data-test-configure-form>
   <NamespaceReminder @mode="save" @noun="configuration" />

--- a/ui/app/components/secret-engine/configure-wif.hbs
+++ b/ui/app/components/secret-engine/configure-wif.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <form {{on "submit" (perform this.submitForm)}} aria-label="configure {{@type}} credentials" data-test-configure-form>
   <NamespaceReminder @mode="save" @noun="configuration" />

--- a/ui/app/components/secret-link.hbs
+++ b/ui/app/components/secret-link.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <LinkTo @route={{this.link.route}} @models={{this.link.models}} @query={{this.query}} @disabled={{@disabled}} ...attributes>
   {{yield}}

--- a/ui/app/components/section-tabs.hbs
+++ b/ui/app/components/section-tabs.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#let (tabs-for-auth-section @model this.tabType @paths) as |tabs|}}
   {{#if tabs.length}}

--- a/ui/app/components/sidebar/frame.hbs
+++ b/ui/app/components/sidebar/frame.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Hds::AppFrame @hasSidebar={{@showSidebar}} @hasHeader={{false}} @hasFooter={{false}} as |Frame|>
   <Frame.Sidebar data-test-sidebar-nav>

--- a/ui/app/components/sidebar/nav/access.hbs
+++ b/ui/app/components/sidebar/nav/access.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Hds::SideNav::Portal @ariaLabel="Access Navigation Links" data-test-sidebar-nav-panel="Access" as |Nav|>
   <Nav.BackLink

--- a/ui/app/components/sidebar/nav/clients.hbs
+++ b/ui/app/components/sidebar/nav/clients.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Hds::SideNav::Portal @ariaLabel="Client Count Navigation Links" data-test-sidebar-nav-panel="Client Count" as |Nav|>
   <Nav.BackLink

--- a/ui/app/components/sidebar/nav/cluster.hbs
+++ b/ui/app/components/sidebar/nav/cluster.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Hds::SideNav::Portal @ariaLabel="Cluster Navigation Links" data-test-sidebar-nav-panel="Cluster" as |Nav|>
   <Nav.Title data-test-sidebar-nav-heading="Vault">Vault</Nav.Title>

--- a/ui/app/components/sidebar/nav/policies.hbs
+++ b/ui/app/components/sidebar/nav/policies.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Hds::SideNav::Portal @ariaLabel="Policies Navigation Links" data-test-sidebar-nav-panel="Policies" as |Nav|>
   <Nav.BackLink

--- a/ui/app/components/sidebar/nav/tools.hbs
+++ b/ui/app/components/sidebar/nav/tools.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Hds::SideNav::Portal @ariaLabel="Tools Navigation Links" data-test-sidebar-nav-panel="Tools" as |Nav|>
   <Nav.BackLink

--- a/ui/app/components/sidebar/user-menu.hbs
+++ b/ui/app/components/sidebar/user-menu.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <BasicDropdown
   @horizontalPosition="right"

--- a/ui/app/components/splash-page.hbs
+++ b/ui/app/components/splash-page.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="splash-page-container section is-flex-v-centered-tablet is-flex-grow-1 is-fullwidth">
   <div class="columns is-centered is-gapless is-fullwidth">

--- a/ui/app/components/token-expire-warning.hbs
+++ b/ui/app/components/token-expire-warning.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if (and this.showWarning (is-after (now interval=1000) @expirationDate))}}
   <Hds::Alert @type="page" @color="critical" data-test-token-expired-banner as |A|>

--- a/ui/app/components/tools/hash.hbs
+++ b/ui/app/components/tools/hash.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.levelLeft>

--- a/ui/app/components/tools/lookup.hbs
+++ b/ui/app/components/tools/lookup.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.levelLeft>

--- a/ui/app/components/tools/random.hbs
+++ b/ui/app/components/tools/random.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.levelLeft>

--- a/ui/app/components/tools/rewrap.hbs
+++ b/ui/app/components/tools/rewrap.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.levelLeft>

--- a/ui/app/components/tools/unwrap.hbs
+++ b/ui/app/components/tools/unwrap.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.levelLeft>

--- a/ui/app/components/tools/wrap.hbs
+++ b/ui/app/components/tools/wrap.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.levelLeft>

--- a/ui/app/components/transform-template-edit.hbs
+++ b/ui/app/components/transform-template-edit.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/app/components/transit-key-actions.hbs
+++ b/ui/app/components/transit-key-actions.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 <div {{did-update this.updateProps @selectedAction}}>
   <MessageError @errorMessage={{this.errors}} />
 

--- a/ui/app/components/wrap-ttl.hbs
+++ b/ui/app/components/wrap-ttl.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="field">
   <TtlPicker

--- a/ui/app/components/z-docfy-filter.hbs
+++ b/ui/app/components/z-docfy-filter.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Hds::Form::TextInput::Field @type="search" placeholder="Filter components" {{on "input" this.filterComponents}} />
 

--- a/ui/app/templates/application.hbs
+++ b/ui/app/templates/application.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Sidebar::Frame @showSidebar={{this.auth.isActiveSession}}>
   <div class="page-container">

--- a/ui/app/templates/components/auth-form-options.hbs
+++ b/ui/app/templates/components/auth-form-options.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#unless this.selectedAuthIsPath}}
   <div class="box has-slim-padding is-shadowless">

--- a/ui/app/templates/components/auth-form.hbs
+++ b/ui/app/templates/components/auth-form.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 <div class="auth-form" data-test-auth-form>
   {{#if this.hasMethodsWithPath}}
     <nav class="tabs is-marginless">

--- a/ui/app/templates/components/auth-jwt.hbs
+++ b/ui/app/templates/components/auth-jwt.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <form id="auth-form" {{on "submit" (action "signIn")}}>
   <div class="field">

--- a/ui/app/templates/components/auth-method/configuration.hbs
+++ b/ui/app/templates/components/auth-method/configuration.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="box is-fullwidth is-sideless is-paddingless is-marginless">
   {{#each @model.attrs as |attr|}}

--- a/ui/app/templates/components/b64-toggle.hbs
+++ b/ui/app/templates/components/b64-toggle.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if this.isBase64}}
   Decode from base64

--- a/ui/app/templates/components/calendar-widget.hbs
+++ b/ui/app/templates/components/calendar-widget.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <BasicDropdown @class="popup-menu" @horizontalPosition="auto-right" @verticalPosition="below" as |D|>
   <D.Trigger data-test-calendar-widget-trigger class={{concat "toolbar-link" (if D.isOpen " is-active")}} @htmlTag="button">

--- a/ui/app/templates/components/console/command-input.hbs
+++ b/ui/app/templates/components/console/command-input.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="console-ui-input" data-test-component="console/command-input">
   {{#if this.isRunning}}

--- a/ui/app/templates/components/console/log-command.hbs
+++ b/ui/app/templates/components/console/log-command.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="is-flex-center">
   <Icon @name="chevron-right" />

--- a/ui/app/templates/components/console/log-error-with-html.hbs
+++ b/ui/app/templates/components/console/log-error-with-html.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{! template-lint-disable no-triple-curlies}}
 <div class="console-ui-alert console-ui-alert--error">

--- a/ui/app/templates/components/console/log-error.hbs
+++ b/ui/app/templates/components/console/log-error.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="console-ui-alert console-ui-alert--error">
   <Icon @name="x-circle-fill" />

--- a/ui/app/templates/components/console/log-help.hbs
+++ b/ui/app/templates/components/console/log-help.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{! template-lint-disable no-whitespace-for-layout }}
 {{! prettier-ignore }}

--- a/ui/app/templates/components/console/log-json.hbs
+++ b/ui/app/templates/components/console/log-json.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="console-ui-output">
   <JsonEditor

--- a/ui/app/templates/components/console/log-list.hbs
+++ b/ui/app/templates/components/console/log-list.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="console-ui-output">
   <pre>

--- a/ui/app/templates/components/console/log-object.hbs
+++ b/ui/app/templates/components/console/log-object.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="console-ui-output">
   <pre>{{this.columns}}</pre>

--- a/ui/app/templates/components/console/log-success.hbs
+++ b/ui/app/templates/components/console/log-success.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="console-ui-alert console-ui-alert--success">
   <Icon @name="check-circle-fill" />

--- a/ui/app/templates/components/console/log-text.hbs
+++ b/ui/app/templates/components/console/log-text.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="console-ui-output">
   <pre>{{@content}}</pre>

--- a/ui/app/templates/components/console/output-log.hbs
+++ b/ui/app/templates/components/console/output-log.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#each this.outputLog as |message|}}
   {{#unless message.hidden}}

--- a/ui/app/templates/components/console/ui-panel.hbs
+++ b/ui/app/templates/components/console/ui-panel.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="console-ui-panel-content">
   <div class="content has-bottom-margin-s">

--- a/ui/app/templates/components/control-group-success.hbs
+++ b/ui/app/templates/components/control-group-success.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if (and this.controlGroupResponse.token this.controlGroupResponse.uiParams.url)}}
   <div class="control-group-success" data-test-navigate-message>

--- a/ui/app/templates/components/control-group.hbs
+++ b/ui/app/templates/components/control-group.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="box is-fullwidth is-bottomless is-sideless">
   <MessageError @model={{this.model}} />

--- a/ui/app/templates/components/database-connection.hbs
+++ b/ui/app/templates/components/database-connection.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/app/templates/components/database-role-edit.hbs
+++ b/ui/app/templates/components/database-role-edit.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 <PageHeader as |p|>
   <p.top>
     <KeyValueHeader @path="vault.cluster.secrets.backend.show" @mode={{@mode}} @root={{@root}} @showCurrent={{true}} />

--- a/ui/app/templates/components/database-role-setting-form.hbs
+++ b/ui/app/templates/components/database-role-setting-form.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="box is-sideless is-fullwidth is-marginless" data-test-role-settings-section>
   <h3 class="title is-5">Role settings</h3>

--- a/ui/app/templates/components/file-to-array-buffer.hbs
+++ b/ui/app/templates/components/file-to-array-buffer.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 <div class="box is-fullwidth is-marginless is-shadowless">
   <div class="field">
     <div class="control is-expanded">

--- a/ui/app/templates/components/form-field-from-model.hbs
+++ b/ui/app/templates/components/form-field-from-model.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{! template-lint-configure simple-unless "warn"  }}
 <div class="field" data-test-form-field-from-model>

--- a/ui/app/templates/components/generate-credentials-database.hbs
+++ b/ui/app/templates/components/generate-credentials-database.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/app/templates/components/generated-item-list.hbs
+++ b/ui/app/templates/components/generated-item-list.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/app/templates/components/generated-item.hbs
+++ b/ui/app/templates/components/generated-item.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/app/templates/components/identity/edit-form.hbs
+++ b/ui/app/templates/components/identity/edit-form.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if (and (eq this.mode "edit") this.model.canDelete)}}
   <Toolbar>

--- a/ui/app/templates/components/identity/entity-nav.hbs
+++ b/ui/app/templates/components/identity/entity-nav.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.levelLeft>

--- a/ui/app/templates/components/identity/item-alias/alias-details.hbs
+++ b/ui/app/templates/components/identity/item-alias/alias-details.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <InfoTableRow @label="Name" @value={{@model.name}} data-test-alias-name={{true}} />
 <InfoTableRow @label="ID" @value={{@model.id}} @addCopyButton={{true}} />

--- a/ui/app/templates/components/identity/item-alias/alias-metadata.hbs
+++ b/ui/app/templates/components/identity/item-alias/alias-metadata.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#each-in @model.metadata as |key value|}}
   <div class="info-table-row is-mobile">

--- a/ui/app/templates/components/identity/item-aliases.hbs
+++ b/ui/app/templates/components/identity/item-aliases.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#each (if @model.alias.id (array @model.alias) @model.aliases) as |item|}}
   <LinkedBlock @params={{array "vault.cluster.access.identity.aliases.show" item.id "details"}} class="list-item-row">

--- a/ui/app/templates/components/identity/item-details.hbs
+++ b/ui/app/templates/components/identity/item-details.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="box is-shadowless is-marginless is-fullwidth">
   {{#if @model.disabled}}

--- a/ui/app/templates/components/identity/item-groups.hbs
+++ b/ui/app/templates/components/identity/item-groups.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if @model.groupIds}}
   {{#each @model.directGroupIds as |gid|}}

--- a/ui/app/templates/components/identity/item-members.hbs
+++ b/ui/app/templates/components/identity/item-members.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if @model.hasMembers}}
   {{#each @model.memberGroupIds as |gid|}}

--- a/ui/app/templates/components/identity/item-metadata.hbs
+++ b/ui/app/templates/components/identity/item-metadata.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#each-in @model.metadata as |key value|}}
   <div class="info-table-row is-mobile">

--- a/ui/app/templates/components/identity/item-parent-groups.hbs
+++ b/ui/app/templates/components/identity/item-parent-groups.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if @model.parentGroupIds.length}}
   {{#each @model.parentGroupIds as |gid|}}

--- a/ui/app/templates/components/identity/item-policies.hbs
+++ b/ui/app/templates/components/identity/item-policies.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#each @model.policies as |policyName|}}
   <LinkedBlock @params={{array "vault.cluster.policy.show" "acl" policyName}} class="list-item-row">

--- a/ui/app/templates/components/identity/lookup-input.hbs
+++ b/ui/app/templates/components/identity/lookup-input.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <form {{action (perform this.lookup) on="submit"}}>
   <div class="field is-flex">

--- a/ui/app/templates/components/identity/popup-alias.hbs
+++ b/ui/app/templates/components/identity/popup-alias.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="has-text-right">
   <Hds::Dropdown @isInline={{true}} @listPosition="bottom-right" as |dd|>

--- a/ui/app/templates/components/identity/popup-members.hbs
+++ b/ui/app/templates/components/identity/popup-members.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="has-text-right">
   <Hds::Dropdown @isInline={{true}} @listPosition="bottom-right" as |dd|>

--- a/ui/app/templates/components/identity/popup-metadata.hbs
+++ b/ui/app/templates/components/identity/popup-metadata.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="has-text-right">
   <Hds::Dropdown @isInline={{true}} @listPosition="bottom-right" as |dd|>

--- a/ui/app/templates/components/identity/popup-policy.hbs
+++ b/ui/app/templates/components/identity/popup-policy.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="has-text-right">
   <Hds::Dropdown @isInline={{true}} @listPosition="bottom-right" as |dd|>

--- a/ui/app/templates/components/key-version-select.hbs
+++ b/ui/app/templates/components/key-version-select.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if (gt this.key.keysForEncryption.length 1)}}
   <div class="field" data-test-transit-key-version-select={{true}}>

--- a/ui/app/templates/components/keymgmt/distribute.hbs
+++ b/ui/app/templates/components/keymgmt/distribute.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if @backend}}
   {{#if this.formErrors}}

--- a/ui/app/templates/components/keymgmt/key-edit.hbs
+++ b/ui/app/templates/components/keymgmt/key-edit.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/app/templates/components/keymgmt/provider-edit.hbs
+++ b/ui/app/templates/components/keymgmt/provider-edit.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/app/templates/components/license-banners.hbs
+++ b/ui/app/templates/components/license-banners.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if (and this.licenseExpired (not this.expiredDismissed))}}
   <Hds::Alert

--- a/ui/app/templates/components/link-status.hbs
+++ b/ui/app/templates/components/link-status.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if (and this.state this.version.isEnterprise)}}
   <Hds::Alert @type="page" @color={{if (eq this.state "connected") "neutral" "warning"}} as |A|>

--- a/ui/app/templates/components/logo-splash.hbs
+++ b/ui/app/templates/components/logo-splash.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="is-flex-v-centered is-flex-grow-1">
   <div class="columns is-centered">

--- a/ui/app/templates/components/mfa/login-enforcement-list-item.hbs
+++ b/ui/app/templates/components/mfa/login-enforcement-list-item.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <LinkedBlock
   class="list-item-row"

--- a/ui/app/templates/components/mfa/method-form.hbs
+++ b/ui/app/templates/components/mfa/method-form.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="box is-sideless is-fullwidth is-marginless" ...attributes>
   {{#each @model.attrs as |attr|}}

--- a/ui/app/templates/components/mfa/method-list-item.hbs
+++ b/ui/app/templates/components/mfa/method-list-item.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <LinkedBlock
   class="list-item-row"

--- a/ui/app/templates/components/mfa/mfa-form.hbs
+++ b/ui/app/templates/components/mfa/mfa-form.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="auth-form" data-test-mfa-form>
   <div class="box is-marginless is-shadowless">

--- a/ui/app/templates/components/mfa/mfa-login-enforcement-form.hbs
+++ b/ui/app/templates/components/mfa/mfa-login-enforcement-form.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div ...attributes>
   <FormFieldLabel

--- a/ui/app/templates/components/mfa/mfa-login-enforcement-header.hbs
+++ b/ui/app/templates/components/mfa/mfa-login-enforcement-header.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if @isInline}}
   <h3 class="title is-5" data-test-mleh-title>Enforcement</h3>

--- a/ui/app/templates/components/mfa/mfa-setup-step-one.hbs
+++ b/ui/app/templates/components/mfa/mfa-setup-step-one.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div ...attributes>
   <p>

--- a/ui/app/templates/components/mfa/mfa-setup-step-two.hbs
+++ b/ui/app/templates/components/mfa/mfa-setup-step-two.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div ...attributes>
   <p>

--- a/ui/app/templates/components/mfa/nav.hbs
+++ b/ui/app/templates/components/mfa/nav.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="tabs-container box is-sideless is-fullwidth is-paddingless is-marginless">
   <nav class="tabs" aria-label="navigation for managing MFA">

--- a/ui/app/templates/components/mount-accessor-select.hbs
+++ b/ui/app/templates/components/mount-accessor-select.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div ...attributes>
   {{#if @label}}

--- a/ui/app/templates/components/namespace-link.hbs
+++ b/ui/app/templates/components/namespace-link.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 <ExternalLink
   @href={{this.namespaceLink}}
   @sameTab={{true}}

--- a/ui/app/templates/components/namespace-picker.hbs
+++ b/ui/app/templates/components/namespace-picker.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="namespace-picker" ...attributes>
   <BasicDropdown @horizontalPosition="left" @verticalPosition="above" @renderInPlace={{true}} as |D|>

--- a/ui/app/templates/components/oidc-callback-splash.hbs
+++ b/ui/app/templates/components/oidc-callback-splash.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="splash-page-container section is-flex-v-centered-tablet is-flex-grow-1 is-fullwidth">
   <div class="columns is-centered is-gapless is-fullwidth">

--- a/ui/app/templates/components/oidc-consent-block.hbs
+++ b/ui/app/templates/components/oidc-consent-block.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if this.didCancel}}
   <h3 class="title is-3" data-test-consent-title>

--- a/ui/app/templates/components/oidc/assignment-form.hbs
+++ b/ui/app/templates/components/oidc/assignment-form.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <form {{on "submit" (perform this.save)}}>
   <div class="box is-sideless is-fullwidth is-marginless">

--- a/ui/app/templates/components/oidc/client-form.hbs
+++ b/ui/app/templates/components/oidc/client-form.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/app/templates/components/oidc/client-list.hbs
+++ b/ui/app/templates/components/oidc/client-list.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#each @model as |client|}}
   <LinkedBlock

--- a/ui/app/templates/components/oidc/key-form.hbs
+++ b/ui/app/templates/components/oidc/key-form.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <form {{on "submit" (perform this.save)}}>
   <div class="box is-sideless is-fullwidth is-bottomless">

--- a/ui/app/templates/components/oidc/provider-form.hbs
+++ b/ui/app/templates/components/oidc/provider-form.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/app/templates/components/oidc/provider-list.hbs
+++ b/ui/app/templates/components/oidc/provider-list.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#each @model as |provider|}}
   <LinkedBlock

--- a/ui/app/templates/components/oidc/scope-form.hbs
+++ b/ui/app/templates/components/oidc/scope-form.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/app/templates/components/okta-number-challenge.hbs
+++ b/ui/app/templates/components/okta-number-challenge.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 {{! todo move to auth/ folder? }}
 <div class="auth-form" data-test-okta-number-challenge>
   <div class="box is-marginless is-shadowless">

--- a/ui/app/templates/components/pgp-file.hbs
+++ b/ui/app/templates/components/pgp-file.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="level is-mobile">
   <div class="level-left">

--- a/ui/app/templates/components/pgp-list.hbs
+++ b/ui/app/templates/components/pgp-list.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#each this.listData as |key index|}}
   <PgpFile @key={{key}} @index={{index}} @onChange={{action "setKey"}} />

--- a/ui/app/templates/components/radial-progress.hbs
+++ b/ui/app/templates/components/radial-progress.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <circle
   data-test-path

--- a/ui/app/templates/components/raft-join.hbs
+++ b/ui/app/templates/components/raft-join.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Hds::Alert @type="inline" @color="warning" as |A|>
   <A.Title class="alert-title">Vault is sealed</A.Title>

--- a/ui/app/templates/components/raft-storage-overview.hbs
+++ b/ui/app/templates/components/raft-storage-overview.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Hds::PageHeader class="has-top-margin-xl has-bottom-margin-m" as |PH|>
   <PH.Title>Raft Storage</PH.Title>

--- a/ui/app/templates/components/raft-storage-restore.hbs
+++ b/ui/app/templates/components/raft-storage-restore.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/app/templates/components/role-aws-edit.hbs
+++ b/ui/app/templates/components/role-aws-edit.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/app/templates/components/role-ssh-edit.hbs
+++ b/ui/app/templates/components/role-ssh-edit.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/app/templates/components/secret-create-or-update.hbs
+++ b/ui/app/templates/components/secret-create-or-update.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if (eq @mode "create")}}
   <form

--- a/ui/app/templates/components/secret-edit-toolbar.hbs
+++ b/ui/app/templates/components/secret-edit-toolbar.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{! template-lint-configure simple-unless "warn" }}
 <Toolbar aria-label="manage secret">

--- a/ui/app/templates/components/secret-edit.hbs
+++ b/ui/app/templates/components/secret-edit.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div {{did-insert this.createKvData @model}}>
   <PageHeader as |p|>

--- a/ui/app/templates/components/secret-form-show.hbs
+++ b/ui/app/templates/components/secret-form-show.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if @isWriteWithoutRead}}
   <EmptyState

--- a/ui/app/templates/components/secret-list/aws-role-item.hbs
+++ b/ui/app/templates/components/secret-list/aws-role-item.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <LinkedBlock
   @params={{array (concat "vault.cluster.secrets.backend." "credentials" (unless @item.id "-root")) @item.id}}

--- a/ui/app/templates/components/secret-list/database-list-item.hbs
+++ b/ui/app/templates/components/secret-list/database-list-item.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <LinkedBlock
   @params={{array "vault.cluster.secrets.backend.show" (if this.keyTypeValue (concat "role/" @item.id) @item.id)}}

--- a/ui/app/templates/components/secret-list/item.hbs
+++ b/ui/app/templates/components/secret-list/item.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <LinkedBlock
   @params={{array

--- a/ui/app/templates/components/secret-list/ssh-role-item.hbs
+++ b/ui/app/templates/components/secret-list/ssh-role-item.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <LinkedBlock
   @params={{array

--- a/ui/app/templates/components/secret-list/transform-list-item.hbs
+++ b/ui/app/templates/components/secret-list/transform-list-item.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if (and @item.updatePath.canRead (not this.isBuiltin))}}
   <LinkedBlock

--- a/ui/app/templates/components/secret-list/transform-transformation-item.hbs
+++ b/ui/app/templates/components/secret-list/transform-transformation-item.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <LinkedBlock
   @params={{array "vault.cluster.secrets.backend.show" @item.id}}

--- a/ui/app/templates/components/shamir-progress.hbs
+++ b/ui/app/templates/components/shamir-progress.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="level">
   <div class="level-left">

--- a/ui/app/templates/components/toolbar-secret-link.hbs
+++ b/ui/app/templates/components/toolbar-secret-link.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <SecretLink
   @mode={{@mode}}

--- a/ui/app/templates/components/transform-advanced-templating.hbs
+++ b/ui/app/templates/components/transform-advanced-templating.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <ToggleButton
   @isOpen={{this.showForm}}

--- a/ui/app/templates/components/transform-create-form.hbs
+++ b/ui/app/templates/components/transform-create-form.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <form onsubmit={{action "createOrUpdate" "create"}}>
   <div class="box is-sideless is-fullwidth is-marginless">

--- a/ui/app/templates/components/transform-edit-form.hbs
+++ b/ui/app/templates/components/transform-edit-form.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <form onsubmit={{action "createOrUpdate" "create"}}>
   <div class="box is-sideless is-fullwidth is-marginless">

--- a/ui/app/templates/components/transform-role-edit.hbs
+++ b/ui/app/templates/components/transform-role-edit.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/app/templates/components/transform-show-transformation.hbs
+++ b/ui/app/templates/components/transform-show-transformation.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="box is-fullwidth is-sideless is-paddingless is-marginless">
   {{#each this.model.transformFieldAttrs as |attr|}}

--- a/ui/app/templates/components/transformation-edit.hbs
+++ b/ui/app/templates/components/transformation-edit.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/app/templates/components/transit-edit.hbs
+++ b/ui/app/templates/components/transit-edit.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/app/templates/components/transit-form-create.hbs
+++ b/ui/app/templates/components/transit-form-create.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <form data-test-transit-create-form onsubmit={{@createOrUpdateKey}}>
   <div class="box is-sideless is-fullwidth is-marginless">

--- a/ui/app/templates/components/transit-form-edit.hbs
+++ b/ui/app/templates/components/transit-form-edit.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <form data-test-transit-edit-form onsubmit={{@createOrUpdateKey}}>
   <div class="box is-sideless is-fullwidth is-marginless">

--- a/ui/app/templates/components/transit-form-show.hbs
+++ b/ui/app/templates/components/transit-form-show.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="tabs-container box is-sideless is-fullwidth is-paddingless is-marginless">
   <nav class="tabs" aria-label="navigation to manage transit backend">

--- a/ui/app/templates/components/transit-key-action/datakey.hbs
+++ b/ui/app/templates/components/transit-key-action/datakey.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <form
   {{on "submit" (fn @doSubmit (hash param=@param context=@context padding_scheme=@padding_scheme nonce=@nonce bits=@bits))}}

--- a/ui/app/templates/components/transit-key-action/decrypt.hbs
+++ b/ui/app/templates/components/transit-key-action/decrypt.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <form
   {{on "submit" (fn @doSubmit (hash ciphertext=@ciphertext padding_scheme=@padding_scheme context=@context nonce=@nonce))}}

--- a/ui/app/templates/components/transit-key-action/encrypt.hbs
+++ b/ui/app/templates/components/transit-key-action/encrypt.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <form
   {{on

--- a/ui/app/templates/components/transit-key-action/export.hbs
+++ b/ui/app/templates/components/transit-key-action/export.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <form
   {{on

--- a/ui/app/templates/components/transit-key-action/hmac.hbs
+++ b/ui/app/templates/components/transit-key-action/hmac.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <form {{on "submit" (fn @doSubmit (hash input=@trackedInput algorithm=@algorithm key_version=@key_version))}} ...attributes>
   <div class="box is-sideless is-fullwidth is-marginless">

--- a/ui/app/templates/components/transit-key-action/rewrap.hbs
+++ b/ui/app/templates/components/transit-key-action/rewrap.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <form
   {{on

--- a/ui/app/templates/components/transit-key-action/sign.hbs
+++ b/ui/app/templates/components/transit-key-action/sign.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <form
   {{on

--- a/ui/app/templates/components/transit-key-action/verify.hbs
+++ b/ui/app/templates/components/transit-key-action/verify.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <form
   {{on

--- a/ui/app/templates/docs.hbs
+++ b/ui/app/templates/docs.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Hds::AppFrame @hasSidebar={{@showSidebar}} @hasHeader={{false}} @hasFooter={{false}} as |Frame|>
   <Frame.Sidebar data-test-sidebar-nav>

--- a/ui/app/templates/error.hbs
+++ b/ui/app/templates/error.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="is-flex-grow-1 is-flex-v-centered">
   <div class="empty-state-content">

--- a/ui/app/templates/loading.hbs
+++ b/ui/app/templates/loading.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if this.isCallback}}
   <OidcCallbackSplash />

--- a/ui/app/templates/vault.hbs
+++ b/ui/app/templates/vault.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{outlet}}
 

--- a/ui/app/templates/vault/cluster.hbs
+++ b/ui/app/templates/vault/cluster.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 <Sidebar::Nav::Cluster />
 {{#if this.vaultVersion.isEnterprise}}
   {{#each this.customMessages.bannerMessages as |bannerMessage|}}

--- a/ui/app/templates/vault/cluster/access.hbs
+++ b/ui/app/templates/vault/cluster/access.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Sidebar::Nav::Access />
 {{outlet}}

--- a/ui/app/templates/vault/cluster/access/control-group-accessor.hbs
+++ b/ui/app/templates/vault/cluster/access/control-group-accessor.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if (has-feature "Control Groups")}}
   <PageHeader as |p|>

--- a/ui/app/templates/vault/cluster/access/control-groups-configure.hbs
+++ b/ui/app/templates/vault/cluster/access/control-groups-configure.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if (has-feature "Control Groups")}}
   <PageHeader as |p|>

--- a/ui/app/templates/vault/cluster/access/control-groups.hbs
+++ b/ui/app/templates/vault/cluster/access/control-groups.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if (has-feature "Control Groups")}}
   <PageHeader as |p|>

--- a/ui/app/templates/vault/cluster/access/error.hbs
+++ b/ui/app/templates/vault/cluster/access/error.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if (eq this.model.httpStatus 404)}}
   <NotFound @model={{this.model}} />

--- a/ui/app/templates/vault/cluster/access/identity/aliases/add.hbs
+++ b/ui/app/templates/vault/cluster/access/identity/aliases/add.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.levelLeft>

--- a/ui/app/templates/vault/cluster/access/identity/aliases/edit.hbs
+++ b/ui/app/templates/vault/cluster/access/identity/aliases/edit.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.levelLeft>

--- a/ui/app/templates/vault/cluster/access/identity/aliases/index.hbs
+++ b/ui/app/templates/vault/cluster/access/identity/aliases/index.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Identity::EntityNav @identityType={{this.identityType}} @model={{this.model}} />
 {{#if this.model.meta.total}}

--- a/ui/app/templates/vault/cluster/access/identity/aliases/show.hbs
+++ b/ui/app/templates/vault/cluster/access/identity/aliases/show.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/app/templates/vault/cluster/access/identity/create.hbs
+++ b/ui/app/templates/vault/cluster/access/identity/create.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.levelLeft>

--- a/ui/app/templates/vault/cluster/access/identity/edit.hbs
+++ b/ui/app/templates/vault/cluster/access/identity/edit.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.levelLeft>

--- a/ui/app/templates/vault/cluster/access/identity/index.hbs
+++ b/ui/app/templates/vault/cluster/access/identity/index.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Identity::EntityNav @identityType={{this.identityType}} @model={{this.model}} />
 {{#if this.model.meta.total}}

--- a/ui/app/templates/vault/cluster/access/identity/merge.hbs
+++ b/ui/app/templates/vault/cluster/access/identity/merge.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.levelLeft>

--- a/ui/app/templates/vault/cluster/access/identity/show.hbs
+++ b/ui/app/templates/vault/cluster/access/identity/show.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/app/templates/vault/cluster/access/leases/error.hbs
+++ b/ui/app/templates/vault/cluster/access/leases/error.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.levelLeft>

--- a/ui/app/templates/vault/cluster/access/leases/index.hbs
+++ b/ui/app/templates/vault/cluster/access/leases/index.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.levelLeft>

--- a/ui/app/templates/vault/cluster/access/leases/list.hbs
+++ b/ui/app/templates/vault/cluster/access/leases/list.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/app/templates/vault/cluster/access/leases/show.hbs
+++ b/ui/app/templates/vault/cluster/access/leases/show.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/app/templates/vault/cluster/access/loading.hbs
+++ b/ui/app/templates/vault/cluster/access/loading.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <LayoutLoading />

--- a/ui/app/templates/vault/cluster/access/method/item/create.hbs
+++ b/ui/app/templates/vault/cluster/access/method/item/create.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <GeneratedItem @mountPath={{this.method}} @model={{this.model}} @mode="create" @itemType={{this.model.itemType}} />

--- a/ui/app/templates/vault/cluster/access/method/item/edit.hbs
+++ b/ui/app/templates/vault/cluster/access/method/item/edit.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <GeneratedItem @mountPath={{this.method}} @model={{this.model}} @mode="edit" @itemType={{this.itemType}} />

--- a/ui/app/templates/vault/cluster/access/method/item/list.hbs
+++ b/ui/app/templates/vault/cluster/access/method/item/list.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <GeneratedItemList
   @model={{this.model}}

--- a/ui/app/templates/vault/cluster/access/method/item/show.hbs
+++ b/ui/app/templates/vault/cluster/access/method/item/show.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <GeneratedItem @mountPath={{this.method}} @model={{this.model}} @itemType={{this.itemType}} @mode="show" />

--- a/ui/app/templates/vault/cluster/access/method/section.hbs
+++ b/ui/app/templates/vault/cluster/access/method/section.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/app/templates/vault/cluster/access/methods.hbs
+++ b/ui/app/templates/vault/cluster/access/methods.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.levelLeft>

--- a/ui/app/templates/vault/cluster/access/mfa/enforcements/create.hbs
+++ b/ui/app/templates/vault/cluster/access/mfa/enforcements/create.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Mfa::MfaLoginEnforcementHeader @heading="New enforcement" />
 <Mfa::MfaLoginEnforcementForm

--- a/ui/app/templates/vault/cluster/access/mfa/enforcements/enforcement/edit.hbs
+++ b/ui/app/templates/vault/cluster/access/mfa/enforcements/enforcement/edit.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Mfa::MfaLoginEnforcementHeader @heading="Update enforcement" />
 <Mfa::MfaLoginEnforcementForm

--- a/ui/app/templates/vault/cluster/access/mfa/enforcements/enforcement/index.hbs
+++ b/ui/app/templates/vault/cluster/access/mfa/enforcements/enforcement/index.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/app/templates/vault/cluster/access/mfa/enforcements/index.hbs
+++ b/ui/app/templates/vault/cluster/access/mfa/enforcements/index.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.levelLeft>

--- a/ui/app/templates/vault/cluster/access/mfa/index.hbs
+++ b/ui/app/templates/vault/cluster/access/mfa/index.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.levelLeft>

--- a/ui/app/templates/vault/cluster/access/mfa/methods/create.hbs
+++ b/ui/app/templates/vault/cluster/access/mfa/methods/create.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/app/templates/vault/cluster/access/mfa/methods/index.hbs
+++ b/ui/app/templates/vault/cluster/access/mfa/methods/index.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.levelLeft>

--- a/ui/app/templates/vault/cluster/access/mfa/methods/method/edit.hbs
+++ b/ui/app/templates/vault/cluster/access/mfa/methods/method/edit.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.levelLeft>

--- a/ui/app/templates/vault/cluster/access/mfa/methods/method/index.hbs
+++ b/ui/app/templates/vault/cluster/access/mfa/methods/method/index.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/app/templates/vault/cluster/access/namespaces.hbs
+++ b/ui/app/templates/vault/cluster/access/namespaces.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{outlet}}

--- a/ui/app/templates/vault/cluster/access/namespaces/create.hbs
+++ b/ui/app/templates/vault/cluster/access/namespaces/create.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if (has-feature "Namespaces")}}
   <PageHeader as |p|>

--- a/ui/app/templates/vault/cluster/access/namespaces/index.hbs
+++ b/ui/app/templates/vault/cluster/access/namespaces/index.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if (has-feature "Namespaces")}}
   <PageHeader as |p|>

--- a/ui/app/templates/vault/cluster/access/oidc.hbs
+++ b/ui/app/templates/vault/cluster/access/oidc.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if this.header}}
   <PageHeader as |p|>

--- a/ui/app/templates/vault/cluster/access/oidc/assignments/assignment/details.hbs
+++ b/ui/app/templates/vault/cluster/access/oidc/assignments/assignment/details.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/app/templates/vault/cluster/access/oidc/assignments/assignment/edit.hbs
+++ b/ui/app/templates/vault/cluster/access/oidc/assignments/assignment/edit.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/app/templates/vault/cluster/access/oidc/assignments/create.hbs
+++ b/ui/app/templates/vault/cluster/access/oidc/assignments/create.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/app/templates/vault/cluster/access/oidc/assignments/index.hbs
+++ b/ui/app/templates/vault/cluster/access/oidc/assignments/index.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Toolbar>
   <ToolbarActions>

--- a/ui/app/templates/vault/cluster/access/oidc/clients/client.hbs
+++ b/ui/app/templates/vault/cluster/access/oidc/clients/client.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if (not-eq this.router.currentRoute.localName "edit")}}
   <PageHeader as |p|>

--- a/ui/app/templates/vault/cluster/access/oidc/clients/client/details.hbs
+++ b/ui/app/templates/vault/cluster/access/oidc/clients/client/details.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Toolbar data-test-oidc-client-toolbar>
   <ToolbarActions>

--- a/ui/app/templates/vault/cluster/access/oidc/clients/client/edit.hbs
+++ b/ui/app/templates/vault/cluster/access/oidc/clients/client/edit.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Oidc::ClientForm
   @model={{this.model}}

--- a/ui/app/templates/vault/cluster/access/oidc/clients/client/providers.hbs
+++ b/ui/app/templates/vault/cluster/access/oidc/clients/client/providers.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Toolbar />
 {{#if (gt this.model.length 0)}}

--- a/ui/app/templates/vault/cluster/access/oidc/clients/create.hbs
+++ b/ui/app/templates/vault/cluster/access/oidc/clients/create.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Oidc::ClientForm
   @model={{this.model}}

--- a/ui/app/templates/vault/cluster/access/oidc/clients/index.hbs
+++ b/ui/app/templates/vault/cluster/access/oidc/clients/index.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Toolbar>
   <ToolbarActions>

--- a/ui/app/templates/vault/cluster/access/oidc/index.hbs
+++ b/ui/app/templates/vault/cluster/access/oidc/index.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="box is-fullwidth is-shadowless" data-test-oidc-landing>
   <p>

--- a/ui/app/templates/vault/cluster/access/oidc/keys/create.hbs
+++ b/ui/app/templates/vault/cluster/access/oidc/keys/create.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/app/templates/vault/cluster/access/oidc/keys/index.hbs
+++ b/ui/app/templates/vault/cluster/access/oidc/keys/index.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Toolbar>
   <ToolbarActions>

--- a/ui/app/templates/vault/cluster/access/oidc/keys/key.hbs
+++ b/ui/app/templates/vault/cluster/access/oidc/keys/key.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if (not-eq this.router.currentRoute.localName "edit")}}
   <PageHeader as |p|>

--- a/ui/app/templates/vault/cluster/access/oidc/keys/key/clients.hbs
+++ b/ui/app/templates/vault/cluster/access/oidc/keys/key/clients.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Toolbar />
 

--- a/ui/app/templates/vault/cluster/access/oidc/keys/key/details.hbs
+++ b/ui/app/templates/vault/cluster/access/oidc/keys/key/details.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Toolbar>
   <ToolbarActions>

--- a/ui/app/templates/vault/cluster/access/oidc/keys/key/edit.hbs
+++ b/ui/app/templates/vault/cluster/access/oidc/keys/key/edit.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/app/templates/vault/cluster/access/oidc/providers/create.hbs
+++ b/ui/app/templates/vault/cluster/access/oidc/providers/create.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Oidc::ProviderForm
   @model={{this.model}}

--- a/ui/app/templates/vault/cluster/access/oidc/providers/index.hbs
+++ b/ui/app/templates/vault/cluster/access/oidc/providers/index.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Toolbar>
   <ToolbarActions>

--- a/ui/app/templates/vault/cluster/access/oidc/providers/provider.hbs
+++ b/ui/app/templates/vault/cluster/access/oidc/providers/provider.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if (not-eq this.router.currentRoute.localName "edit")}}
   <PageHeader as |p|>

--- a/ui/app/templates/vault/cluster/access/oidc/providers/provider/clients.hbs
+++ b/ui/app/templates/vault/cluster/access/oidc/providers/provider/clients.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Toolbar />
 

--- a/ui/app/templates/vault/cluster/access/oidc/providers/provider/details.hbs
+++ b/ui/app/templates/vault/cluster/access/oidc/providers/provider/details.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Toolbar>
   <ToolbarActions>

--- a/ui/app/templates/vault/cluster/access/oidc/providers/provider/edit.hbs
+++ b/ui/app/templates/vault/cluster/access/oidc/providers/provider/edit.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Oidc::ProviderForm
   @model={{this.model}}

--- a/ui/app/templates/vault/cluster/access/oidc/scopes/create.hbs
+++ b/ui/app/templates/vault/cluster/access/oidc/scopes/create.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Oidc::ScopeForm
   @model={{this.model}}

--- a/ui/app/templates/vault/cluster/access/oidc/scopes/index.hbs
+++ b/ui/app/templates/vault/cluster/access/oidc/scopes/index.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Toolbar>
   <ToolbarActions>

--- a/ui/app/templates/vault/cluster/access/oidc/scopes/scope/details.hbs
+++ b/ui/app/templates/vault/cluster/access/oidc/scopes/scope/details.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/app/templates/vault/cluster/access/oidc/scopes/scope/edit.hbs
+++ b/ui/app/templates/vault/cluster/access/oidc/scopes/scope/edit.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Oidc::ScopeForm
   @model={{this.model}}

--- a/ui/app/templates/vault/cluster/access/reset-password-error.hbs
+++ b/ui/app/templates/vault/cluster/access/reset-password-error.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.levelLeft>

--- a/ui/app/templates/vault/cluster/access/reset-password.hbs
+++ b/ui/app/templates/vault/cluster/access/reset-password.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Page::UserpassResetPassword @backend={{this.model.backend}} @username={{this.model.username}} />

--- a/ui/app/templates/vault/cluster/auth.hbs
+++ b/ui/app/templates/vault/cluster/auth.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Auth::Page
   @authMethodQueryParam={{this.authMethod}}

--- a/ui/app/templates/vault/cluster/clients.hbs
+++ b/ui/app/templates/vault/cluster/clients.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Sidebar::Nav::Clients @canReadConfig={{this.model.config.canRead}} />
 {{outlet}}

--- a/ui/app/templates/vault/cluster/clients/config.hbs
+++ b/ui/app/templates/vault/cluster/clients/config.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.levelLeft>

--- a/ui/app/templates/vault/cluster/clients/counts.hbs
+++ b/ui/app/templates/vault/cluster/clients/counts.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Clients::Page::Counts
   @activity={{this.model.activity}}

--- a/ui/app/templates/vault/cluster/clients/counts/acme.hbs
+++ b/ui/app/templates/vault/cluster/clients/counts/acme.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Clients::Page::Acme
   @activity={{this.model.activity}}

--- a/ui/app/templates/vault/cluster/clients/counts/overview.hbs
+++ b/ui/app/templates/vault/cluster/clients/counts/overview.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Clients::Page::Overview
   @activity={{this.model.activity}}

--- a/ui/app/templates/vault/cluster/clients/counts/sync.hbs
+++ b/ui/app/templates/vault/cluster/clients/counts/sync.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Clients::Page::Sync
   @activity={{this.model.activity}}

--- a/ui/app/templates/vault/cluster/clients/counts/token.hbs
+++ b/ui/app/templates/vault/cluster/clients/counts/token.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Clients::Page::Token
   @activity={{this.model.activity}}

--- a/ui/app/templates/vault/cluster/clients/edit.hbs
+++ b/ui/app/templates/vault/cluster/clients/edit.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.levelLeft>

--- a/ui/app/templates/vault/cluster/clients/error.hbs
+++ b/ui/app/templates/vault/cluster/clients/error.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if (eq @model.httpStatus 404)}}
   <NotFound @model={{this.model}} />

--- a/ui/app/templates/vault/cluster/clients/loading.hbs
+++ b/ui/app/templates/vault/cluster/clients/loading.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <LayoutLoading />

--- a/ui/app/templates/vault/cluster/dashboard.hbs
+++ b/ui/app/templates/vault/cluster/dashboard.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Dashboard::Overview
   @replication={{this.model.replication}}

--- a/ui/app/templates/vault/cluster/error.hbs
+++ b/ui/app/templates/vault/cluster/error.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if (eq this.model.httpStatus 404)}}
   <NotFound @model={{this.model}} />

--- a/ui/app/templates/vault/cluster/init.hbs
+++ b/ui/app/templates/vault/cluster/init.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <SplashPage>
   <:header>

--- a/ui/app/templates/vault/cluster/license.hbs
+++ b/ui/app/templates/vault/cluster/license.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <LicenseInfo
   @startTime={{this.model.startTime}}

--- a/ui/app/templates/vault/cluster/loading.hbs
+++ b/ui/app/templates/vault/cluster/loading.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <LayoutLoading />

--- a/ui/app/templates/vault/cluster/mfa-setup.hbs
+++ b/ui/app/templates/vault/cluster/mfa-setup.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <SplashPage>
   <:header>

--- a/ui/app/templates/vault/cluster/not-found.hbs
+++ b/ui/app/templates/vault/cluster/not-found.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <NotFound @model={{this.model}} />

--- a/ui/app/templates/vault/cluster/oidc-callback.hbs
+++ b/ui/app/templates/vault/cluster/oidc-callback.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#in-element this.pageContainer}}
   <OidcCallbackSplash />

--- a/ui/app/templates/vault/cluster/oidc-provider-ns.hbs
+++ b/ui/app/templates/vault/cluster/oidc-provider-ns.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="splash-page-container section is-flex-v-centered-tablet is-flex-grow-1 is-fullwidth">
   <div class="columns is-centered is-gapless is-fullwidth">

--- a/ui/app/templates/vault/cluster/oidc-provider.hbs
+++ b/ui/app/templates/vault/cluster/oidc-provider.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="splash-page-container section is-flex-v-centered-tablet is-flex-grow-1 is-fullwidth">
   <div class="columns is-centered is-gapless is-fullwidth">

--- a/ui/app/templates/vault/cluster/policies.hbs
+++ b/ui/app/templates/vault/cluster/policies.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Sidebar::Nav::Policies />
 {{outlet}}

--- a/ui/app/templates/vault/cluster/policies/create.hbs
+++ b/ui/app/templates/vault/cluster/policies/create.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/app/templates/vault/cluster/policies/error.hbs
+++ b/ui/app/templates/vault/cluster/policies/error.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if (eq this.model.httpStatus 404)}}
   <NotFound @model={{this.model}} />

--- a/ui/app/templates/vault/cluster/policies/index.hbs
+++ b/ui/app/templates/vault/cluster/policies/index.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if (or (eq this.policyType "acl") (has-feature "Sentinel"))}}
   <PageHeader as |p|>

--- a/ui/app/templates/vault/cluster/policies/loading.hbs
+++ b/ui/app/templates/vault/cluster/policies/loading.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <LayoutLoading />

--- a/ui/app/templates/vault/cluster/policy.hbs
+++ b/ui/app/templates/vault/cluster/policy.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Sidebar::Nav::Policies />
 {{outlet}}

--- a/ui/app/templates/vault/cluster/policy/edit.hbs
+++ b/ui/app/templates/vault/cluster/policy/edit.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/app/templates/vault/cluster/policy/error.hbs
+++ b/ui/app/templates/vault/cluster/policy/error.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if (eq this.model.httpStatus 404)}}
   <NotFound @model={{this.model}} />

--- a/ui/app/templates/vault/cluster/policy/loading.hbs
+++ b/ui/app/templates/vault/cluster/policy/loading.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <LayoutLoading />

--- a/ui/app/templates/vault/cluster/policy/show.hbs
+++ b/ui/app/templates/vault/cluster/policy/show.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/app/templates/vault/cluster/redirect.hbs
+++ b/ui/app/templates/vault/cluster/redirect.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <LogoSplash />

--- a/ui/app/templates/vault/cluster/replication-dr-promote/details.hbs
+++ b/ui/app/templates/vault/cluster/replication-dr-promote/details.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <section class="section">
   <div class="container is-widescreen">

--- a/ui/app/templates/vault/cluster/replication-dr-promote/index.hbs
+++ b/ui/app/templates/vault/cluster/replication-dr-promote/index.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <section class="section">
   <div class="container is-widescreen">

--- a/ui/app/templates/vault/cluster/secrets/backend/configuration.hbs
+++ b/ui/app/templates/vault/cluster/secrets/backend/configuration.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 {{! use the index route to view configuration and sibling edit route to edit the configuration. }}
 {{outlet}}

--- a/ui/app/templates/vault/cluster/secrets/backend/configuration/edit.hbs
+++ b/ui/app/templates/vault/cluster/secrets/backend/configuration/edit.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/app/templates/vault/cluster/secrets/backend/configuration/index.hbs
+++ b/ui/app/templates/vault/cluster/secrets/backend/configuration/index.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <SecretListHeader @model={{this.model.secretEngineModel}} @isConfigure={{true}} />
 

--- a/ui/app/templates/vault/cluster/secrets/backend/credentials.hbs
+++ b/ui/app/templates/vault/cluster/secrets/backend/credentials.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if (eq this.model.backendType "database")}}
   <GenerateCredentialsDatabase

--- a/ui/app/templates/vault/cluster/secrets/backend/error.hbs
+++ b/ui/app/templates/vault/cluster/secrets/backend/error.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="box is-shadowless">
   <PageHeader as |p|>

--- a/ui/app/templates/vault/cluster/secrets/backend/list.hbs
+++ b/ui/app/templates/vault/cluster/secrets/backend/list.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <SecretListHeader @model={{this.backendModel}} />
 {{#let (options-for-backend this.backendType this.tab) as |options|}}

--- a/ui/app/templates/vault/cluster/secrets/backend/overview.hbs
+++ b/ui/app/templates/vault/cluster/secrets/backend/overview.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <SecretListHeader @model={{this.model}} />
 

--- a/ui/app/templates/vault/cluster/secrets/backend/secret-edit-layout.hbs
+++ b/ui/app/templates/vault/cluster/secrets/backend/secret-edit-layout.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{component
   (get (options-for-backend this.backendType this.model.idPrefix) "editComponent")

--- a/ui/app/templates/vault/cluster/secrets/backend/sign.hbs
+++ b/ui/app/templates/vault/cluster/secrets/backend/sign.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/app/templates/vault/cluster/secrets/backend/transit-actions-layout.hbs
+++ b/ui/app/templates/vault/cluster/secrets/backend/transit-actions-layout.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="columns">
   <div class="column">

--- a/ui/app/templates/vault/cluster/secrets/backends.hbs
+++ b/ui/app/templates/vault/cluster/secrets/backends.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.levelLeft>

--- a/ui/app/templates/vault/cluster/settings.hbs
+++ b/ui/app/templates/vault/cluster/settings.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{outlet}}

--- a/ui/app/templates/vault/cluster/settings/auth.hbs
+++ b/ui/app/templates/vault/cluster/settings/auth.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Sidebar::Nav::Access />
 {{outlet}}

--- a/ui/app/templates/vault/cluster/settings/auth/configure.hbs
+++ b/ui/app/templates/vault/cluster/settings/auth/configure.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/app/templates/vault/cluster/settings/auth/configure/section.hbs
+++ b/ui/app/templates/vault/cluster/settings/auth/configure/section.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if (eq this.model.section "options")}}
   <AuthConfigForm::Options @model={{this.model.model}} />

--- a/ui/app/templates/vault/cluster/settings/auth/enable.hbs
+++ b/ui/app/templates/vault/cluster/settings/auth/enable.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <MountBackendForm @mountModel={{this.model}} @onMountSuccess={{action "onMountSuccess"}} />

--- a/ui/app/templates/vault/cluster/settings/mount-secret-backend.hbs
+++ b/ui/app/templates/vault/cluster/settings/mount-secret-backend.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <MountBackendForm @mountModel={{this.model}} @mountType="secret" @onMountSuccess={{action "onMountSuccess"}} />

--- a/ui/app/templates/vault/cluster/settings/seal.hbs
+++ b/ui/app/templates/vault/cluster/settings/seal.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.levelLeft>

--- a/ui/app/templates/vault/cluster/storage-restore.hbs
+++ b/ui/app/templates/vault/cluster/storage-restore.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <RaftStorageRestore />

--- a/ui/app/templates/vault/cluster/storage.hbs
+++ b/ui/app/templates/vault/cluster/storage.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <RaftStorageOverview @model={{this.model}} />

--- a/ui/app/templates/vault/cluster/tools.hbs
+++ b/ui/app/templates/vault/cluster/tools.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Sidebar::Nav::Tools />
 {{outlet}}

--- a/ui/app/templates/vault/cluster/tools/error.hbs
+++ b/ui/app/templates/vault/cluster/tools/error.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <NotFound @model={{this.model}} />

--- a/ui/app/templates/vault/cluster/tools/tool.hbs
+++ b/ui/app/templates/vault/cluster/tools/tool.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if (eq this.selectedAction "hash")}}
   <Tools::Hash />

--- a/ui/app/templates/vault/cluster/unseal.hbs
+++ b/ui/app/templates/vault/cluster/unseal.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if this.showLicenseError}}
   <div class="section is-flex-v-centered-tablet is-flex-grow-1 is-fullwidth">

--- a/ui/app/templates/vault/error.hbs
+++ b/ui/app/templates/vault/error.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="is-flex-grow-1 is-flex-v-centered">
   <div class="empty-state-content">

--- a/ui/app/templates/vault/not-found.hbs
+++ b/ui/app/templates/vault/not-found.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <NotFound @model={{this.model}} />

--- a/ui/lib/config-ui/addon/components/messages/message-expiration-date-form.hbs
+++ b/ui/lib/config-ui/addon/components/messages/message-expiration-date-form.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="has-top-padding-xs has-bottom-padding-s is-narrow is-flex-align-baseline">
   <RadioButton

--- a/ui/lib/config-ui/addon/components/messages/page/create-and-edit.hbs
+++ b/ui/lib/config-ui/addon/components/messages/page/create-and-edit.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 <Messages::TabPageHeader
   @authenticated={{@message.authenticated}}
   @pageTitle="{{if @message.isNew 'Create' 'Edit'}} message"

--- a/ui/lib/config-ui/addon/components/messages/page/details.hbs
+++ b/ui/lib/config-ui/addon/components/messages/page/details.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Messages::TabPageHeader
   @authenticated={{@message.authenticated}}

--- a/ui/lib/config-ui/addon/components/messages/page/list.hbs
+++ b/ui/lib/config-ui/addon/components/messages/page/list.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 <Messages::TabPageHeader
   @authenticated={{@authenticated}}
   @pageTitle="Custom messages"

--- a/ui/lib/config-ui/addon/components/messages/preview-image.hbs
+++ b/ui/lib/config-ui/addon/components/messages/preview-image.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Hds::Modal
   @onClose={{fn (mut @showMessagePreviewModal) false}}

--- a/ui/lib/config-ui/addon/components/messages/tab-page-header.hbs
+++ b/ui/lib/config-ui/addon/components/messages/tab-page-header.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   {{#if @breadcrumbs}}

--- a/ui/lib/config-ui/addon/templates/messages/create.hbs
+++ b/ui/lib/config-ui/addon/templates/messages/create.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Messages::Page::CreateAndEdit
   @message={{this.model.message}}

--- a/ui/lib/config-ui/addon/templates/messages/index.hbs
+++ b/ui/lib/config-ui/addon/templates/messages/index.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Messages::Page::List
   @messages={{this.model.messages}}

--- a/ui/lib/config-ui/addon/templates/messages/message/details.hbs
+++ b/ui/lib/config-ui/addon/templates/messages/message/details.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Messages::Page::Details @message={{this.model}} @breadcrumbs={{this.breadcrumbs}} />

--- a/ui/lib/config-ui/addon/templates/messages/message/edit.hbs
+++ b/ui/lib/config-ui/addon/templates/messages/message/edit.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Messages::Page::CreateAndEdit
   @message={{this.model.message}}

--- a/ui/lib/core/addon/components/alert-inline.hbs
+++ b/ui/lib/core/addon/components/alert-inline.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Hds::Alert
   {{did-update this.refresh @message}}

--- a/ui/lib/core/addon/components/autocomplete-input.hbs
+++ b/ui/lib/core/addon/components/autocomplete-input.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div {{did-insert this.setElement}} ...attributes>
   {{#if @label}}

--- a/ui/lib/core/addon/components/certificate-card.hbs
+++ b/ui/lib/core/addon/components/certificate-card.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Hds::Card::Container
   @level="mid"

--- a/ui/lib/core/addon/components/checkbox-grid.hbs
+++ b/ui/lib/core/addon/components/checkbox-grid.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div data-test-checkbox-grid ...attributes>
   <FormFieldLabel for={{@name}} @label={{@label}} @subText={{@subText}} />

--- a/ui/lib/core/addon/components/chevron.hbs
+++ b/ui/lib/core/addon/components/chevron.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Icon
   @name={{this.glyph}}

--- a/ui/lib/core/addon/components/choose-pgp-key-form.hbs
+++ b/ui/lib/core/addon/components/choose-pgp-key-form.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if this.selectedPgp}}
   <form

--- a/ui/lib/core/addon/components/confirm-action.hbs
+++ b/ui/lib/core/addon/components/confirm-action.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if @isInDropdown}}
   {{! Hds component renders <li> and <button> elements }}

--- a/ui/lib/core/addon/components/confirm-modal.hbs
+++ b/ui/lib/core/addon/components/confirm-modal.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{! Replaces ConfirmAction in dropdowns, instead use dd.Interactive + this modal }}
 {{! Destructive action confirmation modal that asks "Are you sure?" or similar @confirmTitle }}

--- a/ui/lib/core/addon/components/confirmation-modal.hbs
+++ b/ui/lib/core/addon/components/confirmation-modal.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if @isActive}}
   <Hds::Modal id="confirmation-modal" @onClose={{@onClose}} @color="critical" as |M|>

--- a/ui/lib/core/addon/components/control-group-inline-error.hbs
+++ b/ui/lib/core/addon/components/control-group-inline-error.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{! This display only template is for rendering control group errors when the error is thrown from a component }}
 

--- a/ui/lib/core/addon/components/copy-secret-dropdown.hbs
+++ b/ui/lib/core/addon/components/copy-secret-dropdown.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{! @onWrap is recommend to be a concurrency task! see <Page::Secret::Details> in KV addon for example }}
 <BasicDropdown

--- a/ui/lib/core/addon/components/download-button.hbs
+++ b/ui/lib/core/addon/components/download-button.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Hds::Button
   data-test-download-button

--- a/ui/lib/core/addon/components/empty-state.hbs
+++ b/ui/lib/core/addon/components/empty-state.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div data-test-component="empty-state" class="empty-state" ...attributes>
   <div class="empty-state-content">

--- a/ui/lib/core/addon/components/enable-input.hbs
+++ b/ui/lib/core/addon/components/enable-input.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if this.enable}}
   {{yield}}

--- a/ui/lib/core/addon/components/external-link.hbs
+++ b/ui/lib/core/addon/components/external-link.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if @sameTab}}
   <a href={{this.href}} ...attributes>

--- a/ui/lib/core/addon/components/field-group-show.hbs
+++ b/ui/lib/core/addon/components/field-group-show.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="box is-fullwidth is-sideless is-paddingless is-marginless">
   {{#each @model.fieldGroups as |fieldGroup|}}

--- a/ui/lib/core/addon/components/filter-input-explicit.hbs
+++ b/ui/lib/core/addon/components/filter-input-explicit.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <form {{on "submit" @handleSearch}}>
   <Hds::SegmentedGroup as |S|>

--- a/ui/lib/core/addon/components/filter-input.hbs
+++ b/ui/lib/core/addon/components/filter-input.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="control {{unless @hideIcon 'has-icons-left'}}" data-test-filter-input-container>
   <input class="filter input" ...attributes {{on "input" this.onInput}} {{did-insert this.focus}} data-test-filter-input />

--- a/ui/lib/core/addon/components/form-error.hbs
+++ b/ui/lib/core/addon/components/form-error.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="has-top-margin-s is-flex is-flex-center" data-test-form-error>
   <div class="is-narrow message-icon">

--- a/ui/lib/core/addon/components/form-field-groups-loop.hbs
+++ b/ui/lib/core/addon/components/form-field-groups-loop.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#each (get @model this.fieldGroups) as |fieldGroup|}}
   {{#each-in fieldGroup as |group fields|}}

--- a/ui/lib/core/addon/components/form-field-groups.hbs
+++ b/ui/lib/core/addon/components/form-field-groups.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#each (get @model this.fieldGroups) as |fieldGroup|}}
   {{#each-in fieldGroup as |group fields|}}

--- a/ui/lib/core/addon/components/form-field-label.hbs
+++ b/ui/lib/core/addon/components/form-field-label.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if @label}}
   <label data-test-form-field-label class="is-label" ...attributes>

--- a/ui/lib/core/addon/components/form-field.hbs
+++ b/ui/lib/core/addon/components/form-field.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{! template-lint-configure simple-unless "warn" }}
 <div class="field" data-test-field={{or @attr.name true}}>

--- a/ui/lib/core/addon/components/form-save-buttons.hbs
+++ b/ui/lib/core/addon/components/form-save-buttons.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="field is-fullwidth box is-bottomless {{if (eq @includeBox false) 'is-shadowless'}}">
   <Hds::ButtonSet>

--- a/ui/lib/core/addon/components/icon.hbs
+++ b/ui/lib/core/addon/components/icon.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if this.isHdsIcon}}
   <Hds::Icon @name={{@name}} @size={{this.size}} @stretched={{@stretched}} @isInline={{true}} ...attributes />

--- a/ui/lib/core/addon/components/info-table-item-array.hbs
+++ b/ui/lib/core/addon/components/info-table-item-array.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{! the class linked-block-item is needed for the read-more component }}
 <div data-test-info-table-item-array {{did-insert this.fetchOptions}} class="linked-block-item">

--- a/ui/lib/core/addon/components/info-table-row.hbs
+++ b/ui/lib/core/addon/components/info-table-row.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if (or (has-block) this.isVisible)}}
   <div class="info-table-row" data-test-component="info-table-row" ...attributes>

--- a/ui/lib/core/addon/components/info-tooltip.hbs
+++ b/ui/lib/core/addon/components/info-tooltip.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <span class="is-inline-block" data-test-component="info-tooltip" data-test-tooltip>
   <ToolTip

--- a/ui/lib/core/addon/components/input-search.hbs
+++ b/ui/lib/core/addon/components/input-search.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="field is-grouped" ...attributes>
   <div class="control is-expanded">

--- a/ui/lib/core/addon/components/json-editor.hbs
+++ b/ui/lib/core/addon/components/json-editor.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div ...attributes>
   {{#if this.getShowToolbar}}

--- a/ui/lib/core/addon/components/key-value-header.hbs
+++ b/ui/lib/core/addon/components/key-value-header.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Hds::Breadcrumb>
   {{#each this.secretPath as |path|}}

--- a/ui/lib/core/addon/components/kv-object-editor.hbs
+++ b/ui/lib/core/addon/components/kv-object-editor.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="field" ...attributes {{did-insert this.createKvData @value}}>
   <FormFieldLabel

--- a/ui/lib/core/addon/components/kv-suggestion-input.hbs
+++ b/ui/lib/core/addon/components/kv-suggestion-input.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 <div ...attributes {{did-update this.updateSuggestions @mountPath}}>
   {{#if @label}}
     <FormFieldLabel for={{this.inputId}} @label={{@label}} @subText={{@subText}} />

--- a/ui/lib/core/addon/components/layout-loading.hbs
+++ b/ui/lib/core/addon/components/layout-loading.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="is-flex-v-centered is-flex-grow-1 loader-inner-page" data-test-layout-loading>
   <div class="columns is-centered">

--- a/ui/lib/core/addon/components/linked-block.hbs
+++ b/ui/lib/core/addon/components/linked-block.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class={{unless @disabled "linked-block"}} role="link" {{on "click" this.onClick}} ...attributes>
   {{yield}}

--- a/ui/lib/core/addon/components/list-item.hbs
+++ b/ui/lib/core/addon/components/list-item.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if @componentName}}
   {{component @componentName item=@item}}

--- a/ui/lib/core/addon/components/list-item/content.hbs
+++ b/ui/lib/core/addon/components/list-item/content.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{yield}}

--- a/ui/lib/core/addon/components/list-item/popup-menu.hbs
+++ b/ui/lib/core/addon/components/list-item/popup-menu.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{yield}}

--- a/ui/lib/core/addon/components/list-view.hbs
+++ b/ui/lib/core/addon/components/list-view.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if (or (and @items.meta @items.meta.total) @items.length)}}
   <div class="box is-fullwidth is-bottomless is-sideless is-paddingless" data-test-list-view-list>

--- a/ui/lib/core/addon/components/loading-dropdown-option.hbs
+++ b/ui/lib/core/addon/components/loading-dropdown-option.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Hds::Button disabled @text="loading" class="link loading-dropdown" @icon="loading" @isIconOnly={{true}} ...attributes />

--- a/ui/lib/core/addon/components/masked-input.hbs
+++ b/ui/lib/core/addon/components/masked-input.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div
   class="masked-input {{if @displayOnly 'display-only'}} {{if @allowCopy 'allow-copy'}}"

--- a/ui/lib/core/addon/components/namespace-reminder.hbs
+++ b/ui/lib/core/addon/components/namespace-reminder.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if this.showMessage}}
   {{#if (has-block)}}

--- a/ui/lib/core/addon/components/navigate-input.hbs
+++ b/ui/lib/core/addon/components/navigate-input.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="navigate-filter">
   <div class="field" data-test-nav-input>

--- a/ui/lib/core/addon/components/object-list-input.hbs
+++ b/ui/lib/core/addon/components/object-list-input.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{yield}}
 {{#each this.inputList as |row index|}}

--- a/ui/lib/core/addon/components/overview-card.hbs
+++ b/ui/lib/core/addon/components/overview-card.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Hds::Card::Container
   @level="mid"

--- a/ui/lib/core/addon/components/page-header-level.hbs
+++ b/ui/lib/core/addon/components/page-header-level.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{! template-lint-disable no-yield-only }}
 {{yield}}

--- a/ui/lib/core/addon/components/page-header.hbs
+++ b/ui/lib/core/addon/components/page-header.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <header class="page-header" ...attributes>
   {{yield (hash top=(component "page-header-level"))}}

--- a/ui/lib/core/addon/components/page/breadcrumbs.hbs
+++ b/ui/lib/core/addon/components/page/breadcrumbs.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Hds::Breadcrumb data-test-breadcrumbs>
   {{#each @breadcrumbs as |breadcrumb|}}

--- a/ui/lib/core/addon/components/page/error.hbs
+++ b/ui/lib/core/addon/components/page/error.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div
   class="box is-sideless has-background-white-bis has-text-grey-light has-text-centered has-tall-padding"

--- a/ui/lib/core/addon/components/policy-example.hbs
+++ b/ui/lib/core/addon/components/policy-example.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="has-bottom-margin-s">
   {{#if (eq @policyType "acl")}}

--- a/ui/lib/core/addon/components/radio-button.hbs
+++ b/ui/lib/core/addon/components/radio-button.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <input
   ...attributes

--- a/ui/lib/core/addon/components/radio-card.hbs
+++ b/ui/lib/core/addon/components/radio-card.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <label
   for={{dasherize (or @title @value)}}

--- a/ui/lib/core/addon/components/replication-dashboard.hbs
+++ b/ui/lib/core/addon/components/replication-dashboard.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="replication-dashboard box is-sideless is-fullwidth is-marginless" data-test-replication-dashboard>
   {{#if this.isReindexing}}

--- a/ui/lib/core/addon/components/replication-header.hbs
+++ b/ui/lib/core/addon/components/replication-header.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader data-test-replication-header as |p|>
   <p.top>

--- a/ui/lib/core/addon/components/replication-page.hbs
+++ b/ui/lib/core/addon/components/replication-page.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div
   class="replication-page"

--- a/ui/lib/core/addon/components/replication-summary-card.hbs
+++ b/ui/lib/core/addon/components/replication-summary-card.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Hds::Card::Container
   @hasBorder={{true}}

--- a/ui/lib/core/addon/components/search-select-placeholder.hbs
+++ b/ui/lib/core/addon/components/search-select-placeholder.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div>
   <div class="field">

--- a/ui/lib/core/addon/components/search-select-with-modal.hbs
+++ b/ui/lib/core/addon/components/search-select-with-modal.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div
   {{did-insert (perform this.fetchOptions)}}

--- a/ui/lib/core/addon/components/search-select.hbs
+++ b/ui/lib/core/addon/components/search-select.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div
   {{did-insert (perform this.fetchOptions)}}

--- a/ui/lib/core/addon/components/secret-list-header-tab.hbs
+++ b/ui/lib/core/addon/components/secret-list-header-tab.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#unless this.dontShowTab}}
   <LinkTo @route="vault.cluster.secrets.backend.list-root" @query={{hash tab=@tab}} data-test-secret-list-tab={{@label}}>

--- a/ui/lib/core/addon/components/secret-list-header.hbs
+++ b/ui/lib/core/addon/components/secret-list-header.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#let (options-for-backend @model.engineType) as |options|}}
   <PageHeader as |p|>

--- a/ui/lib/core/addon/components/secrets-engine-mount-config.hbs
+++ b/ui/lib/core/addon/components/secrets-engine-mount-config.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div ...attributes>
   <ToggleButton

--- a/ui/lib/core/addon/components/selectable-card.hbs
+++ b/ui/lib/core/addon/components/selectable-card.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Hds::Card::Container
   tabindex={{unless @disabled "0"}}

--- a/ui/lib/core/addon/components/shamir/dr-token-flow.hbs
+++ b/ui/lib/core/addon/components/shamir/dr-token-flow.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 {{! THIS COMPONENT RENDERS INSIDE A MODAL (must pass @container to copy buttons) }}
 {{#if this.encodedToken}}
   <p class="has-bottom-margin-l" data-test-dr-token-flow-step="show-token">

--- a/ui/lib/core/addon/components/shamir/flow.hbs
+++ b/ui/lib/core/addon/components/shamir/flow.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Shamir::Form
   @onSubmit={{this.onSubmitKey}}

--- a/ui/lib/core/addon/components/shamir/form.hbs
+++ b/ui/lib/core/addon/components/shamir/form.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <form id="shamir" aria-label="shamir form" {{on "submit" (fn this.onSubmit this.key)}} ...attributes>
   {{#if @errors}}

--- a/ui/lib/core/addon/components/stat-text.hbs
+++ b/ui/lib/core/addon/components/stat-text.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div
   class={{concat "stat-text-container " @size (unless @subText "-no-subText")}}

--- a/ui/lib/core/addon/components/string-list.hbs
+++ b/ui/lib/core/addon/components/string-list.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div
   class="field string-list form-section"

--- a/ui/lib/core/addon/components/sync-status-badge.hbs
+++ b/ui/lib/core/addon/components/sync-status-badge.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Hds::Badge @text={{to-label @status}} @icon={{this.state.icon}} @color={{this.state.color}} ...attributes />

--- a/ui/lib/core/addon/components/text-file.hbs
+++ b/ui/lib/core/addon/components/text-file.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if @uploadOnly}}
   <label id="text-file-input-{{this.elementId}}" class="sr-only">{{or @label "File"}}</label>

--- a/ui/lib/core/addon/components/toggle-button.hbs
+++ b/ui/lib/core/addon/components/toggle-button.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{! DEPRECATED use <Hds::Reveal /> instead https://helios.hashicorp.design/components/reveal }}
 <button type="button" class="button is-transparent has-text-info" {{on "click" (fn @onClick (not @isOpen))}} ...attributes>

--- a/ui/lib/core/addon/components/toggle.hbs
+++ b/ui/lib/core/addon/components/toggle.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Input
   id={{this.safeId}}

--- a/ui/lib/core/addon/components/tool-tip.hbs
+++ b/ui/lib/core/addon/components/tool-tip.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <BasicDropdown
   @renderInPlace={{@renderInPlace}}

--- a/ui/lib/core/addon/components/toolbar-actions.hbs
+++ b/ui/lib/core/addon/components/toolbar-actions.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <nav class="toolbar-actions" aria-label="toolbar actions" ...attributes>
   {{yield}}

--- a/ui/lib/core/addon/components/toolbar-filters.hbs
+++ b/ui/lib/core/addon/components/toolbar-filters.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <nav class="toolbar-filters" aria-label="toolbar filters" ...attributes>
   {{yield}}

--- a/ui/lib/core/addon/components/toolbar-link.hbs
+++ b/ui/lib/core/addon/components/toolbar-link.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if (and @disabled @disabledTooltip)}}
   <ToolTip @verticalPosition="above" as |T|>

--- a/ui/lib/core/addon/components/toolbar.hbs
+++ b/ui/lib/core/addon/components/toolbar.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <nav class="toolbar" aria-label="toolbar" ...attributes>
   <div class="toolbar-scroller">

--- a/ui/lib/core/addon/components/ttl-picker.hbs
+++ b/ui/lib/core/addon/components/ttl-picker.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="has-bottom-margin-m" ...attributes>
   {{#if @hideToggle}}

--- a/ui/lib/core/addon/components/upgrade-page.hbs
+++ b/ui/lib/core/addon/components/upgrade-page.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.levelLeft>

--- a/ui/lib/core/addon/components/vault-logo-spinner.hbs
+++ b/ui/lib/core/addon/components/vault-logo-spinner.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{! template-lint-disable no-inline-styles}}
 <svg

--- a/ui/lib/core/addon/templates/components/edit-form.hbs
+++ b/ui/lib/core/addon/templates/components/edit-form.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <form {{action (perform this.save this.model) on="submit"}}>
   <MessageError @model={{this.model}} data-test-edit-form-error />

--- a/ui/lib/core/addon/templates/components/message-error.hbs
+++ b/ui/lib/core/addon/templates/components/message-error.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if this.displayErrors}}
   {{#each this.displayErrors as |error|}}

--- a/ui/lib/core/addon/templates/components/read-more.hbs
+++ b/ui/lib/core/addon/templates/components/read-more.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div
   class="has-text-grey has-font-weight-normal overflow-ellipsis {{if this.isOpen '' 'is-closed'}} "

--- a/ui/lib/core/addon/templates/components/readonly-form-field.hbs
+++ b/ui/lib/core/addon/templates/components/readonly-form-field.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <label for={{@attr.name}} class="is-label" data-test-readonly-label>
   {{this.labelString}}

--- a/ui/lib/core/addon/templates/components/replication-action-demote.hbs
+++ b/ui/lib/core/addon/templates/components/replication-action-demote.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="action-block is-rounded" data-test-demote-replication>
   <div class="action-block-info">

--- a/ui/lib/core/addon/templates/components/replication-action-disable.hbs
+++ b/ui/lib/core/addon/templates/components/replication-action-disable.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="action-block is-rounded" data-test-disable-replication>
   <div class="action-block-info">

--- a/ui/lib/core/addon/templates/components/replication-action-generate-token.hbs
+++ b/ui/lib/core/addon/templates/components/replication-action-generate-token.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="action-block is-rounded" data-test-generate-token-replication>
   <div class="action-block-info">

--- a/ui/lib/core/addon/templates/components/replication-action-promote.hbs
+++ b/ui/lib/core/addon/templates/components/replication-action-promote.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="action-block is-rounded" data-test-promote-replication>
   <div class="action-block-info">

--- a/ui/lib/core/addon/templates/components/replication-action-recover.hbs
+++ b/ui/lib/core/addon/templates/components/replication-action-recover.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="action-block is-rounded" data-test-recover-replication>
   <div class="action-block-info">

--- a/ui/lib/core/addon/templates/components/replication-action-reindex.hbs
+++ b/ui/lib/core/addon/templates/components/replication-action-reindex.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="action-block is-rounded" data-test-reindex-replication>
   <div class="action-block-info">

--- a/ui/lib/core/addon/templates/components/replication-action-update-primary.hbs
+++ b/ui/lib/core/addon/templates/components/replication-action-update-primary.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="action-block is-rounded" data-test-update-primary-replication>
   <div class="action-block-info">

--- a/ui/lib/core/addon/templates/components/replication-actions.hbs
+++ b/ui/lib/core/addon/templates/components/replication-actions.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if this.loading}}
   <LayoutLoading />

--- a/ui/lib/core/addon/templates/components/replication-secondary-card.hbs
+++ b/ui/lib/core/addon/templates/components/replication-secondary-card.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Hds::Card::Container
   @hasBorder={{true}}

--- a/ui/lib/core/addon/templates/components/replication-table-rows.hbs
+++ b/ui/lib/core/addon/templates/components/replication-table-rows.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="has-top-margin-xl has-bottom-margin-s" data-test-table-rows>
   {{#if (eq this.clusterMode "secondary")}}

--- a/ui/lib/core/addon/templates/components/select.hbs
+++ b/ui/lib/core/addon/templates/components/select.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if this.label}}
   <label for="select-{{this.name}}" class="is-label" data-test-select-label>

--- a/ui/lib/kmip/addon/components/header-credentials.hbs
+++ b/ui/lib/kmip/addon/components/header-credentials.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/lib/kmip/addon/components/kmip/role-form.hbs
+++ b/ui/lib/kmip/addon/components/kmip/role-form.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <form {{on "submit" (perform this.save)}}>
   <MessageError @model={{@model}} data-test-edit-form-error />

--- a/ui/lib/kmip/addon/templates/application.hbs
+++ b/ui/lib/kmip/addon/templates/application.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{outlet}}

--- a/ui/lib/kmip/addon/templates/components/header-scope.hbs
+++ b/ui/lib/kmip/addon/templates/components/header-scope.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/lib/kmip/addon/templates/components/kmip-breadcrumb.hbs
+++ b/ui/lib/kmip/addon/templates/components/kmip-breadcrumb.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Hds::Breadcrumb>
   <Hds::Breadcrumb::Item @text="Secrets" @route="secrets" @isRouteExternal={{true}} data-test-breadcrumb="Secrets" />

--- a/ui/lib/kmip/addon/templates/components/operation-field-display.hbs
+++ b/ui/lib/kmip/addon/templates/components/operation-field-display.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if this.model.operationAll}}
   <AlertInline @type="info" @message="This role allows all KMIP operations" class="is-marginless" />

--- a/ui/lib/kmip/addon/templates/configuration.hbs
+++ b/ui/lib/kmip/addon/templates/configuration.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <HeaderScope />
 <Toolbar>

--- a/ui/lib/kmip/addon/templates/configure.hbs
+++ b/ui/lib/kmip/addon/templates/configure.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/lib/kmip/addon/templates/credentials/generate.hbs
+++ b/ui/lib/kmip/addon/templates/credentials/generate.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/lib/kmip/addon/templates/credentials/index.hbs
+++ b/ui/lib/kmip/addon/templates/credentials/index.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <HeaderCredentials @role={{this.role}} @scope={{this.scope}} />
 <Toolbar>

--- a/ui/lib/kmip/addon/templates/credentials/show.hbs
+++ b/ui/lib/kmip/addon/templates/credentials/show.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/lib/kmip/addon/templates/role.hbs
+++ b/ui/lib/kmip/addon/templates/role.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <HeaderCredentials @role={{this.role}} @scope={{this.scope}} />
 <Toolbar>

--- a/ui/lib/kmip/addon/templates/role/edit.hbs
+++ b/ui/lib/kmip/addon/templates/role/edit.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/lib/kmip/addon/templates/scope/roles.hbs
+++ b/ui/lib/kmip/addon/templates/scope/roles.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/lib/kmip/addon/templates/scope/roles/create.hbs
+++ b/ui/lib/kmip/addon/templates/scope/roles/create.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/lib/kmip/addon/templates/scopes.hbs
+++ b/ui/lib/kmip/addon/templates/scopes.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{outlet}}

--- a/ui/lib/kmip/addon/templates/scopes/create.hbs
+++ b/ui/lib/kmip/addon/templates/scopes/create.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/lib/kmip/addon/templates/scopes/index.hbs
+++ b/ui/lib/kmip/addon/templates/scopes/index.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <HeaderScope />
 <Toolbar>

--- a/ui/lib/kubernetes/addon/components/config-cta.hbs
+++ b/ui/lib/kubernetes/addon/components/config-cta.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <EmptyState
   data-test-config-cta

--- a/ui/lib/kubernetes/addon/components/page/configuration.hbs
+++ b/ui/lib/kubernetes/addon/components/page/configuration.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <TabPageHeader @model={{@backend}} @breadcrumbs={{@breadcrumbs}}>
   <ToolbarLink @route="configure" data-test-toolbar-config-action>

--- a/ui/lib/kubernetes/addon/components/page/configure.hbs
+++ b/ui/lib/kubernetes/addon/components/page/configure.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/lib/kubernetes/addon/components/page/credentials.hbs
+++ b/ui/lib/kubernetes/addon/components/page/credentials.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/lib/kubernetes/addon/components/page/overview.hbs
+++ b/ui/lib/kubernetes/addon/components/page/overview.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <TabPageHeader @model={{@backend}} @breadcrumbs={{@breadcrumbs}}>
   <ToolbarLink @route="configure">Configure Kubernetes</ToolbarLink>

--- a/ui/lib/kubernetes/addon/components/page/role/create-and-edit.hbs
+++ b/ui/lib/kubernetes/addon/components/page/role/create-and-edit.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/lib/kubernetes/addon/components/page/role/details.hbs
+++ b/ui/lib/kubernetes/addon/components/page/role/details.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/lib/kubernetes/addon/components/page/roles.hbs
+++ b/ui/lib/kubernetes/addon/components/page/roles.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <TabPageHeader
   @model={{@backend}}

--- a/ui/lib/kubernetes/addon/components/tab-page-header.hbs
+++ b/ui/lib/kubernetes/addon/components/tab-page-header.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/lib/kubernetes/addon/templates/configuration.hbs
+++ b/ui/lib/kubernetes/addon/templates/configuration.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Page::Configuration @config={{this.model.config}} @backend={{this.model.backend}} @breadcrumbs={{this.breadcrumbs}} />

--- a/ui/lib/kubernetes/addon/templates/configure.hbs
+++ b/ui/lib/kubernetes/addon/templates/configure.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Page::Configure @model={{this.model}} @breadcrumbs={{this.breadcrumbs}} />

--- a/ui/lib/kubernetes/addon/templates/error.hbs
+++ b/ui/lib/kubernetes/addon/templates/error.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <TabPageHeader @model={{this.backend}} @breadcrumbs={{this.breadcrumbs}} />
 

--- a/ui/lib/kubernetes/addon/templates/overview.hbs
+++ b/ui/lib/kubernetes/addon/templates/overview.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Page::Overview
   @promptConfig={{this.model.promptConfig}}

--- a/ui/lib/kubernetes/addon/templates/roles/create.hbs
+++ b/ui/lib/kubernetes/addon/templates/roles/create.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Page::Role::CreateAndEdit @model={{this.model}} @breadcrumbs={{this.breadcrumbs}} />

--- a/ui/lib/kubernetes/addon/templates/roles/index.hbs
+++ b/ui/lib/kubernetes/addon/templates/roles/index.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Page::Roles
   @roles={{this.model.roles}}

--- a/ui/lib/kubernetes/addon/templates/roles/role/credentials.hbs
+++ b/ui/lib/kubernetes/addon/templates/roles/role/credentials.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Page::Credentials @roleName={{this.model.roleName}} @backend={{this.model.backend}} @breadcrumbs={{this.breadcrumbs}} />

--- a/ui/lib/kubernetes/addon/templates/roles/role/details.hbs
+++ b/ui/lib/kubernetes/addon/templates/roles/role/details.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Page::Role::Details @model={{@model}} @breadcrumbs={{this.breadcrumbs}} />

--- a/ui/lib/kubernetes/addon/templates/roles/role/edit.hbs
+++ b/ui/lib/kubernetes/addon/templates/roles/role/edit.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Page::Role::CreateAndEdit @model={{this.model}} @breadcrumbs={{this.breadcrumbs}} />

--- a/ui/lib/kv/addon/components/kv-data-fields.hbs
+++ b/ui/lib/kv/addon/components/kv-data-fields.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#let (find-by "name" "path" @secret.allFields) as |attr|}}
   {{#if (eq @type "edit")}}

--- a/ui/lib/kv/addon/components/kv-delete-modal.hbs
+++ b/ui/lib/kv/addon/components/kv-delete-modal.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Hds::Button
   @text={{or @text (capitalize @mode)}}

--- a/ui/lib/kv/addon/components/kv-list-filter.hbs
+++ b/ui/lib/kv/addon/components/kv-list-filter.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <form {{on "submit" (perform this.handleSearch)}}>
   <Hds::SegmentedGroup as |S|>

--- a/ui/lib/kv/addon/components/kv-metadata-fields.hbs
+++ b/ui/lib/kv/addon/components/kv-metadata-fields.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#each @metadata.formFields as |attr|}}
   {{#if (eq attr.name "customMetadata")}}

--- a/ui/lib/kv/addon/components/kv-page-header.hbs
+++ b/ui/lib/kv/addon/components/kv-page-header.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/lib/kv/addon/components/kv-patch/editor/alerts.hbs
+++ b/ui/lib/kv/addon/components/kv-patch/editor/alerts.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{! display only template for rendering alerts for the kv patch editor }}
 

--- a/ui/lib/kv/addon/components/kv-patch/editor/form.hbs
+++ b/ui/lib/kv/addon/components/kv-patch/editor/form.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <form {{on "submit" this.submit}} data-test-kv-patch-editor>
   <div class="flex column-gap-16 has-top-padding-s">

--- a/ui/lib/kv/addon/components/kv-patch/editor/row.hbs
+++ b/ui/lib/kv/addon/components/kv-patch/editor/row.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{! display only template for kv data rows to edit, delete or undo patching a key/value }}
 

--- a/ui/lib/kv/addon/components/kv-patch/json-form.hbs
+++ b/ui/lib/kv/addon/components/kv-patch/json-form.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <form {{on "submit" this.submit}}>
   <JsonEditor class="has-top-margin-l" @title="Patch data" @valueUpdated={{this.handleJson}} @value={{this.jsonObject}} />

--- a/ui/lib/kv/addon/components/kv-patch/subkeys-reveal.hbs
+++ b/ui/lib/kv/addon/components/kv-patch/subkeys-reveal.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="has-top-margin-m">
   <Toggle @onChange={{fn (mut this.showSubkeys)}} @checked={{this.showSubkeys}} @name="Reveal subkeys">

--- a/ui/lib/kv/addon/components/kv-paths-card.hbs
+++ b/ui/lib/kv/addon/components/kv-paths-card.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div data-test-overview-card-container="Paths" ...attributes>
   <Hds::Text::Display @weight="semibold" @size="300" @tag="h2">

--- a/ui/lib/kv/addon/components/kv-subkeys-card.hbs
+++ b/ui/lib/kv/addon/components/kv-subkeys-card.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <OverviewCard @cardTitle="Subkeys" class="has-top-margin-l" {{style max-height="325px" overflow-y="auto"}}>
   <:customSubtext>

--- a/ui/lib/kv/addon/components/kv-tooltip-timestamp.hbs
+++ b/ui/lib/kv/addon/components/kv-tooltip-timestamp.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{! renders a human readable date with a tooltip containing the API timestamp}}
 <ToolTip @verticalPosition="above" @horizontalPosition="center" as |T|>

--- a/ui/lib/kv/addon/components/kv-version-dropdown.hbs
+++ b/ui/lib/kv/addon/components/kv-version-dropdown.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <BasicDropdown @class="popup-menu" @horizontalPosition="auto-right" @verticalPosition="below" @renderInPlace={{true}} as |D|>
   <D.Trigger data-test-version-dropdown class="toolbar-link {{if D.isOpen ' is-active'}}">

--- a/ui/lib/kv/addon/components/page/configuration.hbs
+++ b/ui/lib/kv/addon/components/page/configuration.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <KvPageHeader @breadcrumbs={{@breadcrumbs}} @mountName={{@mountConfig.id}}>
   <:tabLinks>

--- a/ui/lib/kv/addon/components/page/list.hbs
+++ b/ui/lib/kv/addon/components/page/list.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <KvPageHeader @breadcrumbs={{@breadcrumbs}} @mountName={{@backend}}>
   <:tabLinks>

--- a/ui/lib/kv/addon/components/page/secret/details.hbs
+++ b/ui/lib/kv/addon/components/page/secret/details.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <KvPageHeader @breadcrumbs={{@breadcrumbs}} @secretPath={{@path}}>
   <:syncDetails>

--- a/ui/lib/kv/addon/components/page/secret/edit.hbs
+++ b/ui/lib/kv/addon/components/page/secret/edit.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <KvPageHeader @breadcrumbs={{@breadcrumbs}} @pageTitle="Create New Version">
   <:toolbarFilters>

--- a/ui/lib/kv/addon/components/page/secret/metadata/details.hbs
+++ b/ui/lib/kv/addon/components/page/secret/metadata/details.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <KvPageHeader @breadcrumbs={{@breadcrumbs}} @secretPath={{@path}}>
   <:tabLinks>

--- a/ui/lib/kv/addon/components/page/secret/metadata/edit.hbs
+++ b/ui/lib/kv/addon/components/page/secret/metadata/edit.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <KvPageHeader @breadcrumbs={{@breadcrumbs}} @pageTitle="Edit Secret Metadata" />
 

--- a/ui/lib/kv/addon/components/page/secret/metadata/version-diff.hbs
+++ b/ui/lib/kv/addon/components/page/secret/metadata/version-diff.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <KvPageHeader @breadcrumbs={{@breadcrumbs}} @pageTitle="Version Diff">
   <:toolbarFilters>

--- a/ui/lib/kv/addon/components/page/secret/metadata/version-history.hbs
+++ b/ui/lib/kv/addon/components/page/secret/metadata/version-history.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <KvPageHeader @breadcrumbs={{@breadcrumbs}} @secretPath={{@path}}>
   <:tabLinks>

--- a/ui/lib/kv/addon/components/page/secret/overview.hbs
+++ b/ui/lib/kv/addon/components/page/secret/overview.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <KvPageHeader @breadcrumbs={{@breadcrumbs}} @secretPath={{@path}}>
   <:tabLinks>

--- a/ui/lib/kv/addon/components/page/secret/patch.hbs
+++ b/ui/lib/kv/addon/components/page/secret/patch.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <KvPageHeader @breadcrumbs={{@breadcrumbs}} @pageTitle="Patch Secret to New Version" />
 {{#if this.controlGroupError}}

--- a/ui/lib/kv/addon/components/page/secret/paths.hbs
+++ b/ui/lib/kv/addon/components/page/secret/paths.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <KvPageHeader @breadcrumbs={{@breadcrumbs}} @secretPath={{@path}}>
   <:tabLinks>

--- a/ui/lib/kv/addon/components/page/secrets/create.hbs
+++ b/ui/lib/kv/addon/components/page/secrets/create.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <KvPageHeader @breadcrumbs={{@breadcrumbs}} @pageTitle="Create Secret">
   <:toolbarFilters>

--- a/ui/lib/kv/addon/templates/configuration.hbs
+++ b/ui/lib/kv/addon/templates/configuration.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Page::Configuration
   @engineConfig={{this.model.engineConfig}}

--- a/ui/lib/kv/addon/templates/create.hbs
+++ b/ui/lib/kv/addon/templates/create.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Page::Secrets::Create @secret={{this.model.secret}} @metadata={{this.model.metadata}} @breadcrumbs={{this.breadcrumbs}} />

--- a/ui/lib/kv/addon/templates/error.hbs
+++ b/ui/lib/kv/addon/templates/error.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <KvPageHeader @breadcrumbs={{this.breadcrumbs}} @mountName={{this.mountName}}>
   <:tabLinks>

--- a/ui/lib/kv/addon/templates/list-directory.hbs
+++ b/ui/lib/kv/addon/templates/list-directory.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Page::List
   @secrets={{this.model.secrets}}

--- a/ui/lib/kv/addon/templates/list.hbs
+++ b/ui/lib/kv/addon/templates/list.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Page::List
   @secrets={{this.model.secrets}}

--- a/ui/lib/kv/addon/templates/secret/details/edit.hbs
+++ b/ui/lib/kv/addon/templates/secret/details/edit.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Page::Secret::Edit
   @secret={{this.model.newVersion}}

--- a/ui/lib/kv/addon/templates/secret/details/index.hbs
+++ b/ui/lib/kv/addon/templates/secret/details/index.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Page::Secret::Details
   @backend={{this.model.backend}}

--- a/ui/lib/kv/addon/templates/secret/index.hbs
+++ b/ui/lib/kv/addon/templates/secret/index.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Page::Secret::Overview
   @backend={{this.model.backend}}

--- a/ui/lib/kv/addon/templates/secret/metadata/diff.hbs
+++ b/ui/lib/kv/addon/templates/secret/metadata/diff.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Page::Secret::Metadata::VersionDiff
   @metadata={{this.model.metadata}}

--- a/ui/lib/kv/addon/templates/secret/metadata/edit.hbs
+++ b/ui/lib/kv/addon/templates/secret/metadata/edit.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Page::Secret::Metadata::Edit
   @metadata={{this.model.metadata}}

--- a/ui/lib/kv/addon/templates/secret/metadata/index.hbs
+++ b/ui/lib/kv/addon/templates/secret/metadata/index.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Page::Secret::Metadata::Details
   @backend={{this.model.backend}}

--- a/ui/lib/kv/addon/templates/secret/metadata/versions.hbs
+++ b/ui/lib/kv/addon/templates/secret/metadata/versions.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Page::Secret::Metadata::VersionHistory
   @metadata={{this.model.metadata}}

--- a/ui/lib/kv/addon/templates/secret/patch.hbs
+++ b/ui/lib/kv/addon/templates/secret/patch.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Page::Secret::Patch
   @backend={{this.model.backend}}

--- a/ui/lib/kv/addon/templates/secret/paths.hbs
+++ b/ui/lib/kv/addon/templates/secret/paths.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Page::Secret::Paths
   @path={{this.model.path}}

--- a/ui/lib/ldap/addon/components/accounts-checked-out.hbs
+++ b/ui/lib/ldap/addon/components/accounts-checked-out.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <OverviewCard
   @cardTitle="Accounts checked-out"

--- a/ui/lib/ldap/addon/components/config-cta.hbs
+++ b/ui/lib/ldap/addon/components/config-cta.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <EmptyState
   data-test-config-cta

--- a/ui/lib/ldap/addon/components/page/configuration.hbs
+++ b/ui/lib/ldap/addon/components/page/configuration.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <TabPageHeader @model={{@backendModel}} @breadcrumbs={{@breadcrumbs}}>
   <:toolbarActions>

--- a/ui/lib/ldap/addon/components/page/configure.hbs
+++ b/ui/lib/ldap/addon/components/page/configure.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/lib/ldap/addon/components/page/libraries.hbs
+++ b/ui/lib/ldap/addon/components/page/libraries.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <TabPageHeader @model={{@backendModel}} @breadcrumbs={{@breadcrumbs}}>
   <:toolbarFilters>

--- a/ui/lib/ldap/addon/components/page/library/check-out.hbs
+++ b/ui/lib/ldap/addon/components/page/library/check-out.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/lib/ldap/addon/components/page/library/create-and-edit.hbs
+++ b/ui/lib/ldap/addon/components/page/library/create-and-edit.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/lib/ldap/addon/components/page/library/details.hbs
+++ b/ui/lib/ldap/addon/components/page/library/details.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/lib/ldap/addon/components/page/library/details/accounts.hbs
+++ b/ui/lib/ldap/addon/components/page/library/details/accounts.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="is-grid has-top-margin-l grid-2-columns grid-gap-2">
   <div>

--- a/ui/lib/ldap/addon/components/page/library/details/configuration.hbs
+++ b/ui/lib/ldap/addon/components/page/library/details/configuration.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#each @model.displayFields as |field|}}
   {{#let (get @model field.name) as |value|}}

--- a/ui/lib/ldap/addon/components/page/overview.hbs
+++ b/ui/lib/ldap/addon/components/page/overview.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <TabPageHeader @model={{@backendModel}} @breadcrumbs={{@breadcrumbs}}>
   <:toolbarActions>

--- a/ui/lib/ldap/addon/components/page/role/create-and-edit.hbs
+++ b/ui/lib/ldap/addon/components/page/role/create-and-edit.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/lib/ldap/addon/components/page/role/credentials.hbs
+++ b/ui/lib/ldap/addon/components/page/role/credentials.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/lib/ldap/addon/components/page/role/details.hbs
+++ b/ui/lib/ldap/addon/components/page/role/details.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/lib/ldap/addon/components/page/roles.hbs
+++ b/ui/lib/ldap/addon/components/page/roles.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <TabPageHeader @model={{@backendModel}} @breadcrumbs={{@breadcrumbs}}>
   <:toolbarFilters>

--- a/ui/lib/ldap/addon/components/tab-page-header.hbs
+++ b/ui/lib/ldap/addon/components/tab-page-header.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/lib/ldap/addon/templates/configuration.hbs
+++ b/ui/lib/ldap/addon/templates/configuration.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Page::Configuration
   @configModel={{this.model.configModel}}

--- a/ui/lib/ldap/addon/templates/configure.hbs
+++ b/ui/lib/ldap/addon/templates/configure.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Page::Configure @model={{this.model}} @breadcrumbs={{this.breadcrumbs}} />

--- a/ui/lib/ldap/addon/templates/error.hbs
+++ b/ui/lib/ldap/addon/templates/error.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <TabPageHeader @model={{this.backend}} @breadcrumbs={{this.breadcrumbs}} />
 

--- a/ui/lib/ldap/addon/templates/libraries/create.hbs
+++ b/ui/lib/ldap/addon/templates/libraries/create.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Page::Library::CreateAndEdit @model={{this.model}} @breadcrumbs={{this.breadcrumbs}} />

--- a/ui/lib/ldap/addon/templates/libraries/index.hbs
+++ b/ui/lib/ldap/addon/templates/libraries/index.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Page::Libraries
   @libraries={{this.model.libraries}}

--- a/ui/lib/ldap/addon/templates/libraries/library/check-out.hbs
+++ b/ui/lib/ldap/addon/templates/libraries/library/check-out.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Page::Library::CheckOut @credentials={{@model}} @breadcrumbs={{this.breadcrumbs}} />

--- a/ui/lib/ldap/addon/templates/libraries/library/details.hbs
+++ b/ui/lib/ldap/addon/templates/libraries/library/details.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Page::Library::Details @model={{@model}} @breadcrumbs={{this.breadcrumbs}} />
 

--- a/ui/lib/ldap/addon/templates/libraries/library/details/accounts.hbs
+++ b/ui/lib/ldap/addon/templates/libraries/library/details/accounts.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Page::Library::Details::Accounts @library={{this.model.library}} @statuses={{this.model.statuses}} />

--- a/ui/lib/ldap/addon/templates/libraries/library/details/configuration.hbs
+++ b/ui/lib/ldap/addon/templates/libraries/library/details/configuration.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Page::Library::Details::Configuration @model={{this.model}} />

--- a/ui/lib/ldap/addon/templates/libraries/library/edit.hbs
+++ b/ui/lib/ldap/addon/templates/libraries/library/edit.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Page::Library::CreateAndEdit @model={{this.model}} @breadcrumbs={{this.breadcrumbs}} />

--- a/ui/lib/ldap/addon/templates/libraries/subdirectory.hbs
+++ b/ui/lib/ldap/addon/templates/libraries/subdirectory.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Page::Libraries
   @libraries={{this.model.libraries}}

--- a/ui/lib/ldap/addon/templates/overview.hbs
+++ b/ui/lib/ldap/addon/templates/overview.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Page::Overview
   @promptConfig={{this.model.promptConfig}}

--- a/ui/lib/ldap/addon/templates/roles/create.hbs
+++ b/ui/lib/ldap/addon/templates/roles/create.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Page::Role::CreateAndEdit @model={{this.model}} @breadcrumbs={{this.breadcrumbs}} />

--- a/ui/lib/ldap/addon/templates/roles/index.hbs
+++ b/ui/lib/ldap/addon/templates/roles/index.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Page::Roles
   @roles={{this.model.roles}}

--- a/ui/lib/ldap/addon/templates/roles/role/credentials.hbs
+++ b/ui/lib/ldap/addon/templates/roles/role/credentials.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Page::Role::Credentials @credentials={{@model.credentials}} @error={{@model.error}} @breadcrumbs={{this.breadcrumbs}} />

--- a/ui/lib/ldap/addon/templates/roles/role/details.hbs
+++ b/ui/lib/ldap/addon/templates/roles/role/details.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Page::Role::Details @model={{@model}} @breadcrumbs={{this.breadcrumbs}} />

--- a/ui/lib/ldap/addon/templates/roles/role/edit.hbs
+++ b/ui/lib/ldap/addon/templates/roles/role/edit.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Page::Role::CreateAndEdit @model={{this.model}} @breadcrumbs={{this.breadcrumbs}} />

--- a/ui/lib/ldap/addon/templates/roles/subdirectory.hbs
+++ b/ui/lib/ldap/addon/templates/roles/subdirectory.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#let this.model.roleAncestry.type this.model.roleAncestry.path_to_role as |roleType path_to_role|}}
   <Page::Roles

--- a/ui/lib/open-api-explorer/addon/components/swagger-ui.hbs
+++ b/ui/lib/open-api-explorer/addon/components/swagger-ui.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="box is-fullwidth is-sideless">
   <NamespaceReminder as |R|>

--- a/ui/lib/open-api-explorer/addon/templates/application.hbs
+++ b/ui/lib/open-api-explorer/addon/templates/application.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{outlet}}

--- a/ui/lib/open-api-explorer/addon/templates/index.hbs
+++ b/ui/lib/open-api-explorer/addon/templates/index.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <SwaggerUi />

--- a/ui/lib/pki/addon/components/page/pki-certificate-details.hbs
+++ b/ui/lib/pki/addon/components/page/pki-certificate-details.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Toolbar>
   <ToolbarActions>

--- a/ui/lib/pki/addon/components/page/pki-configuration-details.hbs
+++ b/ui/lib/pki/addon/components/page/pki-configuration-details.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if @hasConfig}}
   <Toolbar aria-label="PKI configuration">

--- a/ui/lib/pki/addon/components/page/pki-configuration-edit.hbs
+++ b/ui/lib/pki/addon/components/page/pki-configuration-edit.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="box is-sideless is-fullwidth is-marginless">
   {{#if this.errors}}

--- a/ui/lib/pki/addon/components/page/pki-configure-create.hbs
+++ b/ui/lib/pki/addon/components/page/pki-configure-create.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/lib/pki/addon/components/page/pki-issuer-details.hbs
+++ b/ui/lib/pki/addon/components/page/pki-issuer-details.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Toolbar>
   <ToolbarActions>

--- a/ui/lib/pki/addon/components/page/pki-issuer-edit.hbs
+++ b/ui/lib/pki/addon/components/page/pki-issuer-edit.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <form {{on "submit" (perform this.save)}}>
   <div class="box is-sideless is-fullwidth is-marginless">

--- a/ui/lib/pki/addon/components/page/pki-issuer-generate-intermediate.hbs
+++ b/ui/lib/pki/addon/components/page/pki-issuer-generate-intermediate.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/lib/pki/addon/components/page/pki-issuer-generate-root.hbs
+++ b/ui/lib/pki/addon/components/page/pki-issuer-generate-root.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/lib/pki/addon/components/page/pki-issuer-import.hbs
+++ b/ui/lib/pki/addon/components/page/pki-issuer-import.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/lib/pki/addon/components/page/pki-issuer-list.hbs
+++ b/ui/lib/pki/addon/components/page/pki-issuer-list.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PkiPaginatedList @backend={{@backend}} @listRoute="issuers.index" @list={{@issuers}}>
   <:actions>

--- a/ui/lib/pki/addon/components/page/pki-issuer-rotate-root.hbs
+++ b/ui/lib/pki/addon/components/page/pki-issuer-rotate-root.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/lib/pki/addon/components/page/pki-key-details.hbs
+++ b/ui/lib/pki/addon/components/page/pki-key-details.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Toolbar>
   <ToolbarActions>

--- a/ui/lib/pki/addon/components/page/pki-key-list.hbs
+++ b/ui/lib/pki/addon/components/page/pki-key-list.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PkiPaginatedList @backend={{@backend}} @listRoute="keys.index" @list={{@keyModels}} @hasConfig={{@hasConfig}}>
   <:actions>

--- a/ui/lib/pki/addon/components/page/pki-overview.hbs
+++ b/ui/lib/pki/addon/components/page/pki-overview.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="is-grid grid-2-columns grid-gap-2 has-top-margin-l">
   <OverviewCard

--- a/ui/lib/pki/addon/components/page/pki-role-details.hbs
+++ b/ui/lib/pki/addon/components/page/pki-role-details.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Toolbar>
   <ToolbarActions>

--- a/ui/lib/pki/addon/components/page/pki-tidy-auto-configure.hbs
+++ b/ui/lib/pki/addon/components/page/pki-tidy-auto-configure.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/lib/pki/addon/components/page/pki-tidy-auto-settings.hbs
+++ b/ui/lib/pki/addon/components/page/pki-tidy-auto-settings.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/lib/pki/addon/components/page/pki-tidy-manual.hbs
+++ b/ui/lib/pki/addon/components/page/pki-tidy-manual.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/lib/pki/addon/components/page/pki-tidy-status.hbs
+++ b/ui/lib/pki/addon/components/page/pki-tidy-status.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Toolbar>
   <ToolbarActions>

--- a/ui/lib/pki/addon/components/parsed-certificate-info-rows.hbs
+++ b/ui/lib/pki/addon/components/parsed-certificate-info-rows.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#each this.possibleFields as |field|}}
   {{#let (get @model field.key) as |value|}}

--- a/ui/lib/pki/addon/components/pki-generate-csr.hbs
+++ b/ui/lib/pki/addon/components/pki-generate-csr.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if @model.id}}
   {{! Model only has ID once form has been submitted and saved }}

--- a/ui/lib/pki/addon/components/pki-generate-root.hbs
+++ b/ui/lib/pki/addon/components/pki-generate-root.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{! Show results if model has an ID, which is only generated after save }}
 {{#if @model.id}}

--- a/ui/lib/pki/addon/components/pki-generate-toggle-groups.hbs
+++ b/ui/lib/pki/addon/components/pki-generate-toggle-groups.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#each-in this.groups as |group fields|}}
   <ToggleButton

--- a/ui/lib/pki/addon/components/pki-import-pem-bundle.hbs
+++ b/ui/lib/pki/addon/components/pki-import-pem-bundle.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if this.importedResponse}}
   <div class="is-flex-start has-top-margin-xs">

--- a/ui/lib/pki/addon/components/pki-info-table-rows.hbs
+++ b/ui/lib/pki/addon/components/pki-info-table-rows.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#each @displayFields as |field|}}
   {{#let (find-by "name" field @model.allFields) as |attr|}}

--- a/ui/lib/pki/addon/components/pki-issuer-cross-sign.hbs
+++ b/ui/lib/pki/addon/components/pki-issuer-cross-sign.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <h3 class="title is-4">Intermediates</h3>
 <div class="box is-fullwidth has-only-top-shadow">

--- a/ui/lib/pki/addon/components/pki-key-form.hbs
+++ b/ui/lib/pki/addon/components/pki-key-form.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{! private_key is only available after initial save }}
 {{#if this.generatedKey.privateKey}}

--- a/ui/lib/pki/addon/components/pki-key-import.hbs
+++ b/ui/lib/pki/addon/components/pki-key-import.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <form {{on "submit" (perform this.submitForm)}} data-test-pki-key-import-form>
   <MessageError @errorMessage={{this.errorBanner}} class="has-top-margin-s" />

--- a/ui/lib/pki/addon/components/pki-key-parameters.hbs
+++ b/ui/lib/pki/addon/components/pki-key-parameters.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{yield}}
 {{#each @fields as |attr|}}

--- a/ui/lib/pki/addon/components/pki-key-usage.hbs
+++ b/ui/lib/pki/addon/components/pki-key-usage.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <CheckboxGrid
   @name="keyUsage"

--- a/ui/lib/pki/addon/components/pki-not-valid-after-form.hbs
+++ b/ui/lib/pki/addon/components/pki-not-valid-after-form.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="column is-narrow is-flex-align-baseline has-text-grey has-right-margin-s has-padding-xs">
   <RadioButton

--- a/ui/lib/pki/addon/components/pki-page-header.hbs
+++ b/ui/lib/pki/addon/components/pki-page-header.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/lib/pki/addon/components/pki-paginated-list.hbs
+++ b/ui/lib/pki/addon/components/pki-paginated-list.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Toolbar>
   <ToolbarActions>

--- a/ui/lib/pki/addon/components/pki-role-form.hbs
+++ b/ui/lib/pki/addon/components/pki-role-form.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <form {{on "submit" (perform this.save)}}>
   <div class="box is-sideless is-fullwidth is-marginless">

--- a/ui/lib/pki/addon/components/pki-role-generate.hbs
+++ b/ui/lib/pki/addon/components/pki-role-generate.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if @model.serialNumber}}
   <Page::PkiCertificateDetails @model={{@model}} @onBack={{this.cancel}} />

--- a/ui/lib/pki/addon/components/pki-sign-intermediate-form.hbs
+++ b/ui/lib/pki/addon/components/pki-sign-intermediate-form.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if @model.id}}
   {{! Model only has ID once form has been submitted and saved }}

--- a/ui/lib/pki/addon/components/pki-tidy-form.hbs
+++ b/ui/lib/pki/addon/components/pki-tidy-form.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <hr class="is-marginless has-background-gray-200" />
 

--- a/ui/lib/pki/addon/templates/application.hbs
+++ b/ui/lib/pki/addon/templates/application.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{outlet}}

--- a/ui/lib/pki/addon/templates/certificates/certificate/details.hbs
+++ b/ui/lib/pki/addon/templates/certificates/certificate/details.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/lib/pki/addon/templates/certificates/index.hbs
+++ b/ui/lib/pki/addon/templates/certificates/index.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PkiPageHeader @backend={{this.model.parentModel}} />
 

--- a/ui/lib/pki/addon/templates/configuration.hbs
+++ b/ui/lib/pki/addon/templates/configuration.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{outlet}}

--- a/ui/lib/pki/addon/templates/configuration/create.hbs
+++ b/ui/lib/pki/addon/templates/configuration/create.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Page::PkiConfigureCreate
   @breadcrumbs={{this.breadcrumbs}}

--- a/ui/lib/pki/addon/templates/configuration/edit.hbs
+++ b/ui/lib/pki/addon/templates/configuration/edit.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/lib/pki/addon/templates/configuration/index.hbs
+++ b/ui/lib/pki/addon/templates/configuration/index.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PkiPageHeader @backend={{this.model.engine}} />
 

--- a/ui/lib/pki/addon/templates/error.hbs
+++ b/ui/lib/pki/addon/templates/error.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/lib/pki/addon/templates/issuers/generate-intermediate.hbs
+++ b/ui/lib/pki/addon/templates/issuers/generate-intermediate.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Page::PkiIssuerGenerateIntermediate @model={{this.model}} @breadcrumbs={{this.breadcrumbs}} />

--- a/ui/lib/pki/addon/templates/issuers/generate-root.hbs
+++ b/ui/lib/pki/addon/templates/issuers/generate-root.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Page::PkiIssuerGenerateRoot @model={{this.model}} @breadcrumbs={{this.breadcrumbs}} />

--- a/ui/lib/pki/addon/templates/issuers/import.hbs
+++ b/ui/lib/pki/addon/templates/issuers/import.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Page::PkiIssuerImport @model={{this.model}} @breadcrumbs={{this.breadcrumbs}} />

--- a/ui/lib/pki/addon/templates/issuers/index.hbs
+++ b/ui/lib/pki/addon/templates/issuers/index.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PkiPageHeader @backend={{this.model.parentModel}} />
 

--- a/ui/lib/pki/addon/templates/issuers/issuer/cross-sign.hbs
+++ b/ui/lib/pki/addon/templates/issuers/issuer/cross-sign.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/lib/pki/addon/templates/issuers/issuer/details.hbs
+++ b/ui/lib/pki/addon/templates/issuers/issuer/details.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/lib/pki/addon/templates/issuers/issuer/edit.hbs
+++ b/ui/lib/pki/addon/templates/issuers/issuer/edit.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/lib/pki/addon/templates/issuers/issuer/rotate-root.hbs
+++ b/ui/lib/pki/addon/templates/issuers/issuer/rotate-root.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Page::PkiIssuerRotateRoot
   @oldRoot={{this.model.oldRoot}}

--- a/ui/lib/pki/addon/templates/issuers/issuer/sign.hbs
+++ b/ui/lib/pki/addon/templates/issuers/issuer/sign.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/lib/pki/addon/templates/keys/create.hbs
+++ b/ui/lib/pki/addon/templates/keys/create.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/lib/pki/addon/templates/keys/import.hbs
+++ b/ui/lib/pki/addon/templates/keys/import.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/lib/pki/addon/templates/keys/index.hbs
+++ b/ui/lib/pki/addon/templates/keys/index.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PkiPageHeader @backend={{this.model.parentModel}} />
 

--- a/ui/lib/pki/addon/templates/keys/key/details.hbs
+++ b/ui/lib/pki/addon/templates/keys/key/details.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/lib/pki/addon/templates/keys/key/edit.hbs
+++ b/ui/lib/pki/addon/templates/keys/key/edit.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/lib/pki/addon/templates/overview.hbs
+++ b/ui/lib/pki/addon/templates/overview.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PkiPageHeader @backend={{this.model.engine}} />
 

--- a/ui/lib/pki/addon/templates/roles/create.hbs
+++ b/ui/lib/pki/addon/templates/roles/create.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/lib/pki/addon/templates/roles/index.hbs
+++ b/ui/lib/pki/addon/templates/roles/index.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PkiPageHeader @backend={{this.model.parentModel}} />
 

--- a/ui/lib/pki/addon/templates/roles/role/details.hbs
+++ b/ui/lib/pki/addon/templates/roles/role/details.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/lib/pki/addon/templates/roles/role/edit.hbs
+++ b/ui/lib/pki/addon/templates/roles/role/edit.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/lib/pki/addon/templates/roles/role/generate.hbs
+++ b/ui/lib/pki/addon/templates/roles/role/generate.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/lib/pki/addon/templates/roles/role/sign.hbs
+++ b/ui/lib/pki/addon/templates/roles/role/sign.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/lib/pki/addon/templates/tidy.hbs
+++ b/ui/lib/pki/addon/templates/tidy.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{outlet}}

--- a/ui/lib/pki/addon/templates/tidy/auto.hbs
+++ b/ui/lib/pki/addon/templates/tidy/auto.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{outlet}}

--- a/ui/lib/pki/addon/templates/tidy/auto/configure.hbs
+++ b/ui/lib/pki/addon/templates/tidy/auto/configure.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Page::PkiTidyAutoConfigure @model={{this.model}} @breadcrumbs={{this.breadcrumbs}} />

--- a/ui/lib/pki/addon/templates/tidy/auto/index.hbs
+++ b/ui/lib/pki/addon/templates/tidy/auto/index.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Page::PkiTidyAutoSettings @model={{this.model}} @breadcrumbs={{this.breadcrumbs}} />

--- a/ui/lib/pki/addon/templates/tidy/index.hbs
+++ b/ui/lib/pki/addon/templates/tidy/index.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PkiPageHeader @backend={{this.model.engine}} />
 

--- a/ui/lib/pki/addon/templates/tidy/manual.hbs
+++ b/ui/lib/pki/addon/templates/tidy/manual.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Page::PkiTidyManual @model={{this.model}} @breadcrumbs={{this.breadcrumbs}} />

--- a/ui/lib/replication/addon/components/enable-replication-form.hbs
+++ b/ui/lib/replication/addon/components/enable-replication-form.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <form {{on "submit" (fn this.onSubmit this.data)}} data-test-replication-enable-form>
   <MessageError @errorMessage={{this.error}} />

--- a/ui/lib/replication/addon/components/page/mode-index.hbs
+++ b/ui/lib/replication/addon/components/page/mode-index.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if @replicationDisabled}}
   <PageHeader as |p|>

--- a/ui/lib/replication/addon/components/replication-overview-mode.hbs
+++ b/ui/lib/replication/addon/components/replication-overview-mode.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Hds::Card::Container @level="mid" @hasBorder={{true}} ...attributes>
   <div class="has-padding-m">

--- a/ui/lib/replication/addon/templates/application.hbs
+++ b/ui/lib/replication/addon/templates/application.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Hds::SideNav::Portal @ariaLabel="Replication Navigation Links" data-test-sidebar-nav-panel="Replication" as |Nav|>
   <Nav.BackLink

--- a/ui/lib/replication/addon/templates/components/known-secondaries-card.hbs
+++ b/ui/lib/replication/addon/templates/components/known-secondaries-card.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Hds::Card::Container
   @hasBorder={{true}}

--- a/ui/lib/replication/addon/templates/components/known-secondaries-table.hbs
+++ b/ui/lib/replication/addon/templates/components/known-secondaries-table.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Hds::Table @caption="Known Secondaries" data-test-known-secondaries-table>
   <:head as |H|>

--- a/ui/lib/replication/addon/templates/components/path-filter-config-list.hbs
+++ b/ui/lib/replication/addon/templates/components/path-filter-config-list.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <h4 class="title is-5">
   Filtered paths

--- a/ui/lib/replication/addon/templates/components/replication-primary-card.hbs
+++ b/ui/lib/replication/addon/templates/components/replication-primary-card.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Hds::Card::Container @hasBorder={{true}} class="has-padding-m {{if this.hasErrorClass 'has-error-border'}}">
   <h3 class="card-title title is-5">{{this.title}}</h3>

--- a/ui/lib/replication/addon/templates/components/replication-summary.hbs
+++ b/ui/lib/replication/addon/templates/components/replication-summary.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if (eq this.attrsForCurrentMode.mode "initializing")}}
   The cluster is initializing replication. This may take some time.

--- a/ui/lib/replication/addon/templates/index.hbs
+++ b/ui/lib/replication/addon/templates/index.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <section class="section">
   <div class="container is-widescreen">

--- a/ui/lib/replication/addon/templates/mode.hbs
+++ b/ui/lib/replication/addon/templates/mode.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <section class="section">
   <div class="container is-widescreen">

--- a/ui/lib/replication/addon/templates/mode/index.hbs
+++ b/ui/lib/replication/addon/templates/mode/index.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Page::ModeIndex
   @replicationDisabled={{this.replicationForMode.replicationDisabled}}

--- a/ui/lib/replication/addon/templates/mode/manage.hbs
+++ b/ui/lib/replication/addon/templates/mode/manage.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <ReplicationActions @model={{this.model}} @onDisable={{action "onDisable"}} @replicationMode={{this.replicationMode}} />

--- a/ui/lib/replication/addon/templates/mode/secondaries/add.hbs
+++ b/ui/lib/replication/addon/templates/mode/secondaries/add.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <form {{action "onSubmit" "secondary-token" "primary" (hash ttl=this.ttl id=this.id) on="submit"}}>
   <div class="box is-fullwidth is-shadowless is-marginless">

--- a/ui/lib/replication/addon/templates/mode/secondaries/config-create.hbs
+++ b/ui/lib/replication/addon/templates/mode/secondaries/config-create.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="box is-fullwidth is-shadowless is-marginless">
   <h4 class="title is-5 is-marginless">

--- a/ui/lib/replication/addon/templates/mode/secondaries/config-edit.hbs
+++ b/ui/lib/replication/addon/templates/mode/secondaries/config-edit.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Toolbar />
 <div class="box is-fullwidth is-shadowless is-marginless">

--- a/ui/lib/replication/addon/templates/mode/secondaries/config-show.hbs
+++ b/ui/lib/replication/addon/templates/mode/secondaries/config-show.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Toolbar>
   <ToolbarActions>

--- a/ui/lib/replication/addon/templates/mode/secondaries/index.hbs
+++ b/ui/lib/replication/addon/templates/mode/secondaries/index.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if this.model.replicationAttrs.isPrimary}}
   <Toolbar>

--- a/ui/lib/replication/addon/templates/mode/secondaries/revoke.hbs
+++ b/ui/lib/replication/addon/templates/mode/secondaries/revoke.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="box is-fullwidth is-shadowless is-marginless">
   <h4 class="title is-5">

--- a/ui/lib/sync/addon/components/secrets/destination-header.hbs
+++ b/ui/lib/sync/addon/components/secrets/destination-header.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <SyncHeader
   @icon={{@destination.icon}}

--- a/ui/lib/sync/addon/components/secrets/landing-cta.hbs
+++ b/ui/lib/sync/addon/components/secrets/landing-cta.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <SyncHeader @title="Secrets Sync">
   <:actions>

--- a/ui/lib/sync/addon/components/secrets/page/destinations.hbs
+++ b/ui/lib/sync/addon/components/secrets/page/destinations.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <SyncHeader @title="Secrets Sync" />
 

--- a/ui/lib/sync/addon/components/secrets/page/destinations/create-and-edit.hbs
+++ b/ui/lib/sync/addon/components/secrets/page/destinations/create-and-edit.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <SyncHeader @title={{this.header.title}} @breadcrumbs={{this.header.breadcrumbs}} />
 

--- a/ui/lib/sync/addon/components/secrets/page/destinations/destination/details.hbs
+++ b/ui/lib/sync/addon/components/secrets/page/destinations/destination/details.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Secrets::DestinationHeader @destination={{@destination}} />
 

--- a/ui/lib/sync/addon/components/secrets/page/destinations/destination/secrets.hbs
+++ b/ui/lib/sync/addon/components/secrets/page/destinations/destination/secrets.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Secrets::DestinationHeader @destination={{@destination}} @refreshList={{this.refreshRoute}} />
 

--- a/ui/lib/sync/addon/components/secrets/page/destinations/destination/sync.hbs
+++ b/ui/lib/sync/addon/components/secrets/page/destinations/destination/sync.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <SyncHeader
   @title="Sync Secrets to {{@destination.name}}"

--- a/ui/lib/sync/addon/components/secrets/page/destinations/select-type.hbs
+++ b/ui/lib/sync/addon/components/secrets/page/destinations/select-type.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <SyncHeader
   @title="Select a Destination"

--- a/ui/lib/sync/addon/components/secrets/page/overview.hbs
+++ b/ui/lib/sync/addon/components/secrets/page/overview.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 {{#unless @isActivated}}
   {{#if (or @licenseHasSecretsSync @isHvdManaged)}}
     {{#unless this.hideOptIn}}

--- a/ui/lib/sync/addon/components/secrets/sync-activation-modal.hbs
+++ b/ui/lib/sync/addon/components/secrets/sync-activation-modal.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Hds::Modal @onClose={{@onClose}} data-test-secrets-sync-opt-in-modal as |M|>
   <M.Header @icon="alert-triangle">

--- a/ui/lib/sync/addon/components/sync-header.hbs
+++ b/ui/lib/sync/addon/components/sync-header.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   {{#if @breadcrumbs}}

--- a/ui/lib/sync/addon/templates/error.hbs
+++ b/ui/lib/sync/addon/templates/error.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <SyncHeader @title="Secrets Sync" @breadcrumbs={{array (hash label="Secrets Sync" route="secrets.overview")}} />
 

--- a/ui/lib/sync/addon/templates/secrets/destinations/create/destination.hbs
+++ b/ui/lib/sync/addon/templates/secrets/destinations/create/destination.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Secrets::Page::Destinations::CreateAndEdit @destination={{this.model}} />

--- a/ui/lib/sync/addon/templates/secrets/destinations/create/index.hbs
+++ b/ui/lib/sync/addon/templates/secrets/destinations/create/index.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Secrets::Page::Destinations::SelectType />

--- a/ui/lib/sync/addon/templates/secrets/destinations/destination/details.hbs
+++ b/ui/lib/sync/addon/templates/secrets/destinations/destination/details.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Secrets::Page::Destinations::Destination::Details @destination={{this.model}} />

--- a/ui/lib/sync/addon/templates/secrets/destinations/destination/edit.hbs
+++ b/ui/lib/sync/addon/templates/secrets/destinations/destination/edit.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Secrets::Page::Destinations::CreateAndEdit @destination={{this.model}} />

--- a/ui/lib/sync/addon/templates/secrets/destinations/destination/secrets.hbs
+++ b/ui/lib/sync/addon/templates/secrets/destinations/destination/secrets.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Secrets::Page::Destinations::Destination::Secrets
   @destination={{this.model.destination}}

--- a/ui/lib/sync/addon/templates/secrets/destinations/destination/sync.hbs
+++ b/ui/lib/sync/addon/templates/secrets/destinations/destination/sync.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Secrets::Page::Destinations::Destination::Sync @destination={{this.model}} />

--- a/ui/lib/sync/addon/templates/secrets/destinations/index.hbs
+++ b/ui/lib/sync/addon/templates/secrets/destinations/index.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Secrets::Page::Destinations
   @destinations={{this.model.destinations}}

--- a/ui/lib/sync/addon/templates/secrets/destinations/loading.hbs
+++ b/ui/lib/sync/addon/templates/secrets/destinations/loading.hbs
@@ -1,6 +1,6 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <LayoutLoading />

--- a/ui/lib/sync/addon/templates/secrets/overview.hbs
+++ b/ui/lib/sync/addon/templates/secrets/overview.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Secrets::Page::Overview
   @destinations={{this.model.destinations}}


### PR DESCRIPTION
### Description
In [this PR for the copywrite tool](https://github.com/hashicorp/copywrite/pull/59) a `~` was added to comments in `.hbs` files for whitespace control. That update was reverted due to some noise in the build output complaining about the format:

```
unexpectedly found "\n  Copyright (c) HashiCorp, Inc.\n  SPDX-License-Identifier: BUSL-1.1\n~" when slicing source, but expected "\n  Copyright (c) HashiCorp, Inc.\n  SPDX-License-Identifier: BUSL-1.1\n"
```
The `copywrite` tool has not been run on Vault UI since prior to the removal of the `~` so this PR updates the comments to the latest format.

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
