### PR TITLE
[VAULT-35183] UI: enable search for updated namespace picker

### DIFF
--- a/ui/app/components/namespace-picker.hbs
+++ b/ui/app/components/namespace-picker.hbs
@@ -9,6 +9,17 @@
     <D.ToggleButton @icon="org" @text={{or this.selected.id "-"}} data-test-namespace-toggle />
 
     <D.Generic>
+      <Hds::Form::TextInput::Field
+        @value={{this.searchInput}}
+        @type="search"
+        placeholder="Search"
+        {{on "input" this.onSearchInput}}
+      />
+    </D.Generic>
+
+    <D.Separator />
+
+    <D.Generic>
       {{this.namespaceLabel}}
       <Hds::BadgeCount @text={{or this.options.length 0}} />
     </D.Generic>
@@ -26,7 +37,7 @@
     {{! Check if the user has permissions to list namespaces. If true, display additional footer options like "Refresh list" and "Manage". }}
     {{#if this.hasListPermissions}}
       <D.Footer @hasDivider={{true}}>
-        <Hds::Button @color="secondary" @text="Refresh list" {{on "click" this.loadOptions}} data-test-refresh-namespaces />
+        <Hds::Button @color="secondary" @text="Refresh list" {{on "click" this.refreshList}} data-test-refresh-namespaces />
         <Hds::Button @color="secondary" @text="Manage" @icon="settings" @route="vault.cluster.access.namespaces" />
       </D.Footer>
     {{/if}}

--- a/ui/app/components/namespace-picker.hbs
+++ b/ui/app/components/namespace-picker.hbs
@@ -21,10 +21,10 @@
 
     <D.Generic>
       {{this.namespaceLabel}}
-      <Hds::BadgeCount @text={{or this.options.length 0}} />
+      <Hds::BadgeCount @text={{or this.namespaceOptions.length 0}} />
     </D.Generic>
 
-    {{#each this.options as |option|}}
+    {{#each this.namespaceOptions as |option|}}
       <D.Checkmark
         @selected={{eq option.id this.selected.id}}
         {{on "click" (fn this.onChange option)}}

--- a/ui/tests/acceptance/enterprise-namespaces-test.js
+++ b/ui/tests/acceptance/enterprise-namespaces-test.js
@@ -31,7 +31,7 @@ module('Acceptance | Enterprise | namespaces', function (hooks) {
       .exists('The root namespace is selected');
   });
 
-  // TODO: Is this test description still accurate?
+  // TODO: revisit test name/description, is this still relevant? A '/' prefix is stripped from namespace on login form
   test('it shows nested namespaces if you log in with a namespace starting with a /', async function (assert) {
     assert.expect(6);
 
@@ -41,17 +41,24 @@ module('Acceptance | Enterprise | namespaces', function (hooks) {
     for (const [i, ns] of nses.entries()) {
       await runCmd(createNS(ns), false);
       await settled();
+
       // the namespace path will include all of the namespaces up to this point
       const targetNamespace = nses.slice(0, i + 1).join('/');
       const url = `/vault/secrets?namespace=${targetNamespace}`;
+
       // this is usually triggered when creating a ns in the form -- trigger a reload of the namespaces manually
       await click(NAMESPACE_PICKER_SELECTORS.toggle);
+
+      // refresh the list of namespaces
+      await waitFor(NAMESPACE_PICKER_SELECTORS.refreshList);
       await click(NAMESPACE_PICKER_SELECTORS.refreshList);
-      await waitFor(NAMESPACE_PICKER_SELECTORS.link(targetNamespace));
+
       // check that the full namespace path, like "beep/boop", shows in the toggle display
+      await waitFor(NAMESPACE_PICKER_SELECTORS.link(targetNamespace));
       assert
         .dom(NAMESPACE_PICKER_SELECTORS.link(targetNamespace))
         .hasText(targetNamespace, `shows the namespace ${targetNamespace} in the toggle component`);
+
       // because quint does not like page reloads, visiting url directly instead of clicking on namespace in toggle
       await visit(url);
     }

--- a/ui/tests/integration/components/namespace-picker-test.js
+++ b/ui/tests/integration/components/namespace-picker-test.js
@@ -1,0 +1,160 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, fillIn, findAll, waitFor, click } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import Service from '@ember/service';
+import { NAMESPACE_PICKER_SELECTORS } from 'vault/tests/helpers/namespace-picker';
+
+const authService = Service.extend({
+  init() {
+    this._super(...arguments);
+    this.set('authData', {
+      userRootNamespace: '',
+    });
+  },
+});
+
+const namespaceService = Service.extend({
+  accessibleNamespaces: null,
+  findNamespacesForUser: null,
+  path: null,
+
+  init() {
+    this._super(...arguments);
+    this.set('accessibleNamespaces', ['parent1', 'parent1/child1']);
+    this.set('findNamespacesForUser', {
+      perform: () => Promise.resolve(),
+    });
+    this.set('path', 'parent1/child1');
+  },
+});
+
+const storeService = Service.extend({
+  findRecord(modelType, id) {
+    return new Promise((resolve, reject) => {
+      if (modelType === 'capabilities' && id === 'sys/namespaces/') {
+        resolve(); // Simulate a successful response
+      } else {
+        reject({ httpStatus: 404, message: 'not found' }); // Simulate an error response
+      }
+    });
+  },
+});
+
+module('Integration | Component | namespace-picker', function (hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function () {
+    this.owner.register('service:auth', authService);
+    this.owner.register('service:namespace', namespaceService);
+    this.owner.register('service:store', storeService);
+  });
+
+  test('it filters namespace options based on search input', async function (assert) {
+    assert.expect(3);
+
+    await render(hbs`<NamespacePicker/>`);
+
+    await click(NAMESPACE_PICKER_SELECTORS.toggle);
+
+    // Verify all namespaces are displayed initially
+    await waitFor(NAMESPACE_PICKER_SELECTORS.link());
+    assert.strictEqual(
+      findAll(NAMESPACE_PICKER_SELECTORS.link()).length,
+      3,
+      'All namespaces are displayed initially'
+    );
+
+    // Simulate typing into the search input
+    await waitFor('[type="search"]');
+    await fillIn('[type="search"]', 'child1');
+
+    // Verify that only namespaces matching the search input are displayed
+    assert.strictEqual(
+      findAll(NAMESPACE_PICKER_SELECTORS.link()).length,
+      1,
+      'Only matching namespaces are displayed after filtering'
+    );
+
+    // Clear the search input
+    await fillIn('[type="search"]', '');
+
+    // Verify all namespaces are displayed after clearing the search input
+    assert.strictEqual(
+      findAll(NAMESPACE_PICKER_SELECTORS.link()).length,
+      3,
+      'All namespaces are displayed after clearing the search input'
+    );
+  });
+
+  test('it updates the namespace list after clicking "Refresh list"', async function (assert) {
+    assert.expect(3);
+
+    // Mock `hasListPermissions`
+    this.owner.lookup('service:namespace').set('hasListPermissions', true);
+
+    await render(hbs`<NamespacePicker />`);
+
+    await click(NAMESPACE_PICKER_SELECTORS.toggle);
+
+    // Dynamically modify the `findNamespacesForUser.perform` method for this test
+    const namespaceService = this.owner.lookup('service:namespace');
+    namespaceService.set('findNamespacesForUser', {
+      perform: () => {
+        namespaceService.set('accessibleNamespaces', [
+          'parent1',
+          'parent1/child1',
+          'new-namespace', // Add a new namespace
+        ]);
+        return Promise.resolve();
+      },
+    });
+
+    // Verify initial namespaces are displayed
+    assert.strictEqual(
+      findAll(NAMESPACE_PICKER_SELECTORS.link()).length,
+      3,
+      'Initially, three namespaces are displayed'
+    );
+
+    // Click the "Refresh list" button
+    await click(NAMESPACE_PICKER_SELECTORS.refreshList);
+
+    // Verify the new namespace is displayed
+    assert.strictEqual(
+      findAll(NAMESPACE_PICKER_SELECTORS.link()).length,
+      4,
+      'After refreshing, four namespaces are displayed'
+    );
+
+    // Verify the new namespace is specifically shown
+    assert
+      .dom(NAMESPACE_PICKER_SELECTORS.link('new-namespace'))
+      .exists('The new namespace "new-namespace" is displayed after refreshing');
+  });
+
+  test('it displays the "Manage" button when the user has permissions', async function (assert) {
+    assert.expect(1);
+
+    // Mock `hasListPermissions` to be true
+    this.owner.lookup('service:namespace').set('hasListPermissions', true);
+
+    await render(hbs`<NamespacePicker />`);
+
+    await click(NAMESPACE_PICKER_SELECTORS.toggle);
+
+    // Find the "Manage" button
+    const manageButton = findAll('a').find((el) => {
+      const spans = el.querySelectorAll('span');
+      return spans[1]?.textContent.trim() === 'Manage';
+    });
+
+    // Verify the "Manage" button is rendered
+    assert.ok(manageButton, 'The "Manage" button is displayed');
+  });
+});


### PR DESCRIPTION
### Description
| ℹ️ **This branch is merging into a feature side branch** (not `main`) |
| --- |

| ℹ️ The current implementation looks ugly, styling will be addressed in a separate PR |
| --- |
- [X] Enable search for updated namespace picker
- [X] Conditionally show `root` in list of namespaces
- [X] Enterprise tests passing ✅ 
  > 239 tests completed in 168817 milliseconds, with 0 failed, 10 skipped, and 0 todo.
1449 assertions of 1449 passed, 0 failed.

### Demo

https://github.com/user-attachments/assets/0e9b5682-e359-4b48-a824-3a5b85d84a5f



### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
