### PR TITLE
add upgrade guide for disable_mlock change in 1.20

### DIFF
--- a/website/content/docs/updates/important-changes.mdx
+++ b/website/content/docs/updates/important-changes.mdx
@@ -18,14 +18,14 @@ valid_change_types: >-
 Always review important or breaking changes and remediation recommendations
 before upgrading Vault.
 
-## Breaking configuration change
+## Breaking configuration change for disable_mlock ((#disable_mlock-config))
 
 | Change       | Affected version | Affected deployments
 | ------------ | ---------------- | --------------------
-| New behavior | 1.20.0           | Vault instances using integrated storage
+| Breaking     | 1.20.0           | Vault instances using integrated storage
 
 In Vault 1.20.0 `disable_mlock` is a required configuration setting for
-clusters using integrated storage. This means that if you are not explicitly
+clusters using *integrated storage*. This means that if you are not explicitly
 setting a value for `disable_mlock`, the following changes must be made prior
 to upgrading.
 

--- a/website/content/docs/updates/important-changes.mdx
+++ b/website/content/docs/updates/important-changes.mdx
@@ -18,6 +18,53 @@ valid_change_types: >-
 Always review important or breaking changes and remediation recommendations
 before upgrading Vault.
 
+## Breaking configuration change
+
+| Change       | Affected version | Affected deployments
+| ------------ | ---------------- | --------------------
+| New behavior | 1.20.0           | Vault instances using integrated storage
+
+In Vault 1.20.0 `disable_mlock` is a required configuration setting for
+clusters using integrated storage. This means that if you are not explicitly
+setting a value for `disable_mlock`, the following changes must be made prior
+to upgrading.
+
+* Clusters missing this config value will fail to start after the upgrade to 1.20.0 *
+
+Before upgrading to Vault 1.20.0, administrators must explicitly add a value for
+`disable_mlock` to the outermost level of the server configuration. See docs.
+This must be done for all server nodes. Prior to Vault 1.20, the default setting
+for `disable_mlock` was false. Therefore if you do not currently have a value
+set for `disable_mlock`, you are using the default setting. If you wish to
+maintain this behavior, you will need to explicitly set
+`disable_mlock = false` prior to upgrade.
+
+For clusters that already set a value for `disable_mlock` no change is required.
+
+### Additional Considerations:
+
+#### Autopilot
+New 1.20.0 nodes are added to the cluster until there is a quorum of upgraded
+nodes. Each of these new nodes will need to have a value for`disable_mlock`
+set.
+
+#### Rolling Upgrades
+Standby nodes are stopped and upgraded one at a time. These node configurations
+will need to be updated before restarting the vault process on the node.
+
+#### dev mode
+If no config is provided, dev mode will start as usual. If a config is provided
+it must have a value for `disable_mlock`
+
+### Cluster types affected
+
+| Cluster Type               | `disable_mlock` required | Note
+|----------------------------|--------------------------|-----
+| Primary                    | Yes                      | value depends on cluster specifics. [See docs]()https://developer.hashicorp.com/vault/docs/configuration#disable_mlock
+| Performance Secondary      | Yes                      | value depends on cluster specifics. [See docs]()https://developer.hashicorp.com/vault/docs/configuration#disable_mlock
+| DR Secondary               | Yes                      | value depends on cluster specifics. [See docs]()https://developer.hashicorp.com/vault/docs/configuration#disable_mlock
+
+
 ## Transit support for Ed25519ph and Ed25519ctx signatures ((#ed25519))
 
 | Change       | Affected version | Affected deployments

--- a/website/content/docs/updates/important-changes.mdx
+++ b/website/content/docs/updates/important-changes.mdx
@@ -29,32 +29,36 @@ clusters using *integrated storage*. This means that if you are not explicitly
 setting a value for `disable_mlock`, the following changes must be made prior
 to upgrading.
 
-* Clusters missing this config value will fail to start after the upgrade to 1.20.0 *
+<Warning>
+
+Clusters missing this config value will fail to start after the upgrade to 1.20.0.
+
+</Warning>
 
 Before upgrading to Vault 1.20.0, administrators must explicitly add a value for
-`disable_mlock` to the outermost level of the server configuration. See docs.
+`disable_mlock` to the outermost level of the server configuration. Refer to the [documentation](/vault/docs/configuration#parameters).
 This must be done for all server nodes. Prior to Vault 1.20, the default setting
-for `disable_mlock` was false. Therefore if you do not currently have a value
+for `disable_mlock` was false. Therefore, if you do not currently have a value
 set for `disable_mlock`, you are using the default setting. If you wish to
 maintain this behavior, you will need to explicitly set
 `disable_mlock = false` prior to upgrade.
 
-For clusters that already set a value for `disable_mlock` no change is required.
+For clusters that already set a value for `disable_mlock`, no change is required.
 
 ### Additional Considerations:
 
 #### Autopilot
 New 1.20.0 nodes are added to the cluster until there is a quorum of upgraded
-nodes. Each of these new nodes will need to have a value for`disable_mlock`
+nodes. Each of these new nodes will need to have a value for `disable_mlock`
 set.
 
-#### Rolling Upgrades
+#### Rolling upgrades
 Standby nodes are stopped and upgraded one at a time. These node configurations
 will need to be updated before restarting the vault process on the node.
 
 #### dev mode
-If no config is provided, dev mode will start as usual. If a config is provided
-it must have a value for `disable_mlock`
+If no config is provided, dev mode will start as usual. If a config is provided,
+it must have a value for `disable_mlock`.
 
 ### Cluster types affected
 

--- a/website/content/docs/updates/important-changes.mdx
+++ b/website/content/docs/updates/important-changes.mdx
@@ -60,9 +60,9 @@ it must have a value for `disable_mlock`
 
 | Cluster Type               | `disable_mlock` required | Note
 |----------------------------|--------------------------|-----
-| Primary                    | Yes                      | value depends on cluster specifics. [See docs]()https://developer.hashicorp.com/vault/docs/configuration#disable_mlock
-| Performance Secondary      | Yes                      | value depends on cluster specifics. [See docs]()https://developer.hashicorp.com/vault/docs/configuration#disable_mlock
-| DR Secondary               | Yes                      | value depends on cluster specifics. [See docs]()https://developer.hashicorp.com/vault/docs/configuration#disable_mlock
+| Primary                    | Yes                      | value depends on cluster specifics. [See docs](/vault/docs/configuration#disable_mlock)
+| Performance Secondary      | Yes                      | value depends on cluster specifics. [See docs](/vault/docs/configuration#disable_mlock)
+| DR Secondary               | Yes                      | value depends on cluster specifics. [See docs](/vault/docs/configuration#disable_mlock)
 
 
 ## Transit support for Ed25519ph and Ed25519ctx signatures ((#ed25519))

--- a/website/content/docs/updates/release-notes.mdx
+++ b/website/content/docs/updates/release-notes.mdx
@@ -40,6 +40,7 @@ description: >-
 | Known issue     | 1.19.x                         | [Automated rotation stops after unseal](/vault/docs/updates/important-changes#rotation-stops)
 | Known issue     | 1.19.x, 1.18.x, 1.17.x, 1.16.x | [Azure Auth fails to authenticate Uniform VMSS instances](/vault/docs/updates/important-changes#azure-vmss)
 | Known issue     | 1.19.x, 1.18.x, 1.17.x, 1.16.x | [External Vault Enterprise plugins can't run on a standby node when it becomes active](/vault/docs/updates/important-changes#external-enterprise-plugins)
+| New behavior    | 1.20.x                         | [`disable_mlock` required for integrated storage](/vault/docs/updates/important-changes#disable_mlock-config)
 
 ## Feature deprecations and EOL
 

--- a/website/content/docs/updates/release-notes.mdx
+++ b/website/content/docs/updates/release-notes.mdx
@@ -41,6 +41,7 @@ description: >-
 | Known issue     | 1.19.x, 1.18.x, 1.17.x, 1.16.x | [Azure Auth fails to authenticate Uniform VMSS instances](/vault/docs/updates/important-changes#azure-vmss)
 | Known issue     | 1.19.x, 1.18.x, 1.17.x, 1.16.x | [External Vault Enterprise plugins can't run on a standby node when it becomes active](/vault/docs/updates/important-changes#external-enterprise-plugins)
 | New behavior    | 1.20.x                         | [`disable_mlock` required for integrated storage](/vault/docs/updates/important-changes#disable_mlock-config)
+| Breaking        | 1.20.x                         | [`disable_mlock` required for integrated storage](/vault/docs/updates/important-changes#disable_mlock-config)
 
 ## Feature deprecations and EOL
 

--- a/website/content/docs/updates/release-notes.mdx
+++ b/website/content/docs/updates/release-notes.mdx
@@ -40,7 +40,7 @@ description: >-
 | Known issue     | 1.19.x                         | [Automated rotation stops after unseal](/vault/docs/updates/important-changes#rotation-stops)
 | Known issue     | 1.19.x, 1.18.x, 1.17.x, 1.16.x | [Azure Auth fails to authenticate Uniform VMSS instances](/vault/docs/updates/important-changes#azure-vmss)
 | Known issue     | 1.19.x, 1.18.x, 1.17.x, 1.16.x | [External Vault Enterprise plugins can't run on a standby node when it becomes active](/vault/docs/updates/important-changes#external-enterprise-plugins)
-| New behavior    | 1.20.x                         | [`disable_mlock` required for integrated storage](/vault/docs/updates/important-changes#disable_mlock-config)
+| Breaking        | 1.20.x                         | [`disable_mlock` required for integrated storage](/vault/docs/updates/important-changes#disable_mlock-config)
 
 ## Feature deprecations and EOL
 

--- a/website/content/docs/updates/release-notes.mdx
+++ b/website/content/docs/updates/release-notes.mdx
@@ -41,7 +41,6 @@ description: >-
 | Known issue     | 1.19.x, 1.18.x, 1.17.x, 1.16.x | [Azure Auth fails to authenticate Uniform VMSS instances](/vault/docs/updates/important-changes#azure-vmss)
 | Known issue     | 1.19.x, 1.18.x, 1.17.x, 1.16.x | [External Vault Enterprise plugins can't run on a standby node when it becomes active](/vault/docs/updates/important-changes#external-enterprise-plugins)
 | New behavior    | 1.20.x                         | [`disable_mlock` required for integrated storage](/vault/docs/updates/important-changes#disable_mlock-config)
-| Breaking        | 1.20.x                         | [`disable_mlock` required for integrated storage](/vault/docs/updates/important-changes#disable_mlock-config)
 
 ## Feature deprecations and EOL
 


### PR DESCRIPTION
### Description
This PR adds a guide for updating Vault configs when using integrated storage for Vault 1.20.0. 

[Jira Issue](https://hashicorp.atlassian.net/browse/VAULT-35291)

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
