### PR TITLE
Vault 34678-Removing estimates from counters api: Handle billing start date updates CE

### DIFF
--- a/command/server.go
+++ b/command/server.go
@@ -1692,7 +1692,7 @@ func (c *ServerCommand) Run(args []string) int {
 				sr.NotifyConfigurationReload(srConfig)
 			}
 
-			if err := core.ReloadCensusManager(false); err != nil {
+			if err := core.ReloadCensusManager(ctx, false); err != nil {
 				c.UI.Error(err.Error())
 			}
 

--- a/vault/activity_log_util_common.go
+++ b/vault/activity_log_util_common.go
@@ -559,19 +559,19 @@ func (a *ActivityLog) namespaceRecordToCountsResponse(record *activity.Namespace
 }
 
 func (a *ActivityLog) GetClientIDsUsageInfo() map[string]struct{} {
-	a.clientIDsUsageInfoLock.Lock()
-	defer a.clientIDsUsageInfoLock.Unlock()
-	return a.clientIDsUsageInfo
+	a.clientIDsUsage.clientIDsUsageInfoLock.Lock()
+	defer a.clientIDsUsage.clientIDsUsageInfoLock.Unlock()
+	return a.clientIDsUsage.clientIDsUsageInfo
 }
 
 func (a *ActivityLog) SetClientIDsUsageInfo(inMemClientIDsMap map[string]struct{}) {
-	a.clientIDsUsageInfoLock.Lock()
-	defer a.clientIDsUsageInfoLock.Unlock()
+	a.clientIDsUsage.clientIDsUsageInfoLock.Lock()
+	defer a.clientIDsUsage.clientIDsUsageInfoLock.Unlock()
 
-	a.clientIDsUsageInfo = inMemClientIDsMap
+	a.clientIDsUsage.clientIDsUsageInfo = inMemClientIDsMap
 }
 
 // GetclientIDsUsageInfoLoaded gets a.clientIDsUsageInfoLoaded for external tests
 func (a *ActivityLog) GetClientIDsUsageInfoLoaded() bool {
-	return a.clientIDsUsageInfoLoaded.Load()
+	return a.clientIDsUsage.clientIDsUsageInfoLoaded.Load()
 }

--- a/vault/census.go
+++ b/vault/census.go
@@ -15,17 +15,17 @@ const utilizationBasePath = "utilization"
 // CensusAgent is a stub for OSS
 type CensusReporter interface{}
 
-func (c *Core) BillingStart() time.Time                          { return time.Time{} }
-func (c *Core) AutomatedLicenseReportingEnabled() bool           { return false }
-func (c *Core) CensusAgent() CensusReporter                      { return nil }
-func (c *Core) teardownCensusManager() error                     { return nil }
-func (c *Core) StartManualCensusSnapshots()                      {}
-func (c *Core) ManualLicenseReportingEnabled() bool              { return false }
-func (c *Core) ManualCensusSnapshotInterval() time.Duration      { return time.Duration(0) }
-func (c *Core) ManualCensusSnapshotRetentionTime() time.Duration { return time.Duration(0) }
-func (c *Core) StartCensusReports(ctx context.Context)           {}
-func (c *Core) SetRetentionMonths(months int) error              { return nil }
-func (c *Core) ReloadCensusManager(licenseChange bool) error     { return nil }
+func (c *Core) BillingStart() time.Time                                           { return time.Time{} }
+func (c *Core) AutomatedLicenseReportingEnabled() bool                            { return false }
+func (c *Core) CensusAgent() CensusReporter                                       { return nil }
+func (c *Core) teardownCensusManager() error                                      { return nil }
+func (c *Core) StartManualCensusSnapshots()                                       {}
+func (c *Core) ManualLicenseReportingEnabled() bool                               { return false }
+func (c *Core) ManualCensusSnapshotInterval() time.Duration                       { return time.Duration(0) }
+func (c *Core) ManualCensusSnapshotRetentionTime() time.Duration                  { return time.Duration(0) }
+func (c *Core) StartCensusReports(ctx context.Context)                            {}
+func (c *Core) SetRetentionMonths(months int) error                               { return nil }
+func (c *Core) ReloadCensusManager(ctx context.Context, licenseChange bool) error { return nil }
 func (c *Core) parseCensusManagerConfig(conf *CoreConfig) (CensusManagerConfig, error) {
 	return CensusManagerConfig{}, nil
 }


### PR DESCRIPTION
### Description
What does this PR do?
Jira: https://hashicorp.atlassian.net/browse/VAULT-34678
Handles cases where billing start date is reset on license change and config updates

- When billing start date is updated, the clientIDs map in memory is reset
- If the billing start date is before the current date, all the existingsclients until the last month are reloaded into memory 
- If it is the current or future date, the clientIDs map in memory is empty

Added test cases that covers the above scenarios.
ReloadCensusManager reuses the `setupClientIDsUsageInfo`to setup clients upon reload

Approved ent: https://github.com/hashicorp/vault-enterprise/pull/7807

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
