### PR TITLE
usage (CE): Fix data race on IdentityStore metric

### DIFF
--- a/vault/identity_store.go
+++ b/vault/identity_store.go
@@ -45,6 +45,12 @@ func (c *Core) IdentityStore() *IdentityStore {
 	return c.identityStore
 }
 
+func (i *IdentityStore) GetDisableLowerCasedNames() bool {
+	i.lock.RLock()
+	defer i.lock.RUnlock()
+	return i.disableLowerCasedNames
+}
+
 func (i *IdentityStore) resetDB() error {
 	var err error
 

--- a/vault/identity_store_util.go
+++ b/vault/identity_store_util.go
@@ -181,9 +181,11 @@ func (i *IdentityStore) activateDeduplication(ctx context.Context, req *logical.
 
 		i.logger.Info("activating identity deduplication, reloading identity store")
 
+		oldDisableLowerCased := i.disableLowerCasedNames
 		i.disableLowerCasedNames = false
 		if err := i.resetDB(); err != nil {
 			i.logger.Error("failed to reset existing identity state: %w", err)
+			i.disableLowerCasedNames = oldDisableLowerCased
 			return
 		}
 

--- a/vault/identity_store_util.go
+++ b/vault/identity_store_util.go
@@ -181,11 +181,9 @@ func (i *IdentityStore) activateDeduplication(ctx context.Context, req *logical.
 
 		i.logger.Info("activating identity deduplication, reloading identity store")
 
-		oldDisableLowerCased := i.disableLowerCasedNames
 		i.disableLowerCasedNames = false
 		if err := i.resetDB(); err != nil {
 			i.logger.Error("failed to reset existing identity state: %w", err)
-			i.disableLowerCasedNames = oldDisableLowerCased
 			return
 		}
 


### PR DESCRIPTION
This PR fixes a legitimate data race caused by two separate goroutines accessing `(*IdentityStore).disableLowerCasedNames` concurrently without locking.

This was found by the race detector in CI.

Enterprise PR: https://github.com/hashicorp/vault-enterprise/pull/7678

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [x] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
