### PR TITLE
[UI] API Client Runtime Fix

### DIFF
--- a/ui/api-client/dist/esm/runtime.js
+++ b/ui/api-client/dist/esm/runtime.js
@@ -326,9 +326,13 @@ export class VoidApiResponse {
     }
     value() {
         return __awaiter(this, void 0, void 0, function* () {
-            var _a;
-            const response = yield ((_a = this.raw) === null || _a === void 0 ? void 0 : _a.json());
-            return camelizeResponseKeys(response);
+            try {
+                const response = yield this.raw.json();
+                return camelizeResponseKeys(response);
+            }
+            catch (e) {
+                return undefined;
+            }
         });
     }
 }

--- a/ui/api-client/dist/runtime.js
+++ b/ui/api-client/dist/runtime.js
@@ -340,9 +340,13 @@ class VoidApiResponse {
     }
     value() {
         return __awaiter(this, void 0, void 0, function* () {
-            var _a;
-            const response = yield ((_a = this.raw) === null || _a === void 0 ? void 0 : _a.json());
-            return camelizeResponseKeys(response);
+            try {
+                const response = yield this.raw.json();
+                return camelizeResponseKeys(response);
+            }
+            catch (e) {
+                return undefined;
+            }
         });
     }
 }

--- a/ui/api-client/src/runtime.ts
+++ b/ui/api-client/src/runtime.ts
@@ -457,8 +457,12 @@ export class JSONApiResponse<T> {
 export class VoidApiResponse {
     constructor(public raw: Response) {}
     async value(): Promise<VoidResponse> {
-        const response = await this.raw?.json();
-        return camelizeResponseKeys(response);
+        try {
+            const response = await this.raw.json();
+            return camelizeResponseKeys(response);
+        } catch (e) {
+            return undefined;
+        }
     }
 }
 


### PR DESCRIPTION
### Description
There was an issue in the API client `VoidApiResponse` handler where truly void responses were triggering an error since the `json` method was being invoked. Enterprise specific tests picked it up but it wasn't an enterprise specific issue and would have impacted all uses of the api client where a response was not being returned from the server. 

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
