### PR TITLE
VAULT-34809 Utilization Report docs

### DIFF
--- a/website/content/api-docs/system/utilization-report.mdx
+++ b/website/content/api-docs/system/utilization-report.mdx
@@ -10,9 +10,9 @@ description: The `/sys/utilization-report` produces a snapshot report of this cl
 
 @include 'alerts/restricted-admin.mdx'
 
-The `/sys/utilization-report` endpoint is a read-only endpoint that produces a snapshot
-report if this cluster's utilization from all namespaces, giving several high-level insights,
-including information about mounts, leases, lease count quotas, PKI, and KV secrets.
+The `/sys/utilization-report` endpoint returns a snapshot utilization report
+for the targeted cluster. The report covers all namespaces and includes
+high-level insights on mounts, leases, lease count quotas, PKI, and KV secrets.
 
 ## Get utilization report
 

--- a/website/content/api-docs/system/utilization-report.mdx
+++ b/website/content/api-docs/system/utilization-report.mdx
@@ -16,7 +16,7 @@ including information about mounts, leases, lease count quotas, PKI, and KV secr
 
 ## Get utilization report
 
-This endpoint produces a snapshot report of this cluster's utilization from all namespaces.
+Return a snapshot utilization report for all namespaces in the cluster.
 
 | Method | Path                      |
 |:-------|:--------------------------|

--- a/website/content/api-docs/system/utilization-report.mdx
+++ b/website/content/api-docs/system/utilization-report.mdx
@@ -1,0 +1,86 @@
+---
+layout: api
+page_title: /sys/utilization-report - HTTP API
+description: The `/sys/utilization-report` produces a snapshot report of this cluster's utilization from all namespaces.
+---
+
+# `/sys/utilization-report`
+
+@include 'alerts/enterprise-only.mdx'
+
+@include 'alerts/restricted-admin.mdx'
+
+The `/sys/utilization-report` endpoint is a read-only endpoint that produces a snapshot
+report if this cluster's utilization from all namespaces, giving several high-level insights,
+including information about mounts, leases, lease count quotas, PKI, and KV secrets.
+
+## Get utilization report
+
+This endpoint produces a snapshot report of this cluster's utilization from all namespaces.
+
+| Method | Path                      |
+|:-------|:--------------------------|
+| `GET`  | `/sys/utilization-report` |
+
+### Sample request
+
+```shell-session
+$ curl \
+    --header "X-Vault-Token: ..." \
+    http://127.0.0.1:8200/v1/sys/utilization-report
+```
+
+### Sample response
+
+```json
+{
+  "request_id": "8fb6005c-74cc-a4ec-6c3c-e396eb11c7ed",
+  "lease_id": "",
+  "renewable": false,
+  "lease_duration": 0,
+  "data": {
+    "auth_methods": {
+      "cert": 1,
+      "token": 2,
+      "userpass": 1
+    },
+    "kvv1_secrets": 0,
+    "kvv2_secrets": 23,
+    "lease_count_quotas": {
+      "global_lease_count_quota": {
+        "capacity": 300000,
+        "count": 1542,
+        "name": "default"
+      },
+      "total_lease_count_quotas": 1
+    },
+    "leases_by_auth_method": {
+      "cert": 0,
+      "token": 1500,
+      "userpass": 42
+    },
+    "namespaces": 2,
+    "pki": {
+      "total_issuers": 2,
+      "total_roles": 3
+    },
+    "replication_status": {
+      "dr_primary": false,
+      "dr_state": "disabled",
+      "pr_primary": false,
+      "pr_state": "disabled"
+    },
+    "secret_engines": {
+      "cubbyhole": 1,
+      "identity": 1,
+      "kv": 1,
+      "pki": 2,
+      "system": 1
+    }
+  },
+  "wrap_info": null,
+  "warnings": null,
+  "auth": null,
+  "mount_type": "system"
+}
+```

--- a/website/data/api-docs-nav-data.json
+++ b/website/data/api-docs-nav-data.json
@@ -571,6 +571,10 @@
         "path": "system/user-lockout"
       },
       {
+        "title": "<code>/sys/utilization-report</code>",
+        "path": "system/utilization-report"
+      },
+      {
         "title": "<code>/sys/loggers</code>",
         "path": "system/loggers"
       },


### PR DESCRIPTION
### Description

Adds documentation for the sys/utilization-report API.

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [x] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
