### PR TITLE
[VAULT-34702] UI: replace generic `<input>` in `NavigateInput` component with equivalent `Hds::Form::TextInput::Base`

### DIFF
--- a/ui/lib/core/addon/components/navigate-input.hbs
+++ b/ui/lib/core/addon/components/navigate-input.hbs
@@ -5,22 +5,18 @@
 
 <div class="navigate-filter">
   <div class="field" data-test-nav-input>
-    <p class="control has-icons-left">
-      <Input
-        id={{this.inputId}}
-        class="filter input"
-        placeholder={{or @placeholder "Filter items"}}
-        @value={{@filter}}
-        @type="text"
-        data-test-component="navigate-input"
-        {{on "input" this.handleInput}}
-        {{on "keyup" this.handleKeyUp}}
-        {{on "keydown" this.handleKeyPress}}
-        {{on "focus" (fn this.setFilterFocused true)}}
-        {{on "blur" (fn this.setFilterFocused false)}}
-        {{did-insert this.maybeFocusInput}}
-      />
-      <Icon @name="search" class="search-icon has-text-grey-light" />
-    </p>
+    <Hds::Form::TextInput::Base
+      id={{this.inputId}}
+      @type="search"
+      @value={{@filter}}
+      placeholder={{or @placeholder "Filter items"}}
+      {{on "input" this.handleInput}}
+      {{on "keyup" this.handleKeyUp}}
+      {{on "keydown" this.handleKeyPress}}
+      {{on "focus" (fn this.setFilterFocused true)}}
+      {{on "blur" (fn this.setFilterFocused false)}}
+      {{did-insert this.maybeFocusInput}}
+      data-test-component="navigate-input"
+    />
   </div>
 </div>


### PR DESCRIPTION
### Description
What does this PR do?

- [x] replace generic `<input>` in `NavigateInput` component with equivalent `Hds::Form::TextInput::Base`

Jira ticket: https://hashicorp.atlassian.net/browse/VAULT-34702

**Before:**
<img width="1067" alt="screenshot_4784" src="https://github.com/user-attachments/assets/f91e5095-7e1d-40d6-8e01-9f790b7cdbfd" />
🕹️ Video: https://github.com/user-attachments/assets/c346d585-8dad-414a-ae7e-63fcfe9622a9

**After:**
<img width="1059" alt="screenshot_4783" src="https://github.com/user-attachments/assets/13a4cb88-5848-45f7-9ae8-9e8352a5d720" />
🕹️ Video: https://github.com/user-attachments/assets/3e11ec51-5e6d-4bb4-ba09-c558379fdabe

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
