### PR TITLE
Add snowflake DB API warning

### DIFF
--- a/builtin/logical/database/path_config_connection.go
+++ b/builtin/logical/database/path_config_connection.go
@@ -648,6 +648,14 @@ func (b *databaseBackend) connectionWriteHandler() framework.OperationFunc {
 				"Vault (or the sdk if using a custom plugin) to gain password policy support", config.PluginName))
 		}
 
+		// We can ignore the error at this point since we're simply adding a warning.
+		dbType, _ := dbw.Type()
+		if dbType == "snowflake" && config.ConnectionDetails["password"] != nil {
+			resp.AddWarning(`[DEPRECATED] Single-factor password authentication is deprecated in Snowflake and will
+be removed by November 2025. Please be ready for multi-factor authentication (MFA) configuration to continue use.
+More information is available at https://www.snowflake.com/en/blog/blocking-single-factor-password-authentification`)
+		}
+
 		b.dbEvent(ctx, "config-write", req.Path, name, true)
 		if len(resp.Warnings) == 0 {
 			return nil, nil


### PR DESCRIPTION
### Description
Adds warnings for newly created or updated snowflake DB secrets configs for the removal of password authentication.

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
