### PR TITLE
VAULT-35628 Add group_by and secondary_rate to RLQ API

### DIFF
--- a/changelog/30447.txt
+++ b/changelog/30447.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+core/quotas: Add new fields to the rate limit quota API to support different grouping modes on enterprise version.
+```

--- a/changelog/30447.txt
+++ b/changelog/30447.txt
@@ -1,3 +1,0 @@
-```release-note:improvement
-core/quotas: Add new fields to the rate limit quota API to support different grouping modes on enterprise version.
-```

--- a/vault/external_tests/quotas/quotas_test.go
+++ b/vault/external_tests/quotas/quotas_test.go
@@ -583,6 +583,16 @@ func TestQuotas_RateLimitQuota_GroupByConfig(t *testing.T) {
 				"secondary_rate": json.Number("0"),
 			},
 		},
+		"explicit_group_by_ip_allowed_in_ce": {
+			reqData: map[string]interface{}{
+				"rate":     100,
+				"group_by": "ip",
+			},
+			expectedReadContains: map[string]interface{}{
+				"group_by":       "ip",
+				"secondary_rate": json.Number("0"),
+			},
+		},
 		"invalid_group_by": {
 			reqData: map[string]interface{}{
 				"rate":     100,
@@ -706,7 +716,6 @@ func TestQuotas_RateLimitQuota_GroupByConfig(t *testing.T) {
 				require.NoError(t, err)
 				require.NotNil(t, resp)
 				require.NotEmpty(t, resp.Data)
-				t.Logf("%+v", resp.Data)
 				for k, v := range tc.expectedReadContains {
 					require.Contains(t, resp.Data, k)
 					require.Equal(t, v, resp.Data[k])

--- a/vault/external_tests/quotas/quotas_test.go
+++ b/vault/external_tests/quotas/quotas_test.go
@@ -544,6 +544,7 @@ func TestQuotas_RateLimitQuota(t *testing.T) {
 	}
 }
 
+// TestQuotas_RateLimitQuota_GroupByConfig tests the validations imposed on the group_by and secondary_rate fields
 func TestQuotas_RateLimitQuota_GroupByConfig(t *testing.T) {
 	conf, opts := teststorage.ClusterSetup(coreConfig, nil, nil)
 	opts.NoDefaultQuotas = true

--- a/vault/external_tests/quotas/quotas_test.go
+++ b/vault/external_tests/quotas/quotas_test.go
@@ -4,6 +4,7 @@
 package quotas
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 	"time"
@@ -11,6 +12,7 @@ import (
 	"github.com/hashicorp/vault/api"
 	"github.com/hashicorp/vault/builtin/credential/userpass"
 	"github.com/hashicorp/vault/builtin/logical/pki"
+	"github.com/hashicorp/vault/helper/constants"
 	"github.com/hashicorp/vault/helper/testhelpers/teststorage"
 	"github.com/hashicorp/vault/sdk/helper/testhelpers/schema"
 	"github.com/hashicorp/vault/sdk/logical"
@@ -539,5 +541,178 @@ func TestQuotas_RateLimitQuota(t *testing.T) {
 	_, numFail, _ = testRPS(reqFunc, 5*time.Second)
 	if numFail > 0 {
 		t.Fatalf("unexpected number of failed requests: %d", numFail)
+	}
+}
+
+func TestQuotas_RateLimitQuota_GroupByConfig(t *testing.T) {
+	conf, opts := teststorage.ClusterSetup(coreConfig, nil, nil)
+	opts.NoDefaultQuotas = true
+	cluster := vault.NewTestCluster(t, conf, opts)
+	cluster.Start()
+	t.Cleanup(cluster.Cleanup)
+
+	core := cluster.Cores[0].Core
+	client := cluster.Cores[0].Client
+
+	vault.TestWaitActive(t, core)
+
+	testCases := map[string]struct {
+		reqData              map[string]interface{}
+		expectedErr          string
+		expectedReadContains map[string]interface{}
+		enterpriseOnly       bool
+		CeOnly               bool
+	}{
+		"group_by_defaults_to_ip": {
+			reqData: map[string]interface{}{
+				"rate": 100,
+			},
+			expectedReadContains: map[string]interface{}{
+				"group_by":       "ip",
+				"secondary_rate": json.Number("0"),
+			},
+		},
+		"explicitly_empty_group_by_defaults_to_ip": {
+			reqData: map[string]interface{}{
+				"rate":     100,
+				"group_by": "",
+			},
+			expectedReadContains: map[string]interface{}{
+				"group_by":       "ip",
+				"secondary_rate": json.Number("0"),
+			},
+		},
+		"invalid_group_by": {
+			reqData: map[string]interface{}{
+				"rate":     100,
+				"group_by": "invalid",
+			},
+			expectedErr: `invalid grouping mode "invalid"`,
+		},
+		"group_by_none_not_allowed_in_ce": {
+			CeOnly: true,
+			reqData: map[string]interface{}{
+				"rate":     100,
+				"group_by": "none",
+			},
+			expectedErr: `grouping mode "none" is only available in Vault Enterprise`,
+		},
+		"group_by_entity_then_none_not_allowed_in_ce": {
+			CeOnly: true,
+			reqData: map[string]interface{}{
+				"rate":     100,
+				"group_by": "entity_then_none",
+			},
+			expectedErr: `grouping mode "entity_then_none" is only available in Vault Enterprise`,
+		},
+		"group_by_entity_then_ip_not_allowed_in_ce": {
+			CeOnly: true,
+			reqData: map[string]interface{}{
+				"rate":     100,
+				"group_by": "entity_then_ip",
+			},
+			expectedErr: `grouping mode "entity_then_ip" is only available in Vault Enterprise`,
+		},
+		"secondary_rate_invalid_with_group_by_none": {
+			enterpriseOnly: true,
+			reqData: map[string]interface{}{
+				"rate":           100,
+				"secondary_rate": 1,
+				"group_by":       "none",
+			},
+			expectedErr: "secondary rate is only valid when using entity-based grouping",
+		},
+		"secondary_rate_invalid_with_group_by_ip": {
+			enterpriseOnly: true,
+			reqData: map[string]interface{}{
+				"rate":           100,
+				"secondary_rate": 1,
+				"group_by":       "ip",
+			},
+			expectedErr: "secondary rate is only valid when using entity-based grouping",
+		},
+		"secondary_rate_defaults_to_rate_with_entity_then_ip": {
+			enterpriseOnly: true,
+			reqData: map[string]interface{}{
+				"rate":           100,
+				"group_by":       "entity_then_ip",
+				"secondary_rate": 0,
+			},
+			expectedReadContains: map[string]interface{}{
+				"group_by":       "entity_then_ip",
+				"secondary_rate": json.Number("100"),
+			},
+		},
+		"secondary_rate_defaults_to_rate_with_entity_then_none": {
+			enterpriseOnly: true,
+			reqData: map[string]interface{}{
+				"rate":     100,
+				"group_by": "entity_then_none",
+			},
+			expectedReadContains: map[string]interface{}{
+				"group_by":       "entity_then_none",
+				"secondary_rate": json.Number("100"),
+			},
+		},
+		"secondary_rate_defaults_to_zero_on_group_by_none": {
+			enterpriseOnly: true,
+			reqData: map[string]interface{}{
+				"rate":     100,
+				"group_by": "none",
+			},
+			expectedReadContains: map[string]interface{}{
+				"group_by":       "none",
+				"secondary_rate": json.Number("0"),
+			},
+		},
+		"secondary_rate_defaults_to_zero_on_group_by_ip": {
+			reqData: map[string]interface{}{
+				"rate":     100,
+				"group_by": "ip",
+			},
+			expectedReadContains: map[string]interface{}{
+				"group_by":       "ip",
+				"secondary_rate": json.Number("0"),
+			},
+		},
+		"secondary_rate_defaults_cannot_be_negative": {
+			reqData: map[string]interface{}{
+				"rate":           100,
+				"group_by":       "entity_then_ip",
+				"secondary_rate": -1,
+			},
+			expectedErr: "secondary rate must be greater than or equal to 0",
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			if tc.enterpriseOnly && !constants.IsEnterprise {
+				t.Skip("skipping test because it is only valid in enterprise")
+			} else if tc.CeOnly && constants.IsEnterprise {
+				t.Skip("skipping test because it is only valid in community edition")
+			}
+
+			_, err := client.Logical().Write("sys/quotas/rate-limit/"+name, tc.reqData)
+
+			if tc.expectedErr != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.expectedErr)
+			} else {
+				require.NoError(t, err)
+
+				resp, err := client.Logical().Read("sys/quotas/rate-limit/" + name)
+				require.NoError(t, err)
+				require.NotNil(t, resp)
+				require.NotEmpty(t, resp.Data)
+				t.Logf("%+v", resp.Data)
+				for k, v := range tc.expectedReadContains {
+					require.Contains(t, resp.Data, k)
+					require.Equal(t, v, resp.Data[k])
+				}
+			}
+
+			_, err = client.Logical().Delete("sys/quotas/rate-limit/" + name)
+			require.NoError(t, err)
+		})
 	}
 }

--- a/vault/external_tests/quotas/quotas_test.go
+++ b/vault/external_tests/quotas/quotas_test.go
@@ -676,6 +676,7 @@ func TestQuotas_RateLimitQuota_GroupByConfig(t *testing.T) {
 			},
 		},
 		"secondary_rate_defaults_cannot_be_negative": {
+			enterpriseOnly: true,
 			reqData: map[string]interface{}{
 				"rate":           100,
 				"group_by":       "entity_then_ip",

--- a/vault/logical_system_quotas.go
+++ b/vault/logical_system_quotas.go
@@ -6,12 +6,12 @@ package vault
 import (
 	"context"
 	"errors"
-	"github.com/hashicorp/vault/helper/constants"
 	"net/http"
 	"strings"
 	"time"
 
 	"github.com/hashicorp/go-secure-stdlib/strutil"
+	"github.com/hashicorp/vault/helper/constants"
 	"github.com/hashicorp/vault/helper/namespace"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/logical"
@@ -229,6 +229,14 @@ requests that contain an entity ID are subject to the "rate" field instead. Defa
 								},
 								"inheritable": {
 									Type:     framework.TypeBool,
+									Required: true,
+								},
+								"group_by": {
+									Type:     framework.TypeString,
+									Required: true,
+								},
+								"secondary_rate": {
+									Type:     framework.TypeFloat,
 									Required: true,
 								},
 							},

--- a/vault/logical_system_quotas.go
+++ b/vault/logical_system_quotas.go
@@ -166,9 +166,9 @@ from any further requests until after the 'block_interval' has elapsed.`,
 					Description: `Attribute by which to group requests by. Valid group_by modes are: 1) "ip" that groups
 requests by their source IP address (group_by defaults to ip if unset); 2) "none" that groups all requests that match
 the rate limit quota rule together; 3) "entity_then_ip" that groups requests by their entity ID for authenticated
-requests that carry one, or by their IP for unauthenticated or otherwise entity-less requests; and 4) "entity_then_none"
-which also groups requests by their entity ID when available, but the rest is all grouped together (i.e. unauthenticated
-or otherwise entity-less).`,
+requests that carry one, or by their IP for unauthenticated requests (or requests whose authentication is not connected
+to an entity); and 4) "entity_then_none" which also groups requests by their entity ID when available, but the rest is
+all grouped together (i.e. unauthenticated or with authentication not connected to an entity).`,
 					Default: "ip",
 				},
 				"secondary_rate": {
@@ -378,8 +378,10 @@ func (b *SystemBackend) handleRateLimitQuotasUpdate() framework.OperationFunc {
 			// before the group_by field was added
 			groupBy = quotas.GroupByIp
 		case quotas.GroupByIp:
-		// valid group_by
+			// valid group_by mode for both ent and CE
 		case quotas.GroupByNone, quotas.GroupByEntityThenIp, quotas.GroupByEntityThenNone:
+			// other group_by modes are only available in Enterprise. Use simple const on API to simplify things, but
+			// keep the evaluation properly contained in ent-only files
 			if !constants.IsEnterprise {
 				return logical.ErrorResponse("grouping mode %q is only available in Vault Enterprise", groupBy), nil
 			}

--- a/vault/logical_system_quotas.go
+++ b/vault/logical_system_quotas.go
@@ -6,6 +6,7 @@ package vault
 import (
 	"context"
 	"errors"
+	"github.com/hashicorp/vault/helper/constants"
 	"net/http"
 	"strings"
 	"time"
@@ -159,6 +160,22 @@ The 'rate' must be positive.`,
 					Type: framework.TypeDurationSecond,
 					Description: `If set, when a client reaches a rate limit threshold, the client will be prohibited
 from any further requests until after the 'block_interval' has elapsed.`,
+				},
+				"group_by": {
+					Type: framework.TypeString,
+					Description: `Attribute by which to group requests by. Valid group_by modes are: 1) "ip" that groups
+requests by their source IP address (group_by defaults to ip if unset); 2) "none" that groups all requests that match
+the rate limit quota rule together; 3) "entity_then_ip" that groups requests by their entity ID for authenticated
+requests that carry one, or by their IP for unauthenticated or otherwise entity-less requests; and 4) "entity_then_none"
+which also groups requests by their entity ID when available, but the rest is all grouped together (i.e. unauthenticated
+or otherwise entity-less).`,
+					Default: "ip",
+				},
+				"secondary_rate": {
+					Type: framework.TypeFloat,
+					Description: `Only available when using the "entity_then_ip" or "entity_then_none" group_by modes.
+This is the rate limit applied to the requests that fall under the "ip" or "none" groupings, while the authenticated
+requests that contain an entity ID are subject to the "rate" field instead. Defaults to the same value as "rate".`,
 				},
 			},
 			Operations: map[logical.Operation]framework.OperationHandler{
@@ -345,9 +362,38 @@ func (b *SystemBackend) handleRateLimitQuotasUpdate() framework.OperationFunc {
 		name := d.Get("name").(string)
 
 		qType := quotas.TypeRateLimit.String()
+
+		groupBy := d.Get("group_by").(string)
+		switch groupBy {
+		case "":
+			// in order to preserve backwards compatibility we default to the IP grouping, which was the behavior
+			// before the group_by field was added
+			groupBy = quotas.GroupByIp
+		case quotas.GroupByIp:
+		// valid group_by
+		case quotas.GroupByNone, quotas.GroupByEntityThenIp, quotas.GroupByEntityThenNone:
+			if !constants.IsEnterprise {
+				return logical.ErrorResponse("grouping mode %q is only available in Vault Enterprise", groupBy), nil
+			}
+		default:
+			return logical.ErrorResponse("invalid grouping mode %q", groupBy), nil
+		}
+
 		rate := d.Get("rate").(float64)
 		if rate <= 0 {
 			return logical.ErrorResponse("'rate' is invalid"), nil
+		}
+
+		secondaryRate := d.Get("secondary_rate").(float64)
+		if groupBy == quotas.GroupByEntityThenIp || groupBy == quotas.GroupByEntityThenNone {
+			if secondaryRate < 0 {
+				return logical.ErrorResponse("secondary rate must be greater than or equal to 0"), nil
+			}
+			if secondaryRate == 0 {
+				secondaryRate = rate
+			}
+		} else if secondaryRate != 0 {
+			return logical.ErrorResponse("secondary rate is only valid when using entity-based grouping"), nil
 		}
 
 		interval := time.Second * time.Duration(d.Get("interval").(int))
@@ -461,16 +507,18 @@ func (b *SystemBackend) handleRateLimitQuotasUpdate() framework.OperationFunc {
 
 		switch {
 		case quota == nil:
-			quota = quotas.NewRateLimitQuota(name, ns.Path, mountPath, pathSuffix, role, inheritable, interval, blockInterval, rate)
+			quota = quotas.NewRateLimitQuota(name, ns.Path, mountPath, pathSuffix, role, quotas.GroupBy(groupBy), inheritable, interval, blockInterval, rate, secondaryRate)
 		default:
 			// Re-inserting the already indexed object in memdb might cause problems.
 			// So, clone the object. See https://github.com/hashicorp/go-memdb/issues/76.
 			clonedQuota := quota.Clone()
 			rlq := clonedQuota.(*quotas.RateLimitQuota)
+			rlq.GroupBy = quotas.GroupBy(groupBy)
 			rlq.NamespacePath = ns.Path
 			rlq.MountPath = mountPath
 			rlq.PathSuffix = pathSuffix
 			rlq.Rate = rate
+			rlq.SecondaryRate = secondaryRate
 			rlq.Inheritable = inheritable
 			rlq.Interval = interval
 			rlq.BlockInterval = blockInterval
@@ -507,9 +555,11 @@ func (b *SystemBackend) handleRateLimitQuotasRead() framework.OperationFunc {
 		data := map[string]interface{}{
 			"type":           qType,
 			"name":           rlq.Name,
+			"group_by":       rlq.GroupBy,
 			"path":           nsPath + rlq.MountPath + rlq.PathSuffix,
 			"role":           rlq.Role,
 			"rate":           rlq.Rate,
+			"secondary_rate": rlq.SecondaryRate,
 			"inheritable":    rlq.Inheritable,
 			"interval":       int(rlq.Interval.Seconds()),
 			"block_interval": int(rlq.BlockInterval.Seconds()),
@@ -558,8 +608,8 @@ var quotasHelp = map[string][2]string{
 mount.`,
 		`A rate limit quota will enforce API rate limiting in a specified interval. A
 rate limit quota can be created at the root level or defined on a namespace or
-mount by specifying a 'path'. The rate limiter is applied to each unique client
-IP address.`,
+mount by specifying a 'path'. The rate limiter is applied to each unique group of
+requests, as defined by the configured grouping method (client IP, entity ID, etc.).`,
 	},
 	"rate-limit-list": {
 		"Lists the names of all the rate limit quotas.",

--- a/vault/quotas/quotas.go
+++ b/vault/quotas/quotas.go
@@ -70,12 +70,19 @@ func (q Type) String() string {
 	return "unknown"
 }
 
+// GroupBy identifies the attribute by which a rate limit quota rule will group the requests
 type GroupBy string
 
 const (
-	GroupByIp             = "ip"
-	GroupByNone           = "none"
-	GroupByEntityThenIp   = "entity_then_ip"
+	// GroupByIp groups requests to which the RLQ applies by the client IP address
+	GroupByIp = "ip"
+	// GroupByNone groups all requests to which the RLQ applies together (i.e. collective rate limit)
+	GroupByNone = "none"
+	// GroupByEntityThenIp groups requests to which the RLQ applies by entity Id if available, otherwise
+	// by the client IP address (e.g. login or root token requests)
+	GroupByEntityThenIp = "entity_then_ip"
+	// GroupByEntityThenNone groups requests to which the RLQ applies by entity Id if available, and all
+	// entity-less requests together (e.g. login or root token requests)
 	GroupByEntityThenNone = "entity_then_none"
 )
 

--- a/vault/quotas/quotas.go
+++ b/vault/quotas/quotas.go
@@ -70,6 +70,15 @@ func (q Type) String() string {
 	return "unknown"
 }
 
+type GroupBy string
+
+const (
+	GroupByIp             = "ip"
+	GroupByNone           = "none"
+	GroupByEntityThenIp   = "entity_then_ip"
+	GroupByEntityThenNone = "entity_then_none"
+)
+
 const (
 	indexID                 = "id"
 	indexName               = "name"

--- a/vault/quotas/quotas_rate_limit_test.go
+++ b/vault/quotas/quotas_rate_limit_test.go
@@ -31,7 +31,7 @@ func TestNewRateLimitQuota(t *testing.T) {
 		rlq       *RateLimitQuota
 		expectErr bool
 	}{
-		{"valid rate", NewRateLimitQuota("test-rate-limiter", "qa", "/foo/bar", "", "", false, time.Second, 0, 16.7), false},
+		{"valid rate", NewRateLimitQuota("test-rate-limiter", "qa", "/foo/bar", "", "", GroupByIp, false, time.Second, 0, 16.7, 0), false},
 	}
 
 	for _, tc := range testCases {
@@ -48,7 +48,7 @@ func TestNewRateLimitQuota(t *testing.T) {
 }
 
 func TestRateLimitQuota_Close(t *testing.T) {
-	rlq := NewRateLimitQuota("test-rate-limiter", "qa", "/foo/bar", "", "", false, time.Second, time.Minute, 16.7)
+	rlq := NewRateLimitQuota("test-rate-limiter", "qa", "/foo/bar", "", "", GroupByIp, false, time.Second, 0, 16.7, 0)
 	require.NoError(t, rlq.initialize(logging.NewVaultLogger(log.Trace), metricsutil.BlackholeSink()))
 	require.NoError(t, rlq.close(context.Background()))
 
@@ -225,7 +225,7 @@ func TestRateLimitQuota_Update(t *testing.T) {
 	view := &logical.InmemStorage{}
 	require.NoError(t, qm.Setup(context.Background(), view, nil))
 
-	quota := NewRateLimitQuota("quota1", "", "", "", "", false, time.Second, 0, 10)
+	quota := NewRateLimitQuota("quota1", "", "", "", "", GroupByIp, false, time.Second, 0, 10, 0)
 	require.NoError(t, qm.SetQuota(context.Background(), TypeRateLimit.String(), quota, true))
 	require.NoError(t, qm.SetQuota(context.Background(), TypeRateLimit.String(), quota, true))
 

--- a/vault/quotas/quotas_test.go
+++ b/vault/quotas/quotas_test.go
@@ -23,7 +23,7 @@ func TestQuotas_MountPathOverwrite(t *testing.T) {
 	view := &logical.InmemStorage{}
 	require.NoError(t, qm.Setup(context.Background(), view, nil))
 
-	quota := NewRateLimitQuota("tq", "", "kv1/", "", "", false, time.Second, 0, 10)
+	quota := NewRateLimitQuota("tq", "", "kv1/", "", "", GroupByIp, false, time.Second, 0, 10, 0)
 	require.NoError(t, qm.SetQuota(context.Background(), TypeRateLimit.String(), quota, false))
 	quota = quota.Clone().(*RateLimitQuota)
 	quota.MountPath = "kv2/"
@@ -52,7 +52,7 @@ func TestQuotas_Precedence(t *testing.T) {
 
 	setQuotaFunc := func(t *testing.T, name, nsPath, mountPath, pathSuffix, role string, inheritable bool) Quota {
 		t.Helper()
-		quota := NewRateLimitQuota(name, nsPath, mountPath, pathSuffix, role, inheritable, time.Second, 0, 10)
+		quota := NewRateLimitQuota(name, nsPath, mountPath, pathSuffix, role, GroupByIp, inheritable, time.Second, 0, 10, 0)
 		require.NoError(t, qm.SetQuota(context.Background(), TypeRateLimit.String(), quota, true))
 		return quota
 	}
@@ -167,7 +167,7 @@ func TestQuotas_QueryResolveRole_RateLimitQuotas(t *testing.T) {
 	require.False(t, required)
 
 	// Create a non-role-based RLQ on mount1/ and make sure it doesn't require role resolution
-	rlq := NewRateLimitQuota("tq", rlqReq.NamespacePath, rlqReq.MountPath, rlqReq.Path, rlqReq.Role, false, 1*time.Minute, 10*time.Second, 10)
+	rlq := NewRateLimitQuota("tq", rlqReq.NamespacePath, rlqReq.MountPath, rlqReq.Path, rlqReq.Role, GroupByIp, false, 1*time.Minute, 0, 10, 0)
 	require.NoError(t, qm.SetQuota(context.Background(), TypeRateLimit.String(), rlq, false))
 
 	required, err = qm.QueryResolveRoleQuotas(rlqReq)
@@ -176,7 +176,7 @@ func TestQuotas_QueryResolveRole_RateLimitQuotas(t *testing.T) {
 
 	// Create a role-based RLQ on mount1/ and make sure it requires role resolution
 	rlqReq.Role = "test"
-	rlq = NewRateLimitQuota("tq", rlqReq.NamespacePath, rlqReq.MountPath, rlqReq.Path, rlqReq.Role, false, 1*time.Minute, 10*time.Second, 10)
+	rlq = NewRateLimitQuota("tq", rlqReq.NamespacePath, rlqReq.MountPath, rlqReq.Path, rlqReq.Role, GroupByIp, false, 1*time.Minute, 0, 10, 0)
 	require.NoError(t, qm.SetQuota(context.Background(), TypeRateLimit.String(), rlq, false))
 
 	required, err = qm.QueryResolveRoleQuotas(rlqReq)


### PR DESCRIPTION
### Description

This PR adds the `group_by` and `secondary_rate` fields to the RLQ API. These won't provide any additional functionality in CE, as we maintain support only to the current behavior there, but now as an explicit "IP" grouping mode. On enterprise we'll add 3 additional grouping modes to support different use cases:
* `group_by: none` groups all requests to which the RLQ applies together (i.e. collective rate limit);
* `group_by: entity_then_ip` groups requests to which the RLQ applies by entity Id if available, otherwise by the client IP address (e.g. login or root token requests);
* `group_by: entity_then_none` groups requests to which the RLQ applies by entity Id if available, and all entity-less requests together (e.g. login or root token requests)

To make things simpler most of the API and storage handling of the new fields will be present in both CE and ent codebases, it's only the evaluation of those fields that'll be moved to the ent codebase.

Jira: [VAULT-35628](https://hashicorp.atlassian.net/browse/VAULT-35628)
RFC: [VLT-352: Identity-based and collective rate limit quotas](https://docs.google.com/document/d/1puB0Yfsmew35Z7YdliFqvgHXldlmTsux9hAtwtV37EY/edit?tab=t.0)
Ent PR: https://github.com/hashicorp/vault-enterprise/pull/7998

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [x] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.


[VAULT-35628]: https://hashicorp.atlassian.net/browse/VAULT-35628?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ