### PR TITLE
Add known issue for sts region/sts endpoint mismatch bug

### DIFF
--- a/website/content/partials/known-issues/aws-fallback-sts.mdx
+++ b/website/content/partials/known-issues/aws-fallback-sts.mdx
@@ -1,0 +1,27 @@
+### STS configuration can fail if STS endpoints are unspecified
+
+#### Affected Versions
+
+- 1.19.0
+
+#### Issue
+
+When configuring an sts endpoint in the AWS Secrets engine, when no sts_endpoint is set, the engine will return
+an error stating that the number of endpoints and regions do not match:
+
+```
+{"errors":["number of regions does not match number of endpoints"]}
+```
+
+#### Workaround
+
+Explicitly set the default endpoint and region when configuring sts:
+
+```
+{
+...
+  sts_region = "us-east-1"
+  sts_endpoint = "https://sts.amazonaws.com"
+...
+}
+```


### PR DESCRIPTION
### Description
Add a brief known issue line for the STS region mismatch issue. Hopefully this won't be in-tree for long.

### TODO only if you're a HashiCorp employee
- [X] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
- [X] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
