### PR TITLE
VAULT-30187: adding aws vault ci permissions to destroy enos aws engine test res

### DIFF
--- a/enos/README.md
+++ b/enos/README.md
@@ -227,15 +227,15 @@ Here are the steps to configure the GitHub Actions service user:
   - Access can be requested by clicking: `Cloud Access` --> `AWS` --> `Request Account Access`.
 
 1. **Create the Terraform Cloud Workspace** - The name of the workspace to be created depends on the 
-   repository for which it is being created, but the pattern is: `<repository>-ci-service-user-iam`,
-   e.g. `vault-ci-service-user-iam`. It is important that the execution mode for the workspace be set 
+   repository for which it is being created, but the pattern is: `<repository>-ci-enos-service-user-iam`,
+   e.g. `vault-ci-enos-service-user-iam`. It is important that the execution mode for the workspace be set 
    to `local`. For help on setting up the workspace, contact the QT team on Slack (#team-quality)
 
 
 2. **Execute the Terraform module**
 ```shell
 > cd ./enos/ci/service-user-iam
-> export TF_WORKSPACE=<repo name>-ci-service-user-iam
+> export TF_WORKSPACE=<repo name>-ci-enos-service-user-iam
 > export TF_TOKEN_app_terraform_io=<Terraform Cloud Token>
 > export TF_VAR_repository=<repository name>
 > terraform init

--- a/enos/ci/service-user-iam/main.tf
+++ b/enos/ci/service-user-iam/main.tf
@@ -74,6 +74,7 @@ data "aws_iam_policy_document" "aws_nuke" {
       "iam:ListAccessKeys",
       "iam:ListAccountAliases",
       "iam:ListGroupsForUser",
+      "iam:ListMFADevices",
       "iam:ListUserPolicies",
       "iam:ListUserTags",
       "iam:ListUsers",


### PR DESCRIPTION
### Description
VAULT-30187: adding aws vault ci permissions to destroy enos aws engine test resources

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
