### PR TITLE
Support reading mysql backend credentials from environment variables

### DIFF
--- a/changelog/30136.txt
+++ b/changelog/30136.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+storage/mysql: Added support for getting mysql backend username and password from the environment variables `VAULT_MYSQL_USERNAME` and `VAULT_MYSQL_PASSWORD`.
+```

--- a/physical/mysql/mysql.go
+++ b/physical/mysql/mysql.go
@@ -13,6 +13,7 @@ import (
 	"io/ioutil"
 	"math"
 	"net/url"
+	"os"
 	"sort"
 	"strconv"
 	"strings"
@@ -268,13 +269,22 @@ func NewMySQLClient(conf map[string]string, logger log.Logger) (*sql.DB, error) 
 	var err error
 
 	// Get the MySQL credentials to perform read/write operations.
-	username, ok := conf["username"]
-	if !ok || username == "" {
-		return nil, fmt.Errorf("missing username")
+	username := os.Getenv("VAULT_MYSQL_USERNAME")
+	if username == "" {
+		confUsername, ok := conf["username"]
+		if !ok || confUsername == "" {
+			return nil, fmt.Errorf("missing username")
+		}
+		username = confUsername
 	}
-	password, ok := conf["password"]
-	if !ok || password == "" {
-		return nil, fmt.Errorf("missing password")
+
+	password := os.Getenv("VAULT_MYSQL_PASSWORD")
+	if password == "" {
+		confPassword, ok := conf["password"]
+		if !ok || confPassword == "" {
+			return nil, fmt.Errorf("missing password")
+		}
+		password = confPassword
 	}
 
 	// Get or set MySQL server address. Defaults to localhost and default port(3306)

--- a/website/content/docs/configuration/storage/mysql.mdx
+++ b/website/content/docs/configuration/storage/mysql.mdx
@@ -43,7 +43,7 @@ storage "mysql" {
 - `tls_ca_file` `(string: "")` – Specifies the path to the CA certificate to
   connect using TLS.
 
-- `plaintext_credentials_transmission` `(string: "")` - Provides authorization
+- `plaintext_connection_allowed` `(string: "")` - Provides authorization
   to send credentials over plaintext. Failure to provide a value AND a failure
   to provide a TLS CA certificate will warn that the credentials are being sent
   over plain text. In the future, failure to do acknowledge or use TLS will
@@ -64,10 +64,10 @@ storage "mysql" {
 Additionally, Vault requires the following authentication information.
 
 - `username` `(string: <required>)` – Specifies the MySQL username to connect to
-  the database.
+  the database. This value can also be set using the `VAULT_MYSQL_USERNAME` environment variable.
 
 - `password` `(string: <required>)` – Specifies the MySQL password to connect to
-  the database.
+  the database. This value can also be set using the `VAULT_MYSQL_PASSWORD` environment variable.
 
 ### High availability parameters
 


### PR DESCRIPTION
### Description
Adds ability to read in mysql backend storage credentials from environment variables. Updates the documentation to support this, as well as correcting the `plaintext_connection_allowed` - it seems like `plaintext_credentials_transmission` has not been a part of the implementation for a while
