### PR TITLE
Update raft.mdx `performance_multiplier` default to actual value

### DIFF
--- a/website/content/docs/configuration/storage/raft.mdx
+++ b/website/content/docs/configuration/storage/raft.mdx
@@ -52,11 +52,11 @@ set [`disable_mlock`](/vault/docs/configuration#disable_mlock) to `true`, and to
   GUID during initialization and writes the value to `data/node-id` in the
   directory specified by the `path` parameter.
 
-- `performance_multiplier` `(integer: 0)` - An integer multiplier used by
-  servers to scale key Raft timing parameters, where each increment translates to approximately 1 – 2 seconds of delay. For example, setting the multiplier to "3" translates to 3 – 6 seconds of total delay.  Tuning  the multiplier affects the time it
+- `performance_multiplier` `(integer: 5)` - An integer multiplier used by
+  servers to scale key Raft timing parameters, where each increment translates to approximately 1 – 2 seconds of delay. For example, setting the multiplier to "3" translates to 3 – 6 seconds of total delay.  Tuning the multiplier affects the time it
   takes Vault to detect leader failures and to perform leader elections, at the
   expense of requiring more network and CPU resources for better performance.
-  Omitting this value or setting it to 0 uses default timing described below.
+  Omitting this value uses default timing described below.
   Lower values are used to tighten timing and increase sensitivity while higher
   values relax timings and reduce sensitivity.
 


### PR DESCRIPTION
In raft config docs, the default for `performance_multiplier` is documented as `0` but should be `5`. Setting `performance_multipler` to `0` causes Vault to fail to initialize and throws the following error:

```
could not start clustered storage: HeartbeatTimeout is too low
```

In the [ApplyConfigSettings function](https://github.com/hashicorp/vault/blob/bec45fd336527ec157c42720dd892160f004c7c1/physical/raft/raft.go#L1072-L1084), the default multiplier value is `5`.

### Description
Updates `performance_multiplier` documented default to ensure Vault initializes and align with actual value.

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
