### PR TITLE
Bump wait timer for flaky OIDC auth method test

### DIFF
--- a/ui/tests/acceptance/oidc-auth-method-test.js
+++ b/ui/tests/acceptance/oidc-auth-method-test.js
@@ -108,7 +108,7 @@ module('Acceptance | oidc auth method', function (hooks) {
 
     setTimeout(() => {
       window.postMessage(buildMessage().data, window.origin);
-    }, DELAY_IN_MS);
+    }, 500);
 
     await click(AUTH_FORM.login);
     assert


### PR DESCRIPTION
### Description
Bumping from 50 to 500 for the remaining flaky `oidc-auth-method-test`. In the long term, there is some code that we could refactor.

- [x] ent test pass on headless.
