### PR TITLE
Switch to enumer tool that works with Go 1.24

### DIFF
--- a/.github/actions/install-external-tools/action.yml
+++ b/.github/actions/install-external-tools/action.yml
@@ -35,5 +35,5 @@ runs:
       shell: bash
     - run: ./.github/scripts/retry-command.sh go install github.com/golangci/revgrep/cmd/revgrep@v0.8.0
       shell: bash
-    - run: ./.github/scripts/retry-command.sh go install github.com/loggerhead/enumer@v0.0.0-20240225233120-0aebd7ae8325
+    - run: ./.github/scripts/retry-command.sh go install github.com/stevendpclark/enumer@v0.0.0-20250122154818-a42b666c3cd3
       shell: bash

--- a/tools/tools.sh
+++ b/tools/tools.sh
@@ -44,7 +44,7 @@ install_external() {
     github.com/favadi/protoc-go-inject-tag@v1.4.0
     github.com/golangci/misspell/cmd/misspell@v0.6.0
     github.com/golangci/revgrep/cmd/revgrep@v0.8.0
-    github.com/loggerhead/enumer@v0.0.0-20240225233120-0aebd7ae8325
+    github.com/stevendpclark/enumer@v0.0.0-20250122154818-a42b666c3cd3
     github.com/rinchsan/gosimports/cmd/gosimports@v0.3.8
     golang.org/x/tools/cmd/goimports@v0.30.0
     google.golang.org/protobuf/cmd/protoc-gen-go@v1.36.5


### PR DESCRIPTION
### Description

Switch out the enumer tool to a version that is compatible with Go 1.24 resolving the following errors when running under that Go version. 

```
enumer: internal error: package "fmt" without types was imported from "github.com/hashicorp/vault/builtin/logical/pki"
builtin/logical/pki/path_config_acme.go:420: running "enumer": exit status 1
enumer: internal error: package "context" without types was imported from "github.com/hashicorp/vault/builtin/logical/pki/pki_backend"
builtin/logical/pki/pki_backend/common.go:29: running "enumer": exit status 1
enumer: internal error: package "context" without types was imported from "github.com/hashicorp/vault/command"
command/operator_generate_root.go:26: running "enumer": exit status 1
enumer: internal error: package "fmt" without types was imported from "github.com/hashicorp/vault/command/agent/exec"
command/agent/exec/exec.go:29: running "enumer": exit status 1
enumer: internal error: package "context" without types was imported from "github.com/hashicorp/vault/command/agentproxyshared/cache"
command/agentproxyshared/cache/api_proxy.go:19: running "enumer": exit status 1
enumer: internal error: package "context" without types was imported from "github.com/hashicorp/vault/command/healthcheck"
command/healthcheck/healthcheck.go:255: running "enumer": exit status 1
enumer: internal error: package "fmt" without types was imported from "github.com/hashicorp/vault/helper/testhelpers"
helper/testhelpers/testhelpers.go:29: running "enumer": exit status 1
enumer: internal error: package "fmt" without types was imported from "github.com/hashicorp/vault/internalshared/configutil"
internalshared/configutil/kms.go:42: running "enumer": exit status 1
enumer: internal error: package "context" without types was imported from "github.com/hashicorp/vault/vault"
vault/core.go:3107: running "enumer": exit status 1
enumer: internal error: package "fmt" without types was imported from "github.com/hashicorp/vault/vault/quotas"
vault/quotas/quotas.go:33: running "enumer": exit status 1
```

### TODO only if you're a HashiCorp employee
- [X] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [X] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
