### PR TITLE
[VAULT-34742] UI: move the generic `select` block in `FormField` under the HDS block

### DIFF
--- a/ui/lib/core/addon/components/form-field.hbs
+++ b/ui/lib/core/addon/components/form-field.hbs
@@ -39,6 +39,46 @@
             <G.Error data-test-field-validation={{this.valuePath}}>{{this.validationError}}</G.Error>
           {{/if}}
         </Hds::Form::Checkbox::Group>
+      {{else}}
+        <Hds::Form::Select::Field
+          name={{@attr.name}}
+          @id={{@attr.name}}
+          {{on "change" this.onChangeWithEvent}}
+          data-test-input={{@attr.name}}
+          @isInvalid={{this.validationError}}
+          as |F|
+        >
+          {{#if this.labelString}}
+            <F.Label data-test-form-field-label>{{this.labelString}}</F.Label>
+          {{/if}}
+          {{#if this.showHelpText}}
+            <F.HelperText data-test-help-text>{{@attr.options.helpText}}</F.HelperText>
+          {{/if}}
+          {{#if @attr.options.subText}}
+            <F.HelperText data-test-label-subtext>
+              {{@attr.options.subText}}
+              {{#if @attr.options.docLink}}
+                <DocLink @path={{@attr.options.docLink}}>See our documentation</DocLink>
+                for help.
+              {{/if}}
+            </F.HelperText>
+          {{/if}}
+          <F.Options>
+            {{#if @attr.options.noDefault}}
+              <option value="">
+                Select one
+              </option>
+            {{/if}}
+            {{#each (path-or-array @attr.options.possibleValues @model) as |val|}}
+              <option selected={{loose-equal (get @model this.valuePath) (or val.value val)}} value={{or val.value val}}>
+                {{or val.displayName val}}
+              </option>
+            {{/each}}
+          </F.Options>
+          {{#if this.validationError}}
+            <F.Error data-test-field-validation={{this.valuePath}}>{{this.validationError}}</F.Error>
+          {{/if}}
+        </Hds::Form::Select::Field>
       {{/if}}
     {{/if}}
   {{else}}
@@ -92,29 +132,6 @@
               </div>
             </div>
           {{/each}}
-        </div>
-      {{else}}
-        <div class="control is-expanded">
-          <div class="select is-fullwidth">
-            <select
-              class="{{if this.validationError 'has-error-border'}}"
-              name={{@attr.name}}
-              id={{@attr.name}}
-              onchange={{this.onChangeWithEvent}}
-              data-test-input={{@attr.name}}
-            >
-              {{#if @attr.options.noDefault}}
-                <option value="">
-                  Select one
-                </option>
-              {{/if}}
-              {{#each (path-or-array @attr.options.possibleValues @model) as |val|}}
-                <option selected={{loose-equal (get @model this.valuePath) (or val.value val)}} value={{or val.value val}}>
-                  {{or val.displayName val}}
-                </option>
-              {{/each}}
-            </select>
-          </div>
         </div>
       {{/if}}
     {{else if (eq @attr.options.editType "dateTimeLocal")}}

--- a/ui/lib/core/addon/components/form-field.js
+++ b/ui/lib/core/addon/components/form-field.js
@@ -92,11 +92,11 @@ export default class FormFieldComponent extends Component {
 
     // here we replicate the logic in the template, to make sure we don't change the order in which the "ifs" are evaluated
     if (options?.possibleValues?.length > 0) {
-      if (options?.editType === 'checkboxList') {
-        return true;
-      } else {
-        // we still have to migrate the `radio` and `select` use cases
+      // we still have to migrate the `radio` use case
+      if (options?.editType === 'radio') {
         return false;
+      } else {
+        return true;
       }
     } else {
       if (type === 'number' || type === 'string') {


### PR DESCRIPTION
### Description
What does this PR do?

- updated logic in `isHdsFormField` of `FormField` to include the generic `select` use case 
- moved template logic for generic `select` in `FormField` under the `isHdsField` block 

Jira ticket: https://hashicorp.atlassian.net/browse/VAULT-34742

### Diffs

A few examples of before vs after:

**Before**:
<img width="1045" alt="screenshot_4824" src="https://github.com/user-attachments/assets/ca1df84e-adcb-468d-850e-adf3dbd94ac8" />

**After**:
<img width="1052" alt="screenshot_4823" src="https://github.com/user-attachments/assets/9b886be9-51f3-4899-b701-ff1a26e377cf" />

---

**Before**:
<img width="1055" alt="screenshot_4825" src="https://github.com/user-attachments/assets/7cd27bf5-fbf2-4954-870a-ac6bb4a789c7" />

**After**:
<img width="1058" alt="screenshot_4826" src="https://github.com/user-attachments/assets/6809d85d-b6e1-4cc7-b789-e134c81bcd01" />

👉 In this case the `@helpText` instead of being hidden behind a tooltip, is exposed as field's helper text (better for accessibility)


### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
