### PR TITLE
Backport of [docs] add known issue where static roles get rotated on upgrade into release/1.18.x

### DIFF
--- a/website/content/docs/release-notes/1.16.1.mdx
+++ b/website/content/docs/release-notes/1.16.1.mdx
@@ -31,7 +31,7 @@ description: |-
 | New default (1.16.13)       | [Vault product usage metrics reporting](/vault/docs/upgrading/upgrade-to-1.6.x#product-usage-reporting)                                                                                      |
 | Deprecation (1.16.13)       | [`default_report_months` is deprecated for the `sys/internal/counters` API](/vault/docs/upgrading/upgrade-to-1.16.x#activity-log-changes)                                                    |
 | Known Issue (1.16.16)       | [Authorization failures using Azure federated identity credentials](/vault/docs/upgrading/upgrade-to-1.16.x#authorization-failures-using-azure-federated-identity-credentials) |
-
+| Known issue (1.16.16)       | [Unexpected static role rotations on upgrade](/vault/docs/upgrading/upgrade-to-1.16.x#static-role-rotations)
 
 ## Vault companion updates
 

--- a/website/content/docs/release-notes/1.17.0.mdx
+++ b/website/content/docs/release-notes/1.17.0.mdx
@@ -31,6 +31,7 @@ description: |-
 | New default (1.17.9)                           | [Vault product usage metrics reporting](/vault/docs/upgrading/upgrade-to-1.17.x#product-usage-reporting)                                                                                         |
 | Deprecation (1.17.9)                           | [`default_report_months` is deprecated for the `sys/internal/counters` API](/vault/docs/upgrading/upgrade-to-1.17.x#activity-log-changes)                                                        |
 | Known Issue (1.17.12)                          | [Authorization failures using Azure federated identity credentials](/vault/docs/upgrading/upgrade-to-1.17.x#authorization-failures-using-azure-federated-identity-credentials) |
+| Known issue (1.17.12)                          | [Unexpected static role rotations on upgrade](/vault/docs/upgrading/upgrade-to-1.17.x#static-role-rotations)
 
 ## Vault companion updates
 

--- a/website/content/docs/release-notes/1.18.0.mdx
+++ b/website/content/docs/release-notes/1.18.0.mdx
@@ -20,6 +20,7 @@ description: |-
 | Beta feature removed (1.18) | [Request limiter removed](/vault/docs/upgrading/upgrade-to-1.18.x#request-limiter-configuration-removal)             |
 | New default (1.18.2)        | [Vault product usage metrics reporting](/vault/docs/upgrading/upgrade-to-1.18.x#product-usage-reporting)             |
 | Known Issue (1.18.5)        | [Authorization failures using Azure federated identity credentials](/vault/docs/upgrading/upgrade-to-1.18.x#authorization-failures-using-azure-federated-identity-credentials) |
+| Known issue (1.18.5)        | [Unexpected static role rotations on upgrade](/vault/docs/upgrading/upgrade-to-1.18.x#static-role-rotations)
 
 ## Vault companion updates
 

--- a/website/content/docs/upgrading/upgrade-to-1.16.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.16.x.mdx
@@ -239,3 +239,5 @@ more details, and information about opt-out.
 @include 'known-issues/database-skip-static-role-rotation.mdx'
 
 @include 'known-issues/azure-unseal-regression.mdx'
+
+@include 'known-issues/static-role-premature-rotations.mdx'

--- a/website/content/docs/upgrading/upgrade-to-1.17.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.17.x.mdx
@@ -211,3 +211,5 @@ more details, and information about opt-out.
 @include 'known-issues/database-skip-static-role-rotation.mdx'
 
 @include 'known-issues/azure-unseal-regression.mdx'
+
+@include 'known-issues/static-role-premature-rotations.mdx'

--- a/website/content/docs/upgrading/upgrade-to-1.18.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.18.x.mdx
@@ -156,3 +156,5 @@ more details, and information about opt-out.
 @include 'known-issues/database-skip-static-role-rotation.mdx'
 
 @include 'known-issues/azure-unseal-regression.mdx'
+
+@include 'known-issues/static-role-premature-rotations.mdx'

--- a/website/content/partials/known-issues/static-role-premature-rotations.mdx
+++ b/website/content/partials/known-issues/static-role-premature-rotations.mdx
@@ -1,0 +1,13 @@
+### Static role rotations on upgrade ((#static-role-rotations))
+
+#### Affected Versions
+- 1.19.0, 1.18.5, 1.17.12, 1.16.16
+
+#### Issue
+Vault automatically rotates existing static roles tied to database and LDAP
+credentials once when upgrading to an affected version. After the one-time
+rotation, the static roles behave as expected.
+
+#### Workaround
+If you rely on LDAP or static database roles, avoid upgrading to the affected
+versions until we fix the issue.


### PR DESCRIPTION
### Description
What does this PR do?

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
