### PR TITLE
UI: Build Okta auth method component

### DIFF
--- a/ui/app/components/auth/form/base.ts
+++ b/ui/app/components/auth/form/base.ts
@@ -11,6 +11,7 @@ import { waitFor } from '@ember/test-waiters';
 import { sanitizePath } from 'core/utils/sanitize-path';
 
 import type AuthService from 'vault/vault/services/auth';
+import type { AuthData } from 'vault/vault/services/auth';
 import type ClusterModel from 'vault/models/cluster';
 import type { HTMLElementEvent } from 'vault/forms';
 
@@ -56,28 +57,25 @@ export default class AuthBase extends Component<Args> {
   }
 
   login = task(
-    waitFor(async (data) => {
+    waitFor(async (formData) => {
       try {
         const authResponse = await this.auth.authenticate({
           clusterId: this.args.cluster.id,
           backend: this.args.authType,
-          data,
+          data: formData,
           selectedAuth: this.args.authType,
         });
 
-        // responsible for redirect after auth data is persisted
-        this.onSuccess(authResponse);
+        this.handleAuthResponse(authResponse);
       } catch (error) {
         this.onError(error as Error);
       }
     })
   );
 
-  // if we move auth service authSuccess method here (or to each auth method component)
-  // then call that before calling parent this.args.onSuccess
-  onSuccess(authResponse: object) {
-    //  responsible for redirect after auth data is persisted
-    this.args.onSuccess(authResponse, this.args.authType);
+  handleAuthResponse(authResponse: AuthData) {
+    // calls onAuthResponse in parent auth/page.js component
+    this.args.onSuccess(authResponse);
   }
 
   onError(error: Error) {

--- a/ui/app/components/auth/form/base.ts
+++ b/ui/app/components/auth/form/base.ts
@@ -8,6 +8,7 @@ import { action } from '@ember/object';
 import { service } from '@ember/service';
 import { task } from 'ember-concurrency';
 import { waitFor } from '@ember/test-waiters';
+import { sanitizePath } from 'core/utils/sanitize-path';
 
 import type AuthService from 'vault/vault/services/auth';
 import type ClusterModel from 'vault/models/cluster';
@@ -39,7 +40,9 @@ export default class AuthBase extends Component<Args> {
     const data: Record<string, FormDataEntryValue | null> = {};
 
     for (const key of formData.keys()) {
-      data[key] = formData.get(key);
+      const value = formData.get(key);
+      // strip leading or trailing slashes from path for consistency
+      data[key] = key === 'path' ? sanitizePath(value) : value;
     }
 
     // If path is not included in the submitted form data,

--- a/ui/app/components/auth/form/okta.hbs
+++ b/ui/app/components/auth/form/okta.hbs
@@ -1,0 +1,37 @@
+{{!
+  Copyright (c) HashiCorp, Inc.
+  SPDX-License-Identifier: BUSL-1.1
+~}}
+
+{{#if this.showNumberChallenge}}
+  <OktaNumberChallenge
+    @correctAnswer={{this.challengeAnswer}}
+    @hasError={{this.oktaVerifyError}}
+    @onReturnToLogin={{this.reset}}
+  />
+{{else}}
+  <form {{on "submit" this.onSubmit}} data-test-auth-form={{@authType}}>
+
+    {{yield to="namespace"}}
+
+    <div class="has-padding-l">
+      {{yield to="back"}}
+      {{yield to="authSelectOptions"}}
+      {{yield to="error"}}
+
+      <Auth::Fields @loginFields={{this.loginFields}} />
+
+      {{yield to="advancedSettings"}}
+
+      <Hds::Button
+        @text="Sign in"
+        @isFullWidth={{true}}
+        type="submit"
+        class="has-top-margin-m has-bottom-margin-m"
+        data-test-auth-submit
+      />
+
+      {{yield to="footer"}}
+    </div>
+  </form>
+{{/if}}

--- a/ui/app/components/auth/form/okta.js
+++ b/ui/app/components/auth/form/okta.js
@@ -4,6 +4,13 @@
  */
 
 import AuthBase from './base';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+import { task, timeout } from 'ember-concurrency';
+import { tracked } from '@glimmer/tracking';
+import { waitFor } from '@ember/test-waiters';
+import errorMessage from 'vault/utils/error-message';
+import uuid from 'core/utils/uuid';
 
 /**
  * @module Auth::Form::Okta
@@ -12,4 +19,80 @@ import AuthBase from './base';
 
 export default class AuthFormOkta extends AuthBase {
   loginFields = [{ name: 'username' }, { name: 'password' }];
+
+  @service auth;
+
+  @tracked challengeAnswer = null;
+  @tracked oktaVerifyError = '';
+  @tracked showNumberChallenge = false;
+
+  login = task(
+    waitFor(async (data) => {
+      // wait for 1s to wait to see if there is a login error before polling
+      await timeout(1000);
+
+      data.nonce = uuid();
+      this.pollForOktaNumberChallenge.perform(data.nonce, data.path);
+
+      try {
+        const authResponse = await this.auth.authenticate({
+          clusterId: this.args.cluster.id,
+          backend: this.args.authType,
+          data,
+          selectedAuth: this.args.authType,
+        });
+
+        this.onSuccess(authResponse);
+      } catch (error) {
+        // if a user fails the okta verify challenge, the POST login request fails (made by this.auth.authenticate above)
+        // bubble those up for consistency instead of managing error state in this component
+        this.onError(error);
+        // cancel polling tasks and reset state
+        this.reset();
+      }
+    })
+  );
+
+  pollForOktaNumberChallenge = task(
+    waitFor(async (nonce, mountPath) => {
+      this.showNumberChallenge = true;
+
+      // keep polling /auth/okta/verify/:nonce API every 1s until response returns with correct_number
+      let response = null;
+      while (response === null) {
+        await timeout(1000);
+        response = await this.requestOktaVerify(nonce, mountPath);
+      }
+
+      // display correct number so user can select on personal MFA device
+      this.challengeAnswer = response;
+    })
+  );
+
+  @action
+  requestOktaVerify(nonce, mountPath) {
+    const url = `/v1/auth/${mountPath}/verify/${nonce}`;
+    return this.auth
+      .ajax(url, 'GET', {})
+      .then((resp) => resp.data.correct_answer)
+      .catch((e) => {
+        // if error status is 404 keep polling for a response
+        if (e.status === 404) {
+          return null;
+        } else {
+          // this would be unusual, but handling just in case
+          this.oktaVerifyError = errorMessage(e);
+        }
+      });
+  }
+
+  @action
+  reset() {
+    // reset tracked variables and stop polling tasks
+    this.challengeAnswer = null;
+    this.oktaVerifyError = '';
+    this.showNumberChallenge = false;
+    this.login.cancelAll();
+    this.pollForOktaNumberChallenge.cancelAll();
+  }
 }

--- a/ui/app/components/auth/form/okta.ts
+++ b/ui/app/components/auth/form/okta.ts
@@ -45,7 +45,7 @@ export default class AuthFormOkta extends AuthBase {
           selectedAuth: this.args.authType,
         });
 
-        this.onSuccess(authResponse);
+        this.handleAuthResponse(authResponse);
       } catch (error) {
         // if a user fails the okta verify challenge, the POST login request fails (made by this.auth.authenticate above)
         // bubble those up for consistency instead of managing error state in this component

--- a/ui/app/components/auth/form/okta.ts
+++ b/ui/app/components/auth/form/okta.ts
@@ -20,13 +20,13 @@ import type AuthService from 'vault/vault/services/auth';
  * */
 
 export default class AuthFormOkta extends AuthBase {
-  loginFields = [{ name: 'username' }, { name: 'password' }];
-
   @service declare readonly auth: AuthService;
 
   @tracked challengeAnswer = '';
   @tracked oktaVerifyError = '';
   @tracked showNumberChallenge = false;
+
+  loginFields = [{ name: 'username' }, { name: 'password' }];
 
   login = task(
     waitFor(async (data) => {

--- a/ui/lib/core/addon/utils/uuid.js
+++ b/ui/lib/core/addon/utils/uuid.js
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import { v4 as uuidv4 } from 'uuid';
+
+/**
+ * Use this instead of uuidv4() so that generated UUIDs can be stubbed in tests.
+ */
+
+export default function uuid() {
+  return uuidv4();
+}

--- a/ui/lib/core/app/utils/uuid.js
+++ b/ui/lib/core/app/utils/uuid.js
@@ -1,0 +1,6 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+export { default } from 'core/utils/uuid';

--- a/ui/tests/integration/components/auth/form/okta-test.js
+++ b/ui/tests/integration/components/auth/form/okta-test.js
@@ -6,10 +6,15 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import { render } from '@ember/test-helpers';
+import { click, fillIn, render } from '@ember/test-helpers';
 import sinon from 'sinon';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import testHelper from './test-helper';
+import { LOGIN_DATA } from 'vault/tests/helpers/auth/auth-helpers';
+import { GENERAL } from 'vault/tests/helpers/general-selectors';
+import { AUTH_FORM } from 'vault/tests/helpers/auth/auth-form-selectors';
+import * as uuid from 'core/utils/uuid';
+import { Response } from 'miragejs';
 
 module('Integration | Component | auth | form | okta', function (hooks) {
   setupRenderingTest(hooks);
@@ -18,15 +23,28 @@ module('Integration | Component | auth | form | okta', function (hooks) {
   hooks.beforeEach(function () {
     this.authType = 'okta';
     this.expectedFields = ['username', 'password'];
-
     this.authenticateStub = sinon.stub(this.owner.lookup('service:auth'), 'authenticate');
     this.cluster = { id: 1 };
     this.onError = sinon.spy();
     this.onSuccess = sinon.spy();
+    // stub uuid so auth/okta/verify request can be stubbed using mirage
+    this.nonce = '12345';
+    sinon.stub(uuid, 'default').returns(this.nonce);
+    this.response = { data: { correct_answer: 68 } };
+    this.server.get(`/auth/:path/verify/${this.nonce}`, () => this.response);
+
     this.expectedSubmit = {
-      default: { path: 'okta', username: 'matilda', password: 'password' },
-      custom: { path: 'custom-okta', username: 'matilda', password: 'password' },
+      default: { path: 'okta', username: 'matilda', password: 'password', nonce: this.nonce },
+      custom: { path: 'custom-okta', username: 'matilda', password: 'password', nonce: this.nonce },
     };
+
+    this.fillInForm = async () => {
+      const { loginData } = LOGIN_DATA.username;
+      for (const [field, value] of Object.entries(loginData)) {
+        await fillIn(GENERAL.inputByAttr(field), value);
+      }
+    };
+
     this.renderComponent = ({ yieldBlock = false } = {}) => {
       if (yieldBlock) {
         return render(hbs`
@@ -52,5 +70,101 @@ module('Integration | Component | auth | form | okta', function (hooks) {
     };
   });
 
-  testHelper(test);
+  testHelper(test, { standardSubmit: false });
+
+  test('it submits form data with defaults', async function (assert) {
+    assert.expect(2);
+    this.server.get(`/auth/okta/verify/${this.nonce}`, () => {
+      // since the yielded input is name="path" we can also assert the okta/verify response is hit as expected
+      assert.true(true, 'it requests okta verify with default mount path');
+      return this.response;
+    });
+
+    await this.renderComponent();
+    await this.fillInForm();
+    await click(AUTH_FORM.login);
+    const [actual] = this.authenticateStub.lastCall.args;
+    assert.propEqual(
+      actual.data,
+      this.expectedSubmit.default,
+      'auth service "authenticate" method is called with form data'
+    );
+  });
+
+  // not representative of real-world submit, that happens in acceptance tests.
+  // component here just yields <:advancedSettings> to test form submits data yielded data
+  test('it submits form data from yielded inputs', async function (assert) {
+    assert.expect(2);
+    this.server.get(`/auth/custom-okta/verify/${this.nonce}`, () => {
+      // since the yielded input is name="path" we can also assert the okta/verify response is hit as expected
+      assert.true(true, 'it requests okta verify with custom mount path');
+      return this.response;
+    });
+
+    await this.renderComponent({ yieldBlock: true });
+    await this.fillInForm();
+    await fillIn(GENERAL.inputByAttr('path'), `custom-${this.authType}`);
+    await click(AUTH_FORM.login);
+    const [actual] = this.authenticateStub.lastCall.args;
+    assert.propEqual(
+      actual.data,
+      this.expectedSubmit.custom,
+      'auth service "authenticate" method is called with yielded form data'
+    );
+  });
+
+  test('it displays okta number challenge answer', async function (assert) {
+    await this.renderComponent();
+    await this.fillInForm();
+    await click(AUTH_FORM.login);
+    assert
+      .dom('[data-test-okta-number-challenge]')
+      .hasText(
+        'To finish signing in, you will need to complete an additional MFA step. Okta verification Select the following number to complete verification: 68 Back to login'
+      );
+  });
+
+  test('it returns to login when "Back to login" is clicked', async function (assert) {
+    await this.renderComponent();
+    await this.fillInForm();
+    await click(AUTH_FORM.login);
+    assert.dom('[data-test-okta-number-challenge]').exists();
+    await click(GENERAL.backButton);
+    assert.dom(AUTH_FORM.authForm('okta')).exists('it returns to okta form');
+    assert.dom('[data-test-okta-number-challenge]').doesNotExist();
+    assert.dom(GENERAL.inputByAttr('username')).hasValue('', 'username is cleared');
+    assert.dom(GENERAL.inputByAttr('password')).hasValue('', 'password is cleared');
+  });
+
+  test('it shows loading state when polling okta verify request', async function (assert) {
+    assert.expect(2);
+    let count = 0;
+    this.server.get(`/auth/okta/verify/${this.nonce}`, () => {
+      count++;
+      assert.dom('[data-test-okta-number-challenge]').hasText(
+        'To finish signing in, you will need to complete an additional MFA step. Please wait... Back to login',
+        count === 1
+          ? // the response hasn't returned anything yet, so the first assertion is just the initial state
+            'it shows loading message before polling initiates'
+          : // by now the response has returned a 404 so this asserts error handling works as expected
+            'it shows loading message while response returns 404'
+      );
+      // okta/verify returns a 404 until the user interacts with okta via their configured MFA app.
+      // to simulate this interaction we return data on the third request - which ends the polling.
+      const response = count < 2 ? new Response(404, {}, { errors: [] }) : this.response;
+      return response;
+    });
+
+    await this.renderComponent();
+    await this.fillInForm();
+    await click(AUTH_FORM.login);
+  });
+
+  test('it renders error message when okta verify request errors', async function (assert) {
+    this.server.get(`/auth/okta/verify/${this.nonce}`, () => new Response(500));
+    await this.renderComponent();
+    await this.fillInForm();
+    await click(AUTH_FORM.login);
+    assert.dom(GENERAL.messageError).hasText('Error An error occurred, please try again');
+  });
 });

--- a/ui/types/vault/services/auth.d.ts
+++ b/ui/types/vault/services/auth.d.ts
@@ -20,6 +20,7 @@ export interface AuthData {
 export default class AuthService extends Service {
   authData: AuthData;
   currentToken: string;
+  mfaErrors: null | Errors[];
   setLastFetch: (time: number) => void;
   handleError: (error: Error) => string | error[] | [error];
   authenticate(params: {
@@ -28,5 +29,13 @@ export default class AuthService extends Service {
     data: Record<string, FormDataEntryValue | null>;
     selectedAuth: string;
   }): Promise<any>;
-  mfaErrors: null | Errors[];
+  ajax: (
+    url: string,
+    method: 'GET' | 'POST' | 'PUT' | 'DELETE',
+    options?: {
+      headers?: Record<string, string>;
+      namespace?: string;
+      data?: Record<string, unknown>;
+    }
+  ) => Promise<any>;
 }


### PR DESCRIPTION
### Description
❗ No user facing changes 

Builds Okta auth method component which displays the OktaNumberChallenge (if configured by the okta profile). Right now the okta logic is spread out across a couple different files: auth service and login-form.js. Now it's all nicely consolidated in one component 🎉 

<img width="600" alt="Screenshot 2025-04-22 at 9 55 39 AM" src="https://github.com/user-attachments/assets/f9ace7e1-4ac8-47d6-ae34-614fda3ac568" />

<img width="600" alt="Screenshot 2025-04-22 at 9 55 55 AM" src="https://github.com/user-attachments/assets/75f2edd7-77dc-4fdd-92df-aa1eec7c7e3a" />

<img width="600" alt="Screenshot 2025-04-22 at 9 56 22 AM" src="https://github.com/user-attachments/assets/0b7e9a6d-9207-45ee-aa27-6fb325d45a91" />


### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
