### PR TITLE
UI: fix doc links for postgres plugin type

### DIFF
--- a/ui/app/models/database/connection.js
+++ b/ui/app/models/database/connection.js
@@ -83,7 +83,7 @@ export default Model.extend({
   disable_escaping: attr('boolean', {
     defaultValue: false,
     subText: 'Turns off the escaping of special characters inside of the username and password fields.',
-    docLink: 'https://developer.hashicorp.com/vault/docs/secrets/databases#disable-character-escaping',
+    docLink: '/vault/docs/secrets/databases#disable-character-escaping',
   }),
 
   // optional
@@ -149,12 +149,11 @@ export default Model.extend({
           'When set to "scram-sha-256", passwords will be hashed by Vault and stored as-is by PostgreSQL. Using "scram-sha-256" requires a minimum version of PostgreSQL 10.',
       },
     ],
-    docLink:
-      'https://developer.hashicorp.com/vault/api-docs/secret/databases/postgresql#password_authentication',
+    docLink: '/vault/api-docs/secret/databases/postgresql#password_authentication',
   }),
   auth_type: attr('string', {
     subText: 'If set to "gcp_iam", will enable IAM authentication to a Google CloudSQL instance.',
-    docLink: 'https://developer.hashicorp.com/vault/api-docs/secret/databases/postgresql#auth_type',
+    docLink: '/vault/api-docs/secret/databases/postgresql#auth_type',
   }),
   service_account_json: attr('string', {
     label: 'Service account JSON',


### PR DESCRIPTION
### Description
What does this PR do?

Fixes documentation links for some postgreSQL input fields that were pointing to invalid doc links

Ex: `https://developer.hashicorp.comhttps//developer.hashicorp.com/vault/api-docs/secret/databases/postgresql#auth_type.`

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
