### PR TITLE
[UI] Ember Data Migration: Form Class Proxy

### DIFF
--- a/ui/app/forms/form.ts
+++ b/ui/app/forms/form.ts
@@ -6,31 +6,56 @@ import { validate } from 'vault/utils/forms/validate';
 import { set } from '@ember/object';
 
 import type { Validations } from 'vault/app-types';
+import type FormField from 'vault/utils/forms/field';
+
+type FormOptions = {
+  isNew?: boolean;
+};
 
 export default class Form {
-  declare data;
+  [key: string]: unknown; // Add an index signature to allow dynamic property assignment for set shim
+  declare data: Record<string, unknown>;
   declare validations: Validations;
+  declare formFields: FormField[];
+  declare isNew: boolean;
 
-  constructor(data = {}, validations?: Validations) {
+  constructor(data = {}, options: FormOptions = {}, validations?: Validations) {
     this.data = data;
+    this.isNew = options.isNew || false;
     // typically this would be defined on the subclass
     // if validations are conditional, it may be preferable to define them during instantiation
     if (validations) {
       this.validations = validations;
     }
+    // to ease migration from Ember Data Models, return a proxy that forwards get/set to the data object for form field props
+    // this allows for form field properties to be accessed directly on the class rather than form.data.someField
+    return new Proxy(this, {
+      get(target, prop: string) {
+        const formFields = Array.isArray(target.formFields) ? target.formFields : [];
+        const formDataKeys = formFields.map((field) => field.name) || [];
+        const getTarget = !Reflect.has(target, prop) && formDataKeys.includes(prop) ? target.data : target;
+        return Reflect.get(getTarget, prop);
+      },
+      set(target, prop: string, value) {
+        const formFields = Array.isArray(target.formFields) ? target.formFields : [];
+        const formDataKeys = formFields.map((field) => field.name) || [];
+        const setTarget = !Reflect.has(target, prop) && formDataKeys.includes(prop) ? target.data : target;
+        return Reflect.set(setTarget, prop, value);
+      },
+    });
   }
 
   // shim this for now but get away from old Ember patterns!
-  set(key: string, val: unknown) {
+  set(key = '', val: unknown) {
     set(this, key, val);
   }
 
   // when overriding in subclass, data can be passed in if serialization of certain values is required
-  // this prevents the underlying data object of being mutated causing potential issues in the view
+  // this prevents the underlying data object from being mutated causing potential issues in the view
   toJSON(data = this.data) {
     // validate the form
     // if validations are not defined the util will ignore and return valid state
-    const formValidation = validate(data, this.validations, 'data');
+    const formValidation = validate(data, this.validations);
     return { ...formValidation, data };
   }
 }

--- a/ui/app/utils/forms/field.ts
+++ b/ui/app/utils/forms/field.ts
@@ -26,7 +26,7 @@ export default class FormField {
     this.type = type;
     this.options = {
       ...options,
-      fieldValue: options.fieldValue || `data.${key}`,
+      fieldValue: options.fieldValue || key,
     };
   }
 }

--- a/ui/tests/unit/forms/form-test.js
+++ b/ui/tests/unit/forms/form-test.js
@@ -4,6 +4,7 @@
  */
 
 import Form from 'vault/forms/form';
+import FormField from 'vault/utils/forms/field';
 import { module, test } from 'qunit';
 
 module('Unit | forms | form', function (hooks) {
@@ -11,14 +12,16 @@ module('Unit | forms | form', function (hooks) {
     this.data = {
       foo: 'bar',
     };
+    this.options = { isNew: true };
     this.validations = {
       foo: [{ type: 'presence', message: 'Foo is required' }],
     };
   });
 
-  test('it should set data and validations on class', async function (assert) {
-    const form = new Form(this.data, this.validations);
+  test('it should set data, options and validations on class', async function (assert) {
+    const form = new Form(this.data, this.options, this.validations);
     assert.deepEqual(form.data, this.data, 'Data is set correctly');
+    assert.true(form.isNew, 'isNew is set correctly');
     assert.deepEqual(form.validations, this.validations, 'Validations are set correctly');
   });
 
@@ -36,10 +39,10 @@ module('Unit | forms | form', function (hooks) {
   });
 
   test('it should validate and return data from toJSON method', async function (assert) {
-    const state = { 'data.foo': { isValid: true, errors: [], warnings: [] } };
+    const state = { foo: { isValid: true, errors: [], warnings: [] } };
     const expected = { isValid: true, state, invalidFormMessage: '', data: this.data };
 
-    const form = new Form(this.data, this.validations);
+    const form = new Form(this.data, this.options, this.validations);
     const json = form.toJSON();
 
     assert.deepEqual(json, expected, 'toJSON returns correct data and validation state');
@@ -50,12 +53,32 @@ module('Unit | forms | form', function (hooks) {
     this.validations.foo = [{ type: 'containsWhiteSpace', message: 'Whitespace is not allowed' }];
 
     const serializedData = { foo: this.data.foo.replace(/\s/g, '_') };
-    const state = { 'data.foo': { isValid: true, errors: [], warnings: [] } };
+    const state = { foo: { isValid: true, errors: [], warnings: [] } };
     const expected = { isValid: true, state, invalidFormMessage: '', data: serializedData };
 
-    const form = new Form(this.data, this.validations);
+    const form = new Form(this.data, this.options, this.validations);
     const json = form.toJSON(serializedData);
 
     assert.deepEqual(json, expected, 'toJSON allows data to be overridden');
+  });
+
+  test('it should proxy get/set to data object for form fields', async function (assert) {
+    class TestForm extends Form {
+      formFields = [new FormField('foo', 'string')];
+    }
+    const form = new TestForm(this.data);
+
+    assert.strictEqual(
+      form.foo,
+      'bar',
+      'data object value returned when accessing form field property on class'
+    );
+    form.foo = 'baz';
+    assert.strictEqual(
+      form.data.foo,
+      'baz',
+      'data object property is set when setting form field property on class'
+    );
+    assert.strictEqual(form.foo, 'baz', 'updated data object value is returned');
   });
 });

--- a/ui/tests/unit/utils/forms/field-test.js
+++ b/ui/tests/unit/utils/forms/field-test.js
@@ -26,6 +26,6 @@ module('Unit | Utility | forms | field', function (hooks) {
   test('it should default field value', async function (assert) {
     this.options.fieldValue = undefined;
     const field = new FormField('test', 'string', this.options);
-    assert.strictEqual(field.options.fieldValue, 'data.test', 'Default field value is set correctly');
+    assert.strictEqual(field.options.fieldValue, 'test', 'Default field value is set correctly');
   });
 });


### PR DESCRIPTION
### Description
This PR returns a proxy from the Form class constructor that proxies get/set of form field properties to the data object. Originally, the `fieldValue` property on form fields was mapped to the data object which worked fine in the `FormField` component. The issue was that there are numerous places where form fields are accessed and set outside of that component. Rather than updating all references to prepend `data.`, the proxy allows for the existing references to function as intended. 

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
