### PR TITLE
[DOCS] Add explicit links to older release notes

### DIFF
--- a/website/content/docs/updates/release-notes.mdx
+++ b/website/content/docs/updates/release-notes.mdx
@@ -12,6 +12,12 @@ description: >-
 
 @include 'release-notes/intro.mdx'
 
+## Previous releases
+
+- [Vault 1.18.x release notes](https://developer.hashicorp.com/vault/docs/v1.18.x/release-notes/1.18.0)
+- [Vault 1.17.x release notes](https://developer.hashicorp.com/vault/docs/v1.18.x/release-notes/1.17.0)
+- [Vault 1.16.x release notes](https://developer.hashicorp.com/vault/docs/v1.18.x/release-notes/1.16.1)
+
 ## Important changes
 
 | Change          | Affected releases              | Description

--- a/website/content/docs/updates/release-notes.mdx
+++ b/website/content/docs/updates/release-notes.mdx
@@ -14,9 +14,12 @@ description: >-
 
 ## Previous releases
 
-- [Vault 1.18.x release notes](/vault/docs/v1.18.x/release-notes/1.18.0)
-- [Vault 1.17.x release notes](/vault/docs/v1.18.x/release-notes/1.17.0)
-- [Vault 1.16.x release notes](/vault/docs/v1.18.x/release-notes/1.16.1)
+- Vault 1.18.x [release notes](/vault/docs/v1.18.x/release-notes/1.18.0) and
+  [important changes](/vault/docs/v1.18.x/upgrading/upgrade-to-1.18.x)
+- Vault 1.17.x [release notes](/vault/docs/v1.17.x/release-notes/1.17.0) and
+  [important changes](/vault/docs/v1.17.x/upgrading/upgrade-to-1.17.x)
+- Vault 1.16.x [release notes](/vault/docs/v1.16.x/release-notes/1.16.1) and
+  [important changes](/vault/docs/v1.16.x/upgrading/upgrade-to-1.16.x)
 
 ## Important changes
 

--- a/website/content/docs/updates/release-notes.mdx
+++ b/website/content/docs/updates/release-notes.mdx
@@ -14,9 +14,9 @@ description: >-
 
 ## Previous releases
 
-- [Vault 1.18.x release notes](https://developer.hashicorp.com/vault/docs/v1.18.x/release-notes/1.18.0)
-- [Vault 1.17.x release notes](https://developer.hashicorp.com/vault/docs/v1.18.x/release-notes/1.17.0)
-- [Vault 1.16.x release notes](https://developer.hashicorp.com/vault/docs/v1.18.x/release-notes/1.16.1)
+- [Vault 1.18.x release notes](/vault/docs/v1.18.x/release-notes/1.18.0)
+- [Vault 1.17.x release notes](/vault/docs/v1.18.x/release-notes/1.17.0)
+- [Vault 1.16.x release notes](/vault/docs/v1.18.x/release-notes/1.16.1)
 
 ## Important changes
 


### PR DESCRIPTION
Add explicit links to older release notes since the version drop-down won't list older versions :(