### PR TITLE
set GOPRIVATE in plugin-update gha ent step

### DIFF
--- a/.github/workflows/plugin-update.yml
+++ b/.github/workflows/plugin-update.yml
@@ -50,6 +50,7 @@ jobs:
         env:
           # Use elevated token to read private repos.
           GITHUB_TOKEN: ${{secrets.ELEVATED_GITHUB_TOKEN}}
+          GOPRIVATE: github.com/hashicorp/*
         run: |
           git config --global url."https://${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
           (cd vault_ent && go get "github.com/hashicorp/${{ inputs.plugin }}@v${{ inputs.version }}" && go mod tidy)


### PR DESCRIPTION
### Description

When doing the first ENT release for this plugin ahead of Vault 1.19 for [VAULT-31444](https://hashicorp.atlassian.net/browse/VAULT-31444), the automated plugin-update workflow kept failing with permission issues so we had to manually create plugin-update PRs for KMSE into vault-enterprise like https://github.com/hashicorp/vault-enterprise/pull/7478 and https://github.com/hashicorp/vault-enterprise/pull/7530.

This PR fixes the plugin-update workflow for our first ENT-only plugin, [vault-plugin-secrets-keymgmt](https://github.com/hashicorp/vault-plugin-secrets-keymgmt) (and presumably other ENT-only plugins in private repositories down the line) by setting the `GOPRIVATE` env var.

Tested by running the plugin-update GHA against https://github.com/hashicorp/vault-enterprise/pull/7646:

Before (failing "Update Enterprise-only plugin" step): https://github.com/hashicorp/vault-enterprise/actions/runs/13507958083/job/37741823563
<img width="1091" alt="image" src="https://github.com/user-attachments/assets/9682ce76-fca2-4f60-ac4a-853b4bc50698" />

After (on this branch; passing "Update Enterprise-only plugin" step; failing "Detect changes" step but that's fine): https://github.com/hashicorp/vault-enterprise/actions/runs/13931207249/job/38988516622
<img width="1089" alt="image" src="https://github.com/user-attachments/assets/df6dcc2b-1d4f-4c76-b832-9864af3c9e85" />


Ticket: [VAULT-34355](https://hashicorp.atlassian.net/browse/VAULT-34355)

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.


[VAULT-31444]: https://hashicorp.atlassian.net/browse/VAULT-31444?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[VAULT-34355]: https://hashicorp.atlassian.net/browse/VAULT-34355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ