### PR TITLE
[UI] Fixes Capabilities Issues in Custom Messages

### DIFF
--- a/ui/lib/config-ui/addon/routes/messages/index.js
+++ b/ui/lib/config-ui/addon/routes/messages/index.js
@@ -6,7 +6,6 @@
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
 import { paginate } from 'core/utils/paginate-list';
-import { PATH_MAP } from 'core/utils/capabilities';
 
 export default class MessagesRoute extends Route {
   @service api;
@@ -63,7 +62,7 @@ export default class MessagesRoute extends Route {
         filterKey: 'title',
       });
       // fetch capabilities for each message path
-      const paths = messages.map((message) => `${PATH_MAP.customMessages}/${message.id}`);
+      const paths = messages.map((message) => this.capabilities.pathFor('customMessages', message));
       const capabilities = await this.capabilities.fetch(paths);
 
       return { params, messages, capabilities };

--- a/ui/lib/config-ui/addon/templates/messages/index.hbs
+++ b/ui/lib/config-ui/addon/templates/messages/index.hbs
@@ -7,4 +7,5 @@
   @messages={{this.model.messages}}
   @authenticated={{this.authenticated}}
   @params={{this.model.params}}
+  @capabilities={{this.model.capabilities}}
 />


### PR DESCRIPTION
### Description
There were some updates to capabilities in #30524 that caused/revealed issues in the custom messages engine that caused some enterprise tests to fail. This PR fixes those issues and enterprise tests are now passing locally.

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
