### PR TITLE
UI: Remove slash from check for admin namespace path

### DIFF
--- a/ui/app/services/namespace.js
+++ b/ui/app/services/namespace.js
@@ -30,11 +30,11 @@ export default class NamespaceService extends Service {
     return this.path === ROOT_NAMESPACE;
   }
 
-  // the top-level namespace is "admin/" for HVD managed clusters accessing the UI
+  // the top-level namespace is "admin" for HVD managed clusters accessing the UI
   // (similar to "root" for self-managed clusters)
   // this getter checks if the user is specifically at the administrative namespace level
   get inHvdAdminNamespace() {
-    return this.flags.isHvdManaged && this.path === 'admin/';
+    return this.flags.isHvdManaged && this.path === 'admin';
   }
 
   get currentNamespace() {

--- a/ui/tests/integration/components/dashboard/overview-test.js
+++ b/ui/tests/integration/components/dashboard/overview-test.js
@@ -165,7 +165,7 @@ module('Integration | Component | dashboard/overview', function (hooks) {
 
       this.version.type = 'enterprise';
       this.flags.featureFlags = ['VAULT_CLOUD_ADMIN_NAMESPACE'];
-      this.namespace.path = 'admin/';
+      this.namespace.path = 'admin';
       this.isRootNamespace = false;
 
       await this.renderComponent();


### PR DESCRIPTION
### Description
When adding the explicit namespace check in https://github.com/hashicorp/vault/pull/30000 I mistakenly added a `/` to the end, but the path is manually set to `admin` by [this getter](https://github.com/hashicorp/vault/blob/629b04c0030041b93aa77f8796d70d8b754d5181/ui/app/services/flags.ts#L37) 

✅ enterprise tests pass
### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
