### PR TITLE
[VAULT-35044] UI: implement action buttons in updated namespace picker

### DIFF
--- a/ui/app/components/namespace-picker.hbs
+++ b/ui/app/components/namespace-picker.hbs
@@ -5,6 +5,7 @@ SPDX-License-Identifier: BUSL-1.1
 
 <div class="namespace-picker" ...attributes>
   <Hds::Form::SuperSelect::Single::Field
+    @afterOptionsComponent={{component "namespace-picker/after-options" loadOptions=this.loadOptions}}
     @ariaLabel="Namespace"
     @onChange={{this.onChange}}
     @options={{this.options}}
@@ -12,6 +13,7 @@ SPDX-License-Identifier: BUSL-1.1
     @searchEnabled={{true}}
     @selected={{this.selected}}
     @selectedItemComponent={{component "namespace-picker/selected-option"}}
+    @showAfterOptions={{this.showAfterOptions}}
     @verticalPosition="above"
     data-test-namespace-toggle
     as |F|

--- a/ui/app/components/namespace-picker.hbs
+++ b/ui/app/components/namespace-picker.hbs
@@ -18,10 +18,6 @@ SPDX-License-Identifier: BUSL-1.1
     data-test-namespace-toggle
     as |F|
   >
-    <F.Options>
-      {{#let F.options as |option|}}
-        <span data-test-namespace-link="{{option.label}}">{{option.label}}</span>
-      {{/let}}
-    </F.Options>
+    <F.Options>{{F.options.label}}</F.Options>
   </Hds::Form::SuperSelect::Single::Field>
 </div>

--- a/ui/app/components/namespace-picker.js
+++ b/ui/app/components/namespace-picker.js
@@ -21,6 +21,7 @@ import { service } from '@ember/service';
 
 export default class NamespacePicker extends Component {
   @service namespace;
+  @service router;
   @service store;
 
   // Show/hide refresh & manage namespaces buttons
@@ -114,7 +115,7 @@ export default class NamespacePicker extends Component {
 
   @action
   async onChange(selected) {
-    // Updated href value instead of using the router in order to trigger a full page reload
-    window.location.href = this.#getNamespaceLink(window.location, selected);
+    this.selected = selected;
+    this.router.transitionTo('vault.cluster.dashboard', { queryParams: { namespace: selected.path } });
   }
 }

--- a/ui/app/components/namespace-picker.js
+++ b/ui/app/components/namespace-picker.js
@@ -7,6 +7,7 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { service } from '@ember/service';
+import { isEmpty } from '@ember/utils';
 
 /**
  * @module NamespacePicker
@@ -35,6 +36,7 @@ export default class NamespacePicker extends Component {
     this.loadOptions();
   }
 
+  // TODO make private when converting from js to ts
   #matchesPath(option, currentNamespace) {
     // TODO: Revisit. A hardcoded check for "path" & "/path" seems hacky, but it fixes a breaking test:
     //  "Acceptance | Enterprise | namespaces: it shows nested namespaces if you log in with a namespace starting with a /"
@@ -42,10 +44,12 @@ export default class NamespacePicker extends Component {
     return option?.path === currentNamespace?.path || `/${option?.path}` === currentNamespace?.path;
   }
 
+  // TODO make private when converting from js to ts
   #getSelected(options, currentNamespace) {
     return options.find((option) => this.#matchesPath(option, currentNamespace));
   }
 
+  // TODO make private when converting from js to ts
   #getOptions(namespace) {
     /* Each namespace option has 3 properties: { id, path, and label }
      *   - id: node / namespace name (displayed when the namespace picker is closed)
@@ -69,12 +73,13 @@ export default class NamespacePicker extends Component {
     ];
   }
 
+  // TODO make private when converting from js to ts
   #getNamespaceLink(location, namespace) {
     const origin = this.#getOrigin(location);
-    const encodedNamespace = encodeURIComponent(namespace.path);
 
     let queryParams = '';
-    if (namespace.path !== '') {
+    if (!isEmpty(namespace.path)) {
+      const encodedNamespace = encodeURIComponent(namespace.path);
       queryParams = `?namespace=${encodedNamespace}`;
     }
 
@@ -82,6 +87,7 @@ export default class NamespacePicker extends Component {
     return `${origin}/ui/vault/dashboard${queryParams}`;
   }
 
+  // TODO make private when converting from js to ts
   #getOrigin(location) {
     return location.protocol + '//' + location.hostname + (location.port ? ':' + location.port : '');
   }

--- a/ui/app/components/namespace-picker/after-options.hbs
+++ b/ui/app/components/namespace-picker/after-options.hbs
@@ -2,8 +2,7 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
 }}
-
-<div class="hds-power-select__after-options">
+<div>
   <Hds::Button
     @color="secondary"
     @text="Refresh List"

--- a/ui/app/components/namespace-picker/after-options.hbs
+++ b/ui/app/components/namespace-picker/after-options.hbs
@@ -1,0 +1,14 @@
+{{!
+  Copyright (c) HashiCorp, Inc.
+  SPDX-License-Identifier: BUSL-1.1
+}}
+
+<div class="hds-power-select__after-options">
+  <Hds::Button
+    @color="secondary"
+    @text="Refresh List"
+    {{on "click" (action "refreshNamespaceList")}}
+    data-test-refresh-namespaces
+  />
+  <Hds::Button @color="secondary" @text="Manage" @icon="settings" @route="vault.cluster.access.namespaces" />
+</div>

--- a/ui/app/components/namespace-picker/after-options.ts
+++ b/ui/app/components/namespace-picker/after-options.ts
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+
+interface AfterOptionsArgs {
+  loadOptions: () => void;
+}
+
+export default class AfterOptions extends Component<AfterOptionsArgs> {
+  @action
+  refreshNamespaceList() {
+    this.args?.loadOptions();
+  }
+}

--- a/ui/app/components/namespace-picker/after-options.ts
+++ b/ui/app/components/namespace-picker/after-options.ts
@@ -10,6 +10,16 @@ interface AfterOptionsArgs {
   loadOptions: () => void;
 }
 
+/**
+ * @module AfterOptions
+ * @description component is used to display action items inside the namespace picker dropdown.
+ *  The "Manage" button directs the user to the namespace management page.
+ *  The "Refresh List" button refrehes the list of namespaces in the dropdown.
+ *
+ * @example
+ * @afterOptionsComponent={{component "namespace-picker/after-options" loadOptions=this.loadOptions}}
+ */
+
 export default class AfterOptions extends Component<AfterOptionsArgs> {
   @action
   refreshNamespaceList() {

--- a/ui/tests/acceptance/enterprise-namespaces-test.js
+++ b/ui/tests/acceptance/enterprise-namespaces-test.js
@@ -25,7 +25,7 @@ module('Acceptance | Enterprise | namespaces', function (hooks) {
     await authPage.login(token);
     await click('[data-test-namespace-toggle]');
     assert.dom('[aria-selected="true"]').hasText('root', 'root renders as current namespace');
-    assert.dom('[data-test-namespace-link]').exists({ count: 1 }, 'Only the root namespace exists');
+    assert.dom('[data-option-index]').exists({ count: 1 }, 'Only the root namespace exists');
   });
 
   test('it shows nested namespaces if you log in with a namespace starting with a /', async function (assert) {
@@ -43,10 +43,10 @@ module('Acceptance | Enterprise | namespaces', function (hooks) {
       // this is usually triggered when creating a ns in the form -- trigger a reload of the namespaces manually
       await click('[data-test-namespace-toggle]');
       await click('[data-test-refresh-namespaces]');
-      await waitFor(`[data-test-namespace-link="${targetNamespace}"]`);
+      await waitFor(`[data-option-index="${i + 1}"]`);
       // check that the full namespace path, like "beep/boop", shows in the toggle display
       assert
-        .dom(`[data-test-namespace-link="${targetNamespace}"]`)
+        .dom(`[data-option-index="${i + 1}"]`)
         .hasText(targetNamespace, `shows the namespace ${targetNamespace} in the toggle component`);
       // because quint does not like page reloads, visiting url directly instead of clicking on namespace in toggle
       await visit(url);
@@ -64,8 +64,8 @@ module('Acceptance | Enterprise | namespaces', function (hooks) {
       .dom('[aria-selected="true"]')
       .hasText('beep/boop', 'current namespace does not begin or end with /');
     assert
-      .dom('[data-test-namespace-link="beep/boop/bop"]')
-      .exists('renders the link to the nested namespace');
+      .dom('[data-option-index="3"]')
+      .hasText('beep/boop/bop', 'shows the full namespace path in the toggle');
   });
 
   test('it shows the regular namespace toolbar when not managed', async function (assert) {


### PR DESCRIPTION
### Description
| ℹ️ **NOTE: This branch is merging into a feature side branch** (not `main`) |
| ---|
- [X] Implement Refresh Namespaces Button
- [X] Implement Manage Namespaces Button
- [X] Redirect to namespace on click
- [X] Enterprise tests passing ✅ 
  > 236 tests completed in 171425 milliseconds, with 0 failed, 10 skipped, and 0 todo.
  > 1432 assertions of 1432 passed, 0 failed.

#### Outstanding items that will be addressed in separate PRs before the feature side branch is merged to main: 
- All/Matching Namespaces Label w/ Count Badge
- "You are logged in with a root token and will have to re-authenticate when switching namespaces."
- Expanded namespace picker width to support long namespace paths
- Tab to auto-complete namespace path
- Styling to match Figma designs
- Add test coverage
- Manual testing

#### Screenshots
| ⚠️  **NOTE: The current implementation looks ugly, styling will be addressed in a separate PR** |
| --- |
|![Screenshot 2025-03-31 at 6 17 49 PM](https://github.com/user-attachments/assets/65b73790-cde3-4d77-9cae-f55ccc23ef66)|

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
