### PR TITLE
Address UI Flaky Tests

### DIFF
--- a/ui/tests/acceptance/auth/mfa-test.js
+++ b/ui/tests/acceptance/auth/mfa-test.js
@@ -6,6 +6,7 @@
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { click, visit, fillIn } from '@ember/test-helpers';
+import { later } from '@ember/runloop';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { AUTH_FORM } from 'vault/tests/helpers/auth/auth-form-selectors';
 import { GENERAL } from 'vault/tests/helpers/general-selectors';
@@ -15,6 +16,7 @@ import { AUTH_METHOD_MAP, fillInLoginFields } from 'vault/tests/helpers/auth/aut
 import { callbackData, windowStub } from 'vault/tests/helpers/oidc-window-stub';
 
 const ENT_ONLY = ['saml'];
+const DELAY_IN_MS = 50;
 
 for (const method of AUTH_METHOD_MAP) {
   const { authType, options } = method;
@@ -53,10 +55,14 @@ for (const method of AUTH_METHOD_MAP) {
 
       if (options?.hasPopupWindow) {
         // fires "message" event which methods that rely on popup windows wait for
-        setTimeout(() => {
-          // set path which is used to set :mount param in the callback url => /auth/:mount/oidc/callback
-          window.postMessage(callbackData({ path: this.mountPath }), window.origin);
-        }, 50);
+        later(
+          this,
+          () => {
+            // set path which is used to set :mount param in the callback url => /auth/:mount/oidc/callback
+            window.postMessage(callbackData({ path: this.mountPath }), window.origin);
+          },
+          DELAY_IN_MS
+        );
       }
 
       await click(AUTH_FORM.login);
@@ -86,10 +92,14 @@ for (const method of AUTH_METHOD_MAP) {
 
       if (options?.hasPopupWindow) {
         // fires "message" event which methods that rely on popup windows wait for
-        setTimeout(() => {
-          // set path which is used to set :mount param in the callback url => /auth/:mount/oidc/callback
-          window.postMessage(callbackData({ path: this.mountPath }), window.origin);
-        }, 50);
+        later(
+          this,
+          () => {
+            // set path which is used to set :mount param in the callback url => /auth/:mount/oidc/callback
+            window.postMessage(callbackData({ path: this.mountPath }), window.origin);
+          },
+          DELAY_IN_MS
+        );
       }
 
       await click(AUTH_FORM.login);
@@ -124,10 +134,14 @@ for (const method of AUTH_METHOD_MAP) {
 
       if (options?.hasPopupWindow) {
         // fires "message" event which methods that rely on popup windows wait for
-        setTimeout(() => {
-          // set path which is used to set :mount param in the callback url => /auth/:mount/oidc/callback
-          window.postMessage(callbackData({ path: this.mountPath }), window.origin);
-        }, 50);
+        later(
+          this,
+          () => {
+            // set path which is used to set :mount param in the callback url => /auth/:mount/oidc/callback
+            window.postMessage(callbackData({ path: this.mountPath }), window.origin);
+          },
+          DELAY_IN_MS
+        );
       }
 
       await click(AUTH_FORM.login);
@@ -155,10 +169,14 @@ for (const method of AUTH_METHOD_MAP) {
 
       if (options?.hasPopupWindow) {
         // fires "message" event which methods that rely on popup windows wait for
-        setTimeout(() => {
-          // set path which is used to set :mount param in the callback url => /auth/:mount/oidc/callback
-          window.postMessage(callbackData({ path: this.mountPath }), window.origin);
-        }, 50);
+        later(
+          this,
+          () => {
+            // set path which is used to set :mount param in the callback url => /auth/:mount/oidc/callback
+            window.postMessage(callbackData({ path: this.mountPath }), window.origin);
+          },
+          DELAY_IN_MS
+        );
       }
 
       await click(AUTH_FORM.login);

--- a/ui/tests/acceptance/auth/mfa-test.js
+++ b/ui/tests/acceptance/auth/mfa-test.js
@@ -6,7 +6,6 @@
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { click, visit, fillIn } from '@ember/test-helpers';
-import { later } from '@ember/runloop';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { AUTH_FORM } from 'vault/tests/helpers/auth/auth-form-selectors';
 import { GENERAL } from 'vault/tests/helpers/general-selectors';
@@ -55,14 +54,10 @@ for (const method of AUTH_METHOD_MAP) {
 
       if (options?.hasPopupWindow) {
         // fires "message" event which methods that rely on popup windows wait for
-        later(
-          this,
-          () => {
-            // set path which is used to set :mount param in the callback url => /auth/:mount/oidc/callback
-            window.postMessage(callbackData({ path: this.mountPath }), window.origin);
-          },
-          DELAY_IN_MS
-        );
+        setTimeout(() => {
+          // set path which is used to set :mount param in the callback url => /auth/:mount/oidc/callback
+          window.postMessage(callbackData({ path: this.mountPath }), window.origin);
+        }, DELAY_IN_MS);
       }
 
       await click(AUTH_FORM.login);
@@ -92,14 +87,10 @@ for (const method of AUTH_METHOD_MAP) {
 
       if (options?.hasPopupWindow) {
         // fires "message" event which methods that rely on popup windows wait for
-        later(
-          this,
-          () => {
-            // set path which is used to set :mount param in the callback url => /auth/:mount/oidc/callback
-            window.postMessage(callbackData({ path: this.mountPath }), window.origin);
-          },
-          DELAY_IN_MS
-        );
+        setTimeout(() => {
+          // set path which is used to set :mount param in the callback url => /auth/:mount/oidc/callback
+          window.postMessage(callbackData({ path: this.mountPath }), window.origin);
+        }, DELAY_IN_MS);
       }
 
       await click(AUTH_FORM.login);
@@ -134,14 +125,10 @@ for (const method of AUTH_METHOD_MAP) {
 
       if (options?.hasPopupWindow) {
         // fires "message" event which methods that rely on popup windows wait for
-        later(
-          this,
-          () => {
-            // set path which is used to set :mount param in the callback url => /auth/:mount/oidc/callback
-            window.postMessage(callbackData({ path: this.mountPath }), window.origin);
-          },
-          DELAY_IN_MS
-        );
+        setTimeout(() => {
+          // set path which is used to set :mount param in the callback url => /auth/:mount/oidc/callback
+          window.postMessage(callbackData({ path: this.mountPath }), window.origin);
+        }, DELAY_IN_MS);
       }
 
       await click(AUTH_FORM.login);
@@ -169,14 +156,10 @@ for (const method of AUTH_METHOD_MAP) {
 
       if (options?.hasPopupWindow) {
         // fires "message" event which methods that rely on popup windows wait for
-        later(
-          this,
-          () => {
-            // set path which is used to set :mount param in the callback url => /auth/:mount/oidc/callback
-            window.postMessage(callbackData({ path: this.mountPath }), window.origin);
-          },
-          DELAY_IN_MS
-        );
+        setTimeout(() => {
+          // set path which is used to set :mount param in the callback url => /auth/:mount/oidc/callback
+          window.postMessage(callbackData({ path: this.mountPath }), window.origin);
+        }, DELAY_IN_MS);
       }
 
       await click(AUTH_FORM.login);

--- a/ui/tests/acceptance/leases-test.js
+++ b/ui/tests/acceptance/leases-test.js
@@ -15,17 +15,17 @@ import { setupApplicationTest } from 'ember-qunit';
 import { v4 as uuidv4 } from 'uuid';
 import secretList from 'vault/tests/pages/secrets/backend/list';
 import secretEdit from 'vault/tests/pages/secrets/backend/kv/edit-secret';
-import mountSecrets from 'vault/tests/pages/settings/mount-secret-backend';
-import { login } from 'vault/tests/helpers/auth/auth-helpers';
+// import mountSecrets from 'vault/tests/pages/settings/mount-secret-backend';
+// import { login } from 'vault/tests/helpers/auth/auth-helpers';
 
 module('Acceptance | leases', function (hooks) {
   setupApplicationTest(hooks);
 
   hooks.beforeEach(async function () {
-    await login();
-    this.enginePath = `kv-for-lease-${uuidv4()}`;
-    // need a version 1 mount for leased secrets here
-    return mountSecrets.visit().path(this.enginePath).type('kv').version(1).submit();
+    // await login();
+    // this.enginePath = `kv-for-lease-${uuidv4()}`;
+    // // need a version 1 mount for leased secrets here
+    // return mountSecrets.visit().path(this.enginePath).type('kv').version(1).submit();
   });
 
   const createSecret = async (context, isRenewable) => {

--- a/ui/tests/acceptance/oidc-auth-method-test.js
+++ b/ui/tests/acceptance/oidc-auth-method-test.js
@@ -15,7 +15,7 @@ import { AUTH_FORM } from 'vault/tests/helpers/auth/auth-form-selectors';
 import { GENERAL } from 'vault/tests/helpers/general-selectors';
 import { ERROR_MISSING_PARAMS, ERROR_WINDOW_CLOSED } from 'vault/components/auth-jwt';
 
-const DELAY_IN_MS = 500;
+const DELAY_IN_MS = 50;
 
 module('Acceptance | oidc auth method', function (hooks) {
   setupApplicationTest(hooks);

--- a/ui/tests/acceptance/oidc-auth-method-test.js
+++ b/ui/tests/acceptance/oidc-auth-method-test.js
@@ -2,7 +2,7 @@
  * Copyright (c) HashiCorp, Inc.
  * SPDX-License-Identifier: BUSL-1.1
  */
-import { module, test } from 'qunit';
+import { module, test, skip } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { click, fillIn, find, visit, waitUntil } from '@ember/test-helpers';
 import { later } from '@ember/runloop';
@@ -113,7 +113,8 @@ module('Acceptance | oidc auth method', function (hooks) {
   });
 
   // coverage for bug where token was selected as auth method for oidc and jwt
-  test('(flaky): it should populate oidc auth method on logout', async function (assert) {
+  // TODO: revisit this test after the auth form refactor as this is not a timeout issue but most likely broken logic that inconsistently fails.
+  skip('(flaky): it should populate oidc auth method on logout', async function (assert) {
     // This test is flaky and hopefully will be less flaky after the auth form refactor
     this.setupMocks();
     await this.selectMethod('oidc');

--- a/ui/tests/acceptance/oidc-auth-method-test.js
+++ b/ui/tests/acceptance/oidc-auth-method-test.js
@@ -2,10 +2,10 @@
  * Copyright (c) HashiCorp, Inc.
  * SPDX-License-Identifier: BUSL-1.1
  */
-import { module, test, skip } from 'qunit';
+import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
-import { click, fillIn, find, visit, waitUntil } from '@ember/test-helpers';
 import { later } from '@ember/runloop';
+import { click, fillIn, find, waitUntil } from '@ember/test-helpers';
 import { logout } from 'vault/tests/helpers/auth/auth-helpers';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { buildMessage, callbackData, windowStub } from 'vault/tests/helpers/oidc-window-stub';
@@ -16,7 +16,7 @@ import { AUTH_FORM } from 'vault/tests/helpers/auth/auth-form-selectors';
 import { GENERAL } from 'vault/tests/helpers/general-selectors';
 import { ERROR_MISSING_PARAMS, ERROR_WINDOW_CLOSED } from 'vault/components/auth-jwt';
 
-const DELAY_IN_MS = 50;
+const DELAY_IN_MS = 500;
 
 module('Acceptance | oidc auth method', function (hooks) {
   setupApplicationTest(hooks);
@@ -45,10 +45,6 @@ module('Acceptance | oidc auth method', function (hooks) {
 
     // select method from dropdown or click auth path tab
     this.selectMethod = async (method, useLink) => {
-      const methodSelector = useLink
-        ? `[data-test-auth-method-link="${method}"]`
-        : '[data-test-select="auth-method"]';
-      await waitUntil(() => find(methodSelector), { timeout: 7000 });
       if (useLink) {
         await click(`[data-test-auth-method-link="${method}"]`);
       } else {
@@ -58,18 +54,19 @@ module('Acceptance | oidc auth method', function (hooks) {
 
     // ensure clean state
     localStorage.removeItem('selectedAuth');
-    await logout();
+    // Cannot log out here because it will cause the internal mount request to be hit before the mocks can interrupt it
   });
 
-  hooks.afterEach(function () {
+  hooks.afterEach(async function () {
     this.openStub.restore();
   });
 
   test('it should login with oidc when selected from auth methods dropdown', async function (assert) {
     assert.expect(1);
     this.setupMocks(assert);
-
+    await logout();
     await this.selectMethod('oidc');
+
     later(() => {
       window.postMessage(buildMessage().data, window.origin);
     }, DELAY_IN_MS);
@@ -79,25 +76,27 @@ module('Acceptance | oidc auth method', function (hooks) {
 
   test('it should login with oidc from listed auth mount tab', async function (assert) {
     assert.expect(3);
-
     this.setupMocks(assert);
 
     this.server.get('/sys/internal/ui/mounts', () => ({
       data: {
         auth: {
-          'test-path/': { description: '', options: {}, type: 'oidc' },
+          'oidc/': { description: '', options: {}, type: 'oidc' },
         },
       },
     }));
+
     // this request is fired twice -- total assertion count should be 3 rather than 2
     // JLR TODO - auth-jwt: verify whether additional request is necessary, especially when glimmerizing component
     // look into whether didReceiveAttrs is necessary to trigger this request
-    this.server.post('/auth/test-path/oidc/auth_url', () => {
+    this.server.post('/auth/oidc/oidc/auth_url', () => {
       assert.ok(true, 'auth_url request made to correct non-standard mount path');
       return { data: { auth_url: 'http://example.com' } };
     });
 
+    await logout();
     await this.selectMethod('oidc', true);
+
     later(() => {
       window.postMessage(buildMessage().data, window.origin);
     }, DELAY_IN_MS);
@@ -106,9 +105,10 @@ module('Acceptance | oidc auth method', function (hooks) {
 
   // coverage for bug where token was selected as auth method for oidc and jwt
   // TODO: revisit this test after the auth form refactor as this is not a timeout issue but most likely broken logic that inconsistently fails.
-  skip('(flaky): it should populate oidc auth method on logout', async function (assert) {
+  test('(flaky): it should populate oidc auth method on logout', async function (assert) {
     // This test is flaky and hopefully will be less flaky after the auth form refactor
     this.setupMocks();
+    await logout();
     await this.selectMethod('oidc');
 
     later(() => {
@@ -116,17 +116,18 @@ module('Acceptance | oidc auth method', function (hooks) {
     }, DELAY_IN_MS);
 
     await click(AUTH_FORM.login);
-    await waitUntil(() => find('[data-test-dashboard-card-header="Vault version"]'));
-    await visit('/vault/logout');
-    // Removing the timeout so the error is clear (the timeout does not help)
-    // await waitUntil(() => find('[data-test-splash-page-content]'), { timeout: 5000 });
+    assert
+      .dom('[data-test-dashboard-card-header="Vault version"]')
+      .exists('Render the dashboard landing page.');
 
+    await logout();
     assert
       .dom('[data-test-select="auth-method"]')
       .hasValue('oidc', 'Previous auth method selected on logout');
   });
 
   test('it should fetch role when switching between oidc/jwt auth methods and changing the mount path', async function (assert) {
+    await logout();
     let reqCount = 0;
     this.server.post('/auth/:method/oidc/auth_url', (schema, req) => {
       reqCount++;
@@ -151,7 +152,7 @@ module('Acceptance | oidc auth method', function (hooks) {
       const errors = role ? ['permission denied'] : ['missing role'];
       return new Response(status, {}, { errors });
     });
-
+    await logout();
     await this.selectMethod('oidc');
     await click(AUTH_FORM.login);
     assert.dom('[data-test-message-error-description]').hasText('Invalid role. Please try again.');
@@ -166,6 +167,7 @@ module('Acceptance | oidc auth method', function (hooks) {
 
     this.setupMocks(assert);
     this.server.get('/auth/foo/oidc/callback', () => setupTotpMfaResponse('foo'));
+    await logout();
     await this.selectMethod('oidc');
     later(() => {
       window.postMessage(buildMessage().data, window.origin);
@@ -179,6 +181,7 @@ module('Acceptance | oidc auth method', function (hooks) {
   test('auth service is called with client_token and cluster data', async function (assert) {
     const authSpy = sinon.spy(this.owner.lookup('service:auth'), 'authenticate');
     this.setupMocks();
+    await logout();
     await this.selectMethod('oidc');
     later(() => {
       window.postMessage(buildMessage().data, window.origin);
@@ -224,7 +227,7 @@ module('Acceptance | oidc auth method', function (hooks) {
       assert.strictEqual(event.data.source, source, `message event fires with source: ${event.data.source}`);
     };
     window.addEventListener('message', assertEvent);
-
+    await logout();
     await this.selectMethod('oidc');
 
     later(() => {
@@ -241,6 +244,7 @@ module('Acceptance | oidc auth method', function (hooks) {
 
   test('it shows error when message posted with state key, wrong params', async function (assert) {
     this.setupMocks();
+    await logout();
     await this.selectMethod('oidc');
     later(() => {
       // callback params are missing "code"
@@ -256,6 +260,7 @@ module('Acceptance | oidc auth method', function (hooks) {
     windowStub({ stub: this.openStub, popup: { closed: true, close: () => {} } });
 
     this.setupMocks();
+    await logout();
     await this.selectMethod('oidc');
     await click(AUTH_FORM.login);
     assert

--- a/ui/tests/acceptance/oidc-auth-method-test.js
+++ b/ui/tests/acceptance/oidc-auth-method-test.js
@@ -70,13 +70,9 @@ module('Acceptance | oidc auth method', function (hooks) {
     this.setupMocks(assert);
 
     await this.selectMethod('oidc');
-    later(
-      this,
-      () => {
-        window.postMessage(buildMessage().data, window.origin);
-      },
-      DELAY_IN_MS
-    );
+    later(() => {
+      window.postMessage(buildMessage().data, window.origin);
+    }, DELAY_IN_MS);
 
     await click(AUTH_FORM.login);
   });
@@ -102,13 +98,9 @@ module('Acceptance | oidc auth method', function (hooks) {
     });
 
     await this.selectMethod('oidc', true);
-    later(
-      this,
-      () => {
-        window.postMessage(buildMessage().data, window.origin);
-      },
-      DELAY_IN_MS
-    );
+    later(() => {
+      window.postMessage(buildMessage().data, window.origin);
+    }, DELAY_IN_MS);
     await click(AUTH_FORM.login);
   });
 
@@ -119,13 +111,9 @@ module('Acceptance | oidc auth method', function (hooks) {
     this.setupMocks();
     await this.selectMethod('oidc');
 
-    later(
-      this,
-      () => {
-        window.postMessage(buildMessage().data, window.origin);
-      },
-      DELAY_IN_MS
-    );
+    later(() => {
+      window.postMessage(buildMessage().data, window.origin);
+    }, DELAY_IN_MS);
 
     await click(AUTH_FORM.login);
     await waitUntil(() => find('[data-test-dashboard-card-header="Vault version"]'));
@@ -179,13 +167,9 @@ module('Acceptance | oidc auth method', function (hooks) {
     this.setupMocks(assert);
     this.server.get('/auth/foo/oidc/callback', () => setupTotpMfaResponse('foo'));
     await this.selectMethod('oidc');
-    later(
-      this,
-      () => {
-        window.postMessage(buildMessage().data, window.origin);
-      },
-      DELAY_IN_MS
-    );
+    later(() => {
+      window.postMessage(buildMessage().data, window.origin);
+    }, DELAY_IN_MS);
 
     await click(AUTH_FORM.login);
     await waitUntil(() => find('[data-test-mfa-form]'));
@@ -196,13 +180,9 @@ module('Acceptance | oidc auth method', function (hooks) {
     const authSpy = sinon.spy(this.owner.lookup('service:auth'), 'authenticate');
     this.setupMocks();
     await this.selectMethod('oidc');
-    later(
-      this,
-      () => {
-        window.postMessage(buildMessage().data, window.origin);
-      },
-      DELAY_IN_MS
-    );
+    later(() => {
+      window.postMessage(buildMessage().data, window.origin);
+    }, DELAY_IN_MS);
     await click(AUTH_FORM.login);
     const [actual] = authSpy.lastCall.args;
     const expected = {
@@ -247,16 +227,12 @@ module('Acceptance | oidc auth method', function (hooks) {
 
     await this.selectMethod('oidc');
 
-    later(
-      this,
-      () => {
-        // first assertion
-        window.postMessage(callbackData({ source: 'miscellaneous-source' }), window.origin);
-        // second assertion
-        window.postMessage(callbackData({ source: 'oidc-callback' }), window.origin);
-      },
-      DELAY_IN_MS
-    );
+    later(() => {
+      // first assertion
+      window.postMessage(callbackData({ source: 'miscellaneous-source' }), window.origin);
+      // second assertion
+      window.postMessage(callbackData({ source: 'oidc-callback' }), window.origin);
+    }, DELAY_IN_MS);
 
     await click(AUTH_FORM.login);
     // cleanup
@@ -266,14 +242,10 @@ module('Acceptance | oidc auth method', function (hooks) {
   test('it shows error when message posted with state key, wrong params', async function (assert) {
     this.setupMocks();
     await this.selectMethod('oidc');
-    later(
-      this,
-      () => {
-        // callback params are missing "code"
-        window.postMessage({ source: 'oidc-callback', state: 'state', foo: 'bar' }, window.origin);
-      },
-      DELAY_IN_MS
-    );
+    later(() => {
+      // callback params are missing "code"
+      window.postMessage({ source: 'oidc-callback', state: 'state', foo: 'bar' }, window.origin);
+    }, DELAY_IN_MS);
     await click(AUTH_FORM.login);
     assert
       .dom(GENERAL.messageError)

--- a/ui/tests/acceptance/oidc-auth-method-test.js
+++ b/ui/tests/acceptance/oidc-auth-method-test.js
@@ -4,7 +4,6 @@
  */
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
-import { later } from '@ember/runloop';
 import { click, fillIn, find, waitUntil } from '@ember/test-helpers';
 import { logout } from 'vault/tests/helpers/auth/auth-helpers';
 import { setupMirage } from 'ember-cli-mirage/test-support';

--- a/ui/tests/acceptance/oidc-auth-method-test.js
+++ b/ui/tests/acceptance/oidc-auth-method-test.js
@@ -104,9 +104,7 @@ module('Acceptance | oidc auth method', function (hooks) {
   });
 
   // coverage for bug where token was selected as auth method for oidc and jwt
-  // TODO: revisit this test after the auth form refactor as this is not a timeout issue but most likely broken logic that inconsistently fails.
-  test('(flaky): it should populate oidc auth method on logout', async function (assert) {
-    // This test is flaky and hopefully will be less flaky after the auth form refactor
+  test('it should populate oidc auth method on logout', async function (assert) {
     this.setupMocks();
     await logout();
     await this.selectMethod('oidc');

--- a/ui/tests/acceptance/oidc-auth-method-test.js
+++ b/ui/tests/acceptance/oidc-auth-method-test.js
@@ -81,7 +81,7 @@ module('Acceptance | oidc auth method', function (hooks) {
     this.server.get('/sys/internal/ui/mounts', () => ({
       data: {
         auth: {
-          'oidc/': { description: '', options: {}, type: 'oidc' },
+          'test-path/': { description: '', options: {}, type: 'oidc' },
         },
       },
     }));
@@ -89,7 +89,7 @@ module('Acceptance | oidc auth method', function (hooks) {
     // this request is fired twice -- total assertion count should be 3 rather than 2
     // JLR TODO - auth-jwt: verify whether additional request is necessary, especially when glimmerizing component
     // look into whether didReceiveAttrs is necessary to trigger this request
-    this.server.post('/auth/oidc/oidc/auth_url', () => {
+    this.server.post('/auth/test-path/oidc/auth_url', () => {
       assert.ok(true, 'auth_url request made to correct non-standard mount path');
       return { data: { auth_url: 'http://example.com' } };
     });

--- a/ui/tests/acceptance/oidc-auth-method-test.js
+++ b/ui/tests/acceptance/oidc-auth-method-test.js
@@ -21,7 +21,7 @@ module('Acceptance | oidc auth method', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  hooks.beforeEach(async function () {
+  hooks.beforeEach(function () {
     this.openStub = windowStub();
 
     this.setupMocks = (assert) => {
@@ -84,7 +84,6 @@ module('Acceptance | oidc auth method', function (hooks) {
         },
       },
     }));
-
     // this request is fired twice -- total assertion count should be 3 rather than 2
     // JLR TODO - auth-jwt: verify whether additional request is necessary, especially when glimmerizing component
     // look into whether didReceiveAttrs is necessary to trigger this request
@@ -95,7 +94,6 @@ module('Acceptance | oidc auth method', function (hooks) {
 
     await logout();
     await this.selectMethod('oidc', true);
-
     setTimeout(() => {
       window.postMessage(buildMessage().data, window.origin);
     }, DELAY_IN_MS);

--- a/ui/tests/acceptance/oidc-auth-method-test.js
+++ b/ui/tests/acceptance/oidc-auth-method-test.js
@@ -67,7 +67,7 @@ module('Acceptance | oidc auth method', function (hooks) {
     await logout();
     await this.selectMethod('oidc');
 
-    later(() => {
+    setTimeout(() => {
       window.postMessage(buildMessage().data, window.origin);
     }, DELAY_IN_MS);
 
@@ -97,7 +97,7 @@ module('Acceptance | oidc auth method', function (hooks) {
     await logout();
     await this.selectMethod('oidc', true);
 
-    later(() => {
+    setTimeout(() => {
       window.postMessage(buildMessage().data, window.origin);
     }, DELAY_IN_MS);
     await click(AUTH_FORM.login);
@@ -109,7 +109,7 @@ module('Acceptance | oidc auth method', function (hooks) {
     await logout();
     await this.selectMethod('oidc');
 
-    later(() => {
+    setTimeout(() => {
       window.postMessage(buildMessage().data, window.origin);
     }, DELAY_IN_MS);
 
@@ -167,7 +167,7 @@ module('Acceptance | oidc auth method', function (hooks) {
     this.server.get('/auth/foo/oidc/callback', () => setupTotpMfaResponse('foo'));
     await logout();
     await this.selectMethod('oidc');
-    later(() => {
+    setTimeout(() => {
       window.postMessage(buildMessage().data, window.origin);
     }, DELAY_IN_MS);
 
@@ -181,7 +181,7 @@ module('Acceptance | oidc auth method', function (hooks) {
     this.setupMocks();
     await logout();
     await this.selectMethod('oidc');
-    later(() => {
+    setTimeout(() => {
       window.postMessage(buildMessage().data, window.origin);
     }, DELAY_IN_MS);
     await click(AUTH_FORM.login);
@@ -228,7 +228,7 @@ module('Acceptance | oidc auth method', function (hooks) {
     await logout();
     await this.selectMethod('oidc');
 
-    later(() => {
+    setTimeout(() => {
       // first assertion
       window.postMessage(callbackData({ source: 'miscellaneous-source' }), window.origin);
       // second assertion
@@ -244,7 +244,7 @@ module('Acceptance | oidc auth method', function (hooks) {
     this.setupMocks();
     await logout();
     await this.selectMethod('oidc');
-    later(() => {
+    setTimeout(() => {
       // callback params are missing "code"
       window.postMessage({ source: 'oidc-callback', state: 'state', foo: 'bar' }, window.origin);
     }, DELAY_IN_MS);

--- a/ui/tests/acceptance/transit-test.js
+++ b/ui/tests/acceptance/transit-test.js
@@ -194,7 +194,7 @@ const testConvergentEncryption = async function (assert, keyName) {
   }
 };
 
-module('Acceptance | transit (flaky)', function (hooks) {
+module('Acceptance | transit', function (hooks) {
   setupApplicationTest(hooks);
 
   hooks.beforeEach(async function () {

--- a/ui/tests/integration/components/auth/login-form-test.js
+++ b/ui/tests/integration/components/auth/login-form-test.js
@@ -159,7 +159,7 @@ module('Integration | Component | auth | login-form', function (hooks) {
 
     await this.renderComponent();
 
-    later(this, () => cancelTimers(), 50);
+    later(() => cancelTimers(), 50);
     await settled();
     const [actual] = authenticateStub.lastCall.args;
     assert.propEqual(

--- a/ui/tests/integration/components/auth/login-form-test.js
+++ b/ui/tests/integration/components/auth/login-form-test.js
@@ -3,11 +3,10 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { _cancelTimers as cancelTimers } from '@ember/runloop';
+import { _cancelTimers as cancelTimers, later } from '@ember/runloop';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { click, fillIn, render, settled } from '@ember/test-helpers';
-import { later } from '@ember/runloop';
 import hbs from 'htmlbars-inline-precompile';
 import sinon from 'sinon';
 import { validate } from 'uuid';

--- a/ui/tests/integration/components/auth/login-form-test.js
+++ b/ui/tests/integration/components/auth/login-form-test.js
@@ -7,6 +7,7 @@ import { _cancelTimers as cancelTimers } from '@ember/runloop';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { click, fillIn, render, settled } from '@ember/test-helpers';
+import { later } from '@ember/runloop';
 import hbs from 'htmlbars-inline-precompile';
 import sinon from 'sinon';
 import { validate } from 'uuid';
@@ -158,7 +159,7 @@ module('Integration | Component | auth | login-form', function (hooks) {
 
     await this.renderComponent();
 
-    setTimeout(() => cancelTimers(), 50);
+    later(this, () => cancelTimers(), 50);
     await settled();
     const [actual] = authenticateStub.lastCall.args;
     assert.propEqual(


### PR DESCRIPTION
- [x] Enterprise tests pass

### Description
Using datadog stats, determined the tests with the most failures. Addressed those here.

The biggest change is how we're using the `logout()` method in the `oidc-auth-method-test`. Previously, the `beforeEach`  did not have an `await` before the `logout()` method, so the logout wasn’t actually completing. When I added the `await`, it caused other issues due to the timing of when `logout()` was being called.

The fix was to move `await logout()` into each test, placing it right before the user selects the auth method. With this change, all tests are now passing.

This test has been responsible for most of our CI failures due to timeouts, so hopefully this significantly reduces those failures. I’ve run the tests multiple times locally—previously I hit frequent timeouts, but I’m not seeing any now 🥳

The other changes: 
Replacing `setTimeout` with `Ember.runloop.later`. The reason for this replacement is `setTimeout` is not recognized by the Ember run loop, while the Ember.run.later method is. From the [docs](https://api.emberjs.com/ember/release/functions/@ember%2Frunloop/later):
>You should use this method whenever you need to run some action after some time instead of using setTimeout().

Note: in the mfa test and oidc auth test we could not use `later()`—I suspect it's because of the nature of the pop out menu. Serving it on a browser, it worked great, but on headless browsers it failed.

