### PR TITLE
enos(cloud-init): fix synchronize-repos

### DIFF
--- a/enos/modules/install_packages/scripts/synchronize-repos.sh
+++ b/enos/modules/install_packages/scripts/synchronize-repos.sh
@@ -107,30 +107,31 @@ synchronize_repos() {
 wait_for_cloud_init() {
   if output=$(sudo cloud-init status --wait); then
     return 0
+  else
+    res=$?
+    case $res in
+      2)
+        {
+          echo "WARNING: cloud-init did not complete successfully but recovered."
+          echo "Exit code: $res"
+          echo "Output: $output"
+          echo "Here are the logs for the failure:"
+          cat /var/log/cloud-init-*
+        } 1>&2
+        return 0
+        ;;
+      *)
+        {
+          echo "cloud-init did not complete successfully."
+          echo "Exit code: $res"
+          echo "Output: $output"
+          echo "Here are the logs for the failure:"
+          cat /var/log/cloud-init-*
+        } 1>&2
+        return 1
+        ;;
+    esac
   fi
-  res=$?
-  case $res in
-    2)
-      {
-        echo "WARNING: cloud-init did not complete successfully but recovered."
-        echo "Exit code: $res"
-        echo "Output: $output"
-        echo "Here are the logs for the failure:"
-        cat /var/log/cloud-init-*
-      } 1>&2
-      return 0
-      ;;
-    *)
-      {
-        echo "cloud-init did not complete successfully."
-        echo "Exit code: $res"
-        echo "Output: $output"
-        echo "Here are the logs for the failure:"
-        cat /var/log/cloud-init-*
-      } 1>&2
-      return 1
-      ;;
-  esac
 }
 
 # Wait for cloud-init if it exists


### PR DESCRIPTION
### Description
`$?` in bash is wonky. When you evaluate an expression in an `if` statement the `$?` variable is only set to the actual exit value in blocks scoped in the statement. Therefore, since we rely on it in synchronize-repos we have to evaluate the rest of the function in a scope of that statement.

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [x] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
