### PR TITLE
add azure auth security improvement to upgrade guide 1.18.x

### DIFF
--- a/website/content/docs/auth/azure.mdx
+++ b/website/content/docs/auth/azure.mdx
@@ -21,7 +21,31 @@ This documentation assumes the Azure method is mounted at the `/auth/azure`
 path in Vault. Since it is possible to enable auth methods at any location,
 please update your API calls accordingly.
 
-## Prerequisites:
+## Token validation ((#token-validation))
+
+Vault validates the resource group (`resource_group_name`), VM name (`vm_name`)
+and VM scale set name (`vmss_name`) parameters against token claims. Depending
+on the identities attached to the machine generating the MSI token, the
+associated claims must include at least one of the following claims
+to pass validation: "xms_mirid" or "xms_az_rid".
+
+System-assigned management identity | "xms_mirid"                                                                                                                                | "xms_az_rid"
+----------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------| ---------------
+Enabled                             | `/subscriptions/{subscription-id}/resourcegroups/{resource-group-name}/providers/Microsoft.Compute/virtualMachines/{virtual-machine-name}` | Does not exist
+Not enabled                         | `/subscriptions/{subscription-id}/resourcegroups/{resource-group-name}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{user-assigned-managed-identity}` |`/subscriptions/{subscription-id}/resourcegroups/{resource-group-name}/providers/Microsoft.Compute/virtualMachines/{virtual-machine-name}`
+
+See [Azure managed identity REST endpoint reference](https://learn.microsoft.com/en-us/azure/app-service/overview-managed-identity?tabs=portal%2Chttp#rest-endpoint-reference) and
+[Managed identities for Azure resources frequently asked questions](https://learn.microsoft.com/en-us/entra/identity/managed-identities-azure-resources/managed-identities-faq#what-identity-will-imds-default-to-if-i-dont-specify-the-identity-in-the-request) for more details on how to request MSI tokens.
+
+When Vault evaluates the token claims, it checks the validation parameter values
+against the claim parameters:
+
+- `{resource-group-name}` must match `resource_group_name`.
+- `{virtual-machine-name}` must match `vm_name` or `{vmss_name}_{instance-id}` if `vmss_name` is provided.
+
+If either check fails, the login also fails.
+
+## Prerequisites
 
 The Azure auth method requires client credentials to access Azure APIs. The following
 are required to configure the auth method:

--- a/website/content/docs/upgrading/upgrade-to-1.18.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.18.x.mdx
@@ -14,6 +14,16 @@ Vault 1.17. **Please read carefully**.
 
 ## Important changes
 
+### Azure auth plugin requires `resource_group_name`, `vm_name`, and `vmss_name` to match the JWT claims on login
+
+Vault versions before 1.19.1, 1.18.7, 1.17.14, and 1.16.18, do not strictly
+validate the `resource_group_name`, `vm_name`, and `vmss_name` parameters
+against their token claims during login with Azure authentication.
+
+Refer to the [Token validation](/vault/docs/auth/azure#token-validation) section
+of the Azure authN plugin guide for more information on the new validation
+requirements.
+
 ### Activity Log Changes
 
 #### Default Activity Log Querying Period


### PR DESCRIPTION
### Description
What does this PR do?
The PR adds azure auth security improvement to upgrade guide 1.18.x. The PR needs https://github.com/hashicorp/vault/pull/29969

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
