### PR TITLE
[VAULT-35716] Handle lists of values in policy parameters

### DIFF
--- a/changelog/30551.txt
+++ b/changelog/30551.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+core/acl: Policies with `allowed_parameters` and `denied_parameters` are now evaluated correctly against
+request parameters with lists of values.
+```

--- a/changelog/30551.txt
+++ b/changelog/30551.txt
@@ -1,4 +1,4 @@
-```release-note:bug
+```release-note:change
 core/acl: Policies with `allowed_parameters` and `denied_parameters` are now evaluated correctly against
-request parameters with lists of values.
+requests where parameters are assigned comma-separated lists of values.
 ```

--- a/vault/acl.go
+++ b/vault/acl.go
@@ -770,30 +770,18 @@ func valueInAllowedParameterList(v interface{}, list []interface{}) bool {
 		return true
 	}
 
-	// If v is a slice, check if all the values in the slice are in the list
-	switch vals := v.(type) {
-	case []interface{}:
-		for _, val := range vals {
-			if !valueInParameterList(val, list) {
+	val := reflect.ValueOf(v)
+	if val.Kind() == reflect.Slice {
+		// If v is a slice, check if all the values in the slice are in the list
+		for i := 0; i < val.Len(); i++ {
+			if !valueInParameterList(val.Index(i).Interface(), list) {
 				return false
 			}
 		}
-	case []string:
-		for _, val := range vals {
-			if !valueInParameterList(val, list) {
-				return false
-			}
-		}
-	case []int:
-		for _, val := range vals {
-			if !valueInParameterList(val, list) {
-				return false
-			}
-		}
-	default:
+	} else {
+		// If v is not a slice, check if the value is in the list
 		return valueInParameterList(v, list)
 	}
-
 	return true
 }
 
@@ -803,30 +791,18 @@ func valueInDeniedParameterList(v interface{}, list []interface{}) bool {
 		return true
 	}
 
-	// If v is a slice, check if any of the values in the slice are in the list
-	switch vals := v.(type) {
-	case []interface{}:
-		for _, val := range vals {
-			if valueInParameterList(val, list) {
+	val := reflect.ValueOf(v)
+	if val.Kind() == reflect.Slice {
+		// If v is a slice, check if any of the values in the slice are in the list
+		for i := 0; i < val.Len(); i++ {
+			if valueInParameterList(val.Index(i).Interface(), list) {
 				return true
 			}
 		}
-	case []string:
-		for _, val := range vals {
-			if valueInParameterList(val, list) {
-				return true
-			}
-		}
-	case []int:
-		for _, val := range vals {
-			if valueInParameterList(val, list) {
-				return true
-			}
-		}
-	default:
+	} else {
+		// If v is not a slice, check if the value is in the list
 		return valueInParameterList(v, list)
 	}
-
 	return false
 }
 

--- a/vault/acl_test.go
+++ b/vault/acl_test.go
@@ -560,62 +560,71 @@ func testACLValuePermissions(t *testing.T, ns *namespace.Namespace) {
 	}
 	type tcase struct {
 		path       string
-		parameters []string
-		values     []interface{}
+		parameters map[string]interface{}
 		allowed    bool
 	}
 
 	tcases := []tcase{
-		{"dev/ops", []string{"allow"}, []interface{}{"good"}, true},
-		{"dev/ops", []string{"allow"}, []interface{}{"bad"}, false},
-		{"foo/bar", []string{"deny"}, []interface{}{"bad"}, false},
-		{"foo/bar", []string{"deny"}, []interface{}{"bad glob"}, false},
-		{"foo/bar", []string{"deny"}, []interface{}{"good"}, true},
-		{"foo/bar", []string{"allow"}, []interface{}{"good"}, true},
-		{"foo/bar", []string{"deny"}, []interface{}{nil}, true},
-		{"foo/bar", []string{"allow"}, []interface{}{nil}, true},
-		{"foo/baz", []string{"aLLow"}, []interface{}{"good"}, true},
-		{"foo/baz", []string{"deny"}, []interface{}{"bad"}, false},
-		{"foo/baz", []string{"deny"}, []interface{}{"good"}, false},
-		{"foo/baz", []string{"allow", "deny"}, []interface{}{"good", "bad"}, false},
-		{"foo/baz", []string{"deny", "allow"}, []interface{}{"good", "bad"}, false},
-		{"foo/baz", []string{"deNy", "allow"}, []interface{}{"bad", "good"}, false},
-		{"foo/baz", []string{"aLLow"}, []interface{}{"bad"}, false},
-		{"foo/baz", []string{"Neither"}, []interface{}{"bad"}, false},
-		{"foo/baz", []string{"allow"}, []interface{}{nil}, false},
-		{"fizz/buzz", []string{"allow_multi"}, []interface{}{"good"}, true},
-		{"fizz/buzz", []string{"allow_multi"}, []interface{}{"good1"}, true},
-		{"fizz/buzz", []string{"allow_multi"}, []interface{}{"good2"}, true},
-		{"fizz/buzz", []string{"allow_multi"}, []interface{}{"glob good2"}, false},
-		{"fizz/buzz", []string{"allow_multi"}, []interface{}{"glob good3"}, true},
-		{"fizz/buzz", []string{"allow_multi"}, []interface{}{"bad"}, false},
-		{"fizz/buzz", []string{"allow_multi"}, []interface{}{"bad"}, false},
-		{"fizz/buzz", []string{"allow_multi", "allow"}, []interface{}{"good1", "good"}, true},
-		{"fizz/buzz", []string{"deny_multi"}, []interface{}{"bad2"}, false},
-		{"fizz/buzz", []string{"deny_multi", "allow_multi"}, []interface{}{"good", "good2"}, false},
-		//	{"test/types", []string{"array"}, []interface{}{[1]string{"good"}}, true},
-		{"test/types", []string{"map"}, []interface{}{map[string]interface{}{"good": "one"}}, true},
-		{"test/types", []string{"map"}, []interface{}{map[string]interface{}{"bad": "one"}}, false},
-		{"test/types", []string{"int"}, []interface{}{1}, true},
-		{"test/types", []string{"int"}, []interface{}{3}, false},
-		{"test/types", []string{"bool"}, []interface{}{false}, true},
-		{"test/types", []string{"bool"}, []interface{}{true}, false},
-		{"test/star", []string{"anything"}, []interface{}{true}, true},
-		{"test/star", []string{"foo"}, []interface{}{true}, true},
-		{"test/star", []string{"bar"}, []interface{}{false}, true},
-		{"test/star", []string{"bar"}, []interface{}{true}, false},
+		{"dev/ops", map[string]interface{}{"allow": "good"}, true},
+		{"dev/ops", map[string]interface{}{"allow": "bad"}, false},
+		{"foo/bar", map[string]interface{}{"deny": "bad"}, false},
+		{"foo/bar", map[string]interface{}{"deny": "bad glob"}, false},
+		{"foo/bar", map[string]interface{}{"deny": "good"}, true},
+		{"foo/bar", map[string]interface{}{"allow": "good"}, true},
+		{"foo/bar", map[string]interface{}{"deny": nil}, true},
+		{"foo/bar", map[string]interface{}{"allow": nil}, true},
+		{"foo/baz", map[string]interface{}{"aLLow": "good"}, true},
+		{"foo/baz", map[string]interface{}{"deny": "bad"}, false},
+		{"foo/baz", map[string]interface{}{"deny": "good"}, false},
+		{"foo/baz", map[string]interface{}{"allow": "good", "deny": "bad"}, false},
+		{"foo/baz", map[string]interface{}{"deny": "good", "allow": "bad"}, false},
+		{"foo/baz", map[string]interface{}{"deNy": "bad", "allow": "good"}, false},
+		{"foo/baz", map[string]interface{}{"aLLow": "bad"}, false},
+		{"foo/baz", map[string]interface{}{"Neither": "bad"}, false},
+		{"foo/baz", map[string]interface{}{"allow": nil}, false},
+		{"fizz/buzz", map[string]interface{}{"allow_multi": "good"}, true},
+		{"fizz/buzz", map[string]interface{}{"allow_multi": "good1"}, true},
+		{"fizz/buzz", map[string]interface{}{"allow_multi": "good2"}, true},
+		{"fizz/buzz", map[string]interface{}{"allow_multi": "glob good2"}, false},
+		{"fizz/buzz", map[string]interface{}{"allow_multi": "glob good3"}, true},
+		{"fizz/buzz", map[string]interface{}{"allow_multi": "bad"}, false},
+		{"fizz/buzz", map[string]interface{}{"allow_multi": "bad"}, false},
+		{"fizz/buzz", map[string]interface{}{"allow_multi": "good1", "allow": "good"}, true},
+		{"fizz/buzz", map[string]interface{}{"deny_multi": "bad2"}, false},
+		{"fizz/buzz", map[string]interface{}{"deny_multi": "good", "allow_multi": "good2"}, false},
+		{"test/types", map[string]interface{}{"map": map[string]interface{}{"good": "one"}}, true},
+		{"test/types", map[string]interface{}{"map": map[string]interface{}{"bad": "one"}}, false},
+		{"test/types", map[string]interface{}{"int": 1}, true},
+		{"test/types", map[string]interface{}{"int": 3}, false},
+		{"test/types", map[string]interface{}{"bool": false}, true},
+		{"test/types", map[string]interface{}{"bool": true}, false},
+		{"test/star", map[string]interface{}{"anything": true}, true},
+		{"test/star", map[string]interface{}{"foo": true}, true},
+		{"test/star", map[string]interface{}{"bar": false}, true},
+		{"test/star", map[string]interface{}{"bar": true}, false},
+		{"test/slice/allow", map[string]interface{}{"allowStr": []string{"good"}}, true},
+		{"test/slice/allow", map[string]interface{}{"allowStr": []string{"good1", "good2 glob"}}, true},
+		{"test/slice/allow", map[string]interface{}{"allowStr": []string{"good1", "bad"}}, false},
+		{"test/slice/allow", map[string]interface{}{"allowInt": []int{1, 2}}, true},
+		{"test/slice/allow", map[string]interface{}{"allowInt": []int{3, 4}}, false},
+		{"test/slice/allow", map[string]interface{}{"allowIface": []interface{}{"good", 1}}, true},
+		{"test/slice/allow", map[string]interface{}{"allowIface": []interface{}{"good", "bad", 1}}, false},
+		{"test/slice/deny", map[string]interface{}{"denyStr": []string{"bad"}}, false},
+		{"test/slice/deny", map[string]interface{}{"denyStr": []string{"good1", "bad2 glob"}}, false},
+		{"test/slice/deny", map[string]interface{}{"denyStr": []string{"good1", "good2"}}, true},
+		{"test/slice/deny", map[string]interface{}{"denyInt": []int{1, 2, 3}}, false},
+		{"test/slice/deny", map[string]interface{}{"denyInt": []int{4, 5}}, true},
+		{"test/slice/deny", map[string]interface{}{"denyIface": []interface{}{"bad", 1}}, false},
+		{"test/slice/deny", map[string]interface{}{"denyIface": []interface{}{"good", "good1", 5}}, true},
 	}
 
 	for _, tc := range tcases {
 		request := &logical.Request{
 			Path: tc.path,
-			Data: make(map[string]interface{}),
+			Data: tc.parameters,
 		}
 		ctx := namespace.ContextWithNamespace(context.Background(), ns)
 
-		for i, parameter := range tc.parameters {
-			request.Data[parameter] = tc.values[i]
-		}
 		for _, op := range toperations {
 			request.Operation = op
 			authResults := acl.AllowOperation(ctx, request, false)
@@ -1329,6 +1338,22 @@ path "test/star" {
 		"bar" = [false]
 	}
 	denied_parameters = {
+	}
+}
+path "test/slice/allow" {
+	policy = "write"
+	allowed_parameters = {
+		"allowStr" = ["good", "good1", "good2*"]
+		"allowInt" = [1, 2, 3]
+		"allowIface" = ["good", 1, 2]
+	}
+}
+path "test/slice/deny" {
+	policy = "write"
+	denied_parameters = {
+		"denyStr" = ["bad", "bad1", "bad2*"]
+		"denyInt" = [1, 2, 3]
+		"denyIface" = ["bad", 1, 2]
 	}
 }
 `


### PR DESCRIPTION
### Description
As reported in [VAULT-35716](https://hashicorp.atlassian.net/browse/VAULT-35716), policies created with `allowed_parameters` or `denied_parameters` do not work as expected if the request assigns a list of values to the allowed/denied parameter instead of a single value. 

eg. with a policy:

```
path "identity/group" {
  capabilities = ["create", "update", "list", "read"]
  denied_parameters = {
    "name" = ["admin_group_*", "ADMIN_GROUP_*", "admin_automation", "ADMIN_AUTOMATION"]
    "policies" = ["*admin-automation-policy*", "*admin-policy*"]    
    
  }
}
```
a request with parameters `{"name":"test_policy_list","policies": ["admin-policy", "admin-automation-policy"], "type": "external"}'` should be denied but is allowed because we do not expect `policies` could be a list of values and attempt to compare the entirety of it as a single value against `*admin-automation-policy*` and then against `*admin-policy*`. 

AFAICT nothing in our documentation prohibits using a list of values, but we do not handle the case. This PR checks if the input is a slice type, and if so, iterates through it so each value in the slice is being checked against the allow/deny list. 


### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.


[VAULT-35716]: https://hashicorp.atlassian.net/browse/VAULT-35716?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ