### PR TITLE
Vault 34579 ce stubs to support external ce to ent plugin upgrade

### DIFF
--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -546,6 +546,10 @@ func (b *SystemBackend) handlePluginCatalogUpdate(ctx context.Context, _ *logica
 		}
 	}
 
+	if resp := validateSha256IsEmptyForEntPluginVersion(pluginVersion, sha256); resp.IsError() {
+		return resp, nil
+	}
+
 	command := d.Get("command").(string)
 	ociImage := d.Get("oci_image").(string)
 	if command == "" && ociImage == "" {

--- a/vault/logical_system_plugins_stubs_oss.go
+++ b/vault/logical_system_plugins_stubs_oss.go
@@ -15,3 +15,7 @@ func validateSHA256(sha256 string) *logical.Response {
 	}
 	return nil
 }
+
+func validateSha256IsEmptyForEntPluginVersion(pluginVersion string, sha256 string) *logical.Response {
+	return nil
+}

--- a/vault/logical_system_test.go
+++ b/vault/logical_system_test.go
@@ -2488,7 +2488,7 @@ func TestSystemBackend_tuneAuth(t *testing.T) {
 			Command: "foo",
 			Args:    []string{},
 			Env:     []string{},
-			Sha256:  []byte{},
+			Sha256:  []byte("sha256"),
 		})
 		if err != nil {
 			t.Fatal(err)
@@ -2625,7 +2625,7 @@ func TestSystemBackend_tune_updatePreV1MountEntryType(t *testing.T) {
 				Command: tc.pluginName,
 				Args:    []string{},
 				Env:     []string{},
-				Sha256:  []byte{},
+				Sha256:  []byte("sha256"),
 			})
 			if err != nil {
 				t.Fatal(err)
@@ -6451,7 +6451,7 @@ func TestValidateVersion_HelpfulErrorWhenBuiltinOverridden(t *testing.T) {
 		Command: command,
 		Args:    nil,
 		Env:     nil,
-		Sha256:  nil,
+		Sha256:  []byte("sha256"),
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/vault/plugincatalog/pin_test.go
+++ b/vault/plugincatalog/pin_test.go
@@ -33,6 +33,7 @@ func TestPluginCatalog_PinnedVersionCRUD(t *testing.T) {
 			Type:    consts.PluginTypeSecrets,
 			Version: version,
 			Command: filepath.Base(file.Name()),
+			Sha256:  []byte("sha256"),
 		})
 		require.NoError(t, err)
 	}

--- a/vault/plugincatalog/plugin_catalog_test.go
+++ b/vault/plugincatalog/plugin_catalog_test.go
@@ -199,6 +199,7 @@ func TestPluginCatalog_CRUD(t *testing.T) {
 		Type:    consts.PluginTypeDatabase,
 		Version: "1.0.0",
 		Command: filepath.Base(file.Name()),
+		Sha256:  []byte{'1'},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -646,7 +647,7 @@ func TestPluginCatalog_ListHandlesPluginNamesWithSlashes(t *testing.T) {
 			Command: command,
 			Args:    nil,
 			Env:     nil,
-			Sha256:  nil,
+			Sha256:  []byte{'1'},
 		})
 		if err != nil {
 			t.Fatal(err)
@@ -1267,6 +1268,7 @@ func TestPluginCatalog_CannotDeletePinnedVersion(t *testing.T) {
 		Type:    consts.PluginTypeSecrets,
 		Version: "1.0.0",
 		Command: filepath.Base(file.Name()),
+		Sha256:  []byte{'1'},
 	})
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
### Description

This PR adds an ENT-only validation `validateSha256IsEmptyForEntPluginVersion` to the `handlePluginCatalogUpdate` functio, along with the CE stub for it.

Links:
- Related ENT PR: https://github.com/hashicorp/vault-enterprise/pull/7695 (which needs to be rebased off `main` after these CE changes are brought into ENT `main`)
- Ticket: [VAULT-34579](https://hashicorp.atlassian.net/browse/VAULT-34579)

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.


[VAULT-34579]: https://hashicorp.atlassian.net/browse/VAULT-34579?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ