### PR TITLE
Reintroduce UpsertGroupRequest for targeted use in external groups refresh CE

### DIFF
--- a/changelog/30069.txt
+++ b/changelog/30069.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+identity: reintroduce RPC functionality for group creates, allowing performance standbys to handle external group changes during login and token renewal
+```

--- a/vault/identity_store.go
+++ b/vault/identity_store.go
@@ -72,6 +72,7 @@ func NewIdentityStore(ctx context.Context, core *Core, config *logical.BackendCo
 		namespacer:             core,
 		metrics:                core.MetricSink(),
 		totpPersister:          core,
+		groupUpdater:           core,
 		tokenStorer:            core,
 		entityCreator:          core,
 		mountLister:            core,

--- a/vault/identity_store_oss.go
+++ b/vault/identity_store_oss.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/vault/helper/identity"
 )
 
-func (c *Core) SendGroupUpdate(context.Context, *identity.Group) (bool, error) {
-	return false, nil
+func (c *Core) SendGroupUpdate(context.Context, *identity.Group) error {
+	return nil
 }
 
 func (c *Core) CreateEntity(ctx context.Context) (*identity.Entity, error) {

--- a/vault/identity_store_structs.go
+++ b/vault/identity_store_structs.go
@@ -110,6 +110,7 @@ type IdentityStore struct {
 	namespacer    Namespacer
 	metrics       metricsutil.Metrics
 	totpPersister TOTPPersister
+	groupUpdater  GroupUpdater
 	tokenStorer   TokenStorer
 	entityCreator EntityCreator
 	mountLister   MountLister
@@ -159,6 +160,12 @@ type TOTPPersister interface {
 }
 
 var _ TOTPPersister = &Core{}
+
+type GroupUpdater interface {
+	SendGroupUpdate(ctx context.Context, group *identity.Group) error
+}
+
+var _ GroupUpdater = &Core{}
 
 type TokenStorer interface {
 	LookupToken(context.Context, string) (*logical.TokenEntry, error)

--- a/vault/identity_store_util.go
+++ b/vault/identity_store_util.go
@@ -2655,6 +2655,7 @@ func (i *IdentityStore) refreshExternalGroupMembershipsByEntityID(ctx context.Co
 
 			err = i.UpsertGroupInTxn(ctx, txn, group, true)
 			if errors.Is(err, logical.ErrReadOnly) {
+				i.logger.Info("forwarding update group request to active", "group_id", group.ID)
 				// Forward the group update to the active node
 				if err := i.groupUpdater.SendGroupUpdate(ctx, group); err != nil {
 					return false, nil, err
@@ -2688,6 +2689,7 @@ func (i *IdentityStore) refreshExternalGroupMembershipsByEntityID(ctx context.Co
 
 			err = i.UpsertGroupInTxn(ctx, txn, group, true)
 			if errors.Is(err, logical.ErrReadOnly) {
+				i.logger.Info("forwarding update group request to active", "group_id", group.ID)
 				// Forward the group update to the active node
 				if err := i.groupUpdater.SendGroupUpdate(ctx, group); err != nil {
 					return false, nil, err


### PR DESCRIPTION
### Description
This change reintroduces the UpsertGroup RPC functionality for use by the refreshExternalGroupMembershipsByEntityID function. Users were unable to log in or renew their tokens if their entity's external group association changed. This issue stemmed from performance standby nodes being unable to write group updates to storage. To fix this regression, we’ve restored the RPC functionality, allowing performance standbys to forward group update logic to the active node.

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
