### PR TITLE
Add tweaks to tests for the new enterprise SCEP test

### DIFF
--- a/command/base_predict_test.go
+++ b/command/base_predict_test.go
@@ -390,6 +390,7 @@ func TestPredict_Plugins(t *testing.T) {
 				"redis-elasticache-database-plugin",
 				"redshift-database-plugin",
 				"saml",
+				"scep",
 				"snowflake-database-plugin",
 				"ssh",
 				"terraform",
@@ -439,6 +440,14 @@ func TestPredict_Plugins(t *testing.T) {
 				if !strutil.StrListContains(act, "saml") {
 					for i, v := range tc.exp {
 						if v == "saml" {
+							tc.exp = append(tc.exp[:i], tc.exp[i+1:]...)
+							break
+						}
+					}
+				}
+				if !strutil.StrListContains(act, "scep") {
+					for i, v := range tc.exp {
+						if v == "scep" {
 							tc.exp = append(tc.exp[:i], tc.exp[i+1:]...)
 							break
 						}

--- a/helper/builtinplugins/registry_test.go
+++ b/helper/builtinplugins/registry_test.go
@@ -99,7 +99,7 @@ func Test_RegistryKeyCounts(t *testing.T) {
 			name:       "number of auth plugins",
 			pluginType: consts.PluginTypeCredential,
 			want:       18,
-			entWant:    1,
+			entWant:    2,
 		},
 		{
 			name:       "number of database plugins",

--- a/scripts/gen_openapi.sh
+++ b/scripts/gen_openapi.sh
@@ -94,6 +94,7 @@ if [[ -n "${VAULT_LICENSE:-}" ]]; then
     vault secrets enable "kmip"
     vault secrets enable "transform"
     vault auth enable "saml"
+    vault auth enable "scep"
 fi
 
 # Output OpenAPI, optionally formatted


### PR DESCRIPTION
### Description

This PR tweaks various test cases for the new enterprise SCEP authorization plugin.

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [X] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [X] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [X] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
