### PR TITLE
Vault-34677-Removing estimates from counters api- handle end of month and end of current billing cycle CE changes

### DIFF
--- a/vault/activity_log_testing_util.go
+++ b/vault/activity_log_testing_util.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/hashicorp/vault/helper/constants"
+	"github.com/hashicorp/vault/helper/timeutil"
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/hashicorp/vault/vault/activity"
 	"google.golang.org/protobuf/testing/protocmp"
@@ -246,4 +247,11 @@ func (a *ActivityLog) GetEnabled() bool {
 // Note: you must do the usual locking scheme when modifying the ActivityLog
 func (c *Core) GetActivityLog() *ActivityLog {
 	return c.activityLog
+}
+
+// SetClock sets the clock on the activity log. This is used for testing with mock clocks
+func (a *ActivityLog) SetClock(clock timeutil.Clock) {
+	a.l.Lock()
+	defer a.l.Unlock()
+	a.clock = clock
 }

--- a/vault/activity_log_util.go
+++ b/vault/activity_log_util.go
@@ -7,6 +7,7 @@ package vault
 
 import (
 	"context"
+	"time"
 )
 
 // sendCurrentFragment is a no-op on OSS
@@ -16,4 +17,8 @@ func (a *ActivityLog) sendCurrentFragment(ctx context.Context) error {
 
 // setupClientIDsUsageInfo is a no-op on OSS
 func (c *Core) setupClientIDsUsageInfo(ctx context.Context) {
+}
+
+// handleClientIDsInMemoryEndOfMonth is a no-op on OSS
+func (a *ActivityLog) handleClientIDsInMemoryEndOfMonth(ctx context.Context, currentTime time.Time) {
 }


### PR DESCRIPTION
### Description
What does this PR do?
JIRA: https://hashicorp.atlassian.net/browse/VAULT-34677

At the end of the current month (start of the next month), update the in-memory map with all the clients seen in the current month.
This is done in the background as the segments for the last month need to be loaded from storage.
If we identify that we are in a new billing cycle at the end of the month, reset the in-memory map as it should only contain clients in the current billing cycle.
Add required tests.
This change should be backported to 1.19.x and 1.19.x+ent and 1.18.x+ent.
**_Note: This change should be reflected only on ent and it is no-op on CE_**

Approved Ent: https://github.com/hashicorp/vault-enterprise/pull/7707

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
