### PR TITLE
[VAULT-34792] UI: refactor `FormField` template code to move `checkboxList` under the newly added HDS block

### DIFF
--- a/ui/lib/core/addon/components/form-field.hbs
+++ b/ui/lib/core/addon/components/form-field.hbs
@@ -26,7 +26,6 @@
           {{/if}}
           {{#each @attr.options.possibleValues as |option|}}
             <G.CheckboxField
-              class={{if this.validationError "has-error-border"}}
               checked={{includes option (get @model this.valuePath)}}
               @value={{option}}
               @id={{option}}

--- a/ui/lib/core/addon/components/form-field.hbs
+++ b/ui/lib/core/addon/components/form-field.hbs
@@ -6,7 +6,24 @@
 {{! template-lint-configure simple-unless "warn" }}
 <div class="field" data-test-field={{or @attr.name true}}>
   {{#if this.isHdsFormField}}
-    {{! TODO the template logic for the form fields migrated to HDS will appear here }}
+    {{#if @attr.options.possibleValues}}
+      {{#if (eq @attr.options.editType "checkboxList")}}
+        <Hds::Form::Checkbox::Group @name={{@attr.name}} data-test-input={{@attr.name}} as |G|>
+          {{#each @attr.options.possibleValues as |option|}}
+            <G.CheckboxField
+              class={{if this.validationError "has-error-border"}}
+              checked={{includes option (get @model this.valuePath)}}
+              @value={{option}}
+              @id={{option}}
+              {{on "change" this.handleChecklist}}
+              as |F|
+            >
+              <F.Label>{{option}}</F.Label>
+            </G.CheckboxField>
+          {{/each}}
+        </Hds::Form::Checkbox::Group>
+      {{/if}}
+    {{/if}}
   {{else}}
     {{#unless this.hideLabel}}
       <FormFieldLabel
@@ -59,21 +76,6 @@
             </div>
           {{/each}}
         </div>
-      {{else if (eq @attr.options.editType "checkboxList")}}
-        <Hds::Form::Checkbox::Group @name={{@attr.name}} data-test-input={{@attr.name}} as |G|>
-          {{#each @attr.options.possibleValues as |option|}}
-            <G.CheckboxField
-              class={{if this.validationError "has-error-border"}}
-              checked={{includes option (get @model this.valuePath)}}
-              @value={{option}}
-              @id={{option}}
-              {{on "change" this.handleChecklist}}
-              as |F|
-            >
-              <F.Label>{{option}}</F.Label>
-            </G.CheckboxField>
-          {{/each}}
-        </Hds::Form::Checkbox::Group>
       {{else}}
         <div class="control is-expanded">
           <div class="select is-fullwidth">

--- a/ui/lib/core/addon/components/form-field.hbs
+++ b/ui/lib/core/addon/components/form-field.hbs
@@ -423,14 +423,14 @@
         class={{if (eq @attr.options.editType "stringArray") "has-top-margin-negative-xxl"}}
       />
     {{/if}}
-    {{#if this.validationWarning}}
-      <AlertInline
-        @type="warning"
-        @message={{this.validationWarning}}
-        @paddingTop={{if (and (not this.validationError) (eq @attr.options.editType "ttl")) false true}}
-        data-test-validation-warning={{this.valuePath}}
-        class={{if (and (not this.validationError) (eq @attr.options.editType "stringArray")) "has-top-margin-negative-xxl"}}
-      />
-    {{/if}}
+  {{/if}}
+  {{#if this.validationWarning}}
+    <AlertInline
+      @type="warning"
+      @message={{this.validationWarning}}
+      @paddingTop={{if (and (not this.validationError) (eq @attr.options.editType "ttl")) false true}}
+      data-test-validation-warning={{this.valuePath}}
+      class={{if (and (not this.validationError) (eq @attr.options.editType "stringArray")) "has-top-margin-negative-xxl"}}
+    />
   {{/if}}
 </div>

--- a/ui/lib/core/addon/components/form-field.hbs
+++ b/ui/lib/core/addon/components/form-field.hbs
@@ -9,6 +9,21 @@
     {{#if @attr.options.possibleValues}}
       {{#if (eq @attr.options.editType "checkboxList")}}
         <Hds::Form::Checkbox::Group @name={{@attr.name}} data-test-input={{@attr.name}} as |G|>
+          {{#if this.labelString}}
+            <G.Legend data-test-form-field-label>{{this.labelString}}</G.Legend>
+          {{/if}}
+          {{#if this.showHelpText}}
+            <G.HelperText data-test-help-text>{{@attr.options.helpText}}</G.HelperText>
+          {{/if}}
+          {{#if @attr.options.subText}}
+            <G.HelperText data-test-label-subtext>
+              {{@attr.options.subText}}
+              {{#if @attr.options.docLink}}
+                <DocLink @path={{@attr.options.docLink}}>See our documentation</DocLink>
+                for help.
+              {{/if}}
+            </G.HelperText>
+          {{/if}}
           {{#each @attr.options.possibleValues as |option|}}
             <G.CheckboxField
               class={{if this.validationError "has-error-border"}}
@@ -21,6 +36,9 @@
               <F.Label>{{option}}</F.Label>
             </G.CheckboxField>
           {{/each}}
+          {{#if this.validationError}}
+            <G.Error data-test-field-validation={{this.valuePath}}>{{this.validationError}}</G.Error>
+          {{/if}}
         </Hds::Form::Checkbox::Group>
       {{/if}}
     {{/if}}

--- a/ui/lib/core/addon/components/form-field.js
+++ b/ui/lib/core/addon/components/form-field.js
@@ -92,8 +92,12 @@ export default class FormFieldComponent extends Component {
 
     // here we replicate the logic in the template, to make sure we don't change the order in which the "ifs" are evaluated
     if (options?.possibleValues?.length > 0) {
-      // we leave these fields as they are (for now)
-      return false;
+      if (options?.editType === 'checkboxList') {
+        return true;
+      } else {
+        // we still have to migrate the `radio` and `select` use cases
+        return false;
+      }
     } else {
       if (type === 'number' || type === 'string') {
         // here we will add the logic for `FormField` inputs (textarea, password, regular text input) that are "converted" to HDS fields


### PR DESCRIPTION
### Description
What does this PR do?

- moved template logic for `checkboxList` of `FilterInput` under the `isHdsField` block
- added handling of `label/helpText/subText/docLink` + validation errors message for `checkboxList`
- moved `validationWarning` block out of the conditional so it can serve both HDS and non-HDS use cases 

Jira ticket: https://hashicorp.atlassian.net/browse/VAULT-34792

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
