### PR TITLE
UI: Updates the namespace service to explicitly check for the HVD managed admin namespace

### DIFF
--- a/ui/app/components/dashboard/overview.ts
+++ b/ui/app/components/dashboard/overview.ts
@@ -6,7 +6,6 @@
 import Component from '@glimmer/component';
 import { service } from '@ember/service';
 
-import type flagsService from 'vault/services/flags';
 import NamespaceService from 'vault/services/namespace';
 
 export type Args = {
@@ -18,7 +17,6 @@ export type Args = {
 };
 
 export default class OverviewComponent extends Component<Args> {
-  @service declare readonly flags: flagsService;
   @service declare readonly namespace: NamespaceService;
 
   /**
@@ -30,13 +28,13 @@ export default class OverviewComponent extends Component<Args> {
   // for HVD clusters, this is the `admin` namespace
   get shouldShowClientCount() {
     const { version, isRootNamespace } = this.args;
-    const { flags, namespace } = this;
+    const { namespace } = this;
 
     // don't show client count if this isn't an enterprise cluster
     if (!version.isEnterprise) return false;
 
     // HVD clusters
-    if (flags.isHvdManaged && namespace.currentNamespace === 'admin') return true;
+    if (namespace.inHvdAdminNamespace) return true;
 
     // SM clusters
     if (isRootNamespace) return true;

--- a/ui/app/services/namespace.js
+++ b/ui/app/services/namespace.js
@@ -12,10 +12,11 @@ import { buildWaiter } from '@ember/test-waiters';
 const waiter = buildWaiter('namespaces');
 const ROOT_NAMESPACE = '';
 export default class NamespaceService extends Service {
-  @service store;
   @service auth;
+  @service flags;
+  @service store;
 
-  //populated by the query param on the cluster route
+  // populated by the query param on the cluster route
   @tracked path = '';
   // list of namespaces available to the current user under the
   // current namespace
@@ -27,6 +28,11 @@ export default class NamespaceService extends Service {
 
   get inRootNamespace() {
     return this.path === ROOT_NAMESPACE;
+  }
+
+  // the "root" namespace is "admin/" for HVD managed clusters accessing the UI
+  get inHvdAdminNamespace() {
+    return this.flags.isHvdManaged && this.path === 'admin/';
   }
 
   get currentNamespace() {

--- a/ui/app/services/namespace.js
+++ b/ui/app/services/namespace.js
@@ -30,7 +30,7 @@ export default class NamespaceService extends Service {
     return this.path === ROOT_NAMESPACE;
   }
 
-  // the top-level namespace is "admin/" for HVD managed clusters accessing the UI 
+  // the top-level namespace is "admin/" for HVD managed clusters accessing the UI
   // (similar to "root" for self-managed clusters)
   // this getter checks if the user is specifically at the administrative namespace level
   get inHvdAdminNamespace() {

--- a/ui/app/services/namespace.js
+++ b/ui/app/services/namespace.js
@@ -30,7 +30,9 @@ export default class NamespaceService extends Service {
     return this.path === ROOT_NAMESPACE;
   }
 
-  // the "root" namespace is "admin/" for HVD managed clusters accessing the UI
+  // the top-level namespace is "admin/" for HVD managed clusters accessing the UI 
+  // (similar to "root" for self-managed clusters)
+  // this getter checks if the user is specifically at the administrative namespace level
   get inHvdAdminNamespace() {
     return this.flags.isHvdManaged && this.path === 'admin/';
   }

--- a/ui/tests/integration/components/dashboard/overview-test.js
+++ b/ui/tests/integration/components/dashboard/overview-test.js
@@ -190,7 +190,7 @@ module('Integration | Component | dashboard/overview', function (hooks) {
 
       await this.renderComponent();
 
-      assert.dom(DASHBOARD.cardName('client-count')).exists();
+      assert.dom(DASHBOARD.cardName('client-count')).doesNotExist();
     });
 
     test('it should hide client count on enterprise in any other namespace when running a managed mode', async function (assert) {

--- a/ui/tests/integration/components/dashboard/overview-test.js
+++ b/ui/tests/integration/components/dashboard/overview-test.js
@@ -165,7 +165,27 @@ module('Integration | Component | dashboard/overview', function (hooks) {
 
       this.version.type = 'enterprise';
       this.flags.featureFlags = ['VAULT_CLOUD_ADMIN_NAMESPACE'];
-      this.namespace.path = 'admin';
+      this.namespace.path = 'admin/';
+      this.isRootNamespace = false;
+
+      await this.renderComponent();
+
+      assert.dom(DASHBOARD.cardName('client-count')).exists();
+    });
+
+    test('it should show not show client count on enterprise in child namespaces called "admin" when running a managed mode', async function (assert) {
+      this.permissions.exactPaths = {
+        'admin/sys/internal/counters/activity': {
+          capabilities: ['read'],
+        },
+        'admin/sys/replication/status': {
+          capabilities: ['read'],
+        },
+      };
+
+      this.version.type = 'enterprise';
+      this.flags.featureFlags = ['VAULT_CLOUD_ADMIN_NAMESPACE'];
+      this.namespace.path = 'ns1/admin';
       this.isRootNamespace = false;
 
       await this.renderComponent();

--- a/ui/types/vault/services/namespace.d.ts
+++ b/ui/types/vault/services/namespace.d.ts
@@ -13,6 +13,7 @@ interface PathsResponse {
 export default class NamespaceService extends Service {
   userRootNamespace: string;
   inRootNamespace: boolean;
+  inHvdAdminNamespace: boolean;
   currentNamespace: string;
   relativeNamespace: string;
   path: string;


### PR DESCRIPTION
### Description
- Fixes an edge case where the client count card would appear for children named `admin/`

✅ enterprise passed

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
