### PR TITLE
UI: Add mirage handler and scenarios for custom login work

### DIFF
--- a/ui/mirage/factories/login-rule.js
+++ b/ui/mirage/factories/login-rule.js
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import { Factory } from 'miragejs';
+
+export default Factory.extend({
+  name: (i) => `Login rule ${i}`,
+  namespace: (i) => `namespace-${i}`,
+  default_auth_type: 'okta',
+  backup_auth_types: () => ['oidc', 'token'],
+  disable_inheritance: false,
+});

--- a/ui/mirage/handlers/custom-login.js
+++ b/ui/mirage/handlers/custom-login.js
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+export default function (server) {
+  // LIST, READ and DELETE requests for default-auth (login customizations)
+  server.get('sys/config/ui/login/default-auth', (schema, req) => {
+    // API expects { data: { list: true } } as query params when making LIST requests
+    if (req.queryParams.list) {
+      const records = schema.db['loginRules'];
+      if (records) {
+        const keys = records.map(({ name }) => name);
+        const key_info = records.reduce((obj, record) => {
+          const { name, namespace, disable_inheritance } = record;
+          // TBD, but likely only limited information will be returned about the record from the LIST request
+          obj[name] = { namespace, disable_inheritance };
+          return obj;
+        }, {});
+        return {
+          data: { keys, key_info },
+        };
+      }
+      return new Response(404, {}, { errors: [] });
+    }
+  });
+
+  server.get('sys/config/ui/login/default-auth/:name', (schema, req) => {
+    // req.params = { name: "Login rule name" }
+    const record = schema.db['loginRules'].findBy(req.params);
+    if (record) {
+      delete record.id; // "name" is the id
+      return { data: record };
+    }
+    return new Response(404, {}, { errors: [] });
+  });
+
+  server.delete('sys/config/ui/login/default-auth/:name', (schema, req) => {
+    const record = schema.db['loginRules'].findBy(req.params);
+    if (record) {
+      schema.db['loginRules'].remove(record);
+      return new Response(204); // No content
+    }
+    return new Response(404, {}, { errors: [] });
+  });
+
+  // UNAUTHENTICATED READ ONLY for login form display logic
+  server.get('sys/internal/ui/default-login-methods', (schema, req) => {
+    const nsHeader = req.requestHeaders['X-Vault-Namespace'];
+    // if no namespace is passed, assume root
+    const namespace = !nsHeader ? '' : nsHeader;
+    const nsRule = schema.db['loginRules'].findBy({ namespace });
+    if (nsRule) {
+      // only data relevant to login form is returned
+      const { default_auth_type, backup_auth_types } = nsRule;
+      return { data: { default_auth_type, backup_auth_types } };
+    }
+    return new Response(404, {}, { errors: [] });
+  });
+}

--- a/ui/mirage/handlers/index.js
+++ b/ui/mirage/handlers/index.js
@@ -7,8 +7,9 @@
 // individual lookup done in mirage config
 import base from './base';
 import chrootNamespace from './chroot-namespace';
-import customMessages from './custom-messages';
 import clients from './clients';
+import customMessages from './custom-messages';
+import customLogin from './custom-login';
 import database from './database';
 import hcpLink from './hcp-link';
 import kms from './kms';
@@ -18,13 +19,15 @@ import mfaConfig from './mfa-config';
 import mfaLogin from './mfa-login';
 import oidcConfig from './oidc-config';
 import reducedDisclosure from './reduced-disclosure';
-import sync from './sync';
 import replication from './replication';
+import sync from './sync';
 
 export {
   base,
   chrootNamespace,
   clients,
+  customLogin,
+  customMessages,
   database,
   hcpLink,
   kms,
@@ -34,7 +37,6 @@ export {
   mfaLogin,
   oidcConfig,
   reducedDisclosure,
-  customMessages,
-  sync,
   replication,
+  sync,
 };

--- a/ui/mirage/scenarios/custom-login.js
+++ b/ui/mirage/scenarios/custom-login.js
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+export default function (server) {
+  server.create('login-rule', {
+    name: 'Root namespace default',
+    namespace: '',
+    default_auth_type: 'userpass',
+    backup_auth_types: ['okta'],
+    disable_inheritance: true,
+  });
+  server.create('login-rule', {
+    namespace: 'admin/',
+    default_auth_type: 'oidc',
+    backup_auth_types: ['token'],
+  });
+  server.create('login-rule', { default_auth_type: 'jwt', backup_auth_types: [] });
+  server.create('login-rule', { default_auth_type: '', backup_auth_types: ['oidc', 'jwt'] });
+  server.create('login-rule', { default_auth_type: '', backup_auth_types: ['token'] });
+}

--- a/ui/mirage/scenarios/index.js
+++ b/ui/mirage/scenarios/index.js
@@ -6,5 +6,6 @@
 import kubernetes from './kubernetes';
 import ldap from './ldap';
 import sync from './sync';
+import customLogin from './custom-login';
 
-export { kubernetes, ldap, sync };
+export { kubernetes, ldap, sync, customLogin };


### PR DESCRIPTION
### Description
Builds mirage to mock API to unblock development of custom logic work for ui team. 

To run mirage with the custom-login handler start yarn with the `MIRAGE_DEV_HANDLER` variable set
```
export MIRAGE_DEV_HANDLER=customLogin; yarn start
```

Now the following requests can be made: 
```js
const adapter = this.store.adapterFor('application');

// GET rule by name
await adapter.ajax(`/v1/sys/config/ui/login/default-auth/${encodeURI('Login rule 1')}`, 'GET');

// LIST rules
await adapter.ajax('/v1/sys/config/ui/login/default-auth', 'GET', { data: { list: true } });

// DELETE rule by name
await adapter.ajax(`/v1/sys/config/ui/login/default-auth/${encodeURI('Login rule 2')}`, 'DELETE');

// GET login rule for namespace 
await adapter.ajax('/v1/sys/internal/ui/default-login-methods', 'GET', {
  unauthenticated: true,
  namespace: '', // "root" namespace
});
await adapter.ajax('/v1/sys/internal/ui/default-login-methods', 'GET', {
  unauthenticated: true,
  namespace: 'admin/',
});
```

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
