### PR TITLE
UI: Build SAML auth component

### DIFF
--- a/ui/app/components/auth/form/okta.ts
+++ b/ui/app/components/auth/form/okta.ts
@@ -64,7 +64,6 @@ export default class AuthFormOkta extends AuthBase {
       let verifyNumber = null;
       while (verifyNumber === null) {
         await timeout(1000);
-        // verifyNumber = await this.requestOktaVerify(nonce, mountPath);
         verifyNumber = await this.requestOktaVerify(nonce, mountPath);
       }
 

--- a/ui/app/components/auth/form/saml.hbs
+++ b/ui/app/components/auth/form/saml.hbs
@@ -1,0 +1,52 @@
+{{!
+  Copyright (c) HashiCorp, Inc.
+  SPDX-License-Identifier: BUSL-1.1
+~}}
+
+<form
+  {{! manage input changes at the <form> level since "path" and "namespace" are yielded }}
+  {{on "submit" this.onSubmit}}
+  data-test-auth-form={{@authType}}
+>
+
+  {{yield to="namespace"}}
+
+  <div class="has-padding-l">
+    {{yield to="back"}}
+    {{yield to="authSelectOptions"}}
+    {{yield to="error"}}
+
+    {{! Authenticating with SAML requires a secure context }}
+    {{#if this.canLoginSaml}}
+      <Auth::Fields @loginFields={{this.loginFields}} />
+
+      {{yield to="advancedSettings"}}
+
+      <Hds::Button
+        @icon={{if this.tasksAreRunning "loading" this.icon}}
+        @isFullWidth={{true}}
+        @text="Sign in with SAML provider"
+        class="has-top-margin-m has-bottom-margin-m"
+        type="submit"
+        data-test-auth-submit
+      />
+
+    {{else}}
+      <Hds::Alert @type="inline" @color="warning" data-test-saml-auth-not-allowed class="has-bottom-margin-m" as |A|>
+        <A.Title>Insecure context detected</A.Title>
+        <A.Description>
+          Logging in with a SAML auth method requires a browser in a secure context.
+        </A.Description>
+        <A.Description class="has-top-margin-xs">
+          <Hds::Link::Standalone
+            @icon="external-link"
+            @text="Read more about secure contexts."
+            @href="https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts"
+          />
+        </A.Description>
+      </Hds::Alert>
+    {{/if}}
+
+    {{yield to="footer"}}
+  </div>
+</form>

--- a/ui/app/components/auth/form/saml.hbs
+++ b/ui/app/components/auth/form/saml.hbs
@@ -3,11 +3,7 @@
   SPDX-License-Identifier: BUSL-1.1
 ~}}
 
-<form
-  {{! manage input changes at the <form> level since "path" and "namespace" are yielded }}
-  {{on "submit" this.onSubmit}}
-  data-test-auth-form={{@authType}}
->
+<form {{on "submit" this.onSubmit}} data-test-auth-form={{@authType}}>
 
   {{yield to="namespace"}}
 

--- a/ui/app/components/auth/form/saml.js
+++ b/ui/app/components/auth/form/saml.js
@@ -24,7 +24,6 @@ export { ERROR_WINDOW_CLOSED };
 
 export default class AuthFormSaml extends AuthBase {
   @service store;
-  @service flags;
 
   @tracked errorMessage;
   @tracked fetchedRole;
@@ -36,15 +35,12 @@ export default class AuthFormSaml extends AuthBase {
     },
   ];
 
-  // set by form inputs
-  _formData = new FormData();
-
   get canLoginSaml() {
     return window.isSecureContext;
   }
 
   get tasksAreRunning() {
-    return this.exchangeSAMLTokenPollID.isRunning;
+    return this.login.isRunning || this.exchangeSAMLTokenPollID.isRunning;
   }
 
   /* Saml auth flow on login button click:

--- a/ui/app/components/auth/form/saml.js
+++ b/ui/app/components/auth/form/saml.js
@@ -4,17 +4,181 @@
  */
 
 import AuthBase from './base';
+import Ember from 'ember';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+import { task, timeout, waitForEvent } from 'ember-concurrency';
+import { tracked } from '@glimmer/tracking';
+import errorMessage from 'vault/utils/error-message';
 
 /**
  * @module Auth::Form::Saml
  * see Auth::Base
  */
 
+const ERROR_WINDOW_CLOSED =
+  'The provider window was closed before authentication was complete. Your web browser may have blocked or closed a pop-up window. Please check your settings and click "Sign in" to try again.';
+const ERROR_TIMEOUT = 'The authentication request has timed out. Please click "Sign in" to try again.';
+
+export { ERROR_WINDOW_CLOSED };
+
 export default class AuthFormSaml extends AuthBase {
+  @service store;
+  @service flags;
+
+  @tracked errorMessage;
+  @tracked fetchedRole;
+
   loginFields = [
     {
       name: 'role',
       helperText: 'Vault will use the default role to sign in if this field is left blank.',
     },
   ];
+
+  // set by form inputs
+  _formData = new FormData();
+
+  get canLoginSaml() {
+    return window.isSecureContext;
+  }
+
+  get tasksAreRunning() {
+    return this.exchangeSAMLTokenPollID.isRunning;
+  }
+
+  /* Saml auth flow on login button click:
+   * 1. find role-saml record which returns role info
+   * 2. open popup at url defined returned from role
+   * 3. watch popup window for close (and cancel polling if it closes)
+   * 4. poll vault for 200 token response
+   * 5. close popup, stop polling, and trigger onSubmit with token data
+   */
+  login = task(async (submitData) => {
+    const { role, path, namespace } = submitData;
+    try {
+      const id = JSON.stringify([path, role]);
+      this.fetchedRole = await this.store.findRecord('role-saml', id, {
+        adapterOptions: { namespace },
+      });
+    } catch (error) {
+      this.onError(errorMessage(error));
+      return;
+    }
+
+    // if role is successfully fetched start SAML auth
+    const samlWindow = await this.startSAMLAuth();
+    await this.exchangeSAMLTokenPollID.perform(samlWindow, submitData);
+  });
+
+  @action
+  async startSAMLAuth() {
+    const win = window;
+    const POPUP_WIDTH = 500;
+    const POPUP_HEIGHT = 600;
+    const left = win.screen.width / 2 - POPUP_WIDTH / 2;
+    const top = win.screen.height / 2 - POPUP_HEIGHT / 2;
+    return win.open(
+      this.fetchedRole.ssoServiceURL,
+      'vaultSAMLWindow',
+      `width=${POPUP_WIDTH},height=${POPUP_HEIGHT},resizable,scrollbars=yes,top=${top},left=${left}`
+    );
+  }
+
+  exchangeSAMLTokenPollID = task(async (samlWindow, submitData) => {
+    // start watching the popup window and the current one
+    this.watchPopup.perform(samlWindow);
+    this.watchCurrent.perform(samlWindow);
+
+    const { path } = submitData;
+
+    // TODO CMB - when wiring up components check if this is still necessary
+    // pass namespace from state back to AuthForm
+    // this.args.onNamespace(namespace);
+
+    const adapter = this.store.adapterFor('auth-method');
+    // Wait up to 3 minutes (180 seconds) for the token to become available
+    for (let i = 0; i < 180; i++) {
+      const WAIT_TIME = Ember.testing ? 50 : 1000;
+      await timeout(WAIT_TIME);
+
+      try {
+        const resp = await adapter.pollSAMLToken(
+          path,
+          this.fetchedRole.tokenPollID,
+          this.fetchedRole.clientVerifier
+        );
+
+        if (resp?.auth) {
+          // We've obtained the Vault token for the authentication flow now log in or pass MFA data
+          const { mfa_requirement, client_token } = resp.auth;
+          // onSubmit calls doSubmit in auth-form.js
+          const samlExchangeData = { token: client_token, mfa_requirement };
+          await this.continueLogin(samlExchangeData);
+          this.closeWindow(samlWindow);
+          return;
+        } else {
+          continue;
+        }
+      } catch (e) {
+        if (e.httpStatus === 401) {
+          // Continue to retry on 401 Unauthorized
+          continue;
+        }
+        return this.cancelLogin(samlWindow, errorMessage(e));
+      }
+    }
+    this.cancelLogin(samlWindow, ERROR_TIMEOUT);
+  });
+
+  async continueLogin(data) {
+    try {
+      const authResponse = await this.auth.authenticate({
+        clusterId: this.args.cluster.id,
+        backend: 'token',
+        data,
+        selectedAuth: this.args.authType,
+      });
+
+      // responsible for redirect after auth data is persisted
+      this.handleAuthResponse(authResponse, this.args.authType);
+    } catch (error) {
+      this.onError(error);
+    }
+  }
+
+  // MANAGE POPUPS
+  watchPopup = task(async (samlWindow) => {
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      const WAIT_TIME = Ember.testing ? 50 : 500;
+
+      await timeout(WAIT_TIME);
+      if (!samlWindow || samlWindow.closed) {
+        return this.handleSAMLError(ERROR_WINDOW_CLOSED);
+      }
+    }
+  });
+
+  watchCurrent = task(async (samlWindow) => {
+    // when user is about to change pages, close the popup window
+    await waitForEvent(window, 'beforeunload');
+    samlWindow?.close();
+  });
+
+  cancelLogin(samlWindow, errorMessage) {
+    this.closeWindow(samlWindow);
+    this.handleSAMLError(errorMessage);
+  }
+
+  closeWindow(samlWindow) {
+    this.watchPopup.cancelAll();
+    this.watchCurrent.cancelAll();
+    samlWindow.close();
+  }
+
+  handleSAMLError(err) {
+    this.exchangeSAMLTokenPollID.cancelAll();
+    this.onError(err);
+  }
 }

--- a/ui/tests/integration/components/auth/form/saml-test.js
+++ b/ui/tests/integration/components/auth/form/saml-test.js
@@ -87,7 +87,7 @@ module('Integration | Component | auth | form | saml', function (hooks) {
     this.server.put('/auth/saml/sso_service_url', (_, req) => {
       const { acs_url, role } = JSON.parse(req.requestBody);
       assert.strictEqual(acs_url, `${window.origin}/v1/auth/saml/callback`, 'it builds acs_url for payload');
-      assert.strictEqual(role, null, 'role has no value');
+      assert.strictEqual(role, '', 'role has no value');
       return {
         data: {
           sso_service_url: 'https://my-single-sign-on-url.com',
@@ -246,7 +246,7 @@ module('Integration | Component | auth | form | saml', function (hooks) {
     const [actual] = this.onError.lastCall.args;
     assert.strictEqual(
       actual,
-      'Authentication failed: permission denied!!: Sinon-provided permission denied!!',
+      'Authentication failed: Sinon-provided permission denied!!',
       'onError called with auth service failure'
     );
   });

--- a/ui/tests/integration/components/auth/form/saml-test.js
+++ b/ui/tests/integration/components/auth/form/saml-test.js
@@ -82,6 +82,17 @@ module('Integration | Component | auth | form | saml', function (hooks) {
       .hasText('Vault will use the default role to sign in if this field is left blank.');
   });
 
+  test('it renders warning if insecure context is detected', async function (assert) {
+    sinon.replaceGetter(window, 'isSecureContext', () => false);
+
+    await this.renderComponent();
+    assert
+      .dom('[data-test-saml-auth-not-allowed]')
+      .hasText(
+        'Insecure context detected Logging in with a SAML auth method requires a browser in a secure context. Read more about secure contexts.'
+      );
+  });
+
   test('it requests sso_service_url and opens popup on submit if role is empty', async function (assert) {
     assert.expect(6);
     this.server.put('/auth/saml/sso_service_url', (_, req) => {

--- a/ui/types/vault/adapters/auth-method.d.ts
+++ b/ui/types/vault/adapters/auth-method.d.ts
@@ -15,4 +15,11 @@ export default interface AuthMethodAdapter extends AdapterRegistry {
   ) => Promise<{
     auth: AuthData;
   }>;
+  pollSAMLToken: (
+    path: string,
+    tokenPollID: string,
+    clientVerifier: string
+  ) => Promise<{
+    auth: AuthData;
+  }>;
 }


### PR DESCRIPTION
### Description
Builds new auth form component for `saml` auth method. Much of the code is transferred from: https://github.com/hashicorp/vault/blob/741721ad0e2f1888114941a3009133cccdc4b7b2/ui/app/components/auth-saml.js (added in https://github.com/hashicorp/vault/pull/22640)

<img width="600" alt="Screenshot 2025-04-29 at 10 21 39 AM" src="https://github.com/user-attachments/assets/2345b337-7bc4-4b83-aea4-03cbbd4df97d" />

# Insecure Context warning
<img width="600" alt="Screenshot 2025-04-29 at 10 22 01 AM" src="https://github.com/user-attachments/assets/30b5e703-cecf-4fec-83f9-9a85faeadd42" />

<img width="600" alt="Screenshot 2025-04-29 at 10 22 25 AM" src="https://github.com/user-attachments/assets/8acfbb78-8c22-4989-b758-7109cfffa316" />

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
