### PR TITLE
Cleanup/vault 35002

### DIFF
--- a/builtin/logical/pki/acme_errors.go
+++ b/builtin/logical/pki/acme_errors.go
@@ -110,7 +110,7 @@ type ErrorResponse struct {
 	StatusCode  int              `json:"-"`
 	Type        string           `json:"type"`
 	Detail      string           `json:"detail"`
-	Subproblems []*ErrorResponse `json:"subproblems,omitempty" mapstructure:"subproblems"`
+	Subproblems []*ErrorResponse `json:"subproblems,omitempty"`
 }
 
 func (e *ErrorResponse) MarshalForStorage() map[string]interface{} {


### PR DESCRIPTION
### Description
Removes an unnecessary tag

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
