### PR TITLE
VAULT-35642: adding comments for the pre-made policy and role

### DIFF
--- a/.github/workflows/test-run-enos-scenario-matrix.yml
+++ b/.github/workflows/test-run-enos-scenario-matrix.yml
@@ -4,6 +4,9 @@ name: enos
 on:
   # Only trigger this working using workflow_call. This workflow requires many
   # secrets that must be inherited from the caller workflow.
+  pull_request:
+    branches:
+      - enos/VAULT-35642
   workflow_call:
     inputs:
       # The name of the artifact that we're going to use for testing. This should

--- a/enos/modules/verify_log_secrets/scripts/scan_logs_for_secrets.sh
+++ b/enos/modules/verify_log_secrets/scripts/scan_logs_for_secrets.sh
@@ -10,6 +10,8 @@ fail() {
 verify_radar_scan_output_file() {
   # Given a file with a radar scan output, filter out tagged false positives and verify that no
   # other secrets remain.
+  jq -eMcn '[inputs] | [.[] | select(.type != "aws_access_key_id") | select((.tags == null) or (.tags | contains(["ignore_rule"]) | not ))] | length == 0' < "$2"
+  echo "-------testing------"
   if ! jq -eMcn '[inputs] | [.[] | select(.type != "aws_access_key_id") | select((.tags == null) or (.tags | contains(["ignore_rule"]) | not ))] | length == 0' < "$2"; then
     found=$(jq -eMn '[inputs] | [.[] | select(.type != "aws_access_key_id") | select((.tags == null) or (.tags | contains(["ignore_rule"]) | not ))]' < "$2")
     fail "failed to radar secrets output: vault radar detected secrets in $1!: $found"

--- a/enos/modules/verify_log_secrets/scripts/scan_logs_for_secrets.sh
+++ b/enos/modules/verify_log_secrets/scripts/scan_logs_for_secrets.sh
@@ -16,6 +16,7 @@ verify_radar_scan_output_file() {
     found=$(jq -eMn '[inputs] | [.[] | select(.type != "aws_access_key_id") | select((.tags == null) or (.tags | contains(["ignore_rule"]) | not ))]' < "$2")
     fail "failed to radar secrets output: vault radar detected secrets in $1!: $found"
   fi
+  exit 1
 }
 
 set -e

--- a/enos/modules/verify_secrets_engines/modules/create/aws.tf
+++ b/enos/modules/verify_secrets_engines/modules/create/aws.tf
@@ -30,14 +30,14 @@ data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 
 # The "DemoUser" policy is a predefined policy created by the security team.
-# It grants the necessary AWS permissions required for role generation via Vault.
+# This policy grants the necessary AWS permissions required for role generation via Vault.
 # Reference: https://github.com/hashicorp/honeybee-templates/blob/main/templates/iam_policy/DemoUser.yaml
 data "aws_iam_policy" "premade_demo_user_policy" {
   name = "DemoUser"
 }
 
 # This role was provisioned by the security team using the repository referenced below.
-# It includes the necessary policies to enable AWS credential generation and rotation via Vault.
+# This role includes the necessary policies to enable AWS credential generation and rotation via Vault.
 # Reference: https://github.com/hashicorp/honeybee-templates/blob/main/templates/iam_role/vault-assumed-role-credentials-demo.yaml
 data "aws_iam_role" "premade_demo_assumed_role" {
   name = "vault-assumed-role-credentials-demo"

--- a/enos/modules/verify_secrets_engines/modules/create/aws.tf
+++ b/enos/modules/verify_secrets_engines/modules/create/aws.tf
@@ -29,11 +29,16 @@ data "aws_caller_identity" "current" {}
 
 data "aws_region" "current" {}
 
-# Using Pre-made policy and role
+# The "DemoUser" policy is a predefined policy created by the security team.
+# It grants the necessary AWS permissions required for role generation via Vault.
+# Reference: https://github.com/hashicorp/honeybee-templates/blob/main/templates/iam_policy/DemoUser.yaml
 data "aws_iam_policy" "premade_demo_user_policy" {
   name = "DemoUser"
 }
 
+# This role was provisioned by the security team using the repository referenced below.
+# It includes the necessary policies to enable AWS credential generation and rotation via Vault.
+# Reference: https://github.com/hashicorp/honeybee-templates/blob/main/templates/iam_role/vault-assumed-role-credentials-demo.yaml
 data "aws_iam_role" "premade_demo_assumed_role" {
   name = "vault-assumed-role-credentials-demo"
 }


### PR DESCRIPTION
### Description
adding comments for the pre-made policy and role

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
