### PR TITLE
secrets/aws: disable environment and shared credential providers when using WIF

### DIFF
--- a/changelog/29982.txt
+++ b/changelog/29982.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-secrets/aws: explicitly disable environment and shared credential providers when using WIF
+secrets/aws: fix a bug where environment and shared credential providers were overriding the WIF configuration
 ```

--- a/changelog/29982.txt
+++ b/changelog/29982.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+secrets/aws: explicitly disable environment and shared credential providers when using WIF
+```


### PR DESCRIPTION
### Description
As of today, WIF is unusable in certain environments that make use of AWS Profiles or environment variables for other purposes, such as using KMS or HVD. This is due to the AWS Secrets Engine picking up the shared credentials in the environment, and adding multiple providers when generating its credential chain.

This PR explicitly disables Shared Credential and Environment Variable Providers if WIF parameters are explicitly set as part of the root AWS Config. If WIF is not being used, environment / shared credentials can be used as expected.