### PR TITLE
VAULT-35686: Update aws nuke to delete enos test IAMUsers

### DIFF
--- a/enos/ci/aws-nuke.yml
+++ b/enos/ci/aws-nuke.yml
@@ -2,31 +2,31 @@
 # SPDX-License-Identifier: BUSL-1.1
 
 regions:
-- eu-north-1
-- ap-south-1
-- eu-west-3
-- eu-west-2
-- eu-west-1
-- ap-northeast-3
-- ap-northeast-2
-- ap-northeast-1
-- sa-east-1
-- ca-central-1
-- ap-southeast-1
-- ap-southeast-2
-- eu-central-1
-- us-east-1
-- us-east-2
-- us-west-1
-- us-west-2
-- global
+  - eu-north-1
+  - ap-south-1
+  - eu-west-3
+  - eu-west-2
+  - eu-west-1
+  - ap-northeast-3
+  - ap-northeast-2
+  - ap-northeast-1
+  - sa-east-1
+  - ca-central-1
+  - ap-southeast-1
+  - ap-southeast-2
+  - eu-central-1
+  - us-east-1
+  - us-east-2
+  - us-west-1
+  - us-west-2
+  - global
 
 blocklist:
- - 1234567890
+  - 1234567890
 
 accounts:
   # replaced in CI
-  ACCOUNT_NUM:
+  774305585021:
     presets:
       - default
       - olderthan
@@ -63,7 +63,7 @@ presets:
       EC2Instance:
         - property: LaunchTime
           type: dateOlderThan
-          value: "TIME_LIMIT"
+          value: "72h"
       EC2NetworkACL:
       EC2RouteTable:
       EC2SecurityGroup:
@@ -72,11 +72,11 @@ presets:
       EC2VPC:
         - property: tag:cloud-nuke-first-seen
           type: dateOlderThan
-          value: "TIME_LIMIT"
+          value: "72h"
       ELBv2:
         - property: tag:cloud-nuke-first-seen
           type: dateOlderThan
-          value: "TIME_LIMIT"
+          value: "72h"
       ELBv2TargetGroup:
       EC2NetworkInterface:
       EC2InternetGateway:
@@ -84,7 +84,7 @@ presets:
       RDSInstance:
         - property: InstanceCreateTime
           type: dateOlderThan
-          value: "TIME_LIMIT"
+          value: "72h"
 
   honeybee:
     # Cloudsec
@@ -132,12 +132,15 @@ presets:
       IAMUserPolicy:
         - "github_actions-vault_ci -> AssumeServiceUserRole"
         - "github_actions-vault_enterprise_ci -> AssumeServiceUserRole"
+      IAMUser:
+        - property: UserName
+          value: "enos*"  # Only delete IAM users whose names start with "testing"
+
 
 resource-types:
   # Run against everything, excluding these:
   excludes:
     # Avoid cloudsec things
-    - IAMUser
     - IAMPolicy
     - IAMUserAccessKey
     - S3Object
@@ -406,4 +409,3 @@ resource-types:
     - WorkSpacesWorkspace
     - XRayGroup
     - XRaySamplingRule
-

--- a/enos/ci/aws-nuke.yml
+++ b/enos/ci/aws-nuke.yml
@@ -133,8 +133,8 @@ presets:
         - "github_actions-vault_ci -> AssumeServiceUserRole"
         - "github_actions-vault_enterprise_ci -> AssumeServiceUserRole"
       IAMUser:
-        - property: UserName
-          value: "enos*"  # Only delete IAM users whose names start with "testing"
+        - type: regex
+          value: "^github_actions-vault_.*"
 
 
 resource-types:


### PR DESCRIPTION
### Description
VAULT-35686: Update aws nuke to delete enos test IAMUsers

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
