### PR TITLE
propgate config.Region in the IAM and STS clients

### DIFF
--- a/builtin/logical/aws/client.go
+++ b/builtin/logical/aws/client.go
@@ -187,10 +187,12 @@ func (b *backend) getRootSTSConfigs(ctx context.Context, s logical.Storage, logg
 		opts = append(opts, awsutil.WithEnvironmentCredentials(false), awsutil.WithSharedCredentials(false))
 	}
 
-	// at this point, in the IAM case, regions contains config.Region, if it was set.
-	//                                 endpoints contains iam_endpoint, if it was set.
-	// in the sts case, regions contains sts_region, if it was set, then the sts_fallback_regions in order, if they were set.
-	//                  endpoints contains sts_endpint, if it wa set, then sts_fallback_endpoints in order, if they were set.
+	// at this point, in the IAM case,
+	// - regions contains config.Region, if it was set.
+	// - endpoints contains iam_endpoint, if it was set.
+	// in the sts case,
+	// - regions contains sts_region, if it was set, then sts_fallback_regions in order, if they were set.
+	// - endpoints contains sts_endpoint, if it was set, then sts_fallback_endpoints in order, if they were set.
 
 	// case in which nothing was supplied
 	if len(regions) == 0 {

--- a/builtin/logical/aws/client.go
+++ b/builtin/logical/aws/client.go
@@ -192,8 +192,6 @@ func (b *backend) getRootSTSConfigs(ctx context.Context, s logical.Storage, logg
 	// in the sts case, regions contains sts_region, if it was set, then the sts_fallback_regions in order, if they were set.
 	//                  endpoints contains sts_endpint, if it wa set, then sts_fallback_endpoints in order, if they were set.
 
-	logger.Info("pre", "region", fmt.Sprintf("%+v", regions), "endpoint", fmt.Sprintf("%+v", endpoints))
-
 	// case in which nothing was supplied
 	if len(regions) == 0 {
 		// fallback region is in descending order, AWS_REGION, or AWS_DEFAULT_REGION, or us-east-1
@@ -211,8 +209,6 @@ func (b *backend) getRootSTSConfigs(ctx context.Context, s logical.Storage, logg
 		return nil, errors.New("number of regions does not match number of endpoints")
 	}
 
-	logger.Info("data", "region", fmt.Sprintf("%+v", regions), "endpoint", fmt.Sprintf("%+v", endpoints))
-
 	for i := 0; i < len(endpoints); i++ {
 		if len(regions) > i {
 			credsConfig.Region = regions[i]
@@ -223,7 +219,6 @@ func (b *backend) getRootSTSConfigs(ctx context.Context, s logical.Storage, logg
 		if err != nil {
 			return nil, err
 		}
-		logger.Info("this pair is", "region", credsConfig.Region, "endpoint", endpoints[i])
 		configs = append(configs, &aws.Config{
 			Credentials: creds,
 			Region:      aws.String(credsConfig.Region),

--- a/builtin/logical/aws/path_config_root_test.go
+++ b/builtin/logical/aws/path_config_root_test.go
@@ -324,10 +324,125 @@ func TestBackend_PathConfigRoot_STSFallback_defaultEndpointRegion(t *testing.T) 
 	}
 	if len(cfgs) != 1 {
 		t.Fatalf("got %d configs, but expected 1", len(cfgs))
+	} else {
+		cfg := cfgs[0]
+		if *(cfg.Endpoint) != matchingSTSEndpoint(*(cfg.Region)) {
+			t.Fatalf("region and endpoint didn't match: %s vs. %s", *(cfg.Region), *(cfg.Endpoint))
+		}
 	}
 }
 
-// TestBackend_PathConfigRoot_IAM_defaultEndpointRegion ensures taht if no endpoints are specified, we can still
+// TestBackend_PathConfigRoot_IAM_specifiedRegion ensures that if a region is set, we get a good config (with a blank
+// endpoint)
+func TestBackend_PathConfigRoot_IAM_specifiedRegion(t *testing.T) {
+	config := logical.TestBackendConfig()
+	config.StorageView = &logical.InmemStorage{}
+	config.System = &testSystemView{}
+
+	b := Backend(config)
+	if err := b.Setup(context.Background(), config); err != nil {
+		t.Fatal(err)
+	}
+
+	desiredRegion := "us-west-2"
+
+	configData := map[string]interface{}{
+		"access_key":              "AKIAEXAMPLE",
+		"secret_key":              "RandomData",
+		"max_retries":             10,
+		"username_template":       defaultUserNameTemplate,
+		"region":                  desiredRegion,
+		"role_arn":                "",
+		"identity_token_audience": "",
+		"identity_token_ttl":      int64(0),
+	}
+
+	configReq := &logical.Request{
+		Operation: logical.UpdateOperation,
+		Storage:   config.StorageView,
+		Path:      "config/root",
+		Data:      configData,
+	}
+
+	_, err := b.HandleRequest(context.Background(), configReq)
+	if err != nil {
+		t.Fatalf("bad: config writing failed: err: %v", err)
+	}
+
+	cfgs, err := b.getRootConfigs(context.Background(), config.StorageView, "iam", b.Logger())
+	if err != nil {
+		t.Fatalf("couldn't get IAM configs with default region/endpoints: %v", err)
+	}
+
+	if len(cfgs) != 1 {
+		t.Fatalf("got %d configs, but expected 1", len(cfgs))
+	}
+
+	if *(cfgs[0].Endpoint) != "" {
+		t.Fatalf("endpoint should have remained blank but it became %s", *(cfgs[0].Endpoint))
+	}
+	if *(cfgs[0].Region) != desiredRegion {
+		t.Fatalf("region changed from config: %s became %s", desiredRegion, *(cfgs[0].Region))
+	}
+}
+
+// TestBackend_PathConfigRoot_IAM_specifiedRegionAndEndpoint ensures that if a region and endpoint are set, we get a
+// good config
+func TestBackend_PathConfigRoot_IAM_specifiedRegionAndEndpoint(t *testing.T) {
+	config := logical.TestBackendConfig()
+	config.StorageView = &logical.InmemStorage{}
+	config.System = &testSystemView{}
+
+	b := Backend(config)
+	if err := b.Setup(context.Background(), config); err != nil {
+		t.Fatal(err)
+	}
+
+	desiredRegion := "custom-region"
+	desiredEndpoint := "https://custom-endpoint.local"
+
+	configData := map[string]interface{}{
+		"access_key":              "AKIAEXAMPLE",
+		"secret_key":              "RandomData",
+		"max_retries":             10,
+		"username_template":       defaultUserNameTemplate,
+		"region":                  desiredRegion,
+		"iam_endpoint":            desiredEndpoint,
+		"role_arn":                "",
+		"identity_token_audience": "",
+		"identity_token_ttl":      int64(0),
+	}
+
+	configReq := &logical.Request{
+		Operation: logical.UpdateOperation,
+		Storage:   config.StorageView,
+		Path:      "config/root",
+		Data:      configData,
+	}
+
+	_, err := b.HandleRequest(context.Background(), configReq)
+	if err != nil {
+		t.Fatalf("bad: config writing failed: err: %v", err)
+	}
+
+	cfgs, err := b.getRootConfigs(context.Background(), config.StorageView, "iam", b.Logger())
+	if err != nil {
+		t.Fatalf("couldn't get IAM configs with default region/endpoints: %v", err)
+	}
+
+	if len(cfgs) != 1 {
+		t.Fatalf("got %d configs, but expected 1", len(cfgs))
+	}
+
+	if *(cfgs[0].Endpoint) != desiredEndpoint {
+		t.Fatalf("endpoint should have been %s but it became %s", desiredEndpoint, *(cfgs[0].Endpoint))
+	}
+	if *(cfgs[0].Region) != desiredRegion {
+		t.Fatalf("region changed from config: %s became %s", desiredRegion, *(cfgs[0].Region))
+	}
+}
+
+// TestBackend_PathConfigRoot_IAM_defaultEndpointRegion ensures that if no endpoints are specified, we can still
 // make a config with the appropriate values.
 func TestBackend_PathConfigRoot_IAM_defaultEndpointRegion(t *testing.T) {
 	config := logical.TestBackendConfig()
@@ -367,6 +482,81 @@ func TestBackend_PathConfigRoot_IAM_defaultEndpointRegion(t *testing.T) {
 	}
 	if len(cfgs) != 1 {
 		t.Fatalf("got %d configs, but expected 1", len(cfgs))
+	} else {
+		// ensure endpoint is blank, because AWS wants that
+		if *(cfgs[0].Endpoint) != "" {
+			t.Fatalf("expected endpoint to be blank but it was %s", *(cfgs[0].Endpoint))
+		}
+	}
+}
+
+// TestBackend_PathConfigRoot_STSIAM_SetEverything ensures that if both IAM and STS are configured, they interact
+// correctly.
+func TestBackend_PathConfigRoot_STSIAM_SetEverything(t *testing.T) {
+	config := logical.TestBackendConfig()
+	config.StorageView = &logical.InmemStorage{}
+	config.System = &testSystemView{}
+
+	b := Backend(config)
+	if err := b.Setup(context.Background(), config); err != nil {
+		t.Fatal(err)
+	}
+
+	desiredRegion := "us-west-2"
+	stsRegion := "us-east-1"
+	stsEndpoint := "https://sts.us-east-1.amazonaws.com"
+
+	configData := map[string]interface{}{
+		"access_key":              "AKIAEXAMPLE",
+		"secret_key":              "RandomData",
+		"max_retries":             10,
+		"username_template":       defaultUserNameTemplate,
+		"region":                  desiredRegion,
+		"sts_region":              stsRegion,
+		"sts_endpoint":            stsEndpoint,
+		"sts_fallback_regions":    "ap-west-1,fake-region-2",
+		"sts_fallback_endpoints":  "1.1.1.1,192.168.2.3",
+		"role_arn":                "",
+		"identity_token_audience": "",
+		"identity_token_ttl":      int64(0),
+	}
+
+	configReq := &logical.Request{
+		Operation: logical.UpdateOperation,
+		Storage:   config.StorageView,
+		Path:      "config/root",
+		Data:      configData,
+	}
+
+	_, err := b.HandleRequest(context.Background(), configReq)
+	if err != nil {
+		t.Fatalf("bad: config writing failed: err: %v", err)
+	}
+
+	// get IAM
+	cfgs, err := b.getRootConfigs(context.Background(), config.StorageView, "iam", b.Logger())
+	if err != nil {
+		t.Fatalf("couldn't get IAM configs with default region/endpoints: %v", err)
+	}
+
+	if len(cfgs) != 1 {
+		t.Fatalf("got %d configs, but expected 1", len(cfgs))
+	}
+
+	if *(cfgs[0].Endpoint) != "" {
+		t.Fatalf("endpoint should have remained blank but it became %s", *(cfgs[0].Endpoint))
+	}
+	if *(cfgs[0].Region) != desiredRegion {
+		t.Fatalf("region changed from config: %s became %s", desiredRegion, *(cfgs[0].Region))
+	}
+
+	// get STS
+	cfgs, err = b.getRootConfigs(context.Background(), config.StorageView, "sts", b.Logger())
+	if err != nil {
+		t.Fatalf("couldn't get IAM configs with default region/endpoints: %v", err)
+	}
+	if len(cfgs) != 3 {
+		t.Fatalf("got %d configs, but expected 3", len(cfgs))
 	}
 }
 

--- a/builtin/logical/aws/path_config_root_test.go
+++ b/builtin/logical/aws/path_config_root_test.go
@@ -318,7 +318,7 @@ func TestBackend_PathConfigRoot_STSFallback_defaultEndpointRegion(t *testing.T) 
 		t.Fatalf("bad: config writing failed: err: %v", err)
 	}
 
-	cfgs, err := b.getRootConfigs(context.Background(), config.StorageView, "sts", b.Logger())
+	cfgs, err := b.getRootSTSConfigs(context.Background(), config.StorageView, b.Logger())
 	if err != nil {
 		t.Fatalf("couldn't get STS configs with default region/endpoints: %v", err)
 	}
@@ -369,20 +369,15 @@ func TestBackend_PathConfigRoot_IAM_specifiedRegion(t *testing.T) {
 		t.Fatalf("bad: config writing failed: err: %v", err)
 	}
 
-	cfgs, err := b.getRootConfigs(context.Background(), config.StorageView, "iam", b.Logger())
+	cfg, err := b.getRootIAMConfig(context.Background(), config.StorageView, b.Logger())
 	if err != nil {
 		t.Fatalf("couldn't get IAM configs with default region/endpoints: %v", err)
 	}
-
-	if len(cfgs) != 1 {
-		t.Fatalf("got %d configs, but expected 1", len(cfgs))
+	if *(cfg.Endpoint) != "" {
+		t.Fatalf("endpoint should have remained blank but it became %s", *(cfg.Endpoint))
 	}
-
-	if *(cfgs[0].Endpoint) != "" {
-		t.Fatalf("endpoint should have remained blank but it became %s", *(cfgs[0].Endpoint))
-	}
-	if *(cfgs[0].Region) != desiredRegion {
-		t.Fatalf("region changed from config: %s became %s", desiredRegion, *(cfgs[0].Region))
+	if *(cfg.Region) != desiredRegion {
+		t.Fatalf("region changed from config: %s became %s", desiredRegion, *(cfg.Region))
 	}
 }
 
@@ -425,20 +420,16 @@ func TestBackend_PathConfigRoot_IAM_specifiedRegionAndEndpoint(t *testing.T) {
 		t.Fatalf("bad: config writing failed: err: %v", err)
 	}
 
-	cfgs, err := b.getRootConfigs(context.Background(), config.StorageView, "iam", b.Logger())
+	cfg, err := b.getRootIAMConfig(context.Background(), config.StorageView, b.Logger())
 	if err != nil {
 		t.Fatalf("couldn't get IAM configs with default region/endpoints: %v", err)
 	}
 
-	if len(cfgs) != 1 {
-		t.Fatalf("got %d configs, but expected 1", len(cfgs))
+	if *(cfg.Endpoint) != desiredEndpoint {
+		t.Fatalf("endpoint should have been %s but it became %s", desiredEndpoint, *(cfg.Endpoint))
 	}
-
-	if *(cfgs[0].Endpoint) != desiredEndpoint {
-		t.Fatalf("endpoint should have been %s but it became %s", desiredEndpoint, *(cfgs[0].Endpoint))
-	}
-	if *(cfgs[0].Region) != desiredRegion {
-		t.Fatalf("region changed from config: %s became %s", desiredRegion, *(cfgs[0].Region))
+	if *(cfg.Region) != desiredRegion {
+		t.Fatalf("region changed from config: %s became %s", desiredRegion, *(cfg.Region))
 	}
 }
 
@@ -476,17 +467,13 @@ func TestBackend_PathConfigRoot_IAM_defaultEndpointRegion(t *testing.T) {
 		t.Fatalf("bad: config writing failed: err: %v", err)
 	}
 
-	cfgs, err := b.getRootConfigs(context.Background(), config.StorageView, "iam", b.Logger())
+	cfg, err := b.getRootIAMConfig(context.Background(), config.StorageView, b.Logger())
 	if err != nil {
 		t.Fatalf("couldn't get IAM configs with default region/endpoints: %v", err)
 	}
-	if len(cfgs) != 1 {
-		t.Fatalf("got %d configs, but expected 1", len(cfgs))
-	} else {
-		// ensure endpoint is blank, because AWS wants that
-		if *(cfgs[0].Endpoint) != "" {
-			t.Fatalf("expected endpoint to be blank but it was %s", *(cfgs[0].Endpoint))
-		}
+	// ensure endpoint is blank, because AWS wants that
+	if *(cfg.Endpoint) != "" {
+		t.Fatalf("expected endpoint to be blank but it was %s", *(cfg.Endpoint))
 	}
 }
 
@@ -534,24 +521,20 @@ func TestBackend_PathConfigRoot_STSIAM_SetEverything(t *testing.T) {
 	}
 
 	// get IAM
-	cfgs, err := b.getRootConfigs(context.Background(), config.StorageView, "iam", b.Logger())
+	cfg, err := b.getRootIAMConfig(context.Background(), config.StorageView, b.Logger())
 	if err != nil {
 		t.Fatalf("couldn't get IAM configs with default region/endpoints: %v", err)
 	}
 
-	if len(cfgs) != 1 {
-		t.Fatalf("got %d configs, but expected 1", len(cfgs))
+	if *(cfg.Endpoint) != "" {
+		t.Fatalf("endpoint should have remained blank but it became %s", *(cfg.Endpoint))
 	}
-
-	if *(cfgs[0].Endpoint) != "" {
-		t.Fatalf("endpoint should have remained blank but it became %s", *(cfgs[0].Endpoint))
-	}
-	if *(cfgs[0].Region) != desiredRegion {
-		t.Fatalf("region changed from config: %s became %s", desiredRegion, *(cfgs[0].Region))
+	if *(cfg.Region) != desiredRegion {
+		t.Fatalf("region changed from config: %s became %s", desiredRegion, *(cfg.Region))
 	}
 
 	// get STS
-	cfgs, err = b.getRootConfigs(context.Background(), config.StorageView, "sts", b.Logger())
+	cfgs, err := b.getRootSTSConfigs(context.Background(), config.StorageView, b.Logger())
 	if err != nil {
 		t.Fatalf("couldn't get IAM configs with default region/endpoints: %v", err)
 	}

--- a/changelog/30312.txt
+++ b/changelog/30312.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+secrets/aws: fix a case where GovCloud wasn't taken into account; fix a case where the region setting wasn't respected
+```


### PR DESCRIPTION
This PR should resolve an issue with certain secrets/aws configurations where we weren't properly handling default values, and additionally where we weren't handling GovCloud iam endpoints.

This change will allow the config.Region setting to flow through as the default in all cases for IAM, and when no stsRegion is set for STS. The fallback values (AWS_REGION, etc) will show up in fewer cases.

In the GovCloud case, it's possible that one might be able to work around the existing issue by setting the `AWS_REGION` environment variable and explicitly setting the `iam_endpoint` value.

Areas of Concern:
I tested this to work on all permutations of IAM and STS endpoints, regions, etc, that I could think of, but
1) We don't have access to GovCloud, so I can't definitively verify that it works there
2) A lot of the behavior of secrets/aws (and AWS in general, frankly) are the result of cascading settings and backwards compatible conventions, and there's just a lot of interlocking space for situations I didn't think of.

### TODO only if you're a HashiCorp employee
- [X] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.