### PR TITLE
[UI] Resolve ember-cli-typescript to 5.3.0

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -189,6 +189,7 @@
     "@embroider/macros": "^1.15.0",
     "socket.io": "^4.6.2",
     "json5": "^1.0.2",
+    "ember-cli-typescript": "^5.3.0",
     "lodash.template@^4.4.0": "patch:lodash.template@npm%3A4.5.0#./.yarn/patches/lodash.template-npm-4.5.0-5272df3039.patch",
     "lodash.template@^4.5.0": "patch:lodash.template@npm%3A4.5.0#./.yarn/patches/lodash.template-npm-4.5.0-5272df3039.patch"
   },

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -132,7 +132,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-create-class-features-plugin@npm:^7.18.6, @babel/helper-create-class-features-plugin@npm:^7.21.0, @babel/helper-create-class-features-plugin@npm:^7.25.9, @babel/helper-create-class-features-plugin@npm:^7.5.5":
+"@babel/helper-create-class-features-plugin@npm:^7.18.6, @babel/helper-create-class-features-plugin@npm:^7.21.0, @babel/helper-create-class-features-plugin@npm:^7.25.9":
   version: 7.26.9
   resolution: "@babel/helper-create-class-features-plugin@npm:7.26.9"
   dependencies:
@@ -374,7 +374,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-proposal-class-properties@npm:^7.1.0, @babel/plugin-proposal-class-properties@npm:^7.16.5, @babel/plugin-proposal-class-properties@npm:^7.16.7, @babel/plugin-proposal-class-properties@npm:^7.18.6":
+"@babel/plugin-proposal-class-properties@npm:^7.16.5, @babel/plugin-proposal-class-properties@npm:^7.16.7, @babel/plugin-proposal-class-properties@npm:^7.18.6":
   version: 7.18.6
   resolution: "@babel/plugin-proposal-class-properties@npm:7.18.6"
   dependencies:
@@ -515,7 +515,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-syntax-typescript@npm:^7.2.0, @babel/plugin-syntax-typescript@npm:^7.25.9":
+"@babel/plugin-syntax-typescript@npm:^7.25.9":
   version: 7.25.9
   resolution: "@babel/plugin-syntax-typescript@npm:7.25.9"
   dependencies:
@@ -1106,31 +1106,6 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 3d8866f2c5cb70d27bfb724bf205f073b59d04fe7e535c63439968579dc79b69055681088b522dab49695bdf1365b00e22aee11e3f3253381e554d89a8aa9dd6
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-transform-typescript@npm:~7.4.0":
-  version: 7.4.5
-  resolution: "@babel/plugin-transform-typescript@npm:7.4.5"
-  dependencies:
-    "@babel/helper-plugin-utils": ^7.0.0
-    "@babel/plugin-syntax-typescript": ^7.2.0
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 2c3aadfba8db8726a1e0c5341578e65ab8a2d46c79844509ccc74bff1c8eaa4943e94f458e4f006a7d21a2ea93025ae3629bdeb9858c7b53967b9f7aee154543
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-transform-typescript@npm:~7.5.0":
-  version: 7.5.5
-  resolution: "@babel/plugin-transform-typescript@npm:7.5.5"
-  dependencies:
-    "@babel/helper-create-class-features-plugin": ^7.5.5
-    "@babel/helper-plugin-utils": ^7.0.0
-    "@babel/plugin-syntax-typescript": ^7.2.0
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: a7a60f461e41db07dd04728c18b1ee9d5ba889f3666f8e209437b4007c2c02fe556ea03c70550077206ca3ac3f70f8da76d0f6a62eed1a9466249a5a1a316a81
   languageName: node
   linkType: hard
 
@@ -4387,7 +4362,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ansi-to-html@npm:^0.6.15, ansi-to-html@npm:^0.6.6":
+"ansi-to-html@npm:^0.6.15":
   version: 0.6.15
   resolution: "ansi-to-html@npm:0.6.15"
   dependencies:
@@ -7911,7 +7886,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ember-cli-babel-plugin-helpers@npm:^1.0.0, ember-cli-babel-plugin-helpers@npm:^1.1.1":
+"ember-cli-babel-plugin-helpers@npm:^1.1.1":
   version: 1.1.1
   resolution: "ember-cli-babel-plugin-helpers@npm:1.1.1"
   checksum: 3dc684317dbc4728d41a61de13d2fb1de5227105c1ba9194005647d2724b469d43aba3b1fa73622f2b5cd04c8283a15568b3a0044ec7a5036c17f336ac098ff5
@@ -8301,64 +8276,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ember-cli-typescript@npm:3.0.0":
-  version: 3.0.0
-  resolution: "ember-cli-typescript@npm:3.0.0"
-  dependencies:
-    "@babel/plugin-transform-typescript": ~7.5.0
-    ansi-to-html: ^0.6.6
-    debug: ^4.0.0
-    ember-cli-babel-plugin-helpers: ^1.0.0
-    execa: ^2.0.0
-    fs-extra: ^8.0.0
-    resolve: ^1.5.0
-    rsvp: ^4.8.1
-    semver: ^6.0.0
-    stagehand: ^1.0.0
-    walk-sync: ^2.0.0
-  checksum: 4ef2732a0743113aa0167365afb972239e51ca227ca0858b1e240f8e449a34c02462973e1669eb7cd1982b0c1db225f1537f1d41360dc3945b6c2b54e566f96a
-  languageName: node
-  linkType: hard
-
-"ember-cli-typescript@npm:^2.0.2":
-  version: 2.0.2
-  resolution: "ember-cli-typescript@npm:2.0.2"
-  dependencies:
-    "@babel/plugin-proposal-class-properties": ^7.1.0
-    "@babel/plugin-transform-typescript": ~7.4.0
-    ansi-to-html: ^0.6.6
-    debug: ^4.0.0
-    ember-cli-babel-plugin-helpers: ^1.0.0
-    execa: ^1.0.0
-    fs-extra: ^7.0.0
-    resolve: ^1.5.0
-    rsvp: ^4.8.1
-    semver: ^6.0.0
-    stagehand: ^1.0.0
-    walk-sync: ^1.0.0
-  checksum: a1eecb5733df78de96eee3d75f1d0425c8e2638fddcdfb4b2fa46b70131df78216fc341419ccdcf4c32ca480c2bc3d91c0390b81b5ad738a409335ae5ff7f993
-  languageName: node
-  linkType: hard
-
-"ember-cli-typescript@npm:^4.1.0, ember-cli-typescript@npm:^4.2.1":
-  version: 4.2.1
-  resolution: "ember-cli-typescript@npm:4.2.1"
-  dependencies:
-    ansi-to-html: ^0.6.15
-    broccoli-stew: ^3.0.0
-    debug: ^4.0.0
-    execa: ^4.0.0
-    fs-extra: ^9.0.1
-    resolve: ^1.5.0
-    rsvp: ^4.8.1
-    semver: ^7.3.2
-    stagehand: ^1.0.0
-    walk-sync: ^2.2.0
-  checksum: bd31698536c0df7fc03b47aa1c7d3f9c6f7e34fae1500c88bdbbc4c0b98b2a7e69230dd71a01d7cd7f563484cf895333f559af68f91527d95e198924e3cb2c24
-  languageName: node
-  linkType: hard
-
-"ember-cli-typescript@npm:^5.0.0":
+"ember-cli-typescript@npm:^5.3.0":
   version: 5.3.0
   resolution: "ember-cli-typescript@npm:5.3.0"
   dependencies:
@@ -9971,23 +9889,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"execa@npm:^2.0.0":
-  version: 2.1.0
-  resolution: "execa@npm:2.1.0"
-  dependencies:
-    cross-spawn: ^7.0.0
-    get-stream: ^5.0.0
-    is-stream: ^2.0.0
-    merge-stream: ^2.0.0
-    npm-run-path: ^3.0.0
-    onetime: ^5.1.0
-    p-finally: ^2.0.0
-    signal-exit: ^3.0.2
-    strip-final-newline: ^2.0.0
-  checksum: 93af9b816a555d0944e0876f4ccd97e0f4593d2049e713518fd5458a7699836449c516c6bb7e6357e11431ec40cce3150625b86d1b1254180faaa0d744265eca
-  languageName: node
-  linkType: hard
-
 "execa@npm:^4.0.0, execa@npm:^4.1.0":
   version: 4.1.0
   resolution: "execa@npm:4.1.0"
@@ -10735,7 +10636,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fs-extra@npm:^8.0.0, fs-extra@npm:^8.0.1, fs-extra@npm:^8.1.0":
+"fs-extra@npm:^8.0.1, fs-extra@npm:^8.1.0":
   version: 8.1.0
   resolution: "fs-extra@npm:8.1.0"
   dependencies:
@@ -14554,15 +14455,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"npm-run-path@npm:^3.0.0":
-  version: 3.1.0
-  resolution: "npm-run-path@npm:3.1.0"
-  dependencies:
-    path-key: ^3.0.0
-  checksum: 141e0b8f0e3b137347a2896572c9a84701754dda0670d3ceb8c56a87702ee03c26227e4517ab93f2904acfc836547315e740b8289bb24ca0cd8ba2b198043b0f
-  languageName: node
-  linkType: hard
-
 "npm-run-path@npm:^4.0.0, npm-run-path@npm:^4.0.1":
   version: 4.0.1
   resolution: "npm-run-path@npm:4.0.1"
@@ -14850,13 +14742,6 @@ __metadata:
   version: 1.0.0
   resolution: "p-finally@npm:1.0.0"
   checksum: 93a654c53dc805dd5b5891bab16eb0ea46db8f66c4bfd99336ae929323b1af2b70a8b0654f8f1eae924b2b73d037031366d645f1fd18b3d30cbd15950cc4b1d4
-  languageName: node
-  linkType: hard
-
-"p-finally@npm:^2.0.0":
-  version: 2.0.1
-  resolution: "p-finally@npm:2.0.1"
-  checksum: 6306a2851c3b28f8b603624f395ae84dce76970498fed8aa6aae2d930595053746edf1e4ee0c4b78a97410d84aa4504d63179f5310d555511ecd226f53ed1e8e
   languageName: node
   linkType: hard
 
@@ -19043,7 +18928,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"walk-sync@npm:^2.0.0, walk-sync@npm:^2.0.2, walk-sync@npm:^2.2.0":
+"walk-sync@npm:^2.0.2, walk-sync@npm:^2.2.0":
   version: 2.2.0
   resolution: "walk-sync@npm:2.2.0"
   dependencies:


### PR DESCRIPTION
### Description
There were a number of warnings output from `ember-cli-typescript` during the build that complained about the `ember-cli-babel` version.

<img width="1511" alt="image" src="https://github.com/user-attachments/assets/63c1ecc5-828c-4871-b713-dcadc006e2bc" />

This was fixed in the [5.3.0 release of ember-cli-typescript](https://github.com/typed-ember/ember-cli-typescript/releases/tag/v5.3.0) (the title says it all 😁). We don't directly use `ember-cli-typescript` but a number of dependencies do and since some have not been updated in recent years they may no longer be maintained. By using yarn to resolve the version to at least `5.3.0` we get rid of the warning and there doesn't appear to be any issues with the build when forcing the dependencies to use the newer version.

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
