### PR TITLE
[UI] API Client Update - Override Query

### DIFF
--- a/ui/api-client/dist/esm/runtime.js
+++ b/ui/api-client/dist/esm/runtime.js
@@ -162,12 +162,6 @@ export class BaseAPI {
     createFetchParams(context, initOverrides) {
         return __awaiter(this, void 0, void 0, function* () {
             let url = this.configuration.basePath + context.path;
-            if (context.query !== undefined && Object.keys(context.query).length !== 0) {
-                // only add the querystring to the URL if there are query parameters.
-                // this is done to avoid urls ending with a "?" character which buggy webservers
-                // do not handle correctly sometimes.
-                url += '?' + this.configuration.queryParamsStringify(context.query);
-            }
             const headers = Object.assign({}, this.configuration.headers, context.headers);
             Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
             const initOverrideFn = typeof initOverrides === "function"
@@ -183,6 +177,12 @@ export class BaseAPI {
                 init: initParams,
                 context,
             })));
+            if (context.query !== undefined && Object.keys(context.query).length !== 0) {
+                // only add the querystring to the URL if there are query parameters.
+                // this is done to avoid urls ending with a "?" character which buggy webservers
+                // do not handle correctly sometimes.
+                url += '?' + this.configuration.queryParamsStringify(context.query);
+            }
             let body;
             if (isFormData(overriddenInit.body)
                 || (overriddenInit.body instanceof URLSearchParams)

--- a/ui/api-client/dist/runtime.js
+++ b/ui/api-client/dist/runtime.js
@@ -170,12 +170,6 @@ class BaseAPI {
     createFetchParams(context, initOverrides) {
         return __awaiter(this, void 0, void 0, function* () {
             let url = this.configuration.basePath + context.path;
-            if (context.query !== undefined && Object.keys(context.query).length !== 0) {
-                // only add the querystring to the URL if there are query parameters.
-                // this is done to avoid urls ending with a "?" character which buggy webservers
-                // do not handle correctly sometimes.
-                url += '?' + this.configuration.queryParamsStringify(context.query);
-            }
             const headers = Object.assign({}, this.configuration.headers, context.headers);
             Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
             const initOverrideFn = typeof initOverrides === "function"
@@ -191,6 +185,12 @@ class BaseAPI {
                 init: initParams,
                 context,
             })));
+            if (context.query !== undefined && Object.keys(context.query).length !== 0) {
+                // only add the querystring to the URL if there are query parameters.
+                // this is done to avoid urls ending with a "?" character which buggy webservers
+                // do not handle correctly sometimes.
+                url += '?' + this.configuration.queryParamsStringify(context.query);
+            }
             let body;
             if (isFormData(overriddenInit.body)
                 || (overriddenInit.body instanceof URLSearchParams)

--- a/ui/api-client/src/runtime.ts
+++ b/ui/api-client/src/runtime.ts
@@ -143,12 +143,6 @@ export class BaseAPI {
 
     private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
         let url = this.configuration.basePath + context.path;
-        if (context.query !== undefined && Object.keys(context.query).length !== 0) {
-            // only add the querystring to the URL if there are query parameters.
-            // this is done to avoid urls ending with a "?" character which buggy webservers
-            // do not handle correctly sometimes.
-            url += '?' + this.configuration.queryParamsStringify(context.query);
-        }
 
         const headers = Object.assign({}, this.configuration.headers, context.headers);
         Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
@@ -172,6 +166,13 @@ export class BaseAPI {
                 context,
             }))
         };
+
+        if (context.query !== undefined && Object.keys(context.query).length !== 0) {
+            // only add the querystring to the URL if there are query parameters.
+            // this is done to avoid urls ending with a "?" character which buggy webservers
+            // do not handle correctly sometimes.
+            url += '?' + this.configuration.queryParamsStringify(context.query);
+        }
 
         let body: any;
         if (isFormData(overriddenInit.body)


### PR DESCRIPTION
### Description
This PR regenerates the api client with changes that allow for the query object to be mutated on a per request basis. This is necessary since the spec does not have all of the query parameters listed for certain endpoints and until that can be updated we need a way to manually add them.

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
