### PR TITLE
vault-35676 Remove current month estimate warning ce changes

### DIFF
--- a/vault/logical_system_activity.go
+++ b/vault/logical_system_activity.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/hashicorp/go-secure-stdlib/parseutil"
 	"github.com/hashicorp/vault/helper/namespace"
-	"github.com/hashicorp/vault/helper/timeutil"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/logical"
 )
@@ -26,9 +25,6 @@ var defaultToRetentionMonthsMaxWarning = fmt.Sprintf("retention_months cannot be
 const (
 	// WarningCurrentBillingPeriodDeprecated is a warning string that is used to indicate that the current_billing_period field, as the default start time will automatically be the billing period start date
 	WarningCurrentBillingPeriodDeprecated = "current_billing_period is deprecated; unless otherwise specified, all requests will default to the current billing period"
-
-	// WarningCurrentMonthIsAnEstimate is a warning string that is used to let the customer know that for this query, the current month's data is estimated.
-	WarningCurrentMonthIsAnEstimate = "Since this usage period includes both the current month and at least one historical month, counts returned in this usage period are an estimate. Client counts for this period will no longer be estimated at the start of the next month."
 
 	// WarningProvidedStartAndEndTimesIgnored is a warning string that is used to indicate that the provided start and end times by the user have been aligned to a billing period's start and end times
 	WarningProvidedStartAndEndTimesIgnored = "start_time and end_time parameters can only be used to specify the beginning or end of the same billing period. The values provided for these parameters are not supported and are ignored. Showing the data for the entire billing period corresponding to start_time. If start_time is not provided, the billing period is determined based on the end_time."
@@ -239,34 +235,6 @@ func (b *SystemBackend) rootActivityPaths() []*framework.Path {
 	return paths
 }
 
-// queryContainsEstimates calculates if the query for client counts will contain estimates.
-// A query between months N-2 and N-1 would not be an estimate, as with a query for month N.
-// But a query between N-2 and N or N-1 and N would be an estimate.
-func queryContainsEstimates(startTime time.Time, endTime time.Time) bool {
-	startTime = timeutil.EndOfMonth(startTime)
-	endTime = timeutil.EndOfMonth(endTime)
-
-	if startTime == endTime {
-		// If we're only estimating the current month, then we have no estimation
-		return false
-	}
-
-	if timeutil.IsCurrentMonth(endTime, time.Now().UTC()) {
-		// Our query includes the current month and previous months, so we have estimation
-		return true
-	}
-
-	// If the endTime is in the future, the behaviour is equivalent to when endTime is set to the current month
-	// (it includes the current month and previous months, so we have estimation)
-	endOfCurrentMonth := timeutil.EndOfMonth(time.Now().UTC())
-	if endTime.After(endOfCurrentMonth) {
-		return true
-	}
-
-	// Our query doesn't include the current month
-	return false
-}
-
 func parseStartEndTimes(d *framework.FieldData, billingStartTime time.Time) (time.Time, time.Time, error) {
 	startTime := d.Get("start_time").(time.Time)
 	endTime := d.Get("end_time").(time.Time)
@@ -379,9 +347,6 @@ func (b *SystemBackend) handleClientMetricQuery(ctx context.Context, req *logica
 		return resp204, err
 	}
 
-	if queryContainsEstimates(startTime, endTime) {
-		warnings = append(warnings, WarningCurrentMonthIsAnEstimate)
-	}
 	if timeWarnings.EndTimeAdjustedToPastMonth {
 		warnings = append(warnings, WarningEndTimeAsCurrentMonthOrFutureIgnored)
 	}


### PR DESCRIPTION
### Description
What does this PR do?
Jira: https://hashicorp.atlassian.net/browse/VAULT-35676
Approved ent: https://github.com/hashicorp/vault-enterprise/pull/7997

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
