### PR TITLE
Replace summary in important changes section

### DIFF
--- a/website/content/docs/updates/important-changes.mdx
+++ b/website/content/docs/updates/important-changes.mdx
@@ -154,6 +154,7 @@ the external group associated with the client entity changes.
 ### Recommendation
 
 Direct all logins and token renewals to the active/primary node.
+Or upgrade to Vault 1.19.3+
 
 
 ## Strict validation for Azure auth login requests ((#strict-azure))
@@ -187,30 +188,22 @@ roles behave as expected.
 
 ### Recommendation
 
-If you rely on LDAP static roles, upgrade to Vault 1.19.2+, 1.18.8+, 1.17.15+,
-or 1.16.19+.
+If you rely on LDAP static roles, upgrade to Vault 1.19.3+, 1.18.9+, 1.17.16+,
+or 1.16.20+.
 
 
 ## Static DB role rotations on upgrade ((#db-static-role-rotations))
 
-| Change       | Affected version  | Affected deployments
-| ------------ | ----------------- | --------------------
-| Known issue  | 1.14.x or earlier | any
+| Change       | Affected version                                                        | Affected deployments
+| ------------ | ----------------------------------------------------------------------- | --------------------
+| Known issue  | 1.19.0 - 1.19.2, 1.18.5 - 1.18.8, 1.17.12 - 1.17.15, 1.16.16 - 1.16.19  | any
 
-When upgrading from Vault version 1.14.x or earlier, Vault automatically rotates
-existing static roles tied to database credentials once when upgrading to an
-affected version. After the one-time rotation, the static roles behave as
-expected.
+Any database static role that was created prior to Vault 1.15.0 will be affected upon upgrading to the affected Vault versions.
+Vault will automatically rotate static database credentials once, for all roles created prior to 1.15.0, when upgrading to affected versions.
+After the one-time rotation, the static roles behave as expected.
 
 ### Recommendation
-
-If you rely on database static roles, avoid directly upgrading to the following
-Vault versions:
-
-- 1.19.0 - 1.19.2
-- 1.18.5 - 1.18.8
-- 1.17.12 - 1.17.15
-- 1.16.16 - 1.16.19
+Upgrade to 1.19.3+, 1.18.9+, 1.17.16, 1.16.20+
 
 
 ## Vault log file missing subsystem logs ((#missing-logs))
@@ -225,7 +218,7 @@ expected in standard error and standard output.
 
 ### Recommendation
 
-Upgrade to one of the following Vault versions: 1.16.1+, 1.17.14+, 1.18.7+,
+Upgrade to one of the following Vault versions: 1.16.18+, 1.17.14+, 1.18.7+,
 1.19.1+
 
 

--- a/website/content/docs/updates/release-notes.mdx
+++ b/website/content/docs/updates/release-notes.mdx
@@ -35,7 +35,7 @@ description: >-
 | Known issue     | 1.19.x                         | [Login/token renewal failures after group changes](/vault/docs/updates/important-changes#group-writes)
 | New behavior    | 1.19.x, 1.18.x, 1.17.x, 1.16.x | [Strict validation for Azure auth login requests](/vault/docs/updates/important-changes#strict-azure)
 | Known issue     | 1.19.x, 1.18.x, 1.17.x, 1.16.x | [Unexpected LDAP static role rotations on upgrade](/vault/docs/updates/important-changes#ldap-static-role-rotations)
-| Known issue     | 1.14.x and earlier             | [Unexpected DB static role rotations on upgrade](/vault/docs/updates/important-changes#db-static-role-rotations)
+| Known issue     | 1.19.x, 1.18.x, 1.17.x, 1.16.x | [Unexpected DB static role rotations on upgrade](/vault/docs/updates/important-changes#db-static-role-rotations)
 | Known issue     | 1.19.x, 1.18.x, 1.17.x, 1.16.x | [Vault log file missing subsystem logs](/vault/docs/updates/important-changes#missing-logs)
 | Known issue     | 1.19.x                         | [Automated rotation stops after unseal](/vault/docs/updates/important-changes#rotation-stops)
 | Known issue     | 1.19.x, 1.18.x, 1.17.x, 1.16.x | [Azure Auth fails to authenticate Uniform VMSS instances](/vault/docs/updates/important-changes#azure-vmss)

--- a/website/content/partials/known-issues/1_19-failures-after-external-group-changes-standby.mdx
+++ b/website/content/partials/known-issues/1_19-failures-after-external-group-changes-standby.mdx
@@ -20,3 +20,4 @@ A related debug message may also appear in Vault server logs:
 
 #### Workaround
 Direct all logins and token renewals to the active node.
+Or upgrade to Vault 1.19.3+

--- a/website/content/partials/known-issues/database-static-role-premature-rotations.mdx
+++ b/website/content/partials/known-issues/database-static-role-premature-rotations.mdx
@@ -13,4 +13,8 @@ Any database static role that was created prior to Vault 1.15.0 will be affected
 Vault will automatically rotate static database credentials once, for all roles created prior to 1.15.0, when upgrading to affected versions. 
 After the one-time rotation, the static roles behave as expected.
 
-
+### Fixed Versions:
+- 1.19.3+
+- 1.18.9+
+- 1.17.16+
+- 1.16.20+

--- a/website/content/partials/known-issues/log_file_flush_issue.mdx
+++ b/website/content/partials/known-issues/log_file_flush_issue.mdx
@@ -1,7 +1,7 @@
 ### Vault log file missing subsystem logs ((#log-file))
 
 #### Fixed Versions
-- 1.16.1, 1.17.14, 1.18.7, 1.19.1
+- 1.16.18, 1.17.14, 1.18.7, 1.19.1
 
 #### Issue
 Vault configured with log_file is not capturing all logs. Some entries, 

--- a/website/content/partials/known-issues/static-role-premature-rotations.mdx
+++ b/website/content/partials/known-issues/static-role-premature-rotations.mdx
@@ -7,10 +7,10 @@
 - 1.16.16, 1.16.17, 1.16.18
 
 #### Fixed Versions
-- 1.19.2
-- 1.18.8
-- 1.17.15
-- 1.16.19
+- 1.19.3+
+- 1.18.9+
+- 1.17.16+
+- 1.16.20+
 
 #### Issue
 Vault automatically rotates existing static roles tied to LDAP


### PR DESCRIPTION
### Description
- Replaces database static role summary in important changes section 
- Add fix version 1.19.3 (not 1.19.0-1.19.2)

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
