### PR TITLE
[DOCS] Hide venafi docs

### DIFF
--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -1814,7 +1814,8 @@
       },
       {
         "title": "Venafi (Certificates)",
-        "path": "secrets/venafi"
+        "path": "secrets/venafi",
+        "hidden": "true"
       }
     ]
   },


### PR DESCRIPTION
Hides Venafi usage docs from the nav while leaving the page findable for folks currently using it.