### PR TITLE
Move CSP error to page component

### DIFF
--- a/ui/app/components/auth-form.js
+++ b/ui/app/components/auth-form.js
@@ -42,7 +42,6 @@ export default Component.extend(DEFAULTS, {
   auth: service(),
   flashMessages: service(),
   store: service(),
-  csp: service('csp-event'),
   version: service(),
   api: service(),
 
@@ -129,13 +128,6 @@ export default Component.extend(DEFAULTS, {
     type = type.toLowerCase();
     const templateName = dasherize(type);
     return templateName;
-  }),
-
-  cspError: computed('csp.connectionViolations.length', function () {
-    if (this.csp.connectionViolations.length) {
-      return `This is a standby Vault node but can't communicate with the active node via request forwarding. Sign in at the active node to use the Vault UI.`;
-    }
-    return '';
   }),
 
   allSupportedMethods: computed('methodsToShow', 'hasMethodsWithPath', 'authMethods', function () {

--- a/ui/app/components/auth/page.hbs
+++ b/ui/app/components/auth/page.hbs
@@ -3,6 +3,12 @@
   SPDX-License-Identifier: BUSL-1.1
 }}
 
+{{#if this.cspError}}
+  <Hds::Alert @type="page" @color="critical" data-test-page-error as |A|>
+    <A.Description>{{this.cspError}}</A.Description>
+  </Hds::Alert>
+{{/if}}
+
 {{#if this.mfaErrors}}
   <Hds::ApplicationState class="has-top-margin-xxl" data-test-error as |A|>
     <A.Header @title="Authentication error" />

--- a/ui/app/components/auth/page.js
+++ b/ui/app/components/auth/page.js
@@ -31,12 +31,22 @@ import { action } from '@ember/object';
  * @param {function} onNamespaceUpdate - callback task that passes user input to the controller to update the login namespace in the url query params
  * */
 
+export const CSP_ERROR =
+  "This is a standby Vault node but can't communicate with the active node via request forwarding. Sign in at the active node to use the Vault UI.";
+
 export default class AuthPage extends Component {
+  @service('csp-event') csp;
   @service flags;
 
   @tracked mfaAuthData;
   @tracked mfaErrors = '';
   @tracked preselectedAuthType;
+
+  get cspError() {
+    const isStandby = this.args.cluster.standby;
+    const hasConnectionViolations = this.csp.connectionViolations.length;
+    return isStandby && hasConnectionViolations ? CSP_ERROR : '';
+  }
 
   get namespaceInput() {
     const namespaceQP = this.args.namespaceQueryParam;

--- a/ui/app/templates/components/auth-form.hbs
+++ b/ui/app/templates/components/auth-form.hbs
@@ -41,7 +41,7 @@
     </nav>
   {{/if}}
   <div class="box is-marginless is-shadowless">
-    <MessageError @errorMessage={{if (and this.cluster.standby this.cspError) this.cspError this.error}} />
+    <MessageError @errorMessage={{this.error}} />
     {{#if this.selectedAuthBackend.path}}
       <div class="has-bottom-margin-s">
         <p class="is-label">{{this.selectedAuthBackend.path}}</p>

--- a/ui/tests/integration/components/auth/login-form-test.js
+++ b/ui/tests/integration/components/auth/login-form-test.js
@@ -5,7 +5,7 @@
 
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { click, fillIn, render, settled } from '@ember/test-helpers';
+import { click, fillIn, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import sinon from 'sinon';
 import { validate } from 'uuid';
@@ -37,16 +37,6 @@ module('Integration | Component | auth | login-form', function (hooks) {
         />
         `);
     };
-  });
-  const CSP_ERR_TEXT = `Error This is a standby Vault node but can't communicate with the active node via request forwarding. Sign in at the active node to use the Vault UI.`;
-  test('it renders error on CSP violation', async function (assert) {
-    assert.expect(2);
-    this.cluster.standby = true;
-    await this.renderComponent();
-    assert.dom(GENERAL.messageError).doesNotExist();
-    this.owner.lookup('service:csp-event').handleEvent({ violatedDirective: 'connect-src' });
-    await settled();
-    assert.dom(GENERAL.messageError).hasText(CSP_ERR_TEXT);
   });
 
   test('it renders with vault style errors', async function (assert) {


### PR DESCRIPTION
### Description
Moves CSP error to page alert, out of auth form

# Before
<img width="600" alt="Screenshot 2025-05-01 at 6 06 37 PM" src="https://github.com/user-attachments/assets/34249d27-0ebc-457c-a0c7-e6f870b9a791" />


# After
<img width="600" alt="Screenshot 2025-05-01 at 6 04 48 PM" src="https://github.com/user-attachments/assets/c7b4e466-aa98-4646-b318-3a4fa7280673" />

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
