### PR TITLE
bugfix: vault register should respect tmpdir

### DIFF
--- a/changelog/29978.txt
+++ b/changelog/29978.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+plugins: plugin registration should honor the `plugin_tmpdir` config
+```

--- a/vault/plugincatalog/plugin_catalog_stubs_oss.go
+++ b/vault/plugincatalog/plugin_catalog_stubs_oss.go
@@ -52,6 +52,7 @@ func (c *PluginCatalog) setInternal(ctx context.Context, plugin pluginutil.SetPl
 		Env:      plugin.Env,
 		Sha256:   plugin.Sha256,
 		Builtin:  false,
+		Tmpdir:   c.tmpdir,
 	}
 	if entryTmp.OCIImage != "" && entryTmp.Runtime != "" {
 		var err error
@@ -112,6 +113,7 @@ func (c *PluginCatalog) setInternal(ctx context.Context, plugin pluginutil.SetPl
 		Env:      plugin.Env,
 		Sha256:   plugin.Sha256,
 		Builtin:  false,
+		Tmpdir:   c.tmpdir,
 	}
 
 	buf, err := json.Marshal(entry)


### PR DESCRIPTION
### Description

When running Vault via systemd and `PrivateTmp=on`, the Vault register command fails, even when setting the `VAULT_PLUGIN_TMPDIR` environment variable:
```
ubuntu@ip-172-25-19-239:~$ vault plugin register -sha256="${SHA256}" -oci_image=hashicorp/vault-plugin-secrets-kv secret my-kv-container
WARNING! VAULT_ADDR and -address unset. Defaulting to https://127.0.0.1:8200/.
Error registering plugin my-kv-container: Error making API request.

URL: PUT https://127.0.0.1:8200/v1/sys/plugins/catalog/secret/my-kv-container
Code: 400. Errors:

* unable to run plugin: 1 error occurred:
        * error creating container: Error response from daemon: invalid mount config for type "bind": bind source path does not exist: /tmp/plugin-dir3781501367
        *
```

This change makes it so that the register flow respects the tmpdir, if set.

With this change, the output looks like:

```
vault plugin register -sha256="${SHA256}" -oci_image=hashicorp/vault-plugin-secrets-kv  secret my-kv-container
WARNING! VAULT_ADDR and -address unset. Defaulting to https://127.0.0.1:8200.
Success! Registered plugin: my-kv-container
```

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
