### PR TITLE
Backport of Add snowflake DB deprecation docs into release/1.17.x

### DIFF
--- a/website/content/api-docs/secret/databases/snowflake.mdx
+++ b/website/content/api-docs/secret/databases/snowflake.mdx
@@ -8,6 +8,12 @@ description: >-
 
 # Snowflake database plugin HTTP API
 
+<Warning title="Password authentication removal">
+    Snowflake is disabling password authentication for all users in&nbsp;
+    <a href="https://www.snowflake.com/en/blog/blocking-single-factor-password-authentification">November of 2025.</a>    
+    &nbsp;HashiCorp is working to support key pair authentication in place of passwords.
+</Warning>
+
 The Snowflake database plugin is one of the supported plugins for the database
 secrets engine. This plugin generates database credentials dynamically based on
 configured roles for the Snowflake database.

--- a/website/content/docs/deprecation/index.mdx
+++ b/website/content/docs/deprecation/index.mdx
@@ -38,6 +38,8 @@ or raise a ticket with your support team.
 
 @include 'deprecation/active-directory-secrets-engine.mdx'
 
+@include 'deprecation/snowflake-password-auth.mdx'
+
 </Tab>
 <Tab heading="PENDING REMOVAL">
 

--- a/website/content/docs/secrets/databases/index.mdx
+++ b/website/content/docs/secrets/databases/index.mdx
@@ -168,7 +168,7 @@ and private key pair to authenticate.
 | [Redis](/vault/docs/secrets/databases/redis)                        | No         | Yes                      | Yes           | Yes          | No                     | password                     |
 | [Redis ElastiCache](/vault/docs/secrets/databases/rediselasticache) | No         | No                       | No            | Yes          | No                     | password                     |
 | [Redshift](/vault/docs/secrets/databases/redshift)                  | No         | Yes                      | Yes           | Yes          | Yes (1.8+)             | password                     |
-| [Snowflake](/vault/docs/secrets/databases/snowflake)                | No         | Yes                      | Yes           | Yes          | Yes (1.8+)             | password, rsa_private_key    |
+| [Snowflake](/vault/docs/secrets/databases/snowflake)                | No         | Yes                      | Yes           | Yes          | Yes (1.8+)             | password(deprecated), rsa_private_key    |
 
 ## Custom plugins
 

--- a/website/content/docs/secrets/databases/snowflake.mdx
+++ b/website/content/docs/secrets/databases/snowflake.mdx
@@ -9,6 +9,12 @@ description: |-
 
 # Snowflake database secrets engine
 
+<Warning title="Password authentication removal">
+    Snowflake is disabling password authentication for all users in&nbsp;
+    <a href="https://www.snowflake.com/en/blog/blocking-single-factor-password-authentification">November of 2025.</a>    
+    &nbsp;HashiCorp is working to support key pair authentication in place of passwords.
+</Warning>
+
 Snowflake is one of the supported plugins for the database secrets engine. This plugin
 generates database credentials dynamically based on configured roles for Snowflake-hosted
 databases and supports [Static Roles](/vault/docs/secrets/databases#static-roles).
@@ -23,7 +29,7 @@ The Snowflake database secrets engine uses
 
 | Plugin Name                 | Root Credential Rotation | Dynamic Roles | Static Roles | Username Customization | Credential Types          |
 | --------------------------- | ------------------------ | ------------- | ------------ | ---------------------- |---------------------------|
-| `snowflake-database-plugin` | Yes                      | Yes           | Yes          | Yes (1.8+)             | password, rsa_private_key |
+| `snowflake-database-plugin` | Yes                      | Yes           | Yes          | Yes (1.8+)             | password(deprecated), rsa_private_key |
 
 ## Setup
 

--- a/website/content/partials/deprecation/snowflake-password-auth.mdx
+++ b/website/content/partials/deprecation/snowflake-password-auth.mdx
@@ -1,0 +1,9 @@
+## Snowflake DB password authentication ((#snowflake-db-password-auth))
+
+| Announced | Expected end of support | Expected removal |
+| :-------: | :---------------------: | :--------------: |
+| APR 2025  | NOV 2025                | N/A
+
+Snowflake is disabling password authentication for all users in [November of 2025](https://www.snowflake.com/en/blog/blocking-single-factor-password-authentification).
+HashiCorp is working to support key pair authentication in place of passwords
+for this database secrets engine.


### PR DESCRIPTION
Backport of https://github.com/hashicorp/vault/pull/30327

### Description
What does this PR do?

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
