### PR TITLE
[DOCS] Fix true setting in nav

### DIFF
--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -1815,7 +1815,7 @@
       {
         "title": "Venafi (Certificates)",
         "path": "secrets/venafi",
-        "hidden": "true"
+        "hidden": true
       }
     ]
   },


### PR DESCRIPTION
Corrects the `"hiddden": true` setting to remove the quotes and actually hide the nav item >_<