### PR TITLE
Allow Root + Intermediate Key_Usage to be set

### DIFF
--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -7430,9 +7430,10 @@ func TestIssuance_SignIntermediateKeyUsages(t *testing.T) {
 		"ttl":         "10h",
 		"issuer_name": "root-ca",
 		"key_name":    "root-key",
-		"key_usage":   "DigitalSignature",
+		"key_usage":   "DigitalSignature,DogPetting",
 	})
 	requireSuccessNonNilResponse(t, resp, err, "expected root generation to succeed")
+	require.Contains(t, resp.Warnings, "Invalid key usage will be ignored: unrecognized key usage DogPetting")
 	rootCertRaw := resp.Data["certificate"]
 	rootCert := parseCert(t, rootCertRaw.(string))
 	require.Equal(t, x509.KeyUsageDigitalSignature, rootCert.KeyUsage&x509.KeyUsageDigitalSignature, "keyUsage Digital Signature was not present")
@@ -7445,10 +7446,11 @@ func TestIssuance_SignIntermediateKeyUsages(t *testing.T) {
 
 	resp, err = CBWrite(b, s, "issuer/root-ca/sign-intermediate", map[string]interface{}{
 		"csr":       csr,
-		"key_usage": "DigitalSignature",
+		"key_usage": "DigitalSignature,KeyEncipherment,KeyAgreement",
 		"ttl":       "60h",
 	})
 	requireSuccessNonNilResponse(t, resp, err, "expected intermediate signing to succeed")
+	require.Contains(t, resp.Warnings, "Invalid key usage: key usage KeyEncipherment is only valid for non-Ca certs; key usage KeyAgreement is only valid for non-Ca certs")
 	intCertRaw := resp.Data["certificate"]
 	intCert := parseCert(t, intCertRaw.(string))
 	require.Equal(t, x509.KeyUsageDigitalSignature, intCert.KeyUsage&x509.KeyUsageDigitalSignature, "keyUsage Digital Signature was not present")

--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -7442,6 +7442,9 @@ func TestIssuance_SignIntermediateKeyUsages(t *testing.T) {
 	rootCertRaw := resp.Data["certificate"]
 	rootCert := parseCert(t, rootCertRaw.(string))
 	require.Equal(t, x509.KeyUsageDigitalSignature, rootCert.KeyUsage&x509.KeyUsageDigitalSignature, "keyUsage Digital Signature was not present")
+	require.Equal(t, x509.KeyUsageCertSign, rootCert.KeyUsage&x509.KeyUsageCertSign, "keyUsage CertSign was not present")
+	require.Equal(t, x509.KeyUsageCRLSign, rootCert.KeyUsage&x509.KeyUsageCRLSign, "keyUsage CRLSign was not present")
+	require.Equal(t, x509.KeyUsageDigitalSignature|x509.KeyUsageCertSign|x509.KeyUsageCRLSign, rootCert.KeyUsage, "unexpected KeyUsage present")
 	resp, err = CBWrite(b, s, "intermediate/generate/internal", map[string]interface{}{
 		"common_name": "myint.com",
 	})
@@ -7459,6 +7462,9 @@ func TestIssuance_SignIntermediateKeyUsages(t *testing.T) {
 	intCertRaw := resp.Data["certificate"]
 	intCert := parseCert(t, intCertRaw.(string))
 	require.Equal(t, x509.KeyUsageDigitalSignature, intCert.KeyUsage&x509.KeyUsageDigitalSignature, "keyUsage Digital Signature was not present")
+	require.Equal(t, x509.KeyUsageCertSign, intCert.KeyUsage&x509.KeyUsageCertSign, "keyUsage CertSign was not present")
+	require.Equal(t, x509.KeyUsageCRLSign, intCert.KeyUsage&x509.KeyUsageCRLSign, "keyUsage CRLSign was not present")
+	require.Equal(t, x509.KeyUsageDigitalSignature|x509.KeyUsageCertSign|x509.KeyUsageCRLSign, intCert.KeyUsage, "unexpected KeyUsage present on intermediate certificate")
 }
 
 var (

--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -7420,6 +7420,11 @@ func TestIssuance_AlwaysEnforceErr(t *testing.T) {
 	})
 }
 
+// TestIssuance_SignIntermediateKeyUsages tests the field "key_usage" both when directly generating a root certificate,
+// and when signing a CA CSR.  In particular, this test verifies that:
+// - the key usage DigitalSignature is added if present
+// - non-existent or invalid key usages return a warning, but are ignored by certificate generation
+// - CertSign and CRLSign are ignored
 func TestIssuance_SignIntermediateKeyUsages(t *testing.T) {
 	t.Parallel()
 	b, s := CreateBackendWithStorage(t)
@@ -7446,7 +7451,7 @@ func TestIssuance_SignIntermediateKeyUsages(t *testing.T) {
 
 	resp, err = CBWrite(b, s, "issuer/root-ca/sign-intermediate", map[string]interface{}{
 		"csr":       csr,
-		"key_usage": "DigitalSignature,KeyEncipherment,KeyAgreement",
+		"key_usage": "CRLSign,CertSign,DigitalSignature,KeyEncipherment,KeyAgreement",
 		"ttl":       "60h",
 	})
 	requireSuccessNonNilResponse(t, resp, err, "expected intermediate signing to succeed")

--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -7435,9 +7435,7 @@ func TestIssuance_SignIntermediateKeyUsages(t *testing.T) {
 	requireSuccessNonNilResponse(t, resp, err, "expected root generation to succeed")
 	rootCertRaw := resp.Data["certificate"]
 	rootCert := parseCert(t, rootCertRaw.(string))
-	// TODO: Help (Victor?)
-	require.NotEqual(t, 0, rootCert.KeyUsage&x509.KeyUsageDigitalSignature, "keyUsage Digital Signature was not present")
-
+	require.Equal(t, x509.KeyUsageDigitalSignature, rootCert.KeyUsage&x509.KeyUsageDigitalSignature, "keyUsage Digital Signature was not present")
 	resp, err = CBWrite(b, s, "intermediate/generate/internal", map[string]interface{}{
 		"common_name": "myint.com",
 	})
@@ -7453,8 +7451,7 @@ func TestIssuance_SignIntermediateKeyUsages(t *testing.T) {
 	requireSuccessNonNilResponse(t, resp, err, "expected intermediate signing to succeed")
 	intCertRaw := resp.Data["certificate"]
 	intCert := parseCert(t, intCertRaw.(string))
-	// TODO: Help (Victor?)
-	require.NotEqual(t, 0, intCert.KeyUsage&x509.KeyUsageDigitalSignature, "keyUsage Digital Signature was not present")
+	require.Equal(t, x509.KeyUsageDigitalSignature, intCert.KeyUsage&x509.KeyUsageDigitalSignature, "keyUsage Digital Signature was not present")
 
 }
 

--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -7452,7 +7452,6 @@ func TestIssuance_SignIntermediateKeyUsages(t *testing.T) {
 	intCertRaw := resp.Data["certificate"]
 	intCert := parseCert(t, intCertRaw.(string))
 	require.Equal(t, x509.KeyUsageDigitalSignature, intCert.KeyUsage&x509.KeyUsageDigitalSignature, "keyUsage Digital Signature was not present")
-
 }
 
 var (

--- a/changelog/30034.txt
+++ b/changelog/30034.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+secrets/pki: fix a bug where key_usage was ignored when generating root certificates, and signing certain
+intermediate certificates.
+```

--- a/sdk/helper/certutil/types.go
+++ b/sdk/helper/certutil/types.go
@@ -820,12 +820,16 @@ type CreationBundle struct {
 // addKeyUsages adds appropriate key usages to the template given the creation
 // information
 func AddKeyUsages(data *CreationBundle, certTemplate *x509.Certificate) {
-	if data.Params.IsCA {
-		certTemplate.KeyUsage = x509.KeyUsage(x509.KeyUsageCertSign | x509.KeyUsageCRLSign)
-		return
-	}
-
 	certTemplate.KeyUsage = data.Params.KeyUsage
+
+	if data.Params.IsCA {
+		if certTemplate.KeyUsage&x509.KeyUsageCertSign == x509.KeyUsage(0) {
+			certTemplate.KeyUsage |= x509.KeyUsageCertSign
+		}
+		if certTemplate.KeyUsage&x509.KeyUsageCRLSign == x509.KeyUsage(0) {
+			certTemplate.KeyUsage |= x509.KeyUsageCRLSign
+		}
+	}
 
 	if data.Params.ExtKeyUsage&AnyExtKeyUsage != 0 {
 		certTemplate.ExtKeyUsage = append(certTemplate.ExtKeyUsage, x509.ExtKeyUsageAny)

--- a/sdk/helper/certutil/types.go
+++ b/sdk/helper/certutil/types.go
@@ -820,11 +820,19 @@ type CreationBundle struct {
 // addKeyUsages adds appropriate key usages to the template given the creation
 // information
 func AddKeyUsages(data *CreationBundle, certTemplate *x509.Certificate) {
-	certTemplate.KeyUsage = data.Params.KeyUsage
-
 	if data.Params.IsCA {
+		// https://cabforum.org/working-groups/server/baseline-requirements/documents/CA-Browser-Forum-TLS-BR-2.1.4.pdf
+		// Per Section 7.1.2.10.7, the only acceptable additional key usage is Digital Signature
+		if data.Params.KeyUsage&x509.KeyUsageDigitalSignature == x509.KeyUsageDigitalSignature {
+			certTemplate.KeyUsage = x509.KeyUsageDigitalSignature
+		} else {
+			certTemplate.KeyUsage = x509.KeyUsage(0)
+		}
 		certTemplate.KeyUsage |= x509.KeyUsageCertSign | x509.KeyUsageCRLSign
+		return
 	}
+
+	certTemplate.KeyUsage = data.Params.KeyUsage
 
 	if data.Params.ExtKeyUsage&AnyExtKeyUsage != 0 {
 		certTemplate.ExtKeyUsage = append(certTemplate.ExtKeyUsage, x509.ExtKeyUsageAny)

--- a/sdk/helper/certutil/types.go
+++ b/sdk/helper/certutil/types.go
@@ -823,12 +823,7 @@ func AddKeyUsages(data *CreationBundle, certTemplate *x509.Certificate) {
 	certTemplate.KeyUsage = data.Params.KeyUsage
 
 	if data.Params.IsCA {
-		if certTemplate.KeyUsage&x509.KeyUsageCertSign == x509.KeyUsage(0) {
-			certTemplate.KeyUsage |= x509.KeyUsageCertSign
-		}
-		if certTemplate.KeyUsage&x509.KeyUsageCRLSign == x509.KeyUsage(0) {
-			certTemplate.KeyUsage |= x509.KeyUsageCRLSign
-		}
+		certTemplate.KeyUsage |= x509.KeyUsageCertSign | x509.KeyUsageCRLSign
 	}
 
 	if data.Params.ExtKeyUsage&AnyExtKeyUsage != 0 {

--- a/website/content/api-docs/secret/pki/index.mdx
+++ b/website/content/api-docs/secret/pki/index.mdx
@@ -751,9 +751,9 @@ intermediary goes beyond the prescribed length.
 
 - `key_usage` `([]string: CRL,CertSign)` - This list of key usages will be added
   to the existing set of key usages, CRL,CertSign, on the generated certificate.
-  Values can be found at https://golang.org/pkg/crypto/x509/#KeyUsage part of the
-  name.  This is overwritten by use_csr_values if a key usage extension exists
-  within the csr.
+  Per the CAB Forum, the only acceptable additional value is `DigitalSignature`,
+  other values will be ignored.  To get a certificate with additional key_usages,
+  first add those key_usage to the CSR, then use use_csr_values instead.
 
 - `exclude_cn_from_sans` `(bool: false)` - If true, the given `common_name` will
   not be included in DNS or Email Subject Alternate Names (as appropriate).
@@ -2166,8 +2166,8 @@ use the values set via `config/urls`.
 
 - `key_usage` `([]string: CRL,CertSign)` - This list of key usages will be added
   to the existing set of key usages, CRL,CertSign, on the generated certificate.
-  Values can be found at https://golang.org/pkg/crypto/x509/#KeyUsage part of the
-  name.
+  Per the CAB Forum, the only acceptable additional value is `DigitalSignature`,
+  other values will be ignored.
 
 - `exclude_cn_from_sans` `(bool: false)` - If true, the given `common_name` will
   not be included in DNS or Email Subject Alternate Names (as appropriate).

--- a/website/content/api-docs/secret/pki/index.mdx
+++ b/website/content/api-docs/secret/pki/index.mdx
@@ -751,9 +751,9 @@ intermediary goes beyond the prescribed length.
 
 - `key_usage` `([]string: CRL,CertSign)` - This list of key usages will be added
   to the existing set of key usages, CRL,CertSign, on the generated certificate.
-  Per the CAB Forum, the only acceptable additional value is `DigitalSignature`,
-  other values will be ignored.  To get a certificate with additional key_usages,
-  first add those key_usage to the CSR, then use use_csr_values instead.
+  Per the CAB Forum requirements, Vault ignores values other than `DigitalSignature`.
+  To get a certificate with additional `key_usage` values, add the desired values to
+  the CSR, then call this function with `use_csr_values` set to `true`.
 
 - `exclude_cn_from_sans` `(bool: false)` - If true, the given `common_name` will
   not be included in DNS or Email Subject Alternate Names (as appropriate).

--- a/website/content/api-docs/secret/pki/index.mdx
+++ b/website/content/api-docs/secret/pki/index.mdx
@@ -2166,8 +2166,7 @@ use the values set via `config/urls`.
 
 - `key_usage` `([]string: CRL,CertSign)` - This list of key usages will be added
   to the existing set of key usages, CRL,CertSign, on the generated certificate.
-  Per the CAB Forum, the only acceptable additional value is `DigitalSignature`,
-  other values will be ignored.
+  Per the CAB Forum, Vault ignores additional values other than `DigitalSignature`.
 
 - `exclude_cn_from_sans` `(bool: false)` - If true, the given `common_name` will
   not be included in DNS or Email Subject Alternate Names (as appropriate).


### PR DESCRIPTION
### Description
Allows Root and Intermediate Key_Usage to be set via CLI, not just in the CSR

Fixes: https://github.com/hashicorp/vault/issues/29362

The test here doesn't successfully fail on a bad branch, so this is a draft right now.

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
