### PR TITLE
[UI] Ember Data Migration - Pagination Util

### DIFF
--- a/ui/lib/core/addon/utils/paginate-list.ts
+++ b/ui/lib/core/addon/utils/paginate-list.ts
@@ -36,7 +36,7 @@ export const paginate = (data: PaginatedData, options: PaginateOptions = {}) => 
       });
     }
 
-    const lastPage = Math.floor(filteredData.length / pageSize);
+    const lastPage = Math.ceil(filteredData.length / pageSize);
     const start = (page - 1) * pageSize;
     const end = start + pageSize;
     filteredData = filteredData.slice(start, end);

--- a/ui/lib/core/addon/utils/paginate-list.ts
+++ b/ui/lib/core/addon/utils/paginate-list.ts
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import config from 'vault/config/environment';
+
+const { DEFAULT_PAGE_SIZE } = config.APP;
+
+type PaginatedData = string | Record<string, string>[];
+type PaginateOptions = {
+  page?: number;
+  pageSize?: number;
+  filter?: string;
+  filterKey?: string;
+};
+
+/**
+ * Util to paginate data set based on page number and size
+ * If filter is provided, it will filter the data prior to paginating
+ */
+
+export const paginate = (data: PaginatedData, options: PaginateOptions = {}) => {
+  const { page = 1, pageSize = DEFAULT_PAGE_SIZE, filter, filterKey } = options;
+  let filteredData = data;
+
+  if (Array.isArray(data)) {
+    // filter data before paginating if filter is provided
+    if (filter) {
+      filteredData = data.filter((item) => {
+        const filterValue = filterKey ? item[filterKey] : item;
+        return filterValue || ''.toLowerCase().includes(filter.toLowerCase());
+      });
+    }
+
+    const lastPage = Math.floor(filteredData.length / pageSize);
+    const start = (page - 1) * pageSize;
+    const end = start + pageSize;
+    filteredData = filteredData.slice(start, end);
+    // add meta data previously from lazyPaginatedQuery since components expect it
+    Object.defineProperty(filteredData, 'meta', {
+      value: {
+        currentPage: page,
+        lastPage,
+        nextPage: page + 1,
+        prevPage: page - 1,
+        total: data.length,
+        filteredTotal: filteredData.length,
+        pageSize,
+      },
+    });
+  }
+
+  return filteredData;
+};

--- a/ui/lib/core/addon/utils/paginate-list.ts
+++ b/ui/lib/core/addon/utils/paginate-list.ts
@@ -29,7 +29,10 @@ export const paginate = (data: PaginatedData, options: PaginateOptions = {}) => 
     if (filter) {
       filteredData = data.filter((item) => {
         const filterValue = filterKey ? item[filterKey] : item;
-        return filterValue || ''.toLowerCase().includes(filter.toLowerCase());
+        if (typeof filterValue === 'string') {
+          return filterValue.toLowerCase().includes(filter.toLowerCase());
+        }
+        return false;
       });
     }
 

--- a/ui/tests/unit/utils/paginate-list-test.js
+++ b/ui/tests/unit/utils/paginate-list-test.js
@@ -39,14 +39,16 @@ module('Unit | Utility | paginate-list', function (hooks) {
 
   test('it should filter items and then paginate', function (assert) {
     let data = ['Test', 'foo', 'test', 'bar', 'test'];
+    let expected = ['Test', 'test'];
     const options = { page: 1, pageSize: 2, filter: 'test' };
 
     let paginatedData = paginate(data, options);
-    assert.strictEqual(paginatedData.length, 2, 'returns correct number of filtered items');
+    assert.deepEqual(paginatedData, expected, 'returns correct number of filtered items');
 
     data = data.map((id) => ({ id }));
+    expected = [{ id: 'Test' }, { id: 'test' }];
     paginatedData = paginate(data, { ...options, filterKey: 'id' });
-    assert.strictEqual(paginatedData.length, 2, 'returns correct number of filtered objects');
+    assert.deepEqual(paginatedData, expected, 'returns correct number of filtered objects');
   });
 
   test('it should add meta data to returned object', function (assert) {

--- a/ui/tests/unit/utils/paginate-list-test.js
+++ b/ui/tests/unit/utils/paginate-list-test.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
 import { paginate } from 'core/utils/paginate-list';
 import { module, test } from 'qunit';
 

--- a/ui/tests/unit/utils/paginate-list-test.js
+++ b/ui/tests/unit/utils/paginate-list-test.js
@@ -1,0 +1,60 @@
+import { paginate } from 'core/utils/paginate-list';
+import { module, test } from 'qunit';
+
+module('Unit | Utility | paginate-list', function (hooks) {
+  hooks.beforeEach(function () {
+    this.items = Array.from({ length: 20 }, (val, i) => i);
+  });
+
+  test('it should return data for non or empty arrays', function (assert) {
+    let items = 'not an array';
+    assert.strictEqual(paginate(items), items, 'returns the same data when input is not an array');
+
+    items = [];
+    assert.deepEqual(paginate(items), items, 'returns the same data when input is an empty array');
+  });
+
+  test('it should use default page and size', function (assert) {
+    const paginatedData = paginate(this.items, { page: 1 });
+    assert.strictEqual(paginatedData.length, 15, 'returns 15 items as default when no page size is set');
+    assert.deepEqual(this.items.slice(0, 15), paginatedData, 'returns first page of items by default');
+  });
+
+  test('it should return items for given page and size', function (assert) {
+    const paginatedData = paginate(this.items, { page: 3, pageSize: 5 });
+    assert.strictEqual(paginatedData.length, 5, 'returns correct number of items based on size');
+    assert.deepEqual(this.items.slice(10, 15), paginatedData, 'returns correct items for given page');
+  });
+
+  test('it should return remaining items on last page', function (assert) {
+    const paginatedData = paginate(this.items, { page: 3, pageSize: 8 });
+    assert.strictEqual(paginatedData.length, 4, 'returns correct number of items on last page');
+    assert.deepEqual(this.items.slice(16), paginatedData, 'returns correct items for last page');
+  });
+
+  test('it should filter items and then paginate', function (assert) {
+    let data = ['Test', 'foo', 'test', 'bar', 'test'];
+    const options = { page: 1, pageSize: 2, filter: 'test' };
+
+    let paginatedData = paginate(data, options);
+    assert.strictEqual(paginatedData.length, 2, 'returns correct number of filtered items');
+
+    data = data.map((id) => ({ id }));
+    paginatedData = paginate(data, { ...options, filterKey: 'id' });
+    assert.strictEqual(paginatedData.length, 2, 'returns correct number of filtered objects');
+  });
+
+  test('it should add meta data to returned object', function (assert) {
+    const { meta } = paginate(this.items, { page: 2, pageSize: 5 });
+    const expectedMeta = {
+      currentPage: 2,
+      lastPage: 4,
+      nextPage: 3,
+      prevPage: 1,
+      total: 20,
+      filteredTotal: 5,
+      pageSize: 5,
+    };
+    assert.deepEqual(meta, expectedMeta, 'returns correct meta data');
+  });
+});

--- a/ui/tests/unit/utils/paginate-list-test.js
+++ b/ui/tests/unit/utils/paginate-list-test.js
@@ -52,16 +52,22 @@ module('Unit | Utility | paginate-list', function (hooks) {
   });
 
   test('it should add meta data to returned object', function (assert) {
-    const { meta } = paginate(this.items, { page: 2, pageSize: 5 });
+    const { meta } = paginate(this.items, { page: 2, pageSize: 3 });
     const expectedMeta = {
       currentPage: 2,
-      lastPage: 4,
+      lastPage: 7,
       nextPage: 3,
       prevPage: 1,
       total: 20,
-      filteredTotal: 5,
-      pageSize: 5,
+      filteredTotal: 3,
+      pageSize: 3,
     };
     assert.deepEqual(meta, expectedMeta, 'returns correct meta data');
+  });
+
+  test('it should return remaining results on last page', async function (assert) {
+    const paginatedData = paginate(this.items, { page: 7, pageSize: 3 });
+    const expected = [18, 19];
+    assert.deepEqual(paginatedData, expected, 'returns correct items for last page');
   });
 });


### PR DESCRIPTION
### Description
This PR adds a pagination util that when used together with the `api` service will replace the functionality of the `lazyPaginatedQuery` method of the `pagination` service. The current pagination service is tightly coupled with Ember Data and has methods to cache the raw data and manage pushing records into the store. This will no longer be necessary so the new util simply slices an array based on the provided pagination options. To maintain backwards compatibility, the `meta` object is returned as expected. 

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
