### PR TITLE
CODEOWNERS: update quality group name and add customer eng to docs

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,6 +3,8 @@
 # those areas of the code.
 #
 # More on CODEOWNERS files: https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
+# Default CODEOWNER primarily for contact purposes
+* @hashicorp/vault
 
 # Select Auth engines are owned by Ecosystem
 /builtin/credential/aws/      @hashicorp/vault-ecosystem
@@ -29,40 +31,60 @@
 /vault/plugin_catalog.go      @hashicorp/vault-ecosystem
 
 # Content on developer.hashicorp.com
-/website/ @hashicorp/vault-education-approvers
+
+# Web presence gets notified of, and can approve changes to web tooling, but not content.
+
+/website/               @hashicorp/web-presence
+/website/data/
+/website/public/
+/website/content/
+
+# Education gets notified of, and can approve changes to web content.
+
+/website/data/          @hashicorp/vault-education-approvers
+/website/public/        @hashicorp/vault-education-approvers
+/website/content/       @hashicorp/vault-education-approvers
+/website/templates/     @hashicorp/vault-education-approvers
+/website/redirects.js   @hashicorp/vault-education-approvers
 
 # Plugin docs
 /website/content/docs/plugins/              @hashicorp/vault-ecosystem @hashicorp/vault-education-approvers
 /website/content/docs/upgrading/plugins.mdx @hashicorp/vault-ecosystem @hashicorp/vault-education-approvers
 
+/ui/  @hashicorp/vault-ui
 # UI code related to Vault's JWT/OIDC auth method and OIDC provider.
 # Changes to these files often require coordination with backend code,
 # so stewards of the backend code are added below for notification.
-/ui/app/components/auth-jwt.js         @hashicorp/vault-ecosystem
-/ui/app/routes/vault/cluster/oidc-*.js @hashicorp/vault-ecosystem
+/ui/app/components/auth-jwt.js         @hashicorp/vault-ui @hashicorp/vault-ecosystem
+/ui/app/routes/vault/cluster/oidc-*.js @hashicorp/vault-ui @hashicorp/vault-ecosystem
 
 # Release config; service account is required for automation tooling.
-/.release/                     @hashicorp/github-secure-vault-core @hashicorp/quality-team
-/.github/workflows/build.yml   @hashicorp/github-secure-vault-core @hashicorp/quality-team
+/.release/                     @hashicorp/github-secure-vault-core @hashicorp/team-vault-quality
+/.github/workflows/build.yml   @hashicorp/github-secure-vault-core @hashicorp/team-vault-quality
 
 # Quality engineering
-/.github/  @hashicorp/quality-team
-/enos/     @hashicorp/quality-team
+/.github/  @hashicorp/team-vault-quality
+/enos/     @hashicorp/team-vault-quality
 
 # Cryptosec
+# Temporarily require the crypto team to approve Go updates as we need to make sure
+# 1.24 doesn't make it onto release branches until the FIPS paperwork has been completed.
+/.go-version                                         @hashicorp/vault-crypto
+
+/api/auth/cert/                                      @hashicorp/vault-crypto
 /builtin/logical/pki/                                @hashicorp/vault-crypto
 /builtin/logical/pkiext/                             @hashicorp/vault-crypto
-/website/content/docs/secrets/pki/                   @hashicorp/vault-crypto
-/website/content/api-docs/secret/pki.mdx             @hashicorp/vault-crypto
+/website/content/docs/secrets/pki/                   @hashicorp/vault-crypto @hashicorp/vault-education-approvers
+/website/content/api-docs/secret/pki.mdx             @hashicorp/vault-crypto @hashicorp/vault-education-approvers
 /builtin/credential/cert/                            @hashicorp/vault-crypto
-/website/content/docs/auth/cert.mdx                  @hashicorp/vault-crypto
-/website/content/api-docs/auth/cert.mdx              @hashicorp/vault-crypto
+/website/content/docs/auth/cert.mdx                  @hashicorp/vault-crypto @hashicorp/vault-education-approvers
+/website/content/api-docs/auth/cert.mdx              @hashicorp/vault-crypto @hashicorp/vault-education-approvers
 /builtin/logical/ssh/                                @hashicorp/vault-crypto
-/website/content/docs/secrets/ssh/                   @hashicorp/vault-crypto
-/website/content/api-docs/secret/ssh.mdx             @hashicorp/vault-crypto
+/website/content/docs/secrets/ssh/                   @hashicorp/vault-crypto @hashicorp/vault-education-approvers
+/website/content/api-docs/secret/ssh.mdx             @hashicorp/vault-crypto @hashicorp/vault-education-approvers
 /builtin/logical/transit/                            @hashicorp/vault-crypto
-/website/content/docs/secrets/transit/               @hashicorp/vault-crypto
-/website/content/api-docs/secret/transit.mdx         @hashicorp/vault-crypto
+/website/content/docs/secrets/transit/               @hashicorp/vault-crypto @hashicorp/vault-education-approvers
+/website/content/api-docs/secret/transit.mdx         @hashicorp/vault-crypto @hashicorp/vault-education-approvers
 /helper/random/                                      @hashicorp/vault-crypto
 /sdk/helper/certutil/                                @hashicorp/vault-crypto
 /sdk/helper/cryptoutil/                              @hashicorp/vault-crypto
@@ -76,12 +98,14 @@
 /vault/managed_key*                                  @hashicorp/vault-crypto
 /vault/seal*                                         @hashicorp/vault-crypto
 /vault/seal/                                         @hashicorp/vault-crypto
-/website/content/docs/configuration/seal/            @hashicorp/vault-crypto
-/website/content/docs/enterprise/sealwrap.mdx        @hashicorp/vault-crypto
-/website/content/api-docs/system/sealwrap-rewrap.mdx @hashicorp/vault-crypto
-/website/content/docs/secrets/transform/             @hashicorp/vault-crypto
-/website/content/api-docs/secret/transform.mdx       @hashicorp/vault-crypto
-/website/content/docs/secrets/kmip-profiles.mdx      @hashicorp/vault-crypto
-/website/content/docs/secrets/kmip.mdx               @hashicorp/vault-crypto
-/website/content/api-docs/secret/kmip.mdx            @hashicorp/vault-crypto
-/website/content/docs/enterprise/fips/               @hashicorp/vault-crypto
+/website/content/docs/configuration/seal/            @hashicorp/vault-crypto @hashicorp/vault-education-approvers
+/website/content/docs/enterprise/sealwrap.mdx        @hashicorp/vault-crypto @hashicorp/vault-education-approvers
+/website/content/api-docs/system/sealwrap-rewrap.mdx @hashicorp/vault-crypto @hashicorp/vault-education-approvers
+/website/content/docs/secrets/transform/             @hashicorp/vault-crypto @hashicorp/vault-education-approvers
+/website/content/api-docs/secret/transform.mdx       @hashicorp/vault-crypto @hashicorp/vault-education-approvers
+/website/content/docs/secrets/kmip-profiles.mdx      @hashicorp/vault-crypto @hashicorp/vault-education-approvers
+/website/content/docs/secrets/kmip.mdx               @hashicorp/vault-crypto @hashicorp/vault-education-approvers
+/website/content/api-docs/secret/kmip.mdx            @hashicorp/vault-crypto @hashicorp/vault-education-approvers
+/website/content/docs/enterprise/fips/               @hashicorp/vault-crypto @hashicorp/vault-education-approvers
+/website/content/docs/platform/k8s                   @hashicorp/vault-ecosystem @hashicorp/vault-education-approvers
+/website/content/                                    @hashicorp/vault-customer-engineering @hashicorp/vault-education-approvers


### PR DESCRIPTION
### Description
Manual backport of https://github.com/hashicorp/vault/pull/30305. Rather than resolve differences in the cherry-pick we accept the latest CODEOWNERS from `main`.

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
