### PR TITLE
Forward Performance Standby Requests when configuring root credentials for AWS and LDAP

### DIFF
--- a/builtin/credential/aws/path_config_client.go
+++ b/builtin/credential/aws/path_config_client.go
@@ -107,6 +107,8 @@ func (b *backend) pathConfigClient() *framework.Path {
 					OperationVerb:   "configure",
 					OperationSuffix: "client",
 				},
+				ForwardPerformanceSecondary: true,
+				ForwardPerformanceStandby:   true,
 			},
 			logical.UpdateOperation: &framework.PathOperation{
 				Callback: b.pathConfigClientCreateUpdate,
@@ -114,6 +116,8 @@ func (b *backend) pathConfigClient() *framework.Path {
 					OperationVerb:   "configure",
 					OperationSuffix: "client",
 				},
+				ForwardPerformanceSecondary: true,
+				ForwardPerformanceStandby:   true,
 			},
 			logical.DeleteOperation: &framework.PathOperation{
 				Callback: b.pathConfigClientDelete,

--- a/builtin/credential/ldap/path_config.go
+++ b/builtin/credential/ldap/path_config.go
@@ -44,6 +44,8 @@ func pathConfig(b *backend) *framework.Path {
 				DisplayAttrs: &framework.DisplayAttributes{
 					OperationVerb: "configure-auth",
 				},
+				ForwardPerformanceSecondary: true,
+				ForwardPerformanceStandby:   true,
 			},
 		},
 

--- a/builtin/logical/aws/path_config_root.go
+++ b/builtin/logical/aws/path_config_root.go
@@ -96,6 +96,8 @@ func pathConfigRoot(b *backend) *framework.Path {
 					OperationVerb:   "configure",
 					OperationSuffix: "root-iam-credentials",
 				},
+				ForwardPerformanceSecondary: true,
+				ForwardPerformanceStandby:   true,
 			},
 			logical.CreateOperation: &framework.PathOperation{
 				Callback: b.pathConfigRootWrite,
@@ -103,6 +105,8 @@ func pathConfigRoot(b *backend) *framework.Path {
 					OperationVerb:   "configure",
 					OperationSuffix: "root-iam-credentials",
 				},
+				ForwardPerformanceSecondary: true,
+				ForwardPerformanceStandby:   true,
 			},
 		},
 

--- a/builtin/logical/database/path_config_connection.go
+++ b/builtin/logical/database/path_config_connection.go
@@ -288,6 +288,8 @@ func pathConfigurePluginConnection(b *databaseBackend) *framework.Path {
 					OperationVerb:   "configure",
 					OperationSuffix: "connection",
 				},
+				ForwardPerformanceSecondary: true,
+				ForwardPerformanceStandby:   true,
 			},
 			logical.UpdateOperation: &framework.PathOperation{
 				Callback: b.connectionWriteHandler(),
@@ -295,6 +297,8 @@ func pathConfigurePluginConnection(b *databaseBackend) *framework.Path {
 					OperationVerb:   "configure",
 					OperationSuffix: "connection",
 				},
+				ForwardPerformanceSecondary: true,
+				ForwardPerformanceStandby:   true,
 			},
 			logical.ReadOperation: &framework.PathOperation{
 				Callback: b.connectionReadHandler(),

--- a/changelog/30039.txt
+++ b/changelog/30039.txt
@@ -1,15 +1,15 @@
 ```release-note:bug
-secrets/aws: Forward Performance Secondary requests when configuring root credentials.
+secrets/aws: fix a panic when a performance standby node attempts to write/update config.
 ```
 
 ```release-note:bug
-auth/aws: Forward Performance Secondary requests when configuring root credentials.
+auth/aws: fix a panic when a performance standby node attempts to write/update config.
 ```
 
 ```release-note:bug
-auth/ldap: Forward Performance Secondary requests when configuring root credentials.
+auth/ldap: fix a panic when a performance standby node attempts to write/update config.
 ```
 
 ```release-note:bug
-secrets/db: Forward Performance Secondary requests when configuring root credentials.
+secrets/db: fix a panic when a performance standby node attempts to write/update config.
 ```

--- a/changelog/30039.txt
+++ b/changelog/30039.txt
@@ -1,0 +1,11 @@
+```release-note:bug
+secrets/aws: Forward Performance Secondary requests when configuring root credentials.
+```
+
+```release-note:bug
+auth/aws: Forward Performance Secondary requests when configuring root credentials.
+```
+
+```release-note:bug
+auth/ldap: Forward Performance Secondary requests when configuring root credentials.
+```

--- a/changelog/30039.txt
+++ b/changelog/30039.txt
@@ -9,3 +9,7 @@ auth/aws: Forward Performance Secondary requests when configuring root credentia
 ```release-note:bug
 auth/ldap: Forward Performance Secondary requests when configuring root credentials.
 ```
+
+```release-note:bug
+secrets/db: Forward Performance Secondary requests when configuring root credentials.
+```


### PR DESCRIPTION
Fixes a bug where Performance Secondaries panic when they attempt to de-register / register jobs to the RM, since the RM is nil on Perf Secondaries. This fix appropriately forwards such requests to the Primary node in the cluster.