### PR TITLE
Docs/add docs for dynamic secrets opertor import

### DIFF
--- a/website/content/docs/import/awssm.mdx
+++ b/website/content/docs/import/awssm.mdx
@@ -28,7 +28,7 @@ Refer to the [HCL syntax](/vault/docs/import#hcl-syntax-1) for arguments common 
 - `vault_namespace` `(string: "")` - The Vault namespace containing the pre-configured AWS secrets engine
   mount path specified in `vault_mount_path` for use with dynamic secrets.
 
-- `vault_address` `(string: "")` - The address of the Vault server to use for dynamic credentials. 
+- `vault_address` `(string: "")` - The address of the Vault server to use for dynamic credentials.
 
 - `vault_credentials_file` `(string: "")` - The path to a file containing a Vault token for the vault server configured above.
 
@@ -45,9 +45,8 @@ Define and configure the `my-aws-source-1` AWS source:
 source_aws {
   name = "my-aws-source-1"
   credentials_profile = "my-cred-profile-name"
-}```
+}
 
-```hcl
 source_aws {
   name = "my-aws-source-2"
   vault_mount_path = "aws"

--- a/website/content/docs/import/awssm.mdx
+++ b/website/content/docs/import/awssm.mdx
@@ -18,6 +18,25 @@ Refer to the [HCL syntax](/vault/docs/import#hcl-syntax-1) for arguments common 
 - `credentials_profile` `(string: "")` - The name of the profile in your credentials file to authenticate with.
   If not set, Vault uses the default credential provider mechanisms.
 
+- `vault_mount_path` `(string: "")` - The Vault mount path to a pre-configured GCP
+  secrets engine used to generate dynamic credentials for the importer.
+
+- `vault_role_name` `(string: "")` - The Vault role used to generate a dynamic
+  credential for the importer. The role name must exist in the pre-configured GCP secrets
+  engine mount.
+
+- `vault_namespace` `(string: "")` - The Vault namespace containing the pre-configured GCP secrets engine
+  mount path specified in `vault_mount_path` for use with dynamic secrets.
+
+- `vault_address` `(string: "")` - The address of the Vault server to use for dynamic credentials. 
+
+- `vault_credentials_file` `(string: "")` - The path to a file containing a Vault token for the vault server configured above.
+
+#### Note
+ - If `credentials_profile` is set, then `vault_mount_path`, `vault_role_name`,`vault_namespace`,`vault_address` and `vault_credentials_file` must be unset.
+
+ - If one of `vault_mount_path`,`vault_role_name`, `vault_namespace`,`vault_address` or `vault_credentials_file`  are set, then `credentials_profile` must be unset.
+
 ## Example
 
 Define and configure the `my-aws-source-1` AWS source:
@@ -26,6 +45,15 @@ Define and configure the `my-aws-source-1` AWS source:
 source_aws {
   name = "my-aws-source-1"
   credentials_profile = "my-cred-profile-name"
+}```
+
+```hcl
+source_aws {
+  vault_mount_path = "aws"
+  vault_role_name  = "temp_user"
+  vault_namespace  = "ns-1"
+  vault_address    = "https://vault.example.com:8200"
+  vault_credentials_file = "/path/to/vault/token"
 }
 ```
 

--- a/website/content/docs/import/awssm.mdx
+++ b/website/content/docs/import/awssm.mdx
@@ -49,6 +49,7 @@ source_aws {
 
 ```hcl
 source_aws {
+  name = "my-aws-source-2"
   vault_mount_path = "aws"
   vault_role_name  = "temp_user"
   vault_namespace  = "ns-1"

--- a/website/content/docs/import/awssm.mdx
+++ b/website/content/docs/import/awssm.mdx
@@ -18,14 +18,14 @@ Refer to the [HCL syntax](/vault/docs/import#hcl-syntax-1) for arguments common 
 - `credentials_profile` `(string: "")` - The name of the profile in your credentials file to authenticate with.
   If not set, Vault uses the default credential provider mechanisms.
 
-- `vault_mount_path` `(string: "")` - The Vault mount path to a pre-configured GCP
+- `vault_mount_path` `(string: "")` - The Vault mount path to a pre-configured AWS
   secrets engine used to generate dynamic credentials for the importer.
 
 - `vault_role_name` `(string: "")` - The Vault role used to generate a dynamic
-  credential for the importer. The role name must exist in the pre-configured GCP secrets
+  credential for the importer. The role name must exist in the pre-configured AWS secrets
   engine mount.
 
-- `vault_namespace` `(string: "")` - The Vault namespace containing the pre-configured GCP secrets engine
+- `vault_namespace` `(string: "")` - The Vault namespace containing the pre-configured AWS secrets engine
   mount path specified in `vault_mount_path` for use with dynamic secrets.
 
 - `vault_address` `(string: "")` - The address of the Vault server to use for dynamic credentials. 

--- a/website/content/docs/import/azurekv.mdx
+++ b/website/content/docs/import/azurekv.mdx
@@ -27,6 +27,26 @@ by a preceding `az login`.
 - `client_id` `(string: "")` - Client ID to use
 - `credentials_file` `(string: "")` - Path to a file with the client secret
 
+- `vault_mount_path` `(string: "")` - The Vault mount path to a pre-configured Azure
+  secrets engine used to generate dynamic credentials for the importer.
+
+- `vault_role_name` `(string: "")` - The Vault role used to generate a dynamic
+  credential for the importer. The role name must exist in the pre-configured Azure secrets
+  engine mount.
+
+- `vault_namespace` `(string: "")` - The Vault namespace containing the pre-configured Azure secrets engine
+  mount path specified in `vault_mount_path` for use with dynamic secrets.
+
+- `vault_address` `(string: "")` - The address of the Vault server to use for dynamic credentials. 
+
+- `vault_credentials_file` `(string: "")` - The path to a file containing a Vault token for the vault server configured above.
+
+#### Note
+ - If `tenant_id`, `client_id` and `credentials_file` is set, then `vault_mount_path`, `vault_role_name`,`vault_namespace`,`vault_address` and `vault_credentials_file` must be unset.
+
+ - If one of `vault_mount_path`,`vault_role_name`, `vault_namespace`,`vault_address` or `vault_credentials_file`  are set, then `tenant_id`, `client_id` and `credentials_file`  must be unset.
+
+
 ## Example
 
 Define and configure the `my-azure-source-1` Azure source:
@@ -35,6 +55,17 @@ Define and configure the `my-azure-source-1` Azure source:
 source_azure {
   name = "my-azure-source-1"
   key_vault_uri = "https://keyvault-1234abcd.vault.azure.net"
+}
+```
+
+```hcl
+source_azure {
+  name             = "my-azure-source-1"
+  vault_mount_path = "azure"
+  vault_role_name  = "my-azure-role-1"
+  vault_namespace  = "ns-1"
+  vault_address    = "https://vault.example.com:8200"
+  vault_credentials_file = "/path/to/vault/token"
 }
 ```
 

--- a/website/content/docs/import/gcpsm.mdx
+++ b/website/content/docs/import/gcpsm.mdx
@@ -43,6 +43,12 @@ Define and configure the `my-gcp-source-1` GCP source:
 
 ```hcl
 source_gcp {
+  credentials_file = "/path/to/credentials-file"
+}
+```
+
+```hcl
+source_gcp {
   name             = "my-gcp-source-1"
   vault_mount_path = "gcp"
   vault_role_name  = "my-gcp-role-1"

--- a/website/content/docs/import/gcpsm.mdx
+++ b/website/content/docs/import/gcpsm.mdx
@@ -24,7 +24,7 @@ Refer to the [HCL syntax](/vault/docs/import#hcl-syntax-1) for arguments common 
   credential for the importer. The role name must exist in the pre-configured GCP secrets
   engine mount.
 
-- `vault_namespace` `(string: "")` - The Vault namespace containing the preconfigured GCP secrets engine
+- `vault_namespace` `(string: "")` - The Vault namespace containing the pre-configured GCP secrets engine
   mount path specified in `vault_mount_path` for use with dynamic secrets.
 
 - `vault_address` `(string: "")` - The address of the Vault server to use for dynamic credentials. 
@@ -34,7 +34,7 @@ Refer to the [HCL syntax](/vault/docs/import#hcl-syntax-1) for arguments common 
 #### Note
  - If `credentials_file` is set, then `vault_mount_path`, `vault_role_name`,`vault_namespace`,`vault_address` and `vault_credentials_file` must be unset.
 
- - If one of `vault_mount_path`,`vault_role_name`, `vault_namespace`,`vault_address` or `vault_credentials_file`  are set, then `credentials` must be unset.
+ - If one of `vault_mount_path`,`vault_role_name`, `vault_namespace`,`vault_address` or `vault_credentials_file`  are set, then `credentials_file` must be unset.
 
 
 ## Example


### PR DESCRIPTION
### Description
What does this PR do?

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
