### PR TITLE
[UI] API Service

### DIFF
--- a/ui/app/config/environment.d.ts
+++ b/ui/app/config/environment.d.ts
@@ -13,7 +13,16 @@ declare const config: {
   podModulePrefix: string;
   locationType: 'history' | 'hash' | 'none';
   rootURL: string;
-  APP: Record<string, unknown>;
+  APP: {
+    POLLING_URLS: string[];
+    NAMESPACE_ROOT_URLS: string[];
+    DEFAULT_PAGE_SIZE: number;
+    LOG_TRANSITIONS?: boolean;
+    LOG_ACTIVE_GENERATION?: boolean;
+    LOG_VIEW_LOOKUPS?: boolean;
+    rootElement?: string;
+    autoboot?: boolean;
+  };
 };
 
 export default config;

--- a/ui/app/lib/local-storage.ts
+++ b/ui/app/lib/local-storage.ts
@@ -3,31 +3,34 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
+import type { ApiError } from 'vault/api';
+
 export default {
   isLocalStorageSupported() {
     try {
       const key = `__storage__test`;
-      window.localStorage.setItem(key, null);
+      window.localStorage.setItem(key, '');
       window.localStorage.removeItem(key);
       return true;
     } catch (e) {
+      const error = e as ApiError;
       // modify the e object so we can customize the error message.
       // e.message is readOnly.
-      e.errors = [`This is likely due to your browser's cookie settings.`];
+      error.errors = [`This is likely due to your browser's cookie settings.`];
       throw e;
     }
   },
 
-  getItem(key) {
+  getItem(key: string) {
     const item = window.localStorage.getItem(key);
     return item && JSON.parse(item);
   },
 
-  setItem(key, val) {
+  setItem(key: string, val: unknown) {
     window.localStorage.setItem(key, JSON.stringify(val));
   },
 
-  removeItem(key) {
+  removeItem(key: string) {
     return window.localStorage.removeItem(key);
   },
 
@@ -35,7 +38,7 @@ export default {
     return Object.keys(window.localStorage);
   },
 
-  cleanupStorage(string, keyToKeep) {
+  cleanupStorage(string: string, keyToKeep: string) {
     if (!string) return;
     const relevantKeys = this.keys().filter((str) => str.startsWith(string));
     relevantKeys?.forEach((key) => {

--- a/ui/app/lib/memory-storage.ts
+++ b/ui/app/lib/memory-storage.ts
@@ -3,19 +3,19 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-const cache = {};
+const cache: { [key: string]: string } = {};
 
 export default {
-  getItem(key) {
-    var item = cache[key];
+  getItem(key: string) {
+    const item = cache[key];
     return item && JSON.parse(item);
   },
 
-  setItem(key, val) {
+  setItem(key: string, val: unknown) {
     cache[key] = JSON.stringify(val);
   },
 
-  removeItem(key) {
+  removeItem(key: string) {
     delete cache[key];
   },
 

--- a/ui/app/services/api.ts
+++ b/ui/app/services/api.ts
@@ -1,0 +1,185 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import Service, { service } from '@ember/service';
+import {
+  Configuration,
+  RequestContext,
+  ResponseContext,
+  AuthApi,
+  IdentityApi,
+  SecretsApi,
+  SystemApi,
+} from '@hashicorp/vault-client-typescript';
+import config from '../config/environment';
+
+import type AuthService from 'vault/services/auth';
+import type NamespaceService from 'vault/services/namespace';
+import type ControlGroupService from 'vault/services/control-group';
+import type FlashMessageService from 'vault/services/flash-messages';
+import type { ApiError, ApiResponse, HeaderMap, XVaultHeaders } from 'vault/api';
+
+export default class ApiService extends Service {
+  @service('auth') declare readonly authService: AuthService;
+  @service('namespace') declare readonly namespaceService: NamespaceService;
+  @service declare readonly controlGroup: ControlGroupService;
+  @service declare readonly flashMessages: FlashMessageService;
+
+  #responseCache = new Map<string, ApiResponse>();
+
+  // -- Pre Request Middleware --
+  setLastFetch = async (context: RequestContext) => {
+    const { url } = context;
+    const isPolling = config.APP.POLLING_URLS.some((str) => url.includes(str));
+
+    if (!isPolling) {
+      this.authService.setLastFetch(Date.now());
+    }
+  };
+
+  getControlGroupToken = async (context: RequestContext) => {
+    const { url, init } = context;
+    const controlGroupToken = this.controlGroup.tokenForUrl(url);
+    let newUrl = url;
+    // if we have a Control Group token that matches the intendedUrl,
+    // unwrap it and return the unwrapped response as if it were the initial request
+    // to do this, we rewrite the request
+    if (controlGroupToken) {
+      const { token } = controlGroupToken;
+      const { headers } = this.buildHeaders({ token });
+      newUrl = '/v1/sys/wrapping/unwrap';
+      init.method = 'POST';
+      init.headers = headers;
+      init.body = JSON.stringify({ token });
+    }
+    return { url: newUrl, init };
+  };
+
+  setHeaders = async (context: RequestContext) => {
+    const { url, init } = context;
+    const headers = new Headers(init.headers);
+    // unauthenticated or clientToken requests should set the header in initOverrides
+    // unauthenticated value should be empty string, not undefined or null
+    if (!headers.has('X-Vault-Token')) {
+      headers.set('X-Vault-Token', this.authService.currentToken);
+    }
+    if (init.method === 'PATCH') {
+      headers.set('Content-Type', 'application/merge-patch+json');
+    }
+    // use initOverrides to set the namespace header to something other than path set in the namespace service
+    // for requests that must be made to root namespace pass empty string as value
+    const namespace = this.namespaceService.path;
+    if (!headers.has('X-Vault-Namespace') && namespace) {
+      headers.set('X-Vault-Namespace', namespace);
+    }
+
+    init.headers = headers;
+    return { url, init };
+  };
+
+  // -- Post Request Middleware --
+  showWarnings = async (context: ResponseContext) => {
+    const response = context.response.clone();
+    const json = await response?.json();
+    // currently there is only 1 endpoint that intentionally hides warnings
+    // handle that here for now, but if more endpoints are added, look for a more scalable pattern
+    const hideWarnings = context.url === '/v1/sys/internal/counters/activity';
+
+    if (json?.warnings && !hideWarnings) {
+      json.warnings.forEach((message: string) => {
+        this.flashMessages.info(message);
+      });
+    }
+  };
+
+  deleteControlGroupToken = async (context: ResponseContext) => {
+    const { url } = context;
+    const controlGroupToken = this.controlGroup.tokenForUrl(url);
+    if (controlGroupToken) {
+      this.controlGroup.deleteControlGroupToken(controlGroupToken.accessor);
+    }
+  };
+
+  formatErrorResponse = async (context: ResponseContext) => {
+    const response = context.response.clone();
+    const { headers, status, statusText } = response;
+
+    // backwards compatibility with Ember Data
+    if (status >= 400) {
+      const error: ApiError = (await response?.json()) || {};
+      error.httpStatus = response?.status;
+      error.path = context.url;
+      // typically the Vault API error response looks like { errors: ['some error message'] }
+      // but sometimes (eg RespondWithStatusCode) it's { data: { error: 'some error message' } }
+      if (error?.data?.error && !error.errors) {
+        // normalize the errors from RespondWithStatusCode
+        error.errors = [error.data.error];
+      }
+      return new Response(JSON.stringify(error), { headers, status, statusText });
+    }
+
+    return;
+  };
+
+  // the responses in the OpenAPI spec don't account for the return values to be under the 'data' key
+  // return the data rather than the entire response
+  // furthermore, some requests require the full response to access things like wrap_info for example
+  // if the response type in the OpenAPI spec is void then undefined is returned regardless of what is returned here
+  // cache the response to be accessed in overridden handlers
+  extractData = async (context: ResponseContext) => {
+    const response = context.response.clone();
+    const { headers, status, statusText } = response;
+
+    if (status >= 200 && status < 300) {
+      const json = await response?.json();
+      // roughing this in for now more as a placeholder
+      // thinking about how to make the outer level response data like wrap_info accessible
+      if (!json.data) {
+        this.#responseCache.set(context.url, json);
+      }
+      return new Response(JSON.stringify(json.data), { headers, status, statusText });
+    }
+
+    return;
+  };
+  // --- End Middleware ---
+
+  configuration = new Configuration({
+    basePath: '/v1',
+    middleware: [
+      { pre: this.setLastFetch },
+      { pre: this.getControlGroupToken },
+      { pre: this.setHeaders },
+      { post: this.showWarnings },
+      { post: this.deleteControlGroupToken },
+      { post: this.formatErrorResponse },
+      { post: this.extractData },
+    ],
+  });
+
+  auth = new AuthApi(this.configuration);
+  identity = new IdentityApi(this.configuration);
+  secrets = new SecretsApi(this.configuration);
+  sys = new SystemApi(this.configuration);
+
+  // convenience method for overriding headers for given requests to ensure consistency
+  // eg. this.api.sys.wrap(data, { headers: { 'X-Vault-Wrap-TTL': wrap } });
+  // -> this.api.sys.wrap(data, this.api.buildHeaders({ wrap }));
+  buildHeaders(headerMap: HeaderMap) {
+    const headers = {} as XVaultHeaders;
+
+    for (const key in headerMap) {
+      const headerKey = {
+        namespace: 'X-Vault-Namespace',
+        token: 'X-Vault-Token',
+        wrap: 'X-Vault-Wrap-TTL',
+      }[key] as keyof XVaultHeaders;
+
+      headers[headerKey] = headerMap[key as keyof HeaderMap];
+    }
+
+    return { headers };
+  }
+}

--- a/ui/app/services/api.ts
+++ b/ui/app/services/api.ts
@@ -81,11 +81,8 @@ export default class ApiService extends Service {
   showWarnings = async (context: ResponseContext) => {
     const response = context.response.clone();
     const json = await response?.json();
-    // currently there is only 1 endpoint that intentionally hides warnings
-    // handle that here for now, but if more endpoints are added, look for a more scalable pattern
-    const hideWarnings = context.url === '/v1/sys/internal/counters/activity';
 
-    if (json?.warnings && !hideWarnings) {
+    if (json?.warnings) {
       json.warnings.forEach((message: string) => {
         this.flashMessages.info(message);
       });

--- a/ui/app/services/api.ts
+++ b/ui/app/services/api.ts
@@ -43,7 +43,7 @@ export default class ApiService extends Service {
     const { url, init } = context;
     const controlGroupToken = this.controlGroup.tokenForUrl(url);
     let newUrl = url;
-    // if we have a Control Group token that matches the intendedUrl,
+    // if we have a Control Group token that matches the url,
     // unwrap it and return the unwrapped response as if it were the initial request
     // to do this, we rewrite the request
     if (controlGroupToken) {

--- a/ui/tests/unit/services/api-test.js
+++ b/ui/tests/unit/services/api-test.js
@@ -1,0 +1,202 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
+
+module('Unit | Service | api', function (hooks) {
+  setupTest(hooks);
+
+  hooks.beforeEach(function () {
+    this.apiService = this.owner.lookup('service:api');
+
+    const authService = this.owner.lookup('service:auth');
+    this.setLastFetch = sinon.spy(authService, 'setLastFetch');
+    this.currentToken = sinon.stub(authService, 'currentToken').value('foobar');
+
+    const namespaceService = this.owner.lookup('service:namespace');
+    this.namespace = sinon.stub(namespaceService, 'path').value('another-ns');
+
+    const controlGroupService = this.owner.lookup('service:control-group');
+    this.wrapInfo = { token: 'ctrl-group', accessor: '84tfdfd5pQ5vOOEMxC2o3Ymt' };
+    this.tokenForUrl = sinon.stub(controlGroupService, 'tokenForUrl').returns(this.wrapInfo);
+    this.deleteControlGroupToken = sinon.spy(controlGroupService, 'deleteControlGroupToken');
+
+    const flashMessageService = this.owner.lookup('service:flash-messages');
+    this.info = sinon.spy(flashMessageService, 'info');
+
+    this.url = '/v1/sys/capabilities-self';
+  });
+
+  test('it should set last fetch time', async function (assert) {
+    await this.apiService.setLastFetch({ url: '/v1/sys/health' });
+    assert.true(this.setLastFetch.notCalled, 'Last fetch is not set for polling url');
+
+    await this.apiService.setLastFetch({ url: '/v1/auth/token/lookup-self' });
+    assert.true(this.setLastFetch.calledOnce, 'Last fetch is set for non polling url');
+  });
+
+  test('it should get control group token', async function (assert) {
+    const context = {
+      url: this.url,
+      init: {
+        method: 'GET',
+        headers: { 'X-Vault-Token': 'root' },
+      },
+    };
+
+    this.tokenForUrl.returns(undefined);
+    const noTokenContext = await this.apiService.getControlGroupToken(context);
+
+    assert.true(this.tokenForUrl.calledWith(context.url), 'Url is passed to tokenForUrl method');
+    assert.deepEqual(context, noTokenContext, 'Original context is returned when no token is present');
+
+    this.tokenForUrl.returns(this.wrapInfo);
+
+    const { token } = this.wrapInfo;
+    const tokenContext = await this.apiService.getControlGroupToken(context);
+    const newContext = {
+      url: '/v1/sys/wrapping/unwrap',
+      init: {
+        method: 'POST',
+        headers: { 'X-Vault-Token': token },
+        body: JSON.stringify({ token }),
+      },
+    };
+
+    assert.deepEqual(tokenContext, newContext, 'New context is returned when token is present');
+  });
+
+  test('it should set headers', async function (assert) {
+    const headers = {
+      'X-Vault-Token': 'root',
+      'X-Vault-Namespace': 'ns1',
+    };
+
+    const {
+      init: { headers: originalHeaders },
+    } = await this.apiService.setHeaders({ init: { headers } });
+
+    assert.strictEqual(
+      originalHeaders.get('X-Vault-Token'),
+      'root',
+      'Original token header value is preserved'
+    );
+    assert.strictEqual(
+      originalHeaders.get('X-Vault-Namespace'),
+      'ns1',
+      'Original namespace header value is preserved'
+    );
+
+    const {
+      init: { headers: newHeaders },
+    } = await this.apiService.setHeaders({ init: {} });
+
+    assert.strictEqual(
+      newHeaders.get('X-Vault-Token'),
+      'foobar',
+      'New token header value from auth service is set'
+    );
+    assert.strictEqual(
+      newHeaders.get('X-Vault-Namespace'),
+      'another-ns',
+      'New namespace header value from namespace service is set'
+    );
+
+    const {
+      init: { headers: contentTypeHeaders },
+    } = await this.apiService.setHeaders({ init: { method: 'PATCH' } });
+
+    assert.strictEqual(
+      contentTypeHeaders.get('Content-Type'),
+      'application/merge-patch+json',
+      'Content type header is set for PATCH method'
+    );
+  });
+
+  test('it should show warnings', async function (assert) {
+    const warnings = ['warning1', 'warning2'];
+    const response = new Response(JSON.stringify({ warnings }));
+
+    await this.apiService.showWarnings({ response });
+
+    assert.true(this.info.firstCall.calledWith(warnings[0]), 'First warning message is shown');
+    assert.true(this.info.secondCall.calledWith(warnings[1]), 'Second warning message is shown');
+
+    this.info.resetHistory();
+    await this.apiService.showWarnings({ response, url: '/v1/sys/internal/counters/activity' });
+
+    assert.true(this.info.notCalled, 'Warnings are suppressed for activity endpoint');
+  });
+
+  test('it should delete control group token', async function (assert) {
+    await this.apiService.deleteControlGroupToken({ url: this.url });
+
+    assert.true(this.tokenForUrl.calledWith(this.url), 'Url is passed to tokenForUrl method');
+    assert.true(
+      this.deleteControlGroupToken.calledWith(this.wrapInfo.accessor),
+      'Control group token is deleted'
+    );
+  });
+
+  test('it should format error response', async function (assert) {
+    const e = { data: { error: 'Something went wrong' } };
+    const response = new Response(JSON.stringify(e), { status: 400 });
+
+    const errorResponse = await this.apiService.formatErrorResponse({ response, url: this.url });
+    const error = await errorResponse.json();
+    const expectedError = {
+      ...e,
+      httpStatus: 400,
+      path: this.url,
+      errors: ['Something went wrong'],
+    };
+
+    assert.deepEqual(error, expectedError, 'Error is reformated and returned');
+  });
+
+  test('it should extract data from response', async function (assert) {
+    const data = { data: { foo: 'bar' } };
+    const response = new Response(JSON.stringify(data), { status: 200 });
+
+    const extractedDataResponse = await this.apiService.extractData({ response, url: this.url });
+    const json = await extractedDataResponse.json();
+
+    assert.deepEqual(json, { foo: 'bar' }, 'Data is extracted and returned');
+  });
+
+  test('it should build headers', async function (assert) {
+    const headerMap = {
+      token: 'foobar',
+      namespace: 'ns1',
+      wrap: '10s',
+    };
+
+    const token = await this.apiService.buildHeaders({ token: headerMap.token });
+    assert.deepEqual(token.headers, { 'X-Vault-Token': headerMap.token }, 'Token header is set');
+
+    const namespace = await this.apiService.buildHeaders({ namespace: headerMap.namespace });
+    assert.deepEqual(
+      namespace.headers,
+      { 'X-Vault-Namespace': headerMap.namespace },
+      'Namespace header is set'
+    );
+
+    const wrapTTL = await this.apiService.buildHeaders({ wrap: headerMap.wrap });
+    assert.deepEqual(wrapTTL.headers, { 'X-Vault-Wrap-TTL': '10s' }, 'Wrap TTL header is set');
+
+    const multi = await this.apiService.buildHeaders(headerMap);
+    assert.deepEqual(
+      multi.headers,
+      {
+        'X-Vault-Token': 'foobar',
+        'X-Vault-Namespace': 'ns1',
+        'X-Vault-Wrap-TTL': '10s',
+      },
+      'All supported headers are set'
+    );
+  });
+});

--- a/ui/tests/unit/services/api-test.js
+++ b/ui/tests/unit/services/api-test.js
@@ -125,11 +125,6 @@ module('Unit | Service | api', function (hooks) {
 
     assert.true(this.info.firstCall.calledWith(warnings[0]), 'First warning message is shown');
     assert.true(this.info.secondCall.calledWith(warnings[1]), 'Second warning message is shown');
-
-    this.info.resetHistory();
-    await this.apiService.showWarnings({ response, url: '/v1/sys/internal/counters/activity' });
-
-    assert.true(this.info.notCalled, 'Warnings are suppressed for activity endpoint');
   });
 
   test('it should delete control group token', async function (assert) {

--- a/ui/tests/unit/services/api-test.js
+++ b/ui/tests/unit/services/api-test.js
@@ -70,50 +70,43 @@ module('Unit | Service | api', function (hooks) {
     assert.deepEqual(tokenContext, newContext, 'New context is returned when token is present');
   });
 
-  test('it should set headers', async function (assert) {
-    const headers = {
+  test('it should set default headers', async function (assert) {
+    const {
+      init: { headers },
+    } = await this.apiService.setHeaders({ init: { method: 'PATCH' } });
+
+    assert.strictEqual(
+      headers.get('X-Vault-Token'),
+      'foobar',
+      'Token header is set with value from auth service'
+    );
+    assert.strictEqual(
+      headers.get('X-Vault-Namespace'),
+      'another-ns',
+      'Namespace header is set with value from namespace service'
+    );
+    assert.strictEqual(
+      headers.get('Content-Type'),
+      'application/merge-patch+json',
+      'Content type header is set for PATCH method'
+    );
+  });
+
+  test('it should override default headers when set on request init', async function (assert) {
+    const initHeaders = {
       'X-Vault-Token': 'root',
       'X-Vault-Namespace': 'ns1',
     };
 
     const {
-      init: { headers: originalHeaders },
-    } = await this.apiService.setHeaders({ init: { headers } });
+      init: { headers },
+    } = await this.apiService.setHeaders({ init: { headers: initHeaders } });
 
+    assert.strictEqual(headers.get('X-Vault-Token'), 'root', 'Token header set on request init is preserved');
     assert.strictEqual(
-      originalHeaders.get('X-Vault-Token'),
-      'root',
-      'Original token header value is preserved'
-    );
-    assert.strictEqual(
-      originalHeaders.get('X-Vault-Namespace'),
+      headers.get('X-Vault-Namespace'),
       'ns1',
-      'Original namespace header value is preserved'
-    );
-
-    const {
-      init: { headers: newHeaders },
-    } = await this.apiService.setHeaders({ init: {} });
-
-    assert.strictEqual(
-      newHeaders.get('X-Vault-Token'),
-      'foobar',
-      'New token header value from auth service is set'
-    );
-    assert.strictEqual(
-      newHeaders.get('X-Vault-Namespace'),
-      'another-ns',
-      'New namespace header value from namespace service is set'
-    );
-
-    const {
-      init: { headers: contentTypeHeaders },
-    } = await this.apiService.setHeaders({ init: { method: 'PATCH' } });
-
-    assert.strictEqual(
-      contentTypeHeaders.get('Content-Type'),
-      'application/merge-patch+json',
-      'Content type header is set for PATCH method'
+      'Namespace header set on request init is preserved'
     );
   });
 

--- a/ui/types/vault/api.d.ts
+++ b/ui/types/vault/api.d.ts
@@ -31,8 +31,8 @@ export interface ApiResponse {
   mount_type: string;
   renewable: boolean;
   request_id: string;
-  warnings: unknown;
-  wrap_info: WrapInfo;
+  warnings: Array<string> | null;
+  wrap_info: WrapInfo | null;
 }
 
 export type HeaderMap =

--- a/ui/types/vault/api.d.ts
+++ b/ui/types/vault/api.d.ts
@@ -1,3 +1,8 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
 export interface ApiError {
   httpStatus: number;
   path: string;

--- a/ui/types/vault/api.d.ts
+++ b/ui/types/vault/api.d.ts
@@ -1,0 +1,53 @@
+export interface ApiError {
+  httpStatus: number;
+  path: string;
+  message: string;
+  errors: Array<string | { [key: string]: unknown; title?: string; message?: string }>;
+  data?: {
+    [key: string]: unknown;
+    error?: string;
+  };
+}
+
+export interface WrapInfo {
+  accessor: string;
+  creation_path: string;
+  creation_time: string;
+  wrapped_accessor: string;
+  token: string;
+  ttl: number;
+}
+
+export interface ApiResponse {
+  auth: unknown;
+  data: unknown;
+  lease_duration: number;
+  lease_id: string;
+  mount_type: string;
+  renewable: boolean;
+  request_id: string;
+  warnings: unknown;
+  wrap_info: WrapInfo;
+}
+
+export type HeaderMap =
+  | {
+      namespace: string;
+    }
+  | {
+      token: string;
+    }
+  | {
+      wrap: string;
+    };
+
+export type XVaultHeaders =
+  | {
+      'X-Vault-Namespace': string;
+    }
+  | {
+      'X-Vault-Token': string;
+    }
+  | {
+      'X-Vault-Wrap-TTL': string;
+    };

--- a/ui/types/vault/services/auth.d.ts
+++ b/ui/types/vault/services/auth.d.ts
@@ -19,4 +19,6 @@ export interface AuthData {
 
 export default class AuthService extends Service {
   authData: AuthData;
+  currentToken: string;
+  setLastFetch: (time: number) => void;
 }

--- a/ui/types/vault/services/control-group.d.ts
+++ b/ui/types/vault/services/control-group.d.ts
@@ -1,0 +1,35 @@
+import Service from '@ember/service';
+
+import type localStorage from 'vault/lib/local-storage';
+import type memoryStorage from 'vault/lib/memory-storage';
+import type { ApiResponse, WrapInfo } from 'vault/api';
+import type Transition from '@ember/routing/transition';
+
+export interface ControlGroupErrorLog {
+  type: string;
+  content: string;
+  href: string;
+  token: string;
+  accessor: string;
+  creation_path: string;
+}
+
+export default class ControlGroupService extends Service {
+  tokenToUnwrap: WrapInfo | null;
+  storage(): localStorage | memoryStorage;
+  keyFromAccessor(accessor: string): string | null;
+  storeControlGroupToken(info: WrapInfo): void;
+  deleteControlGroupToken(accessor: string): void;
+  deleteTokens(): void;
+  wrapInfoForAccessor(accessor: string): string | null;
+  markTokenForUnwrap(accessor: string): void;
+  unmarkTokenForUnwrap(): void;
+  tokenForUrl(url: string): { token: string; accessor: string; creationTime: string } | null;
+  checkForControlGroup(
+    callbackArgs: unknown,
+    response: ApiResponse,
+    wasWrapTTLRequested: boolean
+  ): Promise<unknown>;
+  saveTokenFromError(error: WrapInfo): void;
+  logFromError(error: WrapInfo): ControlGroupErrorLog;
+}

--- a/ui/types/vault/services/control-group.d.ts
+++ b/ui/types/vault/services/control-group.d.ts
@@ -1,3 +1,8 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
 import Service from '@ember/service';
 
 import type localStorage from 'vault/lib/local-storage';

--- a/ui/types/vault/services/namespace.d.ts
+++ b/ui/types/vault/services/namespace.d.ts
@@ -15,6 +15,7 @@ export default class NamespaceService extends Service {
   inRootNamespace: boolean;
   currentNamespace: string;
   relativeNamespace: string;
+  path: string;
   setNamespace: () => void;
   findNamespacesForUser: () => void;
   reset: () => void;


### PR DESCRIPTION
### Description
This PR adds an API service to configure and expose the `vault-client-typescript` API's. The middleware was ported from the application adapter to preserve the global request behavior as much as possible. 

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
