### PR TITLE
docs/vso: update env options for operatorhub deployments

### DIFF
--- a/website/content/docs/platform/k8s/vso/openshift.mdx
+++ b/website/content/docs/platform/k8s/vso/openshift.mdx
@@ -19,10 +19,14 @@ Navigate to the OperatorHub page of your OpenShift cluster and search for `Vault
 
 Set the following environment variables [on the subscription](https://access.redhat.com/solutions/5761251) to customize the Kubernetes Operator behavior.
 
+- [VSO_CLIENT_CACHE_NUM_LOCKS](/vault/docs/platform/k8s/vso/helm#v-controller-manager-clientcache-numlocks)
 - [VSO_CLIENT_CACHE_PERSISTENCE_MODEL](/vault/docs/platform/k8s/vso/helm#v-controller-manager-clientcache-persistencemodel)
 - [VSO_CLIENT_CACHE_SIZE](/vault/docs/platform/k8s/vso/helm#v-controller-manager-clientcache-cachesize)
+- [VSO_KUBE_CLIENT_QPS](/vault/docs/platform/k8s/vso/helm#v-controller-manager-kubeclient-qps)
+- [VSO_KUBE_CLIENT_BURST](/vault/docs/platform/k8s/vso/helm#v-controller-manager-kubeclient-burst)
 - [VSO_MAX_CONCURRENT_RECONCILES](/vault/docs/platform/k8s/vso/helm#v-controller-manager-maxconcurrentreconciles)
 - [VSO_GLOBAL_TRANSFORMATION_OPTIONS](/vault/docs/platform/k8s/vso/helm#v-controller-manager-globaltransformationoptions)
+- [VSO_GLOBAL_VAULT_AUTH_OPTIONS](/vault/docs/platform/k8s/vso/helm#v-controller-manager-globalvaultauthoptions)
 
 ## Helm chart
 


### PR DESCRIPTION
### Description
Updates the list of available environment variable options when deploying Vault Secrets Operator from OperatorHub.

Preview link: https://vault-git-docs-vault-35235update-vso-openshift-3a4435-hashicorp.vercel.app/vault/docs/platform/k8s/vso/openshift#options

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [-] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [-] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [-] **RFC:** If this change has an associated RFC, please link it in the description.
- [-] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
