### PR TITLE
add known issue docs for azure auth uniform vmss regression

### DIFF
--- a/website/content/docs/release-notes/1.16.1.mdx
+++ b/website/content/docs/release-notes/1.16.1.mdx
@@ -34,7 +34,7 @@ description: |-
 | Known issue (1.16.16-1.16.18) | [Unexpected LDAP static role rotations on upgrade](/vault/docs/upgrading/upgrade-to-1.16.x#static-role-rotations) | 
 | Known issue (1.16.16-1.16.19) | [Unexpected Database static role rotations on upgrade](/vault/docs/upgrading/upgrade-to-1.16.x#db-static-role-rotations) | 
 | Known issue (1.16.0)        | [Vault log file missing subsystem logs](/vault/docs/upgrading/upgrade-to-1.16.x#log-files)
-| Known issue (1.16.18)       | [Azure Auth fails to authenticate Uniform VMSS instances](/vault/docs/upgrading/upgrade-to-1.16.x#azure-auth-fails-uniform-vmss) |
+| Known issue (1.16.18+)      | [Azure Auth fails to authenticate Uniform VMSS instances](/vault/docs/upgrading/upgrade-to-1.16.x#azure-auth-fails-uniform-vmss) |
 
 
 ## Vault companion updates

--- a/website/content/docs/release-notes/1.16.1.mdx
+++ b/website/content/docs/release-notes/1.16.1.mdx
@@ -34,6 +34,7 @@ description: |-
 | Known issue (1.16.16-1.16.18) | [Unexpected LDAP static role rotations on upgrade](/vault/docs/upgrading/upgrade-to-1.16.x#static-role-rotations) | 
 | Known issue (1.16.16-1.16.19) | [Unexpected Database static role rotations on upgrade](/vault/docs/upgrading/upgrade-to-1.16.x#db-static-role-rotations) | 
 | Known issue (1.16.0)        | [Vault log file missing subsystem logs](/vault/docs/upgrading/upgrade-to-1.16.x#log-files)
+| Known issue (1.16.18)       | [Azure Auth fails to authenticate Uniform VMSS instances](/vault/docs/upgrading/upgrade-to-1.16.x#azure-auth-fails-uniform-vmss) |
 
 
 ## Vault companion updates

--- a/website/content/docs/release-notes/1.17.0.mdx
+++ b/website/content/docs/release-notes/1.17.0.mdx
@@ -34,6 +34,7 @@ description: |-
 | Known issue (1.17.12-1.17.14)                  | [Unexpected LDAP static role rotations on upgrade](/vault/docs/upgrading/upgrade-to-1.17.x#static-role-rotations) |
 | Known issue (1.17.12-1.17.15)                  | [Unexpected Database static role rotations on upgrade](/vault/docs/upgrading/upgrade-to-1.17.x#db-static-role-rotations) |
 | Known issue (1.17.0)                           | [Vault log file missing subsystem logs](/vault/docs/upgrading/upgrade-to-1.17.x#log-files)
+| Known issue (1.17.14)                          | [Azure Auth fails to authenticate Uniform VMSS instances](/vault/docs/upgrading/upgrade-to-1.17.x#azure-auth-fails-uniform-vmss) |
 
 
 ## Vault companion updates

--- a/website/content/docs/release-notes/1.17.0.mdx
+++ b/website/content/docs/release-notes/1.17.0.mdx
@@ -34,7 +34,7 @@ description: |-
 | Known issue (1.17.12-1.17.14)                  | [Unexpected LDAP static role rotations on upgrade](/vault/docs/upgrading/upgrade-to-1.17.x#static-role-rotations) |
 | Known issue (1.17.12-1.17.15)                  | [Unexpected Database static role rotations on upgrade](/vault/docs/upgrading/upgrade-to-1.17.x#db-static-role-rotations) |
 | Known issue (1.17.0)                           | [Vault log file missing subsystem logs](/vault/docs/upgrading/upgrade-to-1.17.x#log-files)
-| Known issue (1.17.14)                          | [Azure Auth fails to authenticate Uniform VMSS instances](/vault/docs/upgrading/upgrade-to-1.17.x#azure-auth-fails-uniform-vmss) |
+| Known issue (1.17.14+)                         | [Azure Auth fails to authenticate Uniform VMSS instances](/vault/docs/upgrading/upgrade-to-1.17.x#azure-auth-fails-uniform-vmss) |
 
 
 ## Vault companion updates

--- a/website/content/docs/release-notes/1.18.0.mdx
+++ b/website/content/docs/release-notes/1.18.0.mdx
@@ -23,6 +23,7 @@ description: |-
 | Known issue (1.18.5-1.18.7) | [Unexpected LDAP static role rotations on upgrade](/vault/docs/upgrading/upgrade-to-1.18.x#static-role-rotations) | 
 | Known issue (1.18.5-1.18.8) | [Unexpected Database static role rotations on upgrade](/vault/docs/upgrading/upgrade-to-1.18.x#db-static-role-rotations)
 | Known issue (1.18.0)        | [Vault log file missing subsystem logs](/vault/docs/upgrading/upgrade-to-1.18.x#log-files)
+| Known issue (1.18.7)        | [Azure Auth fails to authenticate Uniform VMSS instances](/vault/docs/upgrading/upgrade-to-1.18.x#azure-auth-fails-uniform-vmss) |
 
 
 ## Vault companion updates

--- a/website/content/docs/release-notes/1.18.0.mdx
+++ b/website/content/docs/release-notes/1.18.0.mdx
@@ -23,7 +23,7 @@ description: |-
 | Known issue (1.18.5-1.18.7) | [Unexpected LDAP static role rotations on upgrade](/vault/docs/upgrading/upgrade-to-1.18.x#static-role-rotations) | 
 | Known issue (1.18.5-1.18.8) | [Unexpected Database static role rotations on upgrade](/vault/docs/upgrading/upgrade-to-1.18.x#db-static-role-rotations)
 | Known issue (1.18.0)        | [Vault log file missing subsystem logs](/vault/docs/upgrading/upgrade-to-1.18.x#log-files)
-| Known issue (1.18.7)        | [Azure Auth fails to authenticate Uniform VMSS instances](/vault/docs/upgrading/upgrade-to-1.18.x#azure-auth-fails-uniform-vmss) |
+| Known issue (1.18.7+)       | [Azure Auth fails to authenticate Uniform VMSS instances](/vault/docs/upgrading/upgrade-to-1.18.x#azure-auth-fails-uniform-vmss) |
 
 
 ## Vault companion updates

--- a/website/content/docs/release-notes/1.19.0.mdx
+++ b/website/content/docs/release-notes/1.19.0.mdx
@@ -26,6 +26,7 @@ description: |-
 | Known issue (1.19.0, 1.19.1)                  | [Unexpected LDAP static role rotations on upgrade](/vault/docs/upgrading/upgrade-to-1.19.x#static-role-rotations)
 | Known issue (1.19.0, 1.19.1, 1.19.2)          | [Unexpected Database static role rotations on upgrade](/vault/docs/upgrading/upgrade-to-1.19.x#db-static-role-rotations)
 | Known issue (1.19.0)                          | [Vault log file missing subsystem logs](/vault/docs/upgrading/upgrade-to-1.19.x#log-files)
+| Known issue (1.19.1)                          | [Azure Auth fails to authenticate Uniform VMSS instances](/vault/docs/upgrading/upgrade-to-1.19.x#azure-auth-fails-uniform-vmss)
        
 
 ## Feature deprecations and EOL

--- a/website/content/docs/release-notes/1.19.0.mdx
+++ b/website/content/docs/release-notes/1.19.0.mdx
@@ -26,7 +26,7 @@ description: |-
 | Known issue (1.19.0, 1.19.1)                  | [Unexpected LDAP static role rotations on upgrade](/vault/docs/upgrading/upgrade-to-1.19.x#static-role-rotations)
 | Known issue (1.19.0, 1.19.1, 1.19.2)          | [Unexpected Database static role rotations on upgrade](/vault/docs/upgrading/upgrade-to-1.19.x#db-static-role-rotations)
 | Known issue (1.19.0)                          | [Vault log file missing subsystem logs](/vault/docs/upgrading/upgrade-to-1.19.x#log-files)
-| Known issue (1.19.1)                          | [Azure Auth fails to authenticate Uniform VMSS instances](/vault/docs/upgrading/upgrade-to-1.19.x#azure-auth-fails-uniform-vmss)
+| Known issue (1.19.1+)                         | [Azure Auth fails to authenticate Uniform VMSS instances](/vault/docs/upgrading/upgrade-to-1.19.x#azure-auth-fails-uniform-vmss)
        
 
 ## Feature deprecations and EOL

--- a/website/content/docs/upgrading/upgrade-to-1.16.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.16.x.mdx
@@ -246,3 +246,5 @@ more details, and information about opt-out.
 @include 'known-issues/database-static-role-premature-rotations.mdx'
 
 @include 'known-issues/log_file_flush_issue.mdx'
+
+@include 'known-issues/azure-auth-fails-uniform-vmss.mdx'

--- a/website/content/docs/upgrading/upgrade-to-1.17.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.17.x.mdx
@@ -218,3 +218,4 @@ more details, and information about opt-out.
 
 @include 'known-issues/log_file_flush_issue.mdx'
 
+@include 'known-issues/azure-auth-fails-uniform-vmss.mdx'

--- a/website/content/docs/upgrading/upgrade-to-1.18.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.18.x.mdx
@@ -152,3 +152,5 @@ more details, and information about opt-out.
 @include 'known-issues/database-static-role-premature-rotations.mdx'
 
 @include 'known-issues/log_file_flush_issue.mdx'
+
+@include 'known-issues/azure-auth-fails-uniform-vmss.mdx'

--- a/website/content/docs/upgrading/upgrade-to-1.19.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.19.x.mdx
@@ -104,3 +104,5 @@ As of Vault 1.19.0 the RADIUS authentication plugin will not force case sensitiv
 @include 'known-issues/database-static-role-premature-rotations.mdx'
 
 @include 'known-issues/log_file_flush_issue.mdx'
+
+@include 'known-issues/azure-auth-fails-uniform-vmss.mdx'

--- a/website/content/partials/known-issues/azure-auth-fails-uniform-vmss.mdx
+++ b/website/content/partials/known-issues/azure-auth-fails-uniform-vmss.mdx
@@ -1,11 +1,11 @@
 ### Azure Auth fails to authenticate Uniform VMSS instances ((#azure-auth-fails-uniform-vmss))
 
-#### Affected Versions
+#### Affected versions
 
-- 1.19.1
-- 1.18.7
-- 1.17.14
-- 1.16.18
+- 1.19.1+
+- 1.18.7+
+- 1.17.14+
+- 1.16.18+
 
 #### Issue
 

--- a/website/content/partials/known-issues/azure-auth-fails-uniform-vmss.mdx
+++ b/website/content/partials/known-issues/azure-auth-fails-uniform-vmss.mdx
@@ -1,0 +1,16 @@
+### Azure Auth fails to authenticate Uniform VMSS instances ((#azure-auth-fails-uniform-vmss))
+
+#### Affected Versions
+
+- 1.19.1
+- 1.18.7
+- 1.17.14
+- 1.16.18
+
+#### Issue
+
+Azure Authentication from a uniform VMSS instance with a user assigned managed identity on the VMSS incorrectly results in an error. There was a regression introduced from adding [validations on the JWT claims](/vault/docs/auth/azure#token-validation) against the provided VM, VMSS, and resource group names without accounting for the uniform VMSS format.
+
+#### Workaround
+
+None at this time.


### PR DESCRIPTION
### Description
Adds known issue docs for Azure Auth Uniform VMSS regression related to token validation changes introduced in 1.19.1, 1.18.7, 1.17.14, and 1.16.18.

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- x ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
