### PR TITLE
Ensure logger writes to log_file by preventing overwrite of InterceptLogger's output

### DIFF
--- a/changelog/29917.txt
+++ b/changelog/29917.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core: Fix a bug that prevents certain loggers from writing to a log file.
+```

--- a/command/server.go
+++ b/command/server.go
@@ -420,9 +420,7 @@ func (c *ServerCommand) AutocompleteFlags() complete.Flags {
 }
 
 func (c *ServerCommand) flushLog() {
-	c.logger.(hclog.OutputResettable).ResetOutputWithFlush(&hclog.LoggerOptions{
-		Output: c.logWriter,
-	}, c.logGate)
+	c.logGate.Flush()
 }
 
 func (c *ServerCommand) parseConfig() (*server.Config, []configutil.ConfigError, error) {


### PR DESCRIPTION
### Description
This fixes a bug with how vault handles logging to the log_file in configuration. 

Initially, `ServerCommand.run` sets up a gated writer to standard error, which is passed through configureLogging to `loghelper.Setup`. This setup combines the gated writer with a file (log_file) using a multiwriter, ensuring logs go to both destinations. Later in `server.Run`, vault flushes the gated writer by calling the function `ResetOutputWithFlush`. Unfortunately, this replaces the InterceptLogger’s output with a single writer that logs only to standard error. Some logs still get written to both destinations. This is likely because vault defines some subloggers (like core) before the flush occurs. Naming a sublogger creates a copy of the underlying writer, which remains connected to the original multiwriter.

As a result, loggers created before the flush continue to log to both standard error and the file, while the base logger’s writer gets reset to standard error. This PR removes the logic that replaces the InterceptLogger's output, and instead just flushes the gated writer. 

I did some digging into why we introduced the `ResetOutputWithFlush` function in the first place and found [this PR](https://github.com/hashicorp/vault/pull/8228). Originally, it seems we replaced the gated writer with regular standard err to avoid a dealing with mutexes, but right now we're just replacing the multiwriter (which includes the gated writer) with another gated writer, so I don't think we're reaping the benefit anymore. Simply flushing the gated writer also matches what we do in [agent](https://github.com/hashicorp/vault/blob/main/command/agent.go#L887) and [proxy](ResetOutputWithFlush). 

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
