### PR TITLE
UI: Adding routes for custom login settings 

### DIFF
--- a/ui/app/components/sidebar/nav/cluster.hbs
+++ b/ui/app/components/sidebar/nav/cluster.hbs
@@ -125,6 +125,7 @@
       @text="Custom Messages"
       data-test-sidebar-nav-link="Custom Messages"
     />
+    {{! TODO: wrap this with permission check }}
     <Nav.Link
       @route="vault.cluster.config-ui.login-settings"
       @text="UI Login Rules"

--- a/ui/app/components/sidebar/nav/cluster.hbs
+++ b/ui/app/components/sidebar/nav/cluster.hbs
@@ -127,8 +127,8 @@
     />
     <Nav.Link
       @route="vault.cluster.config-ui.login-settings"
-      @text="Login Settings"
-      data-test-sidebar-nav-link="Login Settings"
+      @text="UI Login Rules"
+      data-test-sidebar-nav-link="UI Login Rules"
     />
   {{/if}}
 </Hds::SideNav::Portal>

--- a/ui/app/components/sidebar/nav/cluster.hbs
+++ b/ui/app/components/sidebar/nav/cluster.hbs
@@ -125,5 +125,10 @@
       @text="Custom Messages"
       data-test-sidebar-nav-link="Custom Messages"
     />
+    <Nav.Link
+      @route="vault.cluster.config-ui.login-settings"
+      @text="Login Settings"
+      data-test-sidebar-nav-link="Login Settings"
+    />
   {{/if}}
 </Hds::SideNav::Portal>

--- a/ui/lib/config-ui/addon/routes.js
+++ b/ui/lib/config-ui/addon/routes.js
@@ -13,4 +13,11 @@ export default buildRoutes(function () {
       this.route('edit');
     });
   });
+
+  this.route('login-settings', function () {
+    this.route('rule', { path: '/:name' }, function () {
+      this.route('details');
+      this.route('list');
+    });
+  });
 });

--- a/ui/lib/config-ui/addon/routes.js
+++ b/ui/lib/config-ui/addon/routes.js
@@ -17,7 +17,6 @@ export default buildRoutes(function () {
   this.route('login-settings', function () {
     this.route('rule', { path: '/:name' }, function () {
       this.route('details');
-      this.route('list');
     });
   });
 });

--- a/ui/lib/config-ui/addon/routes/login-settings/index.js
+++ b/ui/lib/config-ui/addon/routes/login-settings/index.js
@@ -1,0 +1,8 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import Route from '@ember/routing/route';
+
+export default class LoginSettingsRoute extends Route {}

--- a/ui/lib/config-ui/addon/routes/login-settings/rule/details.js
+++ b/ui/lib/config-ui/addon/routes/login-settings/rule/details.js
@@ -1,0 +1,8 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import Route from '@ember/routing/route';
+
+export default class LoginSettingsRuleDetailsRoute extends Route {}

--- a/ui/lib/config-ui/addon/templates/login-settings/index.hbs
+++ b/ui/lib/config-ui/addon/templates/login-settings/index.hbs
@@ -1,0 +1,4 @@
+{{!
+  Copyright (c) HashiCorp, Inc.
+  SPDX-License-Identifier: BUSL-1.1
+}}

--- a/ui/lib/config-ui/addon/templates/login-settings/rule/details.hbs
+++ b/ui/lib/config-ui/addon/templates/login-settings/rule/details.hbs
@@ -1,0 +1,4 @@
+{{!
+  Copyright (c) HashiCorp, Inc.
+  SPDX-License-Identifier: BUSL-1.1
+}}

--- a/ui/tests/integration/components/sidebar/nav/cluster-test.js
+++ b/ui/tests/integration/components/sidebar/nav/cluster-test.js
@@ -75,6 +75,7 @@ module('Integration | Component | sidebar-nav-cluster', function (hooks) {
       'License',
       'Seal Vault',
       'Custom Messages',
+      'UI Login Rules',
     ];
     stubFeaturesAndPermissions(this.owner, true, true);
     await renderComponent();


### PR DESCRIPTION
### Description
What does this PR do?

**[Merging into a side branch]**

mainly an initial setup for future work 
Adding routes for custom login setting pages, 
route added to side nav (for sanity check / instead of manually typing in url)

![image](https://github.com/user-attachments/assets/f0389b7b-f96a-49d9-ad30-a59208354478)


### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
