### PR TITLE
[VAULT-34704] UI: update `FilterInput` component to use `Hds::Form::TextInput`

### DIFF
--- a/ui/lib/core/addon/components/filter-input.hbs
+++ b/ui/lib/core/addon/components/filter-input.hbs
@@ -3,9 +3,11 @@
   SPDX-License-Identifier: BUSL-1.1
 }}
 
-<div class="control {{unless @hideIcon 'has-icons-left'}}" data-test-filter-input-container>
-  <input class="filter input" ...attributes {{on "input" this.onInput}} {{did-insert this.focus}} data-test-filter-input />
-  {{#unless @hideIcon}}
-    <Icon @name="search" class="search-icon has-text-grey-light" data-test-filter-input-icon />
-  {{/unless}}
-</div>
+<Hds::Form::TextInput::Base
+  @type="search"
+  @id={{@id}}
+  @value={{@value}}
+  {{on "input" this.onInput}}
+  data-test-filter-input
+  ...attributes
+/>

--- a/ui/lib/core/addon/components/filter-input.ts
+++ b/ui/lib/core/addon/components/filter-input.ts
@@ -5,25 +5,16 @@
 
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
-import { debounce, next } from '@ember/runloop';
+import { debounce } from '@ember/runloop';
 
 import type { HTMLElementEvent } from 'vault/forms';
 
 interface Args {
   wait?: number; // defaults to 500
-  autofocus?: boolean; // initially focus the input on did-insert
-  hideIcon?: boolean; // hide the search icon in the input
   onInput(value: string): void; // invoked with input value after debounce timer expires
 }
 
 export default class FilterInputComponent extends Component<Args> {
-  @action
-  focus(elem: HTMLElement) {
-    if (this.args.autofocus) {
-      next(() => elem.focus());
-    }
-  }
-
   @action
   onInput(event: HTMLElementEvent<HTMLInputElement>) {
     const wait = this.args.wait || 500;

--- a/ui/lib/core/addon/components/kv-suggestion-input.hbs
+++ b/ui/lib/core/addon/components/kv-suggestion-input.hbs
@@ -7,11 +7,10 @@
     <FormFieldLabel for={{this.inputId}} @label={{@label}} @subText={{@subText}} />
   {{/if}}
   <FilterInput
-    id={{this.inputId}}
+    @id={{this.inputId}}
     placeholder="Path to secret"
-    value={{@value}}
+    @value={{@value}}
     disabled={{not @mountPath}}
-    @hideIcon={{true}}
     @onInput={{this.onInput}}
     {{! used to trigger dropdown to open }}
     {{on "click" this.onInputClick}}

--- a/ui/lib/ldap/addon/components/page/libraries.hbs
+++ b/ui/lib/ldap/addon/components/page/libraries.hbs
@@ -9,7 +9,7 @@
       <FilterInput
         aria-label="Filter libraries"
         placeholder="Filter libraries"
-        value={{this.filterValue}}
+        @value={{this.filterValue}}
         @wait={{200}}
         @onInput={{fn (mut this.filterValue)}}
       />

--- a/ui/lib/ldap/addon/components/page/roles.hbs
+++ b/ui/lib/ldap/addon/components/page/roles.hbs
@@ -9,8 +9,7 @@
       <FilterInput
         aria-label="Filter roles"
         placeholder="Filter roles"
-        value={{@pageFilter}}
-        @autofocus={{true}}
+        @value={{@pageFilter}}
         @onInput={{this.onFilterChange}}
       />
     {{/if}}

--- a/ui/lib/sync/addon/components/secrets/page/destinations.hbs
+++ b/ui/lib/sync/addon/components/secrets/page/destinations.hbs
@@ -32,12 +32,11 @@
     />
     <div class="has-left-margin-s">
       <FilterInput
-        id="name-filter"
+        @id="name-filter"
         aria-label="Filter by name"
         placeholder="Filter by name"
-        value={{@nameFilter}}
+        @value={{@nameFilter}}
         data-test-filter="name"
-        @autofocus={{true}}
         @onInput={{fn this.onFilterChange "name"}}
       />
     </div>

--- a/ui/lib/sync/addon/components/secrets/page/destinations/destination/sync.hbs
+++ b/ui/lib/sync/addon/components/secrets/page/destinations/destination/sync.hbs
@@ -59,9 +59,9 @@
       {{else}}
         <FormFieldLabel for="kv-mount-input" @label="Enter an existing KV engine mount" />
         <FilterInput
-          id="kv-mount-input"
+          @id="kv-mount-input"
           placeholder="KV engine mount path"
-          value={{this.mountPath}}
+          @value={{this.mountPath}}
           @onInput={{fn (mut this.mountPath)}}
           data-test-sync-mount-input
         />

--- a/ui/tests/integration/components/filter-input-test.js
+++ b/ui/tests/integration/components/filter-input-test.js
@@ -17,18 +17,13 @@ module('Integration | Component | filter-input', function (hooks) {
     this.onClick = () => assert.ok(true, 'on click modifier passed to input element');
 
     await render(
-      hbs`<FilterInput aria-label="test-component" placeholder="Filter roles" value="foo" {{on "click" this.onClick}} />`
+      hbs`<FilterInput aria-label="test-component" placeholder="Filter roles" @value="foo" {{on "click" this.onClick}} />`
     );
     await click('[data-test-filter-input]');
     assert
       .dom('[data-test-filter-input]')
       .hasAttribute('placeholder', 'Filter roles', 'Placeholder passed to input element');
     assert.dom('[data-test-filter-input]').hasValue('foo', 'Value passed to input element');
-  });
-
-  test('it should focus input on insert', async function (assert) {
-    await render(hbs`<FilterInput id="hello" aria-label="test-component" @autofocus={{true}} />`);
-    assert.dom('[data-test-filter-input]').isFocused('Input is focussed');
   });
 
   test('it should send input event', async function (assert) {
@@ -40,21 +35,5 @@ module('Integration | Component | filter-input', function (hooks) {
 
     await render(hbs`<FilterInput aria-label="test-component" @wait={{0}} @onInput={{this.onInput}} />`);
     await fillIn('[data-test-filter-input]', 'foo');
-  });
-
-  test('it should render icon', async function (assert) {
-    await render(hbs`<FilterInput aria-label="test-component" />`);
-    assert
-      .dom('[data-test-filter-input-container]')
-      .hasClass('has-icons-left', 'Icon class exists on container');
-    assert.dom('[data-test-filter-input-icon]').exists('Icon renders');
-  });
-
-  test('it should hide icon', async function (assert) {
-    await render(hbs`<FilterInput aria-label="test-component" @hideIcon={{true}} />`);
-    assert
-      .dom('[data-test-filter-input-container]')
-      .doesNotHaveClass('has-icons-left', 'Icon class does not exist on container');
-    assert.dom('[data-test-filter-input-icon]').doesNotExist('Icon is hidden');
   });
 });


### PR DESCRIPTION
### Description
What does this PR do?

- [x] replaces the internal implementation of `FilterInput` with the equivalent `Hds::Form::TextInput::Base`
    - in the process we have made a few structural changes:
        - removed the `<div class="control >` wrapper (not needed anymore)
        - removed the autofocus feature (has negative accessibility implications, see [thread](https://hashicorp.slack.com/archives/C05DGFEBCP2/p1742246879189389))
- [x] updated all the existing `FilterInput` instances to use the correct `Hds::Form::TextInput::Base` arguments/API
- [x] updated the integration tests for the `FilterInput` component

Jira ticket: https://hashicorp.atlassian.net/browse/VAULT-34704

A few video recordings of the updates UIs:
- https://github.com/user-attachments/assets/1415e3ae-ecfd-4747-9471-9bab0a951adf
- https://github.com/user-attachments/assets/0782dbcb-c118-43a2-b62c-a365dda16482
- https://github.com/user-attachments/assets/332f4045-3444-4886-8420-5a878bacdfc7
- https://github.com/user-attachments/assets/041c337b-edbb-485b-a3aa-0068e58364f7

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
