### PR TITLE
Backport 1.19.x: UI: Add auth tests

### DIFF
--- a/ui/app/components/auth/page.hbs
+++ b/ui/app/components/auth/page.hbs
@@ -21,7 +21,7 @@
     <:header>
       {{#if @oidcProviderQueryParam}}
         <div class="box is-shadowless is-flex-v-centered" data-test-auth-logo>
-          <LogoEdition aria-label="Sign in with Hashicorp Vault" />
+          <LogoEdition aria-label="Sign in with Hashicorp Vault" role="img" />
         </div>
       {{else}}
         <div class="is-flex-v-centered has-bottom-margin-xxl">
@@ -37,6 +37,7 @@
               @isIconOnly={{true}}
               @color="tertiary"
               {{on "click" (fn (mut this.mfaAuthData) null)}}
+              data-test-back-button
             />
           {{/if}}
           <h1 class="title is-3">

--- a/ui/app/components/auth/page.js
+++ b/ui/app/components/auth/page.js
@@ -10,12 +10,22 @@ import { action } from '@ember/object';
 
 /**
  * @module AuthPage
- * The Auth::Page wraps OktaNumberChallenge and AuthForm to manage the login flow and is responsible for calling the authenticate method
+ * The Auth::Page is the route template for the login splash view. It renders the Auth::LoginForm or MFA component if an 
+ * mfa validation is returned from the auth request. It also handles display logic if there is an oidc provider query param.
  *
  * @example
- * <Auth::Page @namespaceQueryParam={{this.namespaceQueryParam}} @onAuthSuccess={{action "authSuccess"}} @oidcProviderQueryParam={{this.oidcProvider}} @cluster={{this.model}} @onNamespaceUpdate={{perform this.updateNamespace}} />
+ * <Auth::Page
+ * @authMethodQueryParam={{this.authMethod}}
+ * @cluster={{this.model}}
+ * @namespaceQueryParam={{this.namespaceQueryParam}}
+ * @oidcProviderQueryParam={{this.oidcProvider}}
+ * @onAuthSuccess={{action "authSuccess"}}
+ * @onNamespaceUpdate={{perform this.updateNamespace}}
+ * @wrappedToken={{this.wrappedToken}}
+/>
  *
  * @param {string} authMethodQueryParam - auth method type to login with, updated by selecting an auth method from the dropdown
+ * @param {object} cluster - the ember data cluster model. contains information such as cluster id, name and boolean for if the cluster is in standby
  * @param {string} namespaceQueryParam - namespace to login with, updated by typing in to the namespace input
  * @param {string} oidcProviderQueryParam - oidc provider query param, set in url as "?o=someprovider"
  * @param {function} onAuthSuccess - callback task in controller that receives the auth response (after MFA, if enabled) when login is successful

--- a/ui/tests/acceptance/auth-test.js
+++ b/ui/tests/acceptance/auth-test.js
@@ -19,7 +19,7 @@ import {
 import { login, loginMethod, loginNs, logout } from 'vault/tests/helpers/auth/auth-helpers';
 import { AUTH_FORM } from 'vault/tests/helpers/auth/auth-form-selectors';
 import { v4 as uuidv4 } from 'uuid';
-import { GENERAL } from '../helpers/general-selectors';
+import { GENERAL } from 'vault/tests/helpers/general-selectors';
 
 const ENT_AUTH_METHODS = ['saml'];
 const { rootToken } = VAULT_KEYS;
@@ -263,10 +263,15 @@ module('Acceptance | auth', function (hooks) {
         `write auth/${this.userpass}/users/${this.user} password=${this.user} token_policies=${this.policyName}`,
       ]);
 
-      const options = { username: this.user, password: this.user, 'auth-form-mount-path': this.userpass };
+      const inputValues = {
+        username: this.user,
+        password: this.user,
+        'auth-form-mount-path': this.userpass,
+        'auth-form-ns-input': this.ns,
+      };
 
       // login as user just to get token (this is the only way to generate a token in the UI right now..)
-      await loginMethod('userpass', options, { toggleOptions: true, ns: this.ns });
+      await loginMethod(inputValues, { authType: 'userpass', toggleOptions: true });
       await click('[data-test-user-menu-trigger=""]');
       const token = find('[data-test-copy-button]').getAttribute('data-test-copy-button');
 

--- a/ui/tests/acceptance/auth/mfa-test.js
+++ b/ui/tests/acceptance/auth/mfa-test.js
@@ -1,0 +1,224 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import { module, test } from 'qunit';
+import { setupApplicationTest } from 'ember-qunit';
+import { click, visit, fillIn } from '@ember/test-helpers';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { AUTH_FORM } from 'vault/tests/helpers/auth/auth-form-selectors';
+import { GENERAL } from 'vault/tests/helpers/general-selectors';
+import { MFA_SELECTORS } from 'vault/tests/helpers/mfa/mfa-selectors';
+import { constraintId, setupTotpMfaResponse } from 'vault/tests/helpers/mfa/mfa-helpers';
+import { fillInLoginFields } from 'vault/tests/helpers/auth/auth-helpers';
+import { callbackData, WindowStub } from 'vault/tests/helpers/oidc-window-stub';
+import sinon from 'sinon';
+
+const ENT_ONLY = ['saml'];
+
+// See AUTH_METHOD_TEST_CASES for how request data maps to method types
+// authRequest is the request made on submit and what returns mfa_validation requirements (if any)
+// additionalRequest are any third party requests the auth method expects
+const REQUEST_DATA = {
+  username: {
+    loginData: { username: 'matilda', password: 'password' },
+    stubRequests: (server, path) =>
+      server.post(`/auth/${path}/login/matilda`, () => setupTotpMfaResponse(path)),
+  },
+  github: {
+    loginData: { token: 'mysupersecuretoken' },
+    stubRequests: (server, path) => server.post(`/auth/${path}/login`, () => setupTotpMfaResponse(path)),
+  },
+  oidc: {
+    loginData: { role: 'some-dev' },
+    hasPopupWindow: true,
+    stubRequests: (server, path) => {
+      server.get(`/auth/${path}/oidc/callback`, () => setupTotpMfaResponse(path));
+      server.post(`/auth/${path}/oidc/auth_url`, () => ({
+        data: { auth_url: 'http://dev-foo-bar.com' },
+      }));
+    },
+  },
+  saml: {
+    loginData: { role: 'some-dev' },
+    hasPopupWindow: true,
+    stubRequests: (server, path) => {
+      server.put(`/auth/${path}/token`, () => setupTotpMfaResponse(path));
+      server.put(`/auth/${path}/sso_service_url`, () => ({
+        data: { sso_service_url: 'http://sso-url.hashicorp.com/service', token_poll_id: '1234' },
+      }));
+    },
+  },
+};
+
+// maps auth type to request data (line breaks to help separate and clarify which methods share request paths)
+const AUTH_METHOD_TEST_CASES = [
+  { authType: 'github', options: REQUEST_DATA.github },
+
+  { authType: 'userpass', options: REQUEST_DATA.username },
+  { authType: 'ldap', options: REQUEST_DATA.username },
+  { authType: 'okta', options: REQUEST_DATA.username },
+  { authType: 'radius', options: REQUEST_DATA.username },
+
+  { authType: 'oidc', options: REQUEST_DATA.oidc },
+  { authType: 'jwt', options: REQUEST_DATA.oidc },
+
+  // ENTERPRISE ONLY
+  { authType: 'saml', options: REQUEST_DATA.saml },
+];
+
+for (const method of AUTH_METHOD_TEST_CASES) {
+  const { authType, options } = method;
+  const isEntMethod = ENT_ONLY.includes(authType);
+  // adding "enterprise" to the module title filters it out of the test runner for the CE repo
+  module(`Acceptance | auth | mfa ${authType}${isEntMethod ? ' enterprise' : ''}`, function (hooks) {
+    setupApplicationTest(hooks);
+    setupMirage(hooks);
+
+    hooks.beforeEach(async function () {
+      if (options?.hasPopupWindow) {
+        this.windowStub = sinon.stub(window, 'open').callsFake(() => new WindowStub());
+      }
+      await visit('/vault/auth');
+    });
+
+    hooks.afterEach(function () {
+      if (options?.hasPopupWindow) {
+        this.windowStub.restore();
+      }
+    });
+
+    test(`${authType}: it displays mfa requirement for default paths`, async function (assert) {
+      this.mountPath = authType;
+      options.stubRequests(this.server, this.mountPath);
+
+      const loginKeys = Object.keys(options.loginData);
+      assert.expect(3 + loginKeys.length);
+
+      // Fill in login form
+      await fillIn(AUTH_FORM.method, authType);
+      await fillInLoginFields(options.loginData);
+
+      if (options?.hasPopupWindow) {
+        // fires "message" event which methods that rely on popup windows wait for
+        setTimeout(() => {
+          // set path which is used to set :mount param in the callback url => /auth/:mount/oidc/callback
+          window.postMessage(callbackData({ path: this.mountPath }), window.origin);
+        }, 50);
+      }
+
+      await click(AUTH_FORM.login);
+      assert
+        .dom(MFA_SELECTORS.mfaForm)
+        .hasText(
+          'Multi-factor authentication is enabled for your account. Enter your authentication code to log in. TOTP passcode Verify'
+        );
+      await click(GENERAL.backButton);
+      assert.dom(AUTH_FORM.form).exists('clicking back returns to auth form');
+      assert.dom(GENERAL.selectByAttr('auth-method')).hasValue(authType, 'preserves method type on back');
+      for (const field of loginKeys) {
+        assert.dom(AUTH_FORM.input(field)).hasValue('', `${field} input clears on back`);
+      }
+    });
+
+    test(`${authType}: it displays mfa requirement for custom paths`, async function (assert) {
+      this.mountPath = `${authType}-custom`;
+      options.stubRequests(this.server, this.mountPath);
+      const loginKeys = Object.keys(options.loginData);
+      assert.expect(3 + loginKeys.length);
+
+      // Fill in login form
+      await fillIn(AUTH_FORM.method, authType);
+      // Toggle more options to input a custom mount path
+      await fillInLoginFields(
+        { ...options.loginData, 'auth-form-mount-path': this.mountPath },
+        { toggleOptions: true }
+      );
+
+      if (options?.hasPopupWindow) {
+        // fires "message" event which methods that rely on popup windows wait for
+        setTimeout(() => {
+          // set path which is used to set :mount param in the callback url => /auth/:mount/oidc/callback
+          window.postMessage(callbackData({ path: this.mountPath }), window.origin);
+        }, 50);
+      }
+
+      await click(AUTH_FORM.login);
+      assert
+        .dom(MFA_SELECTORS.mfaForm)
+        .hasText(
+          'Multi-factor authentication is enabled for your account. Enter your authentication code to log in. TOTP passcode Verify'
+        );
+      await click(GENERAL.backButton);
+      assert.dom(AUTH_FORM.form).exists('clicking back returns to auth form');
+      assert.dom(GENERAL.selectByAttr('auth-method')).hasValue(authType, 'preserves method type on back');
+      for (const field of loginKeys) {
+        assert.dom(AUTH_FORM.input(field)).hasValue('', `${field} input clears on back`);
+      }
+    });
+
+    test(`${authType}: it submits mfa requirement for default paths`, async function (assert) {
+      assert.expect(2);
+      this.mountPath = authType;
+      options.stubRequests(this.server, this.mountPath);
+
+      const expectedOtp = '12345';
+      server.post('/sys/mfa/validate', async (_, req) => {
+        const [actualOtp] = JSON.parse(req.requestBody).mfa_payload[constraintId];
+        assert.true(true, 'it makes request to mfa validate endpoint');
+        assert.strictEqual(actualOtp, expectedOtp, 'payload contains otp');
+      });
+
+      // Fill in login form
+      await fillIn(AUTH_FORM.method, authType);
+      await fillInLoginFields(options.loginData);
+
+      if (options?.hasPopupWindow) {
+        // fires "message" event which methods that rely on popup windows wait for
+        setTimeout(() => {
+          // set path which is used to set :mount param in the callback url => /auth/:mount/oidc/callback
+          window.postMessage(callbackData({ path: this.mountPath }), window.origin);
+        }, 50);
+      }
+
+      await click(AUTH_FORM.login);
+      await fillIn(MFA_SELECTORS.passcode(0), expectedOtp);
+      await click(MFA_SELECTORS.validate);
+    });
+
+    test(`${authType}: it submits mfa requirement for custom paths`, async function (assert) {
+      assert.expect(2);
+
+      this.mountPath = `${authType}-custom`;
+      options.stubRequests(this.server, this.mountPath);
+
+      const expectedOtp = '12345';
+      server.post('/sys/mfa/validate', async (_, req) => {
+        const [actualOtp] = JSON.parse(req.requestBody).mfa_payload[constraintId];
+        assert.true(true, 'it makes request to mfa validate endpoint');
+        assert.strictEqual(actualOtp, expectedOtp, 'payload contains otp');
+      });
+
+      // Fill in login form
+      await fillIn(AUTH_FORM.method, authType);
+      // Toggle more options to input a custom mount path
+      await fillInLoginFields(
+        { ...options.loginData, 'auth-form-mount-path': this.mountPath },
+        { toggleOptions: true }
+      );
+
+      if (options?.hasPopupWindow) {
+        // fires "message" event which methods that rely on popup windows wait for
+        setTimeout(() => {
+          // set path which is used to set :mount param in the callback url => /auth/:mount/oidc/callback
+          window.postMessage(callbackData({ path: this.mountPath }), window.origin);
+        }, 50);
+      }
+
+      await click(AUTH_FORM.login);
+      await fillIn(MFA_SELECTORS.passcode(0), expectedOtp);
+      await click(MFA_SELECTORS.validate);
+    });
+  });
+}

--- a/ui/tests/acceptance/oidc-auth-method-test.js
+++ b/ui/tests/acceptance/oidc-auth-method-test.js
@@ -8,18 +8,17 @@ import { setupApplicationTest } from 'ember-qunit';
 import { click, fillIn, find, waitUntil } from '@ember/test-helpers';
 import authPage from 'vault/tests/pages/auth';
 import { setupMirage } from 'ember-cli-mirage/test-support';
-import { fakeWindow, buildMessage } from '../helpers/oidc-window-stub';
+import { WindowStub, buildMessage } from 'vault/tests/helpers/oidc-window-stub';
 import sinon from 'sinon';
-import { later, _cancelTimers as cancelTimers } from '@ember/runloop';
 import { Response } from 'miragejs';
-import { setupTotpMfaResponse } from 'vault/tests/helpers/auth/mfa-helpers';
+import { setupTotpMfaResponse } from 'vault/tests/helpers/mfa/mfa-helpers';
 
 module('Acceptance | oidc auth method', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
   hooks.beforeEach(function () {
-    this.openStub = sinon.stub(window, 'open').callsFake(() => fakeWindow.create());
+    this.openStub = sinon.stub(window, 'open').callsFake(() => new WindowStub());
 
     this.setupMocks = (assert) => {
       this.server.post('/auth/oidc/oidc/auth_url', () => ({
@@ -67,10 +66,9 @@ module('Acceptance | oidc auth method', function (hooks) {
     this.setupMocks(assert);
 
     await this.selectMethod('oidc');
-    later(() => {
+    setTimeout(() => {
       window.postMessage(buildMessage().data, window.origin);
-      cancelTimers();
-    }, 100);
+    }, 50);
 
     await click('[data-test-auth-submit]');
   });
@@ -96,11 +94,9 @@ module('Acceptance | oidc auth method', function (hooks) {
     });
 
     await this.selectMethod('oidc', true);
-    later(() => {
+    setTimeout(() => {
       window.postMessage(buildMessage().data, window.origin);
-      cancelTimers();
     }, 50);
-
     await click('[data-test-auth-submit]');
   });
 
@@ -108,9 +104,9 @@ module('Acceptance | oidc auth method', function (hooks) {
   test('it should populate oidc auth method on logout', async function (assert) {
     this.setupMocks();
     await this.selectMethod('oidc');
-    later(() => {
+
+    setTimeout(() => {
       window.postMessage(buildMessage().data, window.origin);
-      cancelTimers();
     }, 50);
 
     await click('[data-test-auth-submit]');
@@ -163,9 +159,8 @@ module('Acceptance | oidc auth method', function (hooks) {
     this.setupMocks(assert);
     this.server.get('/auth/foo/oidc/callback', () => setupTotpMfaResponse('foo'));
     await this.selectMethod('oidc');
-    later(() => {
+    setTimeout(() => {
       window.postMessage(buildMessage().data, window.origin);
-      cancelTimers();
     }, 50);
 
     await click('[data-test-auth-submit]');

--- a/ui/tests/acceptance/saml-auth-method-test.js
+++ b/ui/tests/acceptance/saml-auth-method-test.js
@@ -10,15 +10,15 @@ import { click, fillIn, find, waitUntil } from '@ember/test-helpers';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { Response } from 'miragejs';
 import authPage from 'vault/tests/pages/auth';
-import { fakeWindow } from 'vault/tests/helpers/oidc-window-stub';
-import { setupTotpMfaResponse } from 'vault/tests/helpers/auth/mfa-helpers';
+import { WindowStub } from 'vault/tests/helpers/oidc-window-stub';
+import { setupTotpMfaResponse } from 'vault/tests/helpers/mfa/mfa-helpers';
 
 module('Acceptance | enterprise saml auth method', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
   hooks.beforeEach(function () {
-    this.openStub = sinon.stub(window, 'open').callsFake(() => fakeWindow.create());
+    this.openStub = sinon.stub(window, 'open').callsFake(() => new WindowStub());
     this.server.put('/auth/saml/sso_service_url', () => ({
       data: {
         sso_service_url: 'http://sso-url.hashicorp.com/service',

--- a/ui/tests/helpers/auth/auth-form-selectors.ts
+++ b/ui/tests/helpers/auth/auth-form-selectors.ts
@@ -14,4 +14,6 @@ export const AUTH_FORM = {
   mountPathInput: '[data-test-auth-form-mount-path]',
   moreOptions: '[data-test-auth-form-options-toggle]',
   namespaceInput: '[data-test-auth-form-ns-input]',
+  logo: '[data-test-auth-logo]',
+  helpText: '[data-test-auth-helptext]',
 };

--- a/ui/tests/helpers/auth/auth-helpers.ts
+++ b/ui/tests/helpers/auth/auth-helpers.ts
@@ -9,6 +9,15 @@ import { AUTH_FORM } from 'vault/tests/helpers/auth/auth-form-selectors';
 
 const { rootToken } = VAULT_KEYS;
 
+// LOGOUT
+export const logout = async () => {
+  // make sure we're always logged out and logged back in
+  await visit('/vault/logout');
+  // clear session storage to ensure we have a clean state
+  window.localStorage.clear();
+  return;
+};
+
 // LOGIN WITH TOKEN
 export const login = async (token = rootToken) => {
   // make sure we're always logged out and logged back in
@@ -28,33 +37,33 @@ export const loginNs = async (ns: string, token = rootToken) => {
 };
 
 // LOGIN WITH NON-TOKEN methods
-/*
-inputValues are for filling in the form values
-the key completes to the input's test selector and fills it in with the corresponding value
-for example: { username: 'bob', password: 'my-password', 'auth-form-mount-path': 'userpasss1' };
-*/
-export const loginMethod = async (
-  methodType: string,
-  inputValues: object,
-  { toggleOptions = false, ns = '' }
-) => {
+interface LoginOptions {
+  authType?: string;
+  toggleOptions?: boolean;
+}
+export const loginMethod = async (loginFields: LoginFields, options: LoginOptions) => {
   // make sure we're always logged out and logged back in
   await logout();
-  await visit(`/vault/auth?with=${methodType}`);
+  await visit(`/vault/auth?with=${options.authType}`);
 
-  if (ns) await fillIn(AUTH_FORM.namespaceInput, ns);
-  if (toggleOptions) await click(AUTH_FORM.moreOptions);
-
-  for (const [input, value] of Object.entries(inputValues)) {
-    await fillIn(AUTH_FORM.input(input), value);
-  }
+  await fillInLoginFields(loginFields, options);
   return click(AUTH_FORM.login);
 };
 
-export const logout = async () => {
-  // make sure we're always logged out and logged back in
-  await visit('/vault/logout');
-  // clear session storage to ensure we have a clean state
-  window.localStorage.clear();
-  return;
+// the keys complete the input's test selector and the helper fills the input with the corresponding value
+interface LoginFields {
+  username?: string;
+  password?: string;
+  token?: string;
+  role?: string;
+  'auth-form-mount-path': string; // todo update selectors
+  'auth-form-ns-input': string; // todo update selectors
+}
+
+export const fillInLoginFields = async (loginFields: LoginFields, { toggleOptions = false } = {}) => {
+  if (toggleOptions) await click(AUTH_FORM.moreOptions);
+
+  for (const [input, value] of Object.entries(loginFields)) {
+    await fillIn(AUTH_FORM.input(input), value);
+  }
 };

--- a/ui/tests/helpers/mfa/mfa-helpers.js
+++ b/ui/tests/helpers/mfa/mfa-helpers.js
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
+export const constraintId = '7028db82-7de3-01d7-26b5-84b147c80966';
+
 export const setupTotpMfaResponse = (mountPath) => ({
   auth: {
     mfa_requirement: {
@@ -12,7 +14,7 @@ export const setupTotpMfaResponse = (mountPath) => ({
           any: [
             {
               type: 'totp',
-              id: '7028db82-7de3-01d7-26b5-84b147c80966',
+              id: constraintId,
               uses_passcode: true,
             },
           ],

--- a/ui/tests/helpers/mfa/mfa-selectors.ts
+++ b/ui/tests/helpers/mfa/mfa-selectors.ts
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+export const MFA_SELECTORS = {
+  mfaForm: '[data-test-mfa-form]',
+  passcode: (idx: number) => `[data-test-mfa-passcode="${idx}"]`,
+  validate: '[data-test-mfa-validate]',
+};

--- a/ui/tests/helpers/oidc-window-stub.js
+++ b/ui/tests/helpers/oidc-window-stub.js
@@ -2,10 +2,17 @@
  * Copyright (c) HashiCorp, Inc.
  * SPDX-License-Identifier: BUSL-1.1
  */
-
-import EmberObject, { computed } from '@ember/object';
+import EmberObject from '@ember/object';
 import Evented from '@ember/object/evented';
 
+export class WindowStub extends EventTarget {
+  close() {
+    this.dispatchEvent(new CustomEvent('close')); // Trigger 'close' event using CustomEvent
+  }
+}
+
+// using Evented is deprecated, but it's the only way we can trigger a message that is trusted
+// by calling window.trigger. Using dispatchEvent will always result in an untrusted event.
 export const fakeWindow = EmberObject.extend(Evented, {
   init() {
     this._super(...arguments);
@@ -13,12 +20,12 @@ export const fakeWindow = EmberObject.extend(Evented, {
       this.set('closed', true);
     });
   },
-  screen: computed(function () {
+  get screen() {
     return {
       height: 600,
       width: 500,
     };
-  }),
+  },
   origin: 'https://my-vault.com',
   closed: false,
   open() {},
@@ -28,11 +35,14 @@ export const fakeWindow = EmberObject.extend(Evented, {
 export const buildMessage = (opts) => ({
   isTrusted: true,
   origin: 'https://my-vault.com',
-  data: {
-    source: 'oidc-callback',
-    path: 'foo',
-    state: 'state',
-    code: 'code',
-  },
+  data: callbackData(),
   ...opts,
+});
+
+export const callbackData = (data = {}) => ({
+  source: 'oidc-callback',
+  path: 'foo',
+  state: 'state',
+  code: 'code',
+  ...data,
 });

--- a/ui/tests/integration/components/auth/login-form-test.js
+++ b/ui/tests/integration/components/auth/login-form-test.js
@@ -1,0 +1,207 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import { _cancelTimers as cancelTimers } from '@ember/runloop';
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { click, fillIn, render, settled } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import sinon from 'sinon';
+import { validate } from 'uuid';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { Response } from 'miragejs';
+import { GENERAL } from 'vault/tests/helpers/general-selectors';
+import { AUTH_FORM } from 'vault/tests/helpers/auth/auth-form-selectors';
+
+module('Integration | Component | auth | login-form', function (hooks) {
+  setupRenderingTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(function () {
+    this.router = this.owner.lookup('service:router');
+    this.auth = this.owner.lookup('service:auth');
+    this.version = this.owner.lookup('service:version');
+    this.cluster = { id: '1' };
+    this.selectedAuth = 'token';
+    this.onSuccess = sinon.spy();
+
+    this.renderComponent = async () => {
+      return render(hbs`
+        <Auth::LoginForm
+          @wrappedToken={{this.wrappedToken}}
+          @cluster={{this.cluster}}
+          @namespace={{this.namespaceQueryParam}}
+          @selectedAuth={{this.authMethod}}
+          @onSuccess={{this.onSuccess}}
+        />
+        `);
+    };
+  });
+  const CSP_ERR_TEXT = `Error This is a standby Vault node but can't communicate with the active node via request forwarding. Sign in at the active node to use the Vault UI.`;
+  test('it renders error on CSP violation', async function (assert) {
+    assert.expect(2);
+    this.cluster.standby = true;
+    await this.renderComponent();
+    assert.dom(GENERAL.messageError).doesNotExist();
+    this.owner.lookup('service:csp-event').handleEvent({ violatedDirective: 'connect-src' });
+    await settled();
+    assert.dom(GENERAL.messageError).hasText(CSP_ERR_TEXT);
+  });
+
+  test('it renders with vault style errors', async function (assert) {
+    assert.expect(1);
+    this.server.get('/auth/token/lookup-self', () => {
+      return new Response(400, { 'Content-Type': 'application/json' }, { errors: ['Not allowed'] });
+    });
+
+    await this.renderComponent();
+    await click(AUTH_FORM.login);
+    assert.dom(GENERAL.messageError).hasText('Error Authentication failed: Not allowed');
+  });
+
+  test('it renders AdapterError style errors', async function (assert) {
+    assert.expect(1);
+    this.server.get('/auth/token/lookup-self', () => {
+      return new Response(400, { 'Content-Type': 'application/json' }, { errors: ['API Error here'] });
+    });
+
+    await this.renderComponent();
+    await click(AUTH_FORM.login);
+    assert
+      .dom(GENERAL.messageError)
+      .hasText('Error Authentication failed: API Error here', 'shows the error from the API');
+  });
+
+  test('it calls auth service authenticate method with expected args', async function (assert) {
+    assert.expect(1);
+    const authenticateStub = sinon.stub(this.auth, 'authenticate');
+    this.selectedAuth = 'foo/'; // set to a non-default path
+    this.server.get('/sys/internal/ui/mounts', () => {
+      return {
+        data: {
+          auth: {
+            'foo/': {
+              type: 'userpass',
+            },
+          },
+        },
+      };
+    });
+
+    await this.renderComponent();
+    await fillIn(AUTH_FORM.input('username'), 'sandy');
+    await fillIn(AUTH_FORM.input('password'), '1234');
+    await click(AUTH_FORM.login);
+    const [actual] = authenticateStub.lastCall.args;
+    const expectedArgs = {
+      backend: 'userpass',
+      clusterId: '1',
+      data: {
+        username: 'sandy',
+        password: '1234',
+        path: 'foo',
+      },
+      selectedAuth: 'foo/',
+    };
+    assert.propEqual(
+      actual,
+      expectedArgs,
+      `it calls auth service authenticate method with expected args: ${JSON.stringify(actual)} `
+    );
+  });
+
+  test('it calls onSuccess with expected args', async function (assert) {
+    assert.expect(3);
+    this.server.get(`auth/token/lookup-self`, () => {
+      return {
+        data: {
+          policies: ['default'],
+        },
+      };
+    });
+
+    await this.renderComponent();
+    await fillIn(AUTH_FORM.input('token'), 'mytoken');
+    await click(AUTH_FORM.login);
+    const [authResponse, backendType, data] = this.onSuccess.lastCall.args;
+    const expected = { isRoot: false, namespace: '', token: 'vault-token☃1' };
+
+    assert.propEqual(
+      authResponse,
+      expected,
+      `it calls onSuccess with response: ${JSON.stringify(authResponse)} `
+    );
+    assert.strictEqual(backendType, 'token', `it calls onSuccess with backend type: ${backendType}`);
+    assert.propEqual(data, { token: 'mytoken' }, `it calls onSuccess with data: ${JSON.stringify(data)}`);
+  });
+
+  test('it makes a request to unwrap if passed a wrappedToken and logs in', async function (assert) {
+    assert.expect(3);
+    const authenticateStub = sinon.stub(this.auth, 'authenticate');
+    this.wrappedToken = '54321';
+
+    this.server.post('/sys/wrapping/unwrap', (_, req) => {
+      assert.strictEqual(req.url, '/v1/sys/wrapping/unwrap', 'makes call to unwrap the token');
+      assert.strictEqual(
+        req.requestHeaders['x-vault-token'],
+        this.wrappedToken,
+        'uses passed wrapped token for the unwrap'
+      );
+      return {
+        auth: {
+          client_token: '12345',
+        },
+      };
+    });
+
+    await this.renderComponent();
+
+    setTimeout(() => cancelTimers(), 50);
+    await settled();
+    const [actual] = authenticateStub.lastCall.args;
+    assert.propEqual(
+      actual,
+      {
+        backend: 'token',
+        clusterId: '1',
+        data: {
+          token: '12345',
+        },
+        selectedAuth: 'token',
+      },
+      `it calls auth service authenticate method with correct args: ${JSON.stringify(actual)} `
+    );
+  });
+
+  test('it should set nonce value as uuid for okta method type', async function (assert) {
+    assert.expect(4);
+    this.server.post('/auth/okta/login/foo', (_, req) => {
+      const { nonce } = JSON.parse(req.requestBody);
+      assert.true(validate(nonce), 'Nonce value passed as uuid for okta login');
+      return {
+        auth: {
+          client_token: '12345',
+          policies: ['default'],
+        },
+      };
+    });
+
+    await this.renderComponent();
+
+    await fillIn(GENERAL.selectByAttr('auth-method'), 'okta');
+    await fillIn(AUTH_FORM.input('username'), 'foo');
+    await fillIn(AUTH_FORM.input('password'), 'bar');
+    await click(AUTH_FORM.login);
+    assert
+      .dom('[data-test-okta-number-challenge]')
+      .hasText(
+        'To finish signing in, you will need to complete an additional MFA step. Please wait... Back to login',
+        'renders okta number challenge on submit'
+      );
+    await click(GENERAL.backButton);
+    assert.dom(AUTH_FORM.form).exists('renders auth form on return to login');
+    assert.dom(GENERAL.selectByAttr('auth-method')).hasValue('okta', 'preserves method type on back');
+  });
+});

--- a/ui/tests/integration/components/auth/login-form-test.js
+++ b/ui/tests/integration/components/auth/login-form-test.js
@@ -145,7 +145,7 @@ module('Integration | Component | auth | login-form', function (hooks) {
     this.server.post('/sys/wrapping/unwrap', (_, req) => {
       assert.strictEqual(req.url, '/v1/sys/wrapping/unwrap', 'makes call to unwrap the token');
       assert.strictEqual(
-        req.requestHeaders['x-vault-token'],
+        req.requestHeaders['X-Vault-Token'],
         this.wrappedToken,
         'uses passed wrapped token for the unwrap'
       );


### PR DESCRIPTION
### Description
✅ enterprise passed
Manual backport of #30033 to hopefully address test flakiness due to use of `later()` from `@ember/runloop`
 
This test in particular:
```
  Acceptance | oidc auth method: it prompts mfa if configured: Chrome 134.0
Test took longer than 60000ms; test timed out. 
More information has been printed to the console. Please use that information to help in debugging.
```

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
