### PR TITLE
[UI] Add engine and auth method mappings to data fetching function

### DIFF
--- a/ui/app/components/usage/page/index.ts
+++ b/ui/app/components/usage/page/index.ts
@@ -7,6 +7,8 @@ import Component from '@ember/component';
 import { service } from '@ember/service';
 import type ApiService from 'vault/services/api';
 import type { getUsageDataFunction, UsageDashboardData } from '@hashicorp/vault-reporting/types/index';
+import { allEngines } from 'vault/helpers/mountable-secret-engines';
+import { allMethods } from 'vault/helpers/mountable-auth-methods';
 import type FlagsService from 'vault/services/flags';
 export default class ClientsActivityComponent extends Component {
   @service declare readonly api: ApiService;
@@ -14,7 +16,22 @@ export default class ClientsActivityComponent extends Component {
 
   handleFetchUsageData: getUsageDataFunction = async () => {
     //TODO: Update client with typed response after the API is updated https://hashicorp.atlassian.net/browse/VAULT-35108
-    const { data = {} } = await this.api.sys.systemReadUtilizationReport();
+    const response = await this.api.sys.systemReadUtilizationReport();
+    const data = response.data as UsageDashboardData;
+    // Replace engine names with display names if available
+    allEngines().forEach((engine) => {
+      if (engine.type in data.secret_engines) {
+        data.secret_engines[engine.displayName] = data.secret_engines[engine.type] || 0;
+        delete data.secret_engines[engine.type];
+      }
+    });
+    // Replace auth method names with display names if available
+    allMethods().forEach((method) => {
+      if (method.type in data.auth_methods) {
+        data.auth_methods[method.displayName] = data.auth_methods[method.type] || 0;
+        delete data.auth_methods[method.type];
+      }
+    });
     return data as UsageDashboardData;
   };
 

--- a/ui/tests/integration/components/usage/page/index-test.js
+++ b/ui/tests/integration/components/usage/page/index-test.js
@@ -4,7 +4,7 @@
 
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'vault/tests/helpers';
-import { render } from '@ember/test-helpers';
+import { findAll, render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import sinon from 'sinon';
 
@@ -25,5 +25,57 @@ module('Integration | Component | usage | Page::Usage', function (hooks) {
   test('it provides the correct fetch function to the dashboard component', async function (assert) {
     await render(hbs`<Usage::Page />`);
     assert.true(this.systemReadUtilizationReportStub.calledOnce, 'fetch function is called on render');
+  });
+
+  test('it remaps data to friendly names if available', async function (assert) {
+    this.systemReadUtilizationReportStub.resolves({
+      data: {
+        auth_methods: { alicloud: 2, cert: 2, userpass: 2, 'unknown-random-method': 1 },
+        kvv1_secrets: 15,
+        kvv2_secrets: 146,
+        lease_count_quotas: {
+          global_lease_count_quota: {
+            capacity: 300000,
+            count: 244121,
+            name: 'default',
+          },
+          total_lease_count_quotas: 2,
+        },
+        namespaces: 10,
+        secrets_sync: 79,
+        pki: { total_issuers: 2, total_roles: 6 },
+        replication_status: {
+          dr_primary: false,
+          dr_state: 'disabled',
+          pr_primary: false,
+          pr_state: 'enabled',
+        },
+        secret_engines: {
+          keymgmt: 5,
+          gcpkms: 10,
+          pki: 11,
+          'unknown-random-engine': 1,
+        },
+      },
+    });
+    await render(hbs`<Usage::Page />`);
+
+    const engineLabels = [...findAll('[data-test-dashboard-secret-engines] .axis g text')].map(
+      (label) => label.textContent
+    );
+    const authMethodLabels = [...findAll('[data-test-dashboard-auth-methods] .axis g text')].map(
+      (label) => label.textContent
+    );
+    assert.deepEqual(
+      engineLabels,
+      ['PKI Certificates', 'Google Cloud KMS', 'Key Management', 'unknown-random-engine'],
+      'Engine labels are correct (sorted DESC)'
+    );
+
+    assert.deepEqual(
+      authMethodLabels,
+      ['AliCloud', 'TLS Certificates', 'Username & Password', 'unknown-random-method'],
+      'Auth method labels are correct (sorted DESC)'
+    );
   });
 });


### PR DESCRIPTION
### Description
Updates the report data fetching function to map in the "Friendly" names for auth methods and secret engine data.
<img width="511" alt="image" src="https://github.com/user-attachments/assets/1fed43f5-45fb-4a3c-abb0-30a277a5612e" />

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
