### PR TITLE
Update CODEOWNERS to require a crypto review for Go updates

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -67,6 +67,10 @@
 /enos/     @hashicorp/quality-team
 
 # Cryptosec
+# Temporarily require the crypto team to approve Go updates as we need to make sure
+# 1.24 doesn't make it onto release branches until the FIPS paperwork has been completed.
+/.go-version                                         @hashicorp/vault-crypto
+
 /api/auth/cert/                                      @hashicorp/vault-crypto
 /builtin/logical/pki/                                @hashicorp/vault-crypto
 /builtin/logical/pkiext/                             @hashicorp/vault-crypto


### PR DESCRIPTION
### Description

Update the `CODEOWNERS` to require the crypto team to sign off on Go updates until all the FIPS paperwork has been completed. We will be updating `main` to 1.24, but the release branches can't get it yet and this seemed to be the easiest way to enforce this for now. 

Once the FIPS paperwork has been completed we will rollback this restriction.

### TODO only if you're a HashiCorp employee
- [X] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
