### PR TITLE
Fix the exposure of sensitive data from inside logs by dropping the entered value inside schema validation function

### DIFF
--- a/sdk/framework/field_data.go
+++ b/sdk/framework/field_data.go
@@ -33,7 +33,7 @@ type FieldData struct {
 // trying to get data out.  Data not in the schema is not
 // an error at this point, so we don't worry about it.
 func (d *FieldData) Validate() error {
-	for field, value := range d.Raw {
+	for field := range d.Raw {
 
 		schema, ok := d.Schema[field]
 		if !ok {
@@ -46,7 +46,7 @@ func (d *FieldData) Validate() error {
 			TypeKVPairs, TypeCommaIntSlice, TypeHeader, TypeFloat, TypeTime:
 			_, _, err := d.getPrimitive(field, schema)
 			if err != nil {
-				return errwrap.Wrapf(fmt.Sprintf("error converting input %v for field %q: {{err}}", value, field), err)
+				return errwrap.Wrapf(fmt.Sprintf("error converting input for field %q: {{err}}", field), err)
 			}
 		default:
 			return fmt.Errorf("unknown field type %q for field %q", schema.Type, field)


### PR DESCRIPTION
### Description
What does this PR do?
This PR prevents sensitive values from being logged when schema validation fails. Previously, malformed user input (such as in KV v2 secret writes) could result in secret values being included in Vault's server or audit logs. Values are now omitted from error messages to avoid accidental data exposure.

<details>

<summary>
Manual testing
</summary>

Steps to reproduce the issue:
 - Created a payload.json file:
 ```
 cat payload.json
{"data": "Sensitive Information Exposed on Logs"}
 ```
 - Create a test cluster and supply the payload to the kv engine endpoint
 
```
amiraslamov ~/Documents/GitHub/vault (main)$ vcm cluster create a
amiraslamov ~/Documents/GitHub/vault (main)$ eval $(vcm node env -cluster=a -active-node)
amiraslamov ~/Documents/GitHub/vault (main)$ vault secrets enable -version=2 kv
Success! Enabled the kv secrets engine at: kv/
amiraslamov ~/Documents/GitHub/vault (main)$ curl --insecure      --header "X-Vault-Token: $VAULT_TOKEN"      --request POST      --data @payload.json      https://127.0.0.1:8200/v1/kv/data/test|jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   177  100   128  100    49   3297   1262 --:--:-- --:--:-- --:--:--  4657
{
  "errors": [
    "error converting input Sensitive Information Exposed on Logs for field \"data\": '' expected a map, got 'string'"
  ]
}
```

Now after the fix:

```
amiraslamov ~/Documents/GitHub/vault (aslamovamir-vault-35402-do-not-expose-sensitive-info-in-field-validation)$ curl --insecure      --header "X-Vault-Token: $VAULT_TOKEN"     
 --request POST      --data @payload.json      https://127.0.0.1:8200/v1/kv/data/test|jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   145  100    90  100    55   1981   1211 --:--:-- --:--:-- --:--:--  3222
{
  "errors": [
    "error converting input for field \"data\": '' expected a map, got 'string'"
  ]
}
```

</details>

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
