### PR TITLE
Fix double-rename bug and locking issues

### DIFF
--- a/vault/identity_store_injector_testonly.go
+++ b/vault/identity_store_injector_testonly.go
@@ -359,7 +359,7 @@ func (i *IdentityStore) createDuplicateEntityAliases() framework.OperationFunc {
 			flags.Count = 2
 		}
 
-		ids, bucketIds, err := i.CreateDuplicateEntityAliasesInStorage(ctx, flags)
+		ids, err := i.CreateDuplicateEntityAliasesInStorage(ctx, flags)
 		if err != nil {
 			i.logger.Error("error creating duplicate entities", "error", err)
 			return logical.ErrorResponse("error creating duplicate entities"), err
@@ -367,8 +367,7 @@ func (i *IdentityStore) createDuplicateEntityAliases() framework.OperationFunc {
 
 		return &logical.Response{
 			Data: map[string]interface{}{
-				"entity_ids":  ids,
-				"bucket_keys": bucketIds,
+				"entity_ids": ids,
 			},
 		}, nil
 	}
@@ -501,58 +500,64 @@ func (i *IdentityStore) CreateDuplicateGroupsInStorage(ctx context.Context, flag
 	return groupIDs, nil
 }
 
-// CreateDuplicateEntityAliasesInStorage creates n entities with a duplicate alias in storage
-// This should only be used in testing
+// CreateDuplicateEntityAliasesInStorage creates n entities with a duplicate
+// alias in storage This should only be used in testing. This method can only
+// create non-local aliases. Local aliases are stored differently.
 //
 // Pass in mount type and accessor to create the entities
-func (i *IdentityStore) CreateDuplicateEntityAliasesInStorage(ctx context.Context, flags DuplicateEntityAliasFlags) ([]string, []string, error) {
-	var bucketKeys []string
+func (i *IdentityStore) CreateDuplicateEntityAliasesInStorage(ctx context.Context, flags DuplicateEntityAliasFlags) ([]string, error) {
 	var entityIDs []string
-
+	if flags.NamespaceID == "" {
+		flags.NamespaceID = namespace.RootNamespaceID
+	}
 	for d := 0; d < flags.Count; d++ {
-		entityID := fmt.Sprintf("%s-%d", flags.Name, d)
+		aliasID, err := uuid.GenerateUUID()
+		if err != nil {
+			return nil, err
+		}
 
-		policyID := fmt.Sprintf("policy-%s-%d", flags.Name, d)
+		// Alias name is either exact match or different case
+		dupAliasName := flags.Name
+		if flags.DifferentCase {
+			dupAliasName = randomCase(flags.Name)
+		}
 
-		entityDupName := fmt.Sprintf("%s-entity-dup-%d", flags.Name, d)
-		aliasDupName := fmt.Sprintf("%s-alias-dup", flags.Name)
+		// In real life alias dupes are due to races where they were auto-created
+		// along with the entities they point to. When we auto create entities like
+		// this they get random names so never collide with each other directly so
+		// don't create entities with duplicate names for this case as it doesn't
+		// match what customers who get in this state see. Instead use the same code
+		// path as CreateOfFetchEntity.
+		e := new(identity.Entity)
+		e.NamespaceID = flags.NamespaceID
+		err = i.sanitizeEntity(ctx, e)
+		if err != nil {
+			return nil, err
+		}
+		entityIDs = append(entityIDs, e.ID)
 
 		a := &identity.Alias{
-			ID:            entityID,
-			CanonicalID:   entityID,
+			ID:            aliasID,
+			CanonicalID:   e.ID,
 			MountAccessor: flags.CommonAliasFlags.MountAccessor,
-			Name:          aliasDupName,
+			Name:          dupAliasName,
 		}
-
-		bucketKey := i.entityPacker.BucketKey(entityID)
-		bucketKeys = append(bucketKeys, bucketKey)
-		entityIDs = append(entityIDs, entityID)
-
-		e := &identity.Entity{
-			ID:   entityID,
-			Name: entityDupName,
-			Aliases: []*identity.Alias{
-				a,
-			},
-			NamespaceID: namespace.RootNamespaceID,
-			BucketKey:   bucketKey,
-			Policies:    []string{policyID},
-		}
+		e.UpsertAlias(a)
 
 		entity, err := ptypes.MarshalAny(e)
 		if err != nil {
-			return nil, nil, err
+			return nil, err
 		}
 		item := &storagepacker.Item{
 			ID:      e.ID,
 			Message: entity,
 		}
 		if err = i.entityPacker.PutItem(ctx, item); err != nil {
-			return nil, nil, err
+			return nil, err
 		}
 	}
 
-	return entityIDs, bucketKeys, nil
+	return entityIDs, nil
 }
 
 // CreateDuplicateLocalEntityAliasInStorage creates a single local entity alias


### PR DESCRIPTION
### Description
Fixes a couple of bugs found while manual testing.

 1. The recent change to persist alias merges accidentally created a situation where we run a second pass at loading entities with rename active without clearing the DB. This means that we end up appending the UUID twice!
 2. We made the activation flag async, but we didn't move the reset of the DB or locking which means that
    a. The actual loading of entities is not done with a lock held!
    b. there could be a gap between clearing the identity store and reloading it where we are not holding the lock and requests that come in would get errors like entity not found etc. 

No changelog needed as these are unreleased bugs.

It's unforunate at least the first one wasn't caught by existing tests so we should add something or add assertions to make sure it is covered. The second it harder to test as it's a concurrency/non-deterministic thing.

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [x] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
