### PR TITLE
PR: Set `autocomplete="off"` for new auth fields

### DIFF
--- a/ui/app/components/auth/fields.hbs
+++ b/ui/app/components/auth/fields.hbs
@@ -6,7 +6,7 @@
 {{#each @loginFields as |field|}}
   {{#let field.name field.label field.helperText as |name label helperText|}}
     <Hds::Form::TextInput::Field
-      autocomplete={{this.setAutocomplete name}}
+      autocomplete="off"
       @type={{this.setInputType name}}
       name={{name}}
       class="has-bottom-margin-m"

--- a/ui/app/components/auth/fields.hbs
+++ b/ui/app/components/auth/fields.hbs
@@ -6,6 +6,7 @@
 {{#each @loginFields as |field|}}
   {{#let field.name field.label field.helperText as |name label helperText|}}
     <Hds::Form::TextInput::Field
+      {{! For security, we do not support autocomplete at this time }}
       autocomplete="off"
       @type={{this.setInputType name}}
       name={{name}}

--- a/ui/app/components/auth/fields.ts
+++ b/ui/app/components/auth/fields.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-// TODO pending feedback from the security team, we may keep autocomplete="off" for login fields
-
 import Component from '@glimmer/component';
 
 interface Args {
@@ -20,15 +18,4 @@ interface Field {
 export default class AuthFields extends Component<Args> {
   // token or password should render as "password" types, otherwise render text inputs
   setInputType = (field: string) => (['token', 'password'].includes(field) ? 'password' : 'text');
-
-  setAutocomplete = (fieldName: string) => {
-    switch (fieldName) {
-      case 'password':
-        return 'current-password';
-      case 'token':
-        return 'off';
-      default:
-        return fieldName;
-    }
-  };
 }

--- a/ui/tests/integration/components/auth/fields-test.js
+++ b/ui/tests/integration/components/auth/fields-test.js
@@ -72,10 +72,10 @@ module('Integration | Component | auth | fields', function (hooks) {
   test('it renders expected autocomplete values', async function (assert) {
     await this.renderComponent();
     const expectedValues = {
-      username: 'username',
-      role: 'role',
+      username: 'off',
+      role: 'off',
       token: 'off',
-      password: 'current-password',
+      password: 'off',
     };
 
     for (const field of this.loginFields) {


### PR DESCRIPTION
### Description
After consulting with security folks, we decided to hold off on implementing "autocomplete" functionality in the login form for now. There's concern this will upset the security expectations of some users. 

We can revisit this if a strong case comes up to support autocomplete. If we end up making this change, we will likely only support autocomplete for non-token fields. 



### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
