### PR TITLE
[VAULT-34116] Skip TestRaftHACluster_Removed_ReAdd until we fix its flakiness

### DIFF
--- a/vault/external_tests/raftha/raft_ha_test.go
+++ b/vault/external_tests/raftha/raft_ha_test.go
@@ -336,6 +336,7 @@ func TestRaft_HA_ExistingCluster(t *testing.T) {
 // them. The removed follower tries to re-join, and the test verifies that it
 // errors and cannot join.
 func TestRaftHACluster_Removed_ReAdd(t *testing.T) {
+	t.Skip("This test is flaky and needs to be fixed before it can be re-enabled")
 	t.Parallel()
 	var conf vault.CoreConfig
 	opts := vault.TestClusterOptions{HandlerFunc: vaulthttp.Handler}


### PR DESCRIPTION
### Description
This PR does what it says on the tin.

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
