### PR TITLE
Refactoring for returning SSH CA public key with managed keys

### DIFF
--- a/builtin/logical/ssh/path_config_ca.go
+++ b/builtin/logical/ssh/path_config_ca.go
@@ -120,18 +120,18 @@ Read operations will return the public key, if already stored/generated.`,
 }
 
 func (b *backend) pathConfigCARead(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
-	publicKeyEntry, err := caKey(ctx, req.Storage, caPublicKey)
+	publicKey, err := getCAPublicKey(ctx, req.Storage)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read CA public key: %w", err)
 	}
 
-	if publicKeyEntry == nil {
+	if publicKey == "" {
 		return logical.ErrorResponse("keys haven't been configured yet"), nil
 	}
 
 	response := &logical.Response{
 		Data: map[string]interface{}{
-			"public_key": publicKeyEntry.Key,
+			"public_key": publicKey,
 		},
 	}
 
@@ -145,10 +145,13 @@ func (b *backend) pathConfigCADelete(ctx context.Context, req *logical.Request, 
 	if err := req.Storage.Delete(ctx, caPublicKeyStoragePath); err != nil {
 		return nil, err
 	}
+	if err := req.Storage.Delete(ctx, caManagedKeyStoragePath); err != nil {
+		return nil, err
+	}
 	return nil, nil
 }
 
-func caKey(ctx context.Context, storage logical.Storage, keyType string) (*keyStorageEntry, error) {
+func readStoredKey(ctx context.Context, storage logical.Storage, keyType string) (*keyStorageEntry, error) {
 	var path, deprecatedPath string
 	switch keyType {
 	case caPrivateKey:
@@ -174,13 +177,11 @@ func caKey(ctx context.Context, storage logical.Storage, keyType string) (*keySt
 			return nil, err
 		}
 		if entry != nil {
-			entry, err = logical.StorageEntryJSON(path, keyStorageEntry{
-				Key: string(entry.Value),
-			})
-			if err != nil {
-				return nil, err
+			newEntry := &logical.StorageEntry{
+				Key:   path,
+				Value: entry.Value,
 			}
-			if err := storage.Put(ctx, entry); err != nil {
+			if err := storage.Put(ctx, newEntry); err != nil {
 				return nil, err
 			}
 			if err = storage.Delete(ctx, deprecatedPath); err != nil {
@@ -201,7 +202,14 @@ func caKey(ctx context.Context, storage logical.Storage, keyType string) (*keySt
 }
 
 func (b *backend) pathConfigCAUpdate(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
-	var err error
+	found, err := caKeysConfigured(ctx, req.Storage)
+	if err != nil {
+		return nil, err
+	}
+	if found {
+		return logical.ErrorResponse("keys are already configured; delete them before reconfiguring"), nil
+	}
+
 	publicKey := data.Get("public_key").(string)
 	privateKey := data.Get("private_key").(string)
 
@@ -241,12 +249,9 @@ func (b *backend) pathConfigCAUpdate(ctx context.Context, req *logical.Request, 
 			return logical.ErrorResponse("if generate_signing_key is false, either both public_key and private_key or a managed key must be provided"), nil
 		}
 
-		errResp, err := createStoredKey(ctx, req.Storage, publicKey, privateKey)
+		err = createStoredKey(ctx, req.Storage, publicKey, privateKey)
 		if err != nil {
 			return nil, err
-		}
-		if errResp != nil {
-			return errResp, nil
 		}
 	}
 
@@ -263,43 +268,29 @@ func (b *backend) pathConfigCAUpdate(ctx context.Context, req *logical.Request, 
 	return nil, nil
 }
 
-func createStoredKey(ctx context.Context, s logical.Storage, publicKey, privateKey string) (*logical.Response, error) {
+func createStoredKey(ctx context.Context, s logical.Storage, publicKey, privateKey string) error {
 	if publicKey == "" || privateKey == "" {
-		return nil, fmt.Errorf("failed to generate or parse the keys")
-	}
-
-	publicKeyEntry, err := caKey(ctx, s, caPublicKey)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read CA public key: %w", err)
-	}
-
-	privateKeyEntry, err := caKey(ctx, s, caPrivateKey)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read CA private key: %w", err)
-	}
-
-	if (publicKeyEntry != nil && publicKeyEntry.Key != "") || (privateKeyEntry != nil && privateKeyEntry.Key != "") {
-		return logical.ErrorResponse("keys are already configured; delete them before reconfiguring"), nil
+		return fmt.Errorf("failed to generate or parse the keys")
 	}
 
 	entry, err := logical.StorageEntryJSON(caPublicKeyStoragePath, &keyStorageEntry{
 		Key: publicKey,
 	})
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	// Save the public key
 	err = s.Put(ctx, entry)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	entry, err = logical.StorageEntryJSON(caPrivateKeyStoragePath, &keyStorageEntry{
 		Key: privateKey,
 	})
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	// Save the private key
@@ -313,13 +304,13 @@ func createStoredKey(ctx context.Context, s logical.Storage, publicKey, privateK
 		// removed
 		if delErr := s.Delete(ctx, caPublicKeyStoragePath); delErr != nil {
 			mErr = multierror.Append(mErr, fmt.Errorf("failed to cleanup CA public key: %w", delErr))
-			return nil, mErr
+			return mErr
 		}
 
-		return nil, err
+		return err
 	}
 
-	return nil, nil
+	return nil
 }
 
 func generateSSHKeyPair(randomSource io.Reader, keyType string, keyBits int) (string, string, error) {
@@ -440,9 +431,9 @@ func (b *backend) createManagedKey(ctx context.Context, s logical.Storage, manag
 	}
 
 	entry, err := logical.StorageEntryJSON(caManagedKeyStoragePath, &managedKeyStorageEntry{
-		PublicKey: string(keyInfo.PublicKey().Marshal()),
-		KeyName:   keyInfo.Name,
-		KeyId:     keyInfo.Uuid,
+		PublicKey: string(ssh.MarshalAuthorizedKey(keyInfo.PublicKey())),
+		KeyName:   keyName,
+		KeyId:     keyId,
 	})
 	if err != nil {
 		return fmt.Errorf("error creating storage entry: %s", err)
@@ -455,4 +446,75 @@ func (b *backend) createManagedKey(ctx context.Context, s logical.Storage, manag
 	}
 
 	return nil
+}
+
+func getCAPublicKey(ctx context.Context, storage logical.Storage) (string, error) {
+	var publicKey string
+
+	storedKeyEntry, err := readStoredKey(ctx, storage, caPublicKey)
+	if err != nil {
+		return "", err
+	}
+
+	if storedKeyEntry == nil {
+		managedKeyEntry, err := readManagedKey(ctx, storage)
+		if err != nil {
+			return "", err
+		}
+
+		if managedKeyEntry == nil {
+			return "", nil
+		}
+
+		publicKey = managedKeyEntry.PublicKey
+	} else {
+		publicKey = storedKeyEntry.Key
+	}
+
+	return publicKey, nil
+}
+
+func readManagedKey(ctx context.Context, storage logical.Storage) (*managedKeyStorageEntry, error) {
+	entry, err := storage.Get(ctx, caManagedKeyStoragePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read CA key of type managed key: %w", err)
+	}
+
+	if entry == nil {
+		return nil, nil
+	}
+
+	var keyEntry managedKeyStorageEntry
+	if err := entry.DecodeJSON(&keyEntry); err != nil {
+		return nil, err
+	}
+
+	return &keyEntry, nil
+}
+
+func caKeysConfigured(ctx context.Context, s logical.Storage) (bool, error) {
+	publicKeyEntry, err := readStoredKey(ctx, s, caPublicKey)
+	if err != nil {
+		return false, fmt.Errorf("failed to read CA public key: %w", err)
+	}
+
+	privateKeyEntry, err := readStoredKey(ctx, s, caPrivateKey)
+	if err != nil {
+		return false, fmt.Errorf("failed to read CA private key: %w", err)
+	}
+
+	if (publicKeyEntry != nil && publicKeyEntry.Key != "") || (privateKeyEntry != nil && privateKeyEntry.Key != "") {
+		return true, nil
+	}
+
+	managedKeyEntry, err := readManagedKey(ctx, s)
+	if err != nil {
+		return false, fmt.Errorf("failed to read CA managed key: %w", err)
+	}
+
+	if managedKeyEntry != nil {
+		return true, nil
+	}
+
+	return false, nil
 }

--- a/builtin/logical/ssh/path_config_ca.go
+++ b/builtin/logical/ssh/path_config_ca.go
@@ -177,11 +177,13 @@ func readStoredKey(ctx context.Context, storage logical.Storage, keyType string)
 			return nil, err
 		}
 		if entry != nil {
-			newEntry := &logical.StorageEntry{
-				Key:   path,
-				Value: entry.Value,
+			entry, err = logical.StorageEntryJSON(path, keyStorageEntry{
+				Key: string(entry.Value),
+			})
+			if err != nil {
+				return nil, err
 			}
-			if err := storage.Put(ctx, newEntry); err != nil {
+			if err := storage.Put(ctx, entry); err != nil {
 				return nil, err
 			}
 			if err = storage.Delete(ctx, deprecatedPath); err != nil {

--- a/builtin/logical/ssh/path_config_ca_test.go
+++ b/builtin/logical/ssh/path_config_ca_test.go
@@ -5,6 +5,8 @@ package ssh
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -37,7 +39,7 @@ func TestSSH_ConfigCAStorageUpgrade(t *testing.T) {
 	}
 
 	// Reading it should return the key as well as upgrade the storage path
-	privateKeyEntry, err := caKey(context.Background(), config.StorageView, caPrivateKey)
+	privateKeyEntry, err := readStoredKey(context.Background(), config.StorageView, caPrivateKey)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -71,7 +73,7 @@ func TestSSH_ConfigCAStorageUpgrade(t *testing.T) {
 	}
 
 	// Reading it should return the key as well as upgrade the storage path
-	publicKeyEntry, err := caKey(context.Background(), config.StorageView, caPublicKey)
+	publicKeyEntry, err := readStoredKey(context.Background(), config.StorageView, caPublicKey)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -275,4 +277,322 @@ func TestSSH_ConfigCAKeyTypes(t *testing.T) {
 	for index, scenario := range cases {
 		createDeleteHelper(t, b, config, index, scenario.keyType, scenario.keyBits)
 	}
+}
+
+func TestReadManagedKey(t *testing.T) {
+	t.Parallel()
+
+	storage := &logical.InmemStorage{}
+	entry, err := readManagedKey(context.Background(), storage)
+	if err != nil {
+		t.Fatalf("error reading managed key: %s", err)
+	}
+
+	if entry != nil {
+		t.Fatal("expected nil, but got a non-nil return")
+	}
+
+	err = writeKey(context.Background(), storage, caManagedKeyStoragePath, "test-managed-key")
+	if err != nil {
+		t.Fatalf("error writing test key: %s", err)
+	}
+
+	entry, err = readManagedKey(context.Background(), storage)
+	if err != nil {
+		t.Fatalf("error reading managed key: %s", err)
+	}
+
+	if entry == nil {
+		t.Fatal("unexpected nil entry")
+	}
+
+	if entry.PublicKey != "test-managed-key" {
+		t.Fatalf("key value mismatch: expected %s, got %s", "test-managed-key", entry.PublicKey)
+	}
+}
+
+func TestReadStoredKey(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		privateKeyStoragePath string
+		publicKeyStoragePath  string
+		publicKey             string
+		privateKey            string
+	}{
+		"stored-keys-configured": {
+			privateKeyStoragePath: caPrivateKeyStoragePath,
+			publicKeyStoragePath:  caPublicKeyStoragePath,
+			publicKey:             testCAPublicKey,
+			privateKey:            testCAPrivateKey,
+		},
+		"deprecated-path-keys-configured": {
+			privateKeyStoragePath: caPrivateKeyStoragePathDeprecated,
+			publicKeyStoragePath:  caPublicKeyStoragePathDeprecated,
+			publicKey:             testCAPublicKey,
+			privateKey:            testCAPrivateKey,
+		},
+	}
+
+	for name, tt := range testCases {
+		t.Run(name, func(t *testing.T) {
+			storage := &logical.InmemStorage{}
+
+			if err := writeKey(ctx, storage, tt.privateKeyStoragePath, tt.privateKey); err != nil {
+				t.Fatalf("error writing private key: %s", err)
+			}
+
+			if err := writeKey(ctx, storage, tt.publicKeyStoragePath, tt.publicKey); err != nil {
+				t.Fatalf("error writing public key: %s", err)
+			}
+
+			publicKeyEntry, err := readStoredKey(context.Background(), storage, caPublicKey)
+			if err != nil {
+				t.Fatalf("error reading public key: %s", err)
+			}
+
+			if publicKeyEntry.Key != tt.publicKey {
+				t.Fatalf("returned key does not match: expected %s, got %s", tt.publicKey, publicKeyEntry.Key)
+			}
+
+			privateKeyEntry, err := readStoredKey(context.Background(), storage, caPrivateKey)
+			if err != nil {
+				t.Fatalf("error reading private key: %s", err)
+			}
+
+			if privateKeyEntry.Key != tt.privateKey {
+				t.Fatalf("returned key does not match: expected %s, got %s", tt.privateKey, privateKeyEntry.Key)
+			}
+		})
+	}
+}
+
+func TestGetCAPublicKey(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		publicKeyStoragePath string
+		publicKey            string
+	}{
+		"stored-keys-configured": {
+			publicKeyStoragePath: caPublicKeyStoragePath,
+			publicKey:            testCAPublicKey,
+		},
+		"deprecated-path-keys-configured": {
+			publicKeyStoragePath: caPublicKeyStoragePathDeprecated,
+			publicKey:            testCAPublicKey,
+		},
+		"managed-key-configured": {
+			publicKeyStoragePath: caManagedKeyStoragePath,
+			publicKey:            testCAPublicKey,
+		},
+		"no-keys-configured": {},
+	}
+
+	for name, tt := range testCases {
+		t.Run(name, func(t *testing.T) {
+			storage := &logical.InmemStorage{}
+			err := writeKey(ctx, storage, tt.publicKeyStoragePath, tt.publicKey)
+			if err != nil {
+				t.Fatalf("error writing key: %s", err)
+			}
+
+			key, err := getCAPublicKey(ctx, storage)
+			if err != nil {
+				t.Fatalf("error retrieving public key: %s", err)
+			}
+
+			if key != tt.publicKey {
+				t.Fatalf("key values do not match: expected %s, got %s", tt.publicKey, key)
+			}
+		})
+	}
+}
+
+func TestCreateStoredKey(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		publicKey  string
+		privateKey string
+		expectErr  bool
+	}{
+		"both-keys-provided": {
+			publicKey:  testCAPublicKey,
+			privateKey: testCAPrivateKey,
+		},
+		"only-public-key": {
+			publicKey: testCAPublicKey,
+			expectErr: true,
+		},
+		"only-private-key": {
+			privateKey: testCAPrivateKey,
+			expectErr:  true,
+		},
+		"empty keys": {
+			expectErr: true,
+		},
+	}
+
+	for name, tt := range testCases {
+		t.Run(name, func(t *testing.T) {
+			storage := &logical.InmemStorage{}
+			err := createStoredKey(context.Background(), storage, tt.publicKey, tt.privateKey)
+			if err != nil && !tt.expectErr {
+				t.Fatalf("unexpected error: %s", err)
+			} else if err == nil && tt.expectErr {
+				t.Fatal("expected error, got nil")
+			}
+
+			if !tt.expectErr {
+				err = readKey(context.Background(), storage, caPublicKeyStoragePath)
+				if err != nil {
+					t.Fatalf("error reading public key: %s", err)
+				}
+
+				err = readKey(context.Background(), storage, caPrivateKeyStoragePath)
+				if err != nil {
+					t.Fatalf("error reading private key: %s", err)
+				}
+			}
+		})
+	}
+}
+
+func TestCAKeysConfigured(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		privateKeyStoragePath string
+		publicKeyStoragePath  string
+		publicKey             string
+		privateKey            string
+		expectedValue         bool
+	}{
+		"stored-keys-configured": {
+			privateKeyStoragePath: caPrivateKeyStoragePath,
+			publicKeyStoragePath:  caPublicKeyStoragePath,
+			publicKey:             testCAPublicKey,
+			privateKey:            testCAPrivateKey,
+			expectedValue:         true,
+		},
+		"deprecated-path-keys-configured": {
+			privateKeyStoragePath: caPrivateKeyStoragePathDeprecated,
+			publicKeyStoragePath:  caPublicKeyStoragePathDeprecated,
+			publicKey:             testCAPublicKey,
+			privateKey:            testCAPrivateKey,
+			expectedValue:         true,
+		},
+		"managed-key-configured": {
+			publicKeyStoragePath: caManagedKeyStoragePath,
+			publicKey:            testCAPublicKey,
+			expectedValue:        true,
+		},
+		"stored-keys-empty": {
+			privateKeyStoragePath: caPrivateKeyStoragePath,
+			publicKeyStoragePath:  caPublicKeyStoragePath,
+			expectedValue:         false,
+		},
+		"deprecated-path-stored-keys-empty": {
+			privateKeyStoragePath: caPrivateKeyStoragePathDeprecated,
+			publicKeyStoragePath:  caPublicKeyStoragePathDeprecated,
+			expectedValue:         false,
+		},
+		"no-storage-entry": {
+			expectedValue: false,
+		},
+	}
+
+	for name, tt := range testCases {
+		t.Run(name, func(t *testing.T) {
+			storage := &logical.InmemStorage{}
+
+			if err := writeKey(ctx, storage, tt.privateKeyStoragePath, tt.privateKey); err != nil {
+				t.Fatalf("error writing private key: %s", err)
+			}
+
+			if err := writeKey(ctx, storage, tt.publicKeyStoragePath, tt.publicKey); err != nil {
+				t.Fatalf("error writing public key: %s", err)
+			}
+
+			keysConfigured, err := caKeysConfigured(context.Background(), storage)
+			if err != nil {
+				t.Fatalf("error checking for configured keys: %s", err)
+			}
+
+			if tt.expectedValue != keysConfigured {
+				t.Fatalf("unexpected return value: expected %v, got %v", tt.expectedValue, keysConfigured)
+			}
+		})
+	}
+}
+
+func writeKey(ctx context.Context, s logical.Storage, path, key string) error {
+	if path == "" {
+		return nil
+	}
+
+	var entry *logical.StorageEntry
+	var err error
+	switch path {
+	case caPublicKeyStoragePathDeprecated, caPublicKeyStoragePath, caPrivateKeyStoragePathDeprecated, caPrivateKeyStoragePath:
+		entry, err = logical.StorageEntryJSON(path, &keyStorageEntry{Key: key})
+		if err != nil {
+			return err
+		}
+	case caManagedKeyStoragePath:
+		entry, err = logical.StorageEntryJSON(path, &managedKeyStorageEntry{
+			KeyId:     "test-key-id",
+			KeyName:   "test-key-name",
+			PublicKey: key,
+		})
+		if err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("unexpected storage path %s", path)
+	}
+
+	return s.Put(ctx, entry)
+}
+
+func readKey(ctx context.Context, s logical.Storage, path string) error {
+	switch path {
+	case caPublicKeyStoragePath, caPrivateKeyStoragePath:
+		var entry keyStorageEntry
+
+		storageEntry, err := s.Get(ctx, path)
+		if err != nil {
+			return fmt.Errorf("error reading public key from storage: %s", err)
+		}
+
+		err = storageEntry.DecodeJSON(&entry)
+		if err != nil {
+			return fmt.Errorf("error decoding storage entry: %s", err)
+		}
+
+		if entry.Key == "" {
+			return errors.New("stored key was empty")
+		}
+	case caManagedKeyStoragePath:
+		var entry managedKeyStorageEntry
+
+		storageEntry, err := s.Get(ctx, path)
+		if err != nil {
+			return fmt.Errorf("error reading managed key from storage: %s", err)
+		}
+
+		err = storageEntry.DecodeJSON(&entry)
+		if err != nil {
+			return fmt.Errorf("error decoding storage entry: %s", err)
+		}
+
+		if entry.KeyId == "" || entry.KeyName == "" || entry.PublicKey == "" {
+			return errors.New("managed key storage fields were empty")
+		}
+	default:
+		return fmt.Errorf("unexpected storage path %s", path)
+	}
+
+	return nil
 }

--- a/builtin/logical/ssh/path_config_ca_test.go
+++ b/builtin/logical/ssh/path_config_ca_test.go
@@ -483,11 +483,6 @@ func TestCAKeysConfigured(t *testing.T) {
 			publicKeyStoragePath:  caPublicKeyStoragePath,
 			expectedValue:         false,
 		},
-		"deprecated-path-stored-keys-empty": {
-			privateKeyStoragePath: caPrivateKeyStoragePathDeprecated,
-			publicKeyStoragePath:  caPublicKeyStoragePathDeprecated,
-			expectedValue:         false,
-		},
 		"no-storage-entry": {
 			expectedValue: false,
 		},
@@ -525,8 +520,13 @@ func writeKey(ctx context.Context, s logical.Storage, path, key string) error {
 	var entry *logical.StorageEntry
 	var err error
 	switch path {
-	case caPublicKeyStoragePathDeprecated, caPublicKeyStoragePath, caPrivateKeyStoragePathDeprecated, caPrivateKeyStoragePath:
+	case caPublicKeyStoragePath, caPrivateKeyStoragePath:
 		entry, err = logical.StorageEntryJSON(path, &keyStorageEntry{Key: key})
+		if err != nil {
+			return err
+		}
+	case caPublicKeyStoragePathDeprecated, caPrivateKeyStoragePathDeprecated:
+		entry, err = logical.StorageEntryJSON(path, []byte(key))
 		if err != nil {
 			return err
 		}

--- a/builtin/logical/ssh/path_config_ca_test.go
+++ b/builtin/logical/ssh/path_config_ca_test.go
@@ -326,12 +326,6 @@ func TestReadStoredKey(t *testing.T) {
 			publicKey:             testCAPublicKey,
 			privateKey:            testCAPrivateKey,
 		},
-		"deprecated-path-keys-configured": {
-			privateKeyStoragePath: caPrivateKeyStoragePathDeprecated,
-			publicKeyStoragePath:  caPublicKeyStoragePathDeprecated,
-			publicKey:             testCAPublicKey,
-			privateKey:            testCAPrivateKey,
-		},
 	}
 
 	for name, tt := range testCases {
@@ -376,10 +370,6 @@ func TestGetCAPublicKey(t *testing.T) {
 	}{
 		"stored-keys-configured": {
 			publicKeyStoragePath: caPublicKeyStoragePath,
-			publicKey:            testCAPublicKey,
-		},
-		"deprecated-path-keys-configured": {
-			publicKeyStoragePath: caPublicKeyStoragePathDeprecated,
 			publicKey:            testCAPublicKey,
 		},
 		"managed-key-configured": {

--- a/builtin/logical/ssh/path_fetch.go
+++ b/builtin/logical/ssh/path_fetch.go
@@ -29,18 +29,18 @@ func pathFetchPublicKey(b *backend) *framework.Path {
 }
 
 func (b *backend) pathFetchPublicKey(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
-	publicKeyEntry, err := caKey(ctx, req.Storage, caPublicKey)
+	publicKey, err := getCAPublicKey(ctx, req.Storage)
 	if err != nil {
 		return nil, err
 	}
-	if publicKeyEntry == nil || publicKeyEntry.Key == "" {
+	if publicKey == "" {
 		return nil, nil
 	}
 
 	response := &logical.Response{
 		Data: map[string]interface{}{
 			logical.HTTPContentType: "text/plain",
-			logical.HTTPRawBody:     []byte(publicKeyEntry.Key),
+			logical.HTTPRawBody:     []byte(publicKey),
 			logical.HTTPStatusCode:  200,
 		},
 	}

--- a/builtin/logical/ssh/path_issue_sign.go
+++ b/builtin/logical/ssh/path_issue_sign.go
@@ -101,7 +101,7 @@ func (b *backend) pathSignIssueCertificateHelper(ctx context.Context, req *logic
 		return logical.ErrorResponse(err.Error()), nil
 	}
 
-	privateKeyEntry, err := caKey(ctx, req.Storage, caPrivateKey)
+	privateKeyEntry, err := readStoredKey(ctx, req.Storage, caPrivateKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read CA private key: %w", err)
 	}

--- a/builtin/logical/ssh/path_roles.go
+++ b/builtin/logical/ssh/path_roles.go
@@ -594,17 +594,17 @@ func (b *backend) checkUpgrade(ctx context.Context, s logical.Storage, n string,
 		// signing key type as we want to make ssh-rsa an explicitly notated
 		// algorithm choice.
 		var publicKey ssh.PublicKey
-		publicKeyEntry, err := caKey(ctx, s, caPublicKey)
+		publicKeyStr, err := getCAPublicKey(ctx, s)
 		if err != nil {
 			b.Logger().Debug(fmt.Sprintf("failed to load public key entry while attempting to migrate: %v", err))
 			goto SKIPVERSION2
 		}
-		if publicKeyEntry == nil || publicKeyEntry.Key == "" {
+		if publicKeyStr == "" {
 			b.Logger().Debug(fmt.Sprintf("got empty public key entry while attempting to migrate"))
 			goto SKIPVERSION2
 		}
 
-		publicKey, err = parsePublicSSHKey(publicKeyEntry.Key)
+		publicKey, err = parsePublicSSHKey(publicKeyStr)
 		if err == nil {
 			// Move an empty signing algorithm to an explicit ssh-rsa (SHA-1)
 			// if this key is of type RSA. This isn't a secure default but


### PR DESCRIPTION
### Description
Refactors SSH CA code to support managed keys.

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
