### PR TITLE
[UI] [HVT-6902] Add acceptance tests for vault-reporting

### DIFF
--- a/ui/tests/acceptance/vault-reporting/index-test.js
+++ b/ui/tests/acceptance/vault-reporting/index-test.js
@@ -1,0 +1,70 @@
+import { module, test } from 'qunit';
+import { setupApplicationTest } from 'ember-qunit';
+import { visit, currentURL, waitFor } from '@ember/test-helpers';
+import { login } from 'vault/tests/helpers/auth/auth-helpers';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+
+module('Acceptance | vault-reporting', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(async function () {
+    await login();
+  });
+
+  test('it visits the usage reporting dashboard and renders the header', async function (assert) {
+    await visit('/vault/usage-reporting');
+    assert.strictEqual(currentURL(), '/vault/usage-reporting', 'navigates to usage reporting dashboard');
+    assert.dom('.hds-page-header').includesText('Vault Usage', 'renders the "Vault Usage" header');
+  });
+
+  test('it renders the counters dashboard block with all expected counters', async function (assert) {
+    await visit('/vault/usage-reporting');
+
+    await waitFor('[data-test-dashboard-counters]');
+    assert.dom('[data-test-dashboard-counters]').exists('renders the counters dashboard block');
+
+    const expectedCounters = ['Child namespaces', 'KV secrets', 'Secrets sync', 'PKI roles'];
+
+    expectedCounters.forEach((counterLabel) => {
+      assert.dom(`[data-test-counter="${counterLabel}"]`).exists(`counter "${counterLabel}" is rendered`);
+    });
+  });
+
+  test('dashboard card links work correctly', async function (assert) {
+    await visit('/vault/usage-reporting');
+    await waitFor('[data-test-dashboard-secret-engines]');
+
+    assert.strictEqual(currentURL(), '/vault/usage-reporting', 'landed on reporting dashboard');
+
+    // Secret Engines
+    const secrets = document.querySelector('[data-test-dashboard-secret-engines]');
+    const secretsLink = secrets.querySelector('[data-test-dashboard-card-title-link]');
+    assert.ok(secretsLink, 'secret engines card title link exists');
+    assert.strictEqual(secretsLink.getAttribute('href'), 'secrets', 'link points to secrets');
+
+    // Auth Methods
+    const auth = document.querySelector('[data-test-dashboard-auth-methods]');
+    const authLink = auth.querySelector('[data-test-dashboard-card-title-link]');
+    assert.ok(authLink, 'auth methods card title link exists');
+    assert.strictEqual(authLink.getAttribute('href'), 'access', 'link points to access');
+
+    // Lease Count Quotas
+    const lease = document.querySelector('[data-test-dashboard-lease-count]');
+    const leaseLink = lease.querySelector('[data-test-dashboard-card-title-link]');
+    assert.ok(leaseLink, 'lease count quota card title link exists');
+    assert.strictEqual(
+      leaseLink.getAttribute('href'),
+      'https://developer.hashicorp.com/vault/docs/enterprise/lease-count-quotas',
+      'link points to external lease count docs'
+    );
+
+    // Cluster Replication
+    const replication = document.querySelector('[data-test-dashboard-cluster-replication]');
+    const replicationLink = replication.querySelector('[data-test-dashboard-card-title-link]');
+    assert.ok(replicationLink, 'replication card title link exists');
+    assert.strictEqual(replicationLink.getAttribute('href'), 'replication', 'link points to replication');
+  });
+
+  //
+});


### PR DESCRIPTION
### Description
[UI] [HVT-6902] Add acceptance tests for vault-reporting

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
