### PR TITLE
add known issue for login/token renewals failing on perf standbys if an external group has changed VAULT-34956

### DIFF
--- a/website/content/docs/release-notes/1.19.0.mdx
+++ b/website/content/docs/release-notes/1.19.0.mdx
@@ -22,6 +22,7 @@ description: |-
 | New behavior (1.19.0)                         | [Anonymized cluster data returned with license utilization](/vault/docs/upgrading/upgrade-to-1.19.x#anon-data)
 | Known issue (1.19.x, 1.18.x, 1.17.x, 1.16.x)  | [Duplicate HSM keys creation when migrating to HSM from Shamir](/vault/docs/upgrading/upgrade-to-1.19.x#hsm-keys)
 | New behavior (1.19.0)                         | [Uppercase values are no longer forced to lower case](/vault/docs/upgrading/upgrade-to-1.19.x#case-sensitive)
+| Known issue (1.19.0)                          | [Login/token renewal failures after group changes](/vault/docs/upgrading/upgrade-to-1.19.x#group-writes)
 
 ## Vault companion updates
 

--- a/website/content/docs/upgrading/upgrade-to-1.19.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.19.x.mdx
@@ -85,3 +85,5 @@ As of Vault 1.19.0 the RADIUS authentication plugin will not force case sensitiv
 ## Known issues and workarounds
 
 @include 'known-issues/duplicate-hsm-key.mdx'
+
+@include 'known-issues/1_19-failures-after-external-group-changes-standby.mdx'

--- a/website/content/partials/known-issues/1_19-failures-after-external-group-changes-standby.mdx
+++ b/website/content/partials/known-issues/1_19-failures-after-external-group-changes-standby.mdx
@@ -1,0 +1,12 @@
+### Login/token renewal failures after group changes (((#group-writes)))
+
+#### Affected Versions
+- 1.19.0 
+
+#### Issue
+Performance standby nodes return a 500 error during login or token renewal if an 
+entity's external group association has changed. This occurs because standbys are 
+unable to persist the updated group membership to storage.
+
+#### Workaround
+Direct all logins and token renewals to the active node. 


### PR DESCRIPTION
### Description
Adds known issue for failed login/token renewals occuring because a perf standby can't write to storage

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
