### PR TITLE
UI: Update remaining copyright headers 

### DIFF
--- a/ui/app/components/auth/fields.hbs
+++ b/ui/app/components/auth/fields.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#each @loginFields as |field|}}
   {{#let field.name field.label field.helperText as |name label helperText|}}

--- a/ui/app/components/auth/form-template.hbs
+++ b/ui/app/components/auth/form-template.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if this.formComponent}}
   {{#let (component this.formComponent) as |AuthFormComponent|}}

--- a/ui/app/components/auth/form/base.hbs
+++ b/ui/app/components/auth/form/base.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{! Auth methods with standard login flows use this template. To implement any custom logic, this template should be copied into a new hbs file for that method. }}
 

--- a/ui/app/components/auth/form/oidc-jwt.hbs
+++ b/ui/app/components/auth/form/oidc-jwt.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <form
   {{did-insert this.initializeFormData}}

--- a/ui/app/components/auth/form/okta.hbs
+++ b/ui/app/components/auth/form/okta.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#if this.showNumberChallenge}}
   <OktaNumberChallenge

--- a/ui/app/components/auth/form/saml.hbs
+++ b/ui/app/components/auth/form/saml.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <form {{on "submit" this.onSubmit}} data-test-auth-form={{@authType}}>
 

--- a/ui/app/components/auth/namespace-input.hbs
+++ b/ui/app/components/auth/namespace-input.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="background-neutral-50 has-padding-l">
   {{#if @hvdManagedNamespace}}

--- a/ui/app/components/auth/tabs.hbs
+++ b/ui/app/components/auth/tabs.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Hds::Tabs @onClickTab={{@onTabClick}} @selectedTabIndex={{@selectedTabIndex}} as |T|>
   {{#each-in @authTabs as |methodType mounts|}}

--- a/ui/app/components/generate-credentials-totp.hbs
+++ b/ui/app/components/generate-credentials-totp.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/app/components/secret-list/totp-list-item.hbs
+++ b/ui/app/components/secret-list/totp-list-item.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <LinkedBlock
   @params={{array "vault.cluster.secrets.backend.show" @item.id}}

--- a/ui/app/components/totp-edit.hbs
+++ b/ui/app/components/totp-edit.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <PageHeader as |p|>
   <p.top>

--- a/ui/app/components/totp/key-create-toggle-groups.hbs
+++ b/ui/app/components/totp/key-create-toggle-groups.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#each-in @groups as |group fields|}}
   <ToggleButton

--- a/ui/app/components/totp/key-create.hbs
+++ b/ui/app/components/totp/key-create.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <form {{on "submit" (perform @onSubmit)}}>
   <div class="box is-sideless is-fullwidth is-marginless">

--- a/ui/app/components/totp/key-details.hbs
+++ b/ui/app/components/totp/key-details.hbs
@@ -1,7 +1,8 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
+
 <Toolbar>
   <ToolbarActions>
     <ToolbarLink @route="vault.cluster.secrets.backend.credentials" @model={{@model.id}}>

--- a/ui/app/components/totp/key-qr-code.hbs
+++ b/ui/app/components/totp/key-qr-code.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class="box is-fullwidth is-sideless is-paddingless is-marginless">
   <MessageError @model={{@model}} />


### PR DESCRIPTION
### Description
Update the headers of `.hbs` files that still contain a `~` to prevent noisy output when building. 

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
