### PR TITLE
UI: Fix KMIP test in 1.19.x

### DIFF
--- a/ui/tests/acceptance/enterprise-kmip-test.js
+++ b/ui/tests/acceptance/enterprise-kmip-test.js
@@ -247,7 +247,7 @@ module('Acceptance | Enterprise | KMIP secrets', function (hooks) {
     assert.strictEqual(rolesPage.listItemLinks.length, 1, 'renders a single role');
     await rolesPage.visitDetail({ backend, scope, role });
     // check that the role details looks right
-    assert.dom('h2').exists({ count: 2 }, 'renders correct section headings');
+    assert.dom('h2').exists({ count: 3 }, 'renders correct section headings');
     assert.dom('[data-test-inline-error-message]').hasText('This role allows all KMIP operations');
     ['Managed Cryptographic Objects', 'Object Attributes', 'Server', 'Other'].forEach((title) => {
       assert.dom(`[data-test-row-label="${title}"]`).exists(`Renders allowed operations row for: ${title}`);


### PR DESCRIPTION
### Description
What does this PR do?

Fixes failing KMIP test for checking header count, was updated in 1.20 but was not backported with HDS upgrade change
noted PR with test fix: #29719  

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
