### PR TITLE
Fix misformatted comment causing the CE-ENT diff to fail

### DIFF
--- a/physical/raft/snapshot_test.go
+++ b/physical/raft/snapshot_test.go
@@ -962,8 +962,8 @@ func TestBoltSnapshotStore_CloseFailure(t *testing.T) {
 	}
 }
 
-// TestLoadReadOnlySnapshot loads a test snapshot file and verifies that there
-// are no errors, and that the expected paths are excluded from the FSM.
+// TestLoadReadOnlySnapshot loads a test snapshot file and verifies that there are no
+// errors, and that the expected paths are excluded from the FSM.
 func TestLoadReadOnlySnapshot(t *testing.T) {
 	t.Parallel()
 	// Load a test snapshot file from the testdata directory.


### PR DESCRIPTION
### Description
What it says on the tin. I pushed up a comment that was formatted differently in the two repos and it's causing our automation some pain. 

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
