### PR TITLE
[DOCS] Update the agent config example

### DIFF
--- a/website/content/docs/agent-and-proxy/agent/index.mdx
+++ b/website/content/docs/agent-and-proxy/agent/index.mdx
@@ -346,6 +346,8 @@ An example configuration, with very contrived values, follows:
 ```hcl
 pid_file = "./pidfile"
 
+log_file = "/var/log/vault-agent.log"
+
 vault {
   address = "https://vault-fqdn:8200"
   retry {
@@ -383,22 +385,10 @@ cache {
   // An empty cache stanza still enables caching
 }
 
-api_proxy {
-  use_auto_auth_token = true
-}
-
-listener "unix" {
-  address = "/path/to/socket"
-  tls_disable = true
-
-  agent_api {
-    enable_quit = true
-  }
-}
-
-listener "tcp" {
-  address = "127.0.0.1:8100"
-  tls_disable = true
+template_config {
+  static_secret_render_interval = "10m"
+  exit_on_retry_failure = true
+  max_connections_per_host = 20
 }
 
 template {


### PR DESCRIPTION
### Description

API proxy feature is being deprecated from Vault Agent, and the users should use Vault Proxy. 

This PR update the [Vault Agent example configuration](https://developer.hashicorp.com/vault/docs/agent-and-proxy/agent#example-configuration) by removing the `api_proxy` and `listener` stanzas. Instead, adding `log_file` and `template_config` to the example.

🔍 [Deploy preview](https://vault-git-docs-update-config-example-hashicorp.vercel.app/vault/docs/agent-and-proxy/agent#example-configuration)

----
### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
