### PR TITLE
VAULT-30187: updating aws-nuke version

### DIFF
--- a/.github/workflows/test-ci-cleanup.yml
+++ b/.github/workflows/test-ci-cleanup.yml
@@ -1,5 +1,8 @@
 name: test-ci-cleanup
 on:
+  pull_request:
+    branches:
+      - enos/VAULT-30187_update_aws_nuke
   schedule:
     # * is a special character in YAML so you have to quote this string
     - cron:  '05 02 * * *'
@@ -28,7 +31,7 @@ jobs:
     needs: setup
     runs-on: ubuntu-latest
     container:
-      image: rebuy/aws-nuke # for ekristen version: https://github.com/ekristen/aws-nuke/pkgs/container/aws-nuke
+      image: ghcr.io/ekristen/aws-nuke:v3.51.0 # https://github.com/ekristen/aws-nuke/pkgs/container/aws-nuke
       options:
          --user root
          -t
@@ -61,7 +64,7 @@ jobs:
         # Filter STDERR because it's super noisy about things we don't have access to
         # Remove --no-dry-run to do dry run
         run: |
-          aws-nuke -c aws-nuke.yml -q --no-dry-run --force 2>/tmp/aws-nuke-error.log || true
+          aws-nuke run -c aws-nuke.yml -q --force 2>/tmp/aws-nuke-error.log | grep -v "level=error" || true
 
   check-quotas:
     needs: [ setup, aws-nuke ]

--- a/.github/workflows/test-ci-cleanup.yml
+++ b/.github/workflows/test-ci-cleanup.yml
@@ -1,6 +1,6 @@
 name: test-ci-cleanup
 on:
-  pull_request:
+  push:
     branches:
       - enos/VAULT-30187_update_aws_nuke
   schedule:

--- a/.github/workflows/test-ci-cleanup.yml
+++ b/.github/workflows/test-ci-cleanup.yml
@@ -1,8 +1,5 @@
 name: test-ci-cleanup
 on:
-  push:
-    branches:
-      - enos/VAULT-30187_update_aws_nuke
   schedule:
     # * is a special character in YAML so you have to quote this string
     - cron:  '05 02 * * *'
@@ -64,7 +61,7 @@ jobs:
         # Filter STDERR because it's super noisy about things we don't have access to
         # Remove --no-dry-run to do dry run
         run: |
-          aws-nuke run -c aws-nuke.yml -q --force 2>/tmp/aws-nuke-error.log | grep -v "level=error" || true
+          aws-nuke run -c aws-nuke.yml -q --no-dry-run --force 2>/tmp/aws-nuke-error.log | grep -v "level=error" || true
 
   check-quotas:
     needs: [ setup, aws-nuke ]

--- a/enos/ci/aws-nuke.yml
+++ b/enos/ci/aws-nuke.yml
@@ -21,7 +21,7 @@ regions:
 - us-west-2
 - global
 
-account-blocklist:
+blocklist:
  - 1234567890
 
 accounts:


### PR DESCRIPTION
### Description
VAULT-30187: updating aws-nuke version

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
