### PR TITLE
[UI] Ember Data Migration - Tools Unwrap Component

### DIFF
--- a/ui/api-client/dist/esm/runtime.d.ts
+++ b/ui/api-client/dist/esm/runtime.d.ts
@@ -157,8 +157,8 @@ export interface ApiResponse<T> {
     value(): Promise<T>;
 }
 export interface VoidResponse {
-    auth: null;
-    data: null;
+    auth: unknown;
+    data: unknown;
     lease_duration: number;
     lease_id: string;
     mount_type: string;

--- a/ui/api-client/dist/esm/runtime.js
+++ b/ui/api-client/dist/esm/runtime.js
@@ -286,7 +286,7 @@ export function canConsumeForm(consumes) {
     return false;
 }
 export class JSONApiResponse {
-    constructor(raw, transformer = (jsonValue) => jsonValue) {
+    constructor(raw, transformer = (jsonValue) => jsonValue === null || jsonValue === void 0 ? void 0 : jsonValue.data) {
         this.raw = raw;
         this.transformer = transformer;
     }

--- a/ui/api-client/dist/esm/runtime.js
+++ b/ui/api-client/dist/esm/runtime.js
@@ -286,13 +286,14 @@ export function canConsumeForm(consumes) {
     return false;
 }
 export class JSONApiResponse {
-    constructor(raw, transformer = (jsonValue) => jsonValue === null || jsonValue === void 0 ? void 0 : jsonValue.data) {
+    constructor(raw, transformer = (jsonValue) => jsonValue) {
         this.raw = raw;
         this.transformer = transformer;
     }
     value() {
         return __awaiter(this, void 0, void 0, function* () {
-            return this.transformer(yield this.raw.json());
+            const response = yield this.raw.json();
+            return this.transformer(response.data);
         });
     }
 }

--- a/ui/api-client/dist/runtime.d.ts
+++ b/ui/api-client/dist/runtime.d.ts
@@ -157,8 +157,8 @@ export interface ApiResponse<T> {
     value(): Promise<T>;
 }
 export interface VoidResponse {
-    auth: null;
-    data: null;
+    auth: unknown;
+    data: unknown;
     lease_duration: number;
     lease_id: string;
     mount_type: string;

--- a/ui/api-client/dist/runtime.js
+++ b/ui/api-client/dist/runtime.js
@@ -298,13 +298,14 @@ function canConsumeForm(consumes) {
     return false;
 }
 class JSONApiResponse {
-    constructor(raw, transformer = (jsonValue) => jsonValue === null || jsonValue === void 0 ? void 0 : jsonValue.data) {
+    constructor(raw, transformer = (jsonValue) => jsonValue) {
         this.raw = raw;
         this.transformer = transformer;
     }
     value() {
         return __awaiter(this, void 0, void 0, function* () {
-            return this.transformer(yield this.raw.json());
+            const response = yield this.raw.json();
+            return this.transformer(response.data);
         });
     }
 }

--- a/ui/api-client/dist/runtime.js
+++ b/ui/api-client/dist/runtime.js
@@ -298,7 +298,7 @@ function canConsumeForm(consumes) {
     return false;
 }
 class JSONApiResponse {
-    constructor(raw, transformer = (jsonValue) => jsonValue) {
+    constructor(raw, transformer = (jsonValue) => jsonValue === null || jsonValue === void 0 ? void 0 : jsonValue.data) {
         this.raw = raw;
         this.transformer = transformer;
     }

--- a/ui/api-client/src/runtime.ts
+++ b/ui/api-client/src/runtime.ts
@@ -396,8 +396,8 @@ export interface ApiResponse<T> {
 }
 
 export interface VoidResponse {
-  auth: null;
-  data: null;
+  auth: unknown;
+  data: unknown;
   lease_duration: number;
   lease_id: string;
   mount_type: string;
@@ -419,7 +419,7 @@ export interface ResponseTransformer<T> {
 }
 
 export class JSONApiResponse<T> {
-    constructor(public raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue) {}
+    constructor(public raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue?.data) {}
 
     async value(): Promise<T> {
         return this.transformer(await this.raw.json());

--- a/ui/api-client/src/runtime.ts
+++ b/ui/api-client/src/runtime.ts
@@ -419,10 +419,11 @@ export interface ResponseTransformer<T> {
 }
 
 export class JSONApiResponse<T> {
-    constructor(public raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue?.data) {}
+    constructor(public raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue) {}
 
     async value(): Promise<T> {
-        return this.transformer(await this.raw.json());
+        const response = await this.raw.json();
+        return this.transformer(response.data);
     }
 }
 

--- a/ui/app/services/api.ts
+++ b/ui/app/services/api.ts
@@ -117,23 +117,6 @@ export default class ApiService extends Service {
 
     return;
   };
-
-  // the responses in the OpenAPI spec don't account for the return values to be under the 'data' key
-  // return the data rather than the entire response
-  // if there is no data then return the full response
-  extractData = async (context: ResponseContext) => {
-    const response = context.response.clone();
-    const { headers, ok, status, statusText } = response;
-
-    if (ok) {
-      const json = await response?.json();
-      if (json.data) {
-        return new Response(JSON.stringify(json.data), { headers, status, statusText });
-      }
-    }
-
-    return;
-  };
   // --- End Middleware ---
 
   configuration = new Configuration({
@@ -145,7 +128,6 @@ export default class ApiService extends Service {
       { post: this.showWarnings },
       { post: this.deleteControlGroupToken },
       { post: this.formatErrorResponse },
-      { post: this.extractData },
     ],
   });
 

--- a/ui/tests/unit/services/api-test.js
+++ b/ui/tests/unit/services/api-test.js
@@ -146,16 +146,6 @@ module('Unit | Service | api', function (hooks) {
     assert.deepEqual(error, expectedError, 'Error is reformated and returned');
   });
 
-  test('it should extract data from response', async function (assert) {
-    const data = { data: { foo: 'bar' } };
-    const response = new Response(JSON.stringify(data), { status: 200 });
-
-    const extractedDataResponse = await this.apiService.extractData({ response, url: this.url });
-    const json = await extractedDataResponse.json();
-
-    assert.deepEqual(json, { foo: 'bar' }, 'Data is extracted and returned');
-  });
-
   test('it should build headers', async function (assert) {
     const headerMap = {
       token: 'foobar',


### PR DESCRIPTION
### Description
This PR converts the `tools/unwrap` component to `ts` and updates it to use the api service.

This component broke the `VoidResponse` pattern which assumed that a response marked as void would only return when there was no data under the `response.data` key. For the unwrap endpoint, the component needs access to both information under the `data` key as well as the outer request object.

The generator runtime template was updated to handle the data extraction in the `JSONApiResponse` class and the `extractData` middleware was removed from the api service. This allows void response types to be returned with the full response from the server while preserving the json responses.

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
