### PR TITLE
backport-assistant: use the latest version of the backport-assistant

### DIFF
--- a/.github/workflows/backport-ce.yml
+++ b/.github/workflows/backport-ce.yml
@@ -13,7 +13,7 @@ jobs:
   backport-targeted-release-branch:
     if: github.event.pull_request.merged && github.repository == 'hashicorp/vault'
     runs-on: ubuntu-latest
-    container: hashicorpdev/backport-assistant:0.5.3
+    container: hashicorpdev/backport-assistant:0.5.8
     steps:
       - name: Backport changes to targeted release branch
         run: |


### PR DESCRIPTION
### Description
Update the backport assistant to the latest version.

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [x] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
