### PR TITLE
feat: Add toggle button to view secrets as YAML

### DIFF
--- a/ui/lib/core/addon/helpers/yamlify.js
+++ b/ui/lib/core/addon/helpers/yamlify.js
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import { helper as buildHelper } from '@ember/component/helper';
+import yaml from 'js-yaml';
+
+export function yamlify(target) {
+  return yaml.dump(target);
+}
+
+export default buildHelper(yamlify);

--- a/ui/lib/core/package.json
+++ b/ui/lib/core/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "autosize": "*",
     "date-fns": "*",
+    "js-yaml": "*",
     "@icholy/duration": "*",
     "base64-js": "*",
     "dompurify": "*",

--- a/ui/lib/kv/addon/components/kv-data-fields.hbs
+++ b/ui/lib/kv/addon/components/kv-data-fields.hbs
@@ -45,6 +45,21 @@
       }}
     />
   {{/if}}
+{{ else if @showYaml}}
+  {{#if (eq @type "details")}}
+    <Hds::CodeBlock
+      data-test-code-block="secret-data"
+      @value={{this.stringifiedSecretDataYaml}}
+      @language="yaml"
+      @hasCopyButton={{true}}
+      @maxHeight="300px"
+      as |CB|
+    >
+      <CB.Title @tag="h3">
+        Version data
+      </CB.Title>
+    </Hds::CodeBlock>
+  {{/if}}
 {{else if (eq @type "details")}}
   {{#each-in @secret.secretData as |key value|}}
     <InfoTableRow @label={{key}} @value={{value}} @alwaysRender={{true}}>

--- a/ui/lib/kv/addon/components/kv-data-fields.js
+++ b/ui/lib/kv/addon/components/kv-data-fields.js
@@ -3,16 +3,17 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import Component from '@glimmer/component';
 import { action } from '@ember/object';
+import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { stringify } from 'core/helpers/stringify';
-
+import { yamlify } from 'core/helpers/yamlify';
 /**
  * @module KvDataFields is used for rendering the fields associated with kv secret data, it hides/shows a json editor and renders validation errors for the json editor
  *
  * <KvDataFields
  *  @showJson={{true}}
+ *  @showYaml={{false}}
  *  @secret={{@secret}}
  *  @type="edit"
  *  @modelValidations={{this.modelValidations}}
@@ -21,6 +22,7 @@ import { stringify } from 'core/helpers/stringify';
  *
  * @param {model} secret - Ember data model: 'kv/data', the new record saved by the form
  * @param {boolean} showJson - boolean passed from parent to hide/show json editor
+ * @param {boolean} showYaml - boolean passed from parent to hide/show YAML editor
  * @param {object} [modelValidations] - object of errors.  If attr.name is in object and has error message display in AlertInline.
  * @param {callback} [pathValidations] - callback function fired for the path input on key up
  * @param {boolean} [type=null] - can be edit, create, or details. Used to change text for some form labels
@@ -39,6 +41,10 @@ export default class KvDataFields extends Component {
 
   get stringifiedSecretData() {
     return this.args.secret?.secretData ? stringify([this.args.secret.secretData], {}) : this.startingValue;
+  }
+
+  get stringifiedSecretDataYaml() {
+    return this.args.secret?.secretData ? yamlify(this.args.secret.secretData) : this.startingValue;
   }
 
   get viewportMargin() {

--- a/ui/lib/kv/addon/components/page/secret/details.hbs
+++ b/ui/lib/kv/addon/components/page/secret/details.hbs
@@ -77,8 +77,11 @@
 
   <:toolbarFilters>
     {{#unless this.emptyState}}
-      <Toggle @name="json" @checked={{this.showJsonView}} @onChange={{fn (mut this.showJsonView)}}>
+      <Toggle @name="json" @checked={{this.showJsonView}} @onChange={{this.setJsonView}}>
         <span class="has-text-grey">JSON</span>
+      </Toggle>
+      <Toggle @name="yaml" @checked={{this.showYamlView}} @onChange={{this.setYamlView}}>
+        <span class="has-text-grey">YAML</span>
       </Toggle>
     {{/unless}}
   </:toolbarFilters>
@@ -176,6 +179,7 @@
 {{else}}
   <KvDataFields
     @showJson={{this.showJsonView}}
+    @showYaml={{this.showYamlView}}
     @secret={{@secret}}
     @modelValidations={{this.modelValidations}}
     @type="details"

--- a/ui/lib/kv/addon/components/page/secret/details.js
+++ b/ui/lib/kv/addon/components/page/secret/details.js
@@ -3,15 +3,15 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import Component from '@glimmer/component';
 import { action } from '@ember/object';
-import { tracked } from '@glimmer/tracking';
 import { next } from '@ember/runloop';
 import { service } from '@ember/service';
-import { task } from 'ember-concurrency';
 import { waitFor } from '@ember/test-waiters';
-import { isDeleted } from 'kv/utils/kv-deleted';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
 import { isAdvancedSecret } from 'core/utils/advanced-secret';
+import { task } from 'ember-concurrency';
+import { isDeleted } from 'kv/utils/kv-deleted';
 
 /**
  * @module KvSecretDetails renders the key/value data of a KV secret.
@@ -45,6 +45,7 @@ export default class KvSecretDetails extends Component {
   @service store;
 
   @tracked showJsonView = false;
+  @tracked showYamlView = false;
   @tracked wrappedData = null;
   @tracked syncStatus = null; // array of association sync status info by destination
 
@@ -55,6 +56,22 @@ export default class KvSecretDetails extends Component {
     if (isAdvancedSecret(this.originalSecret)) {
       // Default to JSON view if advanced
       this.showJsonView = true;
+    }
+  }
+
+  @action
+  setJsonView(checked) {
+    this.showJsonView = checked;
+    if (this.showJsonView) {
+      this.showYamlView = false;
+    }
+  }
+
+  @action
+  setYamlView(checked) {
+    this.showYamlView = checked;
+    if (this.showYamlView) {
+      this.showJsonView = false;
     }
   }
 
@@ -145,7 +162,7 @@ export default class KvSecretDetails extends Component {
   }
 
   get hideHeaders() {
-    return this.showJsonView || this.emptyState;
+    return this.showJsonView || this.showYamlView || this.emptyState;
   }
 
   get versionState() {

--- a/ui/package.json
+++ b/ui/package.json
@@ -143,6 +143,7 @@
     "eslint-plugin-qunit": "^8.0.1",
     "filesize": "^4.2.1",
     "flat": "^6.0.1",
+    "js-yaml": "^4.1.0",
     "jsdoc-babel": "^0.5.0",
     "jsdoc-to-markdown": "^8.0.1",
     "jsondiffpatch": "^0.4.1",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -18907,6 +18907,7 @@ __metadata:
     flat: ^6.0.1
     handlebars: 4.7.7
     highlight.js: ^10.4.1
+    js-yaml: ^4.1.0
     jsdoc-babel: ^0.5.0
     jsdoc-to-markdown: ^8.0.1
     jsondiffpatch: ^0.4.1


### PR DESCRIPTION
### Description
What does this PR do?

This PR adds the ability to view secrets as YAML. The design is minimal and was implemented to see the expected behaviour. I need help in polishing this further.

Fixes #29481 

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
