### PR TITLE
Delta CRL enablement, including tests.

### DIFF
--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -581,6 +581,10 @@ func generateURLSteps(t *testing.T, caCert, caKey string, intdata, reqdata map[s
 			"http://example.com/crl1",
 			"http://example.com/crl2",
 		},
+		DeltaCRLDistributionPoints: []string{
+			"http://example.com/delta1",
+			"http://example.com/delta2",
+		},
 		OCSPServers: []string{
 			"http://example.com/ocsp1",
 			"http://example.com/ocsp2",
@@ -626,9 +630,10 @@ func generateURLSteps(t *testing.T, caCert, caKey string, intdata, reqdata map[s
 			Operation: logical.UpdateOperation,
 			Path:      "config/urls",
 			Data: map[string]interface{}{
-				"issuing_certificates":    strings.Join(expected.IssuingCertificates, ","),
-				"crl_distribution_points": strings.Join(expected.CRLDistributionPoints, ","),
-				"ocsp_servers":            strings.Join(expected.OCSPServers, ","),
+				"issuing_certificates":          strings.Join(expected.IssuingCertificates, ","),
+				"crl_distribution_points":       strings.Join(expected.CRLDistributionPoints, ","),
+				"delta_crl_distribution_points": strings.Join(expected.DeltaCRLDistributionPoints, ","),
+				"ocsp_servers":                  strings.Join(expected.OCSPServers, ","),
 			},
 		},
 
@@ -705,11 +710,17 @@ func generateURLSteps(t *testing.T, caCert, caKey string, intdata, reqdata map[s
 
 				skid, _ := hex.DecodeString("142EB317B75856CBAE500940E61FAF9D8B14C2C6")
 
+				deltaCrlDistributionPoints, err := certutil.ParseDeltaCRLExtension(cert)
+				if err != nil {
+					return fmt.Errorf("error: invalid delta crl extension: %v", err.Error())
+				}
 				switch {
 				case !reflect.DeepEqual(expected.IssuingCertificates, cert.IssuingCertificateURL):
 					return fmt.Errorf("IssuingCertificateURL:\nexpected\n%#v\ngot\n%#v\n", expected.IssuingCertificates, cert.IssuingCertificateURL)
 				case !reflect.DeepEqual(expected.CRLDistributionPoints, cert.CRLDistributionPoints):
 					return fmt.Errorf("CRLDistributionPoints:\nexpected\n%#v\ngot\n%#v\n", expected.CRLDistributionPoints, cert.CRLDistributionPoints)
+				case !reflect.DeepEqual(expected.DeltaCRLDistributionPoints, deltaCrlDistributionPoints):
+					return fmt.Errorf("DeltaCRLDistributionPoints:\nexpected\n%#v\ngot\n%#v\n", expected.DeltaCRLDistributionPoints, deltaCrlDistributionPoints)
 				case !reflect.DeepEqual(expected.OCSPServers, cert.OCSPServer):
 					return fmt.Errorf("OCSPServer:\nexpected\n%#v\ngot\n%#v\n", expected.OCSPServers, cert.OCSPServer)
 				case !reflect.DeepEqual([]string{"intermediate.cert.com"}, cert.DNSNames):
@@ -756,11 +767,17 @@ func generateURLSteps(t *testing.T, caCert, caKey string, intdata, reqdata map[s
 				}
 				cert := certs[0]
 
+				deltaCrlDistributionPoints, err := certutil.ParseDeltaCRLExtension(cert)
+				if err != nil {
+					return fmt.Errorf("error: invalid delta crl extension: %v", err.Error())
+				}
 				switch {
 				case !reflect.DeepEqual(expected.IssuingCertificates, cert.IssuingCertificateURL):
 					return fmt.Errorf("expected\n%#v\ngot\n%#v\n", expected.IssuingCertificates, cert.IssuingCertificateURL)
 				case !reflect.DeepEqual(expected.CRLDistributionPoints, cert.CRLDistributionPoints):
 					return fmt.Errorf("expected\n%#v\ngot\n%#v\n", expected.CRLDistributionPoints, cert.CRLDistributionPoints)
+				case !reflect.DeepEqual(expected.DeltaCRLDistributionPoints, deltaCrlDistributionPoints):
+					return fmt.Errorf("exected\n%#v\ngot\n%#v\n", expected.DeltaCRLDistributionPoints, deltaCrlDistributionPoints)
 				case !reflect.DeepEqual(expected.OCSPServers, cert.OCSPServer):
 					return fmt.Errorf("expected\n%#v\ngot\n%#v\n", expected.OCSPServers, cert.OCSPServer)
 				case !reflect.DeepEqual([]string(nil), cert.DNSNames):
@@ -2093,8 +2110,9 @@ func TestBackend_PathFetchCertList(t *testing.T) {
 
 	// config urls
 	urlsData := map[string]interface{}{
-		"issuing_certificates":    "http://127.0.0.1:8200/v1/pki/ca",
-		"crl_distribution_points": "http://127.0.0.1:8200/v1/pki/crl",
+		"issuing_certificates":          "http://127.0.0.1:8200/v1/pki/ca",
+		"crl_distribution_points":       "http://127.0.0.1:8200/v1/pki/crl",
+		"delta_crl_distribution_points": "http://127.0.0.1:8200/v1/pki/crl/delta",
 	}
 
 	resp, err = b.HandleRequest(context.Background(), &logical.Request{
@@ -5301,6 +5319,9 @@ func TestPerIssuerAIA(t *testing.T) {
 	require.Empty(t, rootCert.OCSPServer)
 	require.Empty(t, rootCert.IssuingCertificateURL)
 	require.Empty(t, rootCert.CRLDistributionPoints)
+	deltaCrlDistributionPoints, err := certutil.ParseDeltaCRLExtension(rootCert)
+	require.NoError(t, err)
+	require.Empty(t, deltaCrlDistributionPoints)
 
 	// Set some local URLs on the issuer.
 	resp, err = CBWrite(b, s, "issuer/default", map[string]interface{}{
@@ -5327,12 +5348,16 @@ func TestPerIssuerAIA(t *testing.T) {
 	require.Empty(t, leafCert.OCSPServer)
 	require.Equal(t, leafCert.IssuingCertificateURL, []string{"https://google.com"})
 	require.Empty(t, leafCert.CRLDistributionPoints)
+	deltaCrlDistributionPoints, err = certutil.ParseDeltaCRLExtension(leafCert)
+	require.NoError(t, err)
+	require.Empty(t, deltaCrlDistributionPoints)
 
 	// Set global URLs and ensure they don't appear on this issuer's leaf.
 	_, err = CBWrite(b, s, "config/urls", map[string]interface{}{
-		"issuing_certificates":    []string{"https://example.com/ca", "https://backup.example.com/ca"},
-		"crl_distribution_points": []string{"https://example.com/crl", "https://backup.example.com/crl"},
-		"ocsp_servers":            []string{"https://example.com/ocsp", "https://backup.example.com/ocsp"},
+		"issuing_certificates":          []string{"https://example.com/ca", "https://backup.example.com/ca"},
+		"crl_distribution_points":       []string{"https://example.com/crl", "https://backup.example.com/crl"},
+		"delta_crl_distribution_points": []string{"https://example.com/crl/delta", "https://backup.example.com/crl/delta"},
+		"ocsp_servers":                  []string{"https://example.com/ocsp", "https://backup.example.com/ocsp"},
 	})
 	require.NoError(t, err)
 	resp, err = CBWrite(b, s, "issuer/default/issue/testing", map[string]interface{}{
@@ -5344,6 +5369,9 @@ func TestPerIssuerAIA(t *testing.T) {
 	require.Empty(t, leafCert.OCSPServer)
 	require.Equal(t, leafCert.IssuingCertificateURL, []string{"https://google.com"})
 	require.Empty(t, leafCert.CRLDistributionPoints)
+	deltaCrlDistributionPoints, err = certutil.ParseDeltaCRLExtension(leafCert)
+	require.NoError(t, err)
+	require.Empty(t, deltaCrlDistributionPoints)
 
 	// Now come back and remove the local modifications and ensure we get
 	// the defaults again.
@@ -5360,6 +5388,9 @@ func TestPerIssuerAIA(t *testing.T) {
 	require.Equal(t, leafCert.IssuingCertificateURL, []string{"https://example.com/ca", "https://backup.example.com/ca"})
 	require.Equal(t, leafCert.OCSPServer, []string{"https://example.com/ocsp", "https://backup.example.com/ocsp"})
 	require.Equal(t, leafCert.CRLDistributionPoints, []string{"https://example.com/crl", "https://backup.example.com/crl"})
+	deltaCrlDistributionPoints, err = certutil.ParseDeltaCRLExtension(leafCert)
+	require.NoError(t, err)
+	require.Equal(t, deltaCrlDistributionPoints, []string{"https://example.com/crl/delta", "https://backup.example.com/crl/delta"})
 
 	// Validate that we can set an issuer name and remove it.
 	_, err = CBPatch(b, s, "issuer/default", map[string]interface{}{
@@ -6282,10 +6313,11 @@ func TestPKI_TemplatedAIAs(t *testing.T) {
 	schema.ValidateResponse(t, schema.GetResponseSchema(t, b.Route("config/cluster"), logical.ReadOperation), resp, true)
 
 	aiaData := map[string]interface{}{
-		"crl_distribution_points": "{{cluster_path}}/issuer/{{issuer_id}}/crl/der",
-		"issuing_certificates":    "{{cluster_aia_path}}/issuer/{{issuer_id}}/der",
-		"ocsp_servers":            "{{cluster_path}}/ocsp",
-		"enable_templating":       true,
+		"crl_distribution_points":       "{{cluster_path}}/issuer/{{issuer_id}}/crl/der",
+		"delta_crl_distribution_points": "{{cluster_path}}/issuer/{{issuer_id}}/crl/delta",
+		"issuing_certificates":          "{{cluster_aia_path}}/issuer/{{issuer_id}}/der",
+		"ocsp_servers":                  "{{cluster_path}}/ocsp",
+		"enable_templating":             true,
 	}
 	_, err = CBWrite(b, s, "config/urls", aiaData)
 	require.NoError(t, err)
@@ -6303,10 +6335,11 @@ func TestPKI_TemplatedAIAs(t *testing.T) {
 
 	// Clearing the config and regenerating the root should still succeed.
 	_, err = CBWrite(b, s, "config/urls", map[string]interface{}{
-		"crl_distribution_points": "{{cluster_path}}/issuer/my-root-id/crl/der",
-		"issuing_certificates":    "{{cluster_aia_path}}/issuer/my-root-id/der",
-		"ocsp_servers":            "{{cluster_path}}/ocsp",
-		"enable_templating":       true,
+		"crl_distribution_points":       "{{cluster_path}}/issuer/my-root-id/crl/der",
+		"delta_crl_distribution_points": "{{cluster_path}}/issuer/my-root-id/crl/delta",
+		"issuing_certificates":          "{{cluster_aia_path}}/issuer/my-root-id/der",
+		"ocsp_servers":                  "{{cluster_path}}/ocsp",
+		"enable_templating":             true,
 	})
 	require.NoError(t, err)
 	resp, err = CBWrite(b, s, "root/generate/internal", rootData)
@@ -6332,22 +6365,27 @@ func TestPKI_TemplatedAIAs(t *testing.T) {
 	require.Equal(t, cert.OCSPServer, []string{"http://localhost:8200/v1/pki/ocsp"})
 	require.Equal(t, cert.IssuingCertificateURL, []string{"http://localhost:8200/cdn/pki/issuer/" + issuerId + "/der"})
 	require.Equal(t, cert.CRLDistributionPoints, []string{"http://localhost:8200/v1/pki/issuer/" + issuerId + "/crl/der"})
+	deltaCrlDistributionPoints, err := certutil.ParseDeltaCRLExtension(cert)
+	require.NoError(t, err)
+	require.Equal(t, deltaCrlDistributionPoints, []string{"http://localhost:8200/v1/pki/issuer/" + issuerId + "/crl/delta"})
 
 	// Modify our issuer to set custom AIAs: these URLs are bad.
 	_, err = CBPatch(b, s, "issuer/default", map[string]interface{}{
-		"enable_aia_url_templating": "false",
-		"crl_distribution_points":   "a",
-		"issuing_certificates":      "b",
-		"ocsp_servers":              "c",
+		"enable_aia_url_templating":     "false",
+		"crl_distribution_points":       "a",
+		"issuing_certificates":          "b",
+		"ocsp_servers":                  "c",
+		"delta_crl_distribution_points": "d",
 	})
 	require.Error(t, err)
 
 	// These URLs are good.
 	_, err = CBPatch(b, s, "issuer/default", map[string]interface{}{
-		"enable_aia_url_templating": "false",
-		"crl_distribution_points":   "http://localhost/a",
-		"issuing_certificates":      "http://localhost/b",
-		"ocsp_servers":              "http://localhost/c",
+		"enable_aia_url_templating":     "false",
+		"crl_distribution_points":       "http://localhost/a",
+		"delta_crl_distribution_points": "http://localhost/d",
+		"issuing_certificates":          "http://localhost/b",
+		"ocsp_servers":                  "http://localhost/c",
 	})
 
 	resp, err = CBWrite(b, s, "issue/testing", map[string]interface{}{
@@ -6360,13 +6398,17 @@ func TestPKI_TemplatedAIAs(t *testing.T) {
 	require.Equal(t, cert.OCSPServer, []string{"http://localhost/c"})
 	require.Equal(t, cert.IssuingCertificateURL, []string{"http://localhost/b"})
 	require.Equal(t, cert.CRLDistributionPoints, []string{"http://localhost/a"})
+	deltaCrlDistributionPoints, err = certutil.ParseDeltaCRLExtension(cert)
+	require.NoError(t, err)
+	require.Equal(t, deltaCrlDistributionPoints, []string{"http://localhost/d"})
 
 	// These URLs are bad, but will fail at issuance time due to AIA templating.
 	resp, err = CBPatch(b, s, "issuer/default", map[string]interface{}{
-		"enable_aia_url_templating": "true",
-		"crl_distribution_points":   "a",
-		"issuing_certificates":      "b",
-		"ocsp_servers":              "c",
+		"enable_aia_url_templating":     "true",
+		"crl_distribution_points":       "a",
+		"issuing_certificates":          "b",
+		"ocsp_servers":                  "c",
+		"delta_crl_distribution_points": "d",
 	})
 	requireSuccessNonNilResponse(t, resp, err)
 	require.NotEmpty(t, resp.Warnings)
@@ -7211,6 +7253,11 @@ func TestPatchIssuer(t *testing.T) {
 			Patched: []string{"http://localhost/v1/pki/crl"},
 		},
 		{
+			Field:   "delta_crl_distribution_points",
+			Before:  []string{"http://localhost/v1/pki-1/crl/delta"},
+			Patched: []string{"http://localhost/v1/pki/crl/delta"},
+		},
+		{
 			Field:   "ocsp_servers",
 			Before:  []string{"http://localhost/v1/pki-1/ocsp"},
 			Patched: []string{"http://localhost/v1/pki/ocsp"},
@@ -7253,9 +7300,10 @@ func testPatchIssuer(t *testing.T, testCases []patchIssuerTestCase) {
 
 			// 3. Add AIA information
 			resp, err = CBPatch(b, s, "issuer/default", map[string]interface{}{
-				"issuing_certificates":    "http://localhost/v1/pki-1/ca",
-				"crl_distribution_points": "http://localhost/v1/pki-1/crl",
-				"ocsp_servers":            "http://localhost/v1/pki-1/ocsp",
+				"issuing_certificates":          "http://localhost/v1/pki-1/ca",
+				"crl_distribution_points":       "http://localhost/v1/pki-1/crl",
+				"delta_crl_distribution_points": "http://localhost/v1/pki-1/crl/delta",
+				"ocsp_servers":                  "http://localhost/v1/pki-1/ocsp",
 			})
 			requireSuccessNonNilResponse(t, resp, err, "failed setting up issuer")
 
@@ -7317,10 +7365,11 @@ func TestGenerateRootCAWithAIA(t *testing.T) {
 	require.NoError(t, err, "failed to write AIA settings")
 
 	_, err = CBWrite(b_root, s_root, "config/urls", map[string]interface{}{
-		"crl_distribution_points": "{{cluster_path}}/issuer/{{issuer_id}}/crl/der",
-		"issuing_certificates":    "{{cluster_aia_path}}/issuer/{{issuer_id}}/der",
-		"ocsp_servers":            "{{cluster_path}}/ocsp",
-		"enable_templating":       true,
+		"crl_distribution_points":       "{{cluster_path}}/issuer/{{issuer_id}}/crl/der",
+		"delta_crl_distribution_points": "{{cluster_path}}/issuer/{{issuer_id}}/crl/delta/der",
+		"issuing_certificates":          "{{cluster_aia_path}}/issuer/{{issuer_id}}/der",
+		"ocsp_servers":                  "{{cluster_path}}/ocsp",
+		"enable_templating":             true,
 	})
 	require.NoError(t, err, "failed to write AIA settings")
 

--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -26,8 +26,6 @@ import (
 	"net"
 	"net/url"
 	"os"
-	"os/exec"
-	"path"
 	"reflect"
 	"slices"
 	"sort"
@@ -48,7 +46,6 @@ import (
 	"github.com/hashicorp/vault/builtin/logical/pki/parsing"
 	"github.com/hashicorp/vault/builtin/logical/pki/pki_backend"
 	"github.com/hashicorp/vault/helper/testhelpers"
-	"github.com/hashicorp/vault/helper/testhelpers/corehelpers"
 	logicaltest "github.com/hashicorp/vault/helper/testhelpers/logical"
 	"github.com/hashicorp/vault/helper/testhelpers/teststorage"
 	vaulthttp "github.com/hashicorp/vault/http"
@@ -7519,52 +7516,6 @@ func TestIssuance_SignIntermediateKeyUsages(t *testing.T) {
 	require.Equal(t, x509.KeyUsageDigitalSignature|x509.KeyUsageCertSign|x509.KeyUsageCRLSign, intCert.KeyUsage, "unexpected KeyUsage present on intermediate certificate")
 }
 
-func TestIssuance_DeltaCRLDistributionPoint(t *testing.T) {
-	t.Parallel()
-	b, s := CreateBackendWithStorage(t)
-
-	// Set up the Mount-Level AIA information
-	resp, err := CBWrite(b, s, "config/urls", map[string]interface{}{
-		"delta_crl_distribution_points": []string{"http://example.com/crl/delta", "http://backup.example.com/crl/delta"},
-	})
-	requireSuccessNonNilResponse(t, resp, err, "expected setting mount-level DeltaCRLDistributionPoints to succeed")
-	require.Contains(t, resp.Warnings, "delta_crl_distribution_points were set: http://example.com/crl/delta, http://backup.example.com/crl/delta but not crl_distribution_points, consider setting crl_distribution_points")
-
-	// Create a (Root) Certificate with this AIA information
-	resp, err = CBWrite(b, s, "root/generate/internal", map[string]interface{}{
-		"common_name": "root myvault.com",
-		"key_type":    "ec",
-		"ttl":         "10h",
-		"issuer_name": "root-ca",
-		"key_name":    "root-key",
-	})
-	requireSuccessNonNilResponse(t, resp, err, "expected root generation to succeed")
-	require.NotNil(t, resp.Data, "expected response to have body")
-	require.NotNil(t, resp.Data["certificate"], "expected response to contain generated certificate")
-
-	// Use openssl to check that the certificate created does have the expected Delta CRL Distribution Point Information
-	tmpDir := t.TempDir()
-	filePath := writeToTmpDir(t, tmpDir, "certificate.pem", resp.Data["certificate"].(string))
-
-	opensslCmd, output, found := findOpenSSL()
-	if !found {
-		t.Skipf("no appropriate OpenSSL version found")
-	}
-	log := corehelpers.NewTestLogger(t)
-	log.Info("Using OpenSSL", "path", opensslCmd, "version", output)
-
-	// The open ssl test:
-	args := []string{
-		"x509",
-		"-noout",
-		"-text",
-		"-in", filePath,
-	}
-	out, err := exec.Command(opensslCmd, args...).CombinedOutput()
-	require.NoError(t, err, "failed running command %s with args: %v\n%s", opensslCmd, args, string(out))
-	require.Contains(t, string(out), "            X509v3 Freshest CRL: \n                Full Name:\n                  URI:http://example.com/crl/delta\n\n                Full Name:\n                  URI:http://backup.example.com/crl/delta", "delta crl extension did not appear as expected on parsed certificate: %v", string(out))
-}
-
 var (
 	initTest  sync.Once
 	rsaCAKey  string
@@ -7574,33 +7525,3 @@ var (
 	edCAKey   string
 	edCACert  string
 )
-
-// Test Helpers Also Used by CMPv2
-func writeToTmpDir(t *testing.T, tmpDir string, filename string, contents string) string {
-	filePath := path.Join(tmpDir, filename)
-	out, err := os.Create(filePath)
-	require.NoError(t, err, "failed creating file %s", filePath)
-	_, err = out.WriteString(contents)
-	require.NoError(t, err, "failed writing to file %s", filePath)
-	err = out.Close()
-	require.NoError(t, err, "failed closing file %s", filePath)
-	return filePath
-}
-
-// Test Helper also Used by CMPv2
-func findOpenSSL() (string, string, bool) {
-	paths := os.Getenv("PATH")
-	for _, pathFolder := range strings.Split(paths, ":") {
-		cmd := path.Join(pathFolder, "openssl")
-		out, err := exec.Command(cmd, "version").CombinedOutput()
-		if err != nil {
-			continue
-		}
-		// We need a v3 version of OpenSSL to properly support the CMP command we run
-		if strings.Contains(string(out), "OpenSSL 3.") {
-			return cmd, string(out), true
-		}
-	}
-
-	return "", "", false
-}

--- a/builtin/logical/pki/issuing/aia.go
+++ b/builtin/logical/pki/issuing/aia.go
@@ -35,7 +35,8 @@ func GetAIAURLs(ctx context.Context, s logical.Storage, i *IssuerEntry) (*certut
 
 	// If none are set (either due to a nil entry or because no URLs have
 	// been provided), fall back to the global AIA URL config.
-	if entries == nil || (len(entries.IssuingCertificates) == 0 && len(entries.CRLDistributionPoints) == 0 && len(entries.OCSPServers) == 0) && len(entries.DeltaCRLDistributionPoints) == 0 && len(entries.DeltaCRLDistributionPoints) == 0 {
+	if entries == nil || (len(entries.IssuingCertificates) == 0 && len(entries.CRLDistributionPoints) == 0 &&
+		len(entries.OCSPServers) == 0) && len(entries.DeltaCRLDistributionPoints) == 0 {
 		var err error
 
 		entries, err = GetGlobalAIAURLs(ctx, s)

--- a/builtin/logical/pki/issuing/aia.go
+++ b/builtin/logical/pki/issuing/aia.go
@@ -17,10 +17,11 @@ import (
 const ClusterConfigPath = "config/cluster"
 
 type AiaConfigEntry struct {
-	IssuingCertificates   []string `json:"issuing_certificates"`
-	CRLDistributionPoints []string `json:"crl_distribution_points"`
-	OCSPServers           []string `json:"ocsp_servers"`
-	EnableTemplating      bool     `json:"enable_templating"`
+	IssuingCertificates        []string `json:"issuing_certificates"`
+	CRLDistributionPoints      []string `json:"crl_distribution_points"`
+	DeltaCRLDistributionPoints []string `json:"delta_crl_distribution_points"`
+	OCSPServers                []string `json:"ocsp_servers"`
+	EnableTemplating           bool     `json:"enable_templating"`
 }
 
 type ClusterConfigEntry struct {
@@ -34,7 +35,7 @@ func GetAIAURLs(ctx context.Context, s logical.Storage, i *IssuerEntry) (*certut
 
 	// If none are set (either due to a nil entry or because no URLs have
 	// been provided), fall back to the global AIA URL config.
-	if entries == nil || (len(entries.IssuingCertificates) == 0 && len(entries.CRLDistributionPoints) == 0 && len(entries.OCSPServers) == 0) {
+	if entries == nil || (len(entries.IssuingCertificates) == 0 && len(entries.CRLDistributionPoints) == 0 && len(entries.OCSPServers) == 0) && len(entries.DeltaCRLDistributionPoints) == 0 && len(entries.DeltaCRLDistributionPoints) == 0 {
 		var err error
 
 		entries, err = GetGlobalAIAURLs(ctx, s)
@@ -57,10 +58,11 @@ func GetGlobalAIAURLs(ctx context.Context, storage logical.Storage) (*AiaConfigE
 	}
 
 	entries := &AiaConfigEntry{
-		IssuingCertificates:   []string{},
-		CRLDistributionPoints: []string{},
-		OCSPServers:           []string{},
-		EnableTemplating:      false,
+		IssuingCertificates:        []string{},
+		CRLDistributionPoints:      []string{},
+		DeltaCRLDistributionPoints: []string{},
+		OCSPServers:                []string{},
+		EnableTemplating:           false,
 	}
 
 	if entry == nil {
@@ -75,14 +77,15 @@ func GetGlobalAIAURLs(ctx context.Context, storage logical.Storage) (*AiaConfigE
 }
 
 func ToURLEntries(ctx context.Context, s logical.Storage, issuer IssuerID, c *AiaConfigEntry) (*certutil.URLEntries, error) {
-	if len(c.IssuingCertificates) == 0 && len(c.CRLDistributionPoints) == 0 && len(c.OCSPServers) == 0 {
+	if len(c.IssuingCertificates) == 0 && len(c.CRLDistributionPoints) == 0 && len(c.OCSPServers) == 0 && len(c.DeltaCRLDistributionPoints) == 0 {
 		return &certutil.URLEntries{}, nil
 	}
 
 	result := certutil.URLEntries{
-		IssuingCertificates:   c.IssuingCertificates[:],
-		CRLDistributionPoints: c.CRLDistributionPoints[:],
-		OCSPServers:           c.OCSPServers[:],
+		IssuingCertificates:        c.IssuingCertificates[:],
+		CRLDistributionPoints:      c.CRLDistributionPoints[:],
+		DeltaCRLDistributionPoints: c.DeltaCRLDistributionPoints[:],
+		OCSPServers:                c.OCSPServers[:],
 	}
 
 	if c.EnableTemplating {
@@ -92,9 +95,10 @@ func ToURLEntries(ctx context.Context, s logical.Storage, issuer IssuerID, c *Ai
 		}
 
 		for name, source := range map[string]*[]string{
-			"issuing_certificates":    &result.IssuingCertificates,
-			"crl_distribution_points": &result.CRLDistributionPoints,
-			"ocsp_servers":            &result.OCSPServers,
+			"issuing_certificates":          &result.IssuingCertificates,
+			"crl_distribution_points":       &result.CRLDistributionPoints,
+			"delta_crl_distribution_points": &result.DeltaCRLDistributionPoints,
+			"ocsp_servers":                  &result.OCSPServers,
 		} {
 			templated := make([]string, len(*source))
 			for index, uri := range *source {

--- a/builtin/logical/pki/path_intermediate.go
+++ b/builtin/logical/pki/path_intermediate.go
@@ -157,11 +157,16 @@ func (b *backend) pathGenerateIntermediate(ctx context.Context, req *logical.Req
 	}
 
 	entries, err := getGlobalAIAURLs(ctx, req.Storage)
-	if err == nil && len(entries.OCSPServers) == 0 && len(entries.IssuingCertificates) == 0 && len(entries.CRLDistributionPoints) == 0 {
+	if err == nil && len(entries.OCSPServers) == 0 && len(entries.IssuingCertificates) == 0 &&
+		len(entries.CRLDistributionPoints) == 0 && len(entries.DeltaCRLDistributionPoints) == 0 {
 		// If the operator hasn't configured any of the URLs prior to
 		// generating this issuer, we should add a warning to the response,
 		// informing them they might want to do so and re-generate the issuer.
 		resp.AddWarning("This mount hasn't configured any authority information access (AIA) fields; this may make it harder for systems to find missing certificates in the chain or to validate revocation status of certificates. Consider updating /config/urls or the newly generated issuer with this information. Since this certificate is an intermediate, it might be useful to regenerate this certificate after fixing this problem for the root mount.")
+	}
+	if (entries.DeltaCRLDistributionPoints != nil && len(entries.DeltaCRLDistributionPoints) > 0) &&
+		(entries.CRLDistributionPoints == nil || len(entries.CRLDistributionPoints) == 0) {
+		resp.AddWarning("This mount has configured delta crl distribution points but no base crl distribution points were set.")
 	}
 
 	switch format {

--- a/builtin/logical/pki/path_manage_issuers.go
+++ b/builtin/logical/pki/path_manage_issuers.go
@@ -492,8 +492,17 @@ func (b *backend) pathImportIssuers(ctx context.Context, req *logical.Request, d
 	// Also while we're here, we should let the user know the next steps.
 	// In particular, if there's no default AIA URLs configuration, we should
 	// tell the user that's probably next.
-	if entries, err := getGlobalAIAURLs(ctx, req.Storage); err == nil && len(entries.IssuingCertificates) == 0 && len(entries.CRLDistributionPoints) == 0 && len(entries.OCSPServers) == 0 {
-		response.AddWarning("This mount hasn't configured any authority information access (AIA) fields; this may make it harder for systems to find missing certificates in the chain or to validate revocation status of certificates. Consider updating /config/urls or the newly generated issuer with this information.")
+	entries, err := getGlobalAIAURLs(ctx, req.Storage)
+	if err != nil {
+		response.AddWarning(fmt.Sprintf("error reading authority information access (AIA) fields: %v", err.Error()))
+	}
+	if err == nil {
+		if len(entries.IssuingCertificates) == 0 && len(entries.CRLDistributionPoints) == 0 && len(entries.DeltaCRLDistributionPoints) == 0 && len(entries.OCSPServers) == 0 {
+			response.AddWarning("This mount hasn't configured any authority information access (AIA) fields; this may make it harder for systems to find missing certificates in the chain or to validate revocation status of certificates. Consider updating /config/urls or the newly generated issuer with this information.")
+		}
+		if len(entries.CRLDistributionPoints) == 0 && len(entries.DeltaCRLDistributionPoints) != 0 {
+			response.AddWarning("delta crl distribution points were set, but no base crl distribution points were set.")
+		}
 	}
 
 	return response, nil

--- a/builtin/logical/pki/path_root.go
+++ b/builtin/logical/pki/path_root.go
@@ -593,7 +593,10 @@ func (b *backend) pathIssuerSignSelfIssued(ctx context.Context, req *logical.Req
 		SigningBundle: nil,
 		CSR:           nil,
 	}
-	certutil.AddDeltaCRLExtension(bundleData, cert)
+	err = certutil.AddDeltaCRLExtension(bundleData, cert)
+	if err != nil {
+		return nil, err
+	}
 
 	// If the requested signature algorithm isn't the same as the signing certificate, and
 	// the user has requested a cross-algorithm signature, reset the template's signing algorithm

--- a/builtin/logical/pki/path_root.go
+++ b/builtin/logical/pki/path_root.go
@@ -217,11 +217,18 @@ func (b *backend) pathCAGenerateRoot(ctx context.Context, req *logical.Request, 
 		resp.AddWarning("This issuer certificate was generated without a Subject; this makes it likely that issuing leaf certs with this certificate will cause TLS validation libraries to reject this certificate.")
 	}
 
-	if len(parsedBundle.Certificate.OCSPServer) == 0 && len(parsedBundle.Certificate.IssuingCertificateURL) == 0 && len(parsedBundle.Certificate.CRLDistributionPoints) == 0 {
+	deltaCrlDistributionPoints, err := certutil.ParseDeltaCRLExtension(parsedBundle.Certificate)
+	if err != nil {
+		return logical.ErrorResponse(fmt.Sprintf("error: invalid delta crl extension: %v", err.Error())), nil
+	}
+	if len(parsedBundle.Certificate.OCSPServer) == 0 && len(parsedBundle.Certificate.IssuingCertificateURL) == 0 && len(parsedBundle.Certificate.CRLDistributionPoints) == 0 && len(deltaCrlDistributionPoints) == 0 {
 		// If the operator hasn't configured any of the URLs prior to
 		// generating this issuer, we should add a warning to the response,
 		// informing them they might want to do so prior to issuing leaves.
 		resp.AddWarning("This mount hasn't configured any authority information access (AIA) fields; this may make it harder for systems to find missing certificates in the chain or to validate revocation status of certificates. Consider updating /config/urls or the newly generated issuer with this information.")
+	}
+	if len(deltaCrlDistributionPoints) > 0 && len(parsedBundle.Certificate.CRLDistributionPoints) == 0 {
+		resp.AddWarning("This mount has configured Delta CRL distribution points are set but no CRL Distribution Points.")
 	}
 
 	switch format {
@@ -484,11 +491,18 @@ func signIntermediateResponse(signingBundle *certutil.CAInfoBundle, parsedBundle
 		resp.AddWarning("This issuer certificate was generated without a Subject; this makes it likely that issuing leaf certs with this certificate will cause TLS validation libraries to reject this certificate.")
 	}
 
-	if len(parsedBundle.Certificate.OCSPServer) == 0 && len(parsedBundle.Certificate.IssuingCertificateURL) == 0 && len(parsedBundle.Certificate.CRLDistributionPoints) == 0 {
+	deltaCrlDistributionPoints, err := certutil.ParseDeltaCRLExtension(parsedBundle.Certificate)
+	if err != nil {
+		return logical.ErrorResponse(fmt.Sprintf("invalid delta crl extension on generated certificate: %v", err.Error())), nil
+	}
+	if len(parsedBundle.Certificate.OCSPServer) == 0 && len(parsedBundle.Certificate.IssuingCertificateURL) == 0 && len(parsedBundle.Certificate.CRLDistributionPoints) == 0 && len(deltaCrlDistributionPoints) == 0 {
 		// If the operator hasn't configured any of the URLs prior to
 		// generating this issuer, we should add a warning to the response,
 		// informing them they might want to do so prior to issuing leaves.
 		resp.AddWarning("This mount hasn't configured any authority information access (AIA) fields; this may make it harder for systems to find missing certificates in the chain or to validate revocation status of certificates. Consider updating /config/urls or the newly generated issuer with this information.")
+	}
+	if len(deltaCrlDistributionPoints) > 0 && len(parsedBundle.Certificate.CRLDistributionPoints) == 0 {
+		resp.AddWarning("This mount has configured delta CRL distribution points, but not CRL distribution points.")
 	}
 
 	caChain := append([]string{cb.Certificate}, cb.CAChain...)
@@ -574,6 +588,12 @@ func (b *backend) pathIssuerSignSelfIssued(ctx context.Context, req *logical.Req
 	cert.IssuingCertificateURL = urls.IssuingCertificates
 	cert.CRLDistributionPoints = urls.CRLDistributionPoints
 	cert.OCSPServer = urls.OCSPServers
+	bundleData := &certutil.CreationBundle{
+		Params:        &certutil.CreationParameters{URLs: urls},
+		SigningBundle: nil,
+		CSR:           nil,
+	}
+	certutil.AddDeltaCRLExtension(bundleData, cert)
 
 	// If the requested signature algorithm isn't the same as the signing certificate, and
 	// the user has requested a cross-algorithm signature, reset the template's signing algorithm

--- a/changelog/30319.txt
+++ b/changelog/30319.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+secrets/pki: Add Delta (Freshest) CRL support to AIA information (both mount-level and issuer configured)
+```

--- a/sdk/helper/certutil/types.go
+++ b/sdk/helper/certutil/types.go
@@ -673,9 +673,10 @@ type IssueData struct {
 }
 
 type URLEntries struct {
-	IssuingCertificates   []string `json:"issuing_certificates" structs:"issuing_certificates" mapstructure:"issuing_certificates"`
-	CRLDistributionPoints []string `json:"crl_distribution_points" structs:"crl_distribution_points" mapstructure:"crl_distribution_points"`
-	OCSPServers           []string `json:"ocsp_servers" structs:"ocsp_servers" mapstructure:"ocsp_servers"`
+	IssuingCertificates        []string `json:"issuing_certificates" structs:"issuing_certificates" mapstructure:"issuing_certificates"`
+	CRLDistributionPoints      []string `json:"crl_distribution_points" structs:"crl_distribution_points" mapstructure:"crl_distribution_points"`
+	DeltaCRLDistributionPoints []string `json:"delta_crl_distribution_points" structs:"delta_crl_distribution_points" mapstructure:"delta_crl_distribution_points"`
+	OCSPServers                []string `json:"ocsp_servers" structs:"ocsp_servers" mapstructure:"ocsp_servers"`
 }
 
 type NotAfterBehavior int


### PR DESCRIPTION
### Description
This introduces a feature which allows Freshest or Delta CRL information to be added to the AIA (Authority Access Information) available on a certificate.  This AIA information is configured per mount or per issuer (as other AIA information is), and a warning is returned if no base CRL information is also specified.

### TODO only if you're a HashiCorp employee
- features aren't backported
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name. Branch name is Jira.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.  Not a full RFC, but tiny internal memo that was approved: https://docs.google.com/document/d/1QmijPA6uD4YdLHMKm1kJsyFKvllXJuAm4t5Z9h3NY2Y/edit?tab=t.0