### PR TITLE
Update vault-plugin-secrets-openldap to v0.15.3

### DIFF
--- a/changelog/30265.txt
+++ b/changelog/30265.txt
@@ -1,0 +1,3 @@
+```release-note:change
+secrets/ldap: Update vault-plugin-secrets-openldap to v0.15.3
+```

--- a/changelog/30265.txt
+++ b/changelog/30265.txt
@@ -1,3 +1,5 @@
-```release-note:change
-secrets/ldap: Update vault-plugin-secrets-openldap to v0.15.3
+```release-note:bug
+secrets/openldap: Prevent static role rotation on upgrade when `NextVaultRotation` is nil.
+Fixes an issue where static roles were unexpectedly rotated after upgrade due to a missing `NextVaultRotation` value. 
+Now sets it to either `LastVaultRotation + RotationPeriod` or `now + RotationPeriod`.
 ```

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ module github.com/hashicorp/vault
 // semantic related to Go module handling), this comment should be updated to explain that.
 //
 // Whenever this value gets updated, sdk/go.mod should be updated to the same value.
-go 1.23.6
+go 1.23.8
 
 replace github.com/hashicorp/vault/api => ./api
 
@@ -159,7 +159,7 @@ require (
 	github.com/hashicorp/vault-plugin-secrets-kubernetes v0.10.0
 	github.com/hashicorp/vault-plugin-secrets-kv v0.21.0
 	github.com/hashicorp/vault-plugin-secrets-mongodbatlas v0.14.0
-	github.com/hashicorp/vault-plugin-secrets-openldap v0.15.2
+	github.com/hashicorp/vault-plugin-secrets-openldap v0.15.3
 	github.com/hashicorp/vault-plugin-secrets-terraform v0.11.0
 	github.com/hashicorp/vault-testing-stepwise v0.3.2
 	github.com/hashicorp/vault/api v1.16.0

--- a/go.sum
+++ b/go.sum
@@ -1607,8 +1607,8 @@ github.com/hashicorp/vault-plugin-secrets-kv v0.21.0 h1:P8WPzAkttLnhZyhTmY15bKlG
 github.com/hashicorp/vault-plugin-secrets-kv v0.21.0/go.mod h1:CY63j85kYvO+GjDvMmZlhyJixoQhEf+SenY/OwNSrpI=
 github.com/hashicorp/vault-plugin-secrets-mongodbatlas v0.14.0 h1:N7zUrgQqvDVUsOZW4x49Cbx6WcjEU5Qwe8hrr4lYvV8=
 github.com/hashicorp/vault-plugin-secrets-mongodbatlas v0.14.0/go.mod h1:nRcr6W9rb3vDMLDGb/ZovsFhrEM8Q1WLNUKDGRaDplM=
-github.com/hashicorp/vault-plugin-secrets-openldap v0.15.2 h1:TJWLlTManbIA1AVVgj+3PTwmsYd2ppf2O4qATrdRc+o=
-github.com/hashicorp/vault-plugin-secrets-openldap v0.15.2/go.mod h1:tJDZLDAk4Y0po8t6OvBf/mwFMScWzhXYiVPH666CAks=
+github.com/hashicorp/vault-plugin-secrets-openldap v0.15.3 h1:2rcCLUoH3bAlr2eneqBQga1BV86LVPTjENcixvaoSAg=
+github.com/hashicorp/vault-plugin-secrets-openldap v0.15.3/go.mod h1:C9YSL/GtIDo0HWfv1HMa+5jiGbJ3ap6ZfDIaBbYtfSo=
 github.com/hashicorp/vault-plugin-secrets-terraform v0.11.0 h1:dIOJ7VKyYU8o9xH1DuD61Fsfl6uSPHy6OrYdEjp4Ku0=
 github.com/hashicorp/vault-plugin-secrets-terraform v0.11.0/go.mod h1:6FNbBAQvISpPqLXdvhV8MvxXKWG9iS+D+spzIGU2WuI=
 github.com/hashicorp/vault-testing-stepwise v0.3.2 h1:FCe0yrbK/hHiHqzu7utLcvCTTKjghWHyXwOQ2lxfoQM=


### PR DESCRIPTION
### Description
Uppdate vault-plugin-secrets-openldap to v0.15.3 

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
