### PR TITLE
test(enos): always build artifacts and test when enos files change

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -159,6 +159,7 @@ jobs:
     #     a merge
     #   * The workflow was triggered by a pull request, the pull request is not a draft, and the UI
     #     or app changed.
+    #   * Our pipeline or test scenarios changed.
     if: |
       needs.setup.outputs.workflow-trigger == 'push' ||
       needs.setup.outputs.workflow-trigger == 'schedule' ||
@@ -169,6 +170,7 @@ jobs:
         (
           contains(fromJSON(needs.setup.outputs.changed-files).groups, 'ui') ||
           contains(fromJSON(needs.setup.outputs.changed-files).groups, 'pipeline') ||
+          contains(fromJSON(needs.setup.outputs.changed-files).groups, 'enos') ||
           contains(fromJSON(needs.setup.outputs.changed-files).groups, 'app')
         )
       )
@@ -215,11 +217,13 @@ jobs:
     #
     #   * The workflow was triggered by on schedule to test building all artifacts.
     #   * The Go app was changed.
+    #   * Our pipeline or test scenarios changed.
     #   * The build/all label is present on a pull request or push.
     if: |
       needs.setup.outputs.workflow-trigger == 'schedule' ||
       contains(fromJSON(needs.setup.outputs.changed-files).groups, 'app') ||
       contains(fromJSON(needs.setup.outputs.changed-files).groups, 'pipeline') ||
+      contains(fromJSON(needs.setup.outputs.changed-files).groups, 'enos') ||
       contains(fromJSON(needs.setup.outputs.labels), 'build/all')
     needs:
       - setup


### PR DESCRIPTION
### Description
Build the artifacts when `enos` files change. Previously `enos` changes we're grouped as pipeline but with the most recent refactor they have their own group category.

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [x] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
