### PR TITLE
Pin CI tool versions 1.19.x (#29665)

### DIFF
--- a/.github/actions/install-external-tools/action.yml
+++ b/.github/actions/install-external-tools/action.yml
@@ -23,15 +23,17 @@ runs:
     - uses: ./.github/actions/set-up-staticcheck
       # We assume that the Go toolchain will be managed by the caller workflow so we don't set one
       # up here.
-    - run: ./.github/scripts/retry-command.sh go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
+      # All tool versions should match the versions in tools/tool.sh
+      # Protobuf tool versions should match what's in Vault's go.mod
+    - run: ./.github/scripts/retry-command.sh go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.36.5
       shell: bash
-    - run: ./.github/scripts/retry-command.sh go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
+    - run: ./.github/scripts/retry-command.sh go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.5.1
       shell: bash
-    - run: ./.github/scripts/retry-command.sh go install github.com/favadi/protoc-go-inject-tag@latest
+    - run: ./.github/scripts/retry-command.sh go install github.com/favadi/protoc-go-inject-tag@v1.4.0
       shell: bash
-    - run: ./.github/scripts/retry-command.sh go install golang.org/x/tools/cmd/goimports@latest
+    - run: ./.github/scripts/retry-command.sh go install golang.org/x/tools/cmd/goimports@v0.30.0
       shell: bash
-    - run: ./.github/scripts/retry-command.sh go install github.com/golangci/revgrep/cmd/revgrep@latest
+    - run: ./.github/scripts/retry-command.sh go install github.com/golangci/revgrep/cmd/revgrep@v0.8.0
       shell: bash
-    - run: ./.github/scripts/retry-command.sh go install github.com/loggerhead/enumer@latest
+    - run: ./.github/scripts/retry-command.sh go install github.com/loggerhead/enumer@v0.0.0-20240225233120-0aebd7ae8325
       shell: bash

--- a/.github/actions/set-up-buf/action.yml
+++ b/.github/actions/set-up-buf/action.yml
@@ -13,7 +13,7 @@ inputs:
   version:
     description: "The version to install (default: latest)"
     type: string
-    default: Latest
+    default: "v1.45.0"
 
 outputs:
   destination:

--- a/.github/actions/set-up-gofumpt/action.yml
+++ b/.github/actions/set-up-gofumpt/action.yml
@@ -13,7 +13,7 @@ inputs:
   version:
     description: "The version to install (default: latest)"
     type: string
-    default: Latest
+    default: "v0.7.0"
 
 outputs:
   destination:

--- a/.github/actions/set-up-gosimports/action.yml
+++ b/.github/actions/set-up-gosimports/action.yml
@@ -13,7 +13,7 @@ inputs:
   version:
     description: "The version to install (default: latest)"
     type: string
-    default: Latest
+    default: "v0.3.8"
 
 outputs:
   destination:

--- a/.github/actions/set-up-gotestsum/action.yml
+++ b/.github/actions/set-up-gotestsum/action.yml
@@ -13,7 +13,7 @@ inputs:
   version:
     description: "The version to install (default: latest)"
     type: string
-    default: Latest
+    default: "v1.12.0"
 
 outputs:
   destination:

--- a/.github/actions/set-up-misspell/action.yml
+++ b/.github/actions/set-up-misspell/action.yml
@@ -13,7 +13,7 @@ inputs:
   version:
     description: "The version to install (default: latest)"
     type: string
-    default: Latest
+    default: "v0.6.0"
 
 outputs:
   destination:

--- a/.github/actions/set-up-shfmt/action.yml
+++ b/.github/actions/set-up-shfmt/action.yml
@@ -13,7 +13,7 @@ inputs:
   version:
     description: "The version to install (default: latest)"
     type: string
-    default: Latest
+    default: "v3.10.0"
 
 outputs:
   destination:

--- a/.github/actions/set-up-sqlc/action.yml
+++ b/.github/actions/set-up-sqlc/action.yml
@@ -13,7 +13,7 @@ inputs:
   version:
     description: "The version to install (default: latest)"
     type: string
-    default: Latest
+    default: "v1.28.0"
 
 outputs:
   destination:

--- a/.github/actions/set-up-staticcheck/action.yml
+++ b/.github/actions/set-up-staticcheck/action.yml
@@ -13,7 +13,7 @@ inputs:
   version:
     description: "The version to install (default: latest)"
     type: string
-    default: Latest
+    default: "v0.6.0"
 
 outputs:
   destination:

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -53,7 +53,7 @@ require (
 	golang.org/x/net v0.37.0
 	golang.org/x/text v0.23.0
 	google.golang.org/grpc v1.69.4
-	google.golang.org/protobuf v1.36.3
+	google.golang.org/protobuf v1.36.5
 )
 
 require (

--- a/sdk/go.sum
+++ b/sdk/go.sum
@@ -661,8 +661,8 @@ google.golang.org/protobuf v1.22.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2
 google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
-google.golang.org/protobuf v1.36.3 h1:82DV7MYdb8anAVi3qge1wSnMDrnKK7ebr+I0hHRN1BU=
-google.golang.org/protobuf v1.36.3/go.mod h1:9fA7Ob0pmnwhb644+1+CVWFRbNajQ6iRojtC/QF5bRE=
+google.golang.org/protobuf v1.36.5 h1:tPhr+woSbjfYvY6/GPufUoYizxw1cF/yFoxJ2fmpwlM=
+google.golang.org/protobuf v1.36.5/go.mod h1:9fA7Ob0pmnwhb644+1+CVWFRbNajQ6iRojtC/QF5bRE=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/tools/tools.sh
+++ b/tools/tools.sh
@@ -36,20 +36,22 @@ install_external() {
   # If you update this please update check_external below as well as our external tools
   # install action .github/actions/install-external-tools/action.yml
   #
+  # All tool versions should match the versions in .github/actions/install-external-tools/action.yml
+  # Protobuf tool versions should match what's in Vault's go.mod.
   tools=(
-    honnef.co/go/tools/cmd/staticcheck@latest
+    honnef.co/go/tools/cmd/staticcheck@v0.6.0
     github.com/bufbuild/buf/cmd/buf@v1.45.0
-    github.com/favadi/protoc-go-inject-tag@latest
-    github.com/golangci/misspell/cmd/misspell@latest
-    github.com/golangci/revgrep/cmd/revgrep@latest
-    github.com/loggerhead/enumer@latest
-    github.com/rinchsan/gosimports/cmd/gosimports@latest
-    golang.org/x/tools/cmd/goimports@latest
-    google.golang.org/protobuf/cmd/protoc-gen-go@latest
-    google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
-    gotest.tools/gotestsum@latest
-    mvdan.cc/gofumpt@latest
-    mvdan.cc/sh/v3/cmd/shfmt@latest
+    github.com/favadi/protoc-go-inject-tag@v1.4.0
+    github.com/golangci/misspell/cmd/misspell@v0.6.0
+    github.com/golangci/revgrep/cmd/revgrep@v0.8.0
+    github.com/loggerhead/enumer@v0.0.0-20240225233120-0aebd7ae8325
+    github.com/rinchsan/gosimports/cmd/gosimports@v0.3.8
+    golang.org/x/tools/cmd/goimports@v0.30.0
+    google.golang.org/protobuf/cmd/protoc-gen-go@v1.36.5
+    google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.5.1
+    gotest.tools/gotestsum@v1.12.0
+    mvdan.cc/gofumpt@v0.7.0
+    mvdan.cc/sh/v3/cmd/shfmt@v3.10.0
   )
 
   echo "==> Installing external tools..."


### PR DESCRIPTION
### Description
Pin the CI tool versions in 1.19.x to match main. A manual backport of https://github.com/hashicorp/vault/pull/29665

This should resolve our proto delta check failing on 1.19.

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [x] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
