### PR TITLE
UI: Fix for failing DB role test

### DIFF
--- a/ui/tests/integration/components/database-role-edit-test.js
+++ b/ui/tests/integration/components/database-role-edit-test.js
@@ -112,9 +112,6 @@ module('Integration | Component | database-role-edit', function (hooks) {
     this.version.type = 'enterprise';
     this.server.post('/sys/capabilities-self', capabilitiesStub('database/static-creds/my-role', ['update']));
 
-    this.modelStatic.password = 'testPass';
-    this.modelStatic.skip_import_rotation = false;
-    this.modelStatic.rotation_period = '172800';
     await render(hbs`<DatabaseRoleEdit @model={{this.modelStatic}} @mode="edit"/>`);
     assert.dom(GENERAL.icon('edit')).exists(); // verify password field is enabled for edit & enable button is rendered bc role hasn't been rotated
   });


### PR DESCRIPTION
### Description
What does this PR do?

Ent tests pass: ✅ 

Separating tests out for checking edit views based on role data
Fixes failing test in CI reported [here](https://github.com/hashicorp/vault-enterprise/actions/runs/14582311209)
