### PR TITLE
adds docs for Enterprise Oracle database plugin with instant client table into release/1.18.x

### DIFF
--- a/website/content/docs/commands/plugin/register.mdx
+++ b/website/content/docs/commands/plugin/register.mdx
@@ -24,17 +24,21 @@ Success! Registered plugin: my-custom-plugin
 
 Register an Enterprise plugin:
 
--> **Note:** See [Plugin managment for Enterprise plugins](/vault/docs/plugins/plugin-management#enterprise-plugins)
-for details on Vault Enterprise compatible versions.
+<Note>
+
+Refer to the [Enterprise plugins](/vault/docs/plugins/plugin-management#enterprise-plugins) section
+of the Plugin management page for Vault compatibility requirements.
+
+</Note>
 
 Before registering Key Management secrets engine v0.16.0+ent for the linux/amd64 system that runs Vault Enterprise,
 `vault-plugin-secrets-keymgmt_v0.16.0+ent_linux_amd64.zip` needs to be downloaded from
 https://releases.hashicorp.com/vault-plugin-secrets-keymgmt and placed in the plugin directory.
 
 ```shell-session
-$ vault plugin register 
+$ vault plugin register
     -version=0.16.0+ent \                      # version must match the plugin version on the releases page
-    secret \        
+    secret \
     vault-plugin-secrets-keymgmt               # name must match the plugin name on the releases page
 Success! Registered plugin: vault-plugin-secrets-keymgmt
 ```

--- a/website/content/docs/secrets/databases/oracle.mdx
+++ b/website/content/docs/secrets/databases/oracle.mdx
@@ -20,6 +20,10 @@ gives an overview of how the engine functions.
 Oracle is one of the supported plugins for the database secrets engine. It is capable of dynamically generating
 credentials based on configured roles for Oracle databases. It also supports [static roles](/vault/docs/secrets/databases#static-roles).
 
+The first enterprise version of the Oracle database secrets plugin is 0.11.0.
+Refer to the [Enterprise plugins](/vault/docs/plugins/plugin-management#enterprise-plugins)
+section of the Plugin management page for Vault compatibility requirements.
+
 ## Capabilities
 
 <Tabs>
@@ -52,9 +56,7 @@ found at its own git repository here:
 <Tabs>
 <Tab heading="Vault" group="vault">
 
-The Oracle database plugin is not bundled in the core Vault code tree and can be
-found at its own git repository here:
-[hashicorp/vault-plugin-database-oracle](https://github.com/hashicorp/vault-plugin-database-oracle)
+The Oracle database plugin is not bundled in the core Vault code tree.
 
 For linux/amd64, pre-built binaries can be found at [the releases page](https://releases.hashicorp.com/vault-plugin-database-oracle)
 
@@ -62,8 +64,17 @@ Before running the plugin you will need to have the Oracle Instant Client
 library installed. These can be downloaded from Oracle. The libraries will need to
 be placed in the default library search path or defined in the ld.so.conf configuration files.
 
-The following privileges are needed by the plugin for minimum functionality. Additional privileges may be needed 
-depending on the SQL configured on the database roles. 
+For the Community Oracle database plugin, the version of the Oracle Instant Client SDK the
+plugin was built with can be found at its own git repository here: [hashicorp/vault-plugin-database-oracle](https://github.com/hashicorp/vault-plugin-database-oracle)
+
+For the Enterprise Oracle database plugin, see the following table:
+
+| Plugin release | Instant Client version |
+| ---------------| -----------------------|
+| 0.11.0+ent     | 19.23                  |
+
+The following privileges are needed by the plugin for minimum functionality. Additional privileges may be needed
+depending on the SQL configured on the database roles.
 
 ```sql
 GRANT CREATE USER to vault WITH ADMIN OPTION;
@@ -76,7 +87,7 @@ GRANT SELECT on v_$sql to vault;
 GRANT ALTER SYSTEM to vault WITH ADMIN OPTION;
 ```
 
-~> Vault needs `ALTER SYSTEM` to terminate user sessions when revoking users. This may be 
+~> Vault needs `ALTER SYSTEM` to terminate user sessions when revoking users. This may be
 substituted with a stored procedure and granted to the Vault administrator user.
 
 If you are running Vault with [mlock enabled](/vault/docs/configuration#disable_mlock),

--- a/website/content/docs/secrets/key-management/index.mdx
+++ b/website/content/docs/secrets/key-management/index.mdx
@@ -27,7 +27,9 @@ Key material will always be securely transferred in accordance with the
 [key import specification](#kms-providers) of the supported KMS providers.
 
 -> **Note:** Key Management secrets engine can be run as an external plugin.
-See [Plugin managment for Enterprise plugins](/vault/docs/plugins/plugin-management#enterprise-plugins)
+
+Refer to the [Enterprise plugins](/vault/docs/plugins/plugin-management#enterprise-plugins) section
+of the Plugin management page
 for details on Vault Enterprise compatible versions and how to register Enterprise plugins.
 
 ## Setup


### PR DESCRIPTION
### Description
What does this PR do?
The PR adds docs for Enterprise Oracle database plugin with instant client table

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
