### PR TITLE
VAULT-34868: Fix Enos Synchronize-repos failure

### DIFF
--- a/enos/modules/install_packages/scripts/synchronize-repos.sh
+++ b/enos/modules/install_packages/scripts/synchronize-repos.sh
@@ -110,7 +110,7 @@ wait_for_cloud_init() {
   fi
   res=$?
   case $res in
-    2)
+    2|0)
       {
         echo "WARNING: cloud-init did not complete successfully but recovered."
         echo "Exit code: $res"

--- a/enos/modules/install_packages/scripts/synchronize-repos.sh
+++ b/enos/modules/install_packages/scripts/synchronize-repos.sh
@@ -149,3 +149,4 @@ while [ "$(date +%s)" -lt "$end_time" ]; do
 done
 
 fail "Timed out waiting for distro repos to be set up"
+

--- a/enos/modules/install_packages/scripts/synchronize-repos.sh
+++ b/enos/modules/install_packages/scripts/synchronize-repos.sh
@@ -110,7 +110,7 @@ wait_for_cloud_init() {
   fi
   res=$?
   case $res in
-    2|0)
+    2 | 0)
       {
         echo "WARNING: cloud-init did not complete successfully but recovered."
         echo "Exit code: $res"

--- a/enos/modules/install_packages/scripts/synchronize-repos.sh
+++ b/enos/modules/install_packages/scripts/synchronize-repos.sh
@@ -108,6 +108,7 @@ wait_for_cloud_init() {
   if output=$(sudo cloud-init status --wait); then
     return 0
   fi
+  echo "----------------$?"
   res=$?
   case $res in
     2 | 0)

--- a/go.mod
+++ b/go.mod
@@ -73,7 +73,7 @@ require (
 	github.com/go-test/deep v1.1.1
 	github.com/go-zookeeper/zk v1.0.3
 	github.com/gocql/gocql v1.0.0
-	github.com/golang-jwt/jwt/v4 v4.5.1
+	github.com/golang-jwt/jwt/v4 v4.5.2
 	github.com/golang/protobuf v1.5.4
 	github.com/google/certificate-transparency-go v1.3.1
 	github.com/google/go-cmp v0.7.0
@@ -400,7 +400,7 @@ require (
 	github.com/go-ozzo/ozzo-validation v3.6.0+incompatible // indirect
 	github.com/goccy/go-json v0.10.2 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
-	github.com/golang-jwt/jwt/v5 v5.2.1 // indirect
+	github.com/golang-jwt/jwt/v5 v5.2.2 // indirect
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
 	github.com/golang-sql/sqlexp v0.1.0 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect

--- a/go.sum
+++ b/go.sum
@@ -1197,10 +1197,10 @@ github.com/goji/httpauth v0.0.0-20160601135302-2da839ab0f4d/go.mod h1:nnjvkQ9ptG
 github.com/golang-jwt/jwt/v4 v4.0.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
 github.com/golang-jwt/jwt/v4 v4.2.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
 github.com/golang-jwt/jwt/v4 v4.5.0/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
-github.com/golang-jwt/jwt/v4 v4.5.1 h1:JdqV9zKUdtaa9gdPlywC3aeoEsR681PlKC+4F5gQgeo=
-github.com/golang-jwt/jwt/v4 v4.5.1/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
-github.com/golang-jwt/jwt/v5 v5.2.1 h1:OuVbFODueb089Lh128TAcimifWaLhJwVflnrgM17wHk=
-github.com/golang-jwt/jwt/v5 v5.2.1/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
+github.com/golang-jwt/jwt/v4 v4.5.2 h1:YtQM7lnr8iZ+j5q71MGKkNw9Mn7AjHM68uc9g5fXeUI=
+github.com/golang-jwt/jwt/v4 v4.5.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
+github.com/golang-jwt/jwt/v5 v5.2.2 h1:Rl4B7itRWVtYIHFrSNd7vhTiz9UpLdi6gZhZ3wEeDy8=
+github.com/golang-jwt/jwt/v5 v5.2.2/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe/go.mod h1:8vg3r2VgvsThLBIFL93Qb5yWzgyZWhEmBwUJWevAkK0=
 github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 h1:au07oEsX2xN0ktxqI+Sida1w446QrXBRJ0nee3SNZlA=
 github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9/go.mod h1:8vg3r2VgvsThLBIFL93Qb5yWzgyZWhEmBwUJWevAkK0=

--- a/ui/app/components/tools/wrap.ts
+++ b/ui/app/components/tools/wrap.ts
@@ -8,7 +8,13 @@ import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { stringify } from 'core/helpers/stringify';
-import errorMessage from 'vault/utils/error-message';
+import apiErrorMessage from 'vault/utils/api-error-message';
+
+import type ApiService from 'vault/services/api';
+import type FlashMessageService from 'vault/services/flash-messages';
+import type { TtlEvent } from 'vault/app-types';
+import type { HTMLElementEvent } from 'vault/forms';
+import type { Editor } from 'codemirror';
 
 /**
  * @module ToolsWrap
@@ -19,12 +25,12 @@ import errorMessage from 'vault/utils/error-message';
  */
 
 export default class ToolsWrap extends Component {
-  @service store;
-  @service flashMessages;
+  @service declare readonly api: ApiService;
+  @service declare readonly flashMessages: FlashMessageService;
 
   @tracked hasLintingErrors = false;
   @tracked token = '';
-  @tracked wrapTTL = null;
+  @tracked wrapTTL = '';
   @tracked wrapData = null;
   @tracked errorMessage = '';
   @tracked showJson = true;
@@ -34,11 +40,11 @@ export default class ToolsWrap extends Component {
     // otherwise the following codemirror modifier check will pass `this._editor.getValue() !== namedArgs.content` and _setValue will be called.
     // the method _setValue moves the cursor to the beginning of the text field.
     // the effect is that the cursor jumps after the first key input.
-    return JSON.stringify({ '': '' }, null, 2);
+    return stringify([{ '': '' }], { skipFormat: false });
   }
 
   get stringifiedWrapData() {
-    return this?.wrapData ? stringify([this.wrapData], {}) : this.startingValue;
+    return this.wrapData ? stringify([this.wrapData], { skipFormat: false }) : this.startingValue;
   }
 
   @action
@@ -51,37 +57,37 @@ export default class ToolsWrap extends Component {
   reset(clearData = true) {
     this.token = '';
     this.errorMessage = '';
-    this.wrapTTL = null;
+    this.wrapTTL = '';
     this.hasLintingErrors = false;
     if (clearData) this.wrapData = null;
   }
 
   @action
-  updateTtl(evt) {
+  updateTtl(evt: TtlEvent) {
     if (!evt) return;
     this.wrapTTL = evt.enabled ? `${evt.seconds}s` : '30m';
   }
 
   @action
-  codemirrorUpdated(val, codemirror) {
+  codemirrorUpdated(val: string, codemirror: Editor) {
     codemirror.performLint();
     this.hasLintingErrors = codemirror?.state.lint.marked?.length > 0;
     if (!this.hasLintingErrors) this.wrapData = JSON.parse(val);
   }
 
   @action
-  async handleSubmit(evt) {
+  async handleSubmit(evt: HTMLElementEvent<HTMLFormElement>) {
     evt.preventDefault();
 
-    const data = this.wrapData;
-    const wrapTTL = this.wrapTTL || null;
+    const data = this.wrapData || {};
+    const wrap = this.wrapTTL || '';
 
     try {
-      const response = await this.store.adapterFor('tools').toolAction('wrap', data, { wrapTTL });
-      this.token = response.wrap_info.token;
+      const { wrap_info } = await this.api.sys.wrap(data, this.api.buildHeaders({ wrap }));
+      this.token = wrap_info?.token || '';
       this.flashMessages.success('Wrap was successful.');
     } catch (error) {
-      this.errorMessage = errorMessage(error);
+      this.errorMessage = await apiErrorMessage(error);
     }
   }
 }

--- a/ui/app/utils/api-error-message.ts
+++ b/ui/app/utils/api-error-message.ts
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+/**
+ * this util was derived from error-message and updated to handle the error context returned from the api service
+ * once Ember Data is fully removed, the error-message util will also be removed
+ * for all requests made with the api service, use this util to display error messages from server
+ */
+
+import { ErrorContext, ApiError } from 'vault/api';
+
+// accepts an error and returns error.errors joined with a comma, error.message or a fallback message
+export default async function (error: unknown, fallbackMessage = 'An error occurred, please try again') {
+  const messageOrFallback = (message?: string) => message || fallbackMessage;
+
+  if ((error as ErrorContext).response instanceof Response) {
+    const apiError: ApiError = await (error as ErrorContext).response?.json();
+
+    if (apiError.errors && typeof apiError.errors[0] === 'string') {
+      return apiError.errors.join(', ');
+    }
+    return messageOrFallback(apiError.message);
+  }
+
+  return messageOrFallback((error as Error)?.message);
+}

--- a/ui/app/utils/error-message.js
+++ b/ui/app/utils/error-message.js
@@ -3,6 +3,13 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
+/**
+ * deprecated in favor of api-error-message for use with the api service
+ * this util will be removed once Ember Data is fully removed
+ * new requests should be made with api service
+ * if Ember Data is still needed during the migration then this util may be used
+ */
+
 // accepts an error and returns error.errors joined with a comma, error.message or a fallback message
 export default function (error, fallbackMessage = 'An error occurred, please try again') {
   if (error instanceof Error && error?.errors && typeof error.errors[0] === 'string') {

--- a/ui/lib/core/addon/components/form-field.hbs
+++ b/ui/lib/core/addon/components/form-field.hbs
@@ -15,8 +15,8 @@
           {{#if this.labelString}}
             <G.Legend data-test-form-field-label>{{this.labelString}}</G.Legend>
           {{/if}}
-          {{#if this.showHelpText}}
-            <G.HelperText data-test-help-text>{{@attr.options.helpText}}</G.HelperText>
+          {{#if this.helpTextString}}
+            <G.HelperText data-test-help-text>{{this.helpTextString}}</G.HelperText>
           {{/if}}
           {{#if @attr.options.subText}}
             <G.HelperText data-test-label-subtext>
@@ -54,8 +54,8 @@
           {{#if this.labelString}}
             <F.Label data-test-form-field-label>{{this.labelString}}</F.Label>
           {{/if}}
-          {{#if this.showHelpText}}
-            <F.HelperText data-test-help-text>{{@attr.options.helpText}}</F.HelperText>
+          {{#if this.helpTextString}}
+            <F.HelperText data-test-help-text>{{this.helpTextString}}</F.HelperText>
           {{/if}}
           {{#if @attr.options.subText}}
             <F.HelperText data-test-label-subtext>
@@ -104,8 +104,8 @@
               {{#if this.labelString}}
                 <F.Label data-test-form-field-label>{{this.labelString}}</F.Label>
               {{/if}}
-              {{#if this.showHelpText}}
-                <F.HelperText data-test-help-text>{{@attr.options.helpText}}</F.HelperText>
+              {{#if this.helpTextString}}
+                <F.HelperText data-test-help-text>{{this.helpTextString}}</F.HelperText>
               {{/if}}
               {{#if @attr.options.subText}}
                 <F.HelperText data-test-label-subtext>
@@ -135,7 +135,7 @@
       <FormFieldLabel
         for={{@attr.name}}
         @label={{this.labelString}}
-        @helpText={{(if this.showHelpText @attr.options.helpText)}}
+        @helpText={{this.helpTextString}}
         @subText={{@attr.options.subText}}
         @docLink={{@attr.options.docLink}}
       />
@@ -205,7 +205,7 @@
           @label={{this.labelString}}
           @labelClass={{if @attr.options.isSectionHeader "title is-4" "is-label"}}
           @subText={{@attr.options.subText}}
-          @helpText={{@attr.options.helpText}}
+          @helpText={{this.helpTextString}}
           @fallbackComponent={{@attr.options.fallbackComponent}}
           @selectLimit={{@attr.options.selectLimit}}
           @backend={{@model.backend}}
@@ -217,7 +217,7 @@
       <MountAccessorSelect
         @name={{@attr.name}}
         @label={{this.labelString}}
-        @helpText={{@attr.options.helpText}}
+        @helpText={{this.helpTextString}}
         @value={{get @model this.valuePath}}
         @onChange={{this.setAndBroadcast}}
       />
@@ -228,7 +228,7 @@
         @onChange={{this.setAndBroadcast}}
         @label={{this.labelString}}
         @labelClass={{if @attr.options.isSectionHeader "title is-4" "is-label"}}
-        @helpText={{@attr.options.helpText}}
+        @helpText={{this.helpTextString}}
         @subText={{@attr.options.subText}}
         @onKeyUp={{this.handleKeyUp}}
         @keyPlaceholder={{@attr.options.keyPlaceholder}}
@@ -243,7 +243,7 @@
         <TextFile
           @label={{this.labelString}}
           @subText={{@attr.options.subText}}
-          @helpText={{@attr.options.helpText}}
+          @helpText={{this.helpTextString}}
           @docLink={{@attr.options.docLink}}
           @onChange={{this.setFile}}
           @validationError={{this.validationError}}
@@ -345,7 +345,7 @@
         class={{if this.validationError "string-list-form-field-error"}}
         data-test-input={{@attr.name}}
         @label={{this.labelString}}
-        @helpText={{if this.showHelpText @attr.options.helpText}}
+        @helpText={{this.helpTextString}}
         @inputValue={{get @model this.valuePath}}
         @onChange={{this.setAndBroadcast}}
         @attrName={{@attr.name}}
@@ -383,7 +383,7 @@
               }}
               @valueUpdated={{fn this.codemirrorUpdated true}}
               @theme={{or @attr.options.theme "hashi"}}
-              @helpText={{@attr.options.helpText}}
+              @helpText={{this.helpTextString}}
               @mode={{@attr.options.mode}}
               @example={{@attr.options.example}}
             >
@@ -442,8 +442,8 @@
         />
         <label for={{@attr.name}} class="is-label" data-test-form-field-label>
           {{this.labelString}}
-          {{#if (and this.showHelpText @attr.options.helpText)}}
-            <InfoTooltip>{{@attr.options.helpText}}</InfoTooltip>
+          {{#if this.helpTextString}}
+            <InfoTooltip>{{this.helpTextString}}</InfoTooltip>
           {{/if}}
         </label>
         {{#if @attr.options.subText}}
@@ -462,7 +462,7 @@
         @title={{this.labelString}}
         @value={{if (get @model this.valuePath) (stringify (get @model this.valuePath)) this.emptyData}}
         @valueUpdated={{fn this.codemirrorUpdated false}}
-        @helpText={{@attr.options.helpText}}
+        @helpText={{this.helpTextString}}
         @example={{@attr.options.example}}
       />
     {{else if (eq @attr.options.editType "yield")}}

--- a/ui/lib/core/addon/components/form-field.hbs
+++ b/ui/lib/core/addon/components/form-field.hbs
@@ -6,6 +6,9 @@
 {{! template-lint-configure simple-unless "warn" }}
 <div class="field" data-test-field={{or @attr.name true}}>
   {{#if this.isHdsFormField}}
+    {{! •••••••••••••••••••••••••••••••••••••••••••••••••••••••• }}
+    {{!                  HDS COMPONENTS - START                  }}
+    {{! •••••••••••••••••••••••••••••••••••••••••••••••••••••••• }}
     {{#if @attr.options.possibleValues}}
       {{#if (eq @attr.options.editType "checkboxList")}}
         <Hds::Form::Checkbox::Group @name={{@attr.name}} data-test-input={{@attr.name}} as |G|>
@@ -80,8 +83,54 @@
           {{/if}}
         </Hds::Form::Select::Field>
       {{/if}}
+    {{else}}
+      {{#if (or (eq @attr.type "number") (eq @attr.type "string"))}}
+        {{#if (eq @attr.options.editType "password")}}
+          <Hds::Form::TextInput::Field
+            @type="password"
+            {{! TODO: about this visibility toggle, see: https://hashicorp.atlassian.net/browse/VAULT-34870 }}
+            @hasVisibilityToggle={{false}}
+            @value={{get @model this.valuePath}}
+            name={{@attr.name}}
+            @isInvalid={{this.validationError}}
+            {{! Prevents browsers from auto-filling }}
+            autocomplete="new-password"
+            spellcheck="false"
+            {{on "input" this.onChangeWithEvent}}
+            data-test-input={{@attr.name}}
+            as |F|
+          >
+            {{#unless this.hideLabel}}
+              {{#if this.labelString}}
+                <F.Label data-test-form-field-label>{{this.labelString}}</F.Label>
+              {{/if}}
+              {{#if this.showHelpText}}
+                <F.HelperText data-test-help-text>{{@attr.options.helpText}}</F.HelperText>
+              {{/if}}
+              {{#if @attr.options.subText}}
+                <F.HelperText data-test-label-subtext>
+                  {{@attr.options.subText}}
+                  {{#if @attr.options.docLink}}
+                    <DocLink @path={{@attr.options.docLink}}>See our documentation</DocLink>
+                    for help.
+                  {{/if}}
+                </F.HelperText>
+              {{/if}}
+            {{/unless}}
+            {{#if this.validationError}}
+              <F.Error data-test-field-validation={{this.valuePath}}>{{this.validationError}}</F.Error>
+            {{/if}}
+          </Hds::Form::TextInput::Field>
+        {{/if}}
+      {{/if}}
     {{/if}}
+    {{! •••••••••••••••••••••••••••••••••••••••••••••••••••••••• }}
+    {{!                  HDS COMPONENTS - END                  }}
+    {{! •••••••••••••••••••••••••••••••••••••••••••••••••••••••• }}
   {{else}}
+    {{! ≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠ }}
+    {{!                NON-HDS COMPONENTS - START                }}
+    {{! ≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠ }}
     {{#unless this.hideLabel}}
       <FormFieldLabel
         for={{@attr.name}}
@@ -321,17 +370,6 @@
             oninput={{this.onChangeWithEvent}}
             class="textarea {{if this.validationError 'has-error-border'}}"
           ></textarea>
-        {{else if (eq @attr.options.editType "password")}}
-          <Input
-            data-test-input={{@attr.name}}
-            @type="password"
-            @value={{get @model this.valuePath}}
-            name={{@attr.name}}
-            class="input"
-            {{! Prevents browsers from auto-filling }}
-            autocomplete="new-password"
-            spellcheck="false"
-          />
         {{else if (eq @attr.options.editType "json")}}
           {{! JSON Editor }}
           {{#let (get @model this.valuePath) as |value|}}
@@ -439,7 +477,11 @@
         class={{if (eq @attr.options.editType "stringArray") "has-top-margin-negative-xxl"}}
       />
     {{/if}}
+    {{! ≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠ }}
+    {{!                NON-HDS COMPONENTS - END                  }}
+    {{! ≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠≠ }}
   {{/if}}
+  {{! ~~~~~~~~~~~~~~ COMMON PART - START ~~~~~~~~~~~~~~ }}
   {{#if this.validationWarning}}
     <AlertInline
       @type="warning"
@@ -449,4 +491,5 @@
       class={{if (and (not this.validationError) (eq @attr.options.editType "stringArray")) "has-top-margin-negative-xxl"}}
     />
   {{/if}}
+  {{! ~~~~~~~~~~~~~~ COMMON PART - END ~~~~~~~~~~~~~~ }}
 </div>

--- a/ui/lib/core/addon/components/form-field.js
+++ b/ui/lib/core/addon/components/form-field.js
@@ -100,9 +100,11 @@ export default class FormFieldComponent extends Component {
       }
     } else {
       if (type === 'number' || type === 'string') {
-        // here we will add the logic for `FormField` inputs (textarea, password, regular text input) that are "converted" to HDS fields
-        // for example: if (options?.editType === 'textarea' || options?.editType === 'password') { return true; }
-        return false;
+        if (options?.editType === 'password') {
+          return true;
+        } else {
+          return false;
+        }
       } else {
         // we leave these fields as they are (for now)
         return false;

--- a/ui/lib/core/addon/components/form-field.js
+++ b/ui/lib/core/addon/components/form-field.js
@@ -130,8 +130,12 @@ export default class FormFieldComponent extends Component {
     return this.args.disabled || false;
   }
 
-  get showHelpText() {
-    return this.args.showHelpText === false ? false : true;
+  get helpTextString() {
+    const helpText = this.args.attr?.options?.helpText;
+    if (this.args.showHelpText !== false && helpText) {
+      return helpText;
+    }
+    return '';
   }
 
   // used in the label element next to the form element

--- a/ui/package.json
+++ b/ui/package.json
@@ -63,6 +63,7 @@
     "@icholy/duration": "^5.1.0",
     "@lineal-viz/lineal": "^0.5.1",
     "@tsconfig/ember": "^2.0.0",
+    "@types/codemirror": "^5.60.15",
     "@types/d3-array": "^3.2.1",
     "@types/ember-data": "^4.4.16",
     "@types/qunit": "^2.19.4",

--- a/ui/tests/integration/components/tools/wrap-test.js
+++ b/ui/tests/integration/components/tools/wrap-test.js
@@ -70,7 +70,7 @@ module('Integration | Component | tools/wrap', function (hooks) {
     this.server.post('sys/wrapping/wrap', (schema, { requestBody, requestHeaders }) => {
       const payload = JSON.parse(requestBody);
       assert.propEqual(payload, JSON.parse(this.wrapData), `payload contains data: ${requestBody}`);
-      assert.strictEqual(requestHeaders['X-Vault-Wrap-TTL'], '30m', 'request header has default wrap ttl');
+      assert.strictEqual(requestHeaders['x-vault-wrap-ttl'], '30m', 'request header has default wrap ttl');
       return {
         wrap_info: {
           token: this.token,
@@ -97,7 +97,7 @@ module('Integration | Component | tools/wrap', function (hooks) {
     this.server.post('sys/wrapping/wrap', (schema, { requestBody, requestHeaders }) => {
       const payload = JSON.parse(requestBody);
       assert.propEqual(payload, JSON.parse(this.wrapData), `payload contains data: ${requestBody}`);
-      assert.strictEqual(requestHeaders['X-Vault-Wrap-TTL'], '1200s', 'request header has updated wrap ttl');
+      assert.strictEqual(requestHeaders['x-vault-wrap-ttl'], '1200s', 'request header has updated wrap ttl');
       // only testing payload/header assertions, no need for return here
       return {};
     });
@@ -143,7 +143,7 @@ module('Integration | Component | tools/wrap', function (hooks) {
     this.server.post('sys/wrapping/wrap', (schema, { requestBody, requestHeaders }) => {
       const payload = JSON.parse(requestBody);
       assert.propEqual(payload, JSON.parse(updatedWrapData), `payload contains data: ${requestBody}`);
-      assert.strictEqual(requestHeaders['X-Vault-Wrap-TTL'], '30m', 'request header has default wrap ttl');
+      assert.strictEqual(requestHeaders['x-vault-wrap-ttl'], '30m', 'request header has default wrap ttl');
       return {
         wrap_info: {
           token: this.token,

--- a/ui/tests/unit/utils/api-error-message-test.js
+++ b/ui/tests/unit/utils/api-error-message-test.js
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import { module, test } from 'qunit';
+import apiErrorMessage from 'vault/utils/api-error-message';
+
+module('Unit | Util | api-error-message', function (hooks) {
+  hooks.beforeEach(function () {
+    this.apiError = {
+      errors: ['first error', 'second error'],
+      message: 'there were some errors',
+    };
+    this.getErrorContext = () => ({ response: new Response(JSON.stringify(this.apiError)) });
+  });
+
+  test('it should return errors from ErrorContext', async function (assert) {
+    const message = await apiErrorMessage(this.getErrorContext());
+    assert.strictEqual(message, 'first error, second error');
+  });
+
+  test('it should return message from ErrorContext when errors are empty', async function (assert) {
+    this.apiError.errors = [];
+    const message = await apiErrorMessage(this.getErrorContext());
+    assert.strictEqual(message, 'there were some errors');
+  });
+
+  test('it should return fallback message for ErrorContext without errors or message', async function (assert) {
+    this.apiError = {};
+    const message = await apiErrorMessage(this.getErrorContext());
+    assert.strictEqual(message, 'An error occurred, please try again');
+  });
+
+  test('it should return message from Error', async function (assert) {
+    const error = new Error('some js type error');
+    const message = await apiErrorMessage(error);
+    assert.strictEqual(message, error.message);
+  });
+
+  test('it should return default fallback', async function (assert) {
+    const message = await apiErrorMessage('some random error');
+    assert.strictEqual(message, 'An error occurred, please try again');
+  });
+
+  test('it should return custom fallback message', async function (assert) {
+    const fallback = 'Everything is broken, sorry';
+    const message = await apiErrorMessage('some random error', fallback);
+    assert.strictEqual(message, fallback);
+  });
+});

--- a/ui/types/vault/api.d.ts
+++ b/ui/types/vault/api.d.ts
@@ -3,6 +3,10 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
+import { ErrorContext } from '@hashicorp/vault-client-typescript';
+
+// re-exporting for convenience since it is associated to ApiError
+export { ErrorContext };
 export interface ApiError {
   httpStatus: number;
   path: string;

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -3260,6 +3260,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/codemirror@npm:^5.60.15":
+  version: 5.60.15
+  resolution: "@types/codemirror@npm:5.60.15"
+  dependencies:
+    "@types/tern": "*"
+  checksum: cfad3f569de48fba3efa44fdfeba77933e231486a52cc80cff7ce6eeeed5b447a5bc2b11e2226bc00ccee332c661e53e35a15cf14eb835f434a6a402d9462f5f
+  languageName: node
+  linkType: hard
+
 "@types/connect@npm:*":
   version: 3.4.38
   resolution: "@types/connect@npm:3.4.38"
@@ -3796,6 +3805,15 @@ __metadata:
   version: 1.2.2
   resolution: "@types/symlink-or-copy@npm:1.2.2"
   checksum: fb8fc2a356d1d7ab222bbea772ca6bf1b4a90b1f14ea46c1522643d3afd018f3b938ead7ba04af88175432a07497c02904bf428008505acf8a4745f1bc6e3892
+  languageName: node
+  linkType: hard
+
+"@types/tern@npm:*":
+  version: 0.23.9
+  resolution: "@types/tern@npm:0.23.9"
+  dependencies:
+    "@types/estree": "*"
+  checksum: 53f229c79edf9454011f5b37c8539e0e760a130beac953d4e2126823de1ac6b0e2a45612596679fb232ec861826584fcaa272e2254a890b410575683423d56a8
   languageName: node
   linkType: hard
 
@@ -18806,6 +18824,7 @@ __metadata:
     "@icholy/duration": ^5.1.0
     "@lineal-viz/lineal": ^0.5.1
     "@tsconfig/ember": ^2.0.0
+    "@types/codemirror": ^5.60.15
     "@types/d3-array": ^3.2.1
     "@types/ember-data": ^4.4.16
     "@types/qunit": ^2.19.4


### PR DESCRIPTION
### Description
VAULT-34868: Fix Enos Synchronize-repos failure

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
