### PR TITLE
Update vault-plugin-secrets-openldap to v0.15.2

### DIFF
--- a/changelog/30079.txt
+++ b/changelog/30079.txt
@@ -1,0 +1,3 @@
+```release-note:change
+secrets/openldap: Update plugin to v0.15.2
+```

--- a/go.mod
+++ b/go.mod
@@ -159,7 +159,7 @@ require (
 	github.com/hashicorp/vault-plugin-secrets-kubernetes v0.10.0
 	github.com/hashicorp/vault-plugin-secrets-kv v0.21.0
 	github.com/hashicorp/vault-plugin-secrets-mongodbatlas v0.14.0
-	github.com/hashicorp/vault-plugin-secrets-openldap v0.15.1
+	github.com/hashicorp/vault-plugin-secrets-openldap v0.15.2
 	github.com/hashicorp/vault-plugin-secrets-terraform v0.11.0
 	github.com/hashicorp/vault-testing-stepwise v0.3.2
 	github.com/hashicorp/vault/api v1.16.0

--- a/go.sum
+++ b/go.sum
@@ -1607,8 +1607,8 @@ github.com/hashicorp/vault-plugin-secrets-kv v0.21.0 h1:P8WPzAkttLnhZyhTmY15bKlG
 github.com/hashicorp/vault-plugin-secrets-kv v0.21.0/go.mod h1:CY63j85kYvO+GjDvMmZlhyJixoQhEf+SenY/OwNSrpI=
 github.com/hashicorp/vault-plugin-secrets-mongodbatlas v0.14.0 h1:N7zUrgQqvDVUsOZW4x49Cbx6WcjEU5Qwe8hrr4lYvV8=
 github.com/hashicorp/vault-plugin-secrets-mongodbatlas v0.14.0/go.mod h1:nRcr6W9rb3vDMLDGb/ZovsFhrEM8Q1WLNUKDGRaDplM=
-github.com/hashicorp/vault-plugin-secrets-openldap v0.15.1 h1:OE2IZXpfcT1Ft1DpQGFwDdbJlFyrqBnhhd/KTIX1GpE=
-github.com/hashicorp/vault-plugin-secrets-openldap v0.15.1/go.mod h1:jztXgadwFYKkmozTgLhUdCNFjJmLhOr88kjbKrJCXEw=
+github.com/hashicorp/vault-plugin-secrets-openldap v0.15.2 h1:TJWLlTManbIA1AVVgj+3PTwmsYd2ppf2O4qATrdRc+o=
+github.com/hashicorp/vault-plugin-secrets-openldap v0.15.2/go.mod h1:tJDZLDAk4Y0po8t6OvBf/mwFMScWzhXYiVPH666CAks=
 github.com/hashicorp/vault-plugin-secrets-terraform v0.11.0 h1:dIOJ7VKyYU8o9xH1DuD61Fsfl6uSPHy6OrYdEjp4Ku0=
 github.com/hashicorp/vault-plugin-secrets-terraform v0.11.0/go.mod h1:6FNbBAQvISpPqLXdvhV8MvxXKWG9iS+D+spzIGU2WuI=
 github.com/hashicorp/vault-testing-stepwise v0.3.2 h1:FCe0yrbK/hHiHqzu7utLcvCTTKjghWHyXwOQ2lxfoQM=


### PR DESCRIPTION
This PR was generated by a GitHub Action. Full log: https://github.com/hashicorp/vault/actions/runs/14133773942