### PR TITLE
ldap: pin test container to latest working version

### DIFF
--- a/builtin/credential/ldap/backend_test.go
+++ b/builtin/credential/ldap/backend_test.go
@@ -329,7 +329,7 @@ func TestLdapAuthBackend_CaseSensitivity(t *testing.T) {
 		}
 	}
 
-	cleanup, cfg := ldap.PrepareTestContainer(t, "master")
+	cleanup, cfg := ldap.PrepareTestContainer(t, ldap.DefaultVersion)
 	defer cleanup()
 	configReq := &logical.Request{
 		Operation: logical.UpdateOperation,
@@ -375,7 +375,7 @@ func TestLdapAuthBackend_UserPolicies(t *testing.T) {
 	var err error
 	b, storage := createBackendWithStorage(t)
 
-	cleanup, cfg := ldap.PrepareTestContainer(t, "master")
+	cleanup, cfg := ldap.PrepareTestContainer(t, ldap.DefaultVersion)
 	defer cleanup()
 	configReq := &logical.Request{
 		Operation: logical.UpdateOperation,
@@ -486,7 +486,7 @@ func factory(t *testing.T) logical.Backend {
 // https://github.com/hashicorp/vault/issues/26183.
 func TestBackend_LoginRegression_AnonBind(t *testing.T) {
 	b := factory(t)
-	cleanup, cfg := ldap.PrepareTestContainer(t, "master")
+	cleanup, cfg := ldap.PrepareTestContainer(t, ldap.DefaultVersion)
 	cfg.AnonymousGroupSearch = true
 	defer cleanup()
 
@@ -521,7 +521,7 @@ func TestBackend_LoginRegression_AnonBind(t *testing.T) {
 // attributes to entity alias metadata.
 func TestBackend_LoginRegression_UserAttr(t *testing.T) {
 	b := factory(t)
-	cleanup, cfg := ldap.PrepareTestContainer(t, "master")
+	cleanup, cfg := ldap.PrepareTestContainer(t, ldap.DefaultVersion)
 	cfg.UserAttr = "givenName"
 	defer cleanup()
 
@@ -552,7 +552,7 @@ func TestBackend_LoginRegression_UserAttr(t *testing.T) {
 
 func TestBackend_basic(t *testing.T) {
 	b := factory(t)
-	cleanup, cfg := ldap.PrepareTestContainer(t, "master")
+	cleanup, cfg := ldap.PrepareTestContainer(t, ldap.DefaultVersion)
 	defer cleanup()
 
 	logicaltest.Test(t, logicaltest.TestCase{
@@ -582,7 +582,7 @@ func TestBackend_basic(t *testing.T) {
 
 func TestBackend_basic_noPolicies(t *testing.T) {
 	b := factory(t)
-	cleanup, cfg := ldap.PrepareTestContainer(t, "master")
+	cleanup, cfg := ldap.PrepareTestContainer(t, ldap.DefaultVersion)
 	defer cleanup()
 
 	logicaltest.Test(t, logicaltest.TestCase{
@@ -600,7 +600,7 @@ func TestBackend_basic_noPolicies(t *testing.T) {
 
 func TestBackend_basic_group_noPolicies(t *testing.T) {
 	b := factory(t)
-	cleanup, cfg := ldap.PrepareTestContainer(t, "master")
+	cleanup, cfg := ldap.PrepareTestContainer(t, ldap.DefaultVersion)
 	defer cleanup()
 
 	logicaltest.Test(t, logicaltest.TestCase{
@@ -621,7 +621,7 @@ func TestBackend_basic_group_noPolicies(t *testing.T) {
 
 func TestBackend_basic_authbind(t *testing.T) {
 	b := factory(t)
-	cleanup, cfg := ldap.PrepareTestContainer(t, "master")
+	cleanup, cfg := ldap.PrepareTestContainer(t, ldap.DefaultVersion)
 	defer cleanup()
 
 	logicaltest.Test(t, logicaltest.TestCase{
@@ -638,7 +638,7 @@ func TestBackend_basic_authbind(t *testing.T) {
 
 func TestBackend_basic_authbind_userfilter(t *testing.T) {
 	b := factory(t)
-	cleanup, cfg := ldap.PrepareTestContainer(t, "master")
+	cleanup, cfg := ldap.PrepareTestContainer(t, ldap.DefaultVersion)
 	defer cleanup()
 
 	// userattr not used in the userfilter should result in a warning in the response
@@ -781,7 +781,7 @@ func TestBackend_basic_authbind_userfilter(t *testing.T) {
 
 func TestBackend_basic_authbind_metadata_name(t *testing.T) {
 	b := factory(t)
-	cleanup, cfg := ldap.PrepareTestContainer(t, "master")
+	cleanup, cfg := ldap.PrepareTestContainer(t, ldap.DefaultVersion)
 	defer cleanup()
 
 	cfg.UserAttr = "cn"
@@ -846,7 +846,7 @@ func addUPNAttributeToLDAPSchemaAndUser(t *testing.T, cfg *ldaputil.ConfigEntry,
 
 func TestBackend_basic_discover(t *testing.T) {
 	b := factory(t)
-	cleanup, cfg := ldap.PrepareTestContainer(t, "master")
+	cleanup, cfg := ldap.PrepareTestContainer(t, ldap.DefaultVersion)
 	defer cleanup()
 
 	logicaltest.Test(t, logicaltest.TestCase{
@@ -863,7 +863,7 @@ func TestBackend_basic_discover(t *testing.T) {
 
 func TestBackend_basic_nogroupdn(t *testing.T) {
 	b := factory(t)
-	cleanup, cfg := ldap.PrepareTestContainer(t, "master")
+	cleanup, cfg := ldap.PrepareTestContainer(t, ldap.DefaultVersion)
 	defer cleanup()
 
 	logicaltest.Test(t, logicaltest.TestCase{
@@ -1313,7 +1313,7 @@ func TestLdapAuthBackend_ConfigUpgrade(t *testing.T) {
 
 	ctx := context.Background()
 
-	cleanup, cfg := ldap.PrepareTestContainer(t, "master")
+	cleanup, cfg := ldap.PrepareTestContainer(t, ldap.DefaultVersion)
 	defer cleanup()
 	configReq := &logical.Request{
 		Operation: logical.UpdateOperation,

--- a/builtin/credential/ldap/path_config_rotate_root_test.go
+++ b/builtin/credential/ldap/path_config_rotate_root_test.go
@@ -22,7 +22,7 @@ func TestRotateRoot(t *testing.T) {
 	ctx := context.Background()
 
 	b, store := createBackendWithStorage(t)
-	cleanup, cfg := ldap.PrepareTestContainer(t, "latest")
+	cleanup, cfg := ldap.PrepareTestContainer(t, ldap.DefaultVersion)
 	defer cleanup()
 	// set up auth config
 	req := &logical.Request{

--- a/helper/testhelpers/ldap/ldaphelper.go
+++ b/helper/testhelpers/ldap/ldaphelper.go
@@ -16,6 +16,10 @@ import (
 	"github.com/hashicorp/vault/sdk/helper/ldaputil"
 )
 
+// DefaultVersion is the default version of the container to pull.
+// NOTE: This is currently pinned to a sha instead of "master", see: https://github.com/rroemhild/docker-test-openldap/issues/62
+const DefaultVersion = "sha256:f4d9c5ba97f9662e9aea082b4aa89233994ca6e232abc1952d5d90da7e16b0eb"
+
 func PrepareTestContainer(t *testing.T, version string) (cleanup func(), cfg *ldaputil.ConfigEntry) {
 	// note: this image isn't supported on arm64 architecture in CI.
 	// but if you're running on Apple Silicon, feel free to comment out the code below locally.

--- a/sdk/helper/docker/testhelpers.go
+++ b/sdk/helper/docker/testhelpers.go
@@ -369,9 +369,15 @@ func (d *Runner) Start(ctx context.Context, addSuffix, forceLocalAddr bool) (*St
 		name += "-" + suffix
 	}
 
+	ref := fmt.Sprintf("%s:%s", d.RunOptions.ImageRepo, d.RunOptions.ImageTag)
+	if strings.Contains(d.RunOptions.ImageTag, ":") {
+		// Handle "tags" that are actually references with a digest, e.g. repo:sha256:1234abcd...
+		ref = fmt.Sprintf("%s@%s", d.RunOptions.ImageRepo, d.RunOptions.ImageTag)
+	}
+
 	cfg := &container.Config{
 		Hostname: name,
-		Image:    fmt.Sprintf("%s:%s", d.RunOptions.ImageRepo, d.RunOptions.ImageTag),
+		Image:    ref,
 		Env:      d.RunOptions.Env,
 		Cmd:      d.RunOptions.Cmd,
 	}

--- a/vault/external_tests/identity/groups_test.go
+++ b/vault/external_tests/identity/groups_test.go
@@ -153,7 +153,7 @@ func TestIdentityStore_ExternalGroupMembershipsAcrossMounts(t *testing.T) {
 	}
 	ldapMountAccessor1 := auths["ldap/"].Accessor
 
-	cleanup, cfg := ldaphelper.PrepareTestContainer(t, "master")
+	cleanup, cfg := ldaphelper.PrepareTestContainer(t, ldaphelper.DefaultVersion)
 	defer cleanup()
 
 	// Configure LDAP auth
@@ -255,7 +255,7 @@ func TestIdentityStore_ExternalGroupMembershipsAcrossMounts(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cleanup2, cfg2 := ldaphelper.PrepareTestContainer(t, "master")
+	cleanup2, cfg2 := ldaphelper.PrepareTestContainer(t, ldaphelper.DefaultVersion)
 	defer cleanup2()
 
 	// Configure LDAP auth

--- a/vault/external_tests/identity/identity_test.go
+++ b/vault/external_tests/identity/identity_test.go
@@ -35,7 +35,7 @@ func TestIdentityStore_ExternalGroupMemberships_DifferentMounts(t *testing.T) {
 	cleanup, config1 := ldaphelper.PrepareTestContainer(t, ldaphelper.DefaultVersion)
 	defer cleanup()
 
-	cleanu2, config2 := ldaphelper.PrepareTestContainer(t, ldaphelper.DefaultVersion)
+	cleanup2, config2 := ldaphelper.PrepareTestContainer(t, ldaphelper.DefaultVersion)
 	defer cleanup2()
 
 	setupFunc := func(path string, cfg *ldaputil.ConfigEntry) string {

--- a/vault/external_tests/identity/identity_test.go
+++ b/vault/external_tests/identity/identity_test.go
@@ -32,10 +32,10 @@ func TestIdentityStore_ExternalGroupMemberships_DifferentMounts(t *testing.T) {
 	require.NoError(t, err)
 	entityID := secret.Data["id"].(string)
 
-	cleanup, config1 := ldaphelper.PrepareTestContainer(t, "master")
+	cleanup, config1 := ldaphelper.PrepareTestContainer(t, ldaphelper.DefaultVersion)
 	defer cleanup()
 
-	cleanup2, config2 := ldaphelper.PrepareTestContainer(t, "master")
+	cleanu2, config2 := ldaphelper.PrepareTestContainer(t, ldaphelper.DefaultVersion)
 	defer cleanup2()
 
 	setupFunc := func(path string, cfg *ldaputil.ConfigEntry) string {
@@ -224,7 +224,7 @@ func TestIdentityStore_Integ_GroupAliases(t *testing.T) {
 		t.Fatalf("bad: group alias: %#v\n", aliasMap)
 	}
 
-	cleanup, cfg := ldaphelper.PrepareTestContainer(t, "master")
+	cleanup, cfg := ldaphelper.PrepareTestContainer(t, ldaphelper.DefaultVersion)
 	defer cleanup()
 
 	// Configure LDAP auth
@@ -459,7 +459,7 @@ func TestIdentityStore_Integ_RemoveFromExternalGroup(t *testing.T) {
 		t.Fatalf("bad: group alias: %#v\n", aliasMap)
 	}
 
-	cleanup, cfg := ldaphelper.PrepareTestContainer(t, "master")
+	cleanup, cfg := ldaphelper.PrepareTestContainer(t, ldaphelper.DefaultVersion)
 	defer cleanup()
 
 	// Configure LDAP auth

--- a/vault/external_tests/policy/policy_test.go
+++ b/vault/external_tests/policy/policy_test.go
@@ -48,7 +48,7 @@ func TestPolicy_NoDefaultPolicy(t *testing.T) {
 	}
 
 	// Configure LDAP auth backend
-	cleanup, cfg := ldaphelper.PrepareTestContainer(t, "master")
+	cleanup, cfg := ldaphelper.PrepareTestContainer(t, ldaphelper.DefaultVersion)
 	defer cleanup()
 
 	_, err = client.Logical().Write("auth/ldap/config", map[string]interface{}{
@@ -106,7 +106,7 @@ func TestPolicy_NoConfiguredPolicy(t *testing.T) {
 	}
 
 	// Configure LDAP auth backend
-	cleanup, cfg := ldaphelper.PrepareTestContainer(t, "master")
+	cleanup, cfg := ldaphelper.PrepareTestContainer(t, ldaphelper.DefaultVersion)
 	defer cleanup()
 
 	_, err = client.Logical().Write("auth/ldap/config", map[string]interface{}{

--- a/vault/external_tests/token/token_test.go
+++ b/vault/external_tests/token/token_test.go
@@ -102,7 +102,7 @@ func TestTokenStore_IdentityPolicies(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cleanup, cfg := ldap.PrepareTestContainer(t, "master")
+	cleanup, cfg := ldap.PrepareTestContainer(t, ldap.DefaultVersion)
 	defer cleanup()
 
 	// Configure LDAP auth


### PR DESCRIPTION
### Description

The test container that we use for many LDAP tests recently merged a breaking change: https://github.com/rroemhild/docker-test-openldap/issues/62

Pin to the latest working version until the issue has been resolved.

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [x] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
