### PR TITLE
[UI] Ember Data Migration - Tools Wrap Component

### DIFF
--- a/ui/app/components/tools/wrap.ts
+++ b/ui/app/components/tools/wrap.ts
@@ -13,7 +13,7 @@ import apiErrorMessage from 'vault/utils/api-error-message';
 import type ApiService from 'vault/services/api';
 import type FlashMessageService from 'vault/services/flash-messages';
 import type { TtlEvent } from 'vault/app-types';
-import { HTMLElementEvent } from 'vault/forms';
+import type { HTMLElementEvent } from 'vault/forms';
 import type { Editor } from 'codemirror';
 
 /**

--- a/ui/app/utils/api-error-message.ts
+++ b/ui/app/utils/api-error-message.ts
@@ -3,6 +3,12 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
+/**
+ * this util was derived from error-message and updated to handle the error context returned from the api service
+ * once Ember Data is fully removed, the error-message util will also be removed
+ * for all requests made with the api service, use this util to display error messages from server
+ */
+
 import { ErrorContext, ApiError } from 'vault/api';
 
 // accepts an error and returns error.errors joined with a comma, error.message or a fallback message

--- a/ui/app/utils/api-error-message.ts
+++ b/ui/app/utils/api-error-message.ts
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import { ErrorContext, ApiError } from 'vault/api';
+
+// accepts an error and returns error.errors joined with a comma, error.message or a fallback message
+export default async function (error: unknown, fallbackMessage = 'An error occurred, please try again') {
+  const messageOrFallback = (message?: string) => message || fallbackMessage;
+
+  if ((error as ErrorContext).response instanceof Response) {
+    const apiError: ApiError = await (error as ErrorContext).response?.json();
+
+    if (apiError.errors && typeof apiError.errors[0] === 'string') {
+      return apiError.errors.join(', ');
+    }
+    return messageOrFallback(apiError.message);
+  }
+
+  return messageOrFallback((error as Error)?.message);
+}

--- a/ui/app/utils/error-message.js
+++ b/ui/app/utils/error-message.js
@@ -3,6 +3,13 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
+/**
+ * deprecated in favor of api-error-message for use with the api service
+ * this util will be removed once Ember Data is fully removed
+ * new requests should be made with api service
+ * if Ember Data is still needed during the migration then this util may be used
+ */
+
 // accepts an error and returns error.errors joined with a comma, error.message or a fallback message
 export default function (error, fallbackMessage = 'An error occurred, please try again') {
   if (error instanceof Error && error?.errors && typeof error.errors[0] === 'string') {

--- a/ui/package.json
+++ b/ui/package.json
@@ -63,6 +63,7 @@
     "@icholy/duration": "^5.1.0",
     "@lineal-viz/lineal": "^0.5.1",
     "@tsconfig/ember": "^2.0.0",
+    "@types/codemirror": "^5.60.15",
     "@types/d3-array": "^3.2.1",
     "@types/ember-data": "^4.4.16",
     "@types/qunit": "^2.19.4",

--- a/ui/tests/integration/components/tools/wrap-test.js
+++ b/ui/tests/integration/components/tools/wrap-test.js
@@ -70,7 +70,7 @@ module('Integration | Component | tools/wrap', function (hooks) {
     this.server.post('sys/wrapping/wrap', (schema, { requestBody, requestHeaders }) => {
       const payload = JSON.parse(requestBody);
       assert.propEqual(payload, JSON.parse(this.wrapData), `payload contains data: ${requestBody}`);
-      assert.strictEqual(requestHeaders['X-Vault-Wrap-TTL'], '30m', 'request header has default wrap ttl');
+      assert.strictEqual(requestHeaders['x-vault-wrap-ttl'], '30m', 'request header has default wrap ttl');
       return {
         wrap_info: {
           token: this.token,
@@ -97,7 +97,7 @@ module('Integration | Component | tools/wrap', function (hooks) {
     this.server.post('sys/wrapping/wrap', (schema, { requestBody, requestHeaders }) => {
       const payload = JSON.parse(requestBody);
       assert.propEqual(payload, JSON.parse(this.wrapData), `payload contains data: ${requestBody}`);
-      assert.strictEqual(requestHeaders['X-Vault-Wrap-TTL'], '1200s', 'request header has updated wrap ttl');
+      assert.strictEqual(requestHeaders['x-vault-wrap-ttl'], '1200s', 'request header has updated wrap ttl');
       // only testing payload/header assertions, no need for return here
       return {};
     });
@@ -143,7 +143,7 @@ module('Integration | Component | tools/wrap', function (hooks) {
     this.server.post('sys/wrapping/wrap', (schema, { requestBody, requestHeaders }) => {
       const payload = JSON.parse(requestBody);
       assert.propEqual(payload, JSON.parse(updatedWrapData), `payload contains data: ${requestBody}`);
-      assert.strictEqual(requestHeaders['X-Vault-Wrap-TTL'], '30m', 'request header has default wrap ttl');
+      assert.strictEqual(requestHeaders['x-vault-wrap-ttl'], '30m', 'request header has default wrap ttl');
       return {
         wrap_info: {
           token: this.token,

--- a/ui/tests/unit/utils/api-error-message-test.js
+++ b/ui/tests/unit/utils/api-error-message-test.js
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import { module, test } from 'qunit';
+import apiErrorMessage from 'vault/utils/api-error-message';
+
+module('Unit | Util | api-error-message', function (hooks) {
+  hooks.beforeEach(function () {
+    this.apiError = {
+      errors: ['first error', 'second error'],
+      message: 'there were some errors',
+    };
+    this.getErrorContext = () => ({ response: new Response(JSON.stringify(this.apiError)) });
+  });
+
+  test('it should return errors from ErrorContext', async function (assert) {
+    const message = await apiErrorMessage(this.getErrorContext());
+    assert.strictEqual(message, 'first error, second error');
+  });
+
+  test('it should return message from ErrorContext when errors are empty', async function (assert) {
+    this.apiError.errors = [];
+    const message = await apiErrorMessage(this.getErrorContext());
+    assert.strictEqual(message, 'there were some errors');
+  });
+
+  test('it should return fallback message for ErrorContext without errors or message', async function (assert) {
+    this.apiError = {};
+    const message = await apiErrorMessage(this.getErrorContext());
+    assert.strictEqual(message, 'An error occurred, please try again');
+  });
+
+  test('it should return message from Error', async function (assert) {
+    const error = new Error('some js type error');
+    const message = await apiErrorMessage(error);
+    assert.strictEqual(message, error.message);
+  });
+
+  test('it should return default fallback', async function (assert) {
+    const message = await apiErrorMessage('some random error');
+    assert.strictEqual(message, 'An error occurred, please try again');
+  });
+
+  test('it should return custom fallback message', async function (assert) {
+    const fallback = 'Everything is broken, sorry';
+    const message = await apiErrorMessage('some random error', fallback);
+    assert.strictEqual(message, fallback);
+  });
+});

--- a/ui/types/vault/api.d.ts
+++ b/ui/types/vault/api.d.ts
@@ -3,6 +3,10 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
+import { ErrorContext } from '@hashicorp/vault-client-typescript';
+
+// re-exporting for convenience since it is associated to ApiError
+export { ErrorContext };
 export interface ApiError {
   httpStatus: number;
   path: string;

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -3260,6 +3260,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/codemirror@npm:^5.60.15":
+  version: 5.60.15
+  resolution: "@types/codemirror@npm:5.60.15"
+  dependencies:
+    "@types/tern": "*"
+  checksum: cfad3f569de48fba3efa44fdfeba77933e231486a52cc80cff7ce6eeeed5b447a5bc2b11e2226bc00ccee332c661e53e35a15cf14eb835f434a6a402d9462f5f
+  languageName: node
+  linkType: hard
+
 "@types/connect@npm:*":
   version: 3.4.38
   resolution: "@types/connect@npm:3.4.38"
@@ -3796,6 +3805,15 @@ __metadata:
   version: 1.2.2
   resolution: "@types/symlink-or-copy@npm:1.2.2"
   checksum: fb8fc2a356d1d7ab222bbea772ca6bf1b4a90b1f14ea46c1522643d3afd018f3b938ead7ba04af88175432a07497c02904bf428008505acf8a4745f1bc6e3892
+  languageName: node
+  linkType: hard
+
+"@types/tern@npm:*":
+  version: 0.23.9
+  resolution: "@types/tern@npm:0.23.9"
+  dependencies:
+    "@types/estree": "*"
+  checksum: 53f229c79edf9454011f5b37c8539e0e760a130beac953d4e2126823de1ac6b0e2a45612596679fb232ec861826584fcaa272e2254a890b410575683423d56a8
   languageName: node
   linkType: hard
 
@@ -18806,6 +18824,7 @@ __metadata:
     "@icholy/duration": ^5.1.0
     "@lineal-viz/lineal": ^0.5.1
     "@tsconfig/ember": ^2.0.0
+    "@types/codemirror": ^5.60.15
     "@types/d3-array": ^3.2.1
     "@types/ember-data": ^4.4.16
     "@types/qunit": ^2.19.4


### PR DESCRIPTION
### Description
This PR converts the `tools/wrap` component to `ts` and updates the wrap request to use the api service. Additionally, types were added for codemirror and an `api-error-message` util was created to handle api errors. 

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
