### PR TITLE
[DOCS] Add an description for performance replication

### DIFF
--- a/website/content/api-docs/system/config-cors.mdx
+++ b/website/content/api-docs/system/config-cors.mdx
@@ -57,9 +57,10 @@ cross-origin requests, as well as headers that are allowed on cross-origin reque
 
 <EnterpriseAlert>
 
-The CORS configuration endpoint does not apply changes across clusters. You must
-invoke the configuration endpoint on each secondary cluster independently to
-mirror the primary cluster CORS configuration.
+The CORS configuration endpoint does not apply changes across clusters. If you
+use performance replication, you must invoke the configuration endpoint on each
+secondary cluster independently to mirror the primary cluster CORS
+configuration.
 
 </EnterpriseAlert>
 

--- a/website/content/api-docs/system/config-cors.mdx
+++ b/website/content/api-docs/system/config-cors.mdx
@@ -55,7 +55,13 @@ $ curl \
 This endpoint allows configuring the origins that are permitted to make
 cross-origin requests, as well as headers that are allowed on cross-origin requests.
 
-**Vault Enterprise:** In performance replication, you set the CORS configuration on the primary and secondary clusters independently. If you want to mirror the CORS configuration set on the primary cluster to its secondary clusters, you need to invoke this endpoint on each cluster. 
+<EnterpriseAlert>
+
+The CORS configuration endpoint does not apply changes across clusters. You must
+invoke the configuration endpoint on each secondary cluster independently to
+mirror the primary cluster CORS configuration
+
+</EnterpriseAlert>
 
 | Method | Path               |
 | :----- | :----------------- |

--- a/website/content/api-docs/system/config-cors.mdx
+++ b/website/content/api-docs/system/config-cors.mdx
@@ -19,8 +19,6 @@ The `/sys/config/cors` endpoint is used to configure CORS settings.
 
 This endpoint returns the current CORS configuration. 
 
-**Vault Enterprise:** In performance replication, you set the CORS configuration on the primary and secondary clusters independently. If you want to mirror the CORS configuration set on the primary cluster to its secondary clusters, you need to invoke this endpoint on each cluster. 
-
 | Method | Path               |
 | :----- | :----------------- |
 | `GET`  | `/sys/config/cors` |
@@ -56,6 +54,8 @@ $ curl \
 
 This endpoint allows configuring the origins that are permitted to make
 cross-origin requests, as well as headers that are allowed on cross-origin requests.
+
+**Vault Enterprise:** In performance replication, you set the CORS configuration on the primary and secondary clusters independently. If you want to mirror the CORS configuration set on the primary cluster to its secondary clusters, you need to invoke this endpoint on each cluster. 
 
 | Method | Path               |
 | :----- | :----------------- |

--- a/website/content/api-docs/system/config-cors.mdx
+++ b/website/content/api-docs/system/config-cors.mdx
@@ -59,7 +59,7 @@ cross-origin requests, as well as headers that are allowed on cross-origin reque
 
 The CORS configuration endpoint does not apply changes across clusters. You must
 invoke the configuration endpoint on each secondary cluster independently to
-mirror the primary cluster CORS configuration
+mirror the primary cluster CORS configuration.
 
 </EnterpriseAlert>
 

--- a/website/content/api-docs/system/config-cors.mdx
+++ b/website/content/api-docs/system/config-cors.mdx
@@ -17,7 +17,9 @@ The `/sys/config/cors` endpoint is used to configure CORS settings.
 
 ## Read CORS settings
 
-This endpoint returns the current CORS configuration.
+This endpoint returns the current CORS configuration. 
+
+**Vault Enterprise:** In performance replication, you set the CORS configuration on the primary and secondary clusters independently. If you want to mirror the CORS configuration set on the primary cluster to its secondary clusters, you need to invoke this endpoint on each cluster. 
 
 | Method | Path               |
 | :----- | :----------------- |


### PR DESCRIPTION
### Description

🎫 [Jira ticket](https://hashicorp.atlassian.net/browse/FRB-1367)

🔍 [Deploy preview](https://vault-git-docs-update-api-config-cor-hashicorp.vercel.app/vault/api-docs/system/config-cors#configure-cors-settings)

This PR adds a sentence to describe how `sys/config/cor` endpoing works with Performance Replication. 

<img width="739" alt="image" src="https://github.com/user-attachments/assets/e7f4089a-689f-46f9-b1fa-40f220ed9566" />


### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
