### PR TITLE
[UI] Capabilities Service Path Bug

### DIFF
--- a/ui/app/services/capabilities.ts
+++ b/ui/app/services/capabilities.ts
@@ -48,23 +48,24 @@ export default class CapabilitiesService extends Service {
   Prepending "relativeNamespace" to the path while making the request to the "userRootNamespace"
   ensures we are querying capabilities-self where the user is most likely to have their policy/permissions.
   */
-  relativeNamespacePaths(paths: string[]) {
+  relativeNamespacePath(path: string) {
     const { relativeNamespace } = this.namespace;
     // sanitizeStart ensures original path doesn't have leading slash
-    return paths.map((path) => (relativeNamespace ? `${relativeNamespace}/${sanitizeStart(path)}` : path));
+    return relativeNamespace ? `${relativeNamespace}/${sanitizeStart(path)}` : path;
   }
 
   // map capabilities to friendly names like canRead, canUpdate, etc.
-  mapCapabilities(relativeNamespacePaths: string[], capabilitiesData: CapabilitiesData) {
+  mapCapabilities(paths: string[], capabilitiesData: CapabilitiesData) {
     const { SUDO_PATHS, SUDO_PATH_PREFIXES } = this;
-    const { relativeNamespace } = this.namespace;
     // request may not return capabilities for all provided paths
     // loop provided paths and map capabilities, defaulting to true for missing paths
-    return relativeNamespacePaths.reduce((mappedCapabilities: MultipleCapabilities, path) => {
-      const capabilities = capabilitiesData[path];
+    return paths.reduce((mappedCapabilities: MultipleCapabilities, path) => {
+      // key in capabilitiesData includes relativeNamespace if applicable
+      const key = this.relativeNamespacePath(path);
+      const capabilities = capabilitiesData[key];
 
       const getCapability = (capability: CapabilityTypes) => {
-        if (!(path in capabilitiesData)) {
+        if (!(key in capabilitiesData)) {
           return true;
         }
         if (!capabilities?.length || capabilities.includes('deny')) {
@@ -74,14 +75,13 @@ export default class CapabilitiesService extends Service {
           return true;
         }
         // if the path is sudo protected, they'll need sudo + the appropriate capability
-        if (SUDO_PATHS.includes(path) || SUDO_PATH_PREFIXES.find((item) => path.startsWith(item))) {
+        if (SUDO_PATHS.includes(key) || SUDO_PATH_PREFIXES.find((item) => key.startsWith(item))) {
           return capabilities.includes('sudo') && capabilities.includes(capability);
         }
         return capabilities.includes(capability);
       };
       // remove relativeNamespace from the path that was added for the request
-      const key = path.replace(relativeNamespace, '');
-      mappedCapabilities[key] = {
+      mappedCapabilities[path] = {
         canCreate: getCapability('create'),
         canDelete: getCapability('delete'),
         canList: getCapability('list'),
@@ -96,13 +96,13 @@ export default class CapabilitiesService extends Service {
 
   async fetch(paths: string[]): Promise<MultipleCapabilities> {
     const payload = {
-      paths: this.relativeNamespacePaths(paths),
+      paths: paths.map((path) => this.relativeNamespacePath(path)),
       namespace: sanitizePath(this.namespace.userRootNamespace),
     };
 
     try {
       const { data } = await this.api.sys.queryTokenSelfCapabilities(payload);
-      return this.mapCapabilities(payload.paths, data as CapabilitiesData);
+      return this.mapCapabilities(paths, data as CapabilitiesData);
     } catch (e) {
       // default to true if there is a problem fetching the model
       // we can rely on the API to gate as a fallback


### PR DESCRIPTION
### Description
This PR fixes an issue in the capabilities service where the data object keys returned did not match the provided paths. The `relativeNamespace` was being stripped from the response key which resulted in the provided path always having a leading slash. The issue was that the path can be provided without a leading slash so this was causing a mismatch and capabilities could not be accessed via the originally provided path.

_This was originally discovered from an enterprise test failure. The full test suite passed locally with these changes._

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
