### PR TITLE
docs(github): add note about `VAULT_AUTH_GITHUB_TOKEN`

### DIFF
--- a/website/content/docs/auth/github.mdx
+++ b/website/content/docs/auth/github.mdx
@@ -37,6 +37,13 @@ path, specify `-path=/my-path` in the CLI.
 $ vault login -method=github token="MY_TOKEN"
 ```
 
+It is also possible to use the `VAULT_AUTH_GITHUB_TOKE` environment variable to authenticate to GitHub, such as:
+
+```shell-session
+$ export VAULT_AUTH_GITHUB_TOKE="MY_TOKEN"
+$ vault login -method=github
+```
+
 ### Via the API
 
 The default endpoint is `auth/github/login`. If this auth method was enabled

--- a/website/content/docs/auth/github.mdx
+++ b/website/content/docs/auth/github.mdx
@@ -37,7 +37,7 @@ path, specify `-path=/my-path` in the CLI.
 $ vault login -method=github token="MY_TOKEN"
 ```
 
-It is also possible to use the `VAULT_AUTH_GITHUB_TOKEN` environment variable to authenticate to GitHub, such as:
+You can also use the `VAULT_AUTH_GITHUB_TOKEN` environment variable to authenticate to GitHub. For example:
 
 ```shell-session
 $ export VAULT_AUTH_GITHUB_TOKEN="MY_TOKEN"

--- a/website/content/docs/auth/github.mdx
+++ b/website/content/docs/auth/github.mdx
@@ -37,10 +37,10 @@ path, specify `-path=/my-path` in the CLI.
 $ vault login -method=github token="MY_TOKEN"
 ```
 
-It is also possible to use the `VAULT_AUTH_GITHUB_TOKE` environment variable to authenticate to GitHub, such as:
+It is also possible to use the `VAULT_AUTH_GITHUB_TOKEN` environment variable to authenticate to GitHub, such as:
 
 ```shell-session
-$ export VAULT_AUTH_GITHUB_TOKE="MY_TOKEN"
+$ export VAULT_AUTH_GITHUB_TOKEN="MY_TOKEN"
 $ vault login -method=github
 ```
 


### PR DESCRIPTION
### Description


### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
