### PR TITLE
🧪 [SPIKE] [VAULT-34728] UI: `<FormField>` - Spike to explore how to update the template logic to handle HDS replacement

### DIFF
--- a/ui/lib/core/addon/components/form-field.hbs
+++ b/ui/lib/core/addon/components/form-field.hbs
@@ -5,6 +5,7 @@
 
 {{! template-lint-configure simple-unless "warn" }}
 <div class="field" data-test-field={{or @attr.name true}}>
+  <pre>Is this HDS? {{if this.isHdsFormField "🍱" "⚡️"}}</pre>
   {{#unless this.hideLabel}}
     <FormFieldLabel
       for={{@attr.name}}

--- a/ui/lib/core/addon/components/form-field.hbs
+++ b/ui/lib/core/addon/components/form-field.hbs
@@ -5,410 +5,413 @@
 
 {{! template-lint-configure simple-unless "warn" }}
 <div class="field" data-test-field={{or @attr.name true}}>
-  <pre>Is this HDS? {{if this.isHdsFormField "🍱" "⚡️"}}</pre>
-  {{#unless this.hideLabel}}
-    <FormFieldLabel
-      for={{@attr.name}}
-      @label={{this.labelString}}
-      @helpText={{(if this.showHelpText @attr.options.helpText)}}
-      @subText={{@attr.options.subText}}
-      @docLink={{@attr.options.docLink}}
-    />
-  {{/unless}}
-  {{#if @attr.options.possibleValues}}
-    {{#if (eq @attr.options.editType "radio")}}
-      <div class="control {{unless this.hasRadioSubText 'columns'}}" data-test-radio-input>
-        {{#each (path-or-array @attr.options.possibleValues @model) as |val|}}
-          <div
-            class="is-flex-center
-              {{if this.hasRadioSubText 'has-top-padding-xs has-bottom-padding-s' 'column is-narrow has-right-margin-s'}}"
-            data-test-input={{@attr.name}}
-          >
-            <RadioButton
-              class="radio"
-              name={{@attr.name}}
-              id={{or val.value val}}
-              value={{or val.value val}}
-              @value={{or val.value val}}
-              @onChange={{this.setAndBroadcast}}
-              @groupValue={{get @model this.valuePath}}
-              @disabled={{and @attr.options.editDisabled (not @model.isNew)}}
-              data-test-radio={{or val.value val}}
-            />
-            <div class="has-left-margin-xs">
-              <label
-                for="{{or val.value val}}"
-                class="has-left-margin-xs is-size-7"
-                data-test-radio-label={{or val.label val.value val}}
-              >
-                {{or val.label val.value val}}
-                {{#if val.helpText}}
-                  <Hds::TooltipButton @text={{val.helpText}} aria-label="More information">
-                    <Hds::Icon @name="info" @isInline={{true}} />
-                  </Hds::TooltipButton>
-                {{/if}}
-                {{#if this.hasRadioSubText}}
-                  <p class="has-left-margin-xs has-text-grey is-size-8" data-test-radio-subText={{val.subText}}>
-                    {{val.subText}}
-                  </p>
-                {{/if}}
-              </label>
+  {{#if this.isHdsFormField}}
+    <pre>Is this HDS? {{if this.isHdsFormField "🍱" "⚡️"}}</pre>
+  {{else}}
+    {{#unless this.hideLabel}}
+      <FormFieldLabel
+        for={{@attr.name}}
+        @label={{this.labelString}}
+        @helpText={{(if this.showHelpText @attr.options.helpText)}}
+        @subText={{@attr.options.subText}}
+        @docLink={{@attr.options.docLink}}
+      />
+    {{/unless}}
+    {{#if @attr.options.possibleValues}}
+      {{#if (eq @attr.options.editType "radio")}}
+        <div class="control {{unless this.hasRadioSubText 'columns'}}" data-test-radio-input>
+          {{#each (path-or-array @attr.options.possibleValues @model) as |val|}}
+            <div
+              class="is-flex-center
+                {{if this.hasRadioSubText 'has-top-padding-xs has-bottom-padding-s' 'column is-narrow has-right-margin-s'}}"
+              data-test-input={{@attr.name}}
+            >
+              <RadioButton
+                class="radio"
+                name={{@attr.name}}
+                id={{or val.value val}}
+                value={{or val.value val}}
+                @value={{or val.value val}}
+                @onChange={{this.setAndBroadcast}}
+                @groupValue={{get @model this.valuePath}}
+                @disabled={{and @attr.options.editDisabled (not @model.isNew)}}
+                data-test-radio={{or val.value val}}
+              />
+              <div class="has-left-margin-xs">
+                <label
+                  for="{{or val.value val}}"
+                  class="has-left-margin-xs is-size-7"
+                  data-test-radio-label={{or val.label val.value val}}
+                >
+                  {{or val.label val.value val}}
+                  {{#if val.helpText}}
+                    <Hds::TooltipButton @text={{val.helpText}} aria-label="More information">
+                      <Hds::Icon @name="info" @isInline={{true}} />
+                    </Hds::TooltipButton>
+                  {{/if}}
+                  {{#if this.hasRadioSubText}}
+                    <p class="has-left-margin-xs has-text-grey is-size-8" data-test-radio-subText={{val.subText}}>
+                      {{val.subText}}
+                    </p>
+                  {{/if}}
+                </label>
+              </div>
             </div>
-          </div>
-        {{/each}}
-      </div>
-    {{else if (eq @attr.options.editType "checkboxList")}}
-      <Hds::Form::Checkbox::Group @name={{@attr.name}} data-test-input={{@attr.name}} as |G|>
-        {{#each @attr.options.possibleValues as |option|}}
-          <G.CheckboxField
-            class={{if this.validationError "has-error-border"}}
-            {{! TODO! here I've replaced `includes` with `eq` because it was not working: `includes` expects a list/array as second argument, while here we're passing a single value - see: https://github.com/DockYard/ember-composable-helpers?tab=readme-ov-file#includes }}
-            checked={{eq option (get @model this.valuePath)}}
-            @value={{option}}
-            @id={{option}}
-            {{on "change" this.handleChecklist}}
-            as |F|
-          >
-            <F.Label>{{option}}</F.Label>
-          </G.CheckboxField>
-        {{/each}}
-      </Hds::Form::Checkbox::Group>
-    {{else}}
-      <div class="control is-expanded">
-        <div class="select is-fullwidth">
-          <select
-            class="{{if this.validationError 'has-error-border'}}"
-            name={{@attr.name}}
-            id={{@attr.name}}
-            onchange={{this.onChangeWithEvent}}
-            data-test-input={{@attr.name}}
-          >
-            {{#if @attr.options.noDefault}}
-              <option value="">
-                Select one
-              </option>
-            {{/if}}
-            {{#each (path-or-array @attr.options.possibleValues @model) as |val|}}
-              <option selected={{loose-equal (get @model this.valuePath) (or val.value val)}} value={{or val.value val}}>
-                {{or val.displayName val}}
-              </option>
-            {{/each}}
-          </select>
+          {{/each}}
         </div>
+      {{else if (eq @attr.options.editType "checkboxList")}}
+        <Hds::Form::Checkbox::Group @name={{@attr.name}} data-test-input={{@attr.name}} as |G|>
+          {{#each @attr.options.possibleValues as |option|}}
+            <G.CheckboxField
+              class={{if this.validationError "has-error-border"}}
+              {{! TODO! here I've replaced `includes` with `eq` because it was not working: `includes` expects a list/array as second argument, while here we're passing a single value - see: https://github.com/DockYard/ember-composable-helpers?tab=readme-ov-file#includes }}
+              checked={{eq option (get @model this.valuePath)}}
+              @value={{option}}
+              @id={{option}}
+              {{on "change" this.handleChecklist}}
+              as |F|
+            >
+              <F.Label>{{option}}</F.Label>
+            </G.CheckboxField>
+          {{/each}}
+        </Hds::Form::Checkbox::Group>
+      {{else}}
+        <div class="control is-expanded">
+          <div class="select is-fullwidth">
+            <select
+              class="{{if this.validationError 'has-error-border'}}"
+              name={{@attr.name}}
+              id={{@attr.name}}
+              onchange={{this.onChangeWithEvent}}
+              data-test-input={{@attr.name}}
+            >
+              {{#if @attr.options.noDefault}}
+                <option value="">
+                  Select one
+                </option>
+              {{/if}}
+              {{#each (path-or-array @attr.options.possibleValues @model) as |val|}}
+                <option selected={{loose-equal (get @model this.valuePath) (or val.value val)}} value={{or val.value val}}>
+                  {{or val.displayName val}}
+                </option>
+              {{/each}}
+            </select>
+          </div>
+        </div>
+      {{/if}}
+    {{else if (eq @attr.options.editType "dateTimeLocal")}}
+      <Input
+        @type="datetime-local"
+        @value={{date-format (get @model this.valuePath) "yyyy-MM-dd'T'HH:mm"}}
+        name={{@attr.name}}
+        id={{@attr.name}}
+        data-test-input={{@attr.name}}
+        class="input has-top-margin-xs has-bottom-margin-xs is-auto-width is-block
+          {{if this.validationError 'has-error-border'}}"
+        {{on "focusout" this.onChangeWithEvent}}
+      />
+    {{else if (eq @attr.options.editType "searchSelect")}}
+      <div class="form-section">
+        <SearchSelect
+          @id={{@attr.name}}
+          @models={{@attr.options.models}}
+          @onChange={{this.setAndBroadcast}}
+          @inputValue={{get @model this.valuePath}}
+          @wildcardLabel={{@attr.options.wildcardLabel}}
+          @label={{this.labelString}}
+          @labelClass={{if @attr.options.isSectionHeader "title is-4" "is-label"}}
+          @subText={{@attr.options.subText}}
+          @helpText={{@attr.options.helpText}}
+          @fallbackComponent={{@attr.options.fallbackComponent}}
+          @selectLimit={{@attr.options.selectLimit}}
+          @backend={{@model.backend}}
+          @disallowNewItems={{@attr.options.onlyAllowExisting}}
+          class={{if this.validationError "dropdown-has-error-border"}}
+        />
       </div>
-    {{/if}}
-  {{else if (eq @attr.options.editType "dateTimeLocal")}}
-    <Input
-      @type="datetime-local"
-      @value={{date-format (get @model this.valuePath) "yyyy-MM-dd'T'HH:mm"}}
-      name={{@attr.name}}
-      id={{@attr.name}}
-      data-test-input={{@attr.name}}
-      class="input has-top-margin-xs has-bottom-margin-xs is-auto-width is-block
-        {{if this.validationError 'has-error-border'}}"
-      {{on "focusout" this.onChangeWithEvent}}
-    />
-  {{else if (eq @attr.options.editType "searchSelect")}}
-    <div class="form-section">
-      <SearchSelect
-        @id={{@attr.name}}
-        @models={{@attr.options.models}}
+    {{else if (eq @attr.options.editType "mountAccessor")}}
+      <MountAccessorSelect
+        @name={{@attr.name}}
+        @label={{this.labelString}}
+        @helpText={{@attr.options.helpText}}
+        @value={{get @model this.valuePath}}
         @onChange={{this.setAndBroadcast}}
-        @inputValue={{get @model this.valuePath}}
-        @wildcardLabel={{@attr.options.wildcardLabel}}
+      />
+    {{else if (eq @attr.options.editType "kv")}}
+      {{! KV Object Editor }}
+      <KvObjectEditor
+        @value={{get @model this.valuePath}}
+        @onChange={{this.setAndBroadcast}}
         @label={{this.labelString}}
         @labelClass={{if @attr.options.isSectionHeader "title is-4" "is-label"}}
-        @subText={{@attr.options.subText}}
         @helpText={{@attr.options.helpText}}
-        @fallbackComponent={{@attr.options.fallbackComponent}}
-        @selectLimit={{@attr.options.selectLimit}}
-        @backend={{@model.backend}}
-        @disallowNewItems={{@attr.options.onlyAllowExisting}}
-        class={{if this.validationError "dropdown-has-error-border"}}
-      />
-    </div>
-  {{else if (eq @attr.options.editType "mountAccessor")}}
-    <MountAccessorSelect
-      @name={{@attr.name}}
-      @label={{this.labelString}}
-      @helpText={{@attr.options.helpText}}
-      @value={{get @model this.valuePath}}
-      @onChange={{this.setAndBroadcast}}
-    />
-  {{else if (eq @attr.options.editType "kv")}}
-    {{! KV Object Editor }}
-    <KvObjectEditor
-      @value={{get @model this.valuePath}}
-      @onChange={{this.setAndBroadcast}}
-      @label={{this.labelString}}
-      @labelClass={{if @attr.options.isSectionHeader "title is-4" "is-label"}}
-      @helpText={{@attr.options.helpText}}
-      @subText={{@attr.options.subText}}
-      @onKeyUp={{this.handleKeyUp}}
-      @keyPlaceholder={{@attr.options.keyPlaceholder}}
-      @valuePlaceholder={{@attr.options.valuePlaceholder}}
-      @isSingleRow={{@attr.options.isSingleRow}}
-      @allowWhiteSpace={{@attr.options.allowWhiteSpace}}
-      class="{{if this.validationError 'error-border-child-inputs'}} {{if @attr.options.isSectionHeader 'form-section'}}"
-    />
-  {{else if (eq @attr.options.editType "file")}}
-    {{! File Input }}
-    <div class="has-bottom-margin-m" data-test-input={{@attr.name}}>
-      <TextFile
-        @label={{this.labelString}}
         @subText={{@attr.options.subText}}
-        @helpText={{@attr.options.helpText}}
-        @docLink={{@attr.options.docLink}}
-        @onChange={{this.setFile}}
-        @validationError={{this.validationError}}
+        @onKeyUp={{this.handleKeyUp}}
+        @keyPlaceholder={{@attr.options.keyPlaceholder}}
+        @valuePlaceholder={{@attr.options.valuePlaceholder}}
+        @isSingleRow={{@attr.options.isSingleRow}}
+        @allowWhiteSpace={{@attr.options.allowWhiteSpace}}
+        class="{{if this.validationError 'error-border-child-inputs'}} {{if @attr.options.isSectionHeader 'form-section'}}"
       />
-    </div>
-  {{else if (eq @attr.options.editType "ttl")}}
-    {{! TTL Picker }}
-    <div class="field">
-      {{#let (or (get @model this.valuePath) @attr.options.setDefault) as |initialValue|}}
-        <TtlPicker
-          data-test-input={{@attr.name}}
-          class={{if this.validationError "ttl-picker-form-field-error"}}
-          @onChange={{this.setAndBroadcastTtl}}
+    {{else if (eq @attr.options.editType "file")}}
+      {{! File Input }}
+      <div class="has-bottom-margin-m" data-test-input={{@attr.name}}>
+        <TextFile
           @label={{this.labelString}}
-          @helperTextDisabled={{or @attr.options.helperTextDisabled "Vault will use the default lease duration."}}
-          @helperTextEnabled={{or @attr.options.helperTextEnabled "Lease will expire after"}}
-          @description={{@attr.helpText}}
-          @initialValue={{initialValue}}
-          @initialEnabled={{if (eq initialValue "0s") false initialValue}}
-          @hideToggle={{@attr.options.hideToggle}}
+          @subText={{@attr.options.subText}}
+          @helpText={{@attr.options.helpText}}
+          @docLink={{@attr.options.docLink}}
+          @onChange={{this.setFile}}
+          @validationError={{this.validationError}}
         />
-      {{/let}}
-    </div>
-  {{else if (eq @attr.options.editType "regex")}}
-    {{! Regex Validated Input }}
-    <RegexValidator
-      @attr={{@attr}}
-      @labelString={{this.labelString}}
-      @value={{or (get @model this.valuePath) @attr.options.defaultValue}}
-      @onChange={{this.onChangeWithEvent}}
-    />
-  {{else if (eq @attr.options.editType "toggleButton")}}
-    {{! Togglable Input }}
-    <Toggle
-      @name="toggle-{{@attr.name}}"
-      @onChange={{this.toggleButton}}
-      @checked={{this.toggleInputEnabled}}
-      data-test-toggle={{@attr.name}}
-      disabled={{this.disabled}}
-    >
-      <span class="has-text-weight-bold is-large">{{this.labelString}}</span><br />
-      <div class="description has-text-grey" data-test-toggle-subtext>
-        <span>
-          {{#if this.toggleInputEnabled}}
-            {{@attr.options.helperTextEnabled}}
-          {{else}}
-            {{@attr.options.helperTextDisabled}}
-          {{/if}}
-        </span>
       </div>
-    </Toggle>
-  {{else if (eq @attr.options.editType "optionalText")}}
-    {{! Togglable Text Input }}
-    <Toggle
-      @name="show-{{@attr.name}}"
-      @onChange={{this.toggleTextShow}}
-      @checked={{this.showToggleTextInput}}
-      data-test-toggle={{@attr.name}}
-    >
-      <span class="ttl-picker-label is-large">{{this.labelString}}</span><br />
-      <div class="description has-text-grey">
+    {{else if (eq @attr.options.editType "ttl")}}
+      {{! TTL Picker }}
+      <div class="field">
+        {{#let (or (get @model this.valuePath) @attr.options.setDefault) as |initialValue|}}
+          <TtlPicker
+            data-test-input={{@attr.name}}
+            class={{if this.validationError "ttl-picker-form-field-error"}}
+            @onChange={{this.setAndBroadcastTtl}}
+            @label={{this.labelString}}
+            @helperTextDisabled={{or @attr.options.helperTextDisabled "Vault will use the default lease duration."}}
+            @helperTextEnabled={{or @attr.options.helperTextEnabled "Lease will expire after"}}
+            @description={{@attr.helpText}}
+            @initialValue={{initialValue}}
+            @initialEnabled={{if (eq initialValue "0s") false initialValue}}
+            @hideToggle={{@attr.options.hideToggle}}
+          />
+        {{/let}}
+      </div>
+    {{else if (eq @attr.options.editType "regex")}}
+      {{! Regex Validated Input }}
+      <RegexValidator
+        @attr={{@attr}}
+        @labelString={{this.labelString}}
+        @value={{or (get @model this.valuePath) @attr.options.defaultValue}}
+        @onChange={{this.onChangeWithEvent}}
+      />
+    {{else if (eq @attr.options.editType "toggleButton")}}
+      {{! Togglable Input }}
+      <Toggle
+        @name="toggle-{{@attr.name}}"
+        @onChange={{this.toggleButton}}
+        @checked={{this.toggleInputEnabled}}
+        data-test-toggle={{@attr.name}}
+        disabled={{this.disabled}}
+      >
+        <span class="has-text-weight-bold is-large">{{this.labelString}}</span><br />
+        <div class="description has-text-grey" data-test-toggle-subtext>
+          <span>
+            {{#if this.toggleInputEnabled}}
+              {{@attr.options.helperTextEnabled}}
+            {{else}}
+              {{@attr.options.helperTextDisabled}}
+            {{/if}}
+          </span>
+        </div>
+      </Toggle>
+    {{else if (eq @attr.options.editType "optionalText")}}
+      {{! Togglable Text Input }}
+      <Toggle
+        @name="show-{{@attr.name}}"
+        @onChange={{this.toggleTextShow}}
+        @checked={{this.showToggleTextInput}}
+        data-test-toggle={{@attr.name}}
+      >
+        <span class="ttl-picker-label is-large">{{this.labelString}}</span><br />
+        <div class="description has-text-grey">
+          {{#if this.showToggleTextInput}}
+            <span>
+              {{@attr.options.subText}}
+              {{#if @attr.options.docLink}}
+                <DocLink @path={{@attr.options.docLink}}>
+                  See our documentation
+                </DocLink>
+                for help.
+              {{/if}}
+            </span>
+          {{else}}
+            <span>
+              {{or @attr.options.defaultSubText "Vault will use the engine default."}}
+              {{#if @attr.options.docLink}}
+                <DocLink @path={{@attr.options.docLink}}>
+                  See our documentation
+                </DocLink>
+                for help.
+              {{/if}}
+            </span>
+          {{/if}}
+        </div>
         {{#if this.showToggleTextInput}}
-          <span>
-            {{@attr.options.subText}}
-            {{#if @attr.options.docLink}}
-              <DocLink @path={{@attr.options.docLink}}>
-                See our documentation
-              </DocLink>
-              for help.
-            {{/if}}
-          </span>
+          <input
+            data-test-input={{@attr.name}}
+            id={{@attr.name}}
+            autocomplete="off"
+            spellcheck="false"
+            value={{or (get @model this.valuePath) @attr.options.defaultValue}}
+            onchange={{this.onChangeWithEvent}}
+            class="input"
+            maxLength={{@attr.options.characterLimit}}
+          />
+        {{/if}}
+      </Toggle>
+    {{else if (eq @attr.options.editType "stringArray")}}
+      <StringList
+        class={{if this.validationError "string-list-form-field-error"}}
+        data-test-input={{@attr.name}}
+        @label={{this.labelString}}
+        @helpText={{if this.showHelpText @attr.options.helpText}}
+        @inputValue={{get @model this.valuePath}}
+        @onChange={{this.setAndBroadcast}}
+        @attrName={{@attr.name}}
+        @subText="{{@attr.options.subText}} Add one item per row."
+      />
+    {{else if (eq @attr.options.sensitive true)}}
+      <MaskedInput
+        @name={{@attr.name}}
+        @value={{or (get @model this.valuePath) @attr.options.defaultValue}}
+        @allowCopy={{if @attr.options.noCopy false true}}
+        @onChange={{this.setAndBroadcast}}
+        @onKeyUp={{@onKeyUp}}
+      />
+    {{else if (or (eq @attr.type "number") (eq @attr.type "string"))}}
+      <div class="control">
+        {{#if (eq @attr.options.editType "textarea")}}
+          {{! Text area }}
+          <textarea
+            data-test-input={{@attr.name}}
+            id={{@attr.name}}
+            value={{or (get @model this.valuePath) @attr.options.defaultValue}}
+            oninput={{this.onChangeWithEvent}}
+            class="textarea {{if this.validationError 'has-error-border'}}"
+          ></textarea>
+        {{else if (eq @attr.options.editType "password")}}
+          <Input
+            data-test-input={{@attr.name}}
+            @type="password"
+            @value={{get @model this.valuePath}}
+            name={{@attr.name}}
+            class="input"
+            {{! Prevents browsers from auto-filling }}
+            autocomplete="new-password"
+            spellcheck="false"
+          />
+        {{else if (eq @attr.options.editType "json")}}
+          {{! JSON Editor }}
+          {{#let (get @model this.valuePath) as |value|}}
+            <JsonEditor
+              data-test-input={{@attr.name}}
+              @title={{this.labelString}}
+              @value={{if
+                value
+                (if (eq @attr.options.mode "ruby") value (stringify (jsonify value)))
+                @attr.options.defaultValue
+              }}
+              @valueUpdated={{fn this.codemirrorUpdated true}}
+              @theme={{or @attr.options.theme "hashi"}}
+              @helpText={{@attr.options.helpText}}
+              @mode={{@attr.options.mode}}
+              @example={{@attr.options.example}}
+            >
+              {{#if @attr.options.allowReset}}
+                <Hds::Button
+                  @text="Clear"
+                  @icon="reload"
+                  class="toolbar-button"
+                  disabled={{not value}}
+                  {{on "click" this.setAndBroadcast}}
+                  data-test-json-clear-button
+                />
+              {{/if}}
+            </JsonEditor>
+          {{/let}}
+          {{#if @attr.options.subText}}
+            <p class="sub-text">
+              {{@attr.options.subText}}
+              {{#if @attr.options.docLink}}
+                <DocLink @path={{@attr.options.docLink}}>
+                  See our documentation
+                </DocLink>
+                for help.
+              {{/if}}
+            </p>
+          {{/if}}
         {{else}}
-          <span>
-            {{or @attr.options.defaultSubText "Vault will use the engine default."}}
-            {{#if @attr.options.docLink}}
-              <DocLink @path={{@attr.options.docLink}}>
-                See our documentation
-              </DocLink>
-              for help.
-            {{/if}}
-          </span>
+          {{! Regular Text Input }}
+          <input
+            data-test-input={{@attr.name}}
+            id={{@attr.name}}
+            readonly={{this.isReadOnly}}
+            disabled={{and @attr.options.editDisabled (not @model.isNew)}}
+            autocomplete="off"
+            spellcheck="false"
+            placeholder={{@attr.options.placeholder}}
+            value={{get @model this.valuePath}}
+            {{on "change" this.onChangeWithEvent}}
+            {{on "input" this.onChangeWithEvent}}
+            {{on "keyup" this.handleKeyUp}}
+            class="input {{if this.validationError 'has-error-border'}}"
+            maxLength={{@attr.options.characterLimit}}
+          />
         {{/if}}
       </div>
-      {{#if this.showToggleTextInput}}
+    {{else if (or (eq @attr.type "boolean") (eq @attr.options.editType "boolean"))}}
+      <div class="b-checkbox">
         <input
-          data-test-input={{@attr.name}}
+          disabled={{this.disabled}}
+          type="checkbox"
           id={{@attr.name}}
-          autocomplete="off"
-          spellcheck="false"
-          value={{or (get @model this.valuePath) @attr.options.defaultValue}}
+          class="styled"
+          checked={{get @model @attr.name}}
           onchange={{this.onChangeWithEvent}}
-          class="input"
-          maxLength={{@attr.options.characterLimit}}
-        />
-      {{/if}}
-    </Toggle>
-  {{else if (eq @attr.options.editType "stringArray")}}
-    <StringList
-      class={{if this.validationError "string-list-form-field-error"}}
-      data-test-input={{@attr.name}}
-      @label={{this.labelString}}
-      @helpText={{if this.showHelpText @attr.options.helpText}}
-      @inputValue={{get @model this.valuePath}}
-      @onChange={{this.setAndBroadcast}}
-      @attrName={{@attr.name}}
-      @subText="{{@attr.options.subText}} Add one item per row."
-    />
-  {{else if (eq @attr.options.sensitive true)}}
-    <MaskedInput
-      @name={{@attr.name}}
-      @value={{or (get @model this.valuePath) @attr.options.defaultValue}}
-      @allowCopy={{if @attr.options.noCopy false true}}
-      @onChange={{this.setAndBroadcast}}
-      @onKeyUp={{@onKeyUp}}
-    />
-  {{else if (or (eq @attr.type "number") (eq @attr.type "string"))}}
-    <div class="control">
-      {{#if (eq @attr.options.editType "textarea")}}
-        {{! Text area }}
-        <textarea
           data-test-input={{@attr.name}}
-          id={{@attr.name}}
-          value={{or (get @model this.valuePath) @attr.options.defaultValue}}
-          oninput={{this.onChangeWithEvent}}
-          class="textarea {{if this.validationError 'has-error-border'}}"
-        ></textarea>
-      {{else if (eq @attr.options.editType "password")}}
-        <Input
-          data-test-input={{@attr.name}}
-          @type="password"
-          @value={{get @model this.valuePath}}
-          name={{@attr.name}}
-          class="input"
-          {{! Prevents browsers from auto-filling }}
-          autocomplete="new-password"
-          spellcheck="false"
         />
-      {{else if (eq @attr.options.editType "json")}}
-        {{! JSON Editor }}
-        {{#let (get @model this.valuePath) as |value|}}
-          <JsonEditor
-            data-test-input={{@attr.name}}
-            @title={{this.labelString}}
-            @value={{if
-              value
-              (if (eq @attr.options.mode "ruby") value (stringify (jsonify value)))
-              @attr.options.defaultValue
-            }}
-            @valueUpdated={{fn this.codemirrorUpdated true}}
-            @theme={{or @attr.options.theme "hashi"}}
-            @helpText={{@attr.options.helpText}}
-            @mode={{@attr.options.mode}}
-            @example={{@attr.options.example}}
-          >
-            {{#if @attr.options.allowReset}}
-              <Hds::Button
-                @text="Clear"
-                @icon="reload"
-                class="toolbar-button"
-                disabled={{not value}}
-                {{on "click" this.setAndBroadcast}}
-                data-test-json-clear-button
-              />
-            {{/if}}
-          </JsonEditor>
-        {{/let}}
+        <label for={{@attr.name}} class="is-label" data-test-form-field-label>
+          {{this.labelString}}
+          {{#if (and this.showHelpText @attr.options.helpText)}}
+            <InfoTooltip>{{@attr.options.helpText}}</InfoTooltip>
+          {{/if}}
+        </label>
         {{#if @attr.options.subText}}
           <p class="sub-text">
             {{@attr.options.subText}}
             {{#if @attr.options.docLink}}
               <DocLink @path={{@attr.options.docLink}}>
-                See our documentation
+                Learn more here.
               </DocLink>
-              for help.
             {{/if}}
           </p>
         {{/if}}
-      {{else}}
-        {{! Regular Text Input }}
-        <input
-          data-test-input={{@attr.name}}
-          id={{@attr.name}}
-          readonly={{this.isReadOnly}}
-          disabled={{and @attr.options.editDisabled (not @model.isNew)}}
-          autocomplete="off"
-          spellcheck="false"
-          placeholder={{@attr.options.placeholder}}
-          value={{get @model this.valuePath}}
-          {{on "change" this.onChangeWithEvent}}
-          {{on "input" this.onChangeWithEvent}}
-          {{on "keyup" this.handleKeyUp}}
-          class="input {{if this.validationError 'has-error-border'}}"
-          maxLength={{@attr.options.characterLimit}}
-        />
-      {{/if}}
-    </div>
-  {{else if (or (eq @attr.type "boolean") (eq @attr.options.editType "boolean"))}}
-    <div class="b-checkbox">
-      <input
-        disabled={{this.disabled}}
-        type="checkbox"
-        id={{@attr.name}}
-        class="styled"
-        checked={{get @model @attr.name}}
-        onchange={{this.onChangeWithEvent}}
-        data-test-input={{@attr.name}}
+      </div>
+    {{else if (eq @attr.type "object")}}
+      <JsonEditor
+        @title={{this.labelString}}
+        @value={{if (get @model this.valuePath) (stringify (get @model this.valuePath)) this.emptyData}}
+        @valueUpdated={{fn this.codemirrorUpdated false}}
+        @helpText={{@attr.options.helpText}}
+        @example={{@attr.options.example}}
       />
-      <label for={{@attr.name}} class="is-label" data-test-form-field-label>
-        {{this.labelString}}
-        {{#if (and this.showHelpText @attr.options.helpText)}}
-          <InfoTooltip>{{@attr.options.helpText}}</InfoTooltip>
-        {{/if}}
-      </label>
-      {{#if @attr.options.subText}}
-        <p class="sub-text">
-          {{@attr.options.subText}}
-          {{#if @attr.options.docLink}}
-            <DocLink @path={{@attr.options.docLink}}>
-              Learn more here.
-            </DocLink>
-          {{/if}}
-        </p>
-      {{/if}}
-    </div>
-  {{else if (eq @attr.type "object")}}
-    <JsonEditor
-      @title={{this.labelString}}
-      @value={{if (get @model this.valuePath) (stringify (get @model this.valuePath)) this.emptyData}}
-      @valueUpdated={{fn this.codemirrorUpdated false}}
-      @helpText={{@attr.options.helpText}}
-      @example={{@attr.options.example}}
-    />
-  {{else if (eq @attr.options.editType "yield")}}
-    {{yield}}
-  {{/if}}
-  {{#if this.validationError}}
-    <AlertInline
-      @type="danger"
-      @message={{this.validationError}}
-      @paddingTop={{not-eq @attr.options.editType "ttl"}}
-      data-test-field-validation={{this.valuePath}}
-      class={{if (eq @attr.options.editType "stringArray") "has-top-margin-negative-xxl"}}
-    />
-  {{/if}}
-  {{#if this.validationWarning}}
-    <AlertInline
-      @type="warning"
-      @message={{this.validationWarning}}
-      @paddingTop={{if (and (not this.validationError) (eq @attr.options.editType "ttl")) false true}}
-      data-test-validation-warning={{this.valuePath}}
-      class={{if (and (not this.validationError) (eq @attr.options.editType "stringArray")) "has-top-margin-negative-xxl"}}
-    />
+    {{else if (eq @attr.options.editType "yield")}}
+      {{yield}}
+    {{/if}}
+    {{#if this.validationError}}
+      <AlertInline
+        @type="danger"
+        @message={{this.validationError}}
+        @paddingTop={{not-eq @attr.options.editType "ttl"}}
+        data-test-field-validation={{this.valuePath}}
+        class={{if (eq @attr.options.editType "stringArray") "has-top-margin-negative-xxl"}}
+      />
+    {{/if}}
+    {{#if this.validationWarning}}
+      <AlertInline
+        @type="warning"
+        @message={{this.validationWarning}}
+        @paddingTop={{if (and (not this.validationError) (eq @attr.options.editType "ttl")) false true}}
+        data-test-validation-warning={{this.valuePath}}
+        class={{if (and (not this.validationError) (eq @attr.options.editType "stringArray")) "has-top-margin-negative-xxl"}}
+      />
+    {{/if}}
   {{/if}}
 </div>

--- a/ui/lib/core/addon/components/form-field.hbs
+++ b/ui/lib/core/addon/components/form-field.hbs
@@ -6,7 +6,50 @@
 {{! template-lint-configure simple-unless "warn" }}
 <div class="field" data-test-field={{or @attr.name true}}>
   {{#if this.isHdsFormField}}
-    <pre>Is this HDS? {{if this.isHdsFormField "🍱" "⚡️"}}</pre>
+    {{#if (or (eq @attr.type "number") (eq @attr.type "string"))}}
+      {{#if (eq @attr.options.editType "password")}}
+        <Hds::Form::TextInput::Field
+          @type="password"
+          {{! TODO discuss with Vault team what they do prefer to do here }}
+          @hasVisibilityToggle={{false}}
+          @value={{get @model this.valuePath}}
+          name={{@attr.name}}
+          @isInvalid={{this.validationError}}
+          {{! Prevents browsers from auto-filling }}
+          autocomplete="new-password"
+          spellcheck="false"
+          data-test-input={{@attr.name}}
+          as |F|
+        >
+          {{#unless this.hideLabel}}
+            <F.Label class="is-label" data-test-form-field-label>{{this.labelString}}</F.Label>
+            {{#if this.showHelpText}}
+              <F.HelperText data-test-help-text>{{@attr.options.helpText}}</F.HelperText>
+            {{/if}}
+            {{#if @attr.options.subText}}
+              <F.HelperText data-test-label-subtext>
+                {{@attr.options.subText}}
+                {{#if @attr.options.docLink}}
+                  <DocLink @path={{@attr.options.docLink}}>See our documentation</DocLink>
+                  for help.
+                {{/if}}
+              </F.HelperText>
+            {{/if}}
+          {{/unless}}
+          {{#if this.validationError}}
+            <F.Error data-test-field-validation={{this.valuePath}}>{{this.validationError}}</F.Error>
+          {{/if}}
+        </Hds::Form::TextInput::Field>
+        {{#if this.validationWarning}}
+          <AlertInline
+            @type="warning"
+            @message={{this.validationWarning}}
+            class="has-top-margin-xs"
+            data-test-validation-warning={{this.valuePath}}
+          />
+        {{/if}}
+      {{/if}}
+    {{/if}}
   {{else}}
     {{#unless this.hideLabel}}
       <FormFieldLabel
@@ -287,6 +330,8 @@
             class="textarea {{if this.validationError 'has-error-border'}}"
           ></textarea>
         {{else if (eq @attr.options.editType "password")}}
+          {{! TODO! remove once it's thoroughly tested  }}
+          {{! NOTE: this code block should never be reached, but it's left here as fallback in case we missed something }}
           <Input
             data-test-input={{@attr.name}}
             @type="password"

--- a/ui/lib/core/addon/components/form-field.hbs
+++ b/ui/lib/core/addon/components/form-field.hbs
@@ -329,19 +329,6 @@
             oninput={{this.onChangeWithEvent}}
             class="textarea {{if this.validationError 'has-error-border'}}"
           ></textarea>
-        {{else if (eq @attr.options.editType "password")}}
-          {{! TODO! remove once it's thoroughly tested  }}
-          {{! NOTE: this code block should never be reached, but it's left here as fallback in case we missed something }}
-          <Input
-            data-test-input={{@attr.name}}
-            @type="password"
-            @value={{get @model this.valuePath}}
-            name={{@attr.name}}
-            class="input"
-            {{! Prevents browsers from auto-filling }}
-            autocomplete="new-password"
-            spellcheck="false"
-          />
         {{else if (eq @attr.options.editType "json")}}
           {{! JSON Editor }}
           {{#let (get @model this.valuePath) as |value|}}

--- a/ui/lib/core/addon/components/form-field.js
+++ b/ui/lib/core/addon/components/form-field.js
@@ -81,6 +81,30 @@ export default class FormFieldComponent extends Component {
     this.toggleInputEnabled = !!modelValue;
   }
 
+  // ---------------------------------------------------------------
+  // IMPORTANT:
+  // this controls the top-level logic in the associated template
+  // to decide which type of form field to render (Vault or HDS)
+  // ---------------------------------------------------------------
+  //
+  get isHdsFormField() {
+    const { type, options } = this.args.attr;
+
+    // here we replicate the logic in the template, to make sure we don't change the order in which the "ifs" are evaluated
+    if (options?.possibleValues?.length > 0) {
+      // for now we leave these fields as they are
+      return false;
+    } else {
+      // converted to HDS fields
+      if ((type === 'number' || type === 'string') && options?.editType === 'password') {
+        return true;
+      } else {
+        // everything is the same as before
+        return false;
+      }
+    }
+  }
+
   get hasRadioSubText() {
     // for 'radio' editType, check to see if every of the possibleValues has a subText and label
     return this.args?.attr?.options?.possibleValues?.any((v) => v.subText);


### PR DESCRIPTION
## 🚨 DO NOT MERGE 🚨

### Description

This PR is a spike (not intended to be merged) is meant as a quick exploration to kick-off a discuss with the Vault UI Engineers and see if this approach (to split the logic between Vault vs HDS components) is acceptable/OK for them. 
If there is agreement than I'll open a proper PR with just this change and build the rest of the PRs for some HDS replacement (eg. password, textarea, select, regular text input) on top of this.

_Notice: the PR points to another spike branch, so I can use the showcase page for local testing, and so the diff is specific to the intended approach to change the code for the `FormField`._

Jira ticket: https://hashicorp.atlassian.net/browse/VAULT-34728

**Before:**
<img width="723" alt="before" src="https://github.com/user-attachments/assets/71813368-6dc4-4d01-9ec2-1840c8968c43" />

**After:**
<img width="737" alt="after" src="https://github.com/user-attachments/assets/0905a371-20a2-4b48-9b19-e266a6e185aa" />

⚠️ Note: I haven't tested the input in the Vault applications, just in the showcase page.

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
