### PR TITLE
VAULT-35385 docs for response_status_code metric

### DIFF
--- a/website/content/docs/internals/telemetry/metrics/core-system.mdx
+++ b/website/content/docs/internals/telemetry/metrics/core-system.mdx
@@ -28,6 +28,8 @@ Vault instance.
 
 @include 'telemetry-metrics/vault/core/in_flight_requests.mdx'
 
+@include 'telemetry-metrics/vault/core/response_status_code.mdx'
+
 @include 'telemetry-metrics/vault/core/leadership_lost.mdx'
 
 @include 'telemetry-metrics/vault/core/leadership_setup_failed.mdx'

--- a/website/content/partials/telemetry-metrics/vault/core/response_status_code.mdx
+++ b/website/content/partials/telemetry-metrics/vault/core/response_status_code.mdx
@@ -4,6 +4,7 @@
 |-------------|--------|----------------------------------------------|
 | counter     | number | Number of responses issued by the local node |
 
-The metric includes two labels, `code`, which is the exact status code of the response,
-and `type`, which is the series of the status code. For example, code might be `429`, and
-`type` might be `4xx`.
+Response code metrics include the following labels:
+
+- `code` - exact HTTP status code of the response, for example, `429`.
+- `type` - HTTP response class of the response status, for example `4xx`.

--- a/website/content/partials/telemetry-metrics/vault/core/response_status_code.mdx
+++ b/website/content/partials/telemetry-metrics/vault/core/response_status_code.mdx
@@ -1,0 +1,9 @@
+### vault.core.response_status_code ((#vault-core-response_status_code))
+
+| Metric type | Value  | Description                                  |
+|-------------|--------|----------------------------------------------|
+| counter     | number | Number of responses issued by the local node |
+
+The metric includes two labels, `code`, which is the exact status code of the response,
+and `type`, which is the series of the status code. For example, code might be `429`, and
+`type` might be `4xx`.


### PR DESCRIPTION
### Description

Docs for https://github.com/hashicorp/vault/pull/30354

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [x] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
