### PR TITLE
enos(install_packages): handle cloud-init exit code 2 and subshells

### DIFF
--- a/enos/modules/install_packages/scripts/synchronize-repos.sh
+++ b/enos/modules/install_packages/scripts/synchronize-repos.sh
@@ -105,12 +105,11 @@ synchronize_repos() {
 # We run as sudo because Amazon Linux 2 throws Python 2.7 errors when running `cloud-init status` as
 # non-root user (known bug).
 wait_for_cloud_init() {
-  output=$(sudo cloud-init status --wait)
+  if output=$(sudo cloud-init status --wait); then
+    return 0
+  fi
   res=$?
   case $res in
-    0)
-      return 0
-      ;;
     2)
       {
         echo "WARNING: cloud-init did not complete successfully but recovered."
@@ -134,8 +133,8 @@ wait_for_cloud_init() {
   esac
 }
 
-# Wait for cloud-init
-wait_for_cloud_init
+# Wait for cloud-init if it exists
+type cloud-init && wait_for_cloud_init
 
 # Synchronizing repos
 begin_time=$(date +%s)


### PR DESCRIPTION
### Description

In the `synchronize-repos.sh` script we use `cloud-init status --wait` to ensure that `cloud-init` is not running when we attempt to sync the repositories. This is all fine and good except that modern versions of `cloud-init` can exit with 2 if they encounter an error but recover. Since we're running the script with `-e` and don't gate the exit with an expression the script will fail rather than recover when we receive that code.

Ought to fix: https://github.com/hashicorp/vault-enterprise/actions/runs/13976392635/job/39133116883

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [x] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
