### PR TITLE
enos(rhel): remove references to 9.4

### DIFF
--- a/enos/modules/install_packages/main.tf
+++ b/enos/modules/install_packages/main.tf
@@ -27,7 +27,7 @@ locals {
     }
     "rhel" = {
       "8.10" = "https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm"
-      "9.4"  = "https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm"
+      "9.5"  = "https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm"
     }
   }
 }

--- a/enos/modules/softhsm_install/main.tf
+++ b/enos/modules/softhsm_install/main.tf
@@ -44,7 +44,7 @@ locals {
     }
     rhel = {
       "8.10" = ["softhsm", "opensc"]
-      "9.4"  = ["softhsm", "opensc"]
+      "9.5"  = ["softhsm", "opensc"]
     }
     ubuntu = {
       "20.04" = ["softhsm", "opensc"]


### PR DESCRIPTION
### Description
Remove straggling references to RHEL 9.4

I'll manually backport them to 1.16-1.18 with the other PR that yanked RHEL 9.4

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [x] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
