### PR TITLE
Vault 34676: set up client count usage map upon startup ce changes

### DIFF
--- a/vault/activity_log.go
+++ b/vault/activity_log.go
@@ -212,6 +212,16 @@ type ActivityLog struct {
 	// precomputedQueryWritten receives an element whenever a precomputed query
 	// is written. It's used for unit testing
 	precomputedQueryWritten chan struct{}
+
+	// The clientIDsUsageInfo map has clientIDs that have been used in the current billing period
+	clientIDsUsageInfo map[string]struct{}
+
+	// clientIDsUsageInfoLock controls access to the clientIDsUsageInfo
+	clientIDsUsageInfoLock sync.RWMutex
+
+	// clientIDsUsageInfoLoaded is set to true when the clientIDsUsageInfo has up-to date information upon startup.
+	// This ensures that the counters api returns exact values for new clients in the current month upon startup.
+	clientIDsUsageInfoLoaded *atomic.Bool
 }
 
 // These non-persistent configuration options allow us to disable
@@ -331,6 +341,8 @@ func NewActivityLog(core *Core, logger log.Logger, view *BarrierView, metrics me
 		standbyFragmentsReceived: make([]*activity.LogFragment, 0),
 		inprocessExport:          atomic.NewBool(false),
 		precomputedQueryWritten:  make(chan struct{}),
+		clientIDsUsageInfo:       make(map[string]struct{}),
+		clientIDsUsageInfoLoaded: new(atomic.Bool),
 	}
 
 	config, err := a.loadConfigOrDefault(core.activeContext)
@@ -1251,9 +1263,114 @@ func (c *Core) setupActivityLogLocked(ctx context.Context, wg *sync.WaitGroup, r
 			manager.retentionWorker(ctx, manager.clock.Now(), months)
 			close(manager.retentionDone)
 		}(manager.retentionMonths)
+
+		// set up clientIDs in memory, this happens as part of post unseal
+		c.postUnsealFuncs = append(c.postUnsealFuncs, func() {
+			// errors are logged within the function
+			c.setupClientIDsUsageInfo(ctx)
+		})
 	}
 
 	return nil
+}
+
+// loadClientIDsToMemory loads all the clientIDs seen into a.clientIDsUsageInfo for a given start and end time
+func (a *ActivityLog) loadClientIDsToMemory(ctx context.Context, startTime, endTime time.Time) error {
+	if startTime.IsZero() || endTime.IsZero() {
+		// nothing to load
+		return nil
+	}
+	times, err := a.availableLogs(ctx, endTime)
+	if err != nil {
+		return fmt.Errorf("error fetching available logs: %w", err)
+	}
+
+	// Filter over just the months we care about
+	filteredList := make([]time.Time, 0, len(times))
+	for _, t := range times {
+		if timeutil.InRange(t, startTime, endTime) {
+			filteredList = append(filteredList, t)
+		}
+	}
+
+	if len(filteredList) == 0 {
+		a.logger.Info("no clientIDs to load to memory", "start_time", startTime, "end_time", endTime)
+		return nil
+	}
+
+	a.logger.Info("starting to load clientIDS to memory", "start_time", startTime, "end_time", endTime, "months_included", filteredList)
+
+	// For each month in the filtered list walk all the log segments
+	inMemClientIDsMap := make(map[string]struct{})
+
+	for _, startTime := range filteredList {
+		inMemClientIDsMap, err = a.getClientIDsForStartTime(ctx, inMemClientIDsMap, startTime)
+		if err != nil {
+			return err
+		}
+	}
+	a.logger.Info("finished loading segments to store client IDs in memory")
+
+	// update in-memory map in activity log
+	a.SetClientIDsUsageInfo(inMemClientIDsMap)
+	return nil
+}
+
+// getClientIDsForStartTime loads each of the entity segments for a particular start time and adds the clientIDs to a map
+func (a *ActivityLog) getClientIDsForStartTime(ctx context.Context, inMemoryClientIDs map[string]struct{}, startTime time.Time) (map[string]struct{}, error) {
+	basePath := activityEntityBasePath + fmt.Sprint(startTime.Unix()) + "/"
+	pathList, err := a.view.List(ctx, basePath)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, path := range pathList {
+		raw, err := a.view.Get(ctx, basePath+path)
+		if err != nil {
+			return nil, err
+		}
+		if raw == nil {
+			a.logger.Warn("expected log segment not found", "startTime", startTime, "segment", path)
+			continue
+		}
+
+		out := &activity.EntityActivityLog{}
+		err = proto.Unmarshal(raw.Value, out)
+		if err != nil {
+			return nil, fmt.Errorf("unable to parse segment %v%v: %w", basePath, path, err)
+		}
+
+		for _, e := range out.Clients {
+			inMemoryClientIDs[e.ClientID] = struct{}{}
+		}
+	}
+	return inMemoryClientIDs, nil
+}
+
+// getStartTimeAndEndTimeUntilLastMonth returns the start time and end time
+// if entireBillingPeriod is set to true, it returns the start time as the start of the current billing cycle and the end of the last month
+// if not, it returns the start of the last month and end of the last month
+func (a *ActivityLog) getStartTimeAndEndTimeUntilLastMonth(entireBillingPeriod bool) (time.Time, time.Time) {
+	currBillingPeriodStartTime := a.core.BillingStart()
+	now := a.clock.Now().UTC()
+
+	// if we are in the first month of the billing cycle, return empty values
+	if timeutil.IsCurrentMonth(currBillingPeriodStartTime, now) {
+		return time.Time{}, time.Time{}
+	}
+
+	// Normalize to start of current month to prevent end of month weirdness
+	startOfCurrMonth := timeutil.StartOfMonth(now)
+
+	// get start time and end time of the last month
+	startOfLastMonth := startOfCurrMonth.AddDate(0, -1, 0)
+	endOfLastMonth := timeutil.EndOfMonth(startOfLastMonth)
+
+	if entireBillingPeriod {
+		// startTime is the billing start time and endTime is the end of last month
+		return currBillingPeriodStartTime, endOfLastMonth
+	}
+	return startOfLastMonth, endOfLastMonth
 }
 
 func (a *ActivityLog) hasRegeneratedACME(ctx context.Context) bool {

--- a/vault/activity_log_testonly_oss_test.go
+++ b/vault/activity_log_testonly_oss_test.go
@@ -1,0 +1,38 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+//go:build testonly && !enterprise
+
+package vault
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/vault/helper/testhelpers/corehelpers"
+	"github.com/stretchr/testify/require"
+)
+
+// TestActivityLog_setupClientIDsUsageInfo_CE verifies that upon startup, the client IDs are not loaded in CE
+func TestActivityLog_setupClientIDsUsageInfo_CE(t *testing.T) {
+	core, _, _ := TestCoreUnsealed(t)
+	a := core.activityLog
+	a.SetEnable(true)
+
+	core.setupClientIDsUsageInfo(context.Background())
+
+	// wait for clientIDs to be loaded into memory
+	verifyClientsLoadedInMemory := func() {
+		corehelpers.RetryUntil(t, 60*time.Second, func() error {
+			if a.GetClientIDsUsageInfoLoaded() {
+				return fmt.Errorf("loaded clientIDs to memory")
+			}
+			return nil
+		})
+	}
+	verifyClientsLoadedInMemory()
+
+	require.Len(t, a.GetClientIDsUsageInfo(), 0)
+}

--- a/vault/activity_log_testonly_test.go
+++ b/vault/activity_log_testonly_test.go
@@ -115,3 +115,86 @@ func TestActivityLog_doPrecomputedQueryCreation(t *testing.T) {
 		})
 	}
 }
+
+// TestActivityLog_getClientIDsForStartTime verifies getClientIDsForStartTime function.
+// It adds data for 4 months previous to the current month and verifies if the correct number of clientIDs are returned based on the startTime.
+func TestActivityLog_getClientIDsForStartTime(t *testing.T) {
+	core, _, token := TestCoreUnsealed(t)
+	a := core.activityLog
+	a.SetEnable(true)
+
+	j, err := clientcountutil.NewActivityLogData(nil).
+		// 8 new clients
+		// across two segments
+		NewPreviousMonthData(4).
+		Segment().NewClientsSeen(5).
+		Segment().NewClientsSeen(3).
+
+		// 2 repeated clients
+		// 10 new clients
+		// across 3 segments
+		NewPreviousMonthData(3).
+		Segment().RepeatedClientsSeen(2).
+		NewClientsSeen(3).
+		Segment().NewClientsSeen(2).
+		Segment().NewClientsSeen(5).
+
+		// 7 new clients
+		// single segment
+		NewPreviousMonthData(2).
+		NewClientsSeen(7).
+
+		// 6 repeated clients
+		// 5 new clients
+		// across 2 segments
+		NewPreviousMonthData(1).
+		Segment().NewClientsSeen(5).
+		Segment().RepeatedClientsSeen(6).
+		ToJSON(generation.WriteOptions_WRITE_ENTITIES)
+	require.NoError(t, err)
+
+	r := logical.TestRequest(t, logical.UpdateOperation, "sys/internal/counters/activity/write")
+	r.Data["input"] = string(j)
+	r.ClientToken = token
+	_, err = core.HandleRequest(namespace.RootContext(context.Background()), r)
+	require.NoError(t, err)
+
+	now := time.Now().UTC()
+	times := map[int]time.Time{}
+	for i := 1; i < 5; i++ {
+		times[i] = timeutil.StartOfMonth(timeutil.MonthsPreviousTo(i, now))
+	}
+	testCases := []struct {
+		name            string
+		startTime       time.Time
+		expectedClients int
+	}{
+		{
+			name:            "startTime 4 months ago",
+			startTime:       times[4],
+			expectedClients: 8, // 8 clients from month 4
+		},
+		{
+			name:            "startTime 3 months ago",
+			startTime:       times[3],
+			expectedClients: 12, // 12 clients from month 3
+		},
+		{
+			name:            "startTime 2 months ago",
+			startTime:       times[2],
+			expectedClients: 7, // 7 clients from month 2
+		},
+		{
+			name:            "startTime 1 months ago",
+			startTime:       times[1],
+			expectedClients: 11, // 11 clients from last month
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			clientIDsMap, err := core.activityLog.getClientIDsForStartTime(context.Background(), make(map[string]struct{}), tc.startTime)
+			require.NoError(t, err)
+			require.Len(t, clientIDsMap, tc.expectedClients)
+		})
+	}
+}

--- a/vault/activity_log_util.go
+++ b/vault/activity_log_util.go
@@ -13,3 +13,7 @@ import (
 func (a *ActivityLog) sendCurrentFragment(ctx context.Context) error {
 	return nil
 }
+
+// setupClientIDsUsageInfo is a no-op on OSS
+func (c *Core) setupClientIDsUsageInfo(ctx context.Context) {
+}

--- a/vault/activity_log_util_common.go
+++ b/vault/activity_log_util_common.go
@@ -535,3 +535,21 @@ func (a *ActivityLog) namespaceRecordToCountsResponse(record *activity.Namespace
 		ACMEClients:      int(record.ACMEClients),
 	}
 }
+
+func (a *ActivityLog) GetClientIDsUsageInfo() map[string]struct{} {
+	a.clientIDsUsageInfoLock.Lock()
+	defer a.clientIDsUsageInfoLock.Unlock()
+	return a.clientIDsUsageInfo
+}
+
+func (a *ActivityLog) SetClientIDsUsageInfo(inMemClientIDsMap map[string]struct{}) {
+	a.clientIDsUsageInfoLock.Lock()
+	defer a.clientIDsUsageInfoLock.Unlock()
+
+	a.clientIDsUsageInfo = inMemClientIDsMap
+}
+
+// GetclientIDsUsageInfoLoaded gets a.clientIDsUsageInfoLoaded for external tests
+func (a *ActivityLog) GetClientIDsUsageInfoLoaded() bool {
+	return a.clientIDsUsageInfoLoaded.Load()
+}


### PR DESCRIPTION
### Description
What does this PR do?
What does this PR do?
Jira: https://hashicorp.atlassian.net/browse/VAULT-34676

A field called clientIDsUsageInfo is added to core struct. This holds the clientIDs in memory.
During post-unseal, the clientIDs from the current billing cycle until the last month are loaded and stored in core.clientIDsUsageInfo on the active node.
Added tests

Approved ENT PR: https://github.com/hashicorp/vault-enterprise/pull/7672

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
