### PR TITLE
Add mount_type to sys/counters/activity response

### DIFF
--- a/changelog/30071.txt
+++ b/changelog/30071.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+activity: mount_type was added to the API response of sys/internal/counters/activity
+```

--- a/vault/activity/query.go
+++ b/vault/activity/query.go
@@ -59,6 +59,7 @@ type MonthlyNamespaceRecord struct {
 
 type MountRecord struct {
 	MountPath string        `json:"mount_path"`
+	MountType string        `json:"mount_type"`
 	Counts    *CountsRecord `json:"counts"`
 }
 

--- a/vault/activity_log_util_common.go
+++ b/vault/activity_log_util_common.go
@@ -392,7 +392,9 @@ func (a *ActivityLog) sortActivityLogMonthsResponse(months []*ResponseMonth) {
 
 const (
 	noMountAccessor     = "no mount accessor (pre-1.10 upgrade?)"
+	noMountPath         = "no mount path (pre-1.10 upgrade?)"
 	DeletedMountFmt     = "deleted mount; accessor %q"
+	DeletedMountPath    = "deleted mount"
 	DeletedNamespaceFmt = "deleted namespace %q"
 )
 
@@ -414,6 +416,26 @@ func (a *ActivityLog) mountAccessorToMountPath(mountAccessor string) string {
 		}
 	}
 	return displayPath
+}
+
+// mountPathToMountType transforms the mount path to the mount type
+// returns a placeholder string if the mount path is empty or deleted
+func (a *ActivityLog) mountPathToMountType(ctx context.Context, mountPath string) string {
+	var mountType string
+	if mountPath == "" {
+		mountType = noMountPath
+	} else {
+		path, valResp := a.core.router.MatchingMountAndEntry(ctx, mountPath)
+		if path == "" {
+			mountType = DeletedMountPath
+		} else {
+			mountType = valResp.Type
+			if !strings.HasSuffix(mountType, "/") {
+				mountType += "/"
+			}
+		}
+	}
+	return mountType
 }
 
 type singleTypeSegmentReader struct {


### PR DESCRIPTION
### Description
Adds mount_type to sys/counters/activity response
ENT PR: https://github.com/hashicorp/vault-enterprise/pull/7656/files

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
