### PR TITLE
UI: Cleanup and update selectors in Secret Engine tests

### DIFF
--- a/changelog/30382.txt
+++ b/changelog/30382.txt
@@ -1,3 +1,0 @@
-```release-note:improvement
-secret/tests : Updating selectors used in secrets test files
-```

--- a/changelog/30382.txt
+++ b/changelog/30382.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+secret/tests : Updating selectors used in secrets test files
+```

--- a/ui/app/components/dashboard/secrets-engines-card.hbs
+++ b/ui/app/components/dashboard/secrets-engines-card.hbs
@@ -40,12 +40,12 @@
                         @route={{backend.backendLink}}
                         @model={{backend.id}}
                         class="has-text-black has-text-weight-semibold overflow-wrap"
-                        data-test-secret-path
+                        data-test-secret-path={{backend.path}}
                       >
                         {{backend.path}}
                       </LinkTo>
                     {{else}}
-                      <span class="has-text-grey" data-test-secret-path>{{backend.path}}</span>
+                      <span class="has-text-grey" data-test-secret-path={{backend.path}}>{{backend.path}}</span>
                     {{/if}}
                   {{/if}}
                 </div>

--- a/ui/app/routes/vault/cluster/secrets/backends.ts
+++ b/ui/app/routes/vault/cluster/secrets/backends.ts
@@ -8,7 +8,7 @@ import { service } from '@ember/service';
 
 import type Store from '@ember-data/store';
 
-export default class ClientsRoute extends Route {
+export default class SecretsBackends extends Route {
   @service declare readonly store: Store;
 
   model() {

--- a/ui/app/routes/vault/cluster/secrets/backends.ts
+++ b/ui/app/routes/vault/cluster/secrets/backends.ts
@@ -6,10 +6,12 @@
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
 
-export default Route.extend({
-  store: service(),
+import type Store from '@ember-data/store';
+
+export default class ClientsRoute extends Route {
+  @service declare readonly store: Store;
 
   model() {
     return this.store.query('secret-engine', {});
-  },
-});
+  }
+}

--- a/ui/app/templates/components/database-connection.hbs
+++ b/ui/app/templates/components/database-connection.hbs
@@ -68,7 +68,7 @@
             @backend={{@model.backend}}
             @type="add"
             @queryParams={{hash initialKey=@model.name itemType="role"}}
-            data-test-secret-create={{true}}
+            data-test-add-role
           >
             Add role
           </ToolbarSecretLink>

--- a/ui/app/templates/components/secret-create-or-update.hbs
+++ b/ui/app/templates/components/secret-create-or-update.hbs
@@ -18,7 +18,7 @@
         <Input
           autocomplete="off"
           spellcheck="false"
-          data-test-secret-path="true"
+          data-test-secret-path="create"
           id="kv-key"
           class="input {{if (get this.validationMessages 'path') 'has-error-border'}}"
           @value={{get @modelForData @modelForData.pathAttr}}

--- a/ui/app/templates/vault/cluster/secrets/backend/list.hbs
+++ b/ui/app/templates/vault/cluster/secrets/backend/list.hbs
@@ -46,7 +46,7 @@
           @backend={{this.backendModel.id}}
           @type="add"
           @queryParams={{hash initialKey=(or this.filter this.baseKey.id) itemType=this.tab}}
-          data-test-secret-create={{true}}
+          data-test-create-secret-link
         >
           {{options.create}}
         </ToolbarSecretLink>

--- a/ui/app/templates/vault/cluster/secrets/backend/overview.hbs
+++ b/ui/app/templates/vault/cluster/secrets/backend/overview.hbs
@@ -15,7 +15,7 @@
           @text="Connect a database"
           @query={{hash itemType="connection"}}
           @route="vault.cluster.secrets.backend.create-root"
-          data-test-secret-create="connections"
+          data-test-create-secret-link
         />
       {{/if}}
     </EmptyState>

--- a/ui/app/templates/vault/cluster/secrets/backends.hbs
+++ b/ui/app/templates/vault/cluster/secrets/backends.hbs
@@ -66,12 +66,12 @@
               @route={{backend.backendLink}}
               @model={{backend.id}}
               class="has-text-black has-text-weight-semibold overflow-wrap"
-              data-test-secret-path
+              data-test-secret-path={{backend.path}}
             >
               {{backend.path}}
             </LinkTo>
           {{else}}
-            <span data-test-secret-path>{{backend.path}}</span>
+            <span data-test-secret-path={{backend.path}}>{{backend.path}}</span>
           {{/if}}
         {{/if}}
       </div>

--- a/ui/tests/acceptance/enterprise-kmse-test.js
+++ b/ui/tests/acceptance/enterprise-kmse-test.js
@@ -12,6 +12,7 @@ import { setupMirage } from 'ember-cli-mirage/test-support';
 import { allEngines } from 'vault/helpers/mountable-secret-engines';
 import { mountBackend } from 'vault/tests/helpers/components/mount-backend-form-helpers';
 import { runCmd } from '../helpers/commands';
+import { SECRET_ENGINE_SELECTORS as SES } from 'vault/tests/helpers/secret-engine/secret-engine-selectors';
 
 module('Acceptance | Enterprise | keymgmt', function (hooks) {
   setupApplicationTest(hooks);
@@ -45,7 +46,7 @@ module('Acceptance | Enterprise | keymgmt', function (hooks) {
     this.server.put(`/${path}/kms/test-keyvault/key/test-key`, () => ({}));
 
     await mountSecrets.enable('keymgmt', path);
-    await click('[data-test-secret-create]');
+    await click(SES.createSecretLink);
     await fillIn('[data-test-input="provider"]', 'azurekeyvault');
     await fillIn('[data-test-input="name"]', 'test-keyvault');
     await fillIn('[data-test-input="keyCollection"]', 'test-keycollection');

--- a/ui/tests/acceptance/enterprise-transform-test.js
+++ b/ui/tests/acceptance/enterprise-transform-test.js
@@ -21,6 +21,7 @@ import { runCmd } from '../helpers/commands';
 import { allEngines } from 'vault/helpers/mountable-secret-engines';
 import { mountBackend } from 'vault/tests/helpers/components/mount-backend-form-helpers';
 import { v4 as uuidv4 } from 'uuid';
+import { SECRET_ENGINE_SELECTORS as SES } from 'vault/tests/helpers/secret-engine/secret-engine-selectors';
 
 const searchSelectComponent = create(searchSelect);
 
@@ -107,8 +108,8 @@ module('Acceptance | Enterprise | Transform secrets', function (hooks) {
     const transformationName = 'foo';
     const roleName = 'foo-role';
     await settled();
-    await transformationsPage.createLink({ backend });
-    await settled();
+    await click(SES.createSecretLink);
+
     assert.strictEqual(
       currentURL(),
       `/vault/secrets/${backend}/create`,
@@ -167,7 +168,7 @@ module('Acceptance | Enterprise | Transform secrets', function (hooks) {
     await click('[data-test-secret-list-tab="Roles"]');
     assert.strictEqual(currentURL(), `/vault/secrets/${backend}/list?tab=role`, 'links to role list page');
     // create role with transformation attached
-    await rolesPage.createLink();
+    await click(SES.createSecretLink);
     assert.strictEqual(
       currentURL(),
       `/vault/secrets/${backend}/create?itemType=role`,
@@ -256,7 +257,7 @@ module('Acceptance | Enterprise | Transform secrets', function (hooks) {
       'links to template list page'
     );
     await settled();
-    await templatesPage.createLink();
+    await click(SES.createSecretLink);
     assert.strictEqual(
       currentURL(),
       `/vault/secrets/${backend}/create?itemType=template`,
@@ -299,8 +300,7 @@ module('Acceptance | Enterprise | Transform secrets', function (hooks) {
       `/vault/secrets/${backend}/list?tab=alphabet`,
       'links to alphabet list page'
     );
-    await alphabetsPage.createLink();
-    await settled();
+    await click(SES.createSecretLink);
     assert.strictEqual(
       currentURL(),
       `/vault/secrets/${backend}/create?itemType=alphabet`,

--- a/ui/tests/acceptance/leases-test.js
+++ b/ui/tests/acceptance/leases-test.js
@@ -15,6 +15,8 @@ import { setupApplicationTest } from 'ember-qunit';
 import { v4 as uuidv4 } from 'uuid';
 import secretList from 'vault/tests/pages/secrets/backend/list';
 import secretEdit from 'vault/tests/pages/secrets/backend/kv/edit-secret';
+import { SECRET_ENGINE_SELECTORS as SES } from 'vault/tests/helpers/secret-engine/secret-engine-selectors';
+
 // import mountSecrets from 'vault/tests/pages/settings/mount-secret-backend';
 // import { login } from 'vault/tests/helpers/auth/auth-helpers';
 
@@ -31,7 +33,7 @@ module('Acceptance | leases', function (hooks) {
   const createSecret = async (context, isRenewable) => {
     context.name = `secret-${uuidv4()}`;
     await secretList.visitRoot({ backend: context.enginePath });
-    await secretList.create();
+    await click(SES.createSecretLink);
     if (isRenewable) {
       await secretEdit.createSecret(context.name, 'ttl', '30h');
     } else {

--- a/ui/tests/acceptance/policies/index-test.js
+++ b/ui/tests/acceptance/policies/index-test.js
@@ -27,7 +27,7 @@ const SELECT = {
   filterBar: '[data-test-component="navigate-input"]',
   delete: '[data-test-confirm-action-trigger]',
   confirmDelete: '[data-test-confirm-button]',
-  createLink: '[data-test-policy-create-link]',
+  createPolicy: '[data-test-policy-create-link]',
   nameInput: '[data-test-policy-input="name"]',
   save: '[data-test-policy-save]',
   createError: '[data-test-message-error]',
@@ -85,7 +85,7 @@ module('Acceptance | policies/acl', function (hooks) {
 
     await visit('/vault/policies/acl');
     // new policy creation
-    await click(SELECT.createLink);
+    await click(SELECT.createPolicy);
 
     await fillIn(SELECT.nameInput, policyName);
     codemirror().setValue(policyString);
@@ -105,7 +105,7 @@ module('Acceptance | policies/acl', function (hooks) {
 
     await visit('/vault/policies/acl');
     // new policy creation
-    await click(SELECT.createLink);
+    await click(SELECT.createPolicy);
 
     await fillIn(SELECT.nameInput, policyName);
     await click(SELECT.save);

--- a/ui/tests/acceptance/secrets/backend/aws/aws-test.js
+++ b/ui/tests/acceptance/secrets/backend/aws/aws-test.js
@@ -79,7 +79,7 @@ module('Acceptance | aws secret backend', function (hooks) {
       'After enabling aws secrets engine it navigates to roles list'
     );
 
-    await click(SES.createSecret);
+    await click(SES.createSecretLink);
     assert.dom(SES.secretHeader).hasText('Create an AWS Role', 'It renders the create role page');
 
     await fillIn(GENERAL.inputByAttr('name'), roleName);

--- a/ui/tests/acceptance/secrets/backend/cubbyhole/secret-test.js
+++ b/ui/tests/acceptance/secrets/backend/cubbyhole/secret-test.js
@@ -9,7 +9,7 @@ import { setupApplicationTest } from 'ember-qunit';
 import { v4 as uuidv4 } from 'uuid';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 
-import editPage from 'vault/tests/pages/secrets/backend/kv/edit-secret';
+import { createSecret } from 'vault/tests/helpers/secret-engine/secret-engine-helpers';
 import showPage from 'vault/tests/pages/secrets/backend/kv/show';
 import listPage from 'vault/tests/pages/secrets/backend/list';
 import { login } from 'vault/tests/helpers/auth/auth-helpers';
@@ -41,10 +41,8 @@ module('Acceptance | secrets/cubbyhole/create', function (hooks) {
       'navigates to the list page'
     );
 
-    await listPage.create();
-    await settled();
-    await editPage.createSecret(kvPath, 'foo', 'bar');
-    await settled();
+    await click(SES.createSecretLink);
+    await createSecret(kvPath, 'foo', 'bar');
     assert.strictEqual(
       currentRouteName(),
       'vault.cluster.secrets.backend.show',

--- a/ui/tests/acceptance/secrets/backend/database/secret-test.js
+++ b/ui/tests/acceptance/secrets/backend/database/secret-test.js
@@ -19,6 +19,7 @@ import searchSelect from 'vault/tests/pages/components/search-select';
 import { deleteEngineCmd, mountEngineCmd, runCmd, tokenWithPolicyCmd } from 'vault/tests/helpers/commands';
 
 import { GENERAL } from 'vault/tests/helpers/general-selectors';
+import { SECRET_ENGINE_SELECTORS as SES } from 'vault/tests/helpers/secret-engine/secret-engine-selectors';
 
 const searchSelectComponent = create(searchSelect);
 
@@ -40,7 +41,7 @@ const newConnection = async (
 
 const navToConnection = async (backend, connection) => {
   await visit('/vault/secrets');
-  await click(`[data-test-secrets-backend-link="${backend}"]`);
+  await click(SES.secretsBackendLink(backend));
   await click('[data-test-secret-list-tab="Connections"]');
   await click(`[data-test-secret-link="${connection}"]`);
   return;
@@ -447,7 +448,7 @@ module('Acceptance | secrets/database/*', function (hooks) {
       ],
     };
     await visit(`/vault/secrets/${backend}/list`);
-    await connectionPage.createLink();
+    await click(SES.createSecretLink);
     assert.strictEqual(currentURL(), `/vault/secrets/${backend}/create`, 'Create link goes to create page');
     assert
       .dom('[data-test-empty-state-title]')
@@ -520,12 +521,12 @@ module('Acceptance | secrets/database/*', function (hooks) {
     assert
       .dom('[data-test-database-connection-reset]')
       .hasText('Reset connection', 'Reset button exists with correct text');
-    assert.dom('[data-test-secret-create]').hasText('Add role', 'Add role button exists with correct text');
+    assert.dom('[data-test-add-role]').hasText('Add role', 'Add role button exists with correct text');
     assert.dom('[data-test-edit-link]').hasText('Edit configuration', 'Edit button exists with correct text');
     // Check with restricted permissions
     await login(token);
     await click('[data-test-sidebar-nav-link="Secrets Engines"]');
-    assert.dom(`[data-test-secrets-backend-link="${backend}"]`).exists('Shows backend on secret list page');
+    assert.dom(SES.secretsBackendLink(backend)).exists('Shows backend on secret list page');
     await navToConnection(backend, connection);
     assert.strictEqual(
       currentURL(),
@@ -538,7 +539,7 @@ module('Acceptance | secrets/database/*', function (hooks) {
     assert
       .dom('[data-test-database-connection-reset]')
       .doesNotExist('Reset button does not show due to permissions');
-    assert.dom('[data-test-secret-create]').doesNotExist('Add role button does not show due to permissions');
+    assert.dom('[data-test-add-role]').doesNotExist('Add role button does not show due to permissions');
     assert.dom('[data-test-edit-link]').doesNotExist('Edit button does not show due to permissions');
     await visit(`/vault/secrets/${backend}/overview`);
     assert.dom('[data-test-overview-card="Connections"]').exists('Connections card exists on overview');
@@ -622,7 +623,7 @@ module('Acceptance | secrets/database/*', function (hooks) {
     assert.dom('[data-test-secret-list-tab="Connections"]').exists('renders connections tab');
     assert.dom('[data-test-secret-list-tab="Roles"]').exists('renders connections tab');
 
-    await click('[data-test-secret-create="connections"]');
+    await click(SES.createSecretLink);
     assert.strictEqual(currentURL(), `/vault/secrets/${backend}/create?itemType=connection`);
 
     // Login with restricted policy

--- a/ui/tests/acceptance/secrets/backend/database/workflow-test.js
+++ b/ui/tests/acceptance/secrets/backend/database/workflow-test.js
@@ -16,6 +16,7 @@ import { login } from 'vault/tests/helpers/auth/auth-helpers';
 import flashMessage from 'vault/tests/pages/components/flash-message';
 import { deleteEngineCmd, mountEngineCmd, runCmd } from 'vault/tests/helpers/commands';
 import { SECRET_ENGINE_SELECTORS as SES } from 'vault/tests/helpers/secret-engine/secret-engine-selectors';
+import connectionPage from 'vault/tests/pages/secrets/backend/database/connection';
 
 const flash = create(flashMessage);
 
@@ -31,7 +32,6 @@ const PAGE = {
   confirmRotate: '[data-test-enable-rotate-connection]',
   skipRotate: '[data-test-enable-connection]',
   // ROLES
-  addRole: '[data-test-secret-create]',
   roleSettingsSection: '[data-test-role-settings-section]',
   statementsSection: '[data-test-statements-section]',
   editRole: '[data-test-edit-link]',
@@ -249,7 +249,7 @@ module('Acceptance | database workflow', function (hooks) {
 
     test('it creates a dynamic role attached to the current connection', async function (assert) {
       const roleName = 'dynamic-role';
-      await click(PAGE.addRole);
+      await click(connectionPage.addRole);
       assert.strictEqual(
         currentURL(),
         `/vault/secrets/${this.backend}/create?initialKey=${this.connection}&itemType=role`,
@@ -375,7 +375,7 @@ module('Acceptance | database workflow', function (hooks) {
       await this.setup({ toggleRotateOff: false });
 
       const roleName = 'static-role';
-      await click(PAGE.addRole);
+      await click(connectionPage.addRole);
       assert.strictEqual(
         currentURL(),
         `/vault/secrets/${this.backend}/create?initialKey=${this.connection}&itemType=role`,
@@ -395,7 +395,7 @@ module('Acceptance | database workflow', function (hooks) {
       await this.setup({ toggleRotateOff: true });
 
       const roleName = 'static-role';
-      await click(PAGE.addRole);
+      await click(connectionPage.addRole);
       assert.strictEqual(
         currentURL(),
         `/vault/secrets/${this.backend}/create?initialKey=${this.connection}&itemType=role`,

--- a/ui/tests/acceptance/secrets/backend/database/workflow-test.js
+++ b/ui/tests/acceptance/secrets/backend/database/workflow-test.js
@@ -16,7 +16,6 @@ import { login } from 'vault/tests/helpers/auth/auth-helpers';
 import flashMessage from 'vault/tests/pages/components/flash-message';
 import { deleteEngineCmd, mountEngineCmd, runCmd } from 'vault/tests/helpers/commands';
 import { SECRET_ENGINE_SELECTORS as SES } from 'vault/tests/helpers/secret-engine/secret-engine-selectors';
-import connectionPage from 'vault/tests/pages/secrets/backend/database/connection';
 
 const flash = create(flashMessage);
 
@@ -32,6 +31,7 @@ const PAGE = {
   confirmRotate: '[data-test-enable-rotate-connection]',
   skipRotate: '[data-test-enable-connection]',
   // ROLES
+  addRole: '[data-test-add-role]',
   roleSettingsSection: '[data-test-role-settings-section]',
   statementsSection: '[data-test-statements-section]',
   editRole: '[data-test-edit-link]',
@@ -249,7 +249,7 @@ module('Acceptance | database workflow', function (hooks) {
 
     test('it creates a dynamic role attached to the current connection', async function (assert) {
       const roleName = 'dynamic-role';
-      await click(connectionPage.addRole);
+      await click(PAGE.addRole);
       assert.strictEqual(
         currentURL(),
         `/vault/secrets/${this.backend}/create?initialKey=${this.connection}&itemType=role`,
@@ -375,7 +375,7 @@ module('Acceptance | database workflow', function (hooks) {
       await this.setup({ toggleRotateOff: false });
 
       const roleName = 'static-role';
-      await click(connectionPage.addRole);
+      await click(PAGE.addRole);
       assert.strictEqual(
         currentURL(),
         `/vault/secrets/${this.backend}/create?initialKey=${this.connection}&itemType=role`,
@@ -395,7 +395,7 @@ module('Acceptance | database workflow', function (hooks) {
       await this.setup({ toggleRotateOff: true });
 
       const roleName = 'static-role';
-      await click(connectionPage.addRole);
+      await click(PAGE.addRole);
       assert.strictEqual(
         currentURL(),
         `/vault/secrets/${this.backend}/create?initialKey=${this.connection}&itemType=role`,

--- a/ui/tests/acceptance/secrets/backend/database/workflow-test.js
+++ b/ui/tests/acceptance/secrets/backend/database/workflow-test.js
@@ -15,13 +15,13 @@ import { setupApplicationTest } from 'vault/tests/helpers';
 import { login } from 'vault/tests/helpers/auth/auth-helpers';
 import flashMessage from 'vault/tests/pages/components/flash-message';
 import { deleteEngineCmd, mountEngineCmd, runCmd } from 'vault/tests/helpers/commands';
+import { SECRET_ENGINE_SELECTORS as SES } from 'vault/tests/helpers/secret-engine/secret-engine-selectors';
 
 const flash = create(flashMessage);
 
 const PAGE = {
   // GENERIC
   emptyStateTitle: '[data-test-empty-state-title]',
-  emptyStateAction: '[data-test-secret-create="connections"]',
   infoRow: '[data-test-component="info-table-row"]',
   infoRowLabel: (label) => `[data-test-row-label="${label}"]`,
   infoRowValue: (label) => `[data-test-row-value="${label}"]`,
@@ -31,7 +31,6 @@ const PAGE = {
   confirmRotate: '[data-test-enable-rotate-connection]',
   skipRotate: '[data-test-enable-connection]',
   // ROLES
-  addRole: '[data-test-secret-create]',
   roleSettingsSection: '[data-test-role-settings-section]',
   statementsSection: '[data-test-statements-section]',
   editRole: '[data-test-edit-link]',
@@ -99,7 +98,7 @@ module('Acceptance | database workflow', function (hooks) {
       });
       await visit(`/vault/secrets/${this.backend}/overview`);
       assert.dom(PAGE.emptyStateTitle).hasText('Connect a database', 'empty state title is correct');
-      await click(PAGE.emptyStateAction);
+      await click(SES.createSecretLink);
       assert.strictEqual(
         currentURL(),
         `/vault/secrets/${this.backend}/create?itemType=connection`,
@@ -136,7 +135,7 @@ module('Acceptance | database workflow', function (hooks) {
       });
       await visit(`/vault/secrets/${this.backend}/overview`);
       assert.dom(PAGE.emptyStateTitle).hasText('Connect a database', 'empty state title is correct');
-      await click(PAGE.emptyStateAction);
+      await click(SES.createSecretLink);
       assert.strictEqual(
         currentURL(),
         `/vault/secrets/${this.backend}/create?itemType=connection`,
@@ -174,7 +173,7 @@ module('Acceptance | database workflow', function (hooks) {
       });
       await visit(`/vault/secrets/${this.backend}/overview`);
       assert.dom(PAGE.emptyStateTitle).hasText('Connect a database', 'empty state title is correct');
-      await click(PAGE.emptyStateAction);
+      await click(SES.createSecretLink);
       assert.strictEqual(
         currentURL(),
         `/vault/secrets/${this.backend}/create?itemType=connection`,
@@ -213,7 +212,7 @@ module('Acceptance | database workflow', function (hooks) {
     test('create connection with rotate failure', async function (assert) {
       await visit(`/vault/secrets/${this.backend}/overview`);
       assert.dom(PAGE.emptyStateTitle).hasText('Connect a database', 'empty state title is correct');
-      await click(PAGE.emptyStateAction);
+      await click(SES.createSecretLink);
       assert.strictEqual(
         currentURL(),
         `/vault/secrets/${this.backend}/create?itemType=connection`,
@@ -249,7 +248,7 @@ module('Acceptance | database workflow', function (hooks) {
 
     test('it creates a dynamic role attached to the current connection', async function (assert) {
       const roleName = 'dynamic-role';
-      await click(PAGE.addRole);
+      await click(SES.createSecretLink);
       assert.strictEqual(
         currentURL(),
         `/vault/secrets/${this.backend}/create?initialKey=${this.connection}&itemType=role`,

--- a/ui/tests/acceptance/secrets/backend/database/workflow-test.js
+++ b/ui/tests/acceptance/secrets/backend/database/workflow-test.js
@@ -31,6 +31,7 @@ const PAGE = {
   confirmRotate: '[data-test-enable-rotate-connection]',
   skipRotate: '[data-test-enable-connection]',
   // ROLES
+  addRole: '[data-test-secret-create]',
   roleSettingsSection: '[data-test-role-settings-section]',
   statementsSection: '[data-test-statements-section]',
   editRole: '[data-test-edit-link]',
@@ -248,7 +249,7 @@ module('Acceptance | database workflow', function (hooks) {
 
     test('it creates a dynamic role attached to the current connection', async function (assert) {
       const roleName = 'dynamic-role';
-      await click(SES.createSecretLink);
+      await click(PAGE.addRole);
       assert.strictEqual(
         currentURL(),
         `/vault/secrets/${this.backend}/create?initialKey=${this.connection}&itemType=role`,

--- a/ui/tests/acceptance/secrets/backend/engines-test.js
+++ b/ui/tests/acceptance/secrets/backend/engines-test.js
@@ -10,28 +10,22 @@ import { setupApplicationTest } from 'ember-qunit';
 import { v4 as uuidv4 } from 'uuid';
 
 import { GENERAL } from 'vault/tests/helpers/general-selectors';
+import { SECRET_ENGINE_SELECTORS as SES } from 'vault/tests/helpers/secret-engine/secret-engine-selectors';
 import { deleteEngineCmd, mountEngineCmd, runCmd } from 'vault/tests/helpers/commands';
 import { login } from 'vault/tests/helpers/auth/auth-helpers';
 import { UNSUPPORTED_ENGINES, mountableEngines } from 'vault/helpers/mountable-secret-engines';
-import { PAGE } from 'vault/tests/helpers/kv/kv-selectors';
-import { SECRET_ENGINE_SELECTORS } from 'vault/tests/helpers/secret-engine/secret-engine-selectors';
-
-const SELECTORS = {
-  backendLink: (path) =>
-    path ? `[data-test-secrets-backend-link="${path}"]` : '[data-test-secrets-backend-link]',
-};
 
 module('Acceptance | secret-engine list view', function (hooks) {
   setupApplicationTest(hooks);
 
   const createSecret = async (path, key, value, enginePath) => {
-    await click(SECRET_ENGINE_SELECTORS.createSecret);
+    await click(SES.createSecret);
     await fillIn('[data-test-secret-path]', path);
 
     await fillIn('[data-test-secret-key]', key);
     await fillIn(GENERAL.inputByAttr(key), value);
     await click('[data-test-secret-save]');
-    await click(SECRET_ENGINE_SELECTORS.crumb(enginePath));
+    await click(SES.crumb(enginePath));
   };
 
   hooks.beforeEach(function () {
@@ -44,8 +38,8 @@ module('Acceptance | secret-engine list view', function (hooks) {
     const enginePath = `alicloud-disable-${this.uid}`;
     await runCmd(mountEngineCmd('alicloud', enginePath));
     await visit('/vault/secrets');
-    assert.dom(SELECTORS.backendLink(enginePath)).exists();
-    const row = SELECTORS.backendLink(enginePath);
+    assert.dom(SES.secretsBackendLink(enginePath)).exists();
+    const row = SES.secretsBackendLink(enginePath);
     await click(`${row} ${GENERAL.menuTrigger}`);
     await click(`${row} ${GENERAL.confirmTrigger}`);
     await click(GENERAL.confirmButton);
@@ -54,7 +48,7 @@ module('Acceptance | secret-engine list view', function (hooks) {
       'vault.cluster.secrets.backends',
       'redirects to the backends page'
     );
-    assert.dom(SELECTORS.backendLink(enginePath)).doesNotExist('does not show the disabled engine');
+    assert.dom(SES.secretsBackendLink(enginePath)).doesNotExist('does not show the disabled engine');
   });
 
   test('it adds disabled css styling to unsupported secret engines', async function (assert) {
@@ -68,14 +62,14 @@ module('Acceptance | secret-engine list view', function (hooks) {
       await visit('/vault/secrets');
       if (UNSUPPORTED_ENGINES.includes(engine)) {
         assert
-          .dom(PAGE.backends.link(enginePath))
+          .dom(SES.secretsBackendLink(enginePath))
           .doesNotHaveClass(
             'linked-block',
             `the linked-block class is not added to the unsupported ${engine}, which effectively disables it.`
           );
       } else {
         assert
-          .dom(PAGE.backends.link(enginePath))
+          .dom(SES.secretsBackendLink(enginePath))
           .hasClass('linked-block', `linked-block class is added to supported ${engine} engines.`);
       }
       // cleanup
@@ -84,7 +78,6 @@ module('Acceptance | secret-engine list view', function (hooks) {
   });
 
   test('it filters by name and engine type', async function (assert) {
-    assert.expect(5);
     const enginePath1 = `aws-1-${this.uid}`;
     const enginePath2 = `aws-2-${this.uid}`;
 
@@ -95,7 +88,7 @@ module('Acceptance | secret-engine list view', function (hooks) {
     await clickTrigger('#filter-by-engine-type');
     await click(GENERAL.searchSelect.option());
 
-    const rows = findAll(SELECTORS.backendLink());
+    const rows = findAll(SES.secretsBackendLink());
     const rowsAws = Array.from(rows).filter((row) => row.innerText.includes('aws'));
 
     assert.strictEqual(rows.length, rowsAws.length, 'all rows returned are aws');
@@ -103,20 +96,24 @@ module('Acceptance | secret-engine list view', function (hooks) {
     await clickTrigger('#filter-by-engine-name');
     const firstItemToSelect = find(GENERAL.searchSelect.option()).innerText;
     await click(GENERAL.searchSelect.option());
-    const singleRow = document.querySelectorAll('[data-test-secrets-backend-link]');
+    const singleRow = document.querySelectorAll(SES.secretsBackendLink());
     assert.strictEqual(singleRow.length, 1, 'returns only one row');
     assert.dom(singleRow[0]).includesText(firstItemToSelect, 'shows the filtered by name engine');
     // clear filter by engine name
     await click(`#filter-by-engine-name ${GENERAL.searchSelect.removeSelected}`);
-    const rowsAgain = document.querySelectorAll('[data-test-secrets-backend-link]');
+    const rowsAgain = document.querySelectorAll(SES.secretsBackendLink());
     assert.ok(rowsAgain.length > 1, 'filter has been removed');
-
-    // verify overflow style exists on engine name
-    assert.dom('[data-test-secret-path]').hasClass('overflow-wrap', 'secret engine name has overflow class ');
 
     // cleanup
     await runCmd(deleteEngineCmd(enginePath1));
     await runCmd(deleteEngineCmd(enginePath2));
+  });
+
+  test('it applies overflow styling', async function (assert) {
+    await visit('/vault/secrets');
+    // not using the secret-engine-selector "secretPath" because I want to return the first node of a querySelectorAll
+    const firstSecretEngine = document.querySelectorAll('[data-test-secret-path]')[0];
+    assert.dom(firstSecretEngine).hasClass('overflow-wrap', 'secret engine name has overflow class ');
   });
 
   test('it allows navigation to a non-nested secret with pagination', async function (assert) {
@@ -128,7 +125,7 @@ module('Acceptance | secret-engine list view', function (hooks) {
 
     // check kv1
     await visit('/vault/secrets');
-    await click(SELECTORS.backendLink(enginePath1));
+    await click(SES.secretsBackendLink(enginePath1));
     for (let i = 0; i <= 15; i++) {
       await createSecret(`secret-${i}`, 'foo', 'bar', enginePath1);
     }
@@ -140,7 +137,7 @@ module('Acceptance | secret-engine list view', function (hooks) {
       `/vault/secrets/${enginePath1}/list?page=2`,
       'After clicking next page in navigates to the second page.'
     );
-    await click(SECRET_ENGINE_SELECTORS.secretLink(secretPath));
+    await click(SES.secretLink(secretPath));
     assert.strictEqual(
       currentURL(),
       `/vault/secrets/${enginePath1}/show/${secretPath}`,
@@ -161,13 +158,13 @@ module('Acceptance | secret-engine list view', function (hooks) {
 
     // check kv1
     await visit('/vault/secrets');
-    await click(SELECTORS.backendLink(enginePath1));
+    await click(SES.secretsBackendLink(enginePath1));
     for (let i = 0; i <= 15; i++) {
       await createSecret(`${parentPath}/secret-${i}`, 'foo', 'bar', enginePath1);
     }
 
     // navigate and check that the children list view is shown from nested secrets
-    await click(SECRET_ENGINE_SELECTORS.secretLink(`${parentPath}/`));
+    await click(SES.secretLink(`${parentPath}/`));
 
     assert.strictEqual(
       currentURL(),

--- a/ui/tests/acceptance/secrets/backend/engines-test.js
+++ b/ui/tests/acceptance/secrets/backend/engines-test.js
@@ -19,7 +19,7 @@ module('Acceptance | secret-engine list view', function (hooks) {
   setupApplicationTest(hooks);
 
   const createSecret = async (path, key, value, enginePath) => {
-    await click(SES.createSecret);
+    await click(SES.createSecretLink);
     await fillIn('[data-test-secret-path]', path);
 
     await fillIn('[data-test-secret-key]', key);

--- a/ui/tests/acceptance/secrets/backend/generic/secret-test.js
+++ b/ui/tests/acceptance/secrets/backend/generic/secret-test.js
@@ -9,13 +9,14 @@ import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { v4 as uuidv4 } from 'uuid';
 
-import editPage from 'vault/tests/pages/secrets/backend/kv/edit-secret';
 import showPage from 'vault/tests/pages/secrets/backend/kv/show';
 import listPage from 'vault/tests/pages/secrets/backend/list';
 import consolePanel from 'vault/tests/pages/components/console/ui-panel';
 import { login } from 'vault/tests/helpers/auth/auth-helpers';
 import { writeSecret } from 'vault/tests/helpers/kv/kv-run-commands';
 import { PAGE } from 'vault/tests/helpers/kv/kv-selectors';
+import { SECRET_ENGINE_SELECTORS as SES } from 'vault/tests/helpers/secret-engine/secret-engine-selectors';
+import { createSecret } from 'vault/tests/helpers/secret-engine/secret-engine-helpers';
 
 import { create } from 'ember-cli-page-object';
 import { deleteEngineCmd, runCmd } from 'vault/tests/helpers/commands';
@@ -42,8 +43,8 @@ module('Acceptance | secrets/generic/create', function (hooks) {
     );
     assert.strictEqual(listPage.secrets.length, 1, 'lists one secret in the backend');
 
-    await listPage.create();
-    await editPage.createSecret(kvPath, 'foo', 'bar');
+    await click(SES.createSecretLink);
+    await createSecret(kvPath, 'foo', 'bar');
     assert.strictEqual(
       currentRouteName(),
       'vault.cluster.secrets.backend.show',
@@ -67,7 +68,7 @@ module('Acceptance | secrets/generic/create', function (hooks) {
     await visit('/vault/secrets');
     await selectChoose('[data-test-component="search-select"]#filter-by-engine-name', path);
     await settled();
-    await click(`[data-test-secrets-backend-link="${path}"]`);
+    await click(SES.secretsBackendLink(path));
     assert.strictEqual(
       currentRouteName(),
       'vault.cluster.secrets.backend.kv.list',

--- a/ui/tests/acceptance/secrets/backend/kv/kv-v2-workflow-edge-cases-test.js
+++ b/ui/tests/acceptance/secrets/backend/kv/kv-v2-workflow-edge-cases-test.js
@@ -34,6 +34,7 @@ import {
 import { clearRecords, writeSecret, writeVersionedSecret } from 'vault/tests/helpers/kv/kv-run-commands';
 import { FORM, PAGE } from 'vault/tests/helpers/kv/kv-selectors';
 import { GENERAL } from 'vault/tests/helpers/general-selectors';
+import { SECRET_ENGINE_SELECTORS as SES } from 'vault/tests/helpers/secret-engine/secret-engine-selectors';
 import codemirror from 'vault/tests/helpers/codemirror';
 import { personas } from 'vault/tests/helpers/kv/policy-generator';
 
@@ -494,7 +495,7 @@ module('Acceptance | Enterprise | kv-v2 workflow | edge cases', function (hooks)
 
   const navToEngine = async (backend) => {
     await click('[data-test-sidebar-nav-link="Secrets Engines"]');
-    return await click(PAGE.backends.link(backend));
+    return await click(SES.secretsBackendLink(backend));
   };
 
   const assertDeleteActions = (assert, expected = ['delete', 'destroy']) => {

--- a/ui/tests/acceptance/secrets/backend/kv/kv-v2-workflow-navigation-test.js
+++ b/ui/tests/acceptance/secrets/backend/kv/kv-v2-workflow-navigation-test.js
@@ -35,6 +35,7 @@ import {
 } from 'vault/tests/helpers/kv/kv-run-commands';
 import { FORM, PAGE } from 'vault/tests/helpers/kv/kv-selectors';
 import { GENERAL } from 'vault/tests/helpers/general-selectors';
+import { SECRET_ENGINE_SELECTORS as SES } from 'vault/tests/helpers/secret-engine/secret-engine-selectors';
 import { setupControlGroup, grantAccess } from 'vault/tests/helpers/control-groups';
 
 const secretPath = `my-#:$=?-secret`;
@@ -44,7 +45,7 @@ const secretPathUrlEncoded = `my-%23:$=%3F-secret`;
 const ALL_TABS = ['Overview', 'Secret', 'Metadata', 'Paths', 'Version History'];
 const navToBackend = async (backend) => {
   await visit(`/vault/secrets`);
-  return click(PAGE.backends.link(backend));
+  return click(SES.secretsBackendLink(backend));
 };
 const assertCorrectBreadcrumbs = (assert, expected) => {
   assert.dom(PAGE.breadcrumbs).hasText(expected.join(' '));

--- a/ui/tests/acceptance/secrets/backend/kv/secret-test.js
+++ b/ui/tests/acceptance/secrets/backend/kv/secret-test.js
@@ -21,6 +21,7 @@ import codemirror from 'vault/tests/helpers/codemirror';
 import { MOUNT_BACKEND_FORM } from 'vault/tests/helpers/components/mount-backend-form-selectors';
 import { GENERAL } from 'vault/tests/helpers/general-selectors';
 import { SECRET_ENGINE_SELECTORS as SS } from 'vault/tests/helpers/secret-engine/secret-engine-selectors';
+import { createSecret } from 'vault/tests/helpers/secret-engine/secret-engine-helpers';
 
 const deleteEngine = async function (enginePath, assert) {
   await login();
@@ -148,8 +149,8 @@ module('Acceptance | secrets/secret/create, read, delete', function (hooks) {
     test('version 1 performs the correct capabilities lookup', async function (assert) {
       // TODO: while this should pass it doesn't really do anything anymore for us as v1 and v2 are completely separate.
       const secretPath = 'foo/bar';
-      await listPage.create();
-      await editPage.createSecret(secretPath, 'foo', 'bar');
+      await click(SS.createSecretLink);
+      await createSecret(secretPath, 'foo', 'bar');
       assert.strictEqual(
         currentRouteName(),
         'vault.cluster.secrets.backend.show',
@@ -205,8 +206,8 @@ module('Acceptance | secrets/secret/create, read, delete', function (hooks) {
 
     test('first level secrets redirect properly upon deletion', async function (assert) {
       const secretPath = 'test';
-      await listPage.create();
-      await editPage.createSecret(secretPath, 'foo', 'bar');
+      await click(SS.createSecretLink);
+      await createSecret(secretPath, 'foo', 'bar');
       await showPage.deleteSecretV1();
       assert.strictEqual(
         currentRouteName(),
@@ -299,8 +300,8 @@ module('Acceptance | secrets/secret/create, read, delete', function (hooks) {
       const paths = ["'some", '"some'];
       for (const path of paths) {
         await listPage.visitRoot({ backend });
-        await listPage.create();
-        await editPage.createSecret(`${path}/2`, 'foo', 'bar');
+        await click(SS.createSecretLink);
+        await createSecret(`${path}/2`, 'foo', 'bar');
         await listPage.visit({ backend, id: path });
         assert.dom(SS.secretLinkATag()).hasText('2', `${path}: secret is displayed properly`);
         await click(SS.secretLink());
@@ -336,8 +337,9 @@ module('Acceptance | secrets/secret/create, read, delete', function (hooks) {
       const content = JSON.stringify({ foo: 'fa', bar: 'boo' });
       const secretPath = `kv-json-${this.uid}`;
       await listPage.visitRoot({ backend: this.backend });
-      await listPage.create();
-      await editPage.path(secretPath).toggleJSON();
+      await click(SS.createSecretLink);
+      await fillIn(SS.secretPath('create'), secretPath);
+      await click(GENERAL.toggleInput('json'));
       codemirror().setValue(content);
       await editPage.save();
 

--- a/ui/tests/acceptance/secrets/backend/ssh/roles-test.js
+++ b/ui/tests/acceptance/secrets/backend/ssh/roles-test.js
@@ -120,7 +120,7 @@ module('Acceptance | ssh | roles', function (hooks) {
     await click(GENERAL.tab(sshPath));
     for (const role of ROLES) {
       // create a role
-      await click(SES.createSecret);
+      await click(SES.createSecretLink);
       assert.dom(SES.secretHeader).includesText('SSH Role', `${role.type}: renders the create page`);
 
       await fillIn(GENERAL.inputByAttr('name'), role.name);

--- a/ui/tests/acceptance/secrets/backend/totp/key-test.js
+++ b/ui/tests/acceptance/secrets/backend/totp/key-test.js
@@ -63,7 +63,7 @@ module('Acceptance | totp key backend', function (hooks) {
       'After enabling totp secrets engine it navigates to keys list'
     );
 
-    await click(SES.createSecret);
+    await click(SES.createSecretLink);
     await createVaultKey(this.keyName, this.issuer, this.accountName);
     await click(GENERAL.backButton);
     await visit(`/vault/secrets/${this.path}`);
@@ -81,7 +81,7 @@ module('Acceptance | totp key backend', function (hooks) {
   });
 
   test('it deletes a key via menu option', async function (assert) {
-    await click(SES.createSecret);
+    await click(SES.createSecretLink);
     await createVaultKey(this.keyName, this.issuer, this.accountName);
     await click(GENERAL.backButton);
     await waitUntil(() => currentURL() === `/vault/secrets/${this.path}/show/${this.keyName}`);
@@ -96,7 +96,7 @@ module('Acceptance | totp key backend', function (hooks) {
   });
 
   test('it creates a key with Vault as the provider', async function (assert) {
-    await click(SES.createSecret);
+    await click(SES.createSecretLink);
     assert.dom(SES.secretHeader).hasText('Create a TOTP key', 'It renders the create key page');
 
     await createVaultKey(this.keyName, this.issuer, this.accountName);
@@ -116,7 +116,7 @@ module('Acceptance | totp key backend', function (hooks) {
   });
 
   test('it creates a key with another service as the provider with URL', async function (assert) {
-    await click(SES.createSecret);
+    await click(SES.createSecretLink);
     assert.dom(SES.secretHeader).hasText('Create a TOTP key', 'It renders the create key page');
     await createNonVaultKey(this.keyName, this.issuer, this.accountName, this.url);
     await waitUntil(() => currentURL() === `/vault/secrets/${this.path}/show/${this.keyName}`);
@@ -131,7 +131,7 @@ module('Acceptance | totp key backend', function (hooks) {
   });
 
   test('it creates a key with another service as the provider with key', async function (assert) {
-    await click(SES.createSecret);
+    await click(SES.createSecretLink);
     assert.dom(SES.secretHeader).hasText('Create a TOTP key', 'It renders the create key page');
     await createNonVaultKey(this.keyName, this.issuer, this.accountName, undefined, this.key);
     await waitUntil(() => currentURL() === `/vault/secrets/${this.path}/show/${this.keyName}`);
@@ -146,7 +146,7 @@ module('Acceptance | totp key backend', function (hooks) {
   });
 
   test('it does not render QR code when exported is false', async function (assert) {
-    await click(SES.createSecret);
+    await click(SES.createSecretLink);
     await createVaultKey(this.keyName, this.issuer, this.accountName, false);
     await waitUntil(() => currentURL() === `/vault/secrets/${this.path}/show/${this.keyName}`);
     assert.dom('[data-test-qr-code]').doesNotExist('QR code is not displayed');

--- a/ui/tests/acceptance/settings/mount-secret-backend-test.js
+++ b/ui/tests/acceptance/settings/mount-secret-backend-test.js
@@ -142,9 +142,7 @@ module('Acceptance | settings/mount-secret-backend', function (hooks) {
 
     await page.secretList();
     await settled();
-    assert
-      .dom(`[data-test-secrets-backend-link=${path}]`)
-      .exists({ count: 1 }, 'renders only one instance of the engine');
+    assert.dom(SES.secretsBackendLink(path)).exists({ count: 1 }, 'renders only one instance of the engine');
   });
 
   test('version 2 with no update to config endpoint still allows mount of secret engine', async function (assert) {

--- a/ui/tests/acceptance/transit-test.js
+++ b/ui/tests/acceptance/transit-test.js
@@ -13,6 +13,7 @@ import { login } from 'vault/tests/helpers/auth/auth-helpers';
 import { deleteEngineCmd, mountEngineCmd, runCmd } from 'vault/tests/helpers/commands';
 import codemirror from 'vault/tests/helpers/codemirror';
 import { GENERAL } from 'vault/tests/helpers/general-selectors';
+import { SECRET_ENGINE_SELECTORS as SES } from 'vault/tests/helpers/secret-engine/secret-engine-selectors';
 
 const SELECTORS = {
   secretLink: '[data-test-secret-link]',
@@ -229,7 +230,7 @@ module('Acceptance | transit', function (hooks) {
     assert.expect(8);
     const type = 'chacha20-poly1305';
     const name = `test-generate-${this.uid}`;
-    await click('[data-test-secret-create]');
+    await click(SES.createSecretLink);
 
     await fillIn(SELECTORS.form('name'), name);
     await fillIn(SELECTORS.form('type'), type);

--- a/ui/tests/helpers/kv/kv-selectors.js
+++ b/ui/tests/helpers/kv/kv-selectors.js
@@ -27,9 +27,6 @@ export const PAGE = {
   toolbarAction: 'nav.toolbar-actions .toolbar-link, nav.toolbar-actions .toolbar-button',
   secretRow: '[data-test-component="info-table-row"]', // replace with infoRow
   // specific page selectors
-  backends: {
-    link: (backend) => `[data-test-secrets-backend-link="${backend}"]`,
-  },
   metadata: {
     requestData: '[data-test-request-data]',
     editBtn: '[data-test-edit-metadata]',

--- a/ui/tests/helpers/secret-engine/secret-engine-helpers.js
+++ b/ui/tests/helpers/secret-engine/secret-engine-helpers.js
@@ -9,6 +9,16 @@ import { SECRET_ENGINE_SELECTORS as SES } from 'vault/tests/helpers/secret-engin
 import { stringArrayToCamelCase } from 'vault/helpers/string-array-to-camel';
 import { v4 as uuidv4 } from 'uuid';
 
+/* Secret Create/Edit methods */
+// ARG TODO unsure if should be moved to another file
+export async function createSecret(path, key, value) {
+  await fillIn(SES.secretPath('create'), path);
+  await fillIn('[data-test-secret-key]', key);
+  await fillIn('[data-test-secret-value] textarea', value);
+  await click('[data-test-secret-save]');
+  return;
+}
+
 export const createSecretsEngine = (store, type, path) => {
   store.pushPayload('secret-engine', {
     modelName: 'secret-engine',

--- a/ui/tests/helpers/secret-engine/secret-engine-selectors.ts
+++ b/ui/tests/helpers/secret-engine/secret-engine-selectors.ts
@@ -17,7 +17,7 @@ export const SECRET_ENGINE_SELECTORS = {
   // ARG TODO try without the optional path because it should always have an id passed in
   secretsBackendLink: (path: string) =>
     path ? `[data-test-secrets-backend-link="${path}"]` : '[data-test-secrets-backend-link]',
-  createSecretLink: '[data-test-create-secret-link',
+  createSecretLink: '[data-test-create-secret-link]',
   secretPath: (name: string) => `[data-test-secret-path="${name}"]`,
   secretHeader: '[data-test-secret-header]',
   secretLink: (name: string) => (name ? `[data-test-secret-link="${name}"]` : '[data-test-secret-link]'),

--- a/ui/tests/helpers/secret-engine/secret-engine-selectors.ts
+++ b/ui/tests/helpers/secret-engine/secret-engine-selectors.ts
@@ -9,12 +9,16 @@ export const SECRET_ENGINE_SELECTORS = {
   configureNote: (name: string) => `[data-test-configure-note="${name}"]`,
   configureTitle: (type: string) => `[data-test-backend-configure-title="${type}"]`,
   configurationToggle: '[data-test-mount-config-toggle]',
-  createSecret: '[data-test-secret-create]',
   crumb: (path: string) => `[data-test-secret-breadcrumb="${path}"] a`,
   error: {
     title: '[data-test-backend-error-title]',
   },
   generateLink: '[data-test-backend-credentials]',
+  // ARG TODO try without the optional path because it should always have an id passed in
+  secretsBackendLink: (path: string) =>
+    path ? `[data-test-secrets-backend-link="${path}"]` : '[data-test-secrets-backend-link]',
+  createSecretLink: '[data-test-create-secret-link',
+  secretPath: (name: string) => `[data-test-secret-path="${name}"]`,
   secretHeader: '[data-test-secret-header]',
   secretLink: (name: string) => (name ? `[data-test-secret-link="${name}"]` : '[data-test-secret-link]'),
   secretLinkMenu: (name: string) => `[data-test-secret-link="${name}"] [data-test-popup-menu-trigger]`,

--- a/ui/tests/integration/components/dashboard/secrets-engines-card-test.js
+++ b/ui/tests/integration/components/dashboard/secrets-engines-card-test.js
@@ -8,6 +8,7 @@ import { setupRenderingTest } from 'vault/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { DASHBOARD } from 'vault/tests/helpers/components/dashboard/dashboard-selectors';
+import { SECRET_ENGINE_SELECTORS as SES } from 'vault/tests/helpers/secret-engine/secret-engine-selectors';
 
 module('Integration | Component | dashboard/secrets-engines-card', function (hooks) {
   setupRenderingTest(hooks);
@@ -31,7 +32,9 @@ module('Integration | Component | dashboard/secrets-engines-card', function (hoo
     await render(hbs`<Dashboard::SecretsEnginesCard @secretsEngines={{this.secretsEngines}} />`);
 
     // verify overflow style exists on secret engine text
-    assert.dom('[data-test-secret-path]').hasClass('overflow-wrap', 'secret engine name has overflow class ');
+    assert
+      .dom(SES.secretPath('kubernetes-test/'))
+      .hasClass('overflow-wrap', 'secret engine name has overflow class ');
 
     assert.dom('[data-test-secrets-engines-card-show-all]').doesNotExist();
   });
@@ -136,8 +139,12 @@ module('Integration | Component | dashboard/secrets-engines-card', function (hoo
 
     test('it adds disabled css styling to unsupported secret engines', async function (assert) {
       await this.renderComponent();
-      assert.dom('[data-test-secrets-engines-row="nomad"] [data-test-view]').doesNotExist();
-      assert.dom('[data-test-secrets-engines-row="nomad"] [data-test-secret-path]').hasClass('has-text-grey');
+      assert
+        .dom(SES.secretPath('secrets-test/'))
+        .hasClass('has-text-black', 'does not apply disabled class to supported secret engine');
+      assert
+        .dom(SES.secretPath('nomad/'))
+        .hasClass('has-text-grey', 'nomad is not a supported secret engine and has disabled class');
     });
   });
 });

--- a/ui/tests/pages/secrets/backend/database/connection.js
+++ b/ui/tests/pages/secrets/backend/database/connection.js
@@ -11,7 +11,6 @@ export default create({
   visit: visitable('/vault/secrets/:backend/list'),
   visitShow: visitable('/vault/secrets/:backend/show/:id'),
   visitCreate: visitable('/vault/secrets/:backend/create'),
-  createLink: clickable('[data-test-secret-create]'),
   dbPlugin: selectable('[data-test-input="plugin_name"]'),
   name: fillable('[data-test-input="name"]'),
   toggleVerify: clickable('[data-test-input="verify_connection"]'),
@@ -20,7 +19,7 @@ export default create({
   username: fillable('[data-test-input="username"]'),
   password: fillable('[data-test-input="password"]'),
   save: clickable('[data-test-secret-save]'),
-  addRole: clickable('[data-test-secret-create]'), // only from connection show
+  addRole: clickable('[data-test-add-role]'), // only from connection show
   enable: clickable('[data-test-enable-connection]'),
   edit: clickable('[data-test-edit-link]'),
   delete: clickable('[data-test-database-connection-delete]'),

--- a/ui/tests/pages/secrets/backend/kv/edit-secret.js
+++ b/ui/tests/pages/secrets/backend/kv/edit-secret.js
@@ -5,7 +5,6 @@
 
 import { Base } from '../create';
 import { clickable, create, fillable } from 'ember-cli-page-object';
-import { settled } from '@ember/test-helpers';
 
 export default create({
   ...Base,
@@ -14,9 +13,4 @@ export default create({
   secretValue: fillable('[data-test-secret-value] textarea'),
   save: clickable('[data-test-secret-save]'),
   toggleJSON: clickable('[data-test-toggle-input="json"]'),
-  createSecret: async function (path, key, value) {
-    await this.path(path).secretKey(key).secretValue(value).save();
-    await settled();
-    return;
-  },
 });

--- a/ui/tests/pages/secrets/backend/list.js
+++ b/ui/tests/pages/secrets/backend/list.js
@@ -18,8 +18,6 @@ import { getter } from 'ember-cli-page-object/macros';
 export default create({
   visit: visitable('/vault/secrets/:backend/list/:id'),
   visitRoot: visitable('/vault/secrets/:backend/list'),
-  create: clickable('[data-test-secret-create]'),
-  createIsPresent: isPresent('[data-test-secret-create]'),
   configure: clickable('[data-test-secret-backend-configure]'),
   configureIsPresent: isPresent('[data-test-secret-backend-configure]'),
   tabs: collection('[data-test-secret-list-tab]'),

--- a/ui/tests/pages/secrets/backend/transform/alphabets.js
+++ b/ui/tests/pages/secrets/backend/transform/alphabets.js
@@ -10,7 +10,6 @@ export default create({
   ...ListView,
   visit: visitable('/vault/secrets/:backend/list?tab=alphabet'),
   visitCreate: visitable('/vault/secrets/:backend/create?itemType=alphabet'),
-  createLink: clickable('[data-test-secret-create]'),
   editLink: clickable('[data-test-edit-link]'),
   name: fillable('[data-test-input="name"]'),
   alphabet: fillable('[data-test-input="alphabet"'),

--- a/ui/tests/pages/secrets/backend/transform/templates.js
+++ b/ui/tests/pages/secrets/backend/transform/templates.js
@@ -10,7 +10,6 @@ export default create({
   ...ListView,
   visit: visitable('/vault/secrets/:backend/list?tab=templates'),
   visitCreate: visitable('/vault/secrets/:backend/create?itemType=template'),
-  createLink: clickable('[data-test-secret-create]'),
   editLink: clickable('[data-test-edit-link]'),
   deleteLink: clickable('[data-test-transformation-template-delete]'),
   name: fillable('[data-test-input="name"]'),

--- a/ui/tests/pages/secrets/backend/transform/transformations.js
+++ b/ui/tests/pages/secrets/backend/transform/transformations.js
@@ -11,7 +11,6 @@ export default create({
   visit: visitable('/vault/secrets/:backend/list'),
   visitShow: visitable('/vault/secrets/:backend/show/:id'),
   visitCreate: visitable('/vault/secrets/:backend/create'),
-  createLink: clickable('[data-test-secret-create]'),
   name: fillable('[data-test-input="name"]'),
   submit: clickable('[data-test-transform-create]'),
   type: fillable('[data-test-input="type"'),

--- a/ui/tests/pages/secrets/backends.js
+++ b/ui/tests/pages/secrets/backends.js
@@ -3,14 +3,13 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { create, visitable, collection, clickable, text } from 'ember-cli-page-object';
+import { create, visitable, collection, clickable } from 'ember-cli-page-object';
 import uiPanel from 'vault/tests/pages/components/console/ui-panel';
 
 export default create({
   consoleToggle: clickable('[data-test-console-toggle]'),
   visit: visitable('/vault/secrets'),
   rows: collection('[data-test-secrets-backend-link]', {
-    path: text('[data-test-secret-path]'),
     menu: clickable('[data-test-popup-menu-trigger]'),
   }),
   configLink: clickable('[data-test-engine-config]', {

--- a/ui/tests/pages/secrets/backends.js
+++ b/ui/tests/pages/secrets/backends.js
@@ -3,13 +3,14 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { create, visitable, collection, clickable } from 'ember-cli-page-object';
+import { create, visitable, collection, clickable, text } from 'ember-cli-page-object';
 import uiPanel from 'vault/tests/pages/components/console/ui-panel';
 
 export default create({
   consoleToggle: clickable('[data-test-console-toggle]'),
   visit: visitable('/vault/secrets'),
   rows: collection('[data-test-secrets-backend-link]', {
+    path: text('[data-test-secret-path]'),
     menu: clickable('[data-test-popup-menu-trigger]'),
   }),
   configLink: clickable('[data-test-engine-config]', {


### PR DESCRIPTION
### Description
What does this PR do?

- Updating data-test selectors on some secret elements
- Updating tests to use common selectors from SECRET_ENGINE_SELECTORS
-  minor cleanup of unused selectors

ENT Tests Pass: ✅ 

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
