### PR TITLE
[Docs] MFA TOTP doc added info

### DIFF
--- a/website/content/docs/auth/login-mfa/index.mdx
+++ b/website/content/docs/auth/login-mfa/index.mdx
@@ -236,13 +236,11 @@ To get started with Login MFA, refer to the [Login MFA](/vault/tutorials/auth-me
 
 Enable a Login MFA method to enforce TOTP on the LDAP auth method.
 
- Authenticator applications are not consistent in their support of encryption algorithms. You should research the algorithms supported by your preferred authenticator app. The [Configure TOTP MFA Method documentation](/vault/api-docs/secret/identity/mfa/totp#algorithm) lists algorithms supported by the Login MFA TOTP method. Google Authenticator supports SHA256.
+<Note title="Authenticator applications and encryption algorithms">
 
-| Authenticator application             | SHA-256  |  SHA-1  |
-| ------------------------------------- | :------: | :-----: |
-| Google Authenticator Chrome extension | &#10060; | &#9989; |
-| Google Authenticator mobile app       | &#9989;  | &#9989; |
-| Yubico Authenticator (PC)             | &#9989;  | &#9989; |
+ Authenticator applications are not consistent in their support of encryption algorithms. You should research the algorithms supported by your preferred authenticator app. The [Configure TOTP MFA Method documentation](/vault/api-docs/secret/identity/mfa/totp#algorithm) lists algorithms supported by the Login MFA TOTP method.
+
+</Note>
 
 Configure the Login MFA TOTP method and note down the resulting `method_id`.
 
@@ -307,3 +305,13 @@ By default, Vault allows for 5 consecutive failed TOTP passcode validation.
 This value can also be configured by adding `max_validation_attempts` to the TOTP configuration.
 If the number of consecutive failed TOTP passcode validation exceeds the configured value, the user
 needs to wait until a fresh TOTP passcode is available.
+
+#### Known compatibility
+
+The following table lists the known authenticator applications and encryption algorithms compatibility. 
+
+| Authenticator application             | SHA-256  |  SHA-1  |
+| ------------------------------------- | :------: | :-----: |
+| Google Authenticator Chrome extension | &#10060; | &#9989; |
+| Google Authenticator mobile app       | &#9989;  | &#9989; |
+| Yubico Authenticator (PC)             | &#9989;  | &#9989; |

--- a/website/content/docs/auth/login-mfa/index.mdx
+++ b/website/content/docs/auth/login-mfa/index.mdx
@@ -236,11 +236,15 @@ To get started with Login MFA, refer to the [Login MFA](/vault/tutorials/auth-me
 
 Enable a Login MFA method to enforce TOTP on the LDAP auth method.
 
-<Note title="Authenticator applications and encryption algorithms">
+Authenticator applications are not consistent in their support of encryption algorithms. You should research the algorithms supported by your preferred authenticator app. The [Configure TOTP MFA Method documentation](/vault/api-docs/secret/identity/mfa/totp#algorithm) lists algorithms supported by the Login MFA TOTP method.
 
- Authenticator applications are not consistent in their support of encryption algorithms. You should research the algorithms supported by your preferred authenticator app. The [Configure TOTP MFA Method documentation](/vault/api-docs/secret/identity/mfa/totp#algorithm) lists algorithms supported by the Login MFA TOTP method.
+The following table lists the known authenticator applications and encryption algorithms compatibility. 
 
-</Note>
+| Authenticator application             |  SHA256  |  SHA1   |
+| ------------------------------------- | :------: | :-----: |
+| Google Authenticator Chrome extension | &#10060; | &#9989; |
+| Google Authenticator mobile app       | &#9989;  | &#9989; |
+| Yubico Authenticator for Desktop      | &#9989;  | &#9989; |
 
 Configure the Login MFA TOTP method and note down the resulting `method_id`.
 
@@ -305,13 +309,3 @@ By default, Vault allows for 5 consecutive failed TOTP passcode validation.
 This value can also be configured by adding `max_validation_attempts` to the TOTP configuration.
 If the number of consecutive failed TOTP passcode validation exceeds the configured value, the user
 needs to wait until a fresh TOTP passcode is available.
-
-#### Known compatibility
-
-The following table lists the known authenticator applications and encryption algorithms compatibility. 
-
-| Authenticator application             | SHA-256  |  SHA-1  |
-| ------------------------------------- | :------: | :-----: |
-| Google Authenticator Chrome extension | &#10060; | &#9989; |
-| Google Authenticator mobile app       | &#9989;  | &#9989; |
-| Yubico Authenticator (PC)             | &#9989;  | &#9989; |

--- a/website/content/docs/auth/login-mfa/index.mdx
+++ b/website/content/docs/auth/login-mfa/index.mdx
@@ -236,11 +236,13 @@ To get started with Login MFA, refer to the [Login MFA](/vault/tutorials/auth-me
 
 Enable a Login MFA method to enforce TOTP on the LDAP auth method.
 
-<Note>
-
  Authenticator applications are not consistent in their support of encryption algorithms. You should research the algorithms supported by your preferred authenticator app. The [Configure TOTP MFA Method documentation](/vault/api-docs/secret/identity/mfa/totp#algorithm) lists algorithms supported by the Login MFA TOTP method. Google Authenticator supports SHA256.
 
-</Note>
+| Authenticator application             | SHA-256  |  SHA-1  |
+| ------------------------------------- | :------: | :-----: |
+| Google Authenticator Chrome extension | &#10060; | &#9989; |
+| Google Authenticator mobile app       | &#9989;  | &#9989; |
+| Yubico Authenticator (PC)             | &#9989;  | &#9989; |
 
 Configure the Login MFA TOTP method and note down the resulting `method_id`.
 


### PR DESCRIPTION
### Description

🎫 [Jira ticket](https://hashicorp.atlassian.net/browse/SPE-1141)

🔍 [Deploy preview](https://vault-git-docs-update-mfa-doc-hashicorp.vercel.app/vault/docs/auth/login-mfa#time-based-one-time-password-totp-1)

This PR:
- Updates the callout title to draw user attention
- Adds "Known compartibility" table at the end as a reference

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
