### PR TITLE
Backport of make correction to known issue to include roles created prior to 1.15.0 into release/1.16.x

### DIFF
--- a/website/content/partials/known-issues/database-static-role-premature-rotations.mdx
+++ b/website/content/partials/known-issues/database-static-role-premature-rotations.mdx
@@ -1,24 +1,16 @@
 ### Database static role rotations on upgrade ((#db-static-role-rotations))
 
-#### Affected Upgrade Path
-* This issue only occurs when upgrading from the following initial versions to the following target versions:
+### Affected Roles
+Any database static role that was created prior to Vault 1.15.0 will be affected upon upgrading to the following Vault versions:
 
-Initial Versions (any version prior to 1.15.0):
-- 1.14.x
-- 1.13.x
-- and earlier
-
-Target Versions:
+### Affected Versions:
 - 1.19.0, 1.19.1, 1.19.2
 - 1.18.5, 1.18.6, 1.18.7, 1.18.8
 - 1.17.12, 1.17.13, 1.17.14, 1.17.15
 - 1.16.16, 1.16.17, 1.16.18, 1.16.19
 
-#### Issue
-Vault automatically rotates existing static roles tied to Database
-credentials once when upgrading to an affected target version from an 
-affected initial version. After the one-time rotation, the static roles behave as expected.
+### Issue
+Vault will automatically rotate static database credentials once, for all roles created prior to 1.15.0, when upgrading to affected versions. 
+After the one-time rotation, the static roles behave as expected.
 
-#### Workaround
-If you rely on Database static roles and are currently on a version prior to 1.15.0, 
-avoid upgrading directly to the target versions listed above.
+


### PR DESCRIPTION
### Description
What does this PR do?

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
