### PR TITLE
Rework certificate authentication client api

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -67,6 +67,7 @@
 /enos/     @hashicorp/quality-team
 
 # Cryptosec
+/api/auth/cert/                                      @hashicorp/vault-crypto
 /builtin/logical/pki/                                @hashicorp/vault-crypto
 /builtin/logical/pkiext/                             @hashicorp/vault-crypto
 /website/content/docs/secrets/pki/                   @hashicorp/vault-crypto @hashicorp/vault-education-approvers

--- a/api/auth/cert/cert_test.go
+++ b/api/auth/cert/cert_test.go
@@ -143,7 +143,7 @@ func TestLogin(t *testing.T) {
 }
 
 // TestNewDefaultCertAuthClient tests the NewDefaultCertAuthClient function validates inputs properly
-func TestNewDefaultCertAuthClient1(t *testing.T) {
+func TestNewDefaultCertAuthClient(t *testing.T) {
 	certs := createCertificates(t)
 	addr := "https://127.0.0.1:8200"
 	tlsConfig := &api.TLSConfig{

--- a/api/auth/cert/cert_test.go
+++ b/api/auth/cert/cert_test.go
@@ -11,15 +11,17 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/json"
 	"encoding/pem"
 	"fmt"
+	"io"
 	"math/big"
 	mathrand "math/rand"
 	"net"
 	"net/http"
 	"os"
 	"path/filepath"
-	"sync"
+	"regexp"
 	"testing"
 	"time"
 
@@ -27,67 +29,219 @@ import (
 	"github.com/hashicorp/vault/api"
 )
 
+var extractMountRe = regexp.MustCompile(`^/v1/auth/([a-z]+)/login$`)
+
+// TestLogin tests the login method of the CertAuth struct with the various overrides we support,
+// the values the client uses to call the server with influence the returned client token so
+// the test can validate we sent what we expected to.
 func TestLogin(t *testing.T) {
-	certDir := createCertificatePairs(t)
+	certs := createCertificates(t)
 
-	wg := &sync.WaitGroup{}
-	wg.Add(1)
-	ln := runTestServer(t, certDir, func(w http.ResponseWriter, r *http.Request) {
-		wg.Done()
-
+	// build up a server that will influence the returned token based on the request
+	ln := runTestServer(t, certs, func(w http.ResponseWriter, r *http.Request) {
+		// Make sure we have a client certificate
 		if r.TLS == nil || len(r.TLS.PeerCertificates) == 0 {
-			t.Fatalf("no client cert provided")
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte("missing peer certificate"))
+			return
 		}
 
-		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{"auth": {"client_token": "test-token"}}`))
-	})
+		// Make sure we get the expected client certificate
+		if r.TLS.PeerCertificates[0].SerialNumber.Cmp(certs.parsedClientCert.SerialNumber) != 0 {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte("incorrect peer certificate provided"))
+			return
+		}
 
-	// Create a new CertAuth struct.
-	auth, err := NewCertAuth(
-		"role-name",
-		filepath.Join(certDir, "client_cert.pem"),
-		filepath.Join(certDir, "client_key.pem"),
-		WithCACert(filepath.Join(certDir, "ca_cert.pem")),
-	)
+		// Extract the mount path from the URL we were called with
+		var mount string
+		if matches := extractMountRe.FindStringSubmatch(r.URL.Path); len(matches) == 2 {
+			mount = matches[1]
+		}
+
+		// Parse out the role name from the request body if provided
+		rawBody, err := io.ReadAll(r.Body)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte("failed reading body: " + err.Error()))
+			return
+		}
+		defer r.Body.Close()
+
+		data := make(map[string]interface{})
+		if err = json.Unmarshal(rawBody, &data); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte("failed parsing body: " + err.Error()))
+			return
+		}
+
+		roleName := "none"
+		if role, ok := data["name"].(string); ok {
+			roleName = role
+		}
+
+		// Build up our token that includes the mount of our cert auth and the role name
+		token := fmt.Sprintf("%s-%s-token", mount, roleName)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(fmt.Sprintf(`{"auth": {"client_token": "%s"}}`, token)))
+	})
+	url := fmt.Sprintf("https://%s", ln.Addr())
+	defaultAuthClient, err := NewDefaultCertAuthClient(url, &api.TLSConfig{
+		CACert:     certs.caCert,
+		ClientCert: certs.clientCert,
+		ClientKey:  certs.clientKey,
+	})
+	if err != nil {
+		t.Fatalf("failed to create default CertAuth: %v", err)
+	}
+
+	defConfig := api.DefaultConfig()
+	defConfig.Address = url
+	baseClient, err := api.NewClient(defConfig)
+	if err != nil {
+		t.Fatalf("failed to create CertAuth client based on base client: %v", err)
+	}
+
+	basedOnClient, err := NewCertAuthClient(baseClient, &api.TLSConfig{
+		CACert:     certs.caCert,
+		ClientCert: certs.clientCert,
+		ClientKey:  certs.clientKey,
+	})
+	if err != nil {
+		t.Fatalf("failed to create CertAuth based on another client: %v", err)
+	}
+
+	tests := []struct {
+		name          string
+		opts          []LoginOption
+		expectedToken string
+	}{
+		{"default", []LoginOption{}, "cert-none-token"},
+		{"with mount path", []LoginOption{WithMountPath("mycert")}, "mycert-none-token"},
+		{"with role", []LoginOption{WithRole("myrole")}, "cert-myrole-token"},
+		{"with mount and role", []LoginOption{WithMountPath("mycert"), WithRole("myrole")}, "mycert-myrole-token"},
+	}
+	for name, certAuthClient := range map[string]*api.Client{"default": defaultAuthClient, "based-on-client": basedOnClient} {
+		for _, test := range tests {
+			t.Run(fmt.Sprintf("%s-%s", name, test.name), func(t *testing.T) {
+				auth, err := NewCertAuth(test.opts...)
+				if err != nil {
+					t.Fatalf("failed to create CertAuth: %v", err)
+				}
+
+				secret, err := auth.Login(context.Background(), certAuthClient)
+				if err != nil {
+					t.Fatalf("failed to login: %v", err)
+				}
+
+				if secret == nil || secret.Auth == nil || secret.Auth.ClientToken != test.expectedToken {
+					t.Fatalf("unexpected response: %v", secret)
+				}
+			})
+		}
+	}
+}
+
+// TestNewDefaultCertAuthClient tests the NewDefaultCertAuthClient function validates inputs properly
+func TestNewDefaultCertAuthClient1(t *testing.T) {
+	certs := createCertificates(t)
+	addr := "https://127.0.0.1:8200"
+	tlsConfig := &api.TLSConfig{
+		CAPath:     certs.caCert,
+		ClientCert: certs.clientCert,
+		ClientKey:  certs.clientKey,
+	}
+	type args struct {
+		address   string
+		tlsConfig *api.TLSConfig
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{"missing address", args{"", tlsConfig}, true},
+		{"missing config", args{addr, nil}, true},
+		{"missing client cert", args{addr, &api.TLSConfig{}}, true},
+		{"ok", args{addr, tlsConfig}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NewDefaultCertAuthClient(tt.args.address, tt.args.tlsConfig)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NewDefaultCertAuthClient() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr {
+				if got == nil {
+					t.Errorf("NewDefaultCertAuthClient() returned nil client")
+					return
+				}
+				if got.Address() != tt.args.address {
+					t.Errorf("NewDefaultCertAuthClient() returned client with address %s, expected %s", got.Address(), tt.args.address)
+				}
+
+				// The Login test will validate that our TLS config was passed in properly.
+			}
+		})
+	}
+}
+
+// TestNewCertAuthClient tests the NewCertAuthClient function validates inputs properly
+func TestNewCertAuthClient(t *testing.T) {
+	certs := createCertificates(t)
+	addr := "https://127.0.0.1:8200"
+	tlsConfig := &api.TLSConfig{
+		CAPath:     certs.caCert,
+		ClientCert: certs.clientCert,
+		ClientKey:  certs.clientKey,
+	}
+	defConfig := api.DefaultConfig()
+	defConfig.Address = addr
+	client, err := api.NewClient(defConfig)
 	if err != nil {
 		t.Fatalf("failed to create CertAuth: %v", err)
 	}
 
-	cfg := api.DefaultConfig()
-	cfg.Address = fmt.Sprintf("https://%s", ln.Addr())
-
-	client, err := api.NewClient(cfg)
-	if err != nil {
-		t.Fatalf("failed to create client: %v", err)
+	type args struct {
+		client    *api.Client
+		tlsConfig *api.TLSConfig
 	}
-
-	secret, err := auth.Login(context.Background(), client)
-	if err != nil {
-		t.Fatalf("failed to login: %v", err)
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{"missing address", args{nil, tlsConfig}, true},
+		{"missing config", args{client, nil}, true},
+		{"missing client cert", args{client, &api.TLSConfig{}}, true},
+		{"ok", args{client, tlsConfig}, false},
 	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NewCertAuthClient(tt.args.client, tt.args.tlsConfig)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NewDefaultCertAuthClient() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr {
+				if got == nil {
+					t.Errorf("NewDefaultCertAuthClient() returned nil client")
+					return
+				}
+				if got.Address() != addr {
+					t.Errorf("NewDefaultCertAuthClient() returned client with address %s, expected %s", got.Address(), addr)
+				}
 
-	if secret == nil || secret.Auth == nil || secret.Auth.ClientToken != "test-token" {
-		t.Fatalf("unexpected response: %v", secret)
-	}
-
-	done := make(chan struct{})
-	go func() {
-		wg.Wait()
-		close(done)
-	}()
-
-	select {
-	case <-done:
-		t.Log("done")
-	case <-time.After(time.Second):
-		t.Error("timeout")
+				// The Login test will validate that our TLS config was passed in properly.
+			}
+		})
 	}
 }
 
-func runTestServer(t *testing.T, certDir string, fn http.HandlerFunc) net.Listener {
+func runTestServer(t *testing.T, cert testCerts, fn http.HandlerFunc) net.Listener {
 	certPool, err := rootcerts.LoadCACerts(&rootcerts.Config{
-		CAPath: filepath.Join(certDir, "ca_cert.pem"),
+		CAPath: cert.caCert,
 	})
 	if err != nil {
 		t.Fatalf("failed to load CA certs: %v", err)
@@ -106,35 +260,41 @@ func runTestServer(t *testing.T, certDir string, fn http.HandlerFunc) net.Listen
 
 	sv := &http.Server{
 		TLSConfig: tlsConfig,
-		Handler:   http.HandlerFunc(fn),
+		Handler:   fn,
 	}
 
 	t.Cleanup(func() {
-		sv.Close()
-		ln.Close()
+		_ = sv.Close()
+		_ = ln.Close()
 	})
 
 	go func() {
-		sv.ServeTLS(ln, filepath.Join(certDir, "server_cert.pem"), filepath.Join(certDir, "server_key.pem"))
+		_ = sv.ServeTLS(ln, cert.serverCert, cert.serverKey)
 	}()
 
 	return ln
 }
 
-func createCertificatePairs(t *testing.T) string {
-	tempDir, err := os.MkdirTemp("", "api_certauth_test")
-	if err != nil {
-		t.Fatal(err)
-	}
+type testCerts struct {
+	caCert           string
+	caKey            string
+	serverCert       string
+	serverKey        string
+	clientCert       string
+	clientKey        string
+	parsedClientCert *x509.Certificate
+}
 
-	t.Logf("test %s, temp dir %s", t.Name(), tempDir)
+func createCertificates(t *testing.T) testCerts {
+	tempDir := t.TempDir()
+
 	caCertTemplate := &x509.Certificate{
 		Subject: pkix.Name{
 			CommonName: "localhost",
 		},
 		DNSNames:              []string{"localhost"},
 		IPAddresses:           []net.IP{net.ParseIP("127.0.0.1")},
-		KeyUsage:              x509.KeyUsage(x509.KeyUsageCertSign | x509.KeyUsageCRLSign),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
 		SerialNumber:          big.NewInt(mathrand.Int63()),
 		NotBefore:             time.Now().Add(-30 * time.Second),
 		NotAfter:              time.Now().Add(262980 * time.Hour),
@@ -157,7 +317,8 @@ func createCertificatePairs(t *testing.T) string {
 		Type:  "CERTIFICATE",
 		Bytes: caBytes,
 	}
-	err = os.WriteFile(filepath.Join(tempDir, "ca_cert.pem"), pem.EncodeToMemory(caCertPEMBlock), 0o755)
+	caCertFile := filepath.Join(tempDir, "ca_cert.pem")
+	err = os.WriteFile(caCertFile, pem.EncodeToMemory(caCertPEMBlock), 0o755)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -169,12 +330,13 @@ func createCertificatePairs(t *testing.T) string {
 		Type:  "EC PRIVATE KEY",
 		Bytes: marshaledCAKey,
 	}
-	err = os.WriteFile(filepath.Join(tempDir, "ca_key.pem"), pem.EncodeToMemory(caKeyPEMBlock), 0o755)
+	caKeyFile := filepath.Join(tempDir, "ca_key.pem")
+	err = os.WriteFile(caKeyFile, pem.EncodeToMemory(caKeyPEMBlock), 0o755)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	createCertificate := func(prefix string) {
+	createCertificate := func(prefix string) *x509.Certificate {
 		key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 		if err != nil {
 			t.Fatal(err)
@@ -219,10 +381,26 @@ func createCertificatePairs(t *testing.T) string {
 		if err != nil {
 			t.Fatal(err)
 		}
+
+		parsedCert, err := x509.ParseCertificate(certBytes)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return parsedCert
 	}
 
-	createCertificate("client")
+	clientCert := createCertificate("client")
 	createCertificate("server")
 
-	return tempDir
+	filepath.Join(tempDir, "client_cert.pem")
+
+	return testCerts{
+		caCert:           caCertFile,
+		caKey:            caKeyFile,
+		serverCert:       filepath.Join(tempDir, "server_cert.pem"),
+		serverKey:        filepath.Join(tempDir, "server_key.pem"),
+		clientCert:       filepath.Join(tempDir, "client_cert.pem"),
+		clientKey:        filepath.Join(tempDir, "client_key.pem"),
+		parsedClientCert: clientCert,
+	}
 }

--- a/api/auth/cert/go.mod
+++ b/api/auth/cert/go.mod
@@ -11,7 +11,7 @@ require (
 
 require (
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
-	github.com/go-jose/go-jose/v4 v4.0.1 // indirect
+	github.com/go-jose/go-jose/v4 v4.0.5 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect

--- a/api/auth/cert/go.sum
+++ b/api/auth/cert/go.sum
@@ -8,12 +8,12 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.16.0 h1:zmkK9Ngbjj+K0yRhTVONQh1p/HknKYSlNT+vZCzyokM=
 github.com/fatih/color v1.16.0/go.mod h1:fL2Sau1YI5c0pdGEVCbKQbLXB6edEj1ZgiY4NijnWvE=
-github.com/go-jose/go-jose/v4 v4.0.1 h1:QVEPDE3OluqXBQZDcnNvQrInro2h0e4eqNbnZSWqS6U=
-github.com/go-jose/go-jose/v4 v4.0.1/go.mod h1:WVf9LFMHh/QVrmqrOfqun0C45tMe3RoiKJMPvgWwLfY=
+github.com/go-jose/go-jose/v4 v4.0.5 h1:M6T8+mKZl/+fNNuFHvGIzDz7BTLQPIounk/b9dw3AaE=
+github.com/go-jose/go-jose/v4 v4.0.5/go.mod h1:s3P1lRrkT8igV8D9OjyL4WRyHvjB6a4JSllnOrmmBOA=
 github.com/go-test/deep v1.0.2 h1:onZX1rnHT3Wv6cqNgYyFOOlgVKJrksuCMCRvJStbMYw=
 github.com/go-test/deep v1.0.2/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
-github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
-github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
@@ -60,8 +60,8 @@ github.com/ryanuber/go-glob v1.0.0 h1:iQh3xXAumdQ+4Ufa5b25cRpC5TYKlno6hsv6Cb3pkB
 github.com/ryanuber/go-glob v1.0.0/go.mod h1:807d1WSdnB0XRJzKNil9Om6lcp/3a0v4qIHxIXzX/Yc=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
-github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 golang.org/x/crypto v0.36.0 h1:AnAEvhDddvBdpY+uR+MyHmuZzzNqXSe/GvuDeob5L34=
 golang.org/x/crypto v0.36.0/go.mod h1:Y4J0ReaxCR1IMaabaSMugxJES1EpwhBHhv2bDHklZvc=
 golang.org/x/net v0.37.0 h1:1zLorHbz+LYj7MQlSf1+2tPIIgibq2eL5xkrGk6f+2c=


### PR DESCRIPTION
### Description

The new certificate client api introduced within https://github.com/hashicorp/vault/pull/29546 had some limitations, while it worked well, due to it using just the address from the passed in api.client, a lot of the properties that could be set weren't being honored unlike the other client APIs when communicating with Vault. 

This is the list of changes being performed, note that we have changed the API removing the TLS options as we now delegate that to passed in client assuming it has been setup correctly. 

 - Use the passed in Vault API client to perform the connection
    - This provides namespace support, retry behaviors and uses the existing secret parsing logic instead of re-implementing it
    - Secondly this means the end-user using this API, doesn't have to setup a Vault API client with all the certificate/TLS logic and then also pass in those details in this API. 
    - We've added some helpers that can aid a user to create a Vault client with the existing api.TLSConfig, with either passing in an existing client that will be cloned or a helper that uses the `api.DefaultConfig`
 - Change the cert auth role to be an optional argument
 - Allow users to use a different cert auth mount point

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [X] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
