### PR TITLE
docs only: add pipeline targets to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,12 @@ ifneq ($(FDB_ENABLED), )
 	BUILD_TAGS+=foundationdb
 endif
 
+# Set BUILD_MINIMAL to a non-empty value to build a minimal version of Vault with only core features.
+BUILD_MINIMAL ?=
+ifneq ($(strip $(BUILD_MINIMAL)),)
+	BUILD_TAGS+=minimal
+endif
+
 default: dev
 
 # bin generates the releasable binaries for Vault
@@ -216,7 +222,7 @@ proto: check-tools-external
 
 	# No additional sed expressions should be added to this list. Going forward
 	# we should just use the variable names choosen by protobuf. These are left
-	# here for backwards compatability, namely for SDK compilation.
+	# here for backwards compatibility, namely for SDK compilation.
 	$(SED) -i -e 's/Id/ID/' -e 's/SPDX-License-IDentifier/SPDX-License-Identifier/' vault/request_forwarding_service.pb.go
 	$(SED) -i -e 's/Idp/IDP/' -e 's/Url/URL/' -e 's/Id/ID/' -e 's/IDentity/Identity/' -e 's/EntityId/EntityID/' -e 's/Api/API/' -e 's/Qr/QR/' -e 's/Totp/TOTP/' -e 's/Mfa/MFA/' -e 's/Pingid/PingID/' -e 's/namespaceId/namespaceID/' -e 's/Ttl/TTL/' -e 's/BoundCidrs/BoundCIDRs/' -e 's/SPDX-License-IDentifier/SPDX-License-Identifier/' helper/identity/types.pb.go helper/identity/mfa/types.pb.go helper/storagepacker/types.pb.go sdk/plugin/pb/backend.pb.go sdk/logical/identity.pb.go vault/activity/activity_log.pb.go
 
@@ -291,6 +297,10 @@ check-tools-external:
 check-tools-internal:
 	@$(CURDIR)/tools/tools.sh check-internal
 
+.PHONY: check-tools-pipeline
+check-tools-pipeline:
+	@$(CURDIR)/tools/tools.sh check-pipeline
+
 check-vault-in-path:
 	@VAULT_BIN=$$(command -v vault) || { echo "vault command not found"; exit 1; }; \
 		[ -x "$$VAULT_BIN" ] || { echo "$$VAULT_BIN not executable"; exit 1; }; \
@@ -307,6 +317,10 @@ tools-external:
 .PHONY: tools-internal
 tools-internal:
 	@$(CURDIR)/tools/tools.sh install-internal
+
+.PHONY: tools-pipeline
+tools-pipeline:
+	@$(CURDIR)/tools/tools.sh install-pipeline
 
 mysql-database-plugin:
 	@CGO_ENABLED=0 $(GO_CMD) build -o bin/mysql-database-plugin ./plugins/database/mysql/mysql-database-plugin
@@ -362,10 +376,6 @@ ci-get-revision:
 ci-get-version-package:
 	@$(CURDIR)/scripts/ci-helper.sh version-package
 
-.PHONY: ci-install-external-tools
-ci-install-external-tools:
-	@$(CURDIR)/scripts/ci-helper.sh install-external-tools
-
 .PHONY: ci-prepare-ent-legal
 ci-prepare-ent-legal:
 	@$(CURDIR)/scripts/ci-helper.sh prepare-ent-legal
@@ -373,10 +383,6 @@ ci-prepare-ent-legal:
 .PHONY: ci-prepare-ce-legal
 ci-prepare-ce-legal:
 	@$(CURDIR)/scripts/ci-helper.sh prepare-ce-legal
-
-.PHONY: ci-update-external-tool-modules
-ci-update-external-tool-modules:
-	@$(CURDIR)/scripts/ci-helper.sh update-external-tool-modules
 
 .PHONY: ci-copywriteheaders
 ci-copywriteheaders:

--- a/tools/tools.sh
+++ b/tools/tools.sh
@@ -97,9 +97,9 @@ install_internal() {
   )
 
   echo "==> Installing internal tools..."
-  pushd "$(repo_root)" &> /dev/null
+  pushd "$(repo_root)/tools" &> /dev/null
   for tool in "${tools[@]}"; do
-    go_install ./tools/"$tool"
+    go_install ./"$tool"
   done
   popd &> /dev/null
 }
@@ -117,6 +117,27 @@ check_internal() {
   for tool in "${tools[@]}"; do
     check_tool internal "$tool"
   done
+}
+
+# Install our pipeline tools. In some cases these may require access to internal repositories so
+# they are excluded from our baseline toolset.
+install_pipeline() {
+  echo "==> Installing pipeline tools..."
+  pushd "$(repo_root)/tools/pipeline" &> /dev/null
+  if env GOPRIVATE=github.com/hashicorp go install ./...; then
+    echo "--> pipeline ✔"
+  else
+    echo "--> pipeline ✖"
+    popd &> /dev/null
+    return 1
+  fi
+  popd &> /dev/null
+}
+
+# Check that all required pipeline tools are installed
+check_pipeline() {
+  echo "==> Checking for pipeline tools..."
+  check_tool pipeline pipeline
 }
 
 # Install tools.
@@ -139,11 +160,17 @@ main() {
   install-internal)
     install_internal
   ;;
+  install-pipeline)
+    install_pipeline
+  ;;
   check-external)
     check_external
   ;;
   check-internal)
     check_internal
+  ;;
+  check-pipeline)
+    check_pipeline
   ;;
   install)
     install


### PR DESCRIPTION
### Description
Sync the `Makefile` and `tools/tools.sh` to support installing the `pipeline` tool in CI, which is required for the docs checks.

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
