### PR TITLE
Backport 1.18.x: Update database and static role rotation issue 

### DIFF
--- a/website/content/docs/release-notes/1.16.1.mdx
+++ b/website/content/docs/release-notes/1.16.1.mdx
@@ -31,7 +31,8 @@ description: |-
 | New default (1.16.13)       | [Vault product usage metrics reporting](/vault/docs/upgrading/upgrade-to-1.6.x#product-usage-reporting)                                                                                      |
 | Deprecation (1.16.13)       | [`default_report_months` is deprecated for the `sys/internal/counters` API](/vault/docs/upgrading/upgrade-to-1.16.x#activity-log-changes)                                                    |
 | Known Issue (1.16.16)       | [Authorization failures using Azure federated identity credentials](/vault/docs/upgrading/upgrade-to-1.16.x#authorization-failures-using-azure-federated-identity-credentials) |
-| Known issue (1.16.16)       | [Unexpected static role rotations on upgrade](/vault/docs/upgrading/upgrade-to-1.16.x#static-role-rotations) | 
+| Known issue (1.16.16-1.16.18) | [Unexpected LDAP static role rotations on upgrade](/vault/docs/upgrading/upgrade-to-1.16.x#static-role-rotations) | 
+| Known issue (1.16.16-1.16.19) | [Unexpected Database static role rotations on upgrade](/vault/docs/upgrading/upgrade-to-1.16.x#db-static-role-rotations) | 
 | Known issue (1.16.0)        | [Vault log file missing subsystem logs](/vault/docs/upgrading/upgrade-to-1.16.x#log-files)
 
 

--- a/website/content/docs/release-notes/1.17.0.mdx
+++ b/website/content/docs/release-notes/1.17.0.mdx
@@ -31,7 +31,8 @@ description: |-
 | New default (1.17.9)                           | [Vault product usage metrics reporting](/vault/docs/upgrading/upgrade-to-1.17.x#product-usage-reporting)                                                                                         |
 | Deprecation (1.17.9)                           | [`default_report_months` is deprecated for the `sys/internal/counters` API](/vault/docs/upgrading/upgrade-to-1.17.x#activity-log-changes)                                                        |
 | Known Issue (1.17.12)                          | [Authorization failures using Azure federated identity credentials](/vault/docs/upgrading/upgrade-to-1.17.x#authorization-failures-using-azure-federated-identity-credentials) |
-| Known issue (1.17.12)                          | [Unexpected static role rotations on upgrade](/vault/docs/upgrading/upgrade-to-1.17.x#static-role-rotations) |
+| Known issue (1.17.12-1.17.14)                  | [Unexpected LDAP static role rotations on upgrade](/vault/docs/upgrading/upgrade-to-1.17.x#static-role-rotations) |
+| Known issue (1.17.12-1.17.15)                  | [Unexpected Database static role rotations on upgrade](/vault/docs/upgrading/upgrade-to-1.17.x#db-static-role-rotations) |
 | Known issue (1.17.0)                           | [Vault log file missing subsystem logs](/vault/docs/upgrading/upgrade-to-1.17.x#log-files)
 
 

--- a/website/content/docs/release-notes/1.18.0.mdx
+++ b/website/content/docs/release-notes/1.18.0.mdx
@@ -20,7 +20,8 @@ description: |-
 | Beta feature removed (1.18) | [Request limiter removed](/vault/docs/upgrading/upgrade-to-1.18.x#request-limiter-configuration-removal)             |
 | New default (1.18.2)        | [Vault product usage metrics reporting](/vault/docs/upgrading/upgrade-to-1.18.x#product-usage-reporting)             |
 | Known Issue (1.18.5)        | [Authorization failures using Azure federated identity credentials](/vault/docs/upgrading/upgrade-to-1.18.x#authorization-failures-using-azure-federated-identity-credentials) |
-| Known issue (1.18.5)        | [Unexpected static role rotations on upgrade](/vault/docs/upgrading/upgrade-to-1.18.x#static-role-rotations) | 
+| Known issue (1.18.5-1.18.7) | [Unexpected LDAP static role rotations on upgrade](/vault/docs/upgrading/upgrade-to-1.18.x#static-role-rotations) | 
+| Known issue (1.18.5-1.18.8) | [Unexpected Database static role rotations on upgrade](/vault/docs/upgrading/upgrade-to-1.18.x#db-static-role-rotations)
 | Known issue (1.18.0)        | [Vault log file missing subsystem logs](/vault/docs/upgrading/upgrade-to-1.18.x#log-files)
 
 

--- a/website/content/partials/known-issues/database-static-role-premature-rotations.mdx
+++ b/website/content/partials/known-issues/database-static-role-premature-rotations.mdx
@@ -1,0 +1,24 @@
+### Database static role rotations on upgrade ((#db-static-role-rotations))
+
+#### Affected Upgrade Path
+* This issue only occurs when upgrading from the following initial versions to the following target versions:
+
+Initial Versions (any version prior to 1.15.0):
+- 1.14.x
+- 1.13.x
+- and earlier
+
+Target Versions:
+- 1.19.0, 1.19.1, 1.19.2
+- 1.18.5, 1.18.6, 1.18.7, 1.18.8
+- 1.17.12, 1.17.13, 1.17.14, 1.17.15
+- 1.16.16, 1.16.17, 1.16.18, 1.16.19
+
+#### Issue
+Vault automatically rotates existing static roles tied to Database
+credentials once when upgrading to an affected target version from an 
+affected initial version. After the one-time rotation, the static roles behave as expected.
+
+#### Workaround
+If you rely on Database static roles and are currently on a version prior to 1.15.0, 
+avoid upgrading directly to the target versions listed above.

--- a/website/content/partials/known-issues/static-role-premature-rotations.mdx
+++ b/website/content/partials/known-issues/static-role-premature-rotations.mdx
@@ -1,13 +1,22 @@
-### Static role rotations on upgrade ((#static-role-rotations))
+### LDAP static role rotations on upgrade ((#static-role-rotations))
 
 #### Affected Versions
-- 1.19.0, 1.18.5, 1.17.12, 1.16.16
+- 1.19.0, 1.19.1
+- 1.18.5, 1.18.6, 1.18.7
+- 1.17.12, 1.17.13, 1.17.14
+- 1.16.16, 1.16.17, 1.16.18
+
+#### Fixed Versions
+- 1.19.2
+- 1.18.8
+- 1.17.15
+- 1.16.19
 
 #### Issue
-Vault automatically rotates existing static roles tied to database and LDAP
+Vault automatically rotates existing static roles tied to LDAP
 credentials once when upgrading to an affected version. After the one-time
 rotation, the static roles behave as expected.
 
 #### Workaround
-If you rely on LDAP or static database roles, avoid upgrading to the affected
-versions until we fix the issue.
+If you rely on LDAP static roles, avoid upgrading to the affected
+versions.


### PR DESCRIPTION
* docs: fix version of static role issue

* add corrected versions and remove database references

* fix phrase

* remove plus

* remove redundant sentence

* add database aspect

* clarify upgrade path

* clarify upgrade path

* fix versions

* remove line

* Update website/content/partials/known-issues/static-role-premature-rotations.mdx

* improve wording

---------

### Description
What does this PR do?

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
