### PR TITLE
[UI] Ember Data Migration - Update Capabilities Service

### DIFF
--- a/ui/docs/models.md
+++ b/ui/docs/models.md
@@ -35,7 +35,7 @@ Other patterns and where they belong in relation to the Model:
 
 - **Validations** - While an argument can go either way about this one, we are going to continue defining these on the Model using our handy [withModelValidation decorator](#withmodelvalidations). The state of validation is directly correlated to a given Record which is a strong reason to keep it on the Model. **TL;DR: Lives on Model**
 
-- **[Capabilities](#capabilities)** - Capabilities are calculated by fetching permissions by path -- often multiple paths, based on the same information we need to fetch the Record data (eg. backend, ID). When using `lazyCapabilities` on the model we kick off one API request for each of the paths we need, while using the capabilities service `fetchMultiplePaths` method we can make one request with all the required paths included. Our best practice is to fetch capabilities outside of the Model (perhaps as part of a route model, or on a user action such as dropdown click open). A downside to this approach is that the API may get re-requested per page we check the capability (eg. list view dropdown and then detail view) -- but we can optimize this in the future by first checking the store for `capabilities` of matching path/ID before sending the API request. **TL;DR: Lives in route or component where they are used**
+- **[Capabilities](#capabilities)** - Capabilities are calculated by fetching permissions by path -- often multiple paths, based on the same information we need to fetch the Record data (eg. backend, ID). When using `lazyCapabilities` on the model we kick off one API request for each of the paths we need, while using the capabilities service `fetch` method we can make one request with all the required paths included. Our best practice is to fetch capabilities outside of the Model (perhaps as part of a route model, or on a user action such as dropdown click open). A downside to this approach is that the API may get re-requested per page we check the capability (eg. list view dropdown and then detail view) -- but we can optimize this in the future by first checking the store for `capabilities` of matching path/ID before sending the API request. **TL;DR: Lives in route or component where they are used**
 
 ## Patterns
 
@@ -218,14 +218,14 @@ async getExportCapabilities(ns = '') {
 ```
 
 **Multiple capabilities checked at once**
-When there are multiple capabilities paths to check, the recommended approach is to use the [capabilities service's](../app/services/capabilities.ts) `fetchMultiplePaths` method. It will pass all the paths in a single API request instead of making a capabilities-self call for each path as the other techniques do. In [this example](../lib/kv/addon/routes/secret.js), we get the capabilities as part of the route's model hook and then return the relevant `can*` values:
+When there are multiple capabilities paths to check, the recommended approach is to use the [capabilities service's](../app/services/capabilities.ts) `fetch` method. It will pass all the paths in a single API request instead of making a capabilities-self call for each path as the other techniques do. In [this example](../lib/kv/addon/routes/secret.js), we get the capabilities as part of the route's model hook and then return the relevant `can*` values:
 
 ```js
 async fetchCapabilities(backend, path) {
   const metadataPath = `${backend}/metadata/${path}`;
   const dataPath = `${backend}/data/${path}`;
   const subkeysPath = `${backend}/subkeys/${path}`;
-  const perms = await this.capabilities.fetchMultiplePaths([metadataPath, dataPath, subkeysPath]);
+  const perms = await this.capabilities.fetch([metadataPath, dataPath, subkeysPath]);
   // returns values keyed at the path
   return {
     metadata: perms[metadataPath],

--- a/ui/lib/kv/addon/routes/secret.js
+++ b/ui/lib/kv/addon/routes/secret.js
@@ -54,7 +54,7 @@ export default class KvSecretRoute extends Route {
     const metadataPath = `${backend}/metadata/${path}`;
     const dataPath = `${backend}/data/${path}`;
     const subkeysPath = `${backend}/subkeys/${path}`;
-    const perms = await this.capabilities.fetchMultiplePaths([metadataPath, dataPath, subkeysPath]);
+    const perms = await this.capabilities.fetch([metadataPath, dataPath, subkeysPath]);
     return {
       metadata: perms[metadataPath],
       data: perms[dataPath],

--- a/ui/lib/replication/addon/routes/application.js
+++ b/ui/lib/replication/addon/routes/application.js
@@ -17,7 +17,7 @@ export default Route.extend(ClusterRoute, {
 
   async fetchCapabilities() {
     const enablePath = (type, cluster) => `sys/replication/${type}/${cluster}/enable`;
-    const perms = await this.capabilities.fetchMultiplePaths([
+    const perms = await this.capabilities.fetch([
       enablePath('dr', 'primary'),
       enablePath('dr', 'primary'),
       enablePath('performance', 'secondary'),

--- a/ui/tests/unit/services/capabilities-test.js
+++ b/ui/tests/unit/services/capabilities-test.js
@@ -13,7 +13,6 @@ module('Unit | Service | capabilities', function (hooks) {
 
   hooks.beforeEach(function () {
     this.capabilities = this.owner.lookup('service:capabilities');
-    this.store = this.owner.lookup('service:store');
     this.generateResponse = ({ path, paths, capabilities }) => {
       if (path) {
         // "capabilities" is an array
@@ -39,50 +38,10 @@ module('Unit | Service | capabilities', function (hooks) {
     };
   });
 
-  module('general methods', function () {
-    test('request: it makes request to capabilities-self with path param', function (assert) {
-      const path = '/my/api/path';
-      const expectedPayload = { paths: [path] };
-      this.server.post('/sys/capabilities-self', (schema, req) => {
-        const actual = JSON.parse(req.requestBody);
-        assert.true(true, 'request made to capabilities-self');
-        assert.propEqual(actual, expectedPayload, `request made with path: ${JSON.stringify(actual)}`);
-        return this.generateResponse({ path, capabilities: ['read'] });
-      });
-      this.capabilities.request({ path });
-    });
-
-    test('request: it makes request to capabilities-self with paths param', function (assert) {
-      const paths = ['/my/api/path', 'another/api/path'];
-      const expectedPayload = { paths };
-      this.server.post('/sys/capabilities-self', (schema, req) => {
-        const actual = JSON.parse(req.requestBody);
-        assert.true(true, 'request made to capabilities-self');
-        assert.propEqual(actual, expectedPayload, `request made with path: ${JSON.stringify(actual)}`);
-        return this.generateResponse({
-          paths,
-          capabilities: { '/my/api/path': ['read'], 'another/api/path': ['read'] },
-        });
-      });
-      this.capabilities.request({ paths });
-    });
-  });
-
-  test('fetchPathCapabilities: it makes request to capabilities-self with path param', function (assert) {
-    const path = '/my/api/path';
-    const expectedPayload = { paths: [path] };
-    this.server.post('/sys/capabilities-self', (schema, req) => {
-      const actual = JSON.parse(req.requestBody);
-      assert.true(true, 'request made to capabilities-self');
-      assert.propEqual(actual, expectedPayload, `request made with path: ${JSON.stringify(actual)}`);
-      return this.generateResponse({ path, capabilities: ['read'] });
-    });
-    this.capabilities.fetchPathCapabilities(path);
-  });
-
-  test('fetchMultiplePaths: it makes request to capabilities-self with paths param', async function (assert) {
+  test('fetch: it makes request to capabilities-self', async function (assert) {
     const paths = ['/my/api/path', 'another/api/path'];
     const expectedPayload = { paths };
+
     this.server.post('/sys/capabilities-self', (schema, req) => {
       const actual = JSON.parse(req.requestBody);
       assert.true(true, 'request made to capabilities-self');
@@ -92,7 +51,8 @@ module('Unit | Service | capabilities', function (hooks) {
         capabilities: { '/my/api/path': ['read', 'list'], 'another/api/path': ['read', 'delete'] },
       });
     });
-    const actual = await this.capabilities.fetchMultiplePaths(paths);
+
+    const actual = await this.capabilities.fetch(paths);
     const expected = {
       '/my/api/path': {
         canCreate: false,
@@ -116,10 +76,10 @@ module('Unit | Service | capabilities', function (hooks) {
     assert.propEqual(actual, expected, `it returns expected response: ${JSON.stringify(actual)}`);
   });
 
-  test('fetchMultiplePaths: it defaults to true if the capabilities request fails', async function (assert) {
+  test('fetch: it defaults to true if the capabilities request fails', async function (assert) {
     // don't stub endpoint which causes request to fail
     const paths = ['/my/api/path', 'another/api/path'];
-    const actual = await this.capabilities.fetchMultiplePaths(paths);
+    const actual = await this.capabilities.fetch(paths);
     const expected = {
       '/my/api/path': {
         canCreate: true,
@@ -143,9 +103,10 @@ module('Unit | Service | capabilities', function (hooks) {
     assert.propEqual(actual, expected, `it returns expected response: ${JSON.stringify(actual)}`);
   });
 
-  test('fetchMultiplePaths: it defaults to true if no model is found', async function (assert) {
+  test('fetch: it defaults to true if no model is found', async function (assert) {
     const paths = ['/my/api/path', 'another/api/path'];
     const expectedPayload = { paths };
+
     this.server.post('/sys/capabilities-self', (schema, req) => {
       const actual = JSON.parse(req.requestBody);
       assert.true(true, 'request made to capabilities-self');
@@ -155,7 +116,8 @@ module('Unit | Service | capabilities', function (hooks) {
         capabilities: { '/my/api/path': ['read', 'list'] },
       });
     });
-    const actual = await this.capabilities.fetchMultiplePaths(paths);
+
+    const actual = await this.capabilities.fetch(paths);
     const expected = {
       '/my/api/path': {
         canCreate: false,
@@ -177,6 +139,30 @@ module('Unit | Service | capabilities', function (hooks) {
       },
     };
     assert.propEqual(actual, expected, `it returns expected response: ${JSON.stringify(actual)}`);
+  });
+
+  test('fetchPathCapabilities: it makes request to capabilities-self and returns capabilities for single path', async function (assert) {
+    const path = '/my/api/path';
+    const expectedPayload = { paths: [path] };
+
+    this.server.post('/sys/capabilities-self', (schema, req) => {
+      const actual = JSON.parse(req.requestBody);
+      assert.true(true, 'request made to capabilities-self');
+      assert.propEqual(actual, expectedPayload, `request made with path: ${JSON.stringify(actual)}`);
+      return this.generateResponse({ path, capabilities: ['read'] });
+    });
+
+    const actual = await this.capabilities.fetchPathCapabilities(path);
+    const expected = {
+      canCreate: false,
+      canDelete: false,
+      canList: false,
+      canPatch: false,
+      canRead: true,
+      canSudo: false,
+      canUpdate: false,
+    };
+    assert.propEqual(actual, expected, 'returns capabilities for provided path');
   });
 
   module('specific methods', function () {
@@ -246,15 +232,12 @@ module('Unit | Service | capabilities', function (hooks) {
     hooks.beforeEach(function () {
       this.nsSvc = this.owner.lookup('service:namespace');
       this.nsSvc.path = 'ns1';
-      this.store.unloadAll('capabilities');
     });
 
     test('fetchPathCapabilities works as expected', async function (assert) {
       const ns = this.nsSvc.path;
       const path = '/my/api/path';
       const expectedAttrs = {
-        // capabilities has ID at non-namespaced path
-        id: path,
         canCreate: false,
         canDelete: false,
         canList: true,
@@ -263,6 +246,7 @@ module('Unit | Service | capabilities', function (hooks) {
         canSudo: false,
         canUpdate: false,
       };
+
       this.server.post('/sys/capabilities-self', (schema, req) => {
         const actual = JSON.parse(req.requestBody);
         assert.strictEqual(req.url, '/v1/sys/capabilities-self', 'request made to capabilities-self');
@@ -276,8 +260,8 @@ module('Unit | Service | capabilities', function (hooks) {
           capabilities: ['read', 'list'],
         });
       });
+
       const actual = await this.capabilities.fetchPathCapabilities(path);
-      assert.strictEqual(this.store.peekAll('capabilities').length, 1, 'adds 1 record');
 
       Object.keys(expectedAttrs).forEach(function (key) {
         assert.strictEqual(
@@ -288,7 +272,7 @@ module('Unit | Service | capabilities', function (hooks) {
       });
     });
 
-    test('fetchMultiplePaths works as expected', async function (assert) {
+    test('fetch works as expected', async function (assert) {
       const ns = this.nsSvc.path;
       const paths = ['/my/api/path', '/another/api/path'];
       const expectedPayload = paths.map((p) => `${ns}${p}`);
@@ -306,7 +290,8 @@ module('Unit | Service | capabilities', function (hooks) {
         });
         return resp;
       });
-      const actual = await this.capabilities.fetchMultiplePaths(paths);
+
+      const actual = await this.capabilities.fetch(paths);
       const expected = {
         '/my/api/path': {
           canCreate: false,
@@ -327,19 +312,7 @@ module('Unit | Service | capabilities', function (hooks) {
           canUpdate: true,
         },
       };
-      assert.deepEqual(actual, expected, 'method returns expected response');
-      assert.strictEqual(this.store.peekAll('capabilities').length, 2, 'adds 2 records');
-      Object.keys(expected).forEach((path) => {
-        const record = this.store.peekRecord('capabilities', path);
-        assert.strictEqual(record.id, path, `record exists with id: ${record.id}`);
-        Object.keys(expected[path]).forEach((attr) => {
-          assert.strictEqual(
-            record[attr],
-            expected[path][attr],
-            `record has correct value for ${attr}: ${record[attr]}`
-          );
-        });
-      });
+      assert.propEqual(actual, expected, 'method returns expected response');
     });
   });
 });


### PR DESCRIPTION
### Description
This PR updates the capabilities service to use the api service to make requests to the `capabilities-self` endpoint. Logic from the capabilities model was moved into the service to maintain backwards compatibility.

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
