### PR TITLE
security(scanner): Suppress CVE-2024-58251 until a new Alpine image image is available

### DIFF
--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -17,8 +17,10 @@ container {
   triage {
     suppress {
       vulnerabilities = [
-        "CVE-2025-46394", // We can't do anything about this until a new Alpine container with busybox 1.38 is available.
-        "GO-2022-0635",   // github.com/aws/aws-sdk-go@v1.x
+        // We can't do anything about these two CVE's until a new Alpine container with busybox 1.38 is available.
+        "CVE-2025-46394",
+        "CVE-2024-58251",
+        "GO-2022-0635", // github.com/aws/aws-sdk-go@v1.x
       ]
     }
   }


### PR DESCRIPTION
### Description
Yet another CVE with busybox was updated today. Suppress it until a new Alpine image with an updated busybox is available. 

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
