### PR TITLE
UI: Updating visibility attr on auth config to be a toggle with direct login link

### DIFF
--- a/ui/app/components/auth-config-form/options.hbs
+++ b/ui/app/components/auth-config-form/options.hbs
@@ -12,10 +12,9 @@
       {{#if (not (includes attr.name @model.userLockoutConfig.modelAttrs))}}
         <FormField data-test-field @attr={{attr}} @model={{@model}} />
         {{#if (eq attr.name "config.listingVisibility")}}
-          <div class="has-top-margin-negative-s has-bottom-margin-l has-text-info">
-            <span class="has-text-grey">UI login link:</span>
-            {{this.getLoginLink}}
-            <Hds::Copy::Button @isIconOnly={{true}} @text="Copy your login link" @textToCopy={{this.getLoginLink}} />
+          <div class="has-top-margin-negative-s has-bottom-margin-l is-flex-center">
+            <Hds::Text::Body @tag="p" @color="faint">UI login link:</Hds::Text::Body>
+            <Hds::Copy::Snippet @textToCopy={{this.getLoginLink}} />
           </div>
         {{/if}}
       {{/if}}

--- a/ui/app/components/auth-config-form/options.hbs
+++ b/ui/app/components/auth-config-form/options.hbs
@@ -12,13 +12,10 @@
       {{#if (not (includes attr.name @model.userLockoutConfig.modelAttrs))}}
         <FormField data-test-field @attr={{attr}} @model={{@model}} />
         {{#if (eq attr.name "config.listingVisibility")}}
-          <div class="has-top-margin-negative-s has-bottom-margin-l">
+          <div class="has-top-margin-negative-s has-bottom-margin-l has-text-info">
             <span class="has-text-grey">UI login link:</span>
-            <Hds::Link::Inline
-              @icon="clipboard-copy"
-              @iconPosition="trailing"
-              @href="https://vault.com/ui/vault/auth?with=username"
-            >https://vault.com/ui/vault/auth?with=username</Hds::Link::Inline>
+            {{this.getLoginLink}}
+            <Hds::Copy::Button @isIconOnly={{true}} @text="Copy your login link" @textToCopy={{this.getLoginLink}} />
           </div>
         {{/if}}
       {{/if}}

--- a/ui/app/components/auth-config-form/options.hbs
+++ b/ui/app/components/auth-config-form/options.hbs
@@ -11,6 +11,16 @@
     {{#each @model.tuneAttrs as |attr|}}
       {{#if (not (includes attr.name @model.userLockoutConfig.modelAttrs))}}
         <FormField data-test-field @attr={{attr}} @model={{@model}} />
+        {{#if (eq attr.name "config.listingVisibility")}}
+          <div class="has-top-margin-negative-s has-bottom-margin-l">
+            <span class="has-text-grey">UI login link:</span>
+            <Hds::Link::Inline
+              @icon="clipboard-copy"
+              @iconPosition="trailing"
+              @href="https://vault.com/ui/vault/auth?with=username"
+            >https://vault.com/ui/vault/auth?with=username</Hds::Link::Inline>
+          </div>
+        {{/if}}
       {{/if}}
     {{/each}}
 

--- a/ui/app/components/auth-config-form/options.js
+++ b/ui/app/components/auth-config-form/options.js
@@ -10,7 +10,6 @@ import { task } from 'ember-concurrency';
 import { waitFor } from '@ember/test-waiters';
 import { tracked } from '@glimmer/tracking';
 import errorMessage from 'vault/utils/error-message';
-import { encodePath } from 'vault/utils/path-encoding-helpers';
 
 /**
  * @module AuthConfigForm/Options
@@ -68,6 +67,6 @@ export default class AuthConfigOptions extends AuthConfigComponent {
   }
 
   get getLoginLink() {
-    return `${window.origin}/ui/vault/auth?with=${encodePath(this.args.model.path)}`;
+    return `${window.origin}/ui/vault/auth?with=${encodeURIComponent(this.args.model.path)}`;
   }
 }

--- a/ui/app/components/auth-config-form/options.js
+++ b/ui/app/components/auth-config-form/options.js
@@ -10,6 +10,7 @@ import { task } from 'ember-concurrency';
 import { waitFor } from '@ember/test-waiters';
 import { tracked } from '@glimmer/tracking';
 import errorMessage from 'vault/utils/error-message';
+import { encodePath } from 'vault/utils/path-encoding-helpers';
 
 /**
  * @module AuthConfigForm/Options
@@ -67,6 +68,6 @@ export default class AuthConfigOptions extends AuthConfigComponent {
   }
 
   get getLoginLink() {
-    return `${window.origin}/ui/vault/auth?with=${this.args.model.type}`;
+    return `${window.origin}/ui/vault/auth?with=${encodePath(this.args.model.path)}`;
   }
 }

--- a/ui/app/components/auth-config-form/options.js
+++ b/ui/app/components/auth-config-form/options.js
@@ -65,4 +65,8 @@ export default class AuthConfigOptions extends AuthConfigComponent {
     this.router.transitionTo('vault.cluster.access.methods').followRedirects();
     this.flashMessages.success('The configuration was saved successfully.');
   }
+
+  get getLoginLink() {
+    return `${window.origin}/ui/vault/auth?with=${this.args.model.type}`;
+  }
 }

--- a/ui/app/models/mount-config.js
+++ b/ui/app/models/mount-config.js
@@ -33,9 +33,11 @@ export default class MountConfigModel extends Model {
   auditNonHmacResponseKeys;
 
   @attr('mountVisibility', {
-    editType: 'boolean',
-    label: 'List method when unauthenticated',
-    defaultValue: false,
+    label: 'Use as preferred UI login method',
+    editType: 'toggleButton',
+    helperTextEnabled: 'Shown as the default login method on the unauthenticated UI login endpoint.',
+    helperTextDisabled:
+      'Turn on the toggle to use this auth mount as the preferred login method during UI login.',
   })
   listingVisibility;
 

--- a/ui/app/models/mount-config.js
+++ b/ui/app/models/mount-config.js
@@ -35,9 +35,10 @@ export default class MountConfigModel extends Model {
   @attr('mountVisibility', {
     label: 'Use as preferred UI login method',
     editType: 'toggleButton',
-    helperTextEnabled: 'Shown as the default login method on the unauthenticated UI login endpoint.',
+    helperTextEnabled:
+      'This mount will be included in the unauthenticated UI login endpoint and display as a preferred login method.',
     helperTextDisabled:
-      'Turn on the toggle to use this auth mount as the preferred login method during UI login.',
+      'Turn on the toggle to use this auth mount as a preferred login method during UI login.',
     defaultValue: false,
   })
   listingVisibility;

--- a/ui/app/models/mount-config.js
+++ b/ui/app/models/mount-config.js
@@ -38,6 +38,7 @@ export default class MountConfigModel extends Model {
     helperTextEnabled: 'Shown as the default login method on the unauthenticated UI login endpoint.',
     helperTextDisabled:
       'Turn on the toggle to use this auth mount as the preferred login method during UI login.',
+    defaultValue: false,
   })
   listingVisibility;
 

--- a/ui/tests/acceptance/auth/test-helper.js
+++ b/ui/tests/acceptance/auth/test-helper.js
@@ -13,7 +13,7 @@ const assertFields = (assert, fields, customSelectors = {}) => {
     if (Object.keys(customSelectors).includes(param)) {
       assert.dom(customSelectors[param]).exists();
     } else if (param === 'config.listingVisibility') {
-      assert.dom(GENERAL.toggleButton('toggle-config.listingVisibility')).exists();
+      assert.dom(GENERAL.toggleInput('toggle-config.listingVisibility')).exists();
     } else {
       assert.dom(GENERAL.inputByAttr(param)).exists();
     }

--- a/ui/tests/acceptance/auth/test-helper.js
+++ b/ui/tests/acceptance/auth/test-helper.js
@@ -12,6 +12,8 @@ const assertFields = (assert, fields, customSelectors = {}) => {
   fields.forEach((param) => {
     if (Object.keys(customSelectors).includes(param)) {
       assert.dom(customSelectors[param]).exists();
+    } else if (param === 'config.listingVisibility') {
+      assert.dom(GENERAL.toggleButton('toggle-config.listingVisibility')).exists();
     } else {
       assert.dom(GENERAL.inputByAttr(param)).exists();
     }

--- a/ui/tests/integration/components/auth-config-form/options-test.js
+++ b/ui/tests/integration/components/auth-config-form/options-test.js
@@ -178,7 +178,7 @@ module('Integration | Component | auth-config-form options', function (hooks) {
       .dom(GENERAL.inputByAttr('config.tokenType'))
       .doesNotExist('does not render tokenType for token auth method');
 
-    await click(GENERAL.inputByAttr('config.listingVisibility'));
+    await click(GENERAL.toggleInput('toggle-config.listingVisibility'));
     await click(GENERAL.ttl.toggle('Default Lease TTL'));
     await fillIn(GENERAL.ttl.input('Default Lease TTL'), '30');
 

--- a/ui/tests/integration/components/auth-config-form/options-test.js
+++ b/ui/tests/integration/components/auth-config-form/options-test.js
@@ -66,7 +66,7 @@ module('Integration | Component | auth-config-form options', function (hooks) {
 
       assert.dom('[data-test-user-lockout-section]').hasText('User lockout configuration');
 
-      await click(GENERAL.inputByAttr('config.listingVisibility'));
+      await click(GENERAL.toggleInput('toggle-config.listingVisibility'));
       await fillIn(GENERAL.inputByAttr('config.tokenType'), 'default-batch');
 
       await click(GENERAL.ttl.toggle('Default Lease TTL'));
@@ -124,7 +124,7 @@ module('Integration | Component | auth-config-form options', function (hooks) {
         .dom('[data-test-user-lockout-section]')
         .doesNotExist(`${type} method does not render user lockout section`);
 
-      await click(GENERAL.inputByAttr('config.listingVisibility'));
+      await click(GENERAL.toggleInput('toggle-config.listingVisibility'));
       await fillIn(GENERAL.inputByAttr('config.tokenType'), 'default-batch');
 
       await click(GENERAL.ttl.toggle('Default Lease TTL'));


### PR DESCRIPTION
### Description
What does this PR do?

### **[Merging into sidebranch]**

Replaces listingVisibility checkbox to be a toggle button and adds a direct login link based on auth type + copy button

### Before:
![image](https://github.com/user-attachments/assets/e005c83b-3202-41e6-b5c5-39e5cc10ca20)


### After:

![image](https://github.com/user-attachments/assets/70ad9299-1f18-47ef-b2d3-fad141e66435)

![image](https://github.com/user-attachments/assets/c3172747-f0a2-4f72-bce2-22be2b5932de)


### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
