### PR TITLE
VAULT-34834: pipeline: add better heuristics for changed files

### DIFF
--- a/.github/actions/metadata/action.yml
+++ b/.github/actions/metadata/action.yml
@@ -11,6 +11,8 @@ description: |
   to maintain compatibility in both execution contexts.
 
 inputs:
+  github-token:
+    description: An elevated Github token to use for searching labels
   vault-version:
     description: |
       The version of vault from hashicorp/action-set-product-version. If set we'll utilize this
@@ -97,7 +99,7 @@ runs:
       name: workflow-metadata
       shell: bash
       env:
-        GH_TOKEN: ${{ github.token }}
+        GH_TOKEN: ${{ inputs.github-token || github.token }}
       run: |
         if [ '${{ github.event_name }}' = 'pull_request' ]; then
           is_draft='${{ github.event.pull_request.draft }}'

--- a/.github/actions/set-up-go/action.yml
+++ b/.github/actions/set-up-go/action.yml
@@ -11,6 +11,9 @@ inputs:
   no-restore:
     description: Whether or not to restore the Go module cache on a cache hit
     default: "false"
+  no-save:
+    description: Whether or not to create a Go module cache on cache miss
+    default: "false"
   go-version:
     description: "Override .go-version"
     default: ""
@@ -68,7 +71,7 @@ runs:
         # keeps cache upload time, download time, and storage size to a minimum.
         path: ${{ steps.metadata.outputs.cache-path }}
         key: ${{ steps.metadata.outputs.cache-key }}
-    - if: steps.cache-modules.outputs.cache-hit != 'true'
+    - if: steps.cache-modules.outputs.cache-hit != 'true' && inputs.no-save != 'false'
       name: Download go modules
       shell: bash
       env:

--- a/.github/actions/set-up-pipeline/action.yml
+++ b/.github/actions/set-up-pipeline/action.yml
@@ -16,6 +16,7 @@ runs:
       with:
         github-token: ${{ inputs.github-token || github.token }}
         no-restore: true # Don't download vault's modules for pipeline
+        no-save: true # Don't attempt to save modules either
     - name: pipeline-metadata
       id: pipeline-metadata
       shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -229,7 +229,12 @@ jobs:
     with:
       # The inputs defined here must be supported in both the build-artifacts-ce and
       # build-artifacts-ent workflows. The implementations should seek to keep a compatible interface.
-      build-all: ${{ contains(fromJSON(needs.setup.outputs.labels), 'build/all') || needs.setup.outputs.workflow-trigger == 'schedule' || contains(fromJSON(needs.setup.outputs.changed-files).groups, 'gomod') }}
+      build-all: |
+        ${{
+          contains(fromJSON(needs.setup.outputs.labels), 'build/all') ||
+          needs.setup.outputs.workflow-trigger == 'schedule' ||
+          contains(fromJSON(needs.setup.outputs.changed-files).groups, 'gotoolchain')
+        }}
       build-date: ${{ needs.setup.outputs.build-date }}
       checkout-ref: ${{ needs.setup.outputs.checkout-ref }}
       compute-build: ${{ needs.setup.outputs.compute-build }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -229,12 +229,7 @@ jobs:
     with:
       # The inputs defined here must be supported in both the build-artifacts-ce and
       # build-artifacts-ent workflows. The implementations should seek to keep a compatible interface.
-      build-all: |
-        ${{
-          contains(fromJSON(needs.setup.outputs.labels), 'build/all') ||
-          needs.setup.outputs.workflow-trigger == 'schedule' ||
-          contains(fromJSON(needs.setup.outputs.changed-files).groups, 'gotoolchain')
-        }}
+      build-all: ${{contains(fromJSON(needs.setup.outputs.labels), 'build/all') || needs.setup.outputs.workflow-trigger == 'schedule' || contains(fromJSON(needs.setup.outputs.changed-files).groups, 'gotoolchain')}}
       build-date: ${{ needs.setup.outputs.build-date }}
       checkout-ref: ${{ needs.setup.outputs.checkout-ref }}
       compute-build: ${{ needs.setup.outputs.compute-build }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,6 +142,7 @@ jobs:
     # Run Go tests if the vault app changed
     if: |
       contains(fromJSON(needs.setup.outputs.changed-files).groups, 'app') ||
+      contains(fromJSON(needs.setup.outputs.changed-files).groups, 'gotoolchain') ||
       contains(fromJSON(needs.setup.outputs.changed-files).groups, 'pipeline')
     name: Run Go tests
     needs: setup
@@ -162,7 +163,9 @@ jobs:
 
   test-go-testonly:
     # Run Go tests tagged with "testonly" if the vault app changed
-    if: contains(fromJSON(needs.setup.outputs.changed-files).groups, 'app')
+    if: |
+      contains(fromJSON(needs.setup.outputs.changed-files).groups, 'app') ||
+      contains(fromJSON(needs.setup.outputs.changed-files).groups, 'gotoolchain')
     name: Run Go tests tagged with testonly
     needs: setup
     uses: ./.github/workflows/test-go.yml
@@ -181,7 +184,12 @@ jobs:
   test-go-race:
     # Run Go test with the data race detector enabled if the vault app changed and we're out of
     # drafts mode.
-    if: contains(fromJSON(needs.setup.outputs.changed-files).groups, 'app') && needs.setup.outputs.is-draft == 'false'
+    if: |
+      needs.setup.outputs.is-draft == 'false' &&
+        (
+          contains(fromJSON(needs.setup.outputs.changed-files).groups, 'app') ||
+          contains(fromJSON(needs.setup.outputs.changed-files).groups, 'gotoolchain')
+        )
     name: Run Go tests with data race detection
     needs: setup
     uses: ./.github/workflows/test-go.yml
@@ -208,7 +216,9 @@ jobs:
     if: |
       contains(fromJSON(needs.setup.outputs.changed-files).groups, 'app') &&
       needs.setup.outputs.is-enterprise == 'true' &&
-      (needs.setup.outputs.workflow-trigger == 'push' || contains(needs.setup.outputs.labels, 'fips'))
+        (
+          needs.setup.outputs.workflow-trigger == 'push' || contains(needs.setup.outputs.labels, 'fips')
+        )
     needs: setup
     uses: ./.github/workflows/test-go.yml
     with:

--- a/tools/pipeline/internal/pkg/changed/checkers.go
+++ b/tools/pipeline/internal/pkg/changed/checkers.go
@@ -41,7 +41,7 @@ func Group(ctx context.Context, file *File, checkers ...FileGroupCheck) {
 	}
 }
 
-// Group takes a context, a slice of files, and one-to-many file group checkers and adds group
+// GroupFiles takes a context, a slice of files, and one-to-many file group checkers and adds group
 // metadata to the files.
 func GroupFiles(ctx context.Context, files []*File, checkers ...FileGroupCheck) {
 	for _, file := range files {

--- a/tools/pipeline/internal/pkg/changed/checkers.go
+++ b/tools/pipeline/internal/pkg/changed/checkers.go
@@ -16,88 +16,253 @@ type FileGroupCheck func(context.Context, *File) FileGroups
 
 // DefaultFileGroupCheckers are the default file group checkers
 var DefaultFileGroupCheckers = []FileGroupCheck{
-	FileGroupCheckerDir,
-	FileGroupCheckerFileName,
-	FileGroupCheckerFileGo,
-	FileGroupCheckerFileProto,
+	FileGroupCheckerApp,
+	FileGroupCheckerAutopilot,
+	FileGroupCheckerChangelog,
+	FileGroupCheckerCommunity,
+	FileGroupCheckerDocs,
+	FileGroupCheckerEnos,
+	FileGroupCheckerEnterprise,
+	FileGroupCheckerGoToolchain,
+	FileGroupCheckerPipeline,
+	FileGroupCheckerProto,
+	FileGroupCheckerWebUI,
 }
 
-// FileGroupCheckerDir is a file group checker that groups based on the files directory
-func FileGroupCheckerDir(ctx context.Context, file *File) FileGroups {
-	name := file.Name()
-	groups := FileGroups{}
+// Group takes a context, a file, and one-to-many file group checkers and adds group metadata to
+// the file.
+func Group(ctx context.Context, file *File, checkers ...FileGroupCheck) {
+	if file == nil || len(checkers) < 1 {
+		return
+	}
 
-	for dir, groups := range map[string]FileGroups{
-		".github":   groups.Add(FileGroupPipeline),
-		"changelog": groups.Add(FileGroupChangelog),
-		"enos":      groups.Add(FileGroupEnos),
-		"tools":     groups.Add(FileGroupTools),
-		"ui":        groups.Add(FileGroupWebUI),
-		"website":   groups.Add(FileGroupDocs),
-	} {
-		if strings.HasPrefix(name, dir+string(os.PathSeparator)) {
-			return groups
+	for _, check := range checkers {
+		file.Groups = file.Groups.Add(check(ctx, file)...)
+	}
+}
+
+// Group takes a context, a slice of files, and one-to-many file group checkers and adds group
+// metadata to the files.
+func GroupFiles(ctx context.Context, files []*File, checkers ...FileGroupCheck) {
+	for _, file := range files {
+		Group(ctx, file, checkers...)
+	}
+}
+
+// FileGroupCheckerApp is a file group checker that groups based on the file being part of the Vault
+// Go app
+func FileGroupCheckerApp(ctx context.Context, file *File) FileGroups {
+	name := file.Name()
+	ext := filepath.Ext(name)
+
+	switch {
+	case hasBaseDir(name, filepath.Join("tools", "pipeline")):
+		return nil
+	case
+		ext == ".go",
+		strings.HasSuffix(name, "go.mod"),
+		strings.HasSuffix(name, "go.sum"):
+		return FileGroups{FileGroupGoApp}
+	default:
+		return nil
+	}
+}
+
+// FileGroupCheckerAutopilot is a file group checker that groups based on the file being part of the
+// raft autopilot system
+func FileGroupCheckerAutopilot(ctx context.Context, file *File) FileGroups {
+	name := file.Name()
+	ext := filepath.Ext(name)
+
+	if ext == ".go" && strings.Contains(name, "raft_autopilot") {
+		return FileGroups{FileGroupAutopilot}
+	}
+
+	return nil
+}
+
+// FileGroupCheckerChangelog is a file group checker that groups based on the file being part of the
+// CHANGELOG
+func FileGroupCheckerChangelog(ctx context.Context, file *File) FileGroups {
+	name := file.Name()
+	if strings.HasPrefix(name, "CHANGELOG") || hasBaseDir(name, "changelog") {
+		return FileGroups{FileGroupChangelog}
+	}
+
+	return nil
+}
+
+// FileGroupCheckerCommunity is a file group checker that groups based on the file being part of the
+// Vault App but a community only file.
+func FileGroupCheckerCommunity(ctx context.Context, file *File) FileGroups {
+	name := file.Name()
+
+	switch filepath.Ext(name) {
+	case ".go":
+		if strings.HasSuffix(name, "_oss.go") || strings.HasSuffix(name, "_ce.go") {
+			return FileGroups{FileGroupCommunity}
+		}
+	case
+		".hcl",
+		".md",
+		".sh",
+		".yaml",
+		".yml":
+		switch {
+		case
+			strings.Contains(name, "-ce"),
+			strings.Contains(name, "_ce"),
+			strings.Contains(name, "-oss"),
+			strings.Contains(name, "_oss"):
+			return FileGroups{FileGroupCommunity}
 		}
 	}
 
 	return nil
 }
 
-// FileGroupCheckerFileName is a file group checker that groups based on the files name
-func FileGroupCheckerFileName(ctx context.Context, file *File) FileGroups {
+// FileGroupCheckerDocs is a file group checker that groups based on the file being part of the
+// documenation.
+func FileGroupCheckerDocs(ctx context.Context, file *File) FileGroups {
 	name := file.Name()
-	groups := FileGroups{}
 
-	switch {
-	case strings.HasPrefix(name, "buf."):
-		return groups.Add(FileGroupProto)
-	case strings.HasPrefix(name, "CHANGELOG"):
-		return groups.Add(FileGroupChangelog)
-	case strings.HasPrefix(name, "CODEOWNERS"):
-		return groups.Add(FileGroupPipeline)
-	case strings.HasSuffix(name, "go.mod") || strings.HasSuffix(name, "go.sum"):
-		return groups.Add(FileGroupGoModules, FileGroupGoApp)
+	if strings.HasPrefix(name, "README.md") || hasBaseDir(name, "website") {
+		return FileGroups{FileGroupDocs}
 	}
 
 	return nil
 }
 
-// FileGroupCheckerFileGo is a file group checker that groups based on the files extension being .go
-func FileGroupCheckerFileGo(ctx context.Context, file *File) FileGroups {
+// FileGroupCheckerEnos is a file group checker that groups based on the file being part of the
+// enos testing framework.
+func FileGroupCheckerEnos(ctx context.Context, file *File) FileGroups {
 	name := file.Name()
 
-	ext := filepath.Ext(name)
-	if ext != ".go" {
-		return nil
-	}
-	groups := FileGroups{}
-	groups = groups.Add(FileGroupGoApp)
-
-	if strings.Contains(name, "raft_autopilot") {
-		groups = groups.Add(FileGroupAutopilot)
+	if strings.Contains(name, "enos") || hasBaseDir(name, "enos") {
+		return FileGroups{FileGroupEnos}
 	}
 
-	if strings.HasSuffix(name, "_ent.go") {
-		groups = groups.Add(FileGroupEnterprise)
-	} else if strings.HasSuffix(name, "_oss.go") || strings.HasSuffix(name, "_ce.go") {
-		groups = groups.Add(FileGroupCommunity)
-	}
-
-	if strings.HasPrefix(name, "tools/pipeline") {
-		groups = groups.Add(FileGroupPipeline)
-	}
-
-	return groups
+	return nil
 }
 
-// FileGroupCheckerFileProto is a file group checker that groups based on the files extension being .proto
-func FileGroupCheckerFileProto(ctx context.Context, file *File) FileGroups {
+// FileGroupCheckerEnterprise is a file group checker that groups based on the file being part of
+// the Vault App but an enterprise only file. Ideally enterprise only files will use common filename
+// schema or directories to reduce our logic here, but some legacy files have been added here.
+// NOTE: Even if we miss a file or two the sky will not fall, only our automation for CE backports
+// could theoretically miss a file and require the author to extract it out themselves before they
+// merge it. Since such files are created in Vault Enterprise there is little risk.
+func FileGroupCheckerEnterprise(ctx context.Context, file *File) FileGroups {
+	name := file.Name()
+
+	// Base directory checks
+	switch {
+	case
+		hasBaseDir(name, "vault_ent"),
+		hasBaseDir(name, filepath.Join("scripts", "dev", "hsm")),
+		hasBaseDir(name, filepath.Join("scripts", "testing")),
+		hasBaseDir(name, filepath.Join("specs")):
+		return FileGroups{FileGroupEnterprise}
+	}
+
+	// File name checks
+	switch filepath.Base(name) {
+	case
+		"Dockerfile-ent",
+		"Dockerfile-ent-hsm":
+		return FileGroups{FileGroupEnterprise}
+	}
+
+	// File extension checks
+	switch filepath.Ext(name) {
+	case ".go":
+		switch {
+		case
+			strings.HasSuffix(name, "_ent.go"),
+			strings.HasSuffix(name, "_ent_test.go"),
+			strings.Contains(name, "_ent") && strings.HasSuffix(name, ".pb.go"):
+			return FileGroups{FileGroupEnterprise}
+		}
+	case ".txt":
+		if hasBaseDir(name, "changelog") && strings.HasPrefix(filepath.Base(name), "_") {
+			return FileGroups{FileGroupEnterprise}
+		}
+	case
+		".proto",
+		".hcl",
+		".md",
+		".sh",
+		".yaml",
+		".yml":
+		switch {
+		case
+			strings.Contains(name, "-ent"),
+			strings.Contains(name, "_ent"),
+			strings.Contains(name, "hsm"),
+			strings.Contains(name, "merkle-tree"):
+			return FileGroups{FileGroupEnterprise}
+		}
+	}
+
+	return nil
+}
+
+// FileGroupCheckerGoToolchain is a file group checker that groups based on the file modifying the
+// Go toolchain or dependencies.
+func FileGroupCheckerGoToolchain(ctx context.Context, file *File) FileGroups {
+	name := file.Name()
+	switch {
+	case
+		name == ".go-version",
+		strings.HasSuffix(name, "go.mod"),
+		strings.HasSuffix(name, "go.sum"):
+		return FileGroups{FileGroupGoToolchain}
+	default:
+		return nil
+	}
+}
+
+// FileGroupCheckerPipeline is a file group checker that groups based on the file is part of the
+// build or CI pipeline.
+func FileGroupCheckerPipeline(ctx context.Context, file *File) FileGroups {
+	name := file.Name()
+
+	switch {
+	case
+		hasBaseDir(name, ".github"),
+		hasBaseDir(name, "scripts"),
+		hasBaseDir(name, filepath.Join("tools", "pipeline")),
+		name == "CODEOWNERS",
+		name == "Dockerfile",
+		name == "Makefile":
+		return FileGroups{FileGroupPipeline}
+	default:
+		return nil
+	}
+}
+
+// FileGroupCheckerProto is a file group checker that groups based on the files extension being .proto
+func FileGroupCheckerProto(ctx context.Context, file *File) FileGroups {
 	name := file.Name()
 
 	ext := filepath.Ext(name)
-	if ext != ".proto" {
-		return nil
+	if ext == ".proto" || strings.HasPrefix(name, "buf.") {
+		return FileGroups{FileGroupProto}
 	}
 
-	return FileGroups{FileGroupProto}
+	return nil
+}
+
+// FileGroupCheckerWebUI is a file group checker that groups based on the files being part of the
+// web UI
+func FileGroupCheckerWebUI(ctx context.Context, file *File) FileGroups {
+	name := file.Name()
+	if hasBaseDir(name, "ui") {
+		return FileGroups{FileGroupWebUI}
+	}
+
+	return nil
+}
+
+func hasBaseDir(name, dir string) bool {
+	return strings.HasPrefix(name, dir+string(os.PathSeparator))
 }

--- a/tools/pipeline/internal/pkg/changed/checkers_test.go
+++ b/tools/pipeline/internal/pkg/changed/checkers_test.go
@@ -11,72 +11,64 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestFileGroupCheckerDir(t *testing.T) {
+func TestFileGroupDefaultCheckers(t *testing.T) {
 	t.Parallel()
 
 	for filename, groups := range map[string]FileGroups{
 		".github/actions/changed-files/actions.yml": {FileGroupPipeline},
 		".github/workflows/build.yml":               {FileGroupPipeline},
-		"changelog/16455.txt":                       {FileGroupChangelog},
-		"enos/Makefile":                             {FileGroupEnos},
-		"tools/pipeline/main.go":                    {FileGroupTools},
-		"ui/lib/ldap/index.js":                      {FileGroupWebUI},
-		"website/content/api-docs/index.mdx":        {FileGroupDocs},
-	} {
-		t.Run(filename, func(t *testing.T) {
-			file := &File{File: &github.CommitFile{Filename: &filename}}
-			require.Equal(t, groups, FileGroupCheckerDir(context.Background(), file))
-		})
-	}
-}
-
-func TestFileGroupCheckerFileName(t *testing.T) {
-	t.Parallel()
-
-	for filename, groups := range map[string]FileGroups{
-		"buf.yml":      {FileGroupProto},
-		"CHANGELOG.md": {FileGroupChangelog},
-		"CODEOWNERS":   {FileGroupPipeline},
-		"go.mod":       {FileGroupGoApp, FileGroupGoModules},
-		"go.sum":       {FileGroupGoApp, FileGroupGoModules},
-	} {
-		t.Run(filename, func(t *testing.T) {
-			file := &File{File: &github.CommitFile{Filename: &filename}}
-			require.Equal(t, groups, FileGroupCheckerFileName(context.Background(), file))
-		})
-	}
-}
-
-func TestFileGroupCheckerFileGo(t *testing.T) {
-	t.Parallel()
-
-	for filename, groups := range map[string]FileGroups{
-		"vault/acl.go":                             {FileGroupGoApp},
-		"command/server/config.go":                 {FileGroupGoApp},
-		"tools/pipeline/main.go":                   {FileGroupGoApp, FileGroupPipeline},
-		"command/operator_raft_autopilot_state.go": {FileGroupGoApp, FileGroupAutopilot},
-		"physical/raft/raft_autopilot.go":          {FileGroupGoApp, FileGroupAutopilot},
-		"http/util_stubs_oss.go":                   {FileGroupGoApp, FileGroupCommunity},
+		".github/workflows/build-artifacts-ce.yml":  {FileGroupCommunity, FileGroupPipeline},
+		".github/workflows/build-artifacts-ent.yml": {FileGroupEnterprise, FileGroupPipeline},
+		".go-version":                              {FileGroupGoToolchain},
 		"audit/backend_ce.go":                      {FileGroupGoApp, FileGroupCommunity},
-		"vault/activity_log_util_ent.go":           {FileGroupGoApp, FileGroupEnterprise},
+		"audit/backend_config_ent.go":              {FileGroupGoApp, FileGroupEnterprise},
+		"builtin/logical/transit/something_ent.go": {FileGroupGoApp, FileGroupEnterprise},
+		"buf.yml":                                           {FileGroupProto},
+		"changelog/1726.txt":                                {FileGroupChangelog},
+		"changelog/_1726.txt":                               {FileGroupChangelog, FileGroupEnterprise},
+		"command/server/config.go":                          {FileGroupGoApp},
+		"command/operator_raft_autopilot_state.go":          {FileGroupGoApp, FileGroupAutopilot},
+		"command/agent_ent_test.go":                         {FileGroupGoApp, FileGroupEnterprise},
+		"enos/enos-samples-ce-build.hcl":                    {FileGroupCommunity, FileGroupEnos},
+		"enos/enos-samples-ent-build.hcl":                   {FileGroupEnos, FileGroupEnterprise},
+		"enos/enos-scenario-smoke.hcl":                      {FileGroupEnos},
+		"enos/enos-scenario-autopilot-ent.hcl":              {FileGroupEnos, FileGroupEnterprise},
+		"go.mod":                                            {FileGroupGoApp, FileGroupGoToolchain},
+		"go.sum":                                            {FileGroupGoApp, FileGroupGoToolchain},
+		"helper/identity/mfa/types.proto":                   {FileGroupProto},
+		"http/util_stubs_oss.go":                            {FileGroupGoApp, FileGroupCommunity},
+		"physical/raft/raft_autopilot.go":                   {FileGroupGoApp, FileGroupAutopilot},
+		"physical/raft/types.proto":                         {FileGroupProto},
+		"scripts/ci-helper.sh":                              {FileGroupPipeline},
+		"scripts/cross/Dockerfile-ent":                      {FileGroupEnterprise, FileGroupPipeline},
+		"scripts/cross/Dockerfile-ent-hsm":                  {FileGroupEnterprise, FileGroupPipeline},
+		"scripts/dev/hsm/README.md":                         {FileGroupEnterprise, FileGroupPipeline},
+		"scripts/dist-ent.sh":                               {FileGroupEnterprise, FileGroupPipeline},
+		"scripts/testing/test-vault-license.sh":             {FileGroupEnterprise, FileGroupPipeline},
+		"scripts/testing/upgrade/README.md":                 {FileGroupEnterprise, FileGroupPipeline},
+		"sdk/database/dbplugin/v5/proto/database_ent.pb.go": {FileGroupGoApp, FileGroupEnterprise},
+		"sdk/database/dbplugin/v5/proto/database_ent.proto": {FileGroupEnterprise, FileGroupProto},
+		"specs/merkle-tree/spec.md":                         {FileGroupEnterprise},
+		"tools/pipeline/main.go":                            {FileGroupPipeline},
+		"ui/lib/ldap/index.js":                              {FileGroupWebUI},
+		"vault/acl.go":                                      {FileGroupGoApp},
+		"vault/activity_log_util_ent.go":                    {FileGroupGoApp, FileGroupEnterprise},
+		"vault/identity_store_ent_test.go":                  {FileGroupGoApp, FileGroupEnterprise},
+		"vault_ent/go.mod":                                  {FileGroupGoApp, FileGroupEnterprise, FileGroupGoToolchain},
+		"vault_ent/go.sum":                                  {FileGroupGoApp, FileGroupEnterprise, FileGroupGoToolchain},
+		"vault_ent/requires_ent.go":                         {FileGroupGoApp, FileGroupEnterprise},
+		"website/content/api-docs/index.mdx":                {FileGroupDocs},
+		"CHANGELOG.md":                                      {FileGroupChangelog},
+		"CODEOWNERS":                                        {FileGroupPipeline},
+		"Dockerfile":                                        {FileGroupPipeline},
+		"Makefile":                                          {FileGroupPipeline},
+		"README.md":                                         {FileGroupDocs},
 	} {
 		t.Run(filename, func(t *testing.T) {
+			t.Parallel()
 			file := &File{File: &github.CommitFile{Filename: &filename}}
-			require.Equal(t, groups, FileGroupCheckerFileGo(context.Background(), file))
-		})
-	}
-}
-
-func TestFileGroupCheckerProto(t *testing.T) {
-	t.Parallel()
-
-	for filename, groups := range map[string]FileGroups{
-		"physical/raft/types.proto":       {FileGroupProto},
-		"helper/identity/mfa/types.proto": {FileGroupProto},
-	} {
-		t.Run(filename, func(t *testing.T) {
-			file := &File{File: &github.CommitFile{Filename: &filename}}
-			require.Equal(t, groups, FileGroupCheckerFileProto(context.Background(), file))
+			Group(context.Background(), file, DefaultFileGroupCheckers...)
+			require.Equal(t, groups, file.Groups)
 		})
 	}
 }

--- a/tools/pipeline/internal/pkg/changed/file.go
+++ b/tools/pipeline/internal/pkg/changed/file.go
@@ -26,18 +26,18 @@ type (
 )
 
 const (
-	FileGroupAutopilot  FileGroup = "autopilot"
-	FileGroupChangelog  FileGroup = "changelog"
-	FileGroupCommunity  FileGroup = "community"
-	FileGroupDocs       FileGroup = "docs"
-	FileGroupEnos       FileGroup = "enos"
-	FileGroupEnterprise FileGroup = "enterprise"
-	FileGroupGoApp      FileGroup = "app"
-	FileGroupGoModules  FileGroup = "gomod"
-	FileGroupPipeline   FileGroup = "pipeline"
-	FileGroupProto      FileGroup = "proto"
-	FileGroupTools      FileGroup = "tools"
-	FileGroupWebUI      FileGroup = "ui"
+	FileGroupAutopilot   FileGroup = "autopilot"
+	FileGroupChangelog   FileGroup = "changelog"
+	FileGroupCommunity   FileGroup = "community"
+	FileGroupDocs        FileGroup = "docs"
+	FileGroupEnos        FileGroup = "enos"
+	FileGroupEnterprise  FileGroup = "enterprise"
+	FileGroupGoApp       FileGroup = "app"
+	FileGroupGoToolchain FileGroup = "gotoolchain"
+	FileGroupPipeline    FileGroup = "pipeline"
+	FileGroupProto       FileGroup = "proto"
+	FileGroupTools       FileGroup = "tools"
+	FileGroupWebUI       FileGroup = "ui"
 )
 
 // Name is the file name of the changed file

--- a/tools/pipeline/internal/pkg/github/list_changed_files.go
+++ b/tools/pipeline/internal/pkg/github/list_changed_files.go
@@ -68,7 +68,7 @@ func (r *ListChangedFilesReq) Run(ctx context.Context, client *gh.Client) (*List
 	}
 
 	if r.GroupFiles {
-		r.groupChangedFiles(ctx, res.Files, changed.DefaultFileGroupCheckers...)
+		changed.GroupFiles(ctx, res.Files, changed.DefaultFileGroupCheckers...)
 		res.Groups = changed.FileGroups{}
 		for _, file := range res.Files {
 			for _, group := range file.Groups {
@@ -144,24 +144,6 @@ func (r *ListChangedFilesReq) getPullFiles(ctx context.Context, client *gh.Clien
 		}
 
 		opts.Page = res.NextPage
-	}
-}
-
-// groupChangedFiles runs the changed files through the default group checkers
-// to add group metadata. It also aggregates a combined group set for all files.
-func (r *ListChangedFilesReq) groupChangedFiles(
-	ctx context.Context,
-	files changed.Files,
-	checks ...changed.FileGroupCheck,
-) {
-	if len(files) < 1 {
-		return
-	}
-
-	for _, file := range files {
-		for _, check := range checks {
-			file.Groups = file.Groups.Add(check(ctx, file)...)
-		}
 	}
 }
 


### PR DESCRIPTION
### Description
To fully support automated Enterprise to Community backports we need to have better changed file detection for community and enterprise only files. Armed with this metadata, future changes will be able to inspect changed files and automatically remove enterprise only files when creating the CE backports.

For this change we now have the following changed file groups:
  - autopilot
  - changelog
  - community
  - docs
  - enos
  - enterprise
  - app
  - gotoolchain
  - pipeline
  - proto
  - tools
  - ui

Not included in the change -- but something I did while updating out checkers -- was generate a list of files that only exist in vault-enteprise and ran every path through the updated enterprise detection rules to ensure that they are categorized appropriately post changes in VAULT-35431. While it's possible that they'll drift, our changed file categorization is best effort anyway and changes will always happen in vault-enterprise and require a developer to approve the changes.

We've also included a few new files into the various groups and updated the various workflows to use the new categories. I've also included a small change to the pipeline composite action whereby we do not handle Go module caching. This will greatly reduce work on doc-only branches that need only ensure that the pipeline binary is compiled.

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
