### PR TITLE
Move fetching unauthenticated mounts to the route

### DIFF
--- a/ui/app/components/auth/form-template.hbs
+++ b/ui/app/components/auth/form-template.hbs
@@ -3,104 +3,106 @@
   SPDX-License-Identifier: BUSL-1.1
 ~}}
 
-{{#if this.formComponent}}
-  {{#let (component this.formComponent) as |AuthFormComponent|}}
-    {{! renders Auth::Form::Base or Auth::Form::<Type>}}
-    <AuthFormComponent
-      @authType={{this.selectedAuthMethod}}
-      @cluster={{@cluster}}
-      @onError={{this.handleError}}
-      @onSuccess={{@onSuccess}}
-    >
-      <:namespace>
-        {{#if (has-feature "Namespaces")}}
-          <Auth::NamespaceInput
-            @disabled={{@oidcProviderQueryParam}}
-            @hvdManagedNamespace={{this.flags.hvdManagedNamespaceRoot}}
-            @namespaceValue={{this.namespaceInput}}
-            @updateNamespace={{this.handleNamespaceUpdate}}
-          />
-        {{/if}}
-      </:namespace>
-
-      <:back>
-        {{#if this.showOtherMethods}}
-          <Hds::Button
-            @text="Back"
-            {{on "click" this.toggleView}}
-            @color="tertiary"
-            @icon="arrow-left"
-            data-test-back-button
-          />
-        {{/if}}
-      </:back>
-
-      {{! TABS OR DROPDOWN }}
-      <:authSelectOptions>
-        <div class="has-bottom-margin-m">
-          {{#if this.renderTabs}}
-            <Auth::Tabs
-              @authTabData={{@authTabData}}
-              @authTabTypes={{this.authTabTypes}}
-              @displayNameHelper={{this.displayName}}
-              @handleTabClick={{this.setAuthType}}
-              @selectedAuthMethod={{this.selectedAuthMethod}}
+<div {{did-insert this.initializeState}}>
+  {{#if this.formComponent}}
+    {{#let (component this.formComponent) as |AuthFormComponent|}}
+      {{! renders Auth::Form::Base or Auth::Form::<Type>}}
+      <AuthFormComponent
+        @authType={{this.selectedAuthMethod}}
+        @cluster={{@cluster}}
+        @onError={{this.handleError}}
+        @onSuccess={{@onSuccess}}
+      >
+        <:namespace>
+          {{#if (has-feature "Namespaces")}}
+            <Auth::NamespaceInput
+              @disabled={{@oidcProviderQueryParam}}
+              @hvdManagedNamespace={{this.flags.hvdManagedNamespaceRoot}}
+              @namespaceValue={{this.namespaceInput}}
+              @updateNamespace={{this.handleNamespaceUpdate}}
             />
-          {{else}}
-            <Hds::Form::Select::Field
-              name="selectedAuthMethod"
-              {{on "input" this.setTypeFromDropdown}}
-              data-test-select="auth type"
-              as |F|
-            >
-              <F.Label class="has-top-margin-m">Auth method</F.Label>
-              <F.Options>
-                {{#each this.availableMethodTypes as |type|}}
-                  <option selected={{eq this.selectedAuthMethod type}} value={{type}}>
-                    {{this.displayName type}}
-                  </option>
-                {{/each}}
-              </F.Options>
-            </Hds::Form::Select::Field>
           {{/if}}
-        </div>
-      </:authSelectOptions>
+        </:namespace>
 
-      <:error>
-        {{#if this.errorMessage}}
-          <MessageError @errorMessage={{this.errorMessage}} />
-        {{/if}}
-      </:error>
+        <:back>
+          {{#if this.showOtherMethods}}
+            <Hds::Button
+              @text="Back"
+              {{on "click" this.toggleView}}
+              @color="tertiary"
+              @icon="arrow-left"
+              data-test-back-button
+            />
+          {{/if}}
+        </:back>
 
-      <:advancedSettings>
-        {{! tabs render their own mount path inputs and token does not support custom paths }}
-        {{#if (and (not this.renderTabs) (not-eq this.selectedAuthMethod "token"))}}
-          <Hds::Reveal @text="Advanced settings" data-test-auth-form-options-toggle class="is-fullwidth">
-            <Hds::Form::TextInput::Field name="path" data-test-input="path" as |F|>
-              <F.Label class="has-top-margin-m">Mount path</F.Label>
-              <F.HelperText>
-                If this authentication method was mounted using a non-default path, input it below. Otherwise Vault will
-                assume the default path
-                <Hds::Text::Code class="code-in-text">{{this.selectedAuthMethod}}</Hds::Text::Code>
-                .</F.HelperText>
-            </Hds::Form::TextInput::Field>
-          </Hds::Reveal>
-        {{/if}}
-      </:advancedSettings>
+        {{! TABS OR DROPDOWN }}
+        <:authSelectOptions>
+          <div class="has-bottom-margin-m">
+            {{#if this.renderTabs}}
+              <Auth::Tabs
+                @authTabData={{@authTabData}}
+                @authTabTypes={{this.authTabTypes}}
+                @displayNameHelper={{this.displayName}}
+                @handleTabClick={{this.setAuthType}}
+                @selectedAuthMethod={{this.selectedAuthMethod}}
+              />
+            {{else}}
+              <Hds::Form::Select::Field
+                name="selectedAuthMethod"
+                {{on "input" this.setTypeFromDropdown}}
+                data-test-select="auth type"
+                as |F|
+              >
+                <F.Label class="has-top-margin-m">Auth method</F.Label>
+                <F.Options>
+                  {{#each this.availableMethodTypes as |type|}}
+                    <option selected={{eq this.selectedAuthMethod type}} value={{type}}>
+                      {{this.displayName type}}
+                    </option>
+                  {{/each}}
+                </F.Options>
+              </Hds::Form::Select::Field>
+            {{/if}}
+          </div>
+        </:authSelectOptions>
 
-      <:footer>
-        {{#if this.renderTabs}}
-          <Hds::Button
-            {{on "click" this.toggleView}}
-            @color="tertiary"
-            @icon="arrow-right"
-            @iconPosition="trailing"
-            @isInline={{true}}
-            @text="Sign in with other methods"
-            data-test-other-methods-button
-          />
-        {{/if}}
-      </:footer>
-    </AuthFormComponent>
-  {{/let}}
-{{/if}}
+        <:error>
+          {{#if this.errorMessage}}
+            <MessageError @errorMessage={{this.errorMessage}} />
+          {{/if}}
+        </:error>
+
+        <:advancedSettings>
+          {{! tabs render their own mount path inputs and token does not support custom paths }}
+          {{#if (and (not this.renderTabs) (not-eq this.selectedAuthMethod "token"))}}
+            <Hds::Reveal @text="Advanced settings" data-test-auth-form-options-toggle class="is-fullwidth">
+              <Hds::Form::TextInput::Field name="path" data-test-input="path" as |F|>
+                <F.Label class="has-top-margin-m">Mount path</F.Label>
+                <F.HelperText>
+                  If this authentication method was mounted using a non-default path, input it below. Otherwise Vault will
+                  assume the default path
+                  <Hds::Text::Code class="code-in-text">{{this.selectedAuthMethod}}</Hds::Text::Code>
+                  .</F.HelperText>
+              </Hds::Form::TextInput::Field>
+            </Hds::Reveal>
+          {{/if}}
+        </:advancedSettings>
+
+        <:footer>
+          {{#if this.renderTabs}}
+            <Hds::Button
+              {{on "click" this.toggleView}}
+              @color="tertiary"
+              @icon="arrow-right"
+              @iconPosition="trailing"
+              @isInline={{true}}
+              @text="Sign in with other methods"
+              data-test-other-methods-button
+            />
+          {{/if}}
+        </:footer>
+      </AuthFormComponent>
+    {{/let}}
+  {{/if}}
+</div>

--- a/ui/app/components/auth/form-template.hbs
+++ b/ui/app/components/auth/form-template.hbs
@@ -40,7 +40,7 @@
         <div class="has-bottom-margin-m">
           {{#if this.renderTabs}}
             <Auth::Tabs
-              @authTabData={{this.authTabData}}
+              @authTabData={{@authTabData}}
               @authTabTypes={{this.authTabTypes}}
               @displayNameHelper={{this.displayName}}
               @handleTabClick={{this.setAuthType}}

--- a/ui/app/components/auth/form-template.hbs
+++ b/ui/app/components/auth/form-template.hbs
@@ -18,7 +18,7 @@
           <Auth::NamespaceInput
             @disabled={{@oidcProviderQueryParam}}
             @hvdManagedNamespace={{this.flags.hvdManagedNamespaceRoot}}
-            @namespace={{this.namespaceInput}}
+            @namespaceValue={{this.namespaceInput}}
             @updateNamespace={{this.handleNamespaceUpdate}}
           />
         {{/if}}

--- a/ui/app/components/auth/form-template.hbs
+++ b/ui/app/components/auth/form-template.hbs
@@ -11,10 +11,9 @@
       @cluster={{@cluster}}
       @onError={{this.handleError}}
       @onSuccess={{@onSuccess}}
-      @wrappedToken={{@wrappedToken}}
     >
       <:namespace>
-        {{#if this.version.isEnterprise}}
+        {{#if (has-feature "Namespaces")}}
           <Auth::NamespaceInput
             @disabled={{@oidcProviderQueryParam}}
             @hvdManagedNamespace={{this.flags.hvdManagedNamespaceRoot}}
@@ -41,16 +40,16 @@
         <div class="has-bottom-margin-m">
           {{#if this.renderTabs}}
             <Auth::Tabs
-              @authTabs={{this.authTabs}}
+              @authTabData={{this.authTabData}}
+              @authTabTypes={{this.authTabTypes}}
               @displayNameHelper={{this.displayName}}
-              @onTabClick={{fn this.handleAuthSelect "tab"}}
+              @handleTabClick={{this.setAuthType}}
               @selectedAuthMethod={{this.selectedAuthMethod}}
-              @selectedTabIndex={{this.selectedTabIndex}}
             />
           {{else}}
             <Hds::Form::Select::Field
               name="selectedAuthMethod"
-              {{on "input" (fn this.handleAuthSelect "dropdown")}}
+              {{on "input" this.setTypeFromDropdown}}
               data-test-select="auth type"
               as |F|
             >

--- a/ui/app/components/auth/form-template.ts
+++ b/ui/app/components/auth/form-template.ts
@@ -34,7 +34,7 @@ import type { HTMLElementEvent } from 'vault/forms';
  * @param {boolean} hasVisibleAuthMounts - whether or not any mounts have been tuned with listing_visibility="unauth"
  * @param {string} namespaceQueryParam - namespace query param from the url
  * @param {function} onSuccess - callback after the initial authentication request, if an mfa_requirement exists the parent renders the mfa form otherwise it fires the authSuccess action in the auth controller and handles transitioning to the app
- * @param {string} preselectedAuthType - auth type to preselect to in login form, set from either local storage (last method used to log in) or on canceled mfa validation
+ * @param {string} presetAuthType - auth type to preselect to in login form, set from either local storage (last method used to log in) or on canceled mfa validation
  *
  * */
 
@@ -45,7 +45,7 @@ interface Args {
   hasVisibleAuthMounts: boolean;
   namespaceQueryParam: string;
   onSuccess: CallableFunction;
-  preselectedAuthType: string; // set by local storage or canceled MFA validation
+  presetAuthType: string; // set by local storage or canceled MFA validation
 }
 
 export default class AuthFormTemplate extends Component<Args> {
@@ -73,13 +73,13 @@ export default class AuthFormTemplate extends Component<Args> {
 
   initializeState() {
     // SET AUTH TYPE
-    if (!this.args.preselectedAuthType) {
+    if (!this.args.presetAuthType) {
       // if nothing has been preselected, select first tab or set to 'token'
       const authType = this.args.hasVisibleAuthMounts ? (this.authTabTypes[0] as string) : 'token';
       this.setAuthType(authType);
     } else {
       // there is a preselected type, set is as the selectedAuthType
-      this.setAuthType(this.args.preselectedAuthType);
+      this.setAuthType(this.args.presetAuthType);
     }
 
     // INITIALLY RENDER TABS OR DROPDOWN
@@ -149,7 +149,7 @@ export default class AuthFormTemplate extends Component<Args> {
       this.setAuthType(firstTab);
     } else {
       // all methods render, reset dropdown
-      this.selectedAuthMethod = this.args.preselectedAuthType || 'token';
+      this.selectedAuthMethod = this.args.presetAuthType || 'token';
     }
   }
 

--- a/ui/app/components/auth/form-template.ts
+++ b/ui/app/components/auth/form-template.ts
@@ -41,7 +41,7 @@ interface Args {
   cluster: ClusterModel;
   handleNamespaceUpdate: CallableFunction;
   preselectedAuthType: string;
-  namespace: string;
+  namespaceQueryParam: string;
   onSuccess: CallableFunction;
 }
 
@@ -97,7 +97,7 @@ export default class AuthFormTemplate extends Component<Args> {
   }
 
   get namespaceInput() {
-    const namespaceQueryParam = this.args.namespace;
+    const namespaceQueryParam = this.args.namespaceQueryParam;
     if (this.flags.hvdManagedNamespaceRoot) {
       // When managed, the user isn't allowed to edit the prefix `admin/`
       // so prefill just the relative path in the namespace input

--- a/ui/app/components/auth/form-template.ts
+++ b/ui/app/components/auth/form-template.ts
@@ -65,32 +65,6 @@ export default class AuthFormTemplate extends Component<Args> {
     return displayName || type;
   };
 
-  constructor(owner: unknown, args: Args) {
-    super(owner, args);
-    // ensures args have settled before setting form state
-    setTimeout(() => this.initializeState(), 0);
-  }
-
-  initializeState() {
-    // SET AUTH TYPE
-    if (!this.args.presetAuthType) {
-      // if nothing has been preselected, select first tab or set to 'token'
-      const authType = this.args.hasVisibleAuthMounts ? (this.authTabTypes[0] as string) : 'token';
-      this.setAuthType(authType);
-    } else {
-      // there is a preselected type, set is as the selectedAuthType
-      this.setAuthType(this.args.presetAuthType);
-    }
-
-    // INITIALLY RENDER TABS OR DROPDOWN
-    // render tabs if selectedAuthMethod is one, otherwise render dropdown (i.e. showOtherMethods = false)
-    if (this.args.hasVisibleAuthMounts) {
-      this.showOtherMethods = this.authTabTypes.includes(this.selectedAuthMethod) ? false : true;
-    } else {
-      this.showOtherMethods = false;
-    }
-  }
-
   get authTabTypes() {
     const visibleMounts = this.args.authTabData;
     return visibleMounts ? Object.keys(visibleMounts) : [];
@@ -128,6 +102,27 @@ export default class AuthFormTemplate extends Component<Args> {
       return true;
     }
     return false;
+  }
+
+  @action
+  initializeState() {
+    // SET AUTH TYPE
+    if (!this.args.presetAuthType) {
+      // if nothing has been preselected, select first tab or set to 'token'
+      const authType = this.args.hasVisibleAuthMounts ? (this.authTabTypes[0] as string) : 'token';
+      this.setAuthType(authType);
+    } else {
+      // there is a preselected type, set is as the selectedAuthType
+      this.setAuthType(this.args.presetAuthType);
+    }
+
+    // INITIALLY RENDER TABS OR DROPDOWN
+    // render tabs if selectedAuthMethod is one, otherwise render dropdown (i.e. showOtherMethods = false)
+    if (this.args.hasVisibleAuthMounts) {
+      this.showOtherMethods = this.authTabTypes.includes(this.selectedAuthMethod) ? false : true;
+    } else {
+      this.showOtherMethods = false;
+    }
   }
 
   @action

--- a/ui/app/components/auth/form-template.ts
+++ b/ui/app/components/auth/form-template.ts
@@ -1,8 +1,3 @@
-/**
- * Copyright (c) HashiCorp, Inc.
- * SPDX-License-Identifier: BUSL-1.1
- */
-
 import Component from '@glimmer/component';
 import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
@@ -15,6 +10,7 @@ import type Store from '@ember-data/store';
 import type VersionService from 'vault/services/version';
 import type ClusterModel from 'vault/models/cluster';
 import type { HTMLElementEvent } from 'vault/forms';
+import type { AuthTabData, VisibleAuthMounts } from 'vault/vault/auth/form';
 
 /**
  * @module Auth::FormTemplate
@@ -45,25 +41,6 @@ interface Args {
   visibleAuthMounts: VisibleAuthMounts;
 }
 
-interface VisibleAuthMounts {
-  [key: string]: {
-    description: string;
-    type: string;
-  };
-}
-
-interface AuthTabData {
-  // key is the auth method type
-  [key: string]: MountData[];
-}
-
-interface MountData {
-  path: string;
-  type: string;
-  description?: string;
-  config?: object | null;
-}
-
 export default class AuthFormTemplate extends Component<Args> {
   @service declare readonly flags: FlagsService;
   @service declare readonly store: Store;
@@ -71,6 +48,7 @@ export default class AuthFormTemplate extends Component<Args> {
 
   // form display logic
   @tracked showOtherMethods = false;
+  @tracked authTabData: AuthTabData | null = null;
 
   // auth login variables
   @tracked selectedAuthMethod = '';
@@ -88,6 +66,9 @@ export default class AuthFormTemplate extends Component<Args> {
   }
 
   initializeState() {
+    // FORMAT MOUNT DATA
+    this.authTabData = this.formatTabs();
+
     // SET AUTH TYPE
     if (!this.args.preselectedAuthType) {
       // if nothing has been preselected, select first tab or set to 'token'
@@ -112,7 +93,7 @@ export default class AuthFormTemplate extends Component<Args> {
     return this.authTabData ? Object.keys(this.authTabData) : [];
   }
 
-  get authTabData() {
+  formatTabs() {
     if (this.args.visibleAuthMounts) {
       const authMounts = this.args.visibleAuthMounts;
       return Object.entries(authMounts).reduce((obj, [path, mountData]) => {

--- a/ui/app/components/auth/form-template.ts
+++ b/ui/app/components/auth/form-template.ts
@@ -72,7 +72,7 @@ export default class AuthFormTemplate extends Component<Args> {
 
   initializeState() {
     // FORMAT MOUNT DATA
-    this.authTabData = this.formatTabs();
+    this.authTabData = this._formatTabs();
 
     // SET AUTH TYPE
     if (!this.args.preselectedAuthType) {
@@ -96,19 +96,6 @@ export default class AuthFormTemplate extends Component<Args> {
 
   get authTabTypes() {
     return this.authTabData ? Object.keys(this.authTabData) : [];
-  }
-
-  formatTabs() {
-    if (this.args.visibleAuthMounts) {
-      const authMounts = this.args.visibleAuthMounts;
-      return Object.entries(authMounts).reduce((obj, [path, mountData]) => {
-        const { type } = mountData;
-        obj[type] ??= []; // if an array doesn't already exist for that type, create it
-        obj[type].push({ path, ...mountData });
-        return obj;
-      }, {} as AuthTabData);
-    }
-    return null;
   }
 
   get availableMethodTypes() {
@@ -175,7 +162,20 @@ export default class AuthFormTemplate extends Component<Args> {
   }
 
   @action
-  async handleNamespaceUpdate(event: HTMLElementEvent<HTMLInputElement>) {
+  handleNamespaceUpdate(event: HTMLElementEvent<HTMLInputElement>) {
     this.args.handleNamespaceUpdate(event.target.value);
+  }
+
+  _formatTabs() {
+    if (this.args.visibleAuthMounts) {
+      const authMounts = this.args.visibleAuthMounts;
+      return Object.entries(authMounts).reduce((obj, [path, mountData]) => {
+        const { type } = mountData;
+        obj[type] ??= []; // if an array doesn't already exist for that type, create it
+        obj[type].push({ path, ...mountData });
+        return obj;
+      }, {} as AuthTabData);
+    }
+    return null;
   }
 }

--- a/ui/app/components/auth/form-template.ts
+++ b/ui/app/components/auth/form-template.ts
@@ -1,3 +1,8 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
 import Component from '@glimmer/component';
 import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';

--- a/ui/app/components/auth/form-template.ts
+++ b/ui/app/components/auth/form-template.ts
@@ -14,8 +14,8 @@ import type FlagsService from 'vault/services/flags';
 import type Store from '@ember-data/store';
 import type VersionService from 'vault/services/version';
 import type ClusterModel from 'vault/models/cluster';
-import type { HTMLElementEvent } from 'vault/forms';
 import type { AuthTabData } from 'vault/vault/auth/form';
+import type { HTMLElementEvent } from 'vault/forms';
 
 /**
  * @module Auth::FormTemplate
@@ -55,7 +55,6 @@ export default class AuthFormTemplate extends Component<Args> {
 
   // form display logic
   @tracked showOtherMethods = false;
-  @tracked authTabData: AuthTabData | null = null;
 
   // auth login variables
   @tracked selectedAuthMethod = '';

--- a/ui/app/components/auth/form/base.hbs
+++ b/ui/app/components/auth/form/base.hbs
@@ -22,7 +22,7 @@
       @text="Sign in"
       @isFullWidth={{true}}
       type="submit"
-      class="has-top-margin-m has-bottom-margin-m"
+      class="has-top-margin-xl has-bottom-margin-xl"
       data-test-auth-submit
     />
 

--- a/ui/app/components/auth/form/base.ts
+++ b/ui/app/components/auth/form/base.ts
@@ -15,7 +15,9 @@ import type AuthService from 'vault/vault/services/auth';
 import type ClusterModel from 'vault/models/cluster';
 import type FlagsService from 'vault/services/flags';
 import type VersionService from 'vault/services/version';
+import type { AuthResponse } from 'vault/vault/services/auth';
 import type { HTMLElementEvent } from 'vault/forms';
+import type { LoginFields } from 'vault/vault/auth/form';
 import type { MfaRequirementApiResponse, ParsedMfaRequirement } from 'vault/vault/auth/mfa';
 
 /**
@@ -33,17 +35,6 @@ interface Args {
   onError: CallableFunction;
   onSuccess: CallableFunction;
 }
-
-interface AuthResponse {
-  namespace: string;
-  token: string; // the name of the token in local storage, not the actual token
-  isRoot: boolean;
-}
-
-export type LoginFields = Partial<Record<(typeof POSSIBLE_FIELDS)[number], string | undefined>> & {
-  path?: string | undefined;
-  namespace?: string | undefined;
-};
 
 export default class AuthBase extends Component<Args> {
   @service declare readonly auth: AuthService;

--- a/ui/app/components/auth/form/oidc-jwt.hbs
+++ b/ui/app/components/auth/form/oidc-jwt.hbs
@@ -35,7 +35,7 @@
       @icon={{if this.tasksAreRunning "loading" this.icon}}
       @isFullWidth={{true}}
       @text="Sign in {{if this.isOIDC this.providerName}}"
-      class="has-top-margin-m has-bottom-margin-m"
+      class="has-top-margin-xl has-bottom-margin-xl"
       type="submit"
       data-test-auth-submit
     />

--- a/ui/app/components/auth/form/okta.hbs
+++ b/ui/app/components/auth/form/okta.hbs
@@ -27,7 +27,7 @@
         @text="Sign in"
         @isFullWidth={{true}}
         type="submit"
-        class="has-top-margin-m has-bottom-margin-m"
+        class="has-top-margin-xl has-bottom-margin-xl"
         data-test-auth-submit
       />
 

--- a/ui/app/components/auth/form/saml.hbs
+++ b/ui/app/components/auth/form/saml.hbs
@@ -22,7 +22,7 @@
         @icon={{if this.tasksAreRunning "loading" this.icon}}
         @isFullWidth={{true}}
         @text="Sign in with SAML provider"
-        class="has-top-margin-m has-bottom-margin-m"
+        class="has-top-margin-xl has-bottom-margin-xl"
         type="submit"
         data-test-auth-submit
       />

--- a/ui/app/components/auth/namespace-input.hbs
+++ b/ui/app/components/auth/namespace-input.hbs
@@ -20,8 +20,8 @@
           />
           <SG.TextInput
             {{on "input" @updateNamespace}}
-            @value={{@namespace}}
-            autocomplete="namespace"
+            @value={{@namespaceValue}}
+            autocomplete="off"
             disabled={{@disabled}}
             name="namespace"
             placeholder="/ (default)"
@@ -33,8 +33,8 @@
   {{else}}
     <Hds::Form::TextInput::Field
       {{on "input" @updateNamespace}}
-      @value={{@namespace}}
-      autocomplete="namespace"
+      @value={{@namespaceValue}}
+      autocomplete="off"
       disabled={{@disabled}}
       name="namespace"
       placeholder="/ (root)"

--- a/ui/app/components/auth/page.js
+++ b/ui/app/components/auth/page.js
@@ -29,6 +29,7 @@ import { action } from '@ember/object';
  * @param {string} oidcProviderQueryParam - oidc provider query param, set in url as "?o=someprovider"
  * @param {function} onAuthSuccess - callback task in controller that receives the auth response (after MFA, if enabled) when login is successful
  * @param {function} onNamespaceUpdate - callback task that passes user input to the controller to update the login namespace in the url query params
+ * @param {object} visibleAuthMounts - keys are auth methods to render as tabs, values is an array of mount data for mounts with listing_visibility="unauth"
  * */
 
 export const CSP_ERROR =
@@ -46,6 +47,20 @@ export default class AuthPage extends Component {
     const isStandby = this.args.cluster.standby;
     const hasConnectionViolations = this.csp.connectionViolations.length;
     return isStandby && hasConnectionViolations ? CSP_ERROR : '';
+  }
+
+  get authTabData() {
+    const visibleAuthMounts = this.args.visibleAuthMounts;
+    if (visibleAuthMounts) {
+      const authMounts = visibleAuthMounts;
+      return Object.entries(authMounts).reduce((obj, [path, mountData]) => {
+        const { type } = mountData;
+        obj[type] ??= []; // if an array doesn't already exist for that type, create it
+        obj[type].push({ path, ...mountData });
+        return obj;
+      }, {});
+    }
+    return null;
   }
 
   get preselectedAuthType() {

--- a/ui/app/components/auth/page.js
+++ b/ui/app/components/auth/page.js
@@ -63,7 +63,7 @@ export default class AuthPage extends Component {
     return null;
   }
 
-  get preselectedAuthType() {
+  get presetAuthType() {
     // for now storedLoginData is just the selectedAuth, plan is to also include namespace
     return this.canceledMfaAuth || this.args.storedLoginData;
   }

--- a/ui/app/components/auth/page.js
+++ b/ui/app/components/auth/page.js
@@ -53,6 +53,27 @@ export default class AuthPage extends Component {
     return this.canceledMfaAuth || this.args.storedLoginData;
   }
 
+  // TODO delete when Auth::FormTemplate is implemented
+  get namespaceInput() {
+    const namespaceQP = this.args.namespaceQueryParam;
+    if (this.flags.hvdManagedNamespaceRoot) {
+      // When managed, the user isn't allowed to edit the prefix `admin/` for their nested namespace
+      const split = namespaceQP.split('/');
+      if (split.length > 1) {
+        split.shift();
+        return `/${split.join('/')}`;
+      }
+      return '';
+    }
+    return namespaceQP;
+  }
+
+  // TODO delete when Auth::FormTemplate is implemented
+  @action
+  handleNamespaceUpdate(event) {
+    this.args.onNamespaceUpdate(event.target.value);
+  }
+
   @action
   onAuthResponse(authResponse, { selectedAuth, path }) {
     const { mfa_requirement } = authResponse;

--- a/ui/app/components/auth/page.js
+++ b/ui/app/components/auth/page.js
@@ -40,7 +40,7 @@ export default class AuthPage extends Component {
 
   @tracked mfaAuthData;
   @tracked mfaErrors = '';
-  @tracked preselectedAuthType;
+  @tracked canceledMfaAuth = '';
 
   get cspError() {
     const isStandby = this.args.cluster.standby;
@@ -48,23 +48,9 @@ export default class AuthPage extends Component {
     return isStandby && hasConnectionViolations ? CSP_ERROR : '';
   }
 
-  get namespaceInput() {
-    const namespaceQP = this.args.namespaceQueryParam;
-    if (this.flags.hvdManagedNamespaceRoot) {
-      // When managed, the user isn't allowed to edit the prefix `admin/` for their nested namespace
-      const split = namespaceQP.split('/');
-      if (split.length > 1) {
-        split.shift();
-        return `/${split.join('/')}`;
-      }
-      return '';
-    }
-    return namespaceQP;
-  }
-
-  @action
-  handleNamespaceUpdate(event) {
-    this.args.onNamespaceUpdate(event.target.value);
+  get preselectedAuthType() {
+    // for now storedLoginData is just the selectedAuth, plan is to also include namespace
+    return this.canceledMfaAuth || this.args.storedLoginData;
   }
 
   @action
@@ -89,7 +75,7 @@ export default class AuthPage extends Component {
   @action
   onCancelMfa() {
     // before resetting mfaAuthData, preserve auth type
-    this.preselectedAuthType = this.mfaAuthData.selectedAuth;
+    this.canceledMfaAuth = this.mfaAuthData.selectedAuth;
     this.mfaAuthData = null;
   }
 

--- a/ui/app/components/auth/tabs.hbs
+++ b/ui/app/components/auth/tabs.hbs
@@ -3,8 +3,8 @@
   SPDX-License-Identifier: BUSL-1.1
 ~}}
 
-<Hds::Tabs @onClickTab={{@onTabClick}} @selectedTabIndex={{@selectedTabIndex}} as |T|>
-  {{#each-in @authTabs as |methodType mounts|}}
+<Hds::Tabs @onClickTab={{this.onClickTab}} @selectedTabIndex={{this.selectedTabIndex}} as |T|>
+  {{#each-in @authTabData as |methodType mounts|}}
     <T.Tab data-test-auth-method={{methodType}}>{{@displayNameHelper methodType}}</T.Tab>
     <T.Panel>
       <div class="has-top-padding-m">

--- a/ui/app/components/auth/tabs.ts
+++ b/ui/app/components/auth/tabs.ts
@@ -9,10 +9,10 @@ import { action } from '@ember/object';
 import type { AuthTabData } from 'vault/vault/auth/form';
 
 interface Args {
-  selectedAuthMethod: string;
   authTabData: AuthTabData;
   authTabTypes: string[];
   handleTabClick: CallableFunction;
+  selectedAuthMethod: string;
 }
 
 export default class AuthTabs extends Component<Args> {

--- a/ui/app/components/auth/tabs.ts
+++ b/ui/app/components/auth/tabs.ts
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+
+interface Args {
+  selectedAuthMethod: string;
+  authTabData: AuthTabData;
+  authTabTypes: string[];
+  handleTabClick: CallableFunction;
+}
+
+interface AuthTabData {
+  // key is the auth method type
+  [key: string]: MountData[];
+}
+
+interface MountData {
+  path: string;
+  type: string;
+  description?: string;
+  config?: object | null;
+}
+
+export default class AuthTabs extends Component<Args> {
+  get selectedTabIndex() {
+    const index = this.args.authTabTypes.indexOf(this.args.selectedAuthMethod);
+    // negative index means the selected method isn't a tab, default to first tab
+    return index < 0 ? 0 : index;
+  }
+
+  @action
+  onClickTab(idx: number) {
+    this.args.handleTabClick(this.args.authTabTypes[idx]);
+  }
+}

--- a/ui/app/components/auth/tabs.ts
+++ b/ui/app/components/auth/tabs.ts
@@ -33,7 +33,7 @@ export default class AuthTabs extends Component<Args> {
   }
 
   @action
-  onClickTab(idx: number) {
+  onClickTab(_event: Event, idx: number) {
     this.args.handleTabClick(this.args.authTabTypes[idx]);
   }
 }

--- a/ui/app/components/auth/tabs.ts
+++ b/ui/app/components/auth/tabs.ts
@@ -6,23 +6,13 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 
+import type { AuthTabData } from 'vault/vault/auth/form';
+
 interface Args {
   selectedAuthMethod: string;
   authTabData: AuthTabData;
   authTabTypes: string[];
   handleTabClick: CallableFunction;
-}
-
-interface AuthTabData {
-  // key is the auth method type
-  [key: string]: MountData[];
-}
-
-interface MountData {
-  path: string;
-  type: string;
-  description?: string;
-  config?: object | null;
 }
 
 export default class AuthTabs extends Component<Args> {

--- a/ui/app/routes/vault/cluster/auth.js
+++ b/ui/app/routes/vault/cluster/auth.js
@@ -36,7 +36,6 @@ export default class AuthRoute extends ClusterRouteBase {
     const visibleAuthMounts = await this.fetchMounts();
     return {
       clusterModel,
-      namespaceInput: this.namespaceInput,
       storedLoginData: this.auth.getAuthType(),
       visibleAuthMounts,
     };

--- a/ui/app/routes/vault/cluster/auth.js
+++ b/ui/app/routes/vault/cluster/auth.js
@@ -9,8 +9,8 @@ import config from 'vault/config/environment';
 
 export default class AuthRoute extends ClusterRouteBase {
   queryParams = {
-    wrapped_token: { refreshModel: true },
     authMethod: { replace: true },
+    wrapped_token: { refreshModel: true },
   };
 
   @service api;
@@ -25,12 +25,21 @@ export default class AuthRoute extends ClusterRouteBase {
   }
 
   async model(params) {
+    const clusterModel = this.modelFor('vault.cluster');
     const wrapped_token = params?.wrapped_token;
     if (wrapped_token) {
-      const clusterModel = this.modelFor('vault.cluster');
       await this.unwrapToken(wrapped_token, clusterModel.id);
     }
-    return super.model(...arguments);
+
+    const visibleAuthMounts = await this.fetchMounts();
+
+    return {
+      clusterModel: clusterModel,
+      visibleAuthMounts,
+      // set in the route because this updates when namespace changes
+      storedLoginData: this.auth.getAuthType(),
+      namespaceInput: this.namespaceInput,
+    };
   }
 
   resetController(controller) {
@@ -46,6 +55,7 @@ export default class AuthRoute extends ClusterRouteBase {
     }
   }
 
+  // authenticates the user if the wrapped_token query param exists
   async unwrapToken(token, clusterId) {
     const authController = this.controllerFor('vault.cluster.auth');
     try {
@@ -61,6 +71,18 @@ export default class AuthRoute extends ClusterRouteBase {
     } catch (e) {
       const { message } = await this.api.parseError(e);
       authController.unwrapTokenError = message;
+    }
+  }
+
+  async fetchMounts() {
+    try {
+      const resp = await this.api.sys.internalUiListEnabledVisibleMounts(
+        this.api.buildHeaders({ token: '' })
+      );
+      return resp.auth;
+    } catch {
+      // swallow the error if there's an error fetching mount data (i.e. invalid namespace)
+      return null;
     }
   }
 }

--- a/ui/app/routes/vault/cluster/auth.js
+++ b/ui/app/routes/vault/cluster/auth.js
@@ -27,8 +27,8 @@ export default class AuthRoute extends ClusterRouteBase {
   async model(params) {
     const clusterModel = this.modelFor('vault.cluster');
     const wrapped_token = params?.wrapped_token;
-    // logs user in directly via URL query param
     if (wrapped_token) {
+      // log user in directly (i.e. no form interaction) via URL query param
       const authResponse = await this.unwrapToken(wrapped_token, clusterModel.id);
       return { clusterModel, unwrapResponse: authResponse };
     }
@@ -47,6 +47,7 @@ export default class AuthRoute extends ClusterRouteBase {
 
   afterModel(model) {
     if (model?.unwrapResponse) {
+      // handles the transition
       return this.controllerFor('vault.cluster.auth').send('authSuccess', model.unwrapResponse);
     }
     if (config.welcomeMessage) {

--- a/ui/app/routes/vault/cluster/auth.js
+++ b/ui/app/routes/vault/cluster/auth.js
@@ -32,13 +32,13 @@ export default class AuthRoute extends ClusterRouteBase {
     }
 
     const visibleAuthMounts = await this.fetchMounts();
-
+    const authTabData = this.formatTabs(visibleAuthMounts);
     return {
+      authTabData,
       clusterModel: clusterModel,
-      visibleAuthMounts,
-      // set in the route because this updates when namespace changes
-      storedLoginData: this.auth.getAuthType(),
+      hasVisibleAuthMounts: !!visibleAuthMounts,
       namespaceInput: this.namespaceInput,
+      storedLoginData: this.auth.getAuthType(),
     };
   }
 
@@ -84,5 +84,18 @@ export default class AuthRoute extends ClusterRouteBase {
       // swallow the error if there's an error fetching mount data (i.e. invalid namespace)
       return null;
     }
+  }
+
+  formatTabs(visibleAuthMounts) {
+    if (visibleAuthMounts) {
+      const authMounts = visibleAuthMounts;
+      return Object.entries(authMounts).reduce((obj, [path, mountData]) => {
+        const { type } = mountData;
+        obj[type] ??= []; // if an array doesn't already exist for that type, create it
+        obj[type].push({ path, ...mountData });
+        return obj;
+      }, {});
+    }
+    return null;
   }
 }

--- a/ui/app/routes/vault/cluster/auth.js
+++ b/ui/app/routes/vault/cluster/auth.js
@@ -32,13 +32,11 @@ export default class AuthRoute extends ClusterRouteBase {
     }
 
     const visibleAuthMounts = await this.fetchMounts();
-    const authTabData = this.formatTabs(visibleAuthMounts);
     return {
-      authTabData,
       clusterModel: clusterModel,
-      hasVisibleAuthMounts: !!visibleAuthMounts,
       namespaceInput: this.namespaceInput,
       storedLoginData: this.auth.getAuthType(),
+      visibleAuthMounts,
     };
   }
 
@@ -84,18 +82,5 @@ export default class AuthRoute extends ClusterRouteBase {
       // swallow the error if there's an error fetching mount data (i.e. invalid namespace)
       return null;
     }
-  }
-
-  formatTabs(visibleAuthMounts) {
-    if (visibleAuthMounts) {
-      const authMounts = visibleAuthMounts;
-      return Object.entries(authMounts).reduce((obj, [path, mountData]) => {
-        const { type } = mountData;
-        obj[type] ??= []; // if an array doesn't already exist for that type, create it
-        obj[type].push({ path, ...mountData });
-        return obj;
-      }, {});
-    }
-    return null;
   }
 }

--- a/ui/app/templates/vault/cluster/auth.hbs
+++ b/ui/app/templates/vault/cluster/auth.hbs
@@ -20,7 +20,7 @@
     @oidcProviderQueryParam={{this.oidcProvider}}
     @onAuthSuccess={{action "authSuccess"}}
     @onNamespaceUpdate={{perform this.updateNamespace}}
-    @visibleAuthMounts={{this.model.visibleAuthMounts}}
     @storedLoginData={{this.model.storedLoginData}}
+    @visibleAuthMounts={{this.model.visibleAuthMounts}}
   />
 {{/if}}

--- a/ui/app/templates/vault/cluster/auth.hbs
+++ b/ui/app/templates/vault/cluster/auth.hbs
@@ -15,10 +15,12 @@
 {{else}}
   <Auth::Page
     @authMethodQueryParam={{this.authMethod}}
-    @cluster={{this.model}}
+    @cluster={{this.model.clusterModel}}
     @namespaceQueryParam={{this.namespaceQueryParam}}
     @oidcProviderQueryParam={{this.oidcProvider}}
     @onAuthSuccess={{action "authSuccess"}}
     @onNamespaceUpdate={{perform this.updateNamespace}}
+    @visibleAuthMounts={{this.model.visibleAuthMounts}}
+    @storedLoginData={{this.model.storedLoginData}}
   />
 {{/if}}

--- a/ui/app/utils/supported-login-methods.ts
+++ b/ui/app/utils/supported-login-methods.ts
@@ -17,7 +17,7 @@ export const BASE_LOGIN_METHODS = [
   },
   {
     type: 'userpass',
-    displayName: 'Username',
+    displayName: 'Userpass',
   },
   {
     type: 'ldap',

--- a/ui/tests/acceptance/oidc-provider-test.js
+++ b/ui/tests/acceptance/oidc-provider-test.js
@@ -155,9 +155,12 @@ module('Acceptance | oidc provider', function (hooks) {
         'Once you log in, you will be redirected back to your application. If you require login credentials, contact your administrator.',
         'Has updated text for client authorization flow'
       );
-    await fillIn(AUTH_FORM.method, authMethodPath);
+
+    await fillIn(GENERAL.selectByAttr('auth-method'), 'userpass');
     await fillIn(GENERAL.inputByAttr('username'), OIDC_USER);
     await fillIn(GENERAL.inputByAttr('password'), USER_PASSWORD);
+    await click(AUTH_FORM.moreOptions);
+    await fillIn(GENERAL.inputByAttr('path'), authMethodPath);
     await click(AUTH_FORM.login);
     assert.strictEqual(currentURL(), url, 'URL is as expected after login');
     assert
@@ -184,7 +187,8 @@ module('Acceptance | oidc provider', function (hooks) {
       currentURL().includes('prompt=login'),
       'Url params no longer include prompt=login after redirect'
     );
-    await fillIn(AUTH_FORM.method, authMethodPath);
+
+    await fillIn(GENERAL.selectByAttr('auth-method'), authMethodPath);
     await fillIn(GENERAL.inputByAttr('username'), OIDC_USER);
     await fillIn(GENERAL.inputByAttr('password'), USER_PASSWORD);
     await click(AUTH_FORM.login);
@@ -199,7 +203,7 @@ module('Acceptance | oidc provider', function (hooks) {
     const { providerName, callback, clientId, authMethodPath } = this.oidcSetupInformation;
     const url = getAuthzUrl(providerName, callback, clientId, { prompt: 'consent' });
     await visit('/vault/logout');
-    await fillIn(AUTH_FORM.method, authMethodPath);
+    await fillIn(GENERAL.selectByAttr('auth-method'), authMethodPath);
     await fillIn(GENERAL.inputByAttr('username'), OIDC_USER);
     await fillIn(GENERAL.inputByAttr('password'), USER_PASSWORD);
     await click(AUTH_FORM.login);

--- a/ui/tests/acceptance/wrapped-token-test.js
+++ b/ui/tests/acceptance/wrapped-token-test.js
@@ -63,7 +63,7 @@ module(`Acceptance | wrapped_token query param functionality`, function (hooks) 
       );
     assert.dom(AUTH_FORM.form).doesNotExist();
     await click(`${GENERAL.pageError.error} button`);
-    waitFor(AUTH_FORM.form);
+    await waitFor(AUTH_FORM.form);
     const url = currentURL();
     assert.false(url.includes('wrapped_token='), `url does not include wrapped_token param: ${url}`);
     assert.strictEqual(currentRouteName(), 'vault.cluster.auth', 'it navigates back to auth route');

--- a/ui/tests/integration/components/auth/form-template-test.js
+++ b/ui/tests/integration/components/auth/form-template-test.js
@@ -53,10 +53,18 @@ module('Integration | Component | auth | form template', function (hooks) {
     assert.dom(GENERAL.selectByAttr('auth type')).hasValue('token');
   });
 
+  test('it selects @preselectedAuthType by default', async function (assert) {
+    this.preselectedAuthType = 'ldap';
+    await this.renderComponent();
+    assert.dom(GENERAL.selectByAttr('auth type')).hasValue('ldap');
+    assert.dom(GENERAL.inputByAttr('username')).exists();
+    assert.dom(GENERAL.inputByAttr('password')).exists();
+  });
+
   test('it does not show toggle buttons when listing visibility is not set', async function (assert) {
     await this.renderComponent();
     assert.dom(GENERAL.backButton).doesNotExist('"Back" button does not render');
-    assert.dom(AUTH_FORM.otherMethodsBtn).doesNotExist('"Sign in with other methods" does not render ');
+    assert.dom(AUTH_FORM.otherMethodsBtn).doesNotExist('"Sign in with other methods" does not render');
   });
 
   test('it displays errors', async function (assert) {
@@ -112,6 +120,9 @@ module('Integration | Component | auth | form template', function (hooks) {
         assert.dom(AUTH_FORM.tabs(m.type)).exists(`${m.type} renders as a tab`);
         assert.dom(AUTH_FORM.tabs(m.type)).hasText(m.display, `${m.type} renders expected display name`);
       });
+      assert
+        .dom(AUTH_FORM.tabBtn('Userpass'))
+        .hasAttribute('aria-selected', 'true', 'it selects the first tab by default');
     });
 
     test('it selects each auth tab and renders form for that type', async function (assert) {
@@ -174,7 +185,7 @@ module('Integration | Component | auth | form template', function (hooks) {
       await click(AUTH_FORM.otherMethodsBtn);
       assert
         .dom(AUTH_FORM.otherMethodsBtn)
-        .doesNotExist('"Sign in with other methods" does not render after it is clicked');
+        .doesNotExist('"Sign in with other methods" does not renderafter it is clicked');
       assert
         .dom(GENERAL.selectByAttr('auth type'))
         .exists('clicking "Sign in with other methods" renders dropdown instead of tabs');
@@ -201,6 +212,24 @@ module('Integration | Component | auth | form template', function (hooks) {
       assert.dom(AUTH_FORM.tabBtn('userpass')).hasAttribute('aria-selected', 'true');
       assert.dom(AUTH_FORM.tabBtn('oidc')).hasAttribute('aria-selected', 'false');
       assert.dom(AUTH_FORM.tabBtn('token')).hasAttribute('aria-selected', 'false');
+    });
+
+    test('it preselects tab if @preselectedAuthType is a tab', async function (assert) {
+      this.preselectedAuthType = 'oidc';
+      await this.renderComponent();
+      assert.dom(AUTH_FORM.authForm('oidc')).exists('oidc tab is selected');
+      assert.dom(AUTH_FORM.tabBtn('oidc')).hasAttribute('aria-selected', 'true');
+    });
+
+    test('if @preselectedAuthType is NOT a tab, dropdown renders with type selected instead of tabs', async function (assert) {
+      this.preselectedAuthType = 'ldap';
+      await this.renderComponent();
+      assert.dom(GENERAL.selectByAttr('auth type')).hasValue('ldap');
+      assert.dom(GENERAL.inputByAttr('username')).exists();
+      assert.dom(GENERAL.inputByAttr('password')).exists();
+
+      assert.dom(GENERAL.backButton).exists('"Back" button renders');
+      assert.dom(AUTH_FORM.otherMethodsBtn).doesNotExist('"Sign in with other methods" does not render');
     });
   });
 

--- a/ui/tests/integration/components/auth/form-template-test.js
+++ b/ui/tests/integration/components/auth/form-template-test.js
@@ -121,8 +121,8 @@ module('Integration | Component | auth | form template', function (hooks) {
         assert.dom(AUTH_FORM.tabs(m.type)).hasText(m.display, `${m.type} renders expected display name`);
       });
       assert
-        .dom(AUTH_FORM.tabBtn('Userpass'))
-        .hasAttribute('aria-selected', 'true', 'it selects the first tab by default');
+        .dom(AUTH_FORM.tabBtn('userpass'))
+        .hasAttribute('aria-selected', 'true', 'it selects the first type by default');
     });
 
     test('it selects each auth tab and renders form for that type', async function (assert) {

--- a/ui/tests/integration/components/auth/form-template-test.js
+++ b/ui/tests/integration/components/auth/form-template-test.js
@@ -31,7 +31,7 @@ module('Integration | Component | auth | form template', function (hooks) {
     this.oidcProviderQueryParam = '';
     this.onAuthResponse = sinon.spy();
     this.onNamespaceChange = sinon.spy();
-    this.preselectedAuthType = '';
+    this.presetAuthType = '';
     this.hasVisibleAuthMounts = false;
     this.authTabData = null;
 
@@ -43,7 +43,7 @@ module('Integration | Component | auth | form template', function (hooks) {
           @namespaceQueryParam={{this.namespaceQueryParam}}
           @oidcProviderQueryParam={{this.oidcProviderQueryParam}}
           @onSuccess={{this.onAuthResponse}}
-          @preselectedAuthType={{this.preselectedAuthType}}
+          @presetAuthType={{this.presetAuthType}}
           @hasVisibleAuthMounts={{this.hasVisibleAuthMounts}}
           @authTabData={{this.authTabData}}
         />`);
@@ -56,8 +56,8 @@ module('Integration | Component | auth | form template', function (hooks) {
     assert.dom(GENERAL.selectByAttr('auth type')).hasValue('token');
   });
 
-  test('it selects @preselectedAuthType by default', async function (assert) {
-    this.preselectedAuthType = 'ldap';
+  test('it selects @presetAuthType by default', async function (assert) {
+    this.presetAuthType = 'ldap';
     await this.renderComponent();
     assert.dom(GENERAL.selectByAttr('auth type')).hasValue('ldap');
     assert.dom(GENERAL.inputByAttr('username')).exists();
@@ -228,15 +228,15 @@ module('Integration | Component | auth | form template', function (hooks) {
       assert.dom(AUTH_FORM.tabBtn('token')).hasAttribute('aria-selected', 'false');
     });
 
-    test('it preselects tab if @preselectedAuthType is a tab', async function (assert) {
-      this.preselectedAuthType = 'oidc';
+    test('it preselects tab if @presetAuthType is a tab', async function (assert) {
+      this.presetAuthType = 'oidc';
       await this.renderComponent();
       assert.dom(AUTH_FORM.authForm('oidc')).exists('oidc tab is selected');
       assert.dom(AUTH_FORM.tabBtn('oidc')).hasAttribute('aria-selected', 'true');
     });
 
-    test('if @preselectedAuthType is NOT a tab, dropdown renders with type selected instead of tabs', async function (assert) {
-      this.preselectedAuthType = 'ldap';
+    test('if @presetAuthType is NOT a tab, dropdown renders with type selected instead of tabs', async function (assert) {
+      this.presetAuthType = 'ldap';
       await this.renderComponent();
       assert.dom(GENERAL.selectByAttr('auth type')).hasValue('ldap');
       assert.dom(GENERAL.inputByAttr('username')).exists();

--- a/ui/tests/integration/components/auth/form-template-test.js
+++ b/ui/tests/integration/components/auth/form-template-test.js
@@ -31,7 +31,9 @@ module('Integration | Component | auth | form template', function (hooks) {
     this.oidcProviderQueryParam = '';
     this.onAuthResponse = sinon.spy();
     this.onNamespaceChange = sinon.spy();
-    this.visibleMounts = null;
+    this.preselectedAuthType = '';
+    this.hasVisibleAuthMounts = false;
+    this.authTabData = null;
 
     this.renderComponent = () => {
       return render(hbs`
@@ -42,7 +44,8 @@ module('Integration | Component | auth | form template', function (hooks) {
           @oidcProviderQueryParam={{this.oidcProviderQueryParam}}
           @onSuccess={{this.onAuthResponse}}
           @preselectedAuthType={{this.preselectedAuthType}}
-          @visibleAuthMounts={{this.visibleMounts}}
+          @hasVisibleAuthMounts={{this.hasVisibleAuthMounts}}
+          @authTabData={{this.authTabData}}
         />`);
     };
   });
@@ -80,27 +83,38 @@ module('Integration | Component | auth | form template', function (hooks) {
 
   module('listing visibility', function (hooks) {
     hooks.beforeEach(function () {
-      this.visibleMounts = {
-        'userpass/': {
-          description: '',
-          options: {},
-          type: 'userpass',
-        },
-        'userpass2/': {
-          description: '',
-          options: {},
-          type: 'userpass',
-        },
-        'my-oidc/': {
-          description: '',
-          options: {},
-          type: 'oidc',
-        },
-        'token/': {
-          description: 'token based credentials',
-          options: null,
-          type: 'token',
-        },
+      this.hasVisibleAuthMounts = true;
+      this.authTabData = {
+        userpass: [
+          {
+            path: 'userpass/',
+            description: '',
+            options: {},
+            type: 'userpass',
+          },
+          {
+            path: 'userpass2/',
+            description: '',
+            options: {},
+            type: 'userpass',
+          },
+        ],
+        oidc: [
+          {
+            path: 'my-oidc/',
+            description: '',
+            options: {},
+            type: 'oidc',
+          },
+        ],
+        token: [
+          {
+            path: 'token/',
+            description: 'token based credentials',
+            options: null,
+            type: 'token',
+          },
+        ],
       };
     });
 

--- a/ui/tests/integration/components/auth/form-template-test.js
+++ b/ui/tests/integration/components/auth/form-template-test.js
@@ -36,7 +36,7 @@ module('Integration | Component | auth | form template', function (hooks) {
     this.renderComponent = () => {
       return render(hbs`
          <Auth::FormTemplate
-          @cluster={{@cluster}}
+          @cluster={{this.cluster}}
           @handleNamespaceUpdate={{this.onNamespaceChange}}
           @namespaceQueryParam={{this.namespaceQueryParam}}
           @oidcProviderQueryParam={{this.oidcProviderQueryParam}}

--- a/ui/types/vault/auth/form.d.ts
+++ b/ui/types/vault/auth/form.d.ts
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+export interface AuthTabData {
+  // key is the auth method type
+  [key: string]: AuthTabMountData[];
+}
+
+interface AuthTabMountData {
+  path: string;
+  type: string;
+  description?: string;
+  config?: object | null;
+}
+
+export type LoginFields = Partial<Record<(typeof POSSIBLE_FIELDS)[number], string | undefined>> & {
+  path?: string | undefined;
+  namespace?: string | undefined;
+};
+
+export interface VisibleAuthMounts {
+  // key is auth mount path
+  [key: string]: {
+    description: string;
+    type: string;
+    options: null | {};
+  };
+}

--- a/ui/types/vault/services/auth.d.ts
+++ b/ui/types/vault/services/auth.d.ts
@@ -19,6 +19,12 @@ export interface AuthData {
   mfa_requirement?: MfaRequirementApiResponse;
 }
 
+export interface AuthResponse {
+  namespace: string;
+  token: string; // the name of the token in local storage, not the actual token
+  isRoot: boolean;
+}
+
 export default class AuthService extends Service {
   authData: AuthData;
   currentToken: string;
@@ -30,7 +36,7 @@ export default class AuthService extends Service {
     backend: string;
     data: object;
     selectedAuth: string;
-  }): Promise<any>;
+  }): Promise<AuthResponse>;
   ajax: (
     url: string,
     method: 'GET' | 'POST' | 'PUT' | 'DELETE',
@@ -40,5 +46,6 @@ export default class AuthService extends Service {
       data?: Record<string, unknown>;
     }
   ) => Promise<any>;
+  getAuthType(): string | undefined;
   _parseMfaResponse(mfaResponse: MfaRequirementApiResponse): ParsedMfaRequirement;
 }


### PR DESCRIPTION
### Description
Fetching mounts in the component started to feel really awkward and resulted in a lot of manual state management. The `sys/internal/ui/mounts` request has to be re-fetched anytime the namespace query param changes anyway (which can happen when the namespace input is updated). 

While I don't entirely agree with the namespace being a query param in the URL (see note below) it's out of scope to change it for this auth form refactor work. In short, fetching this data in the route model hook seems to most sensible and as you can see drastically cleaned up the component logic 🎉 

**Why the namespace param in the url is confusing**
The namespace architecture of the web ui (and vault) is confusing because there is a narrow distinction between **authenticating** vs **navigating** to a namespace. 
- **authenticating**: Users can only log in to namespace where their auth method is mounted**. For example, if the `ldap` method is mounted in the `admin/` namespace, users can only log in to the `admin` namespace. 
- **navigating**: Once authenticated, users can navigate to whatever namespace their policy grants access to. So if a user logs in the `admin/` but has access to `admin/west` they can navigate to that namespace. **But they cannot authenticate to `admin/west`** 

**Tokens generated in a namespace can log in without specifying the namespace and will be navigated accordingly because their root namespace is returned as part of the token data. 

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
