### PR TITLE
[UI] API Client Update - Sync

### DIFF
--- a/ui/api-client/dist/esm/models/EntityAliasesCreateDuplicatesRequest.d.ts
+++ b/ui/api-client/dist/esm/models/EntityAliasesCreateDuplicatesRequest.d.ts
@@ -28,6 +28,12 @@ export interface EntityAliasesCreateDuplicatesRequest {
      */
     differentCase?: boolean;
     /**
+     * Local alias toggle
+     * @type {boolean}
+     * @memberof EntityAliasesCreateDuplicatesRequest
+     */
+    local?: boolean;
+    /**
      * Metadata
      * @type {object}
      * @memberof EntityAliasesCreateDuplicatesRequest

--- a/ui/api-client/dist/esm/models/EntityAliasesCreateDuplicatesRequest.js
+++ b/ui/api-client/dist/esm/models/EntityAliasesCreateDuplicatesRequest.js
@@ -27,6 +27,7 @@ export function EntityAliasesCreateDuplicatesRequestFromJSONTyped(json, ignoreDi
     return {
         'count': json['count'] == null ? undefined : json['count'],
         'differentCase': json['different_case'] == null ? undefined : json['different_case'],
+        'local': json['local'] == null ? undefined : json['local'],
         'metadata': json['metadata'] == null ? undefined : json['metadata'],
         'mountAccessor': json['mount_accessor'] == null ? undefined : json['mount_accessor'],
         'name': json['name'] == null ? undefined : json['name'],
@@ -43,6 +44,7 @@ export function EntityAliasesCreateDuplicatesRequestToJSONTyped(value, ignoreDis
     return {
         'count': value['count'],
         'different_case': value['differentCase'],
+        'local': value['local'],
         'metadata': value['metadata'],
         'mount_accessor': value['mountAccessor'],
         'name': value['name'],

--- a/ui/api-client/dist/esm/models/SystemListSyncAssociationsResponse.d.ts
+++ b/ui/api-client/dist/esm/models/SystemListSyncAssociationsResponse.d.ts
@@ -23,10 +23,22 @@ export interface SystemListSyncAssociationsResponse {
     keyInfo?: object;
     /**
      * List of mounts with at least one association.
-     * @type {Array<object>}
+     * @type {Array<string>}
      * @memberof SystemListSyncAssociationsResponse
      */
-    keys?: Array<object>;
+    keys?: Array<string>;
+    /**
+     * Total number of associations across all destinations.
+     * @type {number}
+     * @memberof SystemListSyncAssociationsResponse
+     */
+    totalAssociations?: number;
+    /**
+     * Total number of synced secrets across all destinations.
+     * @type {number}
+     * @memberof SystemListSyncAssociationsResponse
+     */
+    totalSecrets?: number;
 }
 /**
  * Check if a given object implements the SystemListSyncAssociationsResponse interface.

--- a/ui/api-client/dist/esm/models/SystemListSyncAssociationsResponse.js
+++ b/ui/api-client/dist/esm/models/SystemListSyncAssociationsResponse.js
@@ -27,6 +27,8 @@ export function SystemListSyncAssociationsResponseFromJSONTyped(json, ignoreDisc
     return {
         'keyInfo': json['key_info'] == null ? undefined : json['key_info'],
         'keys': json['keys'] == null ? undefined : json['keys'],
+        'totalAssociations': json['total_associations'] == null ? undefined : json['total_associations'],
+        'totalSecrets': json['total_secrets'] == null ? undefined : json['total_secrets'],
     };
 }
 export function SystemListSyncAssociationsResponseToJSON(json) {
@@ -39,5 +41,7 @@ export function SystemListSyncAssociationsResponseToJSONTyped(value, ignoreDiscr
     return {
         'key_info': value['keyInfo'],
         'keys': value['keys'],
+        'total_associations': value['totalAssociations'],
+        'total_secrets': value['totalSecrets'],
     };
 }

--- a/ui/api-client/dist/esm/models/SystemListSyncDestinationsResponse.d.ts
+++ b/ui/api-client/dist/esm/models/SystemListSyncDestinationsResponse.d.ts
@@ -23,10 +23,16 @@ export interface SystemListSyncDestinationsResponse {
     keyInfo?: object;
     /**
      * List of destination types with at least one destination.
-     * @type {Array<object>}
+     * @type {Array<string>}
      * @memberof SystemListSyncDestinationsResponse
      */
-    keys?: Array<object>;
+    keys?: Array<string>;
+    /**
+     * Total number of destinations across all types.
+     * @type {number}
+     * @memberof SystemListSyncDestinationsResponse
+     */
+    totalDestinations?: number;
 }
 /**
  * Check if a given object implements the SystemListSyncDestinationsResponse interface.

--- a/ui/api-client/dist/esm/models/SystemListSyncDestinationsResponse.js
+++ b/ui/api-client/dist/esm/models/SystemListSyncDestinationsResponse.js
@@ -27,6 +27,7 @@ export function SystemListSyncDestinationsResponseFromJSONTyped(json, ignoreDisc
     return {
         'keyInfo': json['key_info'] == null ? undefined : json['key_info'],
         'keys': json['keys'] == null ? undefined : json['keys'],
+        'totalDestinations': json['total_destinations'] == null ? undefined : json['total_destinations'],
     };
 }
 export function SystemListSyncDestinationsResponseToJSON(json) {
@@ -39,5 +40,6 @@ export function SystemListSyncDestinationsResponseToJSONTyped(value, ignoreDiscr
     return {
         'key_info': value['keyInfo'],
         'keys': value['keys'],
+        'total_destinations': value['totalDestinations'],
     };
 }

--- a/ui/api-client/dist/esm/models/SystemReadSyncDestinationsTypeNameAssociationsResponse.d.ts
+++ b/ui/api-client/dist/esm/models/SystemReadSyncDestinationsTypeNameAssociationsResponse.d.ts
@@ -26,13 +26,13 @@ export interface SystemReadSyncDestinationsTypeNameAssociationsResponse {
      * @type {string}
      * @memberof SystemReadSyncDestinationsTypeNameAssociationsResponse
      */
-    name?: string;
+    storeName?: string;
     /**
      * Type of this secrets store.
      * @type {string}
      * @memberof SystemReadSyncDestinationsTypeNameAssociationsResponse
      */
-    type?: string;
+    storeType?: string;
 }
 /**
  * Check if a given object implements the SystemReadSyncDestinationsTypeNameAssociationsResponse interface.

--- a/ui/api-client/dist/esm/models/SystemReadSyncDestinationsTypeNameAssociationsResponse.js
+++ b/ui/api-client/dist/esm/models/SystemReadSyncDestinationsTypeNameAssociationsResponse.js
@@ -26,8 +26,8 @@ export function SystemReadSyncDestinationsTypeNameAssociationsResponseFromJSONTy
     }
     return {
         'associatedSecrets': json['associated_secrets'] == null ? undefined : json['associated_secrets'],
-        'name': json['name'] == null ? undefined : json['name'],
-        'type': json['type'] == null ? undefined : json['type'],
+        'storeName': json['store_name'] == null ? undefined : json['store_name'],
+        'storeType': json['store_type'] == null ? undefined : json['store_type'],
     };
 }
 export function SystemReadSyncDestinationsTypeNameAssociationsResponseToJSON(json) {
@@ -39,7 +39,7 @@ export function SystemReadSyncDestinationsTypeNameAssociationsResponseToJSONType
     }
     return {
         'associated_secrets': value['associatedSecrets'],
-        'name': value['name'],
-        'type': value['type'],
+        'store_name': value['storeName'],
+        'store_type': value['storeType'],
     };
 }

--- a/ui/api-client/dist/models/EntityAliasesCreateDuplicatesRequest.d.ts
+++ b/ui/api-client/dist/models/EntityAliasesCreateDuplicatesRequest.d.ts
@@ -28,6 +28,12 @@ export interface EntityAliasesCreateDuplicatesRequest {
      */
     differentCase?: boolean;
     /**
+     * Local alias toggle
+     * @type {boolean}
+     * @memberof EntityAliasesCreateDuplicatesRequest
+     */
+    local?: boolean;
+    /**
      * Metadata
      * @type {object}
      * @memberof EntityAliasesCreateDuplicatesRequest

--- a/ui/api-client/dist/models/EntityAliasesCreateDuplicatesRequest.js
+++ b/ui/api-client/dist/models/EntityAliasesCreateDuplicatesRequest.js
@@ -34,6 +34,7 @@ function EntityAliasesCreateDuplicatesRequestFromJSONTyped(json, ignoreDiscrimin
     return {
         'count': json['count'] == null ? undefined : json['count'],
         'differentCase': json['different_case'] == null ? undefined : json['different_case'],
+        'local': json['local'] == null ? undefined : json['local'],
         'metadata': json['metadata'] == null ? undefined : json['metadata'],
         'mountAccessor': json['mount_accessor'] == null ? undefined : json['mount_accessor'],
         'name': json['name'] == null ? undefined : json['name'],
@@ -50,6 +51,7 @@ function EntityAliasesCreateDuplicatesRequestToJSONTyped(value, ignoreDiscrimina
     return {
         'count': value['count'],
         'different_case': value['differentCase'],
+        'local': value['local'],
         'metadata': value['metadata'],
         'mount_accessor': value['mountAccessor'],
         'name': value['name'],

--- a/ui/api-client/dist/models/SystemListSyncAssociationsResponse.d.ts
+++ b/ui/api-client/dist/models/SystemListSyncAssociationsResponse.d.ts
@@ -23,10 +23,22 @@ export interface SystemListSyncAssociationsResponse {
     keyInfo?: object;
     /**
      * List of mounts with at least one association.
-     * @type {Array<object>}
+     * @type {Array<string>}
      * @memberof SystemListSyncAssociationsResponse
      */
-    keys?: Array<object>;
+    keys?: Array<string>;
+    /**
+     * Total number of associations across all destinations.
+     * @type {number}
+     * @memberof SystemListSyncAssociationsResponse
+     */
+    totalAssociations?: number;
+    /**
+     * Total number of synced secrets across all destinations.
+     * @type {number}
+     * @memberof SystemListSyncAssociationsResponse
+     */
+    totalSecrets?: number;
 }
 /**
  * Check if a given object implements the SystemListSyncAssociationsResponse interface.

--- a/ui/api-client/dist/models/SystemListSyncAssociationsResponse.js
+++ b/ui/api-client/dist/models/SystemListSyncAssociationsResponse.js
@@ -34,6 +34,8 @@ function SystemListSyncAssociationsResponseFromJSONTyped(json, ignoreDiscriminat
     return {
         'keyInfo': json['key_info'] == null ? undefined : json['key_info'],
         'keys': json['keys'] == null ? undefined : json['keys'],
+        'totalAssociations': json['total_associations'] == null ? undefined : json['total_associations'],
+        'totalSecrets': json['total_secrets'] == null ? undefined : json['total_secrets'],
     };
 }
 function SystemListSyncAssociationsResponseToJSON(json) {
@@ -46,5 +48,7 @@ function SystemListSyncAssociationsResponseToJSONTyped(value, ignoreDiscriminato
     return {
         'key_info': value['keyInfo'],
         'keys': value['keys'],
+        'total_associations': value['totalAssociations'],
+        'total_secrets': value['totalSecrets'],
     };
 }

--- a/ui/api-client/dist/models/SystemListSyncDestinationsResponse.d.ts
+++ b/ui/api-client/dist/models/SystemListSyncDestinationsResponse.d.ts
@@ -23,10 +23,16 @@ export interface SystemListSyncDestinationsResponse {
     keyInfo?: object;
     /**
      * List of destination types with at least one destination.
-     * @type {Array<object>}
+     * @type {Array<string>}
      * @memberof SystemListSyncDestinationsResponse
      */
-    keys?: Array<object>;
+    keys?: Array<string>;
+    /**
+     * Total number of destinations across all types.
+     * @type {number}
+     * @memberof SystemListSyncDestinationsResponse
+     */
+    totalDestinations?: number;
 }
 /**
  * Check if a given object implements the SystemListSyncDestinationsResponse interface.

--- a/ui/api-client/dist/models/SystemListSyncDestinationsResponse.js
+++ b/ui/api-client/dist/models/SystemListSyncDestinationsResponse.js
@@ -34,6 +34,7 @@ function SystemListSyncDestinationsResponseFromJSONTyped(json, ignoreDiscriminat
     return {
         'keyInfo': json['key_info'] == null ? undefined : json['key_info'],
         'keys': json['keys'] == null ? undefined : json['keys'],
+        'totalDestinations': json['total_destinations'] == null ? undefined : json['total_destinations'],
     };
 }
 function SystemListSyncDestinationsResponseToJSON(json) {
@@ -46,5 +47,6 @@ function SystemListSyncDestinationsResponseToJSONTyped(value, ignoreDiscriminato
     return {
         'key_info': value['keyInfo'],
         'keys': value['keys'],
+        'total_destinations': value['totalDestinations'],
     };
 }

--- a/ui/api-client/dist/models/SystemReadSyncDestinationsTypeNameAssociationsResponse.d.ts
+++ b/ui/api-client/dist/models/SystemReadSyncDestinationsTypeNameAssociationsResponse.d.ts
@@ -26,13 +26,13 @@ export interface SystemReadSyncDestinationsTypeNameAssociationsResponse {
      * @type {string}
      * @memberof SystemReadSyncDestinationsTypeNameAssociationsResponse
      */
-    name?: string;
+    storeName?: string;
     /**
      * Type of this secrets store.
      * @type {string}
      * @memberof SystemReadSyncDestinationsTypeNameAssociationsResponse
      */
-    type?: string;
+    storeType?: string;
 }
 /**
  * Check if a given object implements the SystemReadSyncDestinationsTypeNameAssociationsResponse interface.

--- a/ui/api-client/dist/models/SystemReadSyncDestinationsTypeNameAssociationsResponse.js
+++ b/ui/api-client/dist/models/SystemReadSyncDestinationsTypeNameAssociationsResponse.js
@@ -33,8 +33,8 @@ function SystemReadSyncDestinationsTypeNameAssociationsResponseFromJSONTyped(jso
     }
     return {
         'associatedSecrets': json['associated_secrets'] == null ? undefined : json['associated_secrets'],
-        'name': json['name'] == null ? undefined : json['name'],
-        'type': json['type'] == null ? undefined : json['type'],
+        'storeName': json['store_name'] == null ? undefined : json['store_name'],
+        'storeType': json['store_type'] == null ? undefined : json['store_type'],
     };
 }
 function SystemReadSyncDestinationsTypeNameAssociationsResponseToJSON(json) {
@@ -46,7 +46,7 @@ function SystemReadSyncDestinationsTypeNameAssociationsResponseToJSONTyped(value
     }
     return {
         'associated_secrets': value['associatedSecrets'],
-        'name': value['name'],
-        'type': value['type'],
+        'store_name': value['storeName'],
+        'store_type': value['storeType'],
     };
 }

--- a/ui/api-client/src/models/EntityAliasesCreateDuplicatesRequest.ts
+++ b/ui/api-client/src/models/EntityAliasesCreateDuplicatesRequest.ts
@@ -32,6 +32,12 @@ export interface EntityAliasesCreateDuplicatesRequest {
      */
     differentCase?: boolean;
     /**
+     * Local alias toggle
+     * @type {boolean}
+     * @memberof EntityAliasesCreateDuplicatesRequest
+     */
+    local?: boolean;
+    /**
      * Metadata
      * @type {object}
      * @memberof EntityAliasesCreateDuplicatesRequest
@@ -76,6 +82,7 @@ export function EntityAliasesCreateDuplicatesRequestFromJSONTyped(json: any, ign
         
         'count': json['count'] == null ? undefined : json['count'],
         'differentCase': json['different_case'] == null ? undefined : json['different_case'],
+        'local': json['local'] == null ? undefined : json['local'],
         'metadata': json['metadata'] == null ? undefined : json['metadata'],
         'mountAccessor': json['mount_accessor'] == null ? undefined : json['mount_accessor'],
         'name': json['name'] == null ? undefined : json['name'],
@@ -96,6 +103,7 @@ export function EntityAliasesCreateDuplicatesRequestToJSONTyped(value?: EntityAl
         
         'count': value['count'],
         'different_case': value['differentCase'],
+        'local': value['local'],
         'metadata': value['metadata'],
         'mount_accessor': value['mountAccessor'],
         'name': value['name'],

--- a/ui/api-client/src/models/SystemListSyncAssociationsResponse.ts
+++ b/ui/api-client/src/models/SystemListSyncAssociationsResponse.ts
@@ -27,10 +27,22 @@ export interface SystemListSyncAssociationsResponse {
     keyInfo?: object;
     /**
      * List of mounts with at least one association.
-     * @type {Array<object>}
+     * @type {Array<string>}
      * @memberof SystemListSyncAssociationsResponse
      */
-    keys?: Array<object>;
+    keys?: Array<string>;
+    /**
+     * Total number of associations across all destinations.
+     * @type {number}
+     * @memberof SystemListSyncAssociationsResponse
+     */
+    totalAssociations?: number;
+    /**
+     * Total number of synced secrets across all destinations.
+     * @type {number}
+     * @memberof SystemListSyncAssociationsResponse
+     */
+    totalSecrets?: number;
 }
 
 /**
@@ -52,6 +64,8 @@ export function SystemListSyncAssociationsResponseFromJSONTyped(json: any, ignor
         
         'keyInfo': json['key_info'] == null ? undefined : json['key_info'],
         'keys': json['keys'] == null ? undefined : json['keys'],
+        'totalAssociations': json['total_associations'] == null ? undefined : json['total_associations'],
+        'totalSecrets': json['total_secrets'] == null ? undefined : json['total_secrets'],
     };
 }
 
@@ -68,6 +82,8 @@ export function SystemListSyncAssociationsResponseToJSONTyped(value?: SystemList
         
         'key_info': value['keyInfo'],
         'keys': value['keys'],
+        'total_associations': value['totalAssociations'],
+        'total_secrets': value['totalSecrets'],
     };
 }
 

--- a/ui/api-client/src/models/SystemListSyncDestinationsResponse.ts
+++ b/ui/api-client/src/models/SystemListSyncDestinationsResponse.ts
@@ -27,10 +27,16 @@ export interface SystemListSyncDestinationsResponse {
     keyInfo?: object;
     /**
      * List of destination types with at least one destination.
-     * @type {Array<object>}
+     * @type {Array<string>}
      * @memberof SystemListSyncDestinationsResponse
      */
-    keys?: Array<object>;
+    keys?: Array<string>;
+    /**
+     * Total number of destinations across all types.
+     * @type {number}
+     * @memberof SystemListSyncDestinationsResponse
+     */
+    totalDestinations?: number;
 }
 
 /**
@@ -52,6 +58,7 @@ export function SystemListSyncDestinationsResponseFromJSONTyped(json: any, ignor
         
         'keyInfo': json['key_info'] == null ? undefined : json['key_info'],
         'keys': json['keys'] == null ? undefined : json['keys'],
+        'totalDestinations': json['total_destinations'] == null ? undefined : json['total_destinations'],
     };
 }
 
@@ -68,6 +75,7 @@ export function SystemListSyncDestinationsResponseToJSONTyped(value?: SystemList
         
         'key_info': value['keyInfo'],
         'keys': value['keys'],
+        'total_destinations': value['totalDestinations'],
     };
 }
 

--- a/ui/api-client/src/models/SystemReadSyncDestinationsTypeNameAssociationsResponse.ts
+++ b/ui/api-client/src/models/SystemReadSyncDestinationsTypeNameAssociationsResponse.ts
@@ -30,13 +30,13 @@ export interface SystemReadSyncDestinationsTypeNameAssociationsResponse {
      * @type {string}
      * @memberof SystemReadSyncDestinationsTypeNameAssociationsResponse
      */
-    name?: string;
+    storeName?: string;
     /**
      * Type of this secrets store.
      * @type {string}
      * @memberof SystemReadSyncDestinationsTypeNameAssociationsResponse
      */
-    type?: string;
+    storeType?: string;
 }
 
 /**
@@ -57,8 +57,8 @@ export function SystemReadSyncDestinationsTypeNameAssociationsResponseFromJSONTy
     return {
         
         'associatedSecrets': json['associated_secrets'] == null ? undefined : json['associated_secrets'],
-        'name': json['name'] == null ? undefined : json['name'],
-        'type': json['type'] == null ? undefined : json['type'],
+        'storeName': json['store_name'] == null ? undefined : json['store_name'],
+        'storeType': json['store_type'] == null ? undefined : json['store_type'],
     };
 }
 
@@ -74,8 +74,8 @@ export function SystemReadSyncDestinationsTypeNameAssociationsResponseToJSONType
     return {
         
         'associated_secrets': value['associatedSecrets'],
-        'name': value['name'],
-        'type': value['type'],
+        'store_name': value['storeName'],
+        'store_type': value['storeType'],
     };
 }
 


### PR DESCRIPTION
### Description
This PR updates the API client with some missing parameters for sync endpoints.

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
