### PR TITLE
[UI] Local Testing Workaround

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -37,6 +37,7 @@
     "test:quick": "node scripts/start-vault.js --split=8 --preserve-test-name --parallel",
     "test:quick-oss": "node scripts/start-vault.js -f='!enterprise' --split=8 --preserve-test-name --parallel",
     "test:filter": "node scripts/start-vault.js --server -f='!enterprise'",
+    "test:dev": "node scripts/start-vault.js",
     "vault": "VAULT_REDIRECT_ADDR=http://127.0.0.1:8200 vault server -log-level=error -dev -dev-root-token-id=root -dev-ha -dev-transactional",
     "vault:cluster": "VAULT_REDIRECT_ADDR=http://127.0.0.1:8202 vault server -log-level=error -dev -dev-root-token-id=root -dev-listen-address=127.0.0.1:8202 -dev-ha -dev-transactional"
   },

--- a/ui/scripts/start-vault.js
+++ b/ui/scripts/start-vault.js
@@ -69,9 +69,15 @@ async function processLines(input, eachLine = () => {}) {
       }
     });
     try {
-      // only the test:filter command specifies --server by default
-      const verb = process.argv[2] === '--server' ? 'test' : 'exam';
-      await testHelper.run('ember', [verb, ...process.argv.slice(2)]);
+      // ignore first 2 args (node and path) and extract flags to pass to test/exam command
+      const args = process.argv.slice(2);
+      const withServer = args.includes('--server') || args.includes('-s');
+      // current issue with headless Chrome where an event listener in Hds::Modal is not triggered resulting in a pending test waiter and timeout
+      // the workaround for now is to run the tests in headless firefox for local runs
+      if (!withServer && !process.env.CI) {
+        args.push('--launch=Firefox');
+      }
+      await testHelper.run('ember', ['exam', ...args]);
     } catch (error) {
       console.log(error);
       process.exit(1);

--- a/ui/testem.js
+++ b/ui/testem.js
@@ -25,6 +25,9 @@ module.exports = {
         '--window-size=1440,900',
       ].filter(Boolean),
     },
+    Firefox: {
+      ci: ['--headless'],
+    },
   },
   proxies: {
     '/v1': {


### PR DESCRIPTION
### Description
At some point in the recent past, an update to Chrome(Mac) has caused tests to fail locally when running in headless mode. Specifically, on HDS modal dismiss [the attached listener on the close event](https://github.com/hashicorp/design-system/blob/%40hashicorp/design-system-components%404.13.0/packages/components/src/components/hds/modal/index.ts#L186-L196) is not triggering which results in a pending test waiter that causes a timeout. Interestingly enough, this is not an issue with the linux version of Chrome as witnessed in passing CI runs and on my local linux machine.

This PR updates the `start-vault` script to conditionally add the `--launch` flag to the testing command that will run the tests in headless Firefox instead when the environment is not CI and the server flag is not present.

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
