### PR TITLE
[Hackweek] 🧹 UI: abstract route constants 

### DIFF
--- a/ui/app/app.js
+++ b/ui/app/app.js
@@ -7,6 +7,7 @@ import Application from '@ember/application';
 import Resolver from 'ember-resolver';
 import loadInitializers from 'ember-load-initializers';
 import config from 'vault/config/environment';
+import { ROUTES } from 'vault/utils/routes';
 
 export default class App extends Application {
   modulePrefix = config.modulePrefix;
@@ -129,7 +130,7 @@ export default class App extends Application {
         ],
         externalRoutes: {
           secrets: 'vault.cluster.secrets.backends',
-          externalMountIssuer: 'vault.cluster.secrets.backend.pki.issuers.issuer.details',
+          externalMountIssuer: ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_PKI_ISSUERS_ISSUER_DETAILS,
           secretsListRootConfiguration: 'vault.cluster.secrets.backend.configuration',
         },
       },
@@ -138,7 +139,7 @@ export default class App extends Application {
       dependencies: {
         services: ['flash-messages', 'flags', { 'app-router': 'router' }, 'store', 'pagination', 'version'],
         externalRoutes: {
-          kvSecretOverview: 'vault.cluster.secrets.backend.kv.secret.index',
+          kvSecretOverview: ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_KV_SECRET_INDEX,
           clientCountOverview: 'vault.cluster.clients',
         },
       },

--- a/ui/app/components/alphabet-edit.js
+++ b/ui/app/components/alphabet-edit.js
@@ -9,6 +9,8 @@ import { action } from '@ember/object';
 import { service } from '@ember/service';
 import errorMessage from 'vault/utils/error-message';
 
+import { ROUTES } from 'vault/utils/routes';
+
 /**
  * @module AlphabetEdit
  * `AlphabetEdit` is a component that allows you to create/edit or view an alphabet.
@@ -33,7 +35,7 @@ export default class AlphabetEditComponent extends Component {
     return [
       {
         label: backend,
-        route: 'vault.cluster.secrets.backend.list-root',
+        route: ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_LISTROOT,
         model: backend,
         query: { tab: 'alphabet' },
       },
@@ -45,12 +47,12 @@ export default class AlphabetEditComponent extends Component {
     this.errorMessage = '';
     const { backend, id } = this.args.model;
     if (route === 'list') {
-      this.router.transitionTo('vault.cluster.secrets.backend.list-root', backend, {
+      this.router.transitionTo(ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_LISTROOT, backend, {
         queryParams: { tab: 'alphabet' },
       });
       return;
     } else {
-      this.router.transitionTo('vault.cluster.secrets.backend.show', `alphabet/${id}`);
+      this.router.transitionTo(ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_SHOW, `alphabet/${id}`);
     }
   }
 

--- a/ui/app/components/auth-config-form/config.js
+++ b/ui/app/components/auth-config-form/config.js
@@ -8,6 +8,7 @@ import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { task } from 'ember-concurrency';
 import { waitFor } from '@ember/test-waiters';
+import { ROUTES } from 'vault/utils/routes';
 
 /**
  * @module AuthConfigForm/Config
@@ -38,7 +39,7 @@ export default class AuthConfigBase extends Component {
       }
       return;
     }
-    this.router.transitionTo('vault.cluster.access.methods').followRedirects();
+    this.router.transitionTo(ROUTES.VAULT_CLUSTER_ACCESS_METHODS).followRedirects();
     this.flashMessages.success('The configuration was saved successfully.');
   }
 }

--- a/ui/app/components/auth-config-form/options.js
+++ b/ui/app/components/auth-config-form/options.js
@@ -10,6 +10,7 @@ import { task } from 'ember-concurrency';
 import { waitFor } from '@ember/test-waiters';
 import { tracked } from '@glimmer/tracking';
 import errorMessage from 'vault/utils/error-message';
+import { ROUTES } from 'vault/utils/routes';
 
 /**
  * @module AuthConfigForm/Options
@@ -62,7 +63,7 @@ export default class AuthConfigOptions extends AuthConfigComponent {
       }
       throw err;
     }
-    this.router.transitionTo('vault.cluster.access.methods').followRedirects();
+    this.router.transitionTo(ROUTES.VAULT_CLUSTER_ACCESS_METHODS).followRedirects();
     this.flashMessages.success('The configuration was saved successfully.');
   }
 }

--- a/ui/app/components/dashboard/quick-actions-card.js
+++ b/ui/app/components/dashboard/quick-actions-card.js
@@ -8,6 +8,7 @@ import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { service } from '@ember/service';
 import { pathIsDirectory } from 'kv/utils/kv-breadcrumbs';
+import { ROUTES } from 'vault/utils/routes';
 /**
  * @module DashboardQuickActionsCard
  * DashboardQuickActionsCard component allows users to see a list of secrets engines filtered by
@@ -49,7 +50,7 @@ export default class DashboardQuickActionsCard extends Component {
           subText: 'Path of the secret you want to read.',
           buttonText: 'Read secrets',
           model: 'kv/metadata',
-          route: 'vault.cluster.secrets.backend.kv.secret.index',
+          route: ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_KV_SECRET_INDEX,
           nameKey: 'path',
           queryObject: { pathToSecret: '', backend: this.selectedEngine.id },
           objectKeys: ['path', 'id'],
@@ -59,7 +60,7 @@ export default class DashboardQuickActionsCard extends Component {
           title: 'Role to use',
           buttonText: 'Generate credentials',
           model: 'database/role',
-          route: 'vault.cluster.secrets.backend.credentials',
+          route: ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_CREDENTIALS,
           queryObject: { backend: this.selectedEngine.id },
         };
       case 'Issue certificate':
@@ -68,7 +69,7 @@ export default class DashboardQuickActionsCard extends Component {
           placeholder: 'Type to find a role',
           buttonText: 'Issue leaf certificate',
           model: 'pki/role',
-          route: 'vault.cluster.secrets.backend.pki.roles.role.generate',
+          route: ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_PKI_ROLES_ROLE_GENERATE,
           queryObject: { backend: this.selectedEngine.id },
         };
       case 'View certificate':
@@ -77,7 +78,7 @@ export default class DashboardQuickActionsCard extends Component {
           placeholder: '33:a3:...',
           buttonText: 'View certificate',
           model: 'pki/certificate/base',
-          route: 'vault.cluster.secrets.backend.pki.certificates.certificate.details',
+          route: ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_PKI_CERTIFICATES_CERTIFICATE_DETAILS,
           queryObject: { backend: this.selectedEngine.id },
         };
       case 'View issuer':
@@ -86,7 +87,7 @@ export default class DashboardQuickActionsCard extends Component {
           placeholder: 'Type issuer name or ID',
           buttonText: 'View issuer',
           model: 'pki/issuer',
-          route: 'vault.cluster.secrets.backend.pki.issuers.issuer.details',
+          route: ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_PKI_ISSUERS_ISSUER_DETAILS,
           nameKey: 'issuerName',
           queryObject: { backend: this.selectedEngine.id },
           objectKeys: ['id', 'issuerName'],
@@ -149,7 +150,7 @@ export default class DashboardQuickActionsCard extends Component {
       const path = this.paramValue.path || this.paramValue;
       route = pathIsDirectory(path)
         ? 'vault.cluster.secrets.backend.kv.list-directory'
-        : 'vault.cluster.secrets.backend.kv.secret.index';
+        : ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_KV_SECRET_INDEX;
       param = path;
     }
 

--- a/ui/app/components/database-connection.js
+++ b/ui/app/components/database-connection.js
@@ -10,8 +10,7 @@ import { action } from '@ember/object';
 import { waitFor } from '@ember/test-waiters';
 import { task } from 'ember-concurrency';
 
-const LIST_ROOT_ROUTE = 'vault.cluster.secrets.backend.list-root';
-const SHOW_ROUTE = 'vault.cluster.secrets.backend.show';
+import { ROUTES } from 'vault/utils/routes';
 
 const getErrorMessage = (errors) => {
   let errorMessage = errors?.join('. ') || 'Something went wrong. Check the Vault logs for more information.';
@@ -76,7 +75,7 @@ export default class DatabaseConnectionEdit extends Component {
     if (this.continueWithRotate.isRunning) return;
     this.showSaveModal = false;
     const { name } = this.args.model;
-    this.transitionToRoute(SHOW_ROUTE, name);
+    this.transitionToRoute(ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_SHOW, name);
   }
 
   continueWithRotate = task(
@@ -85,10 +84,10 @@ export default class DatabaseConnectionEdit extends Component {
       try {
         await this.rotateCredentials(backend, name);
         this.flashMessages.success(`Successfully rotated root credentials for connection "${name}"`);
-        this.transitionToRoute(SHOW_ROUTE, name);
+        this.transitionToRoute(ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_SHOW, name);
       } catch (e) {
         this.flashMessages.danger(`Error rotating root credentials: ${e.errors}`);
-        this.transitionToRoute(SHOW_ROUTE, name);
+        this.transitionToRoute(ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_SHOW, name);
       } finally {
         this.showSaveModal = false;
       }
@@ -103,7 +102,7 @@ export default class DatabaseConnectionEdit extends Component {
     secret
       .save()
       .then(() => {
-        this.transitionToRoute(SHOW_ROUTE, secretId);
+        this.transitionToRoute(ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_SHOW, secretId);
       })
       .catch((e) => {
         const errorMessage = getErrorMessage(e.errors);
@@ -117,7 +116,7 @@ export default class DatabaseConnectionEdit extends Component {
     const secret = this.args.model;
     const backend = secret.backend;
     secret.destroyRecord().then(() => {
-      this.transitionToRoute(LIST_ROOT_ROUTE, backend);
+      this.transitionToRoute(ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_LISTROOT, backend);
     });
   }
 

--- a/ui/app/components/database-role-edit.js
+++ b/ui/app/components/database-role-edit.js
@@ -9,6 +9,7 @@ import { tracked } from '@glimmer/tracking';
 import { waitFor } from '@ember/test-waiters';
 import { task } from 'ember-concurrency';
 import errorMessage from 'vault/utils/error-message';
+import { ROUTES } from 'vault/utils/routes';
 
 /**
  * @module DatabaseRoleEdit component is used to configure a database role.
@@ -26,8 +27,6 @@ import errorMessage from 'vault/utils/error-message';
  * @param {string} mode - The mode to render. Either 'create' or 'edit'.
  * @param {string} [initialKey] - The initial key to set for the database role.
  */
-const LIST_ROOT_ROUTE = 'vault.cluster.secrets.backend.list-root';
-const SHOW_ROUTE = 'vault.cluster.secrets.backend.show';
 export default class DatabaseRoleEdit extends Component {
   @service router;
   @service flashMessages;
@@ -85,7 +84,7 @@ export default class DatabaseRoleEdit extends Component {
 
   @action
   generateCreds(roleId, roleType = '') {
-    this.router.transitionTo('vault.cluster.secrets.backend.credentials', roleId, {
+    this.router.transitionTo(ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_CREDENTIALS, roleId, {
       queryParams: { roleType },
     });
   }
@@ -98,7 +97,9 @@ export default class DatabaseRoleEdit extends Component {
       .destroyRecord()
       .then(() => {
         try {
-          this.router.transitionTo(LIST_ROOT_ROUTE, backend, { queryParams: { tab: 'role' } });
+          this.router.transitionTo(ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_LISTROOT, backend, {
+            queryParams: { tab: 'role' },
+          });
         } catch (e) {
           console.debug(e); // eslint-disable-line
         }
@@ -122,7 +123,7 @@ export default class DatabaseRoleEdit extends Component {
       }
       try {
         await model.save();
-        this.router.transitionTo(SHOW_ROUTE, `role/${model.name}`);
+        this.router.transitionTo(ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_SHOW, `role/${model.name}`);
       } catch (e) {
         this.errorMessage = errorMessage(e);
         this.flashMessages.danger(

--- a/ui/app/components/generate-credentials.js
+++ b/ui/app/components/generate-credentials.js
@@ -7,6 +7,7 @@ import { service } from '@ember/service';
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
+import { ROUTES } from 'vault/utils/routes';
 
 const CREDENTIAL_TYPES = {
   ssh: {
@@ -63,7 +64,7 @@ export default class GenerateCredentials extends Component {
       return type.model;
     }
     // if we don't have a mode for that type then redirect them back to the backend list
-    this.router.transitionTo('vault.cluster.secrets.backend.list-root', this.args.backendPath);
+    this.router.transitionTo(ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_LISTROOT, this.args.backendPath);
   }
 
   get helpText() {

--- a/ui/app/components/generated-item.js
+++ b/ui/app/components/generated-item.js
@@ -9,6 +9,7 @@ import Component from '@ember/component';
 import { computed } from '@ember/object';
 import { task } from 'ember-concurrency';
 import { waitFor } from '@ember/test-waiters';
+import { ROUTES } from 'vault/utils/routes';
 
 /**
  * @module GeneratedItem
@@ -66,7 +67,7 @@ export default Component.extend({
         }
         return;
       }
-      this.router.transitionTo('vault.cluster.access.method.item.list').followRedirects();
+      this.router.transitionTo(ROUTES.VAULT_CLUSTER_ACCESS_METHOD_ITEM_LIST).followRedirects();
       this.flashMessages.success(`Successfully saved ${this.itemType} ${this.model.id}.`);
     })
   ),
@@ -93,7 +94,7 @@ export default Component.extend({
     },
     deleteItem() {
       this.model.destroyRecord().then(() => {
-        this.router.transitionTo('vault.cluster.access.method.item.list').followRedirects();
+        this.router.transitionTo(ROUTES.VAULT_CLUSTER_ACCESS_METHOD_ITEM_LIST).followRedirects();
         this.flashMessages.success(`Successfully deleted ${this.itemType} ${this.model.id}.`);
       });
     },

--- a/ui/app/components/get-credentials-card.js
+++ b/ui/app/components/get-credentials-card.js
@@ -29,6 +29,7 @@ import Component from '@glimmer/component';
 import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
+import { ROUTES } from 'vault/utils/routes';
 
 export default class GetCredentialsCard extends Component {
   @service router;
@@ -39,7 +40,7 @@ export default class GetCredentialsCard extends Component {
     evt.preventDefault();
     const role = this.role;
     if (role) {
-      this.router.transitionTo('vault.cluster.secrets.backend.credentials', role);
+      this.router.transitionTo(ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_CREDENTIALS, role);
     }
   }
 

--- a/ui/app/components/identity/edit-form.js
+++ b/ui/app/components/identity/edit-form.js
@@ -34,11 +34,11 @@ export default Component.extend({
       'create-entity': ROUTES.VAULT_CLUSTER_ACCESS_IDENTITY,
       'edit-entity': ROUTES.VAULT_CLUSTER_ACCESS_IDENTITY_SHOW,
       'merge-entity-merge': ROUTES.VAULT_CLUSTER_ACCESS_IDENTITY,
-      'create-entity-alias': 'vault.cluster.access.identity.aliases',
+      'create-entity-alias': ROUTES.VAULT_CLUSTER_ACCESS_IDENTITY_ALIASES_SHOW,
       'edit-entity-alias': ROUTES.VAULT_CLUSTER_ACCESS_IDENTITY_ALIASES_SHOW,
       'create-group': ROUTES.VAULT_CLUSTER_ACCESS_IDENTITY,
       'edit-group': ROUTES.VAULT_CLUSTER_ACCESS_IDENTITY_SHOW,
-      'create-group-alias': 'vault.cluster.access.identity.aliases',
+      'create-group-alias': ROUTES.VAULT_CLUSTER_ACCESS_IDENTITY_ALIASES_SHOW,
       'edit-group-alias': ROUTES.VAULT_CLUSTER_ACCESS_IDENTITY_ALIASES_SHOW,
     };
     const key = model ? `${mode}-${model.identityType}` : 'merge-entity-alias';

--- a/ui/app/components/identity/edit-form.js
+++ b/ui/app/components/identity/edit-form.js
@@ -9,6 +9,7 @@ import { computed } from '@ember/object';
 import { task } from 'ember-concurrency';
 import { humanize } from 'vault/helpers/humanize';
 import { waitFor } from '@ember/test-waiters';
+import { ROUTES } from 'vault/utils/routes';
 
 export default Component.extend({
   flashMessages: service(),
@@ -30,15 +31,15 @@ export default Component.extend({
   cancelLink: computed('mode', 'model.identityType', function () {
     const { model, mode } = this;
     const routes = {
-      'create-entity': 'vault.cluster.access.identity',
-      'edit-entity': 'vault.cluster.access.identity.show',
-      'merge-entity-merge': 'vault.cluster.access.identity',
+      'create-entity': ROUTES.VAULT_CLUSTER_ACCESS_IDENTITY,
+      'edit-entity': ROUTES.VAULT_CLUSTER_ACCESS_IDENTITY_SHOW,
+      'merge-entity-merge': ROUTES.VAULT_CLUSTER_ACCESS_IDENTITY,
       'create-entity-alias': 'vault.cluster.access.identity.aliases',
-      'edit-entity-alias': 'vault.cluster.access.identity.aliases.show',
-      'create-group': 'vault.cluster.access.identity',
-      'edit-group': 'vault.cluster.access.identity.show',
+      'edit-entity-alias': ROUTES.VAULT_CLUSTER_ACCESS_IDENTITY_ALIASES_SHOW,
+      'create-group': ROUTES.VAULT_CLUSTER_ACCESS_IDENTITY,
+      'edit-group': ROUTES.VAULT_CLUSTER_ACCESS_IDENTITY_SHOW,
       'create-group-alias': 'vault.cluster.access.identity.aliases',
-      'edit-group-alias': 'vault.cluster.access.identity.aliases.show',
+      'edit-group-alias': ROUTES.VAULT_CLUSTER_ACCESS_IDENTITY_ALIASES_SHOW,
     };
     const key = model ? `${mode}-${model.identityType}` : 'merge-entity-alias';
     return routes[key];

--- a/ui/app/components/identity/lookup-input.js
+++ b/ui/app/components/identity/lookup-input.js
@@ -7,6 +7,7 @@ import { service } from '@ember/service';
 import Component from '@ember/component';
 import { task } from 'ember-concurrency';
 import { underscore } from 'vault/helpers/underscore';
+import { ROUTES } from 'vault/utils/routes';
 
 export default Component.extend({
   store: service(),
@@ -63,7 +64,7 @@ export default Component.extend({
       return;
     }
     if (response) {
-      return this.router.transitionTo('vault.cluster.access.identity.show', response.id, 'details');
+      return this.router.transitionTo(ROUTES.VAULT_CLUSTER_ACCESS_IDENTITY_SHOW, response.id, 'details');
     } else {
       flash.danger(`We were unable to find an identity ${type} with a "${param}" of "${paramValue}".`);
     }

--- a/ui/app/components/keymgmt/key-edit.js
+++ b/ui/app/components/keymgmt/key-edit.js
@@ -9,6 +9,7 @@ import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { task } from 'ember-concurrency';
 import { waitFor } from '@ember/test-waiters';
+import { ROUTES } from 'vault/utils/routes';
 
 /**
  * @module KeymgmtKeyEdit
@@ -23,8 +24,6 @@ import { waitFor } from '@ember/test-waiters';
  * @param {string} [tab=details] - Options are "details" or "versions" for the show mode only
  */
 
-const LIST_ROOT_ROUTE = 'vault.cluster.secrets.backend.list-root';
-const SHOW_ROUTE = 'vault.cluster.secrets.backend.show';
 export default class KeymgmtKeyEdit extends Component {
   @service store;
   @service router;
@@ -54,7 +53,7 @@ export default class KeymgmtKeyEdit extends Component {
     const { model } = this.args;
     try {
       yield model.save();
-      this.router.transitionTo(SHOW_ROUTE, model.name);
+      this.router.transitionTo(ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_SHOW, model.name);
     } catch (error) {
       let errorMessage = error;
       if (error.errors) {
@@ -65,7 +64,7 @@ export default class KeymgmtKeyEdit extends Component {
       if (!error.errors) {
         // If error was custom from save, only partial fail
         // so it's safe to show the key
-        this.router.transitionTo(SHOW_ROUTE, model.name);
+        this.router.transitionTo(ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_SHOW, model.name);
       }
     }
   }
@@ -89,7 +88,7 @@ export default class KeymgmtKeyEdit extends Component {
     secret
       .destroyRecord()
       .then(() => {
-        this.router.transitionTo(LIST_ROOT_ROUTE, backend);
+        this.router.transitionTo(ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_LISTROOT, backend);
       })
       .catch((e) => {
         this.flashMessages.danger(e.errors?.join('. '));

--- a/ui/app/components/keymgmt/provider-edit.js
+++ b/ui/app/components/keymgmt/provider-edit.js
@@ -10,6 +10,7 @@ import { tracked } from '@glimmer/tracking';
 import { task } from 'ember-concurrency';
 import { waitFor } from '@ember/test-waiters';
 import { removeFromArray } from 'vault/helpers/remove-from-array';
+import { ROUTES } from 'vault/utils/routes';
 
 /**
  * @module KeymgmtProviderEdit
@@ -54,7 +55,7 @@ export default class KeymgmtProviderEdit extends Component {
     const { model } = this.args;
     try {
       yield model.save();
-      this.router.transitionTo('vault.cluster.secrets.backend.show', model.id, {
+      this.router.transitionTo(ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_SHOW, model.id, {
         queryParams: { itemType: 'provider' },
       });
     } catch (error) {

--- a/ui/app/components/role-aws-edit.js
+++ b/ui/app/components/role-aws-edit.js
@@ -6,7 +6,7 @@
 import { isBlank } from '@ember/utils';
 import { set } from '@ember/object';
 import RoleEdit from './role-edit';
-const SHOW_ROUTE = 'vault.cluster.secrets.backend.show';
+import { ROUTES } from 'vault/utils/routes';
 
 export default RoleEdit.extend({
   actions: {
@@ -39,7 +39,7 @@ export default RoleEdit.extend({
 
       this.persist('save', () => {
         this.hasDataChanges();
-        this.transitionToRoute(SHOW_ROUTE, modelId);
+        this.transitionToRoute(ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_SHOW, modelId);
       });
     },
 

--- a/ui/app/components/role-edit.js
+++ b/ui/app/components/role-edit.js
@@ -11,9 +11,7 @@ import Component from '@ember/component';
 import { set } from '@ember/object';
 import FocusOnInsertMixin from 'vault/mixins/focus-on-insert';
 import keys from 'core/utils/key-codes';
-
-const LIST_ROOT_ROUTE = 'vault.cluster.secrets.backend.list-root';
-const SHOW_ROUTE = 'vault.cluster.secrets.backend.show';
+import { ROUTES } from 'vault/utils/routes';
 
 /**
  * @type Class
@@ -52,7 +50,7 @@ export default Component.extend(FocusOnInsertMixin, {
     if (e.keyCode !== keys.ESC || this.mode !== 'show') {
       return;
     }
-    this.transitionToRoute(LIST_ROOT_ROUTE);
+    this.transitionToRoute(ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_LISTROOT);
   },
 
   hasDataChanges() {
@@ -82,7 +80,7 @@ export default Component.extend(FocusOnInsertMixin, {
 
       this.persist('save', () => {
         this.hasDataChanges();
-        this.transitionToRoute(SHOW_ROUTE, modelId);
+        this.transitionToRoute(ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_SHOW, modelId);
       });
     },
 
@@ -97,7 +95,7 @@ export default Component.extend(FocusOnInsertMixin, {
     delete() {
       this.persist('destroyRecord', () => {
         this.hasDataChanges();
-        this.transitionToRoute(LIST_ROOT_ROUTE);
+        this.transitionToRoute(ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_LISTROOT);
       });
     },
 

--- a/ui/app/components/secret-create-or-update.js
+++ b/ui/app/components/secret-create-or-update.js
@@ -36,10 +36,9 @@ import { tracked } from '@glimmer/tracking';
 import { isBlank, isNone } from '@ember/utils';
 import { task, waitForEvent } from 'ember-concurrency';
 import { WHITESPACE_WARNING } from 'vault/utils/model-helpers/validators';
+import { ROUTES } from 'vault/utils/routes';
 
 const LIST_ROUTE = 'vault.cluster.secrets.backend.list';
-const LIST_ROOT_ROUTE = 'vault.cluster.secrets.backend.list-root';
-const SHOW_ROUTE = 'vault.cluster.secrets.backend.show';
 
 export default class SecretCreateOrUpdate extends Component {
   @tracked codemirrorString = null;
@@ -96,7 +95,7 @@ export default class SecretCreateOrUpdate extends Component {
     if (parentKey) {
       this.transitionToRoute(LIST_ROUTE, parentKey);
     } else {
-      this.transitionToRoute(LIST_ROOT_ROUTE);
+      this.transitionToRoute(ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_LISTROOT);
     }
   }
   pathHasWhiteSpace(value) {
@@ -188,7 +187,7 @@ export default class SecretCreateOrUpdate extends Component {
       this.flashMessages.success(
         `Secret ${secretPath} ${type === 'create' ? 'created' : 'updated'} successfully.`
       );
-      this.transitionToRoute(SHOW_ROUTE, secretPath);
+      this.transitionToRoute(ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_SHOW, secretPath);
     });
   }
   @action

--- a/ui/app/components/secret-edit-toolbar.js
+++ b/ui/app/components/secret-edit-toolbar.js
@@ -40,6 +40,7 @@ import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { task } from 'ember-concurrency';
 import { waitFor } from '@ember/test-waiters';
+import { ROUTES } from 'vault/utils/routes';
 
 export default class SecretEditToolbar extends Component {
   @service store;
@@ -56,7 +57,7 @@ export default class SecretEditToolbar extends Component {
   @action
   handleDelete() {
     this.args.model.destroyRecord().then(() => {
-      this.router.transitionTo('vault.cluster.secrets.backend.list-root');
+      this.router.transitionTo(ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_LISTROOT);
     });
   }
 

--- a/ui/app/components/transform-edit-base.js
+++ b/ui/app/components/transform-edit-base.js
@@ -9,9 +9,7 @@ import { isBlank } from '@ember/utils';
 import Component from '@ember/component';
 import { set } from '@ember/object';
 import FocusOnInsertMixin from 'vault/mixins/focus-on-insert';
-
-const LIST_ROOT_ROUTE = 'vault.cluster.secrets.backend.list-root';
-const SHOW_ROUTE = 'vault.cluster.secrets.backend.show';
+import { ROUTES } from 'vault/utils/routes';
 
 export const addToList = (list, itemToAdd) => {
   if (!list || !Array.isArray(list)) return list;
@@ -90,7 +88,7 @@ export default Component.extend(FocusOnInsertMixin, {
     this.persist('destroyRecord', () => {
       this.hasDataChanges();
       callback();
-      this.transitionToRoute(LIST_ROOT_ROUTE, { queryParams: { tab } });
+      this.transitionToRoute(ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_LISTROOT, { queryParams: { tab } });
     });
   },
 
@@ -106,7 +104,7 @@ export default Component.extend(FocusOnInsertMixin, {
     this.persist('save', () => {
       this.hasDataChanges();
       callback();
-      this.transitionToRoute(SHOW_ROUTE, `${modelPrefix}${modelId}`);
+      this.transitionToRoute(ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_SHOW, `${modelPrefix}${modelId}`);
     });
   },
 

--- a/ui/app/components/transform-template-edit.js
+++ b/ui/app/components/transform-template-edit.js
@@ -8,6 +8,7 @@ import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import errorMessage from 'vault/utils/error-message';
+import { ROUTES } from 'vault/utils/routes';
 
 /**
  * @module TransformTemplateEdit
@@ -33,7 +34,7 @@ export default class TransformTemplateEditComponent extends Component {
     return [
       {
         label: backend,
-        route: 'vault.cluster.secrets.backend.list-root',
+        route: ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_LISTROOT,
         model: backend,
         query: { tab: 'template' },
       },
@@ -45,12 +46,12 @@ export default class TransformTemplateEditComponent extends Component {
     this.errorMessage = '';
     const { backend, id } = this.args.model;
     if (route === 'list') {
-      this.router.transitionTo('vault.cluster.secrets.backend.list-root', backend, {
+      this.router.transitionTo(ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_LISTROOT, backend, {
         queryParams: { tab: 'template' },
       });
       return;
     } else {
-      this.router.transitionTo('vault.cluster.secrets.backend.show', `template/${id}`);
+      this.router.transitionTo(ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_SHOW, `template/${id}`);
     }
   }
 

--- a/ui/app/components/transit-edit.js
+++ b/ui/app/components/transit-edit.js
@@ -12,9 +12,7 @@ import { set } from '@ember/object';
 
 import FocusOnInsertMixin from 'vault/mixins/focus-on-insert';
 import keys from 'core/utils/key-codes';
-
-const LIST_ROOT_ROUTE = 'vault.cluster.secrets.backend.list-root';
-const SHOW_ROUTE = 'vault.cluster.secrets.backend.show';
+import { ROUTES } from 'vault/utils/routes';
 
 export default Component.extend(FocusOnInsertMixin, {
   router: service(),
@@ -37,11 +35,11 @@ export default Component.extend(FocusOnInsertMixin, {
     const baseCrumbs = [
       {
         label: 'Secrets',
-        route: 'vault.cluster.secrets',
+        route: ROUTES.VAULT_CLUSTER_SECRETS,
       },
       {
         label: this.key.backend,
-        route: 'vault.cluster.secrets.backend.list-root',
+        route: ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_LISTROOT,
         model: this.key.backend,
       },
     ];
@@ -57,7 +55,7 @@ export default Component.extend(FocusOnInsertMixin, {
         ...baseCrumbs,
         {
           label: this.key.id,
-          route: 'vault.cluster.secrets.backend.show',
+          route: ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_SHOW,
           models: [this.key.backend, this.key.id],
           query: { tab: 'details' },
         },
@@ -86,7 +84,7 @@ export default Component.extend(FocusOnInsertMixin, {
     if (e.keyCode !== keys.ESC || this.mode !== 'show') {
       return;
     }
-    this.transitionToRoute(LIST_ROOT_ROUTE);
+    this.transitionToRoute(ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_LISTROOT);
   },
 
   hasDataChanges() {
@@ -120,7 +118,9 @@ export default Component.extend(FocusOnInsertMixin, {
         'save',
         () => {
           this.hasDataChanges();
-          this.transitionToRoute(SHOW_ROUTE, keyId, { queryParams: { tab: 'details' } });
+          this.transitionToRoute(ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_SHOW, keyId, {
+            queryParams: { tab: 'details' },
+          });
         },
         type === 'create'
       );
@@ -154,7 +154,7 @@ export default Component.extend(FocusOnInsertMixin, {
     deleteKey() {
       this.persistKey('destroyRecord', () => {
         this.hasDataChanges();
-        this.transitionToRoute(LIST_ROOT_ROUTE);
+        this.transitionToRoute(ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_LISTROOT);
       });
     },
   },

--- a/ui/app/controllers/vault/cluster/access/identity/aliases/add.js
+++ b/ui/app/controllers/vault/cluster/access/identity/aliases/add.js
@@ -3,8 +3,9 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
+import { ROUTES } from 'vault/utils/routes';
 import CreateController from '../create';
 
 export default CreateController.extend({
-  showRoute: 'vault.cluster.access.identity.aliases.show',
+  showRoute: ROUTES.VAULT_CLUSTER_ACCESS_IDENTITY_ALIASES_SHOW,
 });

--- a/ui/app/controllers/vault/cluster/access/identity/create.js
+++ b/ui/app/controllers/vault/cluster/access/identity/create.js
@@ -5,13 +5,14 @@
 
 import Controller from '@ember/controller';
 import { service } from '@ember/service';
+import { ROUTES } from 'vault/utils/routes';
 
 /**
  * @type Class
  */
 export default Controller.extend({
   router: service(),
-  showRoute: 'vault.cluster.access.identity.show',
+  showRoute: ROUTES.VAULT_CLUSTER_ACCESS_IDENTITY_SHOW,
   showTab: 'details',
 
   actions: {

--- a/ui/app/controllers/vault/cluster/access/identity/create.js
+++ b/ui/app/controllers/vault/cluster/access/identity/create.js
@@ -20,8 +20,8 @@ export default Controller.extend({
       const isDelete = saveType === 'delete';
       const type = model.identityType;
       const listRoutes = {
-        'entity-alias': 'vault.cluster.access.identity.aliases.index',
-        'group-alias': 'vault.cluster.access.identity.aliases.index',
+        'entity-alias': ROUTES.VAULT_CLUSTER_ACCESS_IDENTITY_ALIASES_INDEX,
+        'group-alias': ROUTES.VAULT_CLUSTER_ACCESS_IDENTITY_ALIASES_INDEX,
         group: 'vault.cluster.access.identity.index',
         entity: 'vault.cluster.access.identity.index',
       };

--- a/ui/app/helpers/tabs-for-auth-section.js
+++ b/ui/app/helpers/tabs-for-auth-section.js
@@ -6,85 +6,86 @@
 import { helper as buildHelper } from '@ember/component/helper';
 import { pluralize } from 'ember-inflector';
 import { capitalize } from '@ember/string';
+import { ROUTES } from 'vault/utils/routes';
 
 const TABS_FOR_SETTINGS = {
   aws: [
     {
       label: 'Client',
-      route: 'vault.cluster.settings.auth.configure.section',
+      route: ROUTES.VAULT_CLUSTER_SETTINGS_AUTH_CONFIGURE_SECTION,
       routeParams: ['client'],
     },
     {
       label: 'Identity Allow List Tidy',
-      route: 'vault.cluster.settings.auth.configure.section',
+      route: ROUTES.VAULT_CLUSTER_SETTINGS_AUTH_CONFIGURE_SECTION,
       routeParams: ['identity-accesslist'],
     },
     {
       label: 'Role Tag Deny List Tidy',
-      route: 'vault.cluster.settings.auth.configure.section',
+      route: ROUTES.VAULT_CLUSTER_SETTINGS_AUTH_CONFIGURE_SECTION,
       routeParams: ['roletag-denylist'],
     },
   ],
   azure: [
     {
       label: 'Configuration',
-      route: 'vault.cluster.settings.auth.configure.section',
+      route: ROUTES.VAULT_CLUSTER_SETTINGS_AUTH_CONFIGURE_SECTION,
       routeParams: ['configuration'],
     },
   ],
   github: [
     {
       label: 'Configuration',
-      route: 'vault.cluster.settings.auth.configure.section',
+      route: ROUTES.VAULT_CLUSTER_SETTINGS_AUTH_CONFIGURE_SECTION,
       routeParams: ['configuration'],
     },
   ],
   gcp: [
     {
       label: 'Configuration',
-      route: 'vault.cluster.settings.auth.configure.section',
+      route: ROUTES.VAULT_CLUSTER_SETTINGS_AUTH_CONFIGURE_SECTION,
       routeParams: ['configuration'],
     },
   ],
   jwt: [
     {
       label: 'Configuration',
-      route: 'vault.cluster.settings.auth.configure.section',
+      route: ROUTES.VAULT_CLUSTER_SETTINGS_AUTH_CONFIGURE_SECTION,
       routeParams: ['configuration'],
     },
   ],
   oidc: [
     {
       label: 'Configuration',
-      route: 'vault.cluster.settings.auth.configure.section',
+      route: ROUTES.VAULT_CLUSTER_SETTINGS_AUTH_CONFIGURE_SECTION,
       routeParams: ['configuration'],
     },
   ],
   kubernetes: [
     {
       label: 'Configuration',
-      route: 'vault.cluster.settings.auth.configure.section',
+      route: ROUTES.VAULT_CLUSTER_SETTINGS_AUTH_CONFIGURE_SECTION,
       routeParams: ['configuration'],
     },
   ],
   ldap: [
     {
       label: 'Configuration',
-      route: 'vault.cluster.settings.auth.configure.section',
+      route: ROUTES.VAULT_CLUSTER_SETTINGS_AUTH_CONFIGURE_SECTION,
       routeParams: ['configuration'],
     },
   ],
   okta: [
     {
       label: 'Configuration',
-      route: 'vault.cluster.settings.auth.configure.section',
+      route: ROUTES.VAULT_CLUSTER_SETTINGS_AUTH_CONFIGURE_SECTION,
       routeParams: ['configuration'],
     },
   ],
   radius: [
     {
       label: 'Configuration',
-      route: 'vault.cluster.settings.auth.configure.section',
+      route: ROUTES.VAULT_CLUSTER_SETTINGS_AUTH_CONFIGURE_SECTION,
       routeParams: ['configuration'],
     },
   ],
@@ -98,7 +99,7 @@ export function tabsForAuthSection([authMethodModel, sectionType = 'authSettings
     tabs = (TABS_FOR_SETTINGS[authMethodModel.type] || []).slice();
     tabs.push({
       label: 'Method Options',
-      route: 'vault.cluster.settings.auth.configure.section',
+      route: ROUTES.VAULT_CLUSTER_SETTINGS_AUTH_CONFIGURE_SECTION,
       routeParams: [authMethodModel.id, 'options'],
     });
     return tabs;
@@ -113,7 +114,7 @@ export function tabsForAuthSection([authMethodModel, sectionType = 'authSettings
     tabs = paths.compact().map((path) => {
       return {
         label: capitalize(pluralize(path.itemName)),
-        route: 'vault.cluster.access.method.item.list',
+        route: ROUTES.VAULT_CLUSTER_ACCESS_METHOD_ITEM_LIST,
         routeParams: [path.itemType],
       };
     });
@@ -122,7 +123,7 @@ export function tabsForAuthSection([authMethodModel, sectionType = 'authSettings
   }
   tabs.push({
     label: 'Configuration',
-    route: 'vault.cluster.access.method.section',
+    route: ROUTES.VAULT_CLUSTER_ACCESS_METHOD_SECTION,
     routeParams: ['configuration'],
   });
 

--- a/ui/app/mixins/backend-crumb.js
+++ b/ui/app/mixins/backend-crumb.js
@@ -5,6 +5,7 @@
 
 import { computed } from '@ember/object';
 import Mixin from '@ember/object/mixin';
+import { ROUTES } from 'vault/utils/routes';
 
 export default Mixin.create({
   backendCrumb: computed('backend', function () {
@@ -17,7 +18,7 @@ export default Mixin.create({
     return {
       label: backend,
       text: backend,
-      path: 'vault.cluster.secrets.backend.list-root',
+      path: ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_LISTROOT,
       model: backend,
     };
   }),

--- a/ui/app/models/mfa-login-enforcement.js
+++ b/ui/app/models/mfa-login-enforcement.js
@@ -11,6 +11,7 @@ import { withModelValidations } from 'vault/decorators/model-validations';
 import { isPresent } from '@ember/utils';
 import { service } from '@ember/service';
 import { addManyToArray, addToArray } from 'vault/helpers/add-to-array';
+import { ROUTES } from 'vault/utils/routes';
 
 const validations = {
   name: [{ type: 'presence', message: 'Name is required' }],
@@ -97,7 +98,7 @@ export default class MfaLoginEnforcementModel extends Model {
         targets = addToArray(targets, {
           key,
           icon: 'user',
-          link: 'vault.cluster.access.identity.show',
+          link: ROUTES.VAULT_CLUSTER_ACCESS_IDENTITY_SHOW,
           linkModels: [key.split('_')[1], model.id, 'details'],
           title: model.name,
           subTitle: model.id,

--- a/ui/app/routes/vault/cluster/access/identity/aliases/add.js
+++ b/ui/app/routes/vault/cluster/access/identity/aliases/add.js
@@ -6,12 +6,13 @@
 import Route from '@ember/routing/route';
 import UnsavedModelRoute from 'vault/mixins/unsaved-model-route';
 import { service } from '@ember/service';
+import { ROUTES } from 'vault/utils/routes';
 
 export default Route.extend(UnsavedModelRoute, {
   store: service(),
 
   model(params) {
-    const itemType = this.modelFor('vault.cluster.access.identity');
+    const itemType = this.modelFor(ROUTES.VAULT_CLUSTER_ACCESS_IDENTITY);
     const modelType = `identity/${itemType}-alias`;
     return this.store.createRecord(modelType, {
       canonicalId: params.item_id,

--- a/ui/app/routes/vault/cluster/access/identity/aliases/edit.js
+++ b/ui/app/routes/vault/cluster/access/identity/aliases/edit.js
@@ -6,12 +6,13 @@
 import Route from '@ember/routing/route';
 import UnsavedModelRoute from 'vault/mixins/unsaved-model-route';
 import { service } from '@ember/service';
+import { ROUTES } from 'vault/utils/routes';
 
 export default Route.extend(UnsavedModelRoute, {
   store: service(),
 
   model(params) {
-    const itemType = this.modelFor('vault.cluster.access.identity');
+    const itemType = this.modelFor(ROUTES.VAULT_CLUSTER_ACCESS_IDENTITY);
     const modelType = `identity/${itemType}-alias`;
     return this.store.findRecord(modelType, params.item_alias_id);
   },

--- a/ui/app/routes/vault/cluster/access/identity/aliases/index.js
+++ b/ui/app/routes/vault/cluster/access/identity/aliases/index.js
@@ -6,12 +6,13 @@
 import Route from '@ember/routing/route';
 import ListRoute from 'core/mixins/list-route';
 import { service } from '@ember/service';
+import { ROUTES } from 'vault/utils/routes';
 
 export default Route.extend(ListRoute, {
   pagination: service(),
 
   model(params) {
-    const itemType = this.modelFor('vault.cluster.access.identity');
+    const itemType = this.modelFor(ROUTES.VAULT_CLUSTER_ACCESS_IDENTITY);
     const modelType = `identity/${itemType}-alias`;
     return this.pagination
       .lazyPaginatedQuery(modelType, {
@@ -31,7 +32,7 @@ export default Route.extend(ListRoute, {
 
   setupController(controller) {
     this._super(...arguments);
-    controller.set('identityType', this.modelFor('vault.cluster.access.identity'));
+    controller.set('identityType', this.modelFor(ROUTES.VAULT_CLUSTER_ACCESS_IDENTITY));
   },
 
   actions: {

--- a/ui/app/routes/vault/cluster/access/identity/aliases/show.js
+++ b/ui/app/routes/vault/cluster/access/identity/aliases/show.js
@@ -9,13 +9,14 @@ import { set } from '@ember/object';
 import Route from '@ember/routing/route';
 import { TABS } from 'vault/helpers/tabs-for-identity-show';
 import { service } from '@ember/service';
+import { ROUTES } from 'vault/utils/routes';
 
 export default Route.extend({
   store: service(),
 
   model(params) {
     const { section } = params;
-    const itemType = this.modelFor('vault.cluster.access.identity') + '-alias';
+    const itemType = this.modelFor(ROUTES.VAULT_CLUSTER_ACCESS_IDENTITY) + '-alias';
     const tabs = TABS[itemType];
     const modelType = `identity/${itemType}`;
     if (!tabs.includes(section)) {

--- a/ui/app/routes/vault/cluster/access/identity/create.js
+++ b/ui/app/routes/vault/cluster/access/identity/create.js
@@ -6,12 +6,13 @@
 import Route from '@ember/routing/route';
 import UnsavedModelRoute from 'vault/mixins/unsaved-model-route';
 import { service } from '@ember/service';
+import { ROUTES } from 'vault/utils/routes';
 
 export default Route.extend(UnsavedModelRoute, {
   store: service(),
 
   model() {
-    const itemType = this.modelFor('vault.cluster.access.identity');
+    const itemType = this.modelFor(ROUTES.VAULT_CLUSTER_ACCESS_IDENTITY);
     const modelType = `identity/${itemType}`;
     return this.store.createRecord(modelType);
   },

--- a/ui/app/routes/vault/cluster/access/identity/edit.js
+++ b/ui/app/routes/vault/cluster/access/identity/edit.js
@@ -6,12 +6,13 @@
 import Route from '@ember/routing/route';
 import UnsavedModelRoute from 'vault/mixins/unsaved-model-route';
 import { service } from '@ember/service';
+import { ROUTES } from 'vault/utils/routes';
 
 export default Route.extend(UnsavedModelRoute, {
   store: service(),
 
   model(params) {
-    const itemType = this.modelFor('vault.cluster.access.identity');
+    const itemType = this.modelFor(ROUTES.VAULT_CLUSTER_ACCESS_IDENTITY);
     const modelType = `identity/${itemType}`;
     return this.store.findRecord(modelType, params.item_id);
   },

--- a/ui/app/routes/vault/cluster/access/identity/index.js
+++ b/ui/app/routes/vault/cluster/access/identity/index.js
@@ -6,12 +6,13 @@
 import Route from '@ember/routing/route';
 import ListRoute from 'core/mixins/list-route';
 import { service } from '@ember/service';
+import { ROUTES } from 'vault/utils/routes';
 
 export default Route.extend(ListRoute, {
   pagination: service(),
 
   model(params) {
-    const itemType = this.modelFor('vault.cluster.access.identity');
+    const itemType = this.modelFor(ROUTES.VAULT_CLUSTER_ACCESS_IDENTITY);
     const modelType = `identity/${itemType}`;
     return this.pagination
       .lazyPaginatedQuery(modelType, {
@@ -31,7 +32,7 @@ export default Route.extend(ListRoute, {
 
   setupController(controller) {
     this._super(...arguments);
-    controller.set('identityType', this.modelFor('vault.cluster.access.identity'));
+    controller.set('identityType', this.modelFor(ROUTES.VAULT_CLUSTER_ACCESS_IDENTITY));
   },
 
   actions: {

--- a/ui/app/routes/vault/cluster/access/identity/merge.js
+++ b/ui/app/routes/vault/cluster/access/identity/merge.js
@@ -6,15 +6,16 @@
 import Route from '@ember/routing/route';
 import UnloadModelRoute from 'vault/mixins/unload-model-route';
 import { service } from '@ember/service';
+import { ROUTES } from 'vault/utils/routes';
 
 export default Route.extend(UnloadModelRoute, {
   store: service(),
   router: service(),
 
   beforeModel() {
-    const itemType = this.modelFor('vault.cluster.access.identity');
+    const itemType = this.modelFor(ROUTES.VAULT_CLUSTER_ACCESS_IDENTITY);
     if (itemType !== 'entity') {
-      return this.router.transitionTo('vault.cluster.access.identity');
+      return this.router.transitionTo(ROUTES.VAULT_CLUSTER_ACCESS_IDENTITY);
     }
   },
 

--- a/ui/app/routes/vault/cluster/access/identity/show.js
+++ b/ui/app/routes/vault/cluster/access/identity/show.js
@@ -10,6 +10,7 @@ import { set } from '@ember/object';
 import Route from '@ember/routing/route';
 import { TABS } from 'vault/helpers/tabs-for-identity-show';
 import { service } from '@ember/service';
+import { ROUTES } from 'vault/utils/routes';
 
 export default Route.extend({
   router: service(),
@@ -17,7 +18,7 @@ export default Route.extend({
 
   model(params) {
     const { section } = params;
-    const itemType = this.modelFor('vault.cluster.access.identity');
+    const itemType = this.modelFor(ROUTES.VAULT_CLUSTER_ACCESS_IDENTITY);
     const tabs = TABS[itemType];
     const modelType = `identity/${itemType}`;
     if (!tabs.includes(section)) {
@@ -59,7 +60,7 @@ export default Route.extend({
   afterModel(resolvedModel) {
     const { section, model } = resolvedModel;
     if (model?.identityType === 'group' && model?.type === 'internal' && section === 'aliases') {
-      return this.router.transitionTo('vault.cluster.access.identity.show', model.id, 'details');
+      return this.router.transitionTo(ROUTES.VAULT_CLUSTER_ACCESS_IDENTITY_SHOW, model.id, 'details');
     }
   },
 

--- a/ui/app/routes/vault/cluster/access/leases/index.js
+++ b/ui/app/routes/vault/cluster/access/leases/index.js
@@ -5,12 +5,16 @@
 
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
+import { ROUTES } from 'vault/utils/routes';
 
 export default class LeasesIndexRoute extends Route {
   @service router;
 
   beforeModel(transition) {
-    if (this.modelFor('vault.cluster.access.leases').canList && transition.targetName === this.routeName) {
+    if (
+      this.modelFor(ROUTES.VAULT_CLUSTER_ACCESS_LEASES).canList &&
+      transition.targetName === this.routeName
+    ) {
       return this.router.replaceWith('vault.cluster.access.leases.list-root');
     } else {
       return;

--- a/ui/app/routes/vault/cluster/access/leases/list.js
+++ b/ui/app/routes/vault/cluster/access/leases/list.js
@@ -7,6 +7,7 @@ import { set } from '@ember/object';
 import { hash } from 'rsvp';
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
+import { ROUTES } from 'vault/utils/routes';
 
 export default Route.extend({
   pagination: service(),
@@ -25,7 +26,7 @@ export default Route.extend({
 
   model(params) {
     const prefix = params.prefix || '';
-    if (this.modelFor('vault.cluster.access.leases').canList) {
+    if (this.modelFor(ROUTES.VAULT_CLUSTER_ACCESS_LEASES).canList) {
       return hash({
         leases: this.pagination
           .lazyPaginatedQuery('lease', {

--- a/ui/app/routes/vault/cluster/access/leases/show.js
+++ b/ui/app/routes/vault/cluster/access/leases/show.js
@@ -9,6 +9,7 @@ import Route from '@ember/routing/route';
 import { service } from '@ember/service';
 import { keyIsFolder, parentKeyForKey } from 'core/utils/key-utils';
 import UnloadModelRoute from 'vault/mixins/unload-model-route';
+import { ROUTES } from 'vault/utils/routes';
 
 export default Route.extend(UnloadModelRoute, {
   store: service(),
@@ -35,7 +36,7 @@ export default Route.extend(UnloadModelRoute, {
       capabilities: hash({
         renew: this.store.findRecord('capabilities', 'sys/leases/renew'),
         revoke: this.store.findRecord('capabilities', 'sys/leases/revoke'),
-        leases: this.modelFor('vault.cluster.access.leases'),
+        leases: this.modelFor(ROUTES.VAULT_CLUSTER_ACCESS_LEASES),
       }),
     });
   },

--- a/ui/app/routes/vault/cluster/access/mfa/methods/index.js
+++ b/ui/app/routes/vault/cluster/access/mfa/methods/index.js
@@ -5,6 +5,7 @@
 
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
+import { ROUTES } from 'vault/utils/routes';
 
 export default class MfaMethodsRoute extends Route {
   @service store;
@@ -22,7 +23,7 @@ export default class MfaMethodsRoute extends Route {
 
   afterModel(model) {
     if (model.length === 0) {
-      this.router.transitionTo('vault.cluster.access.mfa');
+      this.router.transitionTo(ROUTES.VAULT_CLUSTER_ACCESS_MFA);
     }
   }
   setupController(controller, model) {

--- a/ui/app/routes/vault/cluster/access/oidc/clients/index.js
+++ b/ui/app/routes/vault/cluster/access/oidc/clients/index.js
@@ -5,6 +5,7 @@
 
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
+import { ROUTES } from 'vault/utils/routes';
 export default class OidcClientsRoute extends Route {
   @service store;
   @service router;
@@ -21,7 +22,7 @@ export default class OidcClientsRoute extends Route {
 
   afterModel(model) {
     if (model.length === 0) {
-      this.router.transitionTo('vault.cluster.access.oidc');
+      this.router.transitionTo(ROUTES.VAULT_CLUSTER_ACCESS_OIDC);
     }
   }
 }

--- a/ui/app/routes/vault/cluster/secrets/backend.js
+++ b/ui/app/routes/vault/cluster/secrets/backend.js
@@ -5,6 +5,7 @@
 
 import { service } from '@ember/service';
 import Route from '@ember/routing/route';
+import { ROUTES } from 'vault/utils/routes';
 export default Route.extend({
   flashMessages: service(),
   router: service(),
@@ -29,7 +30,7 @@ export default Route.extend({
   afterModel(model, transition) {
     const path = model && model.path;
     if (transition.targetName === this.routeName) {
-      return this.router.replaceWith('vault.cluster.secrets.backend.list-root', path);
+      return this.router.replaceWith(ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_LISTROOT, path);
     }
   },
 });

--- a/ui/app/routes/vault/cluster/secrets/backend/actions.js
+++ b/ui/app/routes/vault/cluster/secrets/backend/actions.js
@@ -5,6 +5,7 @@
 
 import { parentKeyForKey } from 'core/utils/key-utils';
 import EditBase from './secret-edit';
+import { ROUTES } from 'vault/utils/routes';
 
 export default EditBase.extend({
   queryParams: {
@@ -21,7 +22,7 @@ export default EditBase.extend({
     const { backend } = this.paramsFor('vault.cluster.secrets.backend');
     if (this.backendType(backend) !== 'transit') {
       if (parentKey) {
-        return this.router.transitionTo('vault.cluster.secrets.backend.show', parentKey);
+        return this.router.transitionTo(ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_SHOW, parentKey);
       } else {
         return this.router.transitionTo('vault.cluster.secrets.backend.show-root');
       }
@@ -34,16 +35,16 @@ export default EditBase.extend({
     controller.set('breadcrumbs', [
       {
         label: 'Secrets',
-        route: 'vault.cluster.secrets',
+        route: ROUTES.VAULT_CLUSTER_SECRETS,
       },
       {
         label: model.secret.backend,
-        route: 'vault.cluster.secrets.backend.list-root',
+        route: ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_LISTROOT,
         model: model.secret.backend,
       },
       {
         label: model.secret.id,
-        route: 'vault.cluster.secrets.backend.show',
+        route: ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_SHOW,
         models: [model.secret.backend, model.secret.id],
       },
       {

--- a/ui/app/routes/vault/cluster/secrets/backend/credentials.js
+++ b/ui/app/routes/vault/cluster/secrets/backend/credentials.js
@@ -7,6 +7,7 @@ import { resolve } from 'rsvp';
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
 import ControlGroupError from 'vault/lib/control-group-error';
+import { ROUTES } from 'vault/utils/routes';
 
 const SUPPORTED_DYNAMIC_BACKENDS = ['database', 'ssh', 'aws'];
 
@@ -20,7 +21,7 @@ export default Route.extend({
     const { id: backendPath, type: backendType } = this.modelFor('vault.cluster.secrets.backend');
     // redirect if the backend type does not support credentials
     if (!SUPPORTED_DYNAMIC_BACKENDS.includes(backendType)) {
-      return this.router.transitionTo('vault.cluster.secrets.backend.list-root', backendPath);
+      return this.router.transitionTo(ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_LISTROOT, backendPath);
     }
     // hydrate model if backend type is ssh
     if (backendType === 'ssh') {

--- a/ui/app/routes/vault/cluster/secrets/backend/index.js
+++ b/ui/app/routes/vault/cluster/secrets/backend/index.js
@@ -5,11 +5,12 @@
 
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
+import { ROUTES } from 'vault/utils/routes';
 
 export default class BackendIndexRoute extends Route {
   @service router;
 
   beforeModel() {
-    return this.router.replaceWith('vault.cluster.secrets.backend.list-root');
+    return this.router.replaceWith(ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_LISTROOT);
   }
 }

--- a/ui/app/routes/vault/cluster/secrets/backend/list.js
+++ b/ui/app/routes/vault/cluster/secrets/backend/list.js
@@ -12,6 +12,7 @@ import { service } from '@ember/service';
 import { normalizePath } from 'vault/utils/path-encoding-helpers';
 import { assert } from '@ember/debug';
 import { pathIsDirectory } from 'kv/utils/kv-breadcrumbs';
+import { ROUTES } from 'vault/utils/routes';
 
 const SUPPORTED_BACKENDS = supportedSecretBackends();
 
@@ -80,7 +81,7 @@ export default Route.extend({
   beforeModel() {
     const secret = this.secretParam();
     const backend = this.enginePathParam();
-    const { tab } = this.paramsFor('vault.cluster.secrets.backend.list-root');
+    const { tab } = this.paramsFor(ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_LISTROOT);
     const secretEngine = this.store.peekRecord('secret-engine', backend);
     const type = secretEngine?.engineType;
     assert('secretEngine.engineType is not defined', !!type);
@@ -91,7 +92,7 @@ export default Route.extend({
 
     const engineRoute = allEngines().find((engine) => engine.type === type)?.engineRoute;
     if (!type || !SUPPORTED_BACKENDS.includes(type)) {
-      return this.router.transitionTo('vault.cluster.secrets');
+      return this.router.transitionTo(ROUTES.VAULT_CLUSTER_SECRETS);
     }
     if (this.routeName === 'vault.cluster.secrets.backend.list' && !secret.endsWith('/')) {
       return this.router.replaceWith('vault.cluster.secrets.backend.list', secret + '/');

--- a/ui/app/routes/vault/cluster/secrets/backend/secret-edit.js
+++ b/ui/app/routes/vault/cluster/secrets/backend/secret-edit.js
@@ -10,6 +10,7 @@ import { service } from '@ember/service';
 import Route from '@ember/routing/route';
 import { encodePath, normalizePath } from 'vault/utils/path-encoding-helpers';
 import { keyIsFolder, parentKeyForKey } from 'core/utils/key-utils';
+import { ROUTES } from 'vault/utils/routes';
 
 /**
  * @type Class
@@ -91,8 +92,8 @@ export default Route.extend({
             route = 'vault.cluster.secrets.backend.kv.create';
             params = [secretEngine.id];
             break;
-          case this.routeName === 'vault.cluster.secrets.backend.show':
-            route = 'vault.cluster.secrets.backend.kv.secret.index';
+          case this.routeName === ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_SHOW:
+            route = ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_KV_SECRET_INDEX;
             params = [secretEngine.id, secret];
             break;
           case this.routeName === 'vault.cluster.secrets.backend.edit':
@@ -100,7 +101,7 @@ export default Route.extend({
             params = [secretEngine.id, secret];
             break;
           default:
-            route = 'vault.cluster.secrets.backend.kv.secret.index';
+            route = ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_KV_SECRET_INDEX;
             params = [secretEngine.id, secret];
             break;
         }
@@ -111,7 +112,7 @@ export default Route.extend({
         if (parentKey) {
           this.router.transitionTo('vault.cluster.secrets.backend.list', encodePath(parentKey));
         } else {
-          this.router.transitionTo('vault.cluster.secrets.backend.list-root');
+          this.router.transitionTo(ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_LISTROOT);
         }
         return;
       }

--- a/ui/app/routes/vault/cluster/secrets/backend/sign.js
+++ b/ui/app/routes/vault/cluster/secrets/backend/sign.js
@@ -6,6 +6,7 @@
 import Route from '@ember/routing/route';
 import UnloadModel from 'vault/mixins/unload-model-route';
 import { service } from '@ember/service';
+import { ROUTES } from 'vault/utils/routes';
 
 export default Route.extend(UnloadModel, {
   router: service(),
@@ -32,11 +33,11 @@ export default Route.extend(UnloadModel, {
     const backend = backendModel.id;
 
     if (backendModel.type !== 'ssh') {
-      return this.router.transitionTo('vault.cluster.secrets.backend.list-root', backend);
+      return this.router.transitionTo(ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_LISTROOT, backend);
     }
     return this.store.queryRecord('capabilities', this.pathQuery(role, backend)).then((capabilities) => {
       if (!capabilities.canUpdate) {
-        return this.router.transitionTo('vault.cluster.secrets.backend.list-root', backend);
+        return this.router.transitionTo(ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_LISTROOT, backend);
       }
       return this.store.createRecord('ssh-sign', {
         role: {

--- a/ui/app/routes/vault/cluster/settings/auth/configure/index.js
+++ b/ui/app/routes/vault/cluster/settings/auth/configure/index.js
@@ -6,6 +6,7 @@
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
 import { tabsForAuthSection } from 'vault/helpers/tabs-for-auth-section';
+import { ROUTES } from 'vault/utils/routes';
 
 export default class SettingsAuthConfigureRoute extends Route {
   @service router;
@@ -13,6 +14,6 @@ export default class SettingsAuthConfigureRoute extends Route {
   beforeModel() {
     const model = this.modelFor('vault.cluster.settings.auth.configure');
     const section = tabsForAuthSection([model])[0].routeParams.slice().pop();
-    return this.router.transitionTo('vault.cluster.settings.auth.configure.section', section);
+    return this.router.transitionTo(ROUTES.VAULT_CLUSTER_SETTINGS_AUTH_CONFIGURE_SECTION, section);
   }
 }

--- a/ui/app/services/permissions.js
+++ b/ui/app/services/permissions.js
@@ -7,6 +7,7 @@ import Service, { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { sanitizePath, sanitizeStart } from 'core/utils/sanitize-path';
 import { task } from 'ember-concurrency';
+import { ROUTES } from 'vault/utils/routes';
 
 export const PERMISSIONS_BANNER_STATES = {
   readFailed: 'read-failed',
@@ -58,14 +59,14 @@ const API_PATHS = {
 };
 
 const API_PATHS_TO_ROUTE_PARAMS = {
-  'sys/auth': { route: 'vault.cluster.access.methods', models: [] },
-  'identity/entity/id': { route: 'vault.cluster.access.identity', models: ['entities'] },
-  'identity/group/id': { route: 'vault.cluster.access.identity', models: ['groups'] },
-  'sys/leases/lookup': { route: 'vault.cluster.access.leases', models: [] },
-  'sys/namespaces': { route: 'vault.cluster.access.namespaces', models: [] },
-  'sys/control-group/': { route: 'vault.cluster.access.control-groups', models: [] },
-  'identity/mfa/method': { route: 'vault.cluster.access.mfa', models: [] },
-  'identity/oidc/client': { route: 'vault.cluster.access.oidc', models: [] },
+  'sys/auth': { route: ROUTES.VAULT_CLUSTER_ACCESS_METHODS, models: [] },
+  'identity/entity/id': { route: ROUTES.VAULT_CLUSTER_ACCESS_IDENTITY, models: ['entities'] },
+  'identity/group/id': { route: ROUTES.VAULT_CLUSTER_ACCESS_IDENTITY, models: ['groups'] },
+  'sys/leases/lookup': { route: ROUTES.VAULT_CLUSTER_ACCESS_LEASES, models: [] },
+  'sys/namespaces': { route: ROUTES.VAULT_CLUSTER_ACCESS_NAMESPACES, models: [] },
+  'sys/control-group/': { route: ROUTES.VAULT_CLUSTER_ACCESS_CONTROLGROUPS, models: [] },
+  'identity/mfa/method': { route: ROUTES.VAULT_CLUSTER_ACCESS_MFA, models: [] },
+  'identity/oidc/client': { route: ROUTES.VAULT_CLUSTER_ACCESS_OIDC, models: [] },
 };
 
 /*

--- a/ui/app/utils/routes.js
+++ b/ui/app/utils/routes.js
@@ -1,0 +1,35 @@
+export const ROUTES = {
+  LIST: 'list',
+  MESSAGES: 'messages',
+  OVERVIEW: 'overview',
+  ROLES: 'roles',
+  ROLES_ROLE: 'roles.role',
+  ROLES_ROLE_DETAILS: 'roles.role.details',
+  SECRETS: 'secrets',
+
+  VAULT_CLUSTER_ACCESS_CONTROLGROUPS: 'vault.cluster.access.control-groups',
+  VAULT_CLUSTER_ACCESS_IDENTITY: 'vault.cluster.access.identity',
+  VAULT_CLUSTER_ACCESS_IDENTITY_ALIASES_SHOW: 'vault.cluster.access.identity.aliases.show',
+  VAULT_CLUSTER_ACCESS_IDENTITY_SHOW: 'vault.cluster.access.identity.show',
+  VAULT_CLUSTER_ACCESS_LEASES: 'vault.cluster.access.leases',
+  VAULT_CLUSTER_ACCESS_MFA: 'vault.cluster.access.mfa',
+  VAULT_CLUSTER_ACCESS_METHOD_ITEM_LIST: 'vault.cluster.access.method.item.list',
+  VAULT_CLUSTER_ACCESS_METHOD_SECTION: 'vault.cluster.access.method.section',
+  VAULT_CLUSTER_ACCESS_METHODS: 'vault.cluster.access.methods',
+  VAULT_CLUSTER_ACCESS_NAMESPACES: 'vault.cluster.access.namespaces',
+  VAULT_CLUSTER_ACCESS_OIDC: 'vault.cluster.access.oidc',
+
+  VAULT_CLUSTER_SECRETS: 'vault.cluster.secrets',
+  VAULT_CLUSTER_SECRETS_BACKEND_CREDENTIALS: 'vault.cluster.secrets.backend.credentials',
+  VAULT_CLUSTER_SECRETS_BACKEND_KV_SECRET_INDEX: 'vault.cluster.secrets.backend.kv.secret.index',
+  VAULT_CLUSTER_SECRETS_BACKEND_LISTROOT: 'vault.cluster.secrets.backend.list-root',
+  VAULT_CLUSTER_SECRETS_BACKEND_PKI_CERTIFICATES_CERTIFICATE_DETAILS:
+    'vault.cluster.secrets.backend.pki.certificates.certificate.details',
+  VAULT_CLUSTER_SECRETS_BACKEND_PKI_ISSUERS_ISSUER_DETAILS:
+    'vault.cluster.secrets.backend.pki.issuers.issuer.details',
+  VAULT_CLUSTER_SECRETS_BACKEND_PKI_ROLES_ROLE_GENERATE:
+    'vault.cluster.secrets.backend.pki.roles.role.generate',
+  VAULT_CLUSTER_SECRETS_BACKEND_SHOW: 'vault.cluster.secrets.backend.show',
+
+  VAULT_CLUSTER_SETTINGS_AUTH_CONFIGURE_SECTION: 'vault.cluster.settings.auth.configure.section',
+};

--- a/ui/app/utils/routes.js
+++ b/ui/app/utils/routes.js
@@ -9,6 +9,8 @@ export const ROUTES = {
 
   VAULT_CLUSTER_ACCESS_CONTROLGROUPS: 'vault.cluster.access.control-groups',
   VAULT_CLUSTER_ACCESS_IDENTITY: 'vault.cluster.access.identity',
+  VAULT_CLUSTER_ACCESS_IDENTITY_ALIASES_EDIT: 'vault.cluster.access.identity.aliases.edit',
+  VAULT_CLUSTER_ACCESS_IDENTITY_ALIASES_INDEX: 'vault.cluster.access.identity.aliases.index',
   VAULT_CLUSTER_ACCESS_IDENTITY_ALIASES_SHOW: 'vault.cluster.access.identity.aliases.show',
   VAULT_CLUSTER_ACCESS_IDENTITY_SHOW: 'vault.cluster.access.identity.show',
   VAULT_CLUSTER_ACCESS_LEASES: 'vault.cluster.access.leases',

--- a/ui/lib/config-ui/addon/routes/messages/create.js
+++ b/ui/lib/config-ui/addon/routes/messages/create.js
@@ -5,6 +5,7 @@
 
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
+import { ROUTES } from 'vault/utils/routes';
 
 export default class MessagesCreateRoute extends Route {
   @service store;
@@ -45,7 +46,7 @@ export default class MessagesCreateRoute extends Route {
     super.setupController(controller, resolvedModel);
 
     controller.breadcrumbs = [
-      { label: 'Messages', route: 'messages', query: { authenticated: !!resolvedModel.authenticated } },
+      { label: 'Messages', route: ROUTES.messages, query: { authenticated: !!resolvedModel.authenticated } },
       { label: 'Create Message' },
     ];
   }

--- a/ui/lib/config-ui/addon/routes/messages/message/details.js
+++ b/ui/lib/config-ui/addon/routes/messages/message/details.js
@@ -5,6 +5,7 @@
 
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
+import { ROUTES } from 'vault/utils/routes';
 
 export default class MessagesMessageDetailsRoute extends Route {
   @service store;
@@ -19,7 +20,7 @@ export default class MessagesMessageDetailsRoute extends Route {
     super.setupController(controller, resolvedModel);
 
     controller.breadcrumbs = [
-      { label: 'Messages', route: 'messages', query: { authenticated: resolvedModel.authenticated } },
+      { label: 'Messages', route: ROUTES.MESSAGES, query: { authenticated: resolvedModel.authenticated } },
       { label: resolvedModel.title },
     ];
   }

--- a/ui/lib/config-ui/addon/routes/messages/message/edit.js
+++ b/ui/lib/config-ui/addon/routes/messages/message/edit.js
@@ -6,6 +6,7 @@
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
 import { hash } from 'rsvp';
+import { ROUTES } from 'vault/utils/routes';
 
 export default class MessagesMessageEditRoute extends Route {
   @service store;
@@ -30,7 +31,11 @@ export default class MessagesMessageEditRoute extends Route {
     super.setupController(controller, resolvedModel);
 
     controller.breadcrumbs = [
-      { label: 'Messages', route: 'messages', query: { authenticated: resolvedModel.message.authenticated } },
+      {
+        label: 'Messages',
+        route: ROUTES.MESSAGES,
+        query: { authenticated: resolvedModel.message.authenticated },
+      },
       { label: 'Edit Message' },
     ];
   }

--- a/ui/lib/core/addon/components/info-table-item-array.js
+++ b/ui/lib/core/addon/components/info-table-item-array.js
@@ -8,6 +8,7 @@ import { assert } from '@ember/debug';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
+import { ROUTES } from 'vault/utils/routes';
 
 /**
  * @module InfoTableItemArray
@@ -43,11 +44,11 @@ export default class InfoTableItemArray extends Component {
   }
 
   get rootRoute() {
-    return this.args.rootRoute || 'vault.cluster.secrets.backend.list-root';
+    return this.args.rootRoute || ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_LISTROOT;
   }
 
   get itemRoute() {
-    return this.args.itemRoute || 'vault.cluster.secrets.backend.show';
+    return this.args.itemRoute || ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_SHOW;
   }
 
   get doNotTruncate() {

--- a/ui/lib/core/addon/components/navigate-input.js
+++ b/ui/lib/core/addon/components/navigate-input.js
@@ -13,6 +13,7 @@ import Component from '@glimmer/component';
 import { encodePath } from 'vault/utils/path-encoding-helpers';
 import { keyIsFolder, parentKeyForKey } from 'core/utils/key-utils';
 import keys from 'core/utils/key-codes';
+import { ROUTES } from 'vault/utils/routes';
 
 /**
  * @module NavigateInput
@@ -40,7 +41,7 @@ const routeFor = function (type, mode, urls) {
     'secrets-cert': 'vault.cluster.secrets.backend',
     'policy-show': 'vault.cluster.policy',
     'policy-list': 'vault.cluster.policies',
-    leases: 'vault.cluster.access.leases',
+    leases: ROUTES.VAULT_CLUSTER_ACCESS_LEASES,
   };
   // urls object should have create, list, show keys
   // so we'll return that here

--- a/ui/lib/kubernetes/addon/routes/configuration.js
+++ b/ui/lib/kubernetes/addon/routes/configuration.js
@@ -6,6 +6,7 @@
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
 import { withConfig } from 'core/decorators/fetch-secrets-engine-config';
+import { ROUTES } from 'vault/utils/routes';
 
 @withConfig('kubernetes/config')
 export default class KubernetesConfigureRoute extends Route {
@@ -27,8 +28,8 @@ export default class KubernetesConfigureRoute extends Route {
     super.setupController(controller, resolvedModel);
 
     controller.breadcrumbs = [
-      { label: 'Secrets', route: 'secrets', linkExternal: true },
-      { label: resolvedModel.backend.id, route: 'overview', model: resolvedModel.backend },
+      { label: 'Secrets', route: ROUTES.SECRETS, linkExternal: true },
+      { label: resolvedModel.backend.id, route: ROUTES.OVERVIEW, model: resolvedModel.backend },
       { label: 'Configuration' },
     ];
   }

--- a/ui/lib/kubernetes/addon/routes/configure.js
+++ b/ui/lib/kubernetes/addon/routes/configure.js
@@ -6,6 +6,7 @@
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
 import { withConfig } from 'core/decorators/fetch-secrets-engine-config';
+import { ROUTES } from 'vault/utils/routes';
 
 @withConfig('kubernetes/config')
 export default class KubernetesConfigureRoute extends Route {
@@ -21,8 +22,8 @@ export default class KubernetesConfigureRoute extends Route {
     super.setupController(controller, resolvedModel);
 
     controller.breadcrumbs = [
-      { label: 'Secrets', route: 'secrets', linkExternal: true },
-      { label: resolvedModel.backend, route: 'overview', model: resolvedModel.backend },
+      { label: 'Secrets', route: ROUTES.SECRETS, linkExternal: true },
+      { label: resolvedModel.backend, route: ROUTES.OVERVIEW, model: resolvedModel.backend },
       { label: 'Configure' },
     ];
   }

--- a/ui/lib/kubernetes/addon/routes/error.js
+++ b/ui/lib/kubernetes/addon/routes/error.js
@@ -5,6 +5,7 @@
 
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
+import { ROUTES } from 'vault/utils/routes';
 
 export default class KubernetesErrorRoute extends Route {
   @service secretMountPath;
@@ -12,8 +13,8 @@ export default class KubernetesErrorRoute extends Route {
   setupController(controller) {
     super.setupController(...arguments);
     controller.breadcrumbs = [
-      { label: 'Secrets', route: 'secrets', linkExternal: true },
-      { label: this.secretMountPath.currentPath, route: 'overview' },
+      { label: 'Secrets', route: ROUTES.SECRETS, linkExternal: true },
+      { label: this.secretMountPath.currentPath, route: ROUTES.OVERVIEW },
     ];
     controller.backend = this.modelFor('application');
   }

--- a/ui/lib/kubernetes/addon/routes/overview.js
+++ b/ui/lib/kubernetes/addon/routes/overview.js
@@ -7,6 +7,7 @@ import Route from '@ember/routing/route';
 import { service } from '@ember/service';
 import { withConfig } from 'core/decorators/fetch-secrets-engine-config';
 import { hash } from 'rsvp';
+import { ROUTES } from 'vault/utils/routes';
 
 @withConfig('kubernetes/config')
 export default class KubernetesOverviewRoute extends Route {
@@ -26,7 +27,7 @@ export default class KubernetesOverviewRoute extends Route {
     super.setupController(controller, resolvedModel);
 
     controller.breadcrumbs = [
-      { label: 'Secrets', route: 'secrets', linkExternal: true },
+      { label: 'Secrets', route: ROUTES.SECRETS, linkExternal: true },
       { label: resolvedModel.backend.id },
     ];
   }

--- a/ui/lib/kubernetes/addon/routes/roles/create.js
+++ b/ui/lib/kubernetes/addon/routes/roles/create.js
@@ -5,6 +5,7 @@
 
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
+import { ROUTES } from 'vault/utils/routes';
 
 export default class KubernetesRolesCreateRoute extends Route {
   @service store;
@@ -19,8 +20,8 @@ export default class KubernetesRolesCreateRoute extends Route {
     super.setupController(controller, resolvedModel);
 
     controller.breadcrumbs = [
-      { label: resolvedModel.backend, route: 'overview' },
-      { label: 'Roles', route: 'roles', model: resolvedModel.backend },
+      { label: resolvedModel.backend, route: ROUTES.SECRETS },
+      { label: 'Roles', route: ROUTES.ROLES, model: resolvedModel.backend },
       { label: 'Create' },
     ];
   }

--- a/ui/lib/kubernetes/addon/routes/roles/index.js
+++ b/ui/lib/kubernetes/addon/routes/roles/index.js
@@ -7,6 +7,7 @@ import Route from '@ember/routing/route';
 import { service } from '@ember/service';
 import { withConfig } from 'core/decorators/fetch-secrets-engine-config';
 import { hash } from 'rsvp';
+import { ROUTES } from 'vault/utils/routes';
 
 @withConfig('kubernetes/config')
 export default class KubernetesRolesRoute extends Route {
@@ -40,8 +41,8 @@ export default class KubernetesRolesRoute extends Route {
     super.setupController(controller, resolvedModel);
 
     controller.breadcrumbs = [
-      { label: 'Secrets', route: 'secrets', linkExternal: true },
-      { label: resolvedModel.backend.id, route: 'overview', model: resolvedModel.backend },
+      { label: 'Secrets', route: ROUTES.SECRETS, linkExternal: true },
+      { label: resolvedModel.backend.id, route: ROUTES.OVERVIEW, model: resolvedModel.backend },
       { label: 'Roles' },
     ];
   }

--- a/ui/lib/kubernetes/addon/routes/roles/role/credentials.js
+++ b/ui/lib/kubernetes/addon/routes/roles/role/credentials.js
@@ -5,12 +5,13 @@
 
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
+import { ROUTES } from 'vault/utils/routes';
 export default class KubernetesRoleCredentialsRoute extends Route {
   @service secretMountPath;
 
   model() {
     return {
-      roleName: this.paramsFor('roles.role').name,
+      roleName: this.paramsFor(ROUTES.ROLES_ROLE).name,
       backend: this.secretMountPath.currentPath,
     };
   }
@@ -19,9 +20,9 @@ export default class KubernetesRoleCredentialsRoute extends Route {
     super.setupController(controller, resolvedModel);
 
     controller.breadcrumbs = [
-      { label: resolvedModel.backend, route: 'overview' },
-      { label: 'Roles', route: 'roles', model: resolvedModel.backend },
-      { label: resolvedModel.roleName, route: 'roles.role.details' },
+      { label: resolvedModel.backend, route: ROUTES.OVERVIEW },
+      { label: 'Roles', route: ROUTES.ROLES, model: resolvedModel.backend },
+      { label: resolvedModel.roleName, route: ROUTES.ROLES_ROLE_DETAILS },
       { label: 'Credentials' },
     ];
   }

--- a/ui/lib/kubernetes/addon/routes/roles/role/details.js
+++ b/ui/lib/kubernetes/addon/routes/roles/role/details.js
@@ -5,6 +5,7 @@
 
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
+import { ROUTES } from 'vault/utils/routes';
 
 export default class KubernetesRoleDetailsRoute extends Route {
   @service store;
@@ -12,7 +13,7 @@ export default class KubernetesRoleDetailsRoute extends Route {
 
   model() {
     const backend = this.secretMountPath.currentPath;
-    const { name } = this.paramsFor('roles.role');
+    const { name } = this.paramsFor(ROUTES.ROLES_ROLE);
     return this.store.queryRecord('kubernetes/role', { backend, name });
   }
 
@@ -20,8 +21,8 @@ export default class KubernetesRoleDetailsRoute extends Route {
     super.setupController(controller, resolvedModel);
 
     controller.breadcrumbs = [
-      { label: resolvedModel.backend, route: 'overview' },
-      { label: 'Roles', route: 'roles', model: resolvedModel.backend },
+      { label: resolvedModel.backend, route: ROUTES.OVERVIEW },
+      { label: 'Roles', route: ROUTES.ROLES, model: resolvedModel.backend },
       { label: resolvedModel.name },
     ];
   }

--- a/ui/lib/kubernetes/addon/routes/roles/role/edit.js
+++ b/ui/lib/kubernetes/addon/routes/roles/role/edit.js
@@ -5,6 +5,7 @@
 
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
+import { ROUTES } from 'vault/utils/routes';
 
 export default class KubernetesRoleEditRoute extends Route {
   @service store;
@@ -12,7 +13,7 @@ export default class KubernetesRoleEditRoute extends Route {
 
   model() {
     const backend = this.secretMountPath.currentPath;
-    const { name } = this.paramsFor('roles.role');
+    const { name } = this.paramsFor(ROUTES.ROLES_ROLE);
     return this.store.queryRecord('kubernetes/role', { backend, name });
   }
 
@@ -20,9 +21,9 @@ export default class KubernetesRoleEditRoute extends Route {
     super.setupController(controller, resolvedModel);
 
     controller.breadcrumbs = [
-      { label: resolvedModel.backend, route: 'overview' },
-      { label: 'Roles', route: 'roles', model: resolvedModel.backend },
-      { label: resolvedModel.name, route: 'roles.role' },
+      { label: resolvedModel.backend, route: ROUTES.OVERVIEW },
+      { label: 'Roles', route: ROUTES.ROLES, model: resolvedModel.backend },
+      { label: resolvedModel.name, route: ROUTES.ROLES_ROLE },
       { label: 'Edit' },
     ];
   }

--- a/ui/lib/kv/addon/components/page/list.js
+++ b/ui/lib/kv/addon/components/page/list.js
@@ -11,6 +11,7 @@ import { getOwner } from '@ember/owner';
 import { ancestorKeysForKey } from 'core/utils/key-utils';
 import errorMessage from 'vault/utils/error-message';
 import { pathIsDirectory } from 'kv/utils/kv-breadcrumbs';
+import { ROUTES } from 'vault/utils/routes';
 
 /**
  * @module List
@@ -87,6 +88,6 @@ export default class KvListPageComponent extends Component {
     evt.preventDefault();
     pathIsDirectory(this.secretPath)
       ? this.router.transitionTo('vault.cluster.secrets.backend.kv.list-directory', this.secretPath)
-      : this.router.transitionTo('vault.cluster.secrets.backend.kv.secret.index', this.secretPath);
+      : this.router.transitionTo(ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_KV_SECRET_INDEX, this.secretPath);
   }
 }

--- a/ui/lib/kv/addon/components/page/secret/details.js
+++ b/ui/lib/kv/addon/components/page/secret/details.js
@@ -12,6 +12,7 @@ import { task } from 'ember-concurrency';
 import { waitFor } from '@ember/test-waiters';
 import { isDeleted } from 'kv/utils/kv-deleted';
 import { isAdvancedSecret } from 'core/utils/advanced-secret';
+import { ROUTES } from 'vault/utils/routes';
 
 /**
  * @module KvSecretDetails renders the key/value data of a KV secret.
@@ -133,7 +134,7 @@ export default class KvSecretDetails extends Component {
 
   transition() {
     // transition to the overview to prevent automatically reading sensitive secret data
-    this.router.transitionTo('vault.cluster.secrets.backend.kv.secret.index');
+    this.router.transitionTo(ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_KV_SECRET_INDEX);
   }
 
   get version() {

--- a/ui/lib/kv/addon/components/page/secret/edit.js
+++ b/ui/lib/kv/addon/components/page/secret/edit.js
@@ -10,6 +10,7 @@ import { task } from 'ember-concurrency';
 import { service } from '@ember/service';
 import errorMessage from 'vault/utils/error-message';
 import { isAdvancedSecret } from 'core/utils/advanced-secret';
+import { ROUTES } from 'vault/utils/routes';
 
 /**
  * @module KvSecretEdit is used for creating a new version of a secret
@@ -84,7 +85,7 @@ export default class KvSecretEdit extends Component {
         const { secret } = this.args;
         yield secret.save();
         this.flashMessages.success(`Successfully created new version of ${secret.path}.`);
-        this.router.transitionTo('vault.cluster.secrets.backend.kv.secret.index');
+        this.router.transitionTo(ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_KV_SECRET_INDEX);
       }
     } catch (error) {
       let message = errorMessage(error);
@@ -100,6 +101,6 @@ export default class KvSecretEdit extends Component {
 
   @action
   onCancel() {
-    this.router.transitionTo('vault.cluster.secrets.backend.kv.secret.index');
+    this.router.transitionTo(ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_KV_SECRET_INDEX);
   }
 }

--- a/ui/lib/kv/addon/components/page/secret/patch.js
+++ b/ui/lib/kv/addon/components/page/secret/patch.js
@@ -10,6 +10,7 @@ import { tracked } from '@glimmer/tracking';
 import { task } from 'ember-concurrency';
 import { waitFor } from '@ember/test-waiters';
 import errorMessage from 'vault/utils/error-message';
+import { ROUTES } from 'vault/utils/routes';
 
 /**
  * @module KvSecretPatch
@@ -66,7 +67,7 @@ export default class KvSecretPatch extends Component {
     try {
       yield adapter.patchSecret(backend, path, patchData, version);
       this.flashMessages.success(`Successfully patched new version of ${path}.`);
-      this.router.transitionTo('vault.cluster.secrets.backend.kv.secret.index');
+      this.router.transitionTo(ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_KV_SECRET_INDEX);
     } catch (error) {
       if (error.message === 'Control Group encountered') {
         this.controlGroup.saveTokenFromError(error);
@@ -80,7 +81,7 @@ export default class KvSecretPatch extends Component {
 
   @action
   onCancel() {
-    this.router.transitionTo('vault.cluster.secrets.backend.kv.secret.index');
+    this.router.transitionTo(ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_KV_SECRET_INDEX);
   }
 
   isEmpty(object) {

--- a/ui/lib/kv/addon/components/page/secrets/create.js
+++ b/ui/lib/kv/addon/components/page/secrets/create.js
@@ -10,6 +10,7 @@ import { task } from 'ember-concurrency';
 import { service } from '@ember/service';
 import { pathIsFromDirectory } from 'kv/utils/kv-breadcrumbs';
 import errorMessage from 'vault/utils/error-message';
+import { ROUTES } from 'vault/utils/routes';
 
 /**
  * @module KvSecretCreate is used for creating the initial version of a secret
@@ -90,7 +91,7 @@ export default class KvSecretCreate extends Component {
       if (this.errorMessage) {
         this.invalidFormAlert = 'There was an error submitting this form.';
       } else {
-        this.router.transitionTo('vault.cluster.secrets.backend.kv.secret.index', secret.path);
+        this.router.transitionTo(ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_KV_SECRET_INDEX, secret.path);
       }
     }
   }

--- a/ui/lib/kv/addon/routes/configuration.js
+++ b/ui/lib/kv/addon/routes/configuration.js
@@ -6,6 +6,7 @@
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
 import { hash } from 'rsvp';
+import { ROUTES } from 'vault/utils/routes';
 
 export default class KvConfigurationRoute extends Route {
   @service store;
@@ -24,8 +25,8 @@ export default class KvConfigurationRoute extends Route {
   setupController(controller, resolvedModel) {
     super.setupController(controller, resolvedModel);
     controller.breadcrumbs = [
-      { label: 'Secrets', route: 'secrets', linkExternal: true },
-      { label: resolvedModel.mountConfig.id, route: 'list', model: resolvedModel.engineConfig.backend },
+      { label: 'Secrets', route: ROUTES.SECRETS, linkExternal: true },
+      { label: resolvedModel.mountConfig.id, route: ROUTES.LIST, model: resolvedModel.engineConfig.backend },
       { label: 'Configuration' },
     ];
   }

--- a/ui/lib/kv/addon/routes/create.js
+++ b/ui/lib/kv/addon/routes/create.js
@@ -8,6 +8,7 @@ import { service } from '@ember/service';
 import { hash } from 'rsvp';
 import { withConfirmLeave } from 'core/decorators/confirm-leave';
 import { breadcrumbsForSecret } from 'kv/utils/kv-breadcrumbs';
+import { ROUTES } from 'vault/utils/routes';
 
 @withConfirmLeave('model.secret', ['model.metadata'])
 export default class KvSecretsCreateRoute extends Route {
@@ -31,8 +32,8 @@ export default class KvSecretsCreateRoute extends Route {
     super.setupController(controller, resolvedModel);
 
     const crumbs = [
-      { label: 'Secrets', route: 'secrets', linkExternal: true },
-      { label: resolvedModel.backend, route: 'list', model: resolvedModel.backend },
+      { label: 'Secrets', route: ROUTES.SECRETS, linkExternal: true },
+      { label: resolvedModel.backend, route: ROUTES.LIST, model: resolvedModel.backend },
       ...breadcrumbsForSecret(resolvedModel.backend, resolvedModel.path),
       { label: 'Create' },
     ];

--- a/ui/lib/kv/addon/routes/error.js
+++ b/ui/lib/kv/addon/routes/error.js
@@ -5,6 +5,7 @@
 
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
+import { ROUTES } from 'vault/utils/routes';
 
 export default class KvErrorRoute extends Route {
   @service secretMountPath;
@@ -12,8 +13,12 @@ export default class KvErrorRoute extends Route {
   setupController(controller) {
     super.setupController(...arguments);
     controller.breadcrumbs = [
-      { label: 'Secrets', route: 'secrets', linkExternal: true },
-      { label: this.secretMountPath.currentPath, route: 'list', model: this.secretMountPath.currentPath },
+      { label: 'Secrets', route: ROUTES.SECRETS, linkExternal: true },
+      {
+        label: this.secretMountPath.currentPath,
+        route: ROUTES.LIST,
+        model: this.secretMountPath.currentPath,
+      },
     ];
     controller.mountName = this.secretMountPath.currentPath;
   }

--- a/ui/lib/kv/addon/routes/list-directory.js
+++ b/ui/lib/kv/addon/routes/list-directory.js
@@ -7,6 +7,7 @@ import Route from '@ember/routing/route';
 import { service } from '@ember/service';
 import { hash } from 'rsvp';
 import { pathIsDirectory, breadcrumbsForSecret } from 'kv/utils/kv-breadcrumbs';
+import { ROUTES } from 'vault/utils/routes';
 
 export default class KvSecretsListRoute extends Route {
   @service pagination;
@@ -71,14 +72,14 @@ export default class KvSecretsListRoute extends Route {
     resolvedModel.failedDirectoryQuery =
       resolvedModel.secrets === 403 && pathIsDirectory(resolvedModel.pathToSecret);
 
-    let breadcrumbsArray = [{ label: 'Secrets', route: 'secrets', linkExternal: true }];
+    let breadcrumbsArray = [{ label: 'Secrets', route: ROUTES.SECRETS, linkExternal: true }];
     // if on top level don't link the engine breadcrumb label, but if within a directory, do link back to top level.
-    if (this.routeName === 'list') {
+    if (this.routeName === ROUTES.LIST) {
       breadcrumbsArray.push({ label: resolvedModel.backend });
     } else {
       breadcrumbsArray = [
         ...breadcrumbsArray,
-        { label: resolvedModel.backend, route: 'list', model: resolvedModel.backend },
+        { label: resolvedModel.backend, route: ROUTES.LIST, model: resolvedModel.backend },
         ...breadcrumbsForSecret(resolvedModel.backend, resolvedModel.pathToSecret, true),
       ];
     }

--- a/ui/lib/kv/addon/routes/secret.js
+++ b/ui/lib/kv/addon/routes/secret.js
@@ -8,6 +8,7 @@ import { service } from '@ember/service';
 import { hash } from 'rsvp';
 import { action } from '@ember/object';
 import { isDeleted } from 'kv/utils/kv-deleted';
+import { ROUTES } from 'vault/utils/routes';
 
 export default class KvSecretRoute extends Route {
   @service secretMountPath;
@@ -85,7 +86,7 @@ export default class KvSecretRoute extends Route {
   willTransition(transition) {
     // refresh the route if transitioning to secret.index (which happens after delete, undelete or destroy)
     // or transitioning from editing either metadata or secret data (creating a new version)
-    const isToIndex = transition.to.name === 'vault.cluster.secrets.backend.kv.secret.index';
+    const isToIndex = transition.to.name === ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_KV_SECRET_INDEX;
     const isFromEdit = transition.from.localName === 'edit';
     if (isToIndex || isFromEdit) {
       this.refresh();

--- a/ui/lib/kv/addon/routes/secret/index.js
+++ b/ui/lib/kv/addon/routes/secret/index.js
@@ -6,6 +6,7 @@
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
 import { breadcrumbsForSecret } from 'kv/utils/kv-breadcrumbs';
+import { ROUTES } from 'vault/utils/routes';
 
 export default class SecretIndex extends Route {
   @service('app-router') router;
@@ -13,8 +14,8 @@ export default class SecretIndex extends Route {
   setupController(controller, resolvedModel) {
     super.setupController(controller, resolvedModel);
     const breadcrumbsArray = [
-      { label: 'Secrets', route: 'secrets', linkExternal: true },
-      { label: resolvedModel.backend, route: 'list', model: resolvedModel.backend },
+      { label: 'Secrets', route: ROUTES.SECRETS, linkExternal: true },
+      { label: resolvedModel.backend, route: ROUTES.LIST, model: resolvedModel.backend },
       ...breadcrumbsForSecret(resolvedModel.backend, resolvedModel.path, true),
     ];
     controller.breadcrumbs = breadcrumbsArray;

--- a/ui/lib/kv/addon/routes/secret/patch.js
+++ b/ui/lib/kv/addon/routes/secret/patch.js
@@ -6,6 +6,7 @@
 import Route from '@ember/routing/route';
 import { breadcrumbsForSecret } from 'kv/utils/kv-breadcrumbs';
 import { service } from '@ember/service';
+import { ROUTES } from 'vault/utils/routes';
 
 export default class SecretPatch extends Route {
   @service('app-router') router;
@@ -13,8 +14,8 @@ export default class SecretPatch extends Route {
   setupController(controller, resolvedModel) {
     super.setupController(controller, resolvedModel);
     const breadcrumbsArray = [
-      { label: 'Secrets', route: 'secrets', linkExternal: true },
-      { label: resolvedModel.backend, route: 'list', model: resolvedModel.backend },
+      { label: 'Secrets', route: ROUTES.SECRETS, linkExternal: true },
+      { label: resolvedModel.backend, route: ROUTES.LIST, model: resolvedModel.backend },
       ...breadcrumbsForSecret(resolvedModel.backend, resolvedModel.path),
       { label: 'Patch' },
     ];
@@ -24,7 +25,7 @@ export default class SecretPatch extends Route {
   // isPatchAllowed is true if (1) the version is enterprise, (2) a user has "patch" secret + "read" subkeys capabilities, (3) latest secret version is not deleted or destroyed
   redirect(model) {
     if (!model.isPatchAllowed) {
-      this.router.transitionTo('vault.cluster.secrets.backend.kv.secret.index', model.path);
+      this.router.transitionTo(ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_KV_SECRET_INDEX, model.path);
     }
   }
 }

--- a/ui/lib/kv/addon/routes/secret/paths.js
+++ b/ui/lib/kv/addon/routes/secret/paths.js
@@ -5,14 +5,15 @@
 
 import Route from '@ember/routing/route';
 import { breadcrumbsForSecret } from 'kv/utils/kv-breadcrumbs';
+import { ROUTES } from 'vault/utils/routes';
 
 export default class KvSecretPathsRoute extends Route {
   setupController(controller, resolvedModel) {
     super.setupController(controller, resolvedModel);
 
     controller.breadcrumbs = [
-      { label: 'Secrets', route: 'secrets', linkExternal: true },
-      { label: resolvedModel.backend, route: 'list', model: resolvedModel.backend },
+      { label: 'Secrets', route: ROUTES.SECRETS, linkExternal: true },
+      { label: resolvedModel.backend, route: ROUTES.LIST, model: resolvedModel.backend },
       ...breadcrumbsForSecret(resolvedModel.backend, resolvedModel.path),
       { label: 'Paths' },
     ];

--- a/ui/lib/pki/addon/components/page/pki-issuer-edit.ts
+++ b/ui/lib/pki/addon/components/page/pki-issuer-edit.ts
@@ -15,6 +15,7 @@ import type FlashMessageService from 'vault/services/flash-messages';
 import type PkiIssuerModel from 'vault/models/pki/issuer';
 import { removeFromArray } from 'vault/helpers/remove-from-array';
 import { addToArray } from 'vault/helpers/add-to-array';
+import { ROUTES } from 'vault/utils/routes';
 
 interface Args {
   model: PkiIssuerModel;
@@ -33,7 +34,7 @@ export default class PkiIssuerEditComponent extends Component<Args> {
   }
 
   toDetails() {
-    this.router.transitionTo('vault.cluster.secrets.backend.pki.issuers.issuer.details');
+    this.router.transitionTo(ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_PKI_ISSUERS_ISSUER_DETAILS);
   }
 
   @action

--- a/ui/lib/pki/addon/components/page/pki-overview.ts
+++ b/ui/lib/pki/addon/components/page/pki-overview.ts
@@ -12,6 +12,7 @@ import type Store from '@ember-data/store';
 import type RouterService from '@ember/routing/router-service';
 import type PkiIssuerModel from 'vault/models/pki/issuer';
 import type PkiRoleModel from 'vault/models/pki/role';
+import { ROUTES } from 'vault/utils/routes';
 
 interface Args {
   issuers: PkiIssuerModel[] | number;
@@ -30,18 +31,21 @@ export default class PkiOverview extends Component<Args> {
   @action
   transitionToViewCertificates() {
     this.router.transitionTo(
-      'vault.cluster.secrets.backend.pki.certificates.certificate.details',
+      ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_PKI_CERTIFICATES_CERTIFICATE_DETAILS,
       this.certificateValue
     );
   }
   @action
   transitionToIssueCertificates() {
-    this.router.transitionTo('vault.cluster.secrets.backend.pki.roles.role.generate', this.rolesValue);
+    this.router.transitionTo(ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_PKI_ROLES_ROLE_GENERATE, this.rolesValue);
   }
 
   @action
   transitionToIssuerDetails() {
-    this.router.transitionTo('vault.cluster.secrets.backend.pki.issuers.issuer.details', this.issuerValue);
+    this.router.transitionTo(
+      ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_PKI_ISSUERS_ISSUER_DETAILS,
+      this.issuerValue
+    );
   }
 
   @action

--- a/ui/tests/acceptance/access/identity/_shared-alias-tests.js
+++ b/ui/tests/acceptance/access/identity/_shared-alias-tests.js
@@ -101,7 +101,7 @@ export const testAliasDeleteFromForm = async function (name, itemType, assert) {
   await settled();
   assert.strictEqual(
     currentRouteName(),
-    'vault.cluster.access.identity.aliases.edit',
+    ROUTES.VAULT_CLUSTER_ACCESS_IDENTITY_ALIASES_EDIT,
     `${itemType}: navigates to edit on create`
   );
   await page.editForm.delete();
@@ -111,7 +111,7 @@ export const testAliasDeleteFromForm = async function (name, itemType, assert) {
   assert.dom(GENERAL.latestFlashContent).includesText(`Successfully deleted`);
   assert.strictEqual(
     currentRouteName(),
-    'vault.cluster.access.identity.aliases.index',
+    ROUTES.VAULT_CLUSTER_ACCESS_IDENTITY_ALIASES_INDEX,
     `${itemType}: navigates to list page on delete`
   );
   assert.strictEqual(

--- a/ui/tests/acceptance/access/identity/_shared-alias-tests.js
+++ b/ui/tests/acceptance/access/identity/_shared-alias-tests.js
@@ -9,6 +9,7 @@ import page from 'vault/tests/pages/access/identity/aliases/add';
 import aliasIndexPage from 'vault/tests/pages/access/identity/aliases/index';
 import aliasShowPage from 'vault/tests/pages/access/identity/aliases/show';
 import createItemPage from 'vault/tests/pages/access/identity/create';
+import { ROUTES } from 'vault/utils/routes';
 
 export const testAliasCRUD = async function (name, itemType, assert) {
   if (itemType === 'groups') {
@@ -42,7 +43,7 @@ export const testAliasCRUD = async function (name, itemType, assert) {
   );
   assert.strictEqual(
     currentRouteName(),
-    'vault.cluster.access.identity.aliases.show',
+    ROUTES.VAULT_CLUSTER_ACCESS_IDENTITY_ALIASES_SHOW,
     'navigates to the correct route'
   );
   assert.ok(aliasShowPage.nameContains(name), `${itemType}: renders the name on the show page`);

--- a/ui/tests/acceptance/access/identity/_shared-tests.js
+++ b/ui/tests/acceptance/access/identity/_shared-tests.js
@@ -10,6 +10,7 @@ import page from 'vault/tests/pages/access/identity/create';
 import showPage from 'vault/tests/pages/access/identity/show';
 import indexPage from 'vault/tests/pages/access/identity/index';
 import { GENERAL } from 'vault/tests/helpers/general-selectors';
+import { ROUTES } from 'vault/utils/routes';
 const SELECTORS = {
   identityRow: (name) => `[data-test-identity-row="${name}"]`,
   popupMenu: '[data-test-popup-menu-trigger]',
@@ -23,7 +24,7 @@ export const testCRUD = async (name, itemType, assert) => {
   assert.dom(GENERAL.latestFlashContent).includesText('Successfully saved');
   assert.strictEqual(
     currentRouteName(),
-    'vault.cluster.access.identity.show',
+    ROUTES.VAULT_CLUSTER_ACCESS_IDENTITY_SHOW,
     `${itemType}: navigates to show on create`
   );
   assert.ok(showPage.nameContains(name), `${itemType}: renders the name on the show page`);

--- a/ui/tests/acceptance/access/methods-test.js
+++ b/ui/tests/acceptance/access/methods-test.js
@@ -12,6 +12,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { GENERAL } from 'vault/tests/helpers/general-selectors';
 import { mountAuthCmd, runCmd } from 'vault/tests/helpers/commands';
 import { login } from 'vault/tests/helpers/auth/auth-helpers';
+import { ROUTES } from 'vault/utils/routes';
 
 const { searchSelect } = GENERAL;
 
@@ -26,7 +27,11 @@ module('Acceptance | auth-methods list view', function (hooks) {
 
   test('it navigates to auth method', async function (assert) {
     await visit('/vault/access/');
-    assert.strictEqual(currentRouteName(), 'vault.cluster.access.methods', 'navigates to the correct route');
+    assert.strictEqual(
+      currentRouteName(),
+      ROUTES.VAULT_CLUSTER_ACCESS_METHODS,
+      'navigates to the correct route'
+    );
     assert.dom('[data-test-sidebar-nav-link="Authentication Methods"]').hasClass('active');
   });
 

--- a/ui/tests/acceptance/dashboard-test.js
+++ b/ui/tests/acceptance/dashboard-test.js
@@ -30,6 +30,7 @@ import { runCmd, deleteEngineCmd, createNS } from 'vault/tests/helpers/commands'
 import { DASHBOARD } from 'vault/tests/helpers/components/dashboard/dashboard-selectors';
 import { CUSTOM_MESSAGES } from 'vault/tests/helpers/config-ui/message-selectors';
 import { GENERAL } from 'vault/tests/helpers/general-selectors';
+import { ROUTES } from 'vault/utils/routes';
 
 const authenticatedMessageResponse = {
   request_id: '664fbad0-fcd8-9023-4c5b-81a7962e9f4b',
@@ -306,7 +307,7 @@ module('Acceptance | landing page dashboard', function (hooks) {
       await selectChoose(DASHBOARD.searchSelect('params'), 'some-role');
       assert.dom(DASHBOARD.actionButton('Issue leaf certificate')).exists({ count: 1 });
       await click(DASHBOARD.actionButton('Issue leaf certificate'));
-      assert.strictEqual(currentRouteName(), 'vault.cluster.secrets.backend.pki.roles.role.generate');
+      assert.strictEqual(currentRouteName(), ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_PKI_ROLES_ROLE_GENERATE);
 
       await visit('/vault/dashboard');
 
@@ -319,7 +320,7 @@ module('Acceptance | landing page dashboard', function (hooks) {
       await click(DASHBOARD.actionButton('View certificate'));
       assert.strictEqual(
         currentRouteName(),
-        'vault.cluster.secrets.backend.pki.certificates.certificate.details'
+        ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_PKI_CERTIFICATES_CERTIFICATE_DETAILS
       );
 
       await visit('/vault/dashboard');
@@ -331,7 +332,7 @@ module('Acceptance | landing page dashboard', function (hooks) {
       assert.dom(DASHBOARD.actionButton('View issuer')).exists({ count: 1 });
       await selectChoose(DASHBOARD.searchSelect('params'), '.ember-power-select-option', 0);
       await click(DASHBOARD.actionButton('View issuer'));
-      assert.strictEqual(currentRouteName(), 'vault.cluster.secrets.backend.pki.issuers.issuer.details');
+      assert.strictEqual(currentRouteName(), ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_PKI_ISSUERS_ISSUER_DETAILS);
 
       // cleanup engine mount
       await runCmd(deleteEngineCmd(backend));
@@ -370,7 +371,7 @@ module('Acceptance | landing page dashboard', function (hooks) {
       assert.dom(DASHBOARD.actionButton('Generate credentials')).exists({ count: 1 });
       await selectChoose(DASHBOARD.searchSelect('params'), '.ember-power-select-option', 0);
       await click(DASHBOARD.actionButton('Generate credentials'));
-      assert.strictEqual(currentRouteName(), 'vault.cluster.secrets.backend.credentials');
+      assert.strictEqual(currentRouteName(), ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_CREDENTIALS);
       await runCmd(deleteEngineCmd(databaseBackend));
     });
 

--- a/ui/tests/acceptance/pki/pki-overview-test.js
+++ b/ui/tests/acceptance/pki/pki-overview-test.js
@@ -15,6 +15,7 @@ import { runCmd, tokenWithPolicyCmd } from 'vault/tests/helpers/commands';
 import { clearRecords } from 'vault/tests/helpers/pki/pki-helpers';
 import { PKI_OVERVIEW } from 'vault/tests/helpers/pki/pki-selectors';
 import { GENERAL } from 'vault/tests/helpers/general-selectors';
+import { ROUTES } from 'vault/utils/routes';
 const { overviewCard } = GENERAL;
 
 module('Acceptance | pki overview', function (hooks) {
@@ -106,7 +107,7 @@ module('Acceptance | pki overview', function (hooks) {
     await click(PKI_OVERVIEW.issueCertificatePowerSearch);
     await click(PKI_OVERVIEW.firstPowerSelectOption);
     await click(PKI_OVERVIEW.issueCertificateButton);
-    assert.strictEqual(currentRouteName(), 'vault.cluster.secrets.backend.pki.roles.role.generate');
+    assert.strictEqual(currentRouteName(), ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_PKI_ROLES_ROLE_GENERATE);
   });
 
   test('navigates to certificate details page for View Certificates card', async function (assert) {
@@ -117,7 +118,7 @@ module('Acceptance | pki overview', function (hooks) {
     await click(PKI_OVERVIEW.viewCertificateButton);
     assert.strictEqual(
       currentRouteName(),
-      'vault.cluster.secrets.backend.pki.certificates.certificate.details'
+      ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_PKI_CERTIFICATES_CERTIFICATE_DETAILS
     );
   });
 
@@ -127,6 +128,6 @@ module('Acceptance | pki overview', function (hooks) {
     await click(PKI_OVERVIEW.viewIssuerPowerSearch);
     await click(PKI_OVERVIEW.firstPowerSelectOption);
     await click(PKI_OVERVIEW.viewIssuerButton);
-    assert.strictEqual(currentRouteName(), 'vault.cluster.secrets.backend.pki.issuers.issuer.details');
+    assert.strictEqual(currentRouteName(), ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_PKI_ISSUERS_ISSUER_DETAILS);
   });
 });

--- a/ui/tests/acceptance/secrets/backend/cubbyhole/secret-test.js
+++ b/ui/tests/acceptance/secrets/backend/cubbyhole/secret-test.js
@@ -15,6 +15,7 @@ import listPage from 'vault/tests/pages/secrets/backend/list';
 import authPage from 'vault/tests/pages/auth';
 import { assertSecretWrap } from 'vault/tests/helpers/components/secret-edit-toolbar';
 import { SECRET_ENGINE_SELECTORS as SES } from 'vault/tests/helpers/secret-engine/secret-engine-selectors';
+import { ROUTES } from 'vault/utils/routes';
 
 module('Acceptance | secrets/cubbyhole/create', function (hooks) {
   setupApplicationTest(hooks);
@@ -37,7 +38,7 @@ module('Acceptance | secrets/cubbyhole/create', function (hooks) {
     await settled();
     assert.strictEqual(
       currentRouteName(),
-      'vault.cluster.secrets.backend.list-root',
+      ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_LISTROOT,
       'navigates to the list page'
     );
 
@@ -47,7 +48,7 @@ module('Acceptance | secrets/cubbyhole/create', function (hooks) {
     await settled();
     assert.strictEqual(
       currentRouteName(),
-      'vault.cluster.secrets.backend.show',
+      ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_SHOW,
       'redirects to the show page'
     );
     assert.ok(showPage.editIsPresent, 'shows the edit button');

--- a/ui/tests/acceptance/secrets/backend/generic/secret-test.js
+++ b/ui/tests/acceptance/secrets/backend/generic/secret-test.js
@@ -19,6 +19,7 @@ import { PAGE } from 'vault/tests/helpers/kv/kv-selectors';
 
 import { create } from 'ember-cli-page-object';
 import { deleteEngineCmd, runCmd } from 'vault/tests/helpers/commands';
+import { ROUTES } from 'vault/utils/routes';
 
 const cli = create(consolePanel);
 
@@ -37,7 +38,7 @@ module('Acceptance | secrets/generic/create', function (hooks) {
     await listPage.visitRoot({ backend: path });
     assert.strictEqual(
       currentRouteName(),
-      'vault.cluster.secrets.backend.list-root',
+      ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_LISTROOT,
       'navigates to the list page'
     );
     assert.strictEqual(listPage.secrets.length, 1, 'lists one secret in the backend');
@@ -46,7 +47,7 @@ module('Acceptance | secrets/generic/create', function (hooks) {
     await editPage.createSecret(kvPath, 'foo', 'bar');
     assert.strictEqual(
       currentRouteName(),
-      'vault.cluster.secrets.backend.show',
+      ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_SHOW,
       'redirects to the show page'
     );
     assert.ok(showPage.editIsPresent, 'shows the edit button');

--- a/ui/tests/acceptance/secrets/backend/kv/kv-v2-workflow-delete-test.js
+++ b/ui/tests/acceptance/secrets/backend/kv/kv-v2-workflow-delete-test.js
@@ -15,6 +15,7 @@ import { click, currentRouteName, currentURL, waitUntil, visit } from '@ember/te
 import { PAGE } from 'vault/tests/helpers/kv/kv-selectors';
 import sinon from 'sinon';
 import { GENERAL } from 'vault/tests/helpers/general-selectors';
+import { ROUTES } from 'vault/utils/routes';
 
 const ALL_DELETE_ACTIONS = ['delete', 'destroy', 'undelete'];
 const assertDeleteActions = (assert, expected = ['delete', 'destroy']) => {
@@ -335,7 +336,7 @@ module('Acceptance | kv-v2 workflow | delete, undelete, destroy', function (hook
       assertDeleteActions(assert, ['undelete', 'destroy']);
       // undelete flow
       await click(PAGE.detail.undelete);
-      await waitUntil(() => currentRouteName() === 'vault.cluster.secrets.backend.kv.secret.index');
+      await waitUntil(() => currentRouteName() === ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_KV_SECRET_INDEX);
       assert
         .dom(GENERAL.overviewCard.container('Current version'))
         .hasText(`Current version The current version of this secret. 2`);

--- a/ui/tests/acceptance/secrets/backend/kv/kv-v2-workflow-navigation-test.js
+++ b/ui/tests/acceptance/secrets/backend/kv/kv-v2-workflow-navigation-test.js
@@ -36,6 +36,7 @@ import {
 import { FORM, PAGE } from 'vault/tests/helpers/kv/kv-selectors';
 import { GENERAL } from 'vault/tests/helpers/general-selectors';
 import { setupControlGroup, grantAccess } from 'vault/tests/helpers/control-groups';
+import { ROUTES } from 'vault/utils/routes';
 
 const secretPath = `my-#:$=?-secret`;
 // This doesn't encode in a normal way, so hardcoding it here until we sort that out
@@ -91,7 +92,7 @@ const patchRedirectTest = (test, testCase) => {
       `/vault/secrets/${this.backend}/kv/app%2Fnested%2Fsecret`,
       'redirects to index'
     );
-    assert.strictEqual(currentRouteName(), 'vault.cluster.secrets.backend.kv.secret.index');
+    assert.strictEqual(currentRouteName(), ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_KV_SECRET_INDEX);
   });
 };
 
@@ -501,7 +502,7 @@ module('Acceptance | kv-v2 workflow | navigation', function (hooks) {
       // overview tab
       assert.strictEqual(
         currentRouteName(),
-        'vault.cluster.secrets.backend.kv.secret.index',
+        ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_KV_SECRET_INDEX,
         'navs to overview'
       );
       assertCorrectBreadcrumbs(assert, ['Secrets', backend, secretPath]);
@@ -1714,7 +1715,7 @@ path "${this.backend}/subkeys/*" {
       await click(FORM.cancelBtn);
       assert.strictEqual(
         currentRouteName(),
-        'vault.cluster.secrets.backend.kv.secret.index',
+        ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_KV_SECRET_INDEX,
         'navs back to overview'
       );
     });
@@ -1745,7 +1746,7 @@ path "${this.backend}/subkeys/*" {
         `/vault/secrets/${this.backend}/kv/app%2Fnested%2Fsecret`,
         'redirects to index'
       );
-      assert.strictEqual(currentRouteName(), 'vault.cluster.secrets.backend.kv.secret.index');
+      assert.strictEqual(currentRouteName(), ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_KV_SECRET_INDEX);
     });
   });
 });

--- a/ui/tests/acceptance/secrets/backend/kv/secret-test.js
+++ b/ui/tests/acceptance/secrets/backend/kv/secret-test.js
@@ -22,6 +22,7 @@ import codemirror from 'vault/tests/helpers/codemirror';
 import { MOUNT_BACKEND_FORM } from 'vault/tests/helpers/components/mount-backend-form-selectors';
 import { GENERAL } from 'vault/tests/helpers/general-selectors';
 import { SECRET_ENGINE_SELECTORS as SS } from 'vault/tests/helpers/secret-engine/secret-engine-selectors';
+import { ROUTES } from 'vault/utils/routes';
 
 const deleteEngine = async function (enginePath, assert) {
   await logout.visit();
@@ -107,7 +108,7 @@ module('Acceptance | secrets/secret/create, read, delete', function (hooks) {
       await writeSecret(this.backend, secretPath, 'foo', 'bar');
       assert.strictEqual(
         currentRouteName(),
-        'vault.cluster.secrets.backend.kv.secret.index',
+        ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_KV_SECRET_INDEX,
         'redirects to the overview page'
       );
     });
@@ -154,7 +155,7 @@ module('Acceptance | secrets/secret/create, read, delete', function (hooks) {
       await editPage.createSecret(secretPath, 'foo', 'bar');
       assert.strictEqual(
         currentRouteName(),
-        'vault.cluster.secrets.backend.show',
+        ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_SHOW,
         'redirects to the show page'
       );
       assert.ok(showPage.editIsPresent, 'shows the edit button');
@@ -212,7 +213,7 @@ module('Acceptance | secrets/secret/create, read, delete', function (hooks) {
       await showPage.deleteSecretV1();
       assert.strictEqual(
         currentRouteName(),
-        'vault.cluster.secrets.backend.list-root',
+        ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_LISTROOT,
         'redirected to the list page on delete'
       );
     });
@@ -250,7 +251,7 @@ module('Acceptance | secrets/secret/create, read, delete', function (hooks) {
         await click(SS.secretLink());
         assert.strictEqual(
           currentRouteName(),
-          'vault.cluster.secrets.backend.show',
+          ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_SHOW,
           `${path}: show page renders correctly`
         );
       }
@@ -308,7 +309,7 @@ module('Acceptance | secrets/secret/create, read, delete', function (hooks) {
         await click(SS.secretLink());
         assert.strictEqual(
           currentRouteName(),
-          'vault.cluster.secrets.backend.show',
+          ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_SHOW,
           `${path}: show page renders correctly`
         );
         assert.dom('h1.title').hasText(`${path}/2`, 'shows correct page title');
@@ -345,7 +346,7 @@ module('Acceptance | secrets/secret/create, read, delete', function (hooks) {
 
       assert.strictEqual(
         currentRouteName(),
-        'vault.cluster.secrets.backend.show',
+        ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_SHOW,
         'redirects to the show page'
       );
       assert.ok(showPage.editIsPresent, 'shows the edit button');

--- a/ui/tests/acceptance/secrets/backend/ssh/roles-test.js
+++ b/ui/tests/acceptance/secrets/backend/ssh/roles-test.js
@@ -26,6 +26,7 @@ import generatePage from 'vault/tests/pages/secrets/backend/ssh/generate-otp';
 import { runCmd } from 'vault/tests/helpers/commands';
 import { GENERAL } from 'vault/tests/helpers/general-selectors';
 import { SECRET_ENGINE_SELECTORS as SES } from 'vault/tests/helpers/secret-engine/secret-engine-selectors';
+import { ROUTES } from 'vault/utils/routes';
 
 // There is duplication within this test suite. The duplication occurred because two test suites both testing ssh roles were merged.
 // refactoring the tests to remove the duplication would be a good next step as well as removing the tests/pages.
@@ -83,7 +84,7 @@ module('Acceptance | ssh | roles', function (hooks) {
     {
       type: 'otp',
       name: 'otprole',
-      credsRoute: 'vault.cluster.secrets.backend.credentials',
+      credsRoute: ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_CREDENTIALS,
       async fillInCreate() {
         await fillIn(GENERAL.inputByAttr('defaultUser'), 'admin');
         await click(GENERAL.toggleGroup('Options'));
@@ -198,7 +199,7 @@ module('Acceptance | ssh | roles', function (hooks) {
       await settled();
       assert.strictEqual(
         currentRouteName(),
-        'vault.cluster.secrets.backend.list-root',
+        ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_LISTROOT,
         'redirects to list page'
       );
       assert.ok(listPage.backendIsEmpty, 'no roles listed');
@@ -216,7 +217,7 @@ module('Acceptance | ssh | roles', function (hooks) {
       await settled();
       assert.strictEqual(
         currentRouteName(),
-        'vault.cluster.secrets.backend.show',
+        ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_SHOW,
         'redirects to the show page'
       );
       assert.ok(showPage.generateIsPresent, 'shows the generate button');
@@ -227,7 +228,7 @@ module('Acceptance | ssh | roles', function (hooks) {
       await settled();
       assert.strictEqual(
         currentRouteName(),
-        'vault.cluster.secrets.backend.credentials',
+        ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_CREDENTIALS,
         'navs to the credentials page'
       );
 

--- a/ui/tests/acceptance/settings/auth/configure/index-test.js
+++ b/ui/tests/acceptance/settings/auth/configure/index-test.js
@@ -8,6 +8,8 @@ import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { v4 as uuidv4 } from 'uuid';
 
+import { ROUTES } from 'vault/utils/routes';
+
 import enablePage from 'vault/tests/pages/settings/auth/enable';
 import page from 'vault/tests/pages/settings/auth/configure/index';
 import authPage from 'vault/tests/pages/auth';
@@ -25,7 +27,7 @@ module('Acceptance | settings/auth/configure', function (hooks) {
     const type = 'approle';
     await enablePage.enable(type, path);
     await page.visit({ path });
-    assert.strictEqual(currentRouteName(), 'vault.cluster.settings.auth.configure.section');
+    assert.strictEqual(currentRouteName(), ROUTES.VAULT_CLUSTER_SETTINGS_AUTH_CONFIGURE_SECTION);
     assert.strictEqual(
       currentURL(),
       `/vault/settings/auth/configure/${path}/options`,
@@ -38,7 +40,7 @@ module('Acceptance | settings/auth/configure', function (hooks) {
     const type = 'aws';
     await enablePage.enable(type, path);
     await page.visit({ path });
-    assert.strictEqual(currentRouteName(), 'vault.cluster.settings.auth.configure.section');
+    assert.strictEqual(currentRouteName(), ROUTES.VAULT_CLUSTER_SETTINGS_AUTH_CONFIGURE_SECTION);
     assert.strictEqual(
       currentURL(),
       `/vault/settings/auth/configure/${path}/client`,

--- a/ui/tests/acceptance/settings/auth/enable-test.js
+++ b/ui/tests/acceptance/settings/auth/enable-test.js
@@ -11,6 +11,7 @@ import { mountBackend } from 'vault/tests/helpers/components/mount-backend-form-
 import { login } from 'vault/tests/helpers/auth/auth-helpers';
 import { deleteAuthCmd, runCmd } from 'vault/tests/helpers/commands';
 import { GENERAL } from 'vault/tests/helpers/general-selectors';
+import { ROUTES } from 'vault/utils/routes';
 
 module('Acceptance | settings/auth/enable', function (hooks) {
   setupApplicationTest(hooks);
@@ -32,7 +33,7 @@ module('Acceptance | settings/auth/enable', function (hooks) {
       .hasText(`Successfully mounted the ${type} auth method at ${path}.`);
     assert.strictEqual(
       currentRouteName(),
-      'vault.cluster.settings.auth.configure.section',
+      ROUTES.VAULT_CLUSTER_SETTINGS_AUTH_CONFIGURE_SECTION,
       'redirects to the auth config page'
     );
 

--- a/ui/tests/integration/components/get-credentials-card-test.js
+++ b/ui/tests/integration/components/get-credentials-card-test.js
@@ -12,6 +12,7 @@ import { selectChoose } from 'ember-power-select/test-support';
 import hbs from 'htmlbars-inline-precompile';
 import sinon from 'sinon';
 import { setRunOptions } from 'ember-a11y-testing/test-support';
+import { ROUTES } from 'vault/utils/routes';
 
 const storeService = Service.extend({
   query(modelType) {
@@ -79,7 +80,7 @@ module('Integration | Component | get-credentials-card', function (hooks) {
     await click('[data-test-get-credentials]');
     assert.propEqual(
       this.router.transitionTo.lastCall.args,
-      ['vault.cluster.secrets.backend.credentials', 'my-role'],
+      [ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_CREDENTIALS, 'my-role'],
       'transitionTo is called with correct route and role name'
     );
   });

--- a/ui/tests/integration/components/keymgmt/provider-edit-test.js
+++ b/ui/tests/integration/components/keymgmt/provider-edit-test.js
@@ -10,10 +10,11 @@ import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { click, settled, fillIn } from '@ember/test-helpers';
 import { setRunOptions } from 'ember-a11y-testing/test-support';
+import { ROUTES } from 'vault/utils/routes';
 
 const ts = 'data-test-kms-provider';
 const root = {
-  path: 'vault.cluster.secrets.backend.list-root',
+  path: ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_LISTROOT,
   model: 'keymgmt',
   label: 'keymgmt',
   text: 'keymgmt',
@@ -177,7 +178,7 @@ module('Integration | Component | keymgmt/provider-edit', function (hooks) {
       transitionTo(path, model, { queryParams: { itemType } }) {
         assert.strictEqual(
           path,
-          'vault.cluster.secrets.backend.show',
+          ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_SHOW,
           'Show route sent in transitionTo on save'
         );
         assert.strictEqual(model, 'foo', 'Model id sent in transitionTo on save');
@@ -241,7 +242,7 @@ module('Integration | Component | keymgmt/provider-edit', function (hooks) {
       transitionTo(path, model, { queryParams: { itemType } }) {
         assert.strictEqual(
           path,
-          'vault.cluster.secrets.backend.show',
+          ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_SHOW,
           'Show route sent in transitionTo on save'
         );
         assert.strictEqual(model, 'foo', 'Model id sent in transitionTo on save');

--- a/ui/tests/integration/components/kv/page/kv-page-patch-test.js
+++ b/ui/tests/integration/components/kv/page/kv-page-patch-test.js
@@ -16,6 +16,7 @@ import { baseSetup } from 'vault/tests/helpers/kv/kv-run-commands';
 import codemirror from 'vault/tests/helpers/codemirror';
 import { encodePath } from 'vault/utils/path-encoding-helpers';
 import { overrideResponse } from 'vault/tests/helpers/stubs';
+import { ROUTES } from 'vault/utils/routes';
 
 module('Integration | Component | kv-v2 | Page::Secret::Patch', function (hooks) {
   setupRenderingTest(hooks);
@@ -94,7 +95,7 @@ module('Integration | Component | kv-v2 | Page::Secret::Patch', function (hooks)
     const [route] = this.transitionStub.lastCall.args;
     assert.strictEqual(
       route,
-      'vault.cluster.secrets.backend.kv.secret.index',
+      ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_KV_SECRET_INDEX,
       `it transitions on cancel to: ${route}`
     );
   });
@@ -150,7 +151,7 @@ module('Integration | Component | kv-v2 | Page::Secret::Patch', function (hooks)
       const [route] = this.transitionStub.lastCall.args;
       assert.strictEqual(
         route,
-        'vault.cluster.secrets.backend.kv.secret.index',
+        ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_KV_SECRET_INDEX,
         `it transitions on save to: ${route}`
       );
     });
@@ -181,7 +182,7 @@ module('Integration | Component | kv-v2 | Page::Secret::Patch', function (hooks)
       const [route] = this.transitionStub.lastCall.args;
       assert.strictEqual(
         route,
-        'vault.cluster.secrets.backend.kv.secret.index',
+        ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_KV_SECRET_INDEX,
         `it transitions on save to: ${route}`
       );
     });
@@ -272,7 +273,7 @@ module('Integration | Component | kv-v2 | Page::Secret::Patch', function (hooks)
       const [route] = this.transitionStub.lastCall.args;
       assert.strictEqual(
         route,
-        'vault.cluster.secrets.backend.kv.secret.index',
+        ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_KV_SECRET_INDEX,
         `it transitions on save to: ${route}`
       );
     });
@@ -296,7 +297,7 @@ module('Integration | Component | kv-v2 | Page::Secret::Patch', function (hooks)
       const flash = this.flashSpy.lastCall?.args[0] || '';
       assert.strictEqual(
         route,
-        'vault.cluster.secrets.backend.kv.secret.index',
+        ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_KV_SECRET_INDEX,
         `it transitions to overview route: ${route}`
       );
       assert.strictEqual(
@@ -320,7 +321,7 @@ module('Integration | Component | kv-v2 | Page::Secret::Patch', function (hooks)
       const flash = this.flashSpy.lastCall?.args[0] || '';
       assert.strictEqual(
         route,
-        'vault.cluster.secrets.backend.kv.secret.index',
+        ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_KV_SECRET_INDEX,
         `it transitions to overview route: ${route}`
       );
       assert.strictEqual(

--- a/ui/tests/integration/components/kv/page/kv-page-secret-edit-test.js
+++ b/ui/tests/integration/components/kv/page/kv-page-secret-edit-test.js
@@ -14,6 +14,7 @@ import codemirror from 'vault/tests/helpers/codemirror';
 import { FORM, PAGE } from 'vault/tests/helpers/kv/kv-selectors';
 import sinon from 'sinon';
 import { setRunOptions } from 'ember-a11y-testing/test-support';
+import { ROUTES } from 'vault/utils/routes';
 
 module('Integration | Component | kv-v2 | Page::Secret::Edit', function (hooks) {
   setupRenderingTest(hooks);
@@ -101,7 +102,7 @@ module('Integration | Component | kv-v2 | Page::Secret::Edit', function (hooks) 
     const [actual] = this.transitionStub.lastCall.args;
     assert.strictEqual(
       actual,
-      'vault.cluster.secrets.backend.kv.secret.index',
+      ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_KV_SECRET_INDEX,
       'router transitions to secret overview route on save'
     );
   });
@@ -199,7 +200,7 @@ module('Integration | Component | kv-v2 | Page::Secret::Edit', function (hooks) 
     const [actual] = this.transitionStub.lastCall.args;
     assert.strictEqual(
       actual,
-      'vault.cluster.secrets.backend.kv.secret.index',
+      ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_KV_SECRET_INDEX,
       'router transitions to secret overview route on cancel'
     );
   });

--- a/ui/tests/integration/components/kv/page/kv-page-secrets-create-test.js
+++ b/ui/tests/integration/components/kv/page/kv-page-secrets-create-test.js
@@ -14,6 +14,7 @@ import codemirror from 'vault/tests/helpers/codemirror';
 import { FORM } from 'vault/tests/helpers/kv/kv-selectors';
 import sinon from 'sinon';
 import { setRunOptions } from 'ember-a11y-testing/test-support';
+import { ROUTES } from 'vault/utils/routes';
 
 module('Integration | Component | kv-v2 | Page::Secrets::Create', function (hooks) {
   setupRenderingTest(hooks);
@@ -103,7 +104,7 @@ module('Integration | Component | kv-v2 | Page::Secrets::Create', function (hook
     const [actual] = this.transitionStub.lastCall.args;
     assert.strictEqual(
       actual,
-      'vault.cluster.secrets.backend.kv.secret.index',
+      ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_KV_SECRET_INDEX,
       'router transitions to secret overview route on save'
     );
   });

--- a/ui/tests/integration/components/pki/page/pki-issuer-edit-test.js
+++ b/ui/tests/integration/components/pki/page/pki-issuer-edit-test.js
@@ -11,6 +11,7 @@ import { setupEngine } from 'ember-engines/test-support';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { Response } from 'miragejs';
 import sinon from 'sinon';
+import { ROUTES } from 'vault/utils/routes';
 
 const selectors = {
   name: '[data-test-input="issuerName"]',
@@ -42,7 +43,7 @@ module('Integration | Component | pki | Page::PkiIssuerEditPage::PkiIssuerEdit',
     const router = this.owner.lookup('service:router');
     const transitionSpy = sinon.stub(router, 'transitionTo');
     this.transitionCalled = () =>
-      transitionSpy.calledWith('vault.cluster.secrets.backend.pki.issuers.issuer.details');
+      transitionSpy.calledWith(ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_PKI_ISSUERS_ISSUER_DETAILS);
 
     const store = this.owner.lookup('service:store');
     store.pushPayload('pki/issuer', {

--- a/ui/tests/integration/components/transit-edit-test.js
+++ b/ui/tests/integration/components/transit-edit-test.js
@@ -9,6 +9,7 @@ import { click, fillIn, render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { capabilitiesStub } from 'vault/tests/helpers/stubs';
+import { ROUTES } from 'vault/utils/routes';
 
 const SELECTORS = {
   createForm: '[data-test-transit-create-form]',
@@ -29,7 +30,7 @@ module('Integration | Component | transit-edit', function (hooks) {
     this.backendCrumb = {
       label: 'transit',
       text: 'transit',
-      path: 'vault.cluster.secrets.backend.list-root',
+      path: ROUTES.VAULT_CLUSTER_SECRETS_BACKEND_LISTROOT,
       model: 'transit',
     };
   });

--- a/ui/tests/unit/components/identity/edit-form-test.js
+++ b/ui/tests/unit/components/identity/edit-form-test.js
@@ -7,6 +7,7 @@ import EmberObject from '@ember/object';
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
+import { ROUTES } from 'vault/utils/routes';
 
 module('Unit | Component | identity/edit-form', function (hooks) {
   setupTest(hooks);
@@ -15,17 +16,17 @@ module('Unit | Component | identity/edit-form', function (hooks) {
     {
       identityType: 'entity',
       mode: 'create',
-      expected: 'vault.cluster.access.identity',
+      expected: ROUTES.VAULT_CLUSTER_ACCESS_IDENTITY,
     },
     {
       identityType: 'entity',
       mode: 'edit',
-      expected: 'vault.cluster.access.identity.show',
+      expected: ROUTES.VAULT_CLUSTER_ACCESS_IDENTITY_SHOW,
     },
     {
       identityType: 'entity-merge',
       mode: 'merge',
-      expected: 'vault.cluster.access.identity',
+      expected: ROUTES.VAULT_CLUSTER_ACCESS_IDENTITY,
     },
     {
       identityType: 'entity-alias',
@@ -35,17 +36,17 @@ module('Unit | Component | identity/edit-form', function (hooks) {
     {
       identityType: 'entity-alias',
       mode: 'edit',
-      expected: 'vault.cluster.access.identity.aliases.show',
+      expected: ROUTES.VAULT_CLUSTER_ACCESS_IDENTITY_ALIASES_SHOW,
     },
     {
       identityType: 'group',
       mode: 'create',
-      expected: 'vault.cluster.access.identity',
+      expected: ROUTES.VAULT_CLUSTER_ACCESS_IDENTITY,
     },
     {
       identityType: 'group',
       mode: 'edit',
-      expected: 'vault.cluster.access.identity.show',
+      expected: ROUTES.VAULT_CLUSTER_ACCESS_IDENTITY_SHOW,
     },
     {
       identityType: 'group-alias',
@@ -55,7 +56,7 @@ module('Unit | Component | identity/edit-form', function (hooks) {
     {
       identityType: 'group-alias',
       mode: 'edit',
-      expected: 'vault.cluster.access.identity.aliases.show',
+      expected: ROUTES.VAULT_CLUSTER_ACCESS_IDENTITY_ALIASES_SHOW,
     },
   ];
   testCases.forEach(function (testCase) {

--- a/ui/tests/unit/components/identity/edit-form-test.js
+++ b/ui/tests/unit/components/identity/edit-form-test.js
@@ -31,7 +31,7 @@ module('Unit | Component | identity/edit-form', function (hooks) {
     {
       identityType: 'entity-alias',
       mode: 'create',
-      expected: 'vault.cluster.access.identity.aliases',
+      expected: ROUTES.VAULT_CLUSTER_ACCESS_IDENTITY_ALIASES_SHOW,
     },
     {
       identityType: 'entity-alias',
@@ -51,7 +51,7 @@ module('Unit | Component | identity/edit-form', function (hooks) {
     {
       identityType: 'group-alias',
       mode: 'create',
-      expected: 'vault.cluster.access.identity.aliases',
+      expected: ROUTES.VAULT_CLUSTER_ACCESS_IDENTITY_ALIASES_SHOW,
     },
     {
       identityType: 'group-alias',

--- a/ui/tests/unit/services/permissions-test.js
+++ b/ui/tests/unit/services/permissions-test.js
@@ -9,6 +9,7 @@ import Service from '@ember/service';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { overrideResponse } from 'vault/tests/helpers/stubs';
 import { PERMISSIONS_BANNER_STATES } from 'vault/services/permissions';
+import { ROUTES } from 'vault/utils/routes';
 
 const PERMISSIONS_RESPONSE = {
   data: {
@@ -84,7 +85,7 @@ module('Unit | Service | permissions', function (hooks) {
         capabilities: ['read'],
       },
     };
-    const expected = { route: 'vault.cluster.access.identity', models: ['entities'] };
+    const expected = { route: ROUTES.VAULT_CLUSTER_ACCESS_IDENTITY, models: ['entities'] };
     this.service.set('exactPaths', accessPaths);
     assert.deepEqual(this.service.navPathParams('access'), expected);
   });


### PR DESCRIPTION
### Description
- [x] Hackathon project: abstract hardcoded route strings into a constants file 🧹
- [ ] Testing:
  - Address outstanding error on `Secrets Engines`: `Kubernetes`: `Roles`: `Create Role +`:
    <img width="1728" alt="Screenshot 2025-03-18 at 3 39 39 PM" src="https://github.com/user-attachments/assets/11d30536-67c3-451d-8987-8aa91c2fb32c" />



### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
