### PR TITLE
[VAULT-34482] UI: Update Namespace Picker

### DIFF
--- a/changelog/29995.txt
+++ b/changelog/29995.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: Update the Vault Namespace Picker to utilize the Hds::Form::SuperSelect component. Allow the user to navigate to any namespace that the current user has access to.
+```

--- a/ui/app/components/namespace-picker.js
+++ b/ui/app/components/namespace-picker.js
@@ -3,168 +3,47 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
 import { service } from '@ember/service';
-import { alias, gt } from '@ember/object/computed';
-import Component from '@ember/component';
-import { computed } from '@ember/object';
-import { task, timeout } from 'ember-concurrency';
-import pathToTree from 'vault/lib/path-to-tree';
-import { ancestorKeysForKey } from 'core/utils/key-utils';
 
-const DOT_REPLACEMENT = '☃';
-const ANIMATION_DURATION = 250;
+export default class ApplicationComponent extends Component {
+  @service namespace;
 
-export default Component.extend({
-  tagName: '',
-  namespaceService: service('namespace'),
-  auth: service(),
-  store: service(),
-  namespace: null,
-  listCapability: null,
-  canList: false,
+  @tracked selected = this.namespace?.currentNamespace;
+  @tracked options = [];
+  // @tracked groupedOptions = {groupName: '', options: []} // SHANNONTODO: All Namespaces Label
 
-  init() {
-    this._super(...arguments);
-    this.namespaceService?.findNamespacesForUser.perform();
-  },
+  constructor() {
+    super(...arguments);
+    this.loadOptions();
+  }
 
-  didReceiveAttrs() {
-    this._super(...arguments);
+  @action
+  async loadOptions() {
+    await this.namespace?.findNamespacesForUser.perform();
+    this.options = ['root', ...(this.namespace?.accessibleNamespaces || [])];
+    // this.groupedOptions.options = this.options; // SHANNONTODO: All Namespaces Label
+    // this.groupedOptions.groupName = `All namespaces (${this.options.length})`; // SHANNONTODO: All Namespaces Label
+  }
 
-    const ns = this.namespace;
-    const oldNS = this.oldNamespace;
-    if (!oldNS || ns !== oldNS) {
-      this.setForAnimation.perform();
-      this.fetchListCapability.perform();
-    }
-    this.set('oldNamespace', ns);
-  },
+  @action
+  handleChange(selectedOption) {
+    window.location.href = getNamespaceLink(window.location, selectedOption);
+  }
+}
 
-  fetchListCapability: task(function* () {
-    try {
-      const capability = yield this.store.findRecord('capabilities', 'sys/namespaces/');
-      this.set('listCapability', capability);
-      this.set('canList', true);
-    } catch (e) {
-      // If error out on findRecord call it's because you don't have permissions
-      // and therefore don't have permission to manage namespaces
-      this.set('canList', false);
-    }
-  }),
-  setForAnimation: task(function* () {
-    const leaves = this.menuLeaves;
-    const lastLeaves = this.lastMenuLeaves;
-    if (!lastLeaves) {
-      this.set('lastMenuLeaves', leaves);
-      yield timeout(0);
-      return;
-    }
-    const isAdding = leaves.length > lastLeaves.length;
-    const changedLeaves = isAdding ? leaves : lastLeaves;
-    const [changedLeaf] = changedLeaves.slice(-1);
-    this.set('isAdding', isAdding);
-    this.set('changedLeaf', changedLeaf);
+// PRIVATE Helper Functions
 
-    // if we're adding we want to render immediately an animate it in
-    // if we're not adding, we need time to move the item out before
-    // a rerender removes it
-    if (isAdding) {
-      this.set('lastMenuLeaves', leaves);
-      yield timeout(0);
-      return;
-    }
-    yield timeout(ANIMATION_DURATION);
-    this.set('lastMenuLeaves', leaves);
-  }).drop(),
+function getNamespaceLink(location, namespace) {
+  const origin = getOrigin(location);
+  const encodedNamespace = encodeURIComponent(namespace);
 
-  isAnimating: alias('setForAnimation.isRunning'),
+  // The full URL/origin is required so that the page is reloaded.
+  return `${origin}/ui/vault/dashboard?namespace=${encodedNamespace}`;
+}
 
-  namespacePath: alias('namespaceService.path'),
-
-  // this is an array of namespace paths that the current user
-  // has access to
-  accessibleNamespaces: alias('namespaceService.accessibleNamespaces'),
-  inRootNamespace: alias('namespaceService.inRootNamespace'),
-
-  namespaceTree: computed('accessibleNamespaces', function () {
-    const nsList = this.accessibleNamespaces;
-
-    if (!nsList) {
-      return [];
-    }
-    return pathToTree(nsList);
-  }),
-
-  maybeAddRoot(leaves) {
-    const userRoot = this.auth.authData.userRootNamespace;
-    if (userRoot === '') {
-      leaves.unshift('');
-    }
-
-    return leaves.uniq();
-  },
-
-  pathToLeaf(path) {
-    // dots are allowed in namespace paths
-    // so we need to preserve them, and replace slashes with dots
-    // in order to use Ember's get function on the namespace tree
-    // to pull out the correct level
-    return (
-      path
-        // trim trailing slash
-        .replace(/\/$/, '')
-        // replace dots with snowman
-        .replace(/\.+/g, DOT_REPLACEMENT)
-        // replace slash with dots
-        .replace(/\/+/g, '.')
-    );
-  },
-
-  // an array that keeps track of what additional panels to render
-  // on the menu stack
-  // if you're in  'foo/bar/baz',
-  // this array will be: ['foo', 'foo.bar', 'foo.bar.baz']
-  // the template then iterates over this, and does  Ember.get(namespaceTree, leaf)
-  // to render the nodes of each leaf
-
-  // gets set as  'lastMenuLeaves' in the ember concurrency task above
-  menuLeaves: computed('namespacePath', 'namespaceTree', 'pathToLeaf', function () {
-    let ns = this.namespacePath;
-    ns = (ns || '').replace(/^\//, '');
-    let leaves = ancestorKeysForKey(ns);
-    leaves.push(ns);
-    leaves = this.maybeAddRoot(leaves);
-
-    leaves = leaves.map(this.pathToLeaf);
-    return leaves;
-  }),
-
-  // the nodes at the root of the namespace tree
-  // these will get rendered as the bottom layer
-  rootLeaves: computed('namespaceTree', function () {
-    const tree = this.namespaceTree;
-    const leaves = Object.keys(tree);
-    return leaves;
-  }),
-
-  currentLeaf: alias('lastMenuLeaves.lastObject'),
-  canAccessMultipleNamespaces: gt('accessibleNamespaces.length', 1),
-  isUserRootNamespace: computed('auth.authData.userRootNamespace', 'namespacePath', function () {
-    return this.auth.authData.userRootNamespace === this.namespacePath;
-  }),
-
-  namespaceDisplay: computed('namespacePath', 'accessibleNamespaces', 'accessibleNamespaces.[]', function () {
-    const namespace = this.namespacePath;
-    if (!namespace) {
-      return 'root';
-    }
-    const parts = namespace?.split('/');
-    return parts[parts.length - 1];
-  }),
-
-  actions: {
-    refreshNamespaceList() {
-      this.namespaceService.findNamespacesForUser.perform();
-    },
-  },
-});
+function getOrigin(location) {
+  return location.protocol + '//' + location.hostname + (location.port ? ':' + location.port : '');
+}

--- a/ui/app/components/namespace-picker.js
+++ b/ui/app/components/namespace-picker.js
@@ -10,7 +10,9 @@ import { service } from '@ember/service';
 
 export default class ApplicationComponent extends Component {
   @service namespace;
+  @service store;
 
+  @tracked showAfterOptions = false;
   @tracked selected = this.namespace?.currentNamespace;
   @tracked options = [];
   // @tracked groupedOptions = {groupName: '', options: []} // SHANNONTODO: All Namespaces Label
@@ -21,9 +23,22 @@ export default class ApplicationComponent extends Component {
   }
 
   @action
+  async fetchListCapability() {
+    try {
+      await this.store.findRecord('capabilities', 'sys/namespaces/');
+      this.showAfterOptions = true;
+    } catch (e) {
+      // If error out on findRecord call it's because you don't have permissions
+      // and therefore don't have permission to manage namespaces
+      this.showAfterOptions = false;
+    }
+  }
+
+  @action
   async loadOptions() {
     await this.namespace?.findNamespacesForUser.perform();
     this.options = ['root', ...(this.namespace?.accessibleNamespaces || [])];
+    this.fetchListCapability();
     // this.groupedOptions.options = this.options; // SHANNONTODO: All Namespaces Label
     // this.groupedOptions.groupName = `All namespaces (${this.options.length})`; // SHANNONTODO: All Namespaces Label
   }

--- a/ui/app/components/namespace-picker.js
+++ b/ui/app/components/namespace-picker.js
@@ -15,8 +15,7 @@ export default class ApplicationComponent extends Component {
 
   @tracked showAfterOptions = false;
   @tracked selected = {};
-  @tracked options = [];
-  // @tracked groupedOptions = {groupName: '', options: []} // SHANNONTODO: All Namespaces Label
+  @tracked groupedOptions = [{ options: [], groupName: '' }];
 
   constructor() {
     super(...arguments);
@@ -38,11 +37,11 @@ export default class ApplicationComponent extends Component {
   @action
   async loadOptions() {
     await this.namespace?.findNamespacesForUser.perform();
-    this.options = getOptions(this.namespace);
-    this.selected = getSelected(this.options, this.namespace);
+    const options = getOptions(this.namespace);
+    this.selected = getSelected(options, this.namespace);
     this.fetchListCapability();
-    // this.groupedOptions.options = this.options; // SHANNONTODO: All Namespaces Label
-    // this.groupedOptions.groupName = `All namespaces (${this.options.length})`; // SHANNONTODO: All Namespaces Label
+    this.groupedOptions[0].options = options;
+    this.groupedOptions[0].groupName = `All namespaces (${options.length})`;
   }
 
   @action

--- a/ui/app/components/namespace-picker.js
+++ b/ui/app/components/namespace-picker.js
@@ -63,10 +63,10 @@ function matchesPath(option, currentNamespace) {
 
 function getOptions(namespace) {
   return [
-    { namespace: 'root', path: '', display: 'root' },
+    { id: 'root', path: '', label: 'root' },
     ...(namespace?.accessibleNamespaces || []).map((ns) => {
       const parts = ns.split('/');
-      return { namespace: parts[parts.length - 1], path: ns, display: ns };
+      return { id: parts[parts.length - 1], path: ns, label: ns };
     }),
   ];
 }

--- a/ui/app/components/namespace-picker.js
+++ b/ui/app/components/namespace-picker.js
@@ -3,65 +3,31 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
+// SHANNONTODO: add component docs see configer-wif.ts
+
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { service } from '@ember/service';
 
-export default class ApplicationComponent extends Component {
-  @service namespace;
-  @service store;
-  @service router;
-
-  @tracked showAfterOptions = false;
-  @tracked selected = {};
-  @tracked groupedOptions = [{ options: [], groupName: '' }];
-
-  constructor() {
-    super(...arguments);
-    this.loadOptions();
-  }
-
-  @action
-  async fetchListCapability() {
-    try {
-      await this.store.findRecord('capabilities', 'sys/namespaces/');
-      this.showAfterOptions = true;
-    } catch (e) {
-      // If error out on findRecord call it's because you don't have permissions
-      // and therefore don't have permission to manage namespaces
-      this.showAfterOptions = false;
-    }
-  }
-
-  @action
-  async loadOptions() {
-    await this.namespace?.findNamespacesForUser.perform();
-    const options = getOptions(this.namespace);
-    this.selected = getSelected(options, this.namespace);
-    this.fetchListCapability();
-    this.groupedOptions[0].options = options;
-    this.groupedOptions[0].groupName = `All namespaces (${options.length})`;
-  }
-
-  @action
-  handleChange(selected) {
-    window.location.href = getNamespaceLink(window.location, selected);
-  }
-}
-
 // PRIVATE Helper Functions
+// SHANNONTEST post about this pattern in #vault-ui-devs
 
-function getSelected(options, currentNamespace) {
-  return options.find((option) => matchesPath(option, currentNamespace));
-}
-
-function matchesPath(option, currentNamespace) {
+function _matchesPath(option, currentNamespace) {
+  // SHANNONTODO: Revisit this, this seems hacky, but fixes a breaking test
+  // assumption is that namespace shouldn't start with a "/", is this a HVD thing?
+  // or is the test outdated?
   return option?.path === currentNamespace?.path || `/${option?.path}` === currentNamespace?.path;
 }
 
-function getOptions(namespace) {
+function _getSelected(options, currentNamespace) {
+  return options.find((option) => _matchesPath(option, currentNamespace));
+}
+
+function _getOptions(namespace) {
   return [
+    // SHANNONTODO: Add Comment explaining 3 properties because root is blank
+    // SHANNONTODO: HDS Admin User (and others?) should never see root
     { id: 'root', path: '', label: 'root' },
     ...(namespace?.accessibleNamespaces || []).map((ns) => {
       const parts = ns.split('/');
@@ -70,8 +36,8 @@ function getOptions(namespace) {
   ];
 }
 
-function getNamespaceLink(location, namespace) {
-  const origin = getOrigin(location);
+function _getNamespaceLink(location, namespace) {
+  const origin = _getOrigin(location);
   const encodedNamespace = encodeURIComponent(namespace.path);
 
   let queryParams = '';
@@ -83,6 +49,56 @@ function getNamespaceLink(location, namespace) {
   return `${origin}/ui/vault/dashboard${queryParams}`;
 }
 
-function getOrigin(location) {
+function _getOrigin(location) {
   return location.protocol + '//' + location.hostname + (location.port ? ':' + location.port : '');
+}
+
+export default class ApplicationComponent extends Component {
+  @service namespace;
+  @service store;
+
+  // Show/hide refresh & manage namespaces buttons
+  @tracked showAfterOptions = false;
+
+  @tracked selected = {};
+  @tracked groupedOptions = [{ options: [], groupName: '' }];
+
+  constructor() {
+    super(...arguments);
+    this.loadOptions();
+  }
+
+  // SHANNONTODO this is fetching sys internal namespaces capabilities, is this still needed??
+  @action
+  async fetchListCapability() {
+    try {
+      // SHANNONTODO test w/o capabilities
+      await this.store.findRecord('capabilities', 'sys/namespaces/');
+      this.showAfterOptions = true;
+    } catch (e) {
+      // If error out on findRecord call it's because you don't have permissions
+      // and therefore don't have permission to manage namespaces
+      this.showAfterOptions = false;
+    }
+  }
+
+  @action
+  async loadOptions() {
+    // SHANNONTODO Currently this never throws an error, should we handle error situation? Check w/ design
+    await this.namespace?.findNamespacesForUser.perform();
+
+    const options = _getOptions(this.namespace);
+    this.selected = _getSelected(options, this.namespace);
+    await this.fetchListCapability();
+
+    // SHANNONTODO: add comment
+    this.groupedOptions[0].options = options;
+    this.groupedOptions[0].groupName = `All namespaces (${options.length})`;
+  }
+
+  @action
+  handleChange(selected) {
+    // SHANNONTODO add github comment
+    window.location.href = _getNamespaceLink(window.location, selected);
+  }
 }

--- a/ui/app/components/namespace-picker/after-options.hbs
+++ b/ui/app/components/namespace-picker/after-options.hbs
@@ -1,0 +1,9 @@
+{{!
+  Copyright (c) HashiCorp, Inc.
+  SPDX-License-Identifier: BUSL-1.1
+}}
+
+<div class="hds-power-select__after-options">
+  <Hds::Button @color="secondary" @text="Refresh List" {{on "click" (action "refreshNamespaceList")}} />
+  <Hds::Button @color="secondary" @text="Manage" @icon="settings" @route="vault.cluster.access.namespaces" />
+</div>

--- a/ui/app/components/namespace-picker/after-options.hbs
+++ b/ui/app/components/namespace-picker/after-options.hbs
@@ -4,6 +4,11 @@
 }}
 
 <div class="hds-power-select__after-options">
-  <Hds::Button @color="secondary" @text="Refresh List" {{on "click" (action "refreshNamespaceList")}} />
+  <Hds::Button
+    @color="secondary"
+    @text="Refresh List"
+    {{on "click" (action "refreshNamespaceList")}}
+    data-test-refresh-namespaces
+  />
   <Hds::Button @color="secondary" @text="Manage" @icon="settings" @route="vault.cluster.access.namespaces" />
 </div>

--- a/ui/app/components/namespace-picker/after-options.js
+++ b/ui/app/components/namespace-picker/after-options.js
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+
+export default class AfterOptions extends Component {
+  @action
+  refreshNamespaceList() {
+    this.args?.loadOptions();
+  }
+}

--- a/ui/app/components/namespace-picker/selected-option.hbs
+++ b/ui/app/components/namespace-picker/selected-option.hbs
@@ -1,0 +1,11 @@
+{{!
+  Copyright (c) HashiCorp, Inc.
+  SPDX-License-Identifier: BUSL-1.1
+}}
+
+<Hds::Text::Body>
+  <div class="is-flex-center is-flex-1">
+    <Icon @name="org" />
+    <span>{{@option}}</span>
+  </div>
+</Hds::Text::Body>

--- a/ui/app/components/namespace-picker/selected-option.hbs
+++ b/ui/app/components/namespace-picker/selected-option.hbs
@@ -6,6 +6,6 @@
 <Hds::Text::Body>
   <div class="is-flex-center is-flex-1">
     <Icon @name="org" />
-    <span>{{@option}}</span>
+    <span>{{@option.namespace}}</span>
   </div>
 </Hds::Text::Body>

--- a/ui/app/components/namespace-picker/selected-option.hbs
+++ b/ui/app/components/namespace-picker/selected-option.hbs
@@ -6,6 +6,6 @@
 <Hds::Text::Body>
   <div class="is-flex-center is-flex-1">
     <Icon @name="org" />
-    <span>{{@option.namespace}}</span>
+    <span>{{@option.id}}</span>
   </div>
 </Hds::Text::Body>

--- a/ui/app/components/sidebar/frame.hbs
+++ b/ui/app/components/sidebar/frame.hbs
@@ -38,10 +38,7 @@
 
       <:footer>
         {{#if (has-feature "Namespaces")}}
-          <NamespacePicker
-            @namespace={{this.clusterController.namespaceQueryParam}}
-            class="hds-side-nav-hide-when-minimized"
-          />
+          <NamespacePicker class="hds-side-nav-hide-when-minimized" />
         {{/if}}
       </:footer>
     </Hds::SideNav>

--- a/ui/app/services/flags.ts
+++ b/ui/app/services/flags.ts
@@ -29,6 +29,7 @@ export default class FlagsService extends Service {
   @tracked featureFlags: string[] = [];
 
   get isHvdManaged(): boolean {
+    // SHANNONTODO - HVD Hack
     return this.featureFlags?.includes(FLAGS.vaultCloudNamespace);
   }
 

--- a/ui/app/services/namespace.js
+++ b/ui/app/services/namespace.js
@@ -93,8 +93,4 @@ export default class NamespaceService extends Service {
       waiter.endAsync(waiterToken);
     }
   }
-
-  reset() {
-    this.accessibleNamespaces = null;
-  }
 }

--- a/ui/app/services/namespace.js
+++ b/ui/app/services/namespace.js
@@ -93,4 +93,8 @@ export default class NamespaceService extends Service {
       waiter.endAsync(waiterToken);
     }
   }
+
+  reset() {
+    this.accessibleNamespaces = null;
+  }
 }

--- a/ui/app/templates/components/namespace-picker.hbs
+++ b/ui/app/templates/components/namespace-picker.hbs
@@ -4,116 +4,26 @@
 }}
 
 <div class="namespace-picker" ...attributes>
-  <BasicDropdown @horizontalPosition="left" @verticalPosition="above" @renderInPlace={{true}} as |D|>
-    <D.Trigger
-      @htmlTag="button"
-      class="button is-transparent namespace-picker-trigger has-current-color"
-      data-test-namespace-toggle
-    >
-      <div class="is-flex-center is-flex-1">
-        <Icon @name="org" />
-        <span class="is-flex-1 is-word-break has-text-left is-size-6 has-left-margin-xs">{{this.namespaceDisplay}}</span>
-      </div>
-      <Icon @name="caret" />
-    </D.Trigger>
-    <D.Content @defaultClass="namespace-picker-content">
-      <div class="is-mobile level-left">
-        <h5 class="list-header">Current namespace</h5>
-      </div>
-      <div class="namespace-header-bar level is-mobile">
-        <div class="level-left">
-          <header>
-            <div class="level is-mobile namespace-link">
-              <span class="level-left" data-test-current-namespace>
-                {{if this.namespacePath (concat this.namespacePath "/") "root"}}
-              </span>
-            </div>
-          </header>
-        </div>
-      </div>
-      <div class="namespace-list {{if this.isAnimating 'animated-list'}}">
-        {{#if this.auth.isRootToken}}
-          <div class="has-left-margin-s has-right-margin-s">
-            <span><Icon @name="alert-triangle-fill" class="has-text-highlight" /></span>
-            <span class="is-size-8 has-text-semibold">
-              You are logged in with a root token and will have to reauthenticate when switching namespaces.
-            </span>
-          </div>
-        {{/if}}
-
-        <div class="is-mobile level-left">
-          {{#if this.isUserRootNamespace}}
-            <h5 class="list-header">Namespaces</h5>
-          {{else}}
-            <NamespaceLink
-              @targetNamespace={{or
-                (object-at (dec 2 this.menuLeaves.length) this.lastMenuLeaves)
-                this.auth.authData.userRootNamespace
-              }}
-              @class="namespace-link is-current button is-transparent icon"
-            >
-              <div class="is-flex-align-baseline">
-                <Hds::Button
-                  @text="Go back"
-                  @icon="chevron-left"
-                  @isIconOnly={{true}}
-                  @color="tertiary"
-                  class="is-flex-align-baseline"
-                />
-                <p class="is-size-8 has-text-grey has-text-weight-semibold is-uppercase">Namespaces</p>
-              </div>
-            </NamespaceLink>
-          {{/if}}
-        </div>
-        {{#if (includes "" this.lastMenuLeaves)}}
-          {{! leaf is '' which is the root namespace, and then we need to iterate the root leaves }}
-          <div class="leaf-panel {{if (eq '' this.currentLeaf) 'leaf-panel-current' 'leaf-panel-left'}} ">
-            {{#each this.rootLeaves as |rootLeaf|}}
-              <NamespaceLink @targetNamespace={{rootLeaf}} @class="namespace-link" @showLastSegment={{true}} />
-            {{/each}}
-          </div>
-        {{/if}}
-        {{#each this.lastMenuLeaves as |leaf|}}
-          {{#if leaf}}
-            <div
-              class="leaf-panel
-                {{if (eq leaf this.currentLeaf) 'leaf-panel-current' 'leaf-panel-left'}}
-                {{if (and this.isAdding (eq leaf this.changedLeaf)) 'leaf-panel-adding'}}
-                {{if (and (not this.isAdding) (eq leaf this.changedLeaf)) 'leaf-panel-exiting'}}
-                "
-            >
-              {{#each-in (get this.namespaceTree leaf) as |leafName|}}
-                <NamespaceLink
-                  @targetNamespace={{concat leaf "/" leafName}}
-                  @class="namespace-link"
-                  @showLastSegment={{true}}
-                />
-              {{/each-in}}
-            </div>
-          {{/if}}
-        {{/each}}
-        {{#if this.canList}}
-          <div class="leaf-panel leaf-panel-current">
-            <div class="level">
-              <span class="level-left">
-                <LinkTo @route="vault.cluster.access.namespaces" class="is-block namespace-link namespace-manage-link">
-                  Manage Namespaces
-                </LinkTo>
-              </span>
-              <span class="level-right">
-                <Hds::Button
-                  @text="Refresh namespace list"
-                  @icon="reload"
-                  @isIconOnly={{true}}
-                  @color="tertiary"
-                  data-test-refresh-namespaces
-                  {{on "click" (action "refreshNamespaceList")}}
-                />
-              </span>
-            </div>
-          </div>
-        {{/if}}
-      </div>
-    </D.Content>
-  </BasicDropdown>
+  <Hds::Form::SuperSelect::Single::Field
+    @afterOptionsComponent={{component "namespace-picker/after-options" loadOptions=this.loadOptions}}
+    @selectedItemComponent={{component "namespace-picker/selected-option"}}
+    @label="Namespace"
+    @placeholder="Search"
+    @options={{this.options}}
+    @selected={{this.selected}}
+    @onChange={{this.handleChange}}
+    @searchEnabled={{true}}
+    @showAfterOptions={{true}}
+    @verticalPosition="above"
+    as |F|
+  >
+    <F.Label>Namespace</F.Label>
+    <F.Options>
+      {{#let F.options as |option|}}
+        <ExternalLink @href={{this.getNamespaceLink option}} @sameTab={{true}}>
+          {{option}}
+        </ExternalLink>
+      {{/let}}
+    </F.Options>
+  </Hds::Form::SuperSelect::Single::Field>
 </div>

--- a/ui/app/templates/components/namespace-picker.hbs
+++ b/ui/app/templates/components/namespace-picker.hbs
@@ -5,6 +5,7 @@ SPDX-License-Identifier: BUSL-1.1
 
 <div class="namespace-picker" ...attributes>
   <Hds::Form::SuperSelect::Single::Field
+    {{! SHANNONTODO add github comment explaining that this implementation isn't in the hds examples, but got it from the source code for the examples }}
     @afterOptionsComponent={{component "namespace-picker/after-options" loadOptions=this.loadOptions}}
     @selectedItemComponent={{component "namespace-picker/selected-option"}}
     @label="Namespace"

--- a/ui/app/templates/components/namespace-picker.hbs
+++ b/ui/app/templates/components/namespace-picker.hbs
@@ -5,7 +5,10 @@ SPDX-License-Identifier: BUSL-1.1
 
 <div class="namespace-picker" ...attributes>
   <Hds::Form::SuperSelect::Single::Field
-    {{! SHANNONTODO add github comment explaining that this implementation isn't in the hds examples, but got it from the source code for the examples }}
+    {{! 
+      This implementation isn't in the documented hds code examples; instead I referenced the hds source code for the examples, see:
+      https://github.com/hashicorp/design-system/blob/9e7362a8d048f88a361636a2564646ba4b65b77f/showcase/app/templates/components/form/super-select.hbs#L337 
+    }}
     @afterOptionsComponent={{component "namespace-picker/after-options" loadOptions=this.loadOptions}}
     @selectedItemComponent={{component "namespace-picker/selected-option"}}
     @label="Namespace"

--- a/ui/app/templates/components/namespace-picker.hbs
+++ b/ui/app/templates/components/namespace-picker.hbs
@@ -21,7 +21,7 @@ SPDX-License-Identifier: BUSL-1.1
     <F.Label>Namespace</F.Label>
     <F.Options>
       {{#let F.options as |option|}}
-        <span data-test-namespace-link="{{option.display}}">{{option.display}}</span>
+        <span data-test-namespace-link="{{option.label}}">{{option.label}}</span>
       {{/let}}
     </F.Options>
   </Hds::Form::SuperSelect::Single::Field>

--- a/ui/app/templates/components/namespace-picker.hbs
+++ b/ui/app/templates/components/namespace-picker.hbs
@@ -1,6 +1,6 @@
 {{!
-  Copyright (c) HashiCorp, Inc.
-  SPDX-License-Identifier: BUSL-1.1
+Copyright (c) HashiCorp, Inc.
+SPDX-License-Identifier: BUSL-1.1
 }}
 
 <div class="namespace-picker" ...attributes>
@@ -13,7 +13,7 @@
     @selected={{this.selected}}
     @onChange={{this.handleChange}}
     @searchEnabled={{true}}
-    @showAfterOptions={{true}}
+    @showAfterOptions={{this.showAfterOptions}}
     @verticalPosition="above"
     as |F|
   >

--- a/ui/app/templates/components/namespace-picker.hbs
+++ b/ui/app/templates/components/namespace-picker.hbs
@@ -18,7 +18,6 @@ SPDX-License-Identifier: BUSL-1.1
     data-test-namespace-toggle
     as |F|
   >
-    <F.Label>Namespace</F.Label>
     <F.Options>
       {{#let F.options as |option|}}
         <span data-test-namespace-link="{{option.label}}">{{option.label}}</span>

--- a/ui/app/templates/components/namespace-picker.hbs
+++ b/ui/app/templates/components/namespace-picker.hbs
@@ -15,14 +15,13 @@ SPDX-License-Identifier: BUSL-1.1
     @searchEnabled={{true}}
     @showAfterOptions={{this.showAfterOptions}}
     @verticalPosition="above"
+    data-test-namespace-toggle
     as |F|
   >
     <F.Label>Namespace</F.Label>
     <F.Options>
       {{#let F.options as |option|}}
-        <ExternalLink @href={{this.getNamespaceLink option}} @sameTab={{true}}>
-          {{option}}
-        </ExternalLink>
+        <span data-test-namespace-link="{{option.display}}">{{option.display}}</span>
       {{/let}}
     </F.Options>
   </Hds::Form::SuperSelect::Single::Field>

--- a/ui/app/templates/components/namespace-picker.hbs
+++ b/ui/app/templates/components/namespace-picker.hbs
@@ -9,7 +9,7 @@ SPDX-License-Identifier: BUSL-1.1
     @selectedItemComponent={{component "namespace-picker/selected-option"}}
     @label="Namespace"
     @placeholder="Search"
-    @options={{this.options}}
+    @options={{this.groupedOptions}}
     @selected={{this.selected}}
     @onChange={{this.handleChange}}
     @searchEnabled={{true}}

--- a/ui/tests/acceptance/enterprise-namespaces-test.js
+++ b/ui/tests/acceptance/enterprise-namespaces-test.js
@@ -24,8 +24,8 @@ module('Acceptance | Enterprise | namespaces', function (hooks) {
     await logout.visit();
     await authPage.login(token);
     await click('[data-test-namespace-toggle]');
-    assert.dom('[data-test-current-namespace]').hasText('root', 'root renders as current namespace');
-    assert.dom('[data-test-namespace-link]').doesNotExist('Additional namespace have been cleared');
+    assert.dom('[aria-selected="true"]').hasText('root', 'root renders as current namespace');
+    assert.dom('[data-test-namespace-link]').exists({ count: 1 }, 'Only the root namespace exists');
   });
 
   test('it shows nested namespaces if you log in with a namespace starting with a /', async function (assert) {
@@ -47,7 +47,7 @@ module('Acceptance | Enterprise | namespaces', function (hooks) {
       // check that the single namespace "beep" or "boop" not "beep/boop" shows in the toggle display
       assert
         .dom(`[data-test-namespace-link="${targetNamespace}"]`)
-        .hasText(ns, `shows the namespace ${ns} in the toggle component`);
+        .hasText(targetNamespace, `shows the namespace ${targetNamespace} in the toggle component`);
       // because quint does not like page reloads, visiting url directly instead of clicking on namespace in toggle
       await visit(url);
     }
@@ -59,8 +59,10 @@ module('Acceptance | Enterprise | namespaces', function (hooks) {
     await authPage.tokenInput('root').submit();
     await settled();
     await click('[data-test-namespace-toggle]');
-    await waitFor('[data-test-current-namespace]');
-    assert.dom('[data-test-current-namespace]').hasText('/beep/boop/', 'current namespace begins with a /');
+    await waitFor('[aria-selected="true"]');
+    assert
+      .dom('[aria-selected="true"]')
+      .hasText('beep/boop', 'current namespace does not begin or end with /');
     assert
       .dom('[data-test-namespace-link="beep/boop/bop"]')
       .exists('renders the link to the nested namespace');

--- a/ui/tests/acceptance/enterprise-replication-test.js
+++ b/ui/tests/acceptance/enterprise-replication-test.js
@@ -91,7 +91,10 @@ module('Acceptance | Enterprise | replication', function (hooks) {
     await click('#deny');
     await clickTrigger();
     await searchSelect.options.objectAt(0).click();
-    const mountPath = find('[data-test-selected-option="0"]').innerText?.trim();
+
+    await click('[data-test-namespace-toggle]');
+
+    const mountPath = find('[data-option-index="0"]').innerText?.trim();
     await click('[data-test-secondary-add]');
 
     await pollCluster(this.owner);
@@ -108,8 +111,8 @@ module('Acceptance | Enterprise | replication', function (hooks) {
     );
     assert.dom('[data-test-mount-config-mode]').includesText(mode, 'show page renders the correct mode');
     assert
-      .dom('[data-test-mount-config-paths]')
-      .includesText(`${mountPath}/`, 'show page renders the correct mount path');
+      .dom('[data-test-namespace-toggle]')
+      .includesText(`${mountPath}`, 'show page renders the correct mount path');
 
     // delete config by choosing "no filter" in the edit screen
     await click('[data-test-replication-link="edit-mount-config"]');


### PR DESCRIPTION
### Description
| ℹ️ **NOTE: This branch is merging into a feature sidebranch** (not `main`) |
| ---|
- [X] Changelog update
- [X] Replace Picker w/ HDS Super Select
- [X] Implement Refresh Namespaces Button
- [X] Implement Manage Namespaces Button works
- [X] Redirect to Namespace on click
- [ ] Fix a11y issues (9)
- [x] Enterprise tests pass ✅ 
  > 230 tests completed in 155733 milliseconds, with 0 failed, 10 skipped, and 0 todo.
  > 1415 assertions of 1415 passed, 0 failed.

#### Outstanding items that will be addressed in separate PRs before the feature sidebranch is merged to main: 
- All/Matching Namespaces Label w/ Count Badge
- "You are logged in with a root token and will have to re-authenticate when switching namespaces."
- Expanded namespace picker width to support long namespace paths
- Tab to auto-complete namespace path
- Styling to match Figma designs
- Add test coverage
- Manual testing

#### Screenshots
| ⚠️  **NOTE: The current implementation looks ugly, styling will be addressed in a separate PR** |
| --- |
![Screenshot 2025-03-21 at 11 35 42 AM](https://github.com/user-attachments/assets/95175607-e1a9-4f9b-a44f-2070e06efac5)
![Screenshot 2025-03-21 at 11 35 49 AM](https://github.com/user-attachments/assets/1dcf3dc0-d637-40a3-99ca-5164011cd4aa)
![Screenshot 2025-03-21 at 11 35 58 AM](https://github.com/user-attachments/assets/9464adc1-dbdf-4ecc-a9d0-50c862d352fe)
![Screenshot 2025-03-21 at 11 36 10 AM](https://github.com/user-attachments/assets/edd08e1f-da0f-4959-b267-61861e5a57c0)
![Screenshot 2025-03-21 at 11 36 36 AM](https://github.com/user-attachments/assets/5b183af2-4493-4db8-91a6-129944f64259)
![Screenshot 2025-03-21 at 11 36 45 AM](https://github.com/user-attachments/assets/753f3d03-f996-4adf-a14c-38f18b6a6bff)



### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
