### PR TITLE
Bugfix/vault 35002

### DIFF
--- a/builtin/logical/pki/acme_errors.go
+++ b/builtin/logical/pki/acme_errors.go
@@ -110,7 +110,7 @@ type ErrorResponse struct {
 	StatusCode  int              `json:"-"`
 	Type        string           `json:"type"`
 	Detail      string           `json:"detail"`
-	Subproblems []*ErrorResponse `json:"subproblems"`
+	Subproblems []*ErrorResponse `json:"subproblems,omitempty" mapstructure:"subproblems"`
 }
 
 func (e *ErrorResponse) MarshalForStorage() map[string]interface{} {

--- a/builtin/logical/pki/acme_state_test.go
+++ b/builtin/logical/pki/acme_state_test.go
@@ -62,5 +62,4 @@ func TestErrorResponseNoSubproblems(t *testing.T) {
 	require.True(t, ok, "Detail on Raw Body of Error response should exist, but doesn't")
 	subProblems, ok := body["subproblems"]
 	require.False(t, ok, "subproblems on Raw Body of Error response should be omitted, but exists with value %v", subProblems)
-
 }

--- a/builtin/logical/pki/acme_state_test.go
+++ b/builtin/logical/pki/acme_state_test.go
@@ -4,6 +4,7 @@
 package pki
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -40,4 +41,26 @@ func TestAcmeNonces(t *testing.T) {
 		nonce = nonces[i]
 		require.False(t, a.RedeemNonce(nonce))
 	}
+}
+
+func TestErrorResponseNoSubproblems(t *testing.T) {
+	t.Parallel()
+	errResponse, err := TranslateError(ErrAlreadyRevoked)
+	if err != nil {
+		return
+	}
+	require.NoError(t, err, "already revoked should generate an error response")
+	require.NotNil(t, errResponse.Data)
+	body := map[string]string{}
+	rawBody, ok := errResponse.Data["http_raw_body"]
+	err = json.Unmarshal(rawBody.([]byte), &body)
+	require.True(t, ok, "Raw Body of Error response should exist, but doesn't")
+	typeString, ok := body["type"]
+	require.True(t, ok, "Type on Raw Body of Error response should exist, but doesn't")
+	require.Equal(t, typeString, "urn:ietf:params:acme:error:alreadyRevoked")
+	_, ok = body["detail"]
+	require.True(t, ok, "Detail on Raw Body of Error response should exist, but doesn't")
+	subProblems, ok := body["subproblems"]
+	require.False(t, ok, "subproblems on Raw Body of Error response should be omitted, but exists with value %v", subProblems)
+
 }


### PR DESCRIPTION
### Description
Removes subproblems from the acme error body (in the header), with a simple test to confirm

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - not a security vulnerability
- [x] doesn't change any signatures
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name. - branch name
- [x] no RFC, nor Ent-PR