### PR TITLE
Missing OpenAPI Fields For Custom Messages 

### DIFF
--- a/vault/logical_system_custom_messages.go
+++ b/vault/logical_system_custom_messages.go
@@ -19,6 +19,49 @@ import (
 // uiCustomMessagePaths returns a slice of *framework.Path elements that are
 // added to the receiver SystemBackend.
 func (b *SystemBackend) uiCustomMessagePaths() []*framework.Path {
+	responseFieldSchema := map[string]*framework.FieldSchema{
+		"id": {
+			Type:     framework.TypeString,
+			Required: true,
+		},
+		"title": {
+			Type:     framework.TypeString,
+			Required: true,
+		},
+		"authenticated": {
+			Type:     framework.TypeBool,
+			Required: true,
+		},
+		"type": {
+			Type:     framework.TypeBool,
+			Required: true,
+		},
+		"message": {
+			Type:     framework.TypeString,
+			Required: true,
+		},
+		"link": {
+			Type:     framework.TypeMap,
+			Required: false,
+		},
+		"start_time": {
+			Type:     framework.TypeTime,
+			Required: true,
+		},
+		"end_time": {
+			Type:     framework.TypeTime,
+			Required: true,
+		},
+		"active": {
+			Type:     framework.TypeBool,
+			Required: true,
+		},
+		"options": {
+			Type:     framework.TypeMap,
+			Required: false,
+		},
+	}
+
 	return []*framework.Path{
 		{
 			Pattern: "config/ui/custom-messages/$",
@@ -32,14 +75,17 @@ func (b *SystemBackend) uiCustomMessagePaths() []*framework.Path {
 				"authenticated": {
 					Type:     framework.TypeBool,
 					Required: false,
+					Query:    true,
 				},
 				"active": {
 					Type:     framework.TypeBool,
 					Required: false,
+					Query:    true,
 				},
 				"type": {
 					Type:     framework.TypeString,
 					Required: false,
+					Query:    true,
 				},
 			},
 			Operations: map[logical.Operation]framework.OperationHandler{
@@ -49,6 +95,16 @@ func (b *SystemBackend) uiCustomMessagePaths() []*framework.Path {
 					Responses: map[int][]framework.Response{
 						http.StatusOK: {{
 							Description: "OK",
+							Fields: map[string]*framework.FieldSchema{
+								"keys": {
+									Type:     framework.TypeStringSlice,
+									Required: true,
+								},
+								"key_info": {
+									Type:     framework.TypeMap,
+									Required: true,
+								},
+							},
 						}},
 					},
 				},
@@ -167,12 +223,7 @@ func (b *SystemBackend) uiCustomMessagePaths() []*framework.Path {
 					Responses: map[int][]framework.Response{
 						http.StatusOK: {{
 							Description: "OK",
-							Fields: map[string]*framework.FieldSchema{
-								"id": {
-									Type:     framework.TypeString,
-									Required: true,
-								},
-							},
+							Fields:      responseFieldSchema,
 						}},
 					},
 
@@ -187,12 +238,6 @@ func (b *SystemBackend) uiCustomMessagePaths() []*framework.Path {
 					Responses: map[int][]framework.Response{
 						http.StatusNoContent: {{
 							Description: "OK",
-							Fields: map[string]*framework.FieldSchema{
-								"id": {
-									Type:     framework.TypeString,
-									Required: true,
-								},
-							},
 						}},
 					},
 
@@ -207,44 +252,7 @@ func (b *SystemBackend) uiCustomMessagePaths() []*framework.Path {
 					Responses: map[int][]framework.Response{
 						http.StatusOK: {{
 							Description: "OK",
-							Fields: map[string]*framework.FieldSchema{
-								"id": {
-									Type:     framework.TypeString,
-									Required: true,
-								},
-								"title": {
-									Type:     framework.TypeString,
-									Required: true,
-								},
-								"authenticated": {
-									Type:     framework.TypeBool,
-									Required: true,
-								},
-								"type": {
-									Type:     framework.TypeBool,
-									Required: true,
-								},
-								"message": {
-									Type:     framework.TypeString,
-									Required: true,
-								},
-								"link": {
-									Type:     framework.TypeMap,
-									Required: false,
-								},
-								"start_time": {
-									Type:     framework.TypeTime,
-									Required: true,
-								},
-								"end_time": {
-									Type:     framework.TypeTime,
-									Required: true,
-								},
-								"options": {
-									Type:     framework.TypeMap,
-									Required: false,
-								},
-							},
+							Fields:      responseFieldSchema,
 						}},
 					},
 

--- a/vault/logical_system_paths.go
+++ b/vault/logical_system_paths.go
@@ -3107,6 +3107,10 @@ func (b *SystemBackend) capabilitiesPaths() []*framework.Path {
 					Type:        framework.TypeCommaStringSlice,
 					Description: "Paths on which capabilities are being queried.",
 				},
+				"namespace": {
+					Type:        framework.TypeString,
+					Description: "Namespace for which capabilities are being queried.",
+				},
 			},
 
 			Operations: map[logical.Operation]framework.OperationHandler{


### PR DESCRIPTION
### Description
This PR adds missing fields for custom messages so that they appear in the generated OpenAPI spec.

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
