### PR TITLE
VAULT-35615 security(scanner): suppress CVE-2025-46394 1.19.x (#30350)

### DIFF
--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -1,27 +1,25 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-container {
-	dependencies = true
-	alpine_secdb = true
-	secrets      = true
+binary {
+  secrets    = false
+  go_modules = false
+  osv        = true
+  oss_index  = true
+  nvd        = false
 }
 
-binary {
-	secrets      = false
-	go_modules   = true
-	go_stdlib    = true
-	osv          = true
-	oss_index    = true
-	nvd          = false
+container {
+  dependencies    = true
+  alpine_security = true
+  secrets         = true
 
-	# Triage items that are _safe_ to ignore here. Note that this list should be
-	# periodically cleaned up to remove items that are no longer found by the scanner.
-	triage {
-		suppress {
-			vulnerabilities = [
-				"GO-2022-0635", // github.com/aws/aws-sdk-go@v1.55.5
-			]
-		}
-	}
+  triage {
+    suppress {
+      vulnerabilities = [
+        "CVE-2025-46394", // We can't do anything about this until a new Alpine container with busybox 1.38 is available.
+        "GO-2022-0635",   // github.com/aws/aws-sdk-go@v1.x
+      ]
+    }
+  }
 }

--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -17,8 +17,10 @@ container {
   triage {
     suppress {
       vulnerabilities = [
-        "CVE-2025-46394", // We can't do anything about this until a new Alpine container with busybox 1.38 is available.
-        "GO-2022-0635",   // github.com/aws/aws-sdk-go@v1.x
+        // We can't do anything about these two CVE's until a new Alpine container with busybox 1.38 is available.
+        "CVE-2025-46394",
+        "CVE-2024-58251",
+        "GO-2022-0635", // github.com/aws/aws-sdk-go@v1.x
       ]
     }
   }

--- a/scan.hcl
+++ b/scan.hcl
@@ -3,18 +3,20 @@
 
 repository {
   go_modules = true
-  osv = true
-  secrets {
-    all = true
-  } 
+  osv        = true
+
   dependabot {
-    required = true
+    required     = true
     check_config = true
   }
-  
+
+  plugin "codeql" {
+    languages = ["go"]
+  }
+
   plugin "semgrep" {
     use_git_ignore = true
-    exclude = ["vendor"]
+    exclude        = ["vendor"]
     config = [
       "tools/semgrep/ci",
       "p/r2c-security-audit",
@@ -24,8 +26,8 @@ repository {
     ]
     exclude_rule = ["generic.html-templates.security.unquoted-attribute-var.unquoted-attribute-var"]
   }
-  
-  plugin "codeql" {
-    languages = ["go"]
+
+  secrets {
+    all = true
   }
 }


### PR DESCRIPTION
### Description
A manual backport of https://github.com/hashicorp/vault/pull/30350

An upstream CVE in busybox is tripping the security scanner: https://github.com/hashicorp/crt-workflows-common/actions/runs/14623987904/job/41031896870#step:9:16

Since this will require a new version of Alpine we can’t do much except suppress it until a new version has been released with Busybox >= 1.38

We’re already rolling on the latest Alpine 3 so we ought to get the fix as soon as it’s released and available, but this will unbreak the pipeline until then.

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
