### PR TITLE
VAULT-35624: Common snapshot source interface

### DIFF
--- a/vault/logical_system_raft.go
+++ b/vault/logical_system_raft.go
@@ -613,9 +613,14 @@ func (b *SystemBackend) handleStorageRaftSnapshotWrite(force bool, makeSealer fu
 		if !ok {
 			return logical.ErrorResponse("raft storage is not in use"), logical.ErrInvalidRequest
 		}
-		body, ok := logical.ContextOriginalBodyValue(ctx)
-		if !ok {
-			return nil, errors.New("no reader for request")
+
+		source, err := b.makeSnapshotSource(ctx, d)
+		if err != nil {
+			return nil, err
+		}
+		body, err := source.ReadCloser(ctx)
+		if err != nil {
+			return nil, err
 		}
 
 		var sealer snapshot.Sealer

--- a/vault/logical_system_stubs_oss.go
+++ b/vault/logical_system_stubs_oss.go
@@ -5,6 +5,15 @@
 
 package vault
 
+import (
+	"context"
+	"errors"
+
+	"github.com/hashicorp/vault/sdk/framework"
+	"github.com/hashicorp/vault/sdk/logical"
+	"github.com/hashicorp/vault/vault/snapshots"
+)
+
 //go:generate go run github.com/hashicorp/vault/tools/stubmaker
 
 type entSystemBackend struct{}
@@ -14,3 +23,11 @@ func entUnauthenticatedPaths() []string {
 }
 
 func (s *SystemBackend) entInit() {}
+
+func (s *SystemBackend) makeSnapshotSource(ctx context.Context, _ *framework.FieldData) (snapshots.Source, error) {
+	body, ok := logical.ContextOriginalBodyValue(ctx)
+	if !ok {
+		return nil, errors.New("no reader for request")
+	}
+	return snapshots.NewManualSnapshotSource(body), nil
+}

--- a/vault/snapshots/source.go
+++ b/vault/snapshots/source.go
@@ -1,0 +1,35 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package snapshots
+
+import (
+	"context"
+	"io"
+)
+
+// Source is used to read raw snapshot data
+type Source interface {
+	ReadCloser(ctx context.Context) (io.ReadCloser, error)
+	Type(ctx context.Context) string
+}
+
+var _ Source = (*manualUploadSource)(nil)
+
+type manualUploadSource struct {
+	r io.ReadCloser
+}
+
+// NewManualSnapshotSource creates a new Source that returns the wrapped reader
+// as the snapshot data
+func NewManualSnapshotSource(r io.ReadCloser) Source {
+	return &manualUploadSource{r: r}
+}
+
+func (m *manualUploadSource) Type(_ context.Context) string {
+	return "manual"
+}
+
+func (m *manualUploadSource) ReadCloser(_ context.Context) (io.ReadCloser, error) {
+	return m.r, nil
+}


### PR DESCRIPTION
### Description
This PR adds a snapshots package and in it, a Source interface. In CE, we have only one source for snapshots, which is a manual file upload.

Ent PR: https://github.com/hashicorp/vault-enterprise/pull/7922

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
