### PR TITLE
enos(mlock): sync enos changes from main to 1.19

### DIFF
--- a/enos/README.md
+++ b/enos/README.md
@@ -227,15 +227,15 @@ Here are the steps to configure the GitHub Actions service user:
   - Access can be requested by clicking: `Cloud Access` --> `AWS` --> `Request Account Access`.
 
 1. **Create the Terraform Cloud Workspace** - The name of the workspace to be created depends on the 
-   repository for which it is being created, but the pattern is: `<repository>-ci-service-user-iam`,
-   e.g. `vault-ci-service-user-iam`. It is important that the execution mode for the workspace be set 
+   repository for which it is being created, but the pattern is: `<repository>-ci-enos-service-user-iam`,
+   e.g. `vault-ci-enos-service-user-iam`. It is important that the execution mode for the workspace be set 
    to `local`. For help on setting up the workspace, contact the QT team on Slack (#team-quality)
 
 
 2. **Execute the Terraform module**
 ```shell
 > cd ./enos/ci/service-user-iam
-> export TF_WORKSPACE=<repo name>-ci-service-user-iam
+> export TF_WORKSPACE=<repo name>-ci-enos-service-user-iam
 > export TF_TOKEN_app_terraform_io=<Terraform Cloud Token>
 > export TF_VAR_repository=<repository name>
 > terraform init

--- a/enos/ci/aws-nuke.yml
+++ b/enos/ci/aws-nuke.yml
@@ -21,7 +21,7 @@ regions:
 - us-west-2
 - global
 
-account-blocklist:
+blocklist:
  - 1234567890
 
 accounts:
@@ -55,6 +55,7 @@ presets:
       EC2InternetGatewayAttachment:
         - property: DefaultVPC
           value: "true"
+
   olderthan:
     # Filters resources by age (when available)
     # TIME_LIMIT replaced in CI
@@ -91,12 +92,21 @@ presets:
       IAMRole:
         - property: tag:hc-config-as-code
           value: "honeybee"
+        - property: Name
+          type: glob
+          value: "vault-assumed-role-credentials-demo"
       IAMRolePolicy:
         - property: tag:role:hc-config-as-code
           value: "honeybee"
+        - property: role:RoleName
+          type: glob
+          value: "vault-assumed-role-credentials-demo"
       IAMRolePolicyAttachment:
         - property: tag:role:hc-config-as-code
           value: "honeybee"
+        - property: Name
+          type: glob
+          value: "vault-assumed-role-credentials-demo"
 
   enos:
     # Existing CI to be cleaned up later
@@ -396,3 +406,4 @@ resource-types:
     - WorkSpacesWorkspace
     - XRayGroup
     - XRaySamplingRule
+

--- a/enos/enos-globals.hcl
+++ b/enos/enos-globals.hcl
@@ -156,6 +156,7 @@ globals {
     bundle  = "/opt/vault/bin"
     package = "/usr/bin"
   }
-  vault_license_path = abspath(var.vault_license_path != null ? var.vault_license_path : joinpath(path.root, "./support/vault.hclic"))
-  vault_tag_key      = "vault-cluster"
+  vault_license_path  = abspath(var.vault_license_path != null ? var.vault_license_path : joinpath(path.root, "./support/vault.hclic"))
+  vault_tag_key       = "vault-cluster"
+  vault_disable_mlock = false
 }

--- a/enos/modules/start_vault/main.tf
+++ b/enos/modules/start_vault/main.tf
@@ -188,7 +188,9 @@ resource "enos_vault_start" "leader" {
   bin_path    = local.bin_path
   config_dir  = var.config_dir
   config_mode = var.config_mode
-  environment = var.environment
+  environment = merge(var.environment, {
+    VAULT_DISABLE_MLOCK = var.disable_mlock
+  })
   config = {
     api_addr     = local.api_addrs_internal[tonumber(each.value)][var.ip_version]
     cluster_addr = local.cluster_addrs_internal[tonumber(each.value)][var.ip_version]
@@ -230,7 +232,9 @@ resource "enos_vault_start" "followers" {
   bin_path    = local.bin_path
   config_dir  = var.config_dir
   config_mode = var.config_mode
-  environment = var.environment
+  environment = merge(var.environment, {
+    VAULT_DISABLE_MLOCK = var.disable_mlock
+  })
   config = {
     api_addr     = local.api_addrs_internal[tonumber(each.value)][var.ip_version]
     cluster_addr = local.cluster_addrs_internal[tonumber(each.value)][var.ip_version]

--- a/enos/modules/start_vault/variables.tf
+++ b/enos/modules/start_vault/variables.tf
@@ -34,6 +34,12 @@ variable "config_mode" {
   }
 }
 
+variable "disable_mlock" {
+  type        = bool
+  description = "Disable mlock for Vault process."
+  default     = false
+}
+
 variable "environment" {
   description = "Optional Vault configuration environment variables to set starting Vault"
   type        = map(string)

--- a/enos/modules/vault_cluster/main.tf
+++ b/enos/modules/vault_cluster/main.tf
@@ -20,6 +20,7 @@ locals {
   bin_path               = "${var.install_dir}/vault"
   consul_bin_path        = "${var.consul_install_dir}/consul"
   enable_audit_devices   = var.enable_audit_devices && var.initialize_cluster
+  disable_mlock          = false
   // In order to get Terraform to plan we have to use collections with keys
   // that are known at plan time. In order for our module to work our var.hosts
   // must be a map with known keys at plan time. Here we're creating locals
@@ -156,6 +157,7 @@ module "start_vault" {
   cluster_tag_key           = var.cluster_tag_key
   config_dir                = var.config_dir
   config_mode               = var.config_mode
+  disable_mlock             = local.disable_mlock
   external_storage_port     = var.external_storage_port
   hosts                     = var.hosts
   install_dir               = var.install_dir


### PR DESCRIPTION
### Description

Synchronize the `enos` directory with that of `main` after changes introduced in https://github.com/hashicorp/vault/pull/29974 were not backported.

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [x] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
