### PR TITLE
VAULT-35498: fix typo in secrets sync docs

### DIFF
--- a/website/content/docs/sync/index.mdx
+++ b/website/content/docs/sync/index.mdx
@@ -35,11 +35,11 @@ Activating the feature can be done through one of several methods:
 
 1. Activation directly through the UI.
 
-1. Acitvation through the CLI:
-  
+1. Activation through the CLI:
+
   ```shell-session
   $ vault write -f sys/activation-flags/secrets-sync/activate
-  ``` 
+  ```
 
 1. Activation through a POST or PUT request:
 
@@ -258,7 +258,7 @@ for each destination type below:
 ### Endpoint security
 
 By default, Vault restricts the allowed IP addresses and port numbers used by the sync clients to safeguard against
-server-side request forgery (SSRF). All special purpose IPs defined at the IANA special-purpose registry for 
+server-side request forgery (SSRF). All special purpose IPs defined at the IANA special-purpose registry for
 [IPv4](https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml) and
 [IPv6](https://www.iana.org/assignments/iana-ipv6-special-registry/iana-ipv6-special-registry.xhtml) are blocked, while the only
 two allowed ports are 80 and 443.


### PR DESCRIPTION
### Description
What does this PR do?
Fix typo in secrets sync documentation

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
