### PR TITLE
wip

### DIFF
--- a/vault/logical_system_activity.go
+++ b/vault/logical_system_activity.go
@@ -282,6 +282,11 @@ func getBillingPeriodTimes(d *framework.FieldData, billingStartTime time.Time) (
 	startTime := d.Get("start_time").(time.Time)
 	endTime := d.Get("end_time").(time.Time)
 
+	// ensure the end time is always later than the start time
+	if !startTime.IsZero() && !endTime.IsZero() && startTime.After(endTime) {
+		return time.Time{}, time.Time{}, false, fmt.Errorf("start_time is later than end_time")
+	}
+
 	var alignedStartTime, alignedEndTime time.Time
 	var timesAligned bool
 
@@ -301,11 +306,6 @@ func getBillingPeriodTimes(d *framework.FieldData, billingStartTime time.Time) (
 	// if the end time is in the current period, cap it at today
 	if alignedEndTime.After(time.Now().UTC()) {
 		alignedEndTime = time.Now().UTC()
-	}
-
-	// ensure the end time is always later than the start time
-	if alignedStartTime.After(alignedEndTime) {
-		return time.Time{}, time.Time{}, false, fmt.Errorf("start_time is later than end_time")
 	}
 
 	// Determine if any alignment occurred

--- a/vault/logical_system_activity.go
+++ b/vault/logical_system_activity.go
@@ -408,7 +408,13 @@ func (b *SystemBackend) handleClientMetricQuery(ctx context.Context, req *logica
 	}
 
 	var err error
-	startTime, endTime, timesAligned, err = getBillingPeriodTimes(d, b.Core.BillingStart())
+	// allow arbitrary start and end times if billing start date is zero, which means the cluster is CE
+	// for ENT, we get the whole billing period by aligning the given start and end times
+	if b.Core.BillingStart().IsZero() {
+		startTime, endTime, err = parseStartEndTimes(d, b.Core.BillingStart())
+	} else {
+		startTime, endTime, timesAligned, err = getBillingPeriodTimes(d, b.Core.BillingStart())
+	}
 	if err != nil {
 		return logical.ErrorResponse(err.Error()), nil
 	}

--- a/vault/logical_system_activity.go
+++ b/vault/logical_system_activity.go
@@ -258,11 +258,12 @@ func queryContainsEstimates(startTime time.Time, endTime time.Time) bool {
 	return false
 }
 
-// alignToBillingPeriod identifies the start of a billing period to which the given time
-// belongs based on the start of the current billing period
-func alignToBillingPeriod(billingStartTime, givenTime time.Time) time.Time {
+// alignToBillingPeriodStart finds the start of the billing period that contains the given time.
+// It assumes a yearly billing cycle starting at billingStartTime and moves backward in one-year
+// increments if givenTime is before the current period's start.
+func alignToBillingPeriodStart(billingStartTime, givenTime time.Time) time.Time {
 	periodStart := billingStartTime
-	// keep moving 1 year (billing cycle duration) back if the given time
+	// keep moving 1 year back if the given time
 	// is before the start of the current billing cycle
 	for givenTime.Before(periodStart) {
 		periodStart = periodStart.AddDate(-1, 0, 0)
@@ -286,7 +287,7 @@ func getBillingPeriodTimes(d *framework.FieldData, billingStartTime time.Time) (
 		alignedEndTime = time.Now().UTC()
 	} else if !startTime.IsZero() {
 		// if the start time is specified, align it to the beginning of a billing period
-		alignedStartTime = alignToBillingPeriod(billingStartTime, startTime)
+		alignedStartTime = alignToBillingPeriodStart(billingStartTime, startTime)
 		alignedEndTime = alignedStartTime.AddDate(1, 0, 0).UTC()
 
 		// If the next billing period is after today, set end time to today
@@ -295,7 +296,7 @@ func getBillingPeriodTimes(d *framework.FieldData, billingStartTime time.Time) (
 		}
 	} else {
 		// If only endTime is provided, determine the corresponding billing period based on the end time
-		alignedStartTime = alignToBillingPeriod(billingStartTime, endTime)
+		alignedStartTime = alignToBillingPeriodStart(billingStartTime, endTime)
 		alignedEndTime = alignedStartTime.AddDate(1, 0, 0).UTC()
 
 		// If the end time is in the current period, cap it at today

--- a/vault/logical_system_activity.go
+++ b/vault/logical_system_activity.go
@@ -284,25 +284,19 @@ func getBillingPeriodTimes(d *framework.FieldData, billingStartTime time.Time) (
 	if startTime.IsZero() && endTime.IsZero() {
 		// if both start time and end time are not specified, return current billing period
 		alignedStartTime = billingStartTime.UTC()
-		alignedEndTime = time.Now().UTC()
 	} else if !startTime.IsZero() {
 		// if the start time is specified, align it to the beginning of a billing period
 		alignedStartTime = alignToBillingPeriodStart(billingStartTime, startTime)
-		alignedEndTime = alignedStartTime.AddDate(1, 0, 0).UTC()
-
-		// If the next billing period is after today, set end time to today
-		if alignedEndTime.After(time.Now().UTC()) {
-			alignedEndTime = time.Now().UTC()
-		}
 	} else {
 		// If only endTime is provided, determine the corresponding billing period based on the end time
 		alignedStartTime = alignToBillingPeriodStart(billingStartTime, endTime)
-		alignedEndTime = alignedStartTime.AddDate(1, 0, 0).UTC()
+	}
 
-		// If the end time is in the current period, cap it at today
-		if alignedEndTime.After(time.Now().UTC()) {
-			alignedEndTime = time.Now().UTC()
-		}
+	// align end time
+	alignedEndTime = alignedStartTime.AddDate(1, 0, 0).UTC()
+	// if the end time is in the current period, cap it at today
+	if alignedEndTime.After(time.Now().UTC()) {
+		alignedEndTime = time.Now().UTC()
 	}
 
 	// ensure the end time is always later than the start time

--- a/vault/logical_system_activity_test.go
+++ b/vault/logical_system_activity_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestAlignToBillingPeriodStart tests alignToBillingPeriodStart for correct alignment of the start time
+// TestAlignToBillingPeriodStart tests alignToBillingPeriodStart for correct alignment of the start time and end time
 func TestAlignToBillingPeriodStart(t *testing.T) {
 	// assume the billing start time is February 1, 2023
 	billingStartTime := time.Date(2023, time.February, 1, 0, 0, 0, 0, time.UTC)
@@ -19,36 +19,67 @@ func TestAlignToBillingPeriodStart(t *testing.T) {
 	tests := map[string]struct {
 		givenTime time.Time
 		expected  time.Time
+		byEndTime bool
 	}{
 		"same as billing start time: given start time is February 1, 2023": {
 			givenTime: time.Date(2023, time.February, 1, 0, 0, 0, 0, time.UTC),
 			expected:  billingStartTime,
 		},
+		"same as billing start time: given end time is February 1, 2023": {
+			givenTime: time.Date(2023, time.February, 1, 0, 0, 0, 0, time.UTC),
+			expected:  billingStartTime.AddDate(-1, 0, 0),
+			byEndTime: true,
+		},
 		"within the same billing period: given start time is February 3, 2023": {
 			givenTime: time.Date(2023, time.June, 3, 0, 0, 0, 0, time.UTC),
 			expected:  billingStartTime,
 		},
+		"within the same billing period: given end time is February 3, 2023": {
+			givenTime: time.Date(2023, time.June, 3, 0, 0, 0, 0, time.UTC),
+			expected:  billingStartTime,
+			byEndTime: true,
+		},
 		"before the current billing period: given start time is December 20, 2022": {
 			givenTime: time.Date(2022, time.December, 20, 0, 0, 0, 0, time.UTC),
-			expected:  time.Date(2022, time.February, 1, 0, 0, 0, 0, time.UTC),
+			expected:  billingStartTime.AddDate(-1, 0, 0),
+		},
+		"before the current billing period: given end time is December 20, 2022": {
+			givenTime: time.Date(2022, time.December, 20, 0, 0, 0, 0, time.UTC),
+			expected:  billingStartTime.AddDate(-1, 0, 0),
+			byEndTime: true,
 		},
 		"exactly one year before the billing start time: given start time is February 1, 2022": {
 			givenTime: time.Date(2022, time.February, 1, 0, 0, 0, 0, time.UTC),
-			expected:  time.Date(2022, time.February, 1, 0, 0, 0, 0, time.UTC),
+			expected:  billingStartTime.AddDate(-1, 0, 0),
+		},
+		"exactly one year before the billing start time: given end time is February 1, 2022": {
+			givenTime: time.Date(2022, time.February, 1, 0, 0, 0, 0, time.UTC),
+			expected:  billingStartTime.AddDate(-2, 0, 0),
+			byEndTime: true,
 		},
 		"several years in the past: given start time is March 10, 2015": {
 			givenTime: time.Date(2015, time.March, 10, 0, 0, 0, 0, time.UTC),
 			expected:  time.Date(2015, time.February, 1, 0, 0, 0, 0, time.UTC),
 		},
+		"several years in the past: given end time is March 10, 2015": {
+			givenTime: time.Date(2015, time.March, 10, 0, 0, 0, 0, time.UTC),
+			expected:  time.Date(2015, time.February, 1, 0, 0, 0, 0, time.UTC),
+			byEndTime: true,
+		},
 		"several years in the future: given start time is April 15, 2029": {
 			givenTime: time.Date(2029, time.April, 15, 0, 0, 0, 0, time.UTC),
 			expected:  billingStartTime,
+		},
+		"several years in the future: given end time is April 15, 2029": {
+			givenTime: time.Date(2029, time.April, 15, 0, 0, 0, 0, time.UTC),
+			expected:  billingStartTime,
+			byEndTime: true,
 		},
 	}
 
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			actual := alignToBillingPeriodStart(billingStartTime, tt.givenTime)
+			actual := alignToBillingPeriodStart(billingStartTime, tt.givenTime, tt.byEndTime)
 			require.Equal(t, tt.expected, actual)
 		})
 	}
@@ -116,6 +147,13 @@ func TestGetBillingPeriodTimes(t *testing.T) {
 			expectedEndTime:    currentBillingEndDate.AddDate(-1, 0, 0),
 			expectAlignedTimes: true,
 		},
+		"Start time provided to be at exact current billing period start": {
+			givenStartTime:     currentBillingStartDate,
+			givenEndTime:       time.Time{},
+			expectedStartTime:  currentBillingStartDate,
+			expectedEndTime:    currentTime,
+			expectAlignedTimes: false,
+		},
 		"End time provided to be 5 months after the current billing period start time within the current billing cycle": {
 			givenStartTime: time.Time{},
 			givenEndTime: func() time.Time {
@@ -126,27 +164,124 @@ func TestGetBillingPeriodTimes(t *testing.T) {
 			expectedEndTime:    currentTime,
 			expectAlignedTimes: true,
 		},
-		// "Start and end time in the same billing period": {
-		// 	givenStartTime:     time.Date(2023, time.February, 1, 0, 0, 0, 0, time.UTC),
-		// 	givenEndTime:       time.Date(2024, time.February, 1, 0, 0, 0, 0, time.UTC),
-		// 	expectedStartTime:  currentBillingStartDate,
-		// 	expectedEndTime:    currentBillingEndDate,
-		// 	expectAlignedTimes: false,
-		// },
-		// "Start time at exact billing start, end time ignored": {
-		// 	givenStartTime:     time.Date(2023, time.February, 1, 0, 0, 0, 0, time.UTC),
-		// 	givenEndTime:       time.Time{},
-		// 	expectedStartTime:  currentBillingStartDate,
-		// 	expectedEndTime:    currentBillingEndDate,
-		// 	expectAlignedTimes: false,
-		// },
-		// "End time in current billing period, should cap at today": {
-		// 	givenStartTime:     time.Time{},
-		// 	givenEndTime:       time.Date(2023, time.May, 15, 0, 0, 0, 0, time.UTC),
-		// 	expectedStartTime:  currentBillingStartDate,
-		// 	expectedEndTime:    currentBillingEndDate,
-		// 	expectAlignedTimes: true,
-		// },
+		"End time provided to be 7 months after the current time outside the current billing cycle": {
+			givenStartTime: time.Time{},
+			givenEndTime: func() time.Time {
+				sevenMonthsForward := currentTime.AddDate(0, 7, 0)
+				return time.Date(sevenMonthsForward.Year(), sevenMonthsForward.Month(), 1, 2, 0, 0, 0, time.UTC)
+			}(),
+			expectedStartTime:  currentBillingStartDate,
+			expectedEndTime:    currentTime,
+			expectAlignedTimes: true,
+		},
+		"End time provided to be 4 months after the current billing cycle end time outside the current billing cycle": {
+			givenStartTime: time.Time{},
+			givenEndTime: func() time.Time {
+				fourMonthsForward := currentBillingEndDate.AddDate(0, 4, 0)
+				return time.Date(fourMonthsForward.Year(), fourMonthsForward.Month(), 3, 13, 0, 0, 0, time.UTC)
+			}(),
+			expectedStartTime:  currentBillingStartDate,
+			expectedEndTime:    currentTime,
+			expectAlignedTimes: true,
+		},
+		"End time provided to be 2 years before the current time outside the current billing cycle": {
+			givenStartTime: time.Time{},
+			givenEndTime: func() time.Time {
+				twoYearsAgo := currentTime.AddDate(-2, 0, 0)
+				return time.Date(twoYearsAgo.Year(), twoYearsAgo.Month(), 13, 21, 0, 0, 0, time.UTC)
+			}(),
+			expectedStartTime:  currentBillingStartDate.AddDate(-2, 0, 0),
+			expectedEndTime:    currentBillingEndDate.AddDate(-2, 0, 0),
+			expectAlignedTimes: true,
+		},
+		"End time provided to be at exact current billing period start": {
+			givenStartTime:     time.Time{},
+			givenEndTime:       currentBillingStartDate,
+			expectedStartTime:  currentBillingStartDate.AddDate(-1, 0, 0),
+			expectedEndTime:    currentBillingStartDate,
+			expectAlignedTimes: false,
+		},
+		"End time provided to be 2 years and 2 months before current billing period start": {
+			givenStartTime:     time.Time{},
+			givenEndTime:       currentBillingStartDate.AddDate(-2, -2, 0),
+			expectedStartTime:  currentBillingStartDate.AddDate(-3, 0, 0),
+			expectedEndTime:    currentBillingStartDate.AddDate(-2, 0, 0),
+			expectAlignedTimes: true,
+		},
+		"End time provided to be 2 years before current billing period start": {
+			givenStartTime:     time.Time{},
+			givenEndTime:       currentBillingStartDate.AddDate(-2, 0, 0),
+			expectedStartTime:  currentBillingStartDate.AddDate(-3, 0, 0),
+			expectedEndTime:    currentBillingStartDate.AddDate(-2, 0, 0),
+			expectAlignedTimes: false,
+		},
+		"End time provided to be 2 years and 2 months after the current billing period start": {
+			givenStartTime:     time.Time{},
+			givenEndTime:       currentBillingStartDate.AddDate(2, 2, 20),
+			expectedStartTime:  currentBillingStartDate,
+			expectedEndTime:    currentTime,
+			expectAlignedTimes: true,
+		},
+		"Start time is before the current billing cycle start date and end time is within the current billing cycle": {
+			givenStartTime: func() time.Time {
+				threeMonthsAgo := currentBillingStartDate.AddDate(0, -2, -3)
+				return time.Date(threeMonthsAgo.Year(), threeMonthsAgo.Month(), 12, 11, 0, 0, 0, time.UTC)
+			}(),
+			givenEndTime: func() time.Time {
+				oneMonthForward := currentBillingStartDate.AddDate(0, 1, 6)
+				return time.Date(oneMonthForward.Year(), oneMonthForward.Month(), 13, 24, 0, 0, 0, time.UTC)
+			}(),
+			expectedStartTime:  currentBillingStartDate.AddDate(-1, 0, 0),
+			expectedEndTime:    currentBillingEndDate.AddDate(-1, 0, 0),
+			expectAlignedTimes: true,
+		},
+		"Start time is within the current billing cycle and end time is after the current time": {
+			givenStartTime: func() time.Time {
+				twoDaysForward := currentBillingStartDate.AddDate(0, 0, 2)
+				return time.Date(twoDaysForward.Year(), twoDaysForward.Month(), 1, 14, 0, 0, 0, time.UTC)
+			}(),
+			givenEndTime: func() time.Time {
+				oneMonthForward := currentTime.AddDate(0, 1, 10)
+				return time.Date(oneMonthForward.Year(), oneMonthForward.Month(), 13, 24, 0, 0, 0, time.UTC)
+			}(),
+			expectedStartTime:  currentBillingStartDate,
+			expectedEndTime:    currentTime,
+			expectAlignedTimes: true,
+		},
+		"Both start time and end time are after the current time": {
+			givenStartTime: func() time.Time {
+				twoDaysForward := currentTime.AddDate(1, 2, 2)
+				return time.Date(twoDaysForward.Year(), twoDaysForward.Month(), 3, 12, 0, 0, 0, time.UTC)
+			}(),
+			givenEndTime: func() time.Time {
+				oneMonthForward := currentTime.AddDate(1, 2, 10)
+				return time.Date(oneMonthForward.Year(), oneMonthForward.Month(), 13, 24, 0, 0, 0, time.UTC)
+			}(),
+			expectedStartTime:  currentBillingStartDate,
+			expectedEndTime:    currentTime,
+			expectAlignedTimes: true,
+		},
+		"Start and end time in the same billing period from 1 year ago": {
+			givenStartTime:     currentBillingStartDate.AddDate(-1, 0, 0),
+			givenEndTime:       currentBillingStartDate,
+			expectedStartTime:  currentBillingStartDate.AddDate(-1, 0, 0),
+			expectedEndTime:    currentBillingStartDate,
+			expectAlignedTimes: false,
+		},
+		"Start time at exact current billing start, end time ignored and capped to today": {
+			givenStartTime:     currentBillingStartDate,
+			givenEndTime:       currentBillingEndDate,
+			expectedStartTime:  currentBillingStartDate,
+			expectedEndTime:    currentTime,
+			expectAlignedTimes: true,
+		},
+		"End time in current billing period, should cap at today": {
+			givenStartTime:     time.Time{},
+			givenEndTime:       currentBillingStartDate.AddDate(0, 0, 23),
+			expectedStartTime:  currentBillingStartDate,
+			expectedEndTime:    currentTime,
+			expectAlignedTimes: true,
+		},
 	}
 
 	for name, tt := range tests {

--- a/vault/logical_system_activity_test.go
+++ b/vault/logical_system_activity_test.go
@@ -7,11 +7,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/hashicorp/vault/sdk/framework"
+	"github.com/stretchr/testify/require"
 )
 
-// TestAlignToBillingPeriod tests alignToBillingPeriod for correct alignment of the start time
-func TestAlignToBillingPeriod(t *testing.T) {
+// TestAlignToBillingPeriodStart tests alignToBillingPeriodStart for correct alignment of the start time
+func TestAlignToBillingPeriodStart(t *testing.T) {
 	// assume the billing start time is February 1, 2023
 	billingStartTime := time.Date(2023, time.February, 1, 0, 0, 0, 0, time.UTC)
 
@@ -48,7 +49,132 @@ func TestAlignToBillingPeriod(t *testing.T) {
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
 			actual := alignToBillingPeriodStart(billingStartTime, tt.givenTime)
-			assert.Equal(t, tt.expected, actual)
+			require.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
+func TestGetBillingPeriodTimes(t *testing.T) {
+	// establish the current billing period
+	currentTime := time.Now().UTC()
+	// assume the date of the current billing period is 7 months prior to current time, but with the day set to 1 and the rest to 0
+	sevenMonthsAgo := currentTime.AddDate(0, -7, 0).UTC()
+	currentBillingStartDate := time.Date(sevenMonthsAgo.Year(), sevenMonthsAgo.Month(), 1, 0, 0, 0, 0, time.UTC)
+	currentBillingEndDate := currentBillingStartDate.AddDate(1, 0, 0).UTC()
+
+	tests := map[string]struct {
+		givenStartTime     time.Time
+		givenEndTime       time.Time
+		expectedStartTime  time.Time
+		expectedEndTime    time.Time
+		expectAlignedTimes bool
+	}{
+		"No start or end time provided, should return times from current billing period start time to now": {
+			givenStartTime:     time.Time{},
+			givenEndTime:       time.Time{},
+			expectedStartTime:  currentBillingStartDate,
+			expectedEndTime:    currentTime,
+			expectAlignedTimes: false,
+		},
+		"Start time provided to be 2 months after the current billing period start time within the current billing cycle": {
+			givenStartTime: func() time.Time {
+				twoMonthsForward := currentBillingStartDate.AddDate(0, 2, 0)
+				return time.Date(twoMonthsForward.Year(), twoMonthsForward.Month(), 10, 0, 0, 0, 0, time.UTC)
+			}(),
+			givenEndTime:       time.Time{},
+			expectedStartTime:  currentBillingStartDate,
+			expectedEndTime:    currentTime,
+			expectAlignedTimes: true,
+		},
+		"Start time provided to be 5 months after the current time outside the current billing cycle": {
+			givenStartTime: func() time.Time {
+				fiveMonthsForward := currentTime.AddDate(0, 5, 0)
+				return time.Date(fiveMonthsForward.Year(), fiveMonthsForward.Month(), 2, 2, 0, 0, 0, time.UTC)
+			}(),
+			givenEndTime:       time.Time{},
+			expectedStartTime:  currentBillingStartDate,
+			expectedEndTime:    currentTime,
+			expectAlignedTimes: true,
+		},
+		"Start time provided to be 3 months after the current billing cycle end time outside the current billing cycle": {
+			givenStartTime: func() time.Time {
+				threeMonthsForward := currentBillingEndDate.AddDate(0, 3, 0)
+				return time.Date(threeMonthsForward.Year(), threeMonthsForward.Month(), 1, 23, 0, 0, 0, time.UTC)
+			}(),
+			givenEndTime:       time.Time{},
+			expectedStartTime:  currentBillingStartDate,
+			expectedEndTime:    currentTime,
+			expectAlignedTimes: true,
+		},
+		"Start time provided to be 1 year before the current time outside the current billing cycle": {
+			givenStartTime: func() time.Time {
+				oneYearAgo := currentTime.AddDate(-1, 0, 0)
+				return time.Date(oneYearAgo.Year(), oneYearAgo.Month(), 1, 0, 0, 0, 0, time.UTC)
+			}(),
+			givenEndTime:       time.Time{},
+			expectedStartTime:  currentBillingStartDate.AddDate(-1, 0, 0),
+			expectedEndTime:    currentBillingEndDate.AddDate(-1, 0, 0),
+			expectAlignedTimes: true,
+		},
+		"End time provided to be 5 months after the current billing period start time within the current billing cycle": {
+			givenStartTime: time.Time{},
+			givenEndTime: func() time.Time {
+				fiveMonthsForward := currentBillingStartDate.AddDate(0, 5, 0)
+				return time.Date(fiveMonthsForward.Year(), fiveMonthsForward.Month(), 23, 5, 0, 0, 0, time.UTC)
+			}(),
+			expectedStartTime:  currentBillingStartDate,
+			expectedEndTime:    currentTime,
+			expectAlignedTimes: true,
+		},
+		// "Start and end time in the same billing period": {
+		// 	givenStartTime:     time.Date(2023, time.February, 1, 0, 0, 0, 0, time.UTC),
+		// 	givenEndTime:       time.Date(2024, time.February, 1, 0, 0, 0, 0, time.UTC),
+		// 	expectedStartTime:  currentBillingStartDate,
+		// 	expectedEndTime:    currentBillingEndDate,
+		// 	expectAlignedTimes: false,
+		// },
+		// "Start time at exact billing start, end time ignored": {
+		// 	givenStartTime:     time.Date(2023, time.February, 1, 0, 0, 0, 0, time.UTC),
+		// 	givenEndTime:       time.Time{},
+		// 	expectedStartTime:  currentBillingStartDate,
+		// 	expectedEndTime:    currentBillingEndDate,
+		// 	expectAlignedTimes: false,
+		// },
+		// "End time in current billing period, should cap at today": {
+		// 	givenStartTime:     time.Time{},
+		// 	givenEndTime:       time.Date(2023, time.May, 15, 0, 0, 0, 0, time.UTC),
+		// 	expectedStartTime:  currentBillingStartDate,
+		// 	expectedEndTime:    currentBillingEndDate,
+		// 	expectAlignedTimes: true,
+		// },
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			d := &framework.FieldData{
+				Schema: map[string]*framework.FieldSchema{
+					"start_time": {
+						Type: framework.TypeTime,
+					},
+					"end_time": {
+						Type: framework.TypeTime,
+					},
+				},
+				Raw: map[string]any{
+					"start_time": tt.givenStartTime.Format(time.RFC3339Nano),
+					"end_time":   tt.givenEndTime.Format(time.RFC3339Nano),
+				},
+			}
+
+			actualStart, actualEnd, actualAligned, err := getBillingPeriodTimes(d, currentBillingStartDate)
+			require.NoError(t, err)
+			currentTime = time.Now().UTC()
+
+			require.Equal(t, tt.expectedStartTime, actualStart, "Expected start time did not match")
+			// since end time might have the current value, we need to truncate the end times up to minutes when comparing
+			// time.Now().UTC() is called at slightly different moments, resulting in tiny differences in the timestamp
+			require.Equal(t, tt.expectedEndTime.Truncate(time.Minute), actualEnd.Truncate(time.Minute), "Expected end time did not match")
+			require.Equal(t, tt.expectAlignedTimes, actualAligned, "Expected alignment flag did not match")
 		})
 	}
 }

--- a/vault/logical_system_activity_test.go
+++ b/vault/logical_system_activity_test.go
@@ -1,0 +1,54 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package vault
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestAlignToBillingPeriod tests alignToBillingPeriod for correct alignment of the start time
+func TestAlignToBillingPeriod(t *testing.T) {
+	// assume the billing start time is February 1, 2023
+	billingStartTime := time.Date(2023, time.February, 1, 0, 0, 0, 0, time.UTC)
+
+	tests := map[string]struct {
+		givenTime time.Time
+		expected  time.Time
+	}{
+		"same as billing start time: given start time is February 1, 2023": {
+			givenTime: time.Date(2023, time.February, 1, 0, 0, 0, 0, time.UTC),
+			expected:  billingStartTime,
+		},
+		"within the same billing period: given start time is February 3, 2023": {
+			givenTime: time.Date(2023, time.June, 3, 0, 0, 0, 0, time.UTC),
+			expected:  billingStartTime,
+		},
+		"before the current billing period: given start time is December 20, 2022": {
+			givenTime: time.Date(2022, time.December, 20, 0, 0, 0, 0, time.UTC),
+			expected:  time.Date(2022, time.February, 1, 0, 0, 0, 0, time.UTC),
+		},
+		"exactly one year before the billing start time: given start time is February 1, 2022": {
+			givenTime: time.Date(2022, time.February, 1, 0, 0, 0, 0, time.UTC),
+			expected:  time.Date(2022, time.February, 1, 0, 0, 0, 0, time.UTC),
+		},
+		"several years in the past: given start time is March 10, 2015": {
+			givenTime: time.Date(2015, time.March, 10, 0, 0, 0, 0, time.UTC),
+			expected:  time.Date(2015, time.February, 1, 0, 0, 0, 0, time.UTC),
+		},
+		"several years in the future: given start time is April 15, 2029": {
+			givenTime: time.Date(2029, time.April, 15, 0, 0, 0, 0, time.UTC),
+			expected:  billingStartTime,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			actual := alignToBillingPeriodStart(billingStartTime, tt.givenTime)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}


### PR DESCRIPTION
### Description
What does this PR do?
The counters api endpoint is updated to only show client counts for an entire billing period. By default, it will return the activity information of the current billing period. 
The start_time and end_time parameters will still be available but can only be used to specify the beginning or end of a billing period, not specific dates within/outside a billing period. If specified, The counters API will return data for the billing period corresponding to the specified start time, meaning the start time of the query will be aligned with the start of the billing period to which it belongs, regardless of the exact date provided by the user. If only end_time is specified, the query will be aligned with the start of the billing period to which the end_time belongs to.

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
