### PR TITLE
[VAULT-35469] UI: navigate to namespace on enter/return

### DIFF
--- a/ui/app/components/namespace-picker.hbs
+++ b/ui/app/components/namespace-picker.hbs
@@ -12,10 +12,19 @@
       <Hds::Form::TextInput::Field
         @value={{this.searchInput}}
         @type="search"
+        aria-label="Search namespaces"
         placeholder="Search"
+        {{on "keydown" this.onKeyDown}}
         {{on "input" this.onSearchInput}}
+        {{did-insert this.focusSearchInput}}
       />
     </D.Generic>
+
+    {{#if this.hasSearchInput}}
+      <D.Generic>
+        {{this.searchInputHelpText}}
+      </D.Generic>
+    {{/if}}
 
     <D.Separator />
 

--- a/ui/app/components/namespace-picker.js
+++ b/ui/app/components/namespace-picker.js
@@ -7,7 +7,7 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { service } from '@ember/service';
-import keys from 'core/utils/key-codes';
+import { KEYS } from 'core/utils/keyboard-keys';
 
 /**
  * @module NamespacePicker
@@ -74,7 +74,7 @@ export default class NamespacePicker extends Component {
     ];
 
     // Conditionally add the root namespace
-    if (this.auth.authData.userRootNamespace === '') {
+    if (this.auth?.authData?.userRootNamespace === '') {
       options.unshift({ id: 'root', path: '', label: 'root' });
     }
 
@@ -142,7 +142,7 @@ export default class NamespacePicker extends Component {
 
   @action
   async onKeyDown(event) {
-    if (event.keyCode === keys.ENTER && this.searchInput?.trim()) {
+    if (event.key === KEYS.ENTER && this.searchInput?.trim()) {
       const matchingNamespace = this.allNamespaces.find((ns) => ns.label === this.searchInput.trim());
 
       if (matchingNamespace) {

--- a/ui/app/components/namespace-picker.js
+++ b/ui/app/components/namespace-picker.js
@@ -31,7 +31,8 @@ export default class NamespacePicker extends Component {
 
   @tracked allNamespaces = [];
   @tracked searchInput = '';
-  @tracked searchInputHelpText = 'Enter a full path in the search bar and hit ↵ key to navigate faster.';
+  @tracked searchInputHelpText =
+    "Enter a full path in the search bar and hit the 'Enter' ↵ key to navigate faster.";
   @tracked selected = {};
 
   constructor() {
@@ -147,6 +148,7 @@ export default class NamespacePicker extends Component {
 
       if (matchingNamespace) {
         this.selected = matchingNamespace;
+        this.searchInput = '';
         this.router.transitionTo('vault.cluster.dashboard', {
           queryParams: { namespace: matchingNamespace.path },
         });

--- a/ui/lib/core/addon/utils/key-codes.js
+++ b/ui/lib/core/addon/utils/key-codes.js
@@ -3,6 +3,13 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
+/*
+ * DEPRCATED (see: https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode).
+ *
+ * TODO: Replace all instances with `event.key` (use lib/core/addon/utils/keyboard-keys.ts).
+ * `event.keyCode` is deprecated and will be removed in future versions of browsers.
+ */
+
 // a map of keyCode for use in keyboard event handlers
 export default {
   ENTER: 13,

--- a/ui/lib/core/addon/utils/keyboard-keys.ts
+++ b/ui/lib/core/addon/utils/keyboard-keys.ts
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+/**
+ * @module keyboard-keys
+ * @description Utility for mapping key names to their corresponding `event.key` values for use in keyboard event handlers.
+ */
+export enum KEYS {
+  ENTER = 'Enter',
+  ESC = 'Escape',
+  TAB = 'Tab',
+  LEFT = 'ArrowLeft',
+  UP = 'ArrowUp',
+  RIGHT = 'ArrowRight',
+  DOWN = 'ArrowDown',
+  T = 'F5',
+  BACKSPACE = 'Backspace',
+}

--- a/ui/tests/acceptance/enterprise-namespaces-test.js
+++ b/ui/tests/acceptance/enterprise-namespaces-test.js
@@ -75,17 +75,13 @@ module('Acceptance | Enterprise | namespaces', function (hooks) {
   });
 
   test('it filters namespaces based on search input', async function (assert) {
-    assert.expect(7);
+    assert.expect(6);
 
     await click(NAMESPACE_PICKER_SELECTORS.toggle);
 
     // Verify all namespaces are displayed initially
     assert.dom(NAMESPACE_PICKER_SELECTORS.link()).exists('Namespace link(s) exist');
-    assert.strictEqual(
-      findAll(NAMESPACE_PICKER_SELECTORS.link()).length,
-      5,
-      'All namespaces are displayed initially'
-    );
+    const allNamespaces = findAll(NAMESPACE_PICKER_SELECTORS.link());
 
     // Verify the search input field exists
     assert.dom(NAMESPACE_PICKER_SELECTORS.searchInput).exists('The namespace search field exists');
@@ -118,7 +114,7 @@ module('Acceptance | Enterprise | namespaces', function (hooks) {
     await fillIn(NAMESPACE_PICKER_SELECTORS.searchInput, '');
     assert.strictEqual(
       findAll(NAMESPACE_PICKER_SELECTORS.link()).length,
-      5,
+      allNamespaces.length,
       'All namespaces are displayed after clearing search input'
     );
   });
@@ -200,6 +196,7 @@ module('Acceptance | Enterprise | namespaces', function (hooks) {
 
       // check that the full namespace path, like "beep/boop", shows in the toggle display
       await waitFor(NAMESPACE_PICKER_SELECTORS.link(targetNamespace));
+
       assert
         .dom(NAMESPACE_PICKER_SELECTORS.link(targetNamespace))
         .hasText(targetNamespace, `shows the namespace ${targetNamespace} in the toggle component`);
@@ -216,14 +213,12 @@ module('Acceptance | Enterprise | namespaces', function (hooks) {
     await waitFor(`svg${GENERAL.icon('check')}`);
 
     // Find the selected element with the check icon & ensure it exists
-    const checkIcon = document.querySelector(
-      `${NAMESPACE_PICKER_SELECTORS.link()} svg${GENERAL.icon('check')}`
-    );
-    assert.ok(checkIcon, 'A selected namespace link with the check icon exists');
+    const checkIcon = find(`${NAMESPACE_PICKER_SELECTORS.link()} ${GENERAL.icon('check')}`);
+    assert.dom(checkIcon).exists('A selected namespace link with the check icon exists');
 
     // Get the selected namespace with the data-test-namespace-link attribute & ensure it exists
-    const selectedNamespace = checkIcon.closest(NAMESPACE_PICKER_SELECTORS.link());
-    assert.ok(selectedNamespace, 'The selected namespace link exists');
+    const selectedNamespace = checkIcon?.closest(NAMESPACE_PICKER_SELECTORS.link());
+    assert.dom(selectedNamespace).exists('The selected namespace link exists');
 
     // Verify that the selected namespace has the correct data-test-namespace-link attribute and path value
     assert.strictEqual(

--- a/ui/tests/acceptance/enterprise-namespaces-test.js
+++ b/ui/tests/acceptance/enterprise-namespaces-test.js
@@ -39,8 +39,6 @@ module('Acceptance | Enterprise | namespaces', function (hooks) {
   });
 
   test('it focuses the search input field when the component is loaded', async function (assert) {
-    assert.expect(1);
-
     await click(NAMESPACE_PICKER_SELECTORS.toggle);
 
     // Verify that the search input field is focused
@@ -53,8 +51,6 @@ module('Acceptance | Enterprise | namespaces', function (hooks) {
   });
 
   test('it navigates to the matching namespace when Enter is pressed', async function (assert) {
-    assert.expect(2);
-
     await click(NAMESPACE_PICKER_SELECTORS.toggle);
 
     // Simulate typing into the search input
@@ -75,8 +71,6 @@ module('Acceptance | Enterprise | namespaces', function (hooks) {
   });
 
   test('it filters namespaces based on search input', async function (assert) {
-    assert.expect(6);
-
     await click(NAMESPACE_PICKER_SELECTORS.toggle);
 
     // Verify all namespaces are displayed initially
@@ -120,8 +114,6 @@ module('Acceptance | Enterprise | namespaces', function (hooks) {
   });
 
   test('it updates the namespace list after clicking "Refresh list"', async function (assert) {
-    assert.expect(3);
-
     await click(NAMESPACE_PICKER_SELECTORS.toggle);
 
     // Verify that the namespace list was fetched on load
@@ -150,8 +142,6 @@ module('Acceptance | Enterprise | namespaces', function (hooks) {
   });
 
   test('it displays the "Manage" button with the correct URL', async function (assert) {
-    assert.expect(1);
-
     await click(NAMESPACE_PICKER_SELECTORS.toggle);
 
     // Verify the "Manage" button is rendered and has the correct URL

--- a/ui/tests/helpers/namespace-picker.js
+++ b/ui/tests/helpers/namespace-picker.js
@@ -7,4 +7,5 @@ export const NAMESPACE_PICKER_SELECTORS = {
   link: (link) => (link ? `[data-test-namespace-link="${link}"]` : '[data-test-namespace-link]'),
   refreshList: '[data-test-refresh-namespaces]',
   toggle: '[data-test-namespace-toggle]',
+  searchInput: 'input[type="search"]',
 };

--- a/ui/tests/integration/components/namespace-picker-test.js
+++ b/ui/tests/integration/components/namespace-picker-test.js
@@ -45,8 +45,6 @@ module('Integration | Component | namespace-picker', function (hooks) {
   });
 
   test('it focuses the search input field when the component is loaded', async function (assert) {
-    assert.expect(1);
-
     await render(hbs`<NamespacePicker />`);
 
     await click(NAMESPACE_PICKER_SELECTORS.toggle);
@@ -61,8 +59,6 @@ module('Integration | Component | namespace-picker', function (hooks) {
   });
 
   test('it filters namespace options based on search input', async function (assert) {
-    assert.expect(3);
-
     await render(hbs`<NamespacePicker/>`);
 
     await click(NAMESPACE_PICKER_SELECTORS.toggle);
@@ -98,8 +94,6 @@ module('Integration | Component | namespace-picker', function (hooks) {
   });
 
   test('it updates the namespace list after clicking "Refresh list"', async function (assert) {
-    assert.expect(3);
-
     // Mock `hasListPermissions`
     this.owner.lookup('service:namespace').set('hasListPermissions', true);
 
@@ -144,8 +138,6 @@ module('Integration | Component | namespace-picker', function (hooks) {
   });
 
   test('it displays the "Manage" button when the user has permissions', async function (assert) {
-    assert.expect(1);
-
     // Mock `hasListPermissions` to be true
     this.owner.lookup('service:namespace').set('hasListPermissions', true);
 

--- a/ui/tests/integration/components/namespace-picker-test.js
+++ b/ui/tests/integration/components/namespace-picker-test.js
@@ -10,31 +10,20 @@ import hbs from 'htmlbars-inline-precompile';
 import Service from '@ember/service';
 import { NAMESPACE_PICKER_SELECTORS } from 'vault/tests/helpers/namespace-picker';
 
-const authService = Service.extend({
-  init() {
-    this._super(...arguments);
-    this.set('authData', {
-      userRootNamespace: '',
-    });
-  },
-});
+class AuthService extends Service {
+  authData = { userRootNamespace: '' };
+}
 
-const namespaceService = Service.extend({
-  accessibleNamespaces: null,
-  findNamespacesForUser: null,
-  path: null,
+class NamespaceService extends Service {
+  accessibleNamespaces = ['parent1', 'parent1/child1'];
+  path = 'parent1/child1';
 
-  init() {
-    this._super(...arguments);
-    this.set('accessibleNamespaces', ['parent1', 'parent1/child1']);
-    this.set('findNamespacesForUser', {
-      perform: () => Promise.resolve(),
-    });
-    this.set('path', 'parent1/child1');
-  },
-});
+  findNamespacesForUser = {
+    perform: () => Promise.resolve(),
+  };
+}
 
-const storeService = Service.extend({
+class StoreService extends Service {
   findRecord(modelType, id) {
     return new Promise((resolve, reject) => {
       if (modelType === 'capabilities' && id === 'sys/namespaces/') {
@@ -43,16 +32,16 @@ const storeService = Service.extend({
         reject({ httpStatus: 404, message: 'not found' }); // Simulate an error response
       }
     });
-  },
-});
+  }
+}
 
 module('Integration | Component | namespace-picker', function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function () {
-    this.owner.register('service:auth', authService);
-    this.owner.register('service:namespace', namespaceService);
-    this.owner.register('service:store', storeService);
+    this.owner.register('service:auth', AuthService);
+    this.owner.register('service:namespace', NamespaceService);
+    this.owner.register('service:store', StoreService);
   });
 
   test('it focuses the search input field when the component is loaded', async function (assert) {

--- a/ui/tests/integration/components/namespace-picker-test.js
+++ b/ui/tests/integration/components/namespace-picker-test.js
@@ -5,7 +5,7 @@
 
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, fillIn, findAll, waitFor, click } from '@ember/test-helpers';
+import { render, fillIn, findAll, waitFor, click, find } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import Service from '@ember/service';
 import { NAMESPACE_PICKER_SELECTORS } from 'vault/tests/helpers/namespace-picker';
@@ -55,6 +55,22 @@ module('Integration | Component | namespace-picker', function (hooks) {
     this.owner.register('service:store', storeService);
   });
 
+  test('it focuses the search input field when the component is loaded', async function (assert) {
+    assert.expect(1);
+
+    await render(hbs`<NamespacePicker />`);
+
+    await click(NAMESPACE_PICKER_SELECTORS.toggle);
+
+    // Verify that the search input field is focused
+    const searchInput = find(NAMESPACE_PICKER_SELECTORS.searchInput);
+    assert.strictEqual(
+      document.activeElement,
+      searchInput,
+      'The search input field is focused on component load'
+    );
+  });
+
   test('it filters namespace options based on search input', async function (assert) {
     assert.expect(3);
 
@@ -71,8 +87,8 @@ module('Integration | Component | namespace-picker', function (hooks) {
     );
 
     // Simulate typing into the search input
-    await waitFor('[type="search"]');
-    await fillIn('[type="search"]', 'child1');
+    await waitFor(NAMESPACE_PICKER_SELECTORS.searchInput);
+    await fillIn(NAMESPACE_PICKER_SELECTORS.searchInput, 'child1');
 
     // Verify that only namespaces matching the search input are displayed
     assert.strictEqual(
@@ -82,7 +98,7 @@ module('Integration | Component | namespace-picker', function (hooks) {
     );
 
     // Clear the search input
-    await fillIn('[type="search"]', '');
+    await fillIn(NAMESPACE_PICKER_SELECTORS.searchInput, '');
 
     // Verify all namespaces are displayed after clearing the search input
     assert.strictEqual(


### PR DESCRIPTION
### Description
What does this PR do?
- [x] Navigate directly to namespace on search for valid namespace name and click the Enter/Return key
- [x] Enterprise tests passing:
  > 248 tests completed in 182277 milliseconds, with 0 failed, 10 skipped, and 0 todo.
1468 assertions of 1468 passed, 0 failed.

### Demo
https://github.com/user-attachments/assets/1aa0a709-c0ea-46c9-820c-420d46db9a86

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
