### PR TITLE
Fix reported typos (#29894)

### DIFF
--- a/website/content/api-docs/system/mounts.mdx
+++ b/website/content/api-docs/system/mounts.mdx
@@ -10,7 +10,7 @@ The `/sys/mounts` endpoint is used to manage secrets engines in Vault.
 
 ## List mounted secrets engines
 
-This endpoints lists all the mounted secrets engines.
+This endpoint lists all the mounted secrets engines.
 
 | Method | Path          |
 | :----- | :------------ |

--- a/website/content/docs/commands/secrets/enable.mdx
+++ b/website/content/docs/commands/secrets/enable.mdx
@@ -10,7 +10,7 @@ description: |-
 
 # secrets enable
 
-The `secrets enable` command enables a secrets engine at a given path. If an
+The `secrets enable` command enables a secrets engine at a given path. If a
 secrets engine already exists at the given path, an error is returned. After the
 secrets engine is enabled, it usually needs configuration. The configuration
 varies by secrets engine.

--- a/website/content/docs/concepts/seal.mdx
+++ b/website/content/docs/concepts/seal.mdx
@@ -16,7 +16,7 @@ _Unsealing_ is the process of obtaining the plaintext root key necessary to
 read the decryption key to decrypt the data, allowing access to the Vault.
 
 Prior to unsealing, almost no operations are possible with Vault. For
-example authentication, managing the mount tables, etc. are all not possible.
+example, authentication, managing the mount tables, etc. are all not possible.
 The only possible operations are to unseal the Vault and check the status
 of the seal.
 


### PR DESCRIPTION
### Description
What does this PR do?

- Manual backport to 1.17.x (will also backport to 1.16.x for Vault associate study materials accuracy)

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
