### PR TITLE
Added certificate section to LDAP Auth method documentation.

### DIFF
--- a/website/content/docs/auth/ldap.mdx
+++ b/website/content/docs/auth/ldap.mdx
@@ -148,6 +148,12 @@ For anonymous search, `discoverdn` must be set to `true`, and `deny_null_bind` m
   LDAP users log in using `sAMAccountName` or `userPrincipalName` when the
   `upndomain` parameter is set.
 
+### Certificates
+
+Vault also reads certificates stored in Operating Systems (OS) certificate trust store for Vault LDAP Authentication Method and so you may wish to use that instead of specifying the CA certificate via the certificate parameter that may be omitted altogether when initially configuring the method.
+
+This trust store is read during Vault startup only. CA certificate additions to the OS trust store will require a restart to the Vault process before the LDAP authentication method can use those to establish new LDAP connections to the configured server address.
+
 ### Group membership resolution
 
 Once a user has been authenticated, the LDAP auth method must know how to resolve which groups the user is a member of. The configuration for this can vary depending on your LDAP server and your directory schema. There are two main strategies when resolving group membership - the first is searching for the authenticated user object and following an attribute to groups it is a member of. The second is to search for group objects of which the authenticated user is a member of. Both methods are supported.


### PR DESCRIPTION
### Description
What does this PR do?

Added certificate section to LDAP Auth method documentation.
This section explains how the LDAP auth method reads the OS trust store.
