### PR TITLE
[UI] API Client Updates - Sync

### DIFF
--- a/ui/api-client/dist/esm/models/SystemPatchSyncDestinationsAwsSmNameResponse.d.ts
+++ b/ui/api-client/dist/esm/models/SystemPatchSyncDestinationsAwsSmNameResponse.d.ts
@@ -28,6 +28,24 @@ export interface SystemPatchSyncDestinationsAwsSmNameResponse {
      */
     name?: string;
     /**
+     * List of key value pairs of Vault configuration options.
+     * @type {object}
+     * @memberof SystemPatchSyncDestinationsAwsSmNameResponse
+     */
+    options?: object;
+    /**
+     * Error message if the purge job failed.
+     * @type {string}
+     * @memberof SystemPatchSyncDestinationsAwsSmNameResponse
+     */
+    purgeError?: string;
+    /**
+     * Timestamp of when a purge job was initiated when deleting a destination.
+     * @type {Date}
+     * @memberof SystemPatchSyncDestinationsAwsSmNameResponse
+     */
+    purgeInitiatedAt?: Date;
+    /**
      * Type of this secrets store.
      * @type {string}
      * @memberof SystemPatchSyncDestinationsAwsSmNameResponse

--- a/ui/api-client/dist/esm/models/SystemPatchSyncDestinationsAwsSmNameResponse.js
+++ b/ui/api-client/dist/esm/models/SystemPatchSyncDestinationsAwsSmNameResponse.js
@@ -27,6 +27,9 @@ export function SystemPatchSyncDestinationsAwsSmNameResponseFromJSONTyped(json, 
     return {
         'connectionDetails': json['connection_details'] == null ? undefined : json['connection_details'],
         'name': json['name'] == null ? undefined : json['name'],
+        'options': json['options'] == null ? undefined : json['options'],
+        'purgeError': json['purge_error'] == null ? undefined : json['purge_error'],
+        'purgeInitiatedAt': json['purge_initiated_at'] == null ? undefined : (new Date(json['purge_initiated_at'])),
         'type': json['type'] == null ? undefined : json['type'],
     };
 }
@@ -40,6 +43,9 @@ export function SystemPatchSyncDestinationsAwsSmNameResponseToJSONTyped(value, i
     return {
         'connection_details': value['connectionDetails'],
         'name': value['name'],
+        'options': value['options'],
+        'purge_error': value['purgeError'],
+        'purge_initiated_at': value['purgeInitiatedAt'] == null ? undefined : ((value['purgeInitiatedAt']).toISOString()),
         'type': value['type'],
     };
 }

--- a/ui/api-client/dist/esm/models/SystemPatchSyncDestinationsAzureKvNameResponse.d.ts
+++ b/ui/api-client/dist/esm/models/SystemPatchSyncDestinationsAzureKvNameResponse.d.ts
@@ -28,6 +28,24 @@ export interface SystemPatchSyncDestinationsAzureKvNameResponse {
      */
     name?: string;
     /**
+     * List of key value pairs of Vault configuration options.
+     * @type {object}
+     * @memberof SystemPatchSyncDestinationsAzureKvNameResponse
+     */
+    options?: object;
+    /**
+     * Error message if the purge job failed.
+     * @type {string}
+     * @memberof SystemPatchSyncDestinationsAzureKvNameResponse
+     */
+    purgeError?: string;
+    /**
+     * Timestamp of when a purge job was initiated when deleting a destination.
+     * @type {Date}
+     * @memberof SystemPatchSyncDestinationsAzureKvNameResponse
+     */
+    purgeInitiatedAt?: Date;
+    /**
      * Type of this secrets store.
      * @type {string}
      * @memberof SystemPatchSyncDestinationsAzureKvNameResponse

--- a/ui/api-client/dist/esm/models/SystemPatchSyncDestinationsAzureKvNameResponse.js
+++ b/ui/api-client/dist/esm/models/SystemPatchSyncDestinationsAzureKvNameResponse.js
@@ -27,6 +27,9 @@ export function SystemPatchSyncDestinationsAzureKvNameResponseFromJSONTyped(json
     return {
         'connectionDetails': json['connection_details'] == null ? undefined : json['connection_details'],
         'name': json['name'] == null ? undefined : json['name'],
+        'options': json['options'] == null ? undefined : json['options'],
+        'purgeError': json['purge_error'] == null ? undefined : json['purge_error'],
+        'purgeInitiatedAt': json['purge_initiated_at'] == null ? undefined : (new Date(json['purge_initiated_at'])),
         'type': json['type'] == null ? undefined : json['type'],
     };
 }
@@ -40,6 +43,9 @@ export function SystemPatchSyncDestinationsAzureKvNameResponseToJSONTyped(value,
     return {
         'connection_details': value['connectionDetails'],
         'name': value['name'],
+        'options': value['options'],
+        'purge_error': value['purgeError'],
+        'purge_initiated_at': value['purgeInitiatedAt'] == null ? undefined : ((value['purgeInitiatedAt']).toISOString()),
         'type': value['type'],
     };
 }

--- a/ui/api-client/dist/esm/models/SystemPatchSyncDestinationsGcpSmNameResponse.d.ts
+++ b/ui/api-client/dist/esm/models/SystemPatchSyncDestinationsGcpSmNameResponse.d.ts
@@ -28,6 +28,24 @@ export interface SystemPatchSyncDestinationsGcpSmNameResponse {
      */
     name?: string;
     /**
+     * List of key value pairs of Vault configuration options.
+     * @type {object}
+     * @memberof SystemPatchSyncDestinationsGcpSmNameResponse
+     */
+    options?: object;
+    /**
+     * Error message if the purge job failed.
+     * @type {string}
+     * @memberof SystemPatchSyncDestinationsGcpSmNameResponse
+     */
+    purgeError?: string;
+    /**
+     * Timestamp of when a purge job was initiated when deleting a destination.
+     * @type {Date}
+     * @memberof SystemPatchSyncDestinationsGcpSmNameResponse
+     */
+    purgeInitiatedAt?: Date;
+    /**
      * Type of this secrets store.
      * @type {string}
      * @memberof SystemPatchSyncDestinationsGcpSmNameResponse

--- a/ui/api-client/dist/esm/models/SystemPatchSyncDestinationsGcpSmNameResponse.js
+++ b/ui/api-client/dist/esm/models/SystemPatchSyncDestinationsGcpSmNameResponse.js
@@ -27,6 +27,9 @@ export function SystemPatchSyncDestinationsGcpSmNameResponseFromJSONTyped(json, 
     return {
         'connectionDetails': json['connection_details'] == null ? undefined : json['connection_details'],
         'name': json['name'] == null ? undefined : json['name'],
+        'options': json['options'] == null ? undefined : json['options'],
+        'purgeError': json['purge_error'] == null ? undefined : json['purge_error'],
+        'purgeInitiatedAt': json['purge_initiated_at'] == null ? undefined : (new Date(json['purge_initiated_at'])),
         'type': json['type'] == null ? undefined : json['type'],
     };
 }
@@ -40,6 +43,9 @@ export function SystemPatchSyncDestinationsGcpSmNameResponseToJSONTyped(value, i
     return {
         'connection_details': value['connectionDetails'],
         'name': value['name'],
+        'options': value['options'],
+        'purge_error': value['purgeError'],
+        'purge_initiated_at': value['purgeInitiatedAt'] == null ? undefined : ((value['purgeInitiatedAt']).toISOString()),
         'type': value['type'],
     };
 }

--- a/ui/api-client/dist/esm/models/SystemPatchSyncDestinationsGhNameResponse.d.ts
+++ b/ui/api-client/dist/esm/models/SystemPatchSyncDestinationsGhNameResponse.d.ts
@@ -28,6 +28,24 @@ export interface SystemPatchSyncDestinationsGhNameResponse {
      */
     name?: string;
     /**
+     * List of key value pairs of Vault configuration options.
+     * @type {object}
+     * @memberof SystemPatchSyncDestinationsGhNameResponse
+     */
+    options?: object;
+    /**
+     * Error message if the purge job failed.
+     * @type {string}
+     * @memberof SystemPatchSyncDestinationsGhNameResponse
+     */
+    purgeError?: string;
+    /**
+     * Timestamp of when a purge job was initiated when deleting a destination.
+     * @type {Date}
+     * @memberof SystemPatchSyncDestinationsGhNameResponse
+     */
+    purgeInitiatedAt?: Date;
+    /**
      * Type of this secrets store.
      * @type {string}
      * @memberof SystemPatchSyncDestinationsGhNameResponse

--- a/ui/api-client/dist/esm/models/SystemPatchSyncDestinationsGhNameResponse.js
+++ b/ui/api-client/dist/esm/models/SystemPatchSyncDestinationsGhNameResponse.js
@@ -27,6 +27,9 @@ export function SystemPatchSyncDestinationsGhNameResponseFromJSONTyped(json, ign
     return {
         'connectionDetails': json['connection_details'] == null ? undefined : json['connection_details'],
         'name': json['name'] == null ? undefined : json['name'],
+        'options': json['options'] == null ? undefined : json['options'],
+        'purgeError': json['purge_error'] == null ? undefined : json['purge_error'],
+        'purgeInitiatedAt': json['purge_initiated_at'] == null ? undefined : (new Date(json['purge_initiated_at'])),
         'type': json['type'] == null ? undefined : json['type'],
     };
 }
@@ -40,6 +43,9 @@ export function SystemPatchSyncDestinationsGhNameResponseToJSONTyped(value, igno
     return {
         'connection_details': value['connectionDetails'],
         'name': value['name'],
+        'options': value['options'],
+        'purge_error': value['purgeError'],
+        'purge_initiated_at': value['purgeInitiatedAt'] == null ? undefined : ((value['purgeInitiatedAt']).toISOString()),
         'type': value['type'],
     };
 }

--- a/ui/api-client/dist/esm/models/SystemPatchSyncDestinationsInMemNameResponse.d.ts
+++ b/ui/api-client/dist/esm/models/SystemPatchSyncDestinationsInMemNameResponse.d.ts
@@ -28,6 +28,24 @@ export interface SystemPatchSyncDestinationsInMemNameResponse {
      */
     name?: string;
     /**
+     * List of key value pairs of Vault configuration options.
+     * @type {object}
+     * @memberof SystemPatchSyncDestinationsInMemNameResponse
+     */
+    options?: object;
+    /**
+     * Error message if the purge job failed.
+     * @type {string}
+     * @memberof SystemPatchSyncDestinationsInMemNameResponse
+     */
+    purgeError?: string;
+    /**
+     * Timestamp of when a purge job was initiated when deleting a destination.
+     * @type {Date}
+     * @memberof SystemPatchSyncDestinationsInMemNameResponse
+     */
+    purgeInitiatedAt?: Date;
+    /**
      * Type of this secrets store.
      * @type {string}
      * @memberof SystemPatchSyncDestinationsInMemNameResponse

--- a/ui/api-client/dist/esm/models/SystemPatchSyncDestinationsInMemNameResponse.js
+++ b/ui/api-client/dist/esm/models/SystemPatchSyncDestinationsInMemNameResponse.js
@@ -27,6 +27,9 @@ export function SystemPatchSyncDestinationsInMemNameResponseFromJSONTyped(json, 
     return {
         'connectionDetails': json['connection_details'] == null ? undefined : json['connection_details'],
         'name': json['name'] == null ? undefined : json['name'],
+        'options': json['options'] == null ? undefined : json['options'],
+        'purgeError': json['purge_error'] == null ? undefined : json['purge_error'],
+        'purgeInitiatedAt': json['purge_initiated_at'] == null ? undefined : (new Date(json['purge_initiated_at'])),
         'type': json['type'] == null ? undefined : json['type'],
     };
 }
@@ -40,6 +43,9 @@ export function SystemPatchSyncDestinationsInMemNameResponseToJSONTyped(value, i
     return {
         'connection_details': value['connectionDetails'],
         'name': value['name'],
+        'options': value['options'],
+        'purge_error': value['purgeError'],
+        'purge_initiated_at': value['purgeInitiatedAt'] == null ? undefined : ((value['purgeInitiatedAt']).toISOString()),
         'type': value['type'],
     };
 }

--- a/ui/api-client/dist/esm/models/SystemPatchSyncDestinationsVercelProjectNameResponse.d.ts
+++ b/ui/api-client/dist/esm/models/SystemPatchSyncDestinationsVercelProjectNameResponse.d.ts
@@ -28,6 +28,24 @@ export interface SystemPatchSyncDestinationsVercelProjectNameResponse {
      */
     name?: string;
     /**
+     * List of key value pairs of Vault configuration options.
+     * @type {object}
+     * @memberof SystemPatchSyncDestinationsVercelProjectNameResponse
+     */
+    options?: object;
+    /**
+     * Error message if the purge job failed.
+     * @type {string}
+     * @memberof SystemPatchSyncDestinationsVercelProjectNameResponse
+     */
+    purgeError?: string;
+    /**
+     * Timestamp of when a purge job was initiated when deleting a destination.
+     * @type {Date}
+     * @memberof SystemPatchSyncDestinationsVercelProjectNameResponse
+     */
+    purgeInitiatedAt?: Date;
+    /**
      * Type of this secrets store.
      * @type {string}
      * @memberof SystemPatchSyncDestinationsVercelProjectNameResponse

--- a/ui/api-client/dist/esm/models/SystemPatchSyncDestinationsVercelProjectNameResponse.js
+++ b/ui/api-client/dist/esm/models/SystemPatchSyncDestinationsVercelProjectNameResponse.js
@@ -27,6 +27,9 @@ export function SystemPatchSyncDestinationsVercelProjectNameResponseFromJSONType
     return {
         'connectionDetails': json['connection_details'] == null ? undefined : json['connection_details'],
         'name': json['name'] == null ? undefined : json['name'],
+        'options': json['options'] == null ? undefined : json['options'],
+        'purgeError': json['purge_error'] == null ? undefined : json['purge_error'],
+        'purgeInitiatedAt': json['purge_initiated_at'] == null ? undefined : (new Date(json['purge_initiated_at'])),
         'type': json['type'] == null ? undefined : json['type'],
     };
 }
@@ -40,6 +43,9 @@ export function SystemPatchSyncDestinationsVercelProjectNameResponseToJSONTyped(
     return {
         'connection_details': value['connectionDetails'],
         'name': value['name'],
+        'options': value['options'],
+        'purge_error': value['purgeError'],
+        'purge_initiated_at': value['purgeInitiatedAt'] == null ? undefined : ((value['purgeInitiatedAt']).toISOString()),
         'type': value['type'],
     };
 }

--- a/ui/api-client/dist/esm/models/SystemReadSyncDestinationsAwsSmNameResponse.d.ts
+++ b/ui/api-client/dist/esm/models/SystemReadSyncDestinationsAwsSmNameResponse.d.ts
@@ -28,6 +28,24 @@ export interface SystemReadSyncDestinationsAwsSmNameResponse {
      */
     name?: string;
     /**
+     * List of key value pairs of Vault configuration options.
+     * @type {object}
+     * @memberof SystemReadSyncDestinationsAwsSmNameResponse
+     */
+    options?: object;
+    /**
+     * Error message if the purge job failed.
+     * @type {string}
+     * @memberof SystemReadSyncDestinationsAwsSmNameResponse
+     */
+    purgeError?: string;
+    /**
+     * Timestamp of when a purge job was initiated when deleting a destination.
+     * @type {Date}
+     * @memberof SystemReadSyncDestinationsAwsSmNameResponse
+     */
+    purgeInitiatedAt?: Date;
+    /**
      * Type of this secrets store.
      * @type {string}
      * @memberof SystemReadSyncDestinationsAwsSmNameResponse

--- a/ui/api-client/dist/esm/models/SystemReadSyncDestinationsAwsSmNameResponse.js
+++ b/ui/api-client/dist/esm/models/SystemReadSyncDestinationsAwsSmNameResponse.js
@@ -27,6 +27,9 @@ export function SystemReadSyncDestinationsAwsSmNameResponseFromJSONTyped(json, i
     return {
         'connectionDetails': json['connection_details'] == null ? undefined : json['connection_details'],
         'name': json['name'] == null ? undefined : json['name'],
+        'options': json['options'] == null ? undefined : json['options'],
+        'purgeError': json['purge_error'] == null ? undefined : json['purge_error'],
+        'purgeInitiatedAt': json['purge_initiated_at'] == null ? undefined : (new Date(json['purge_initiated_at'])),
         'type': json['type'] == null ? undefined : json['type'],
     };
 }
@@ -40,6 +43,9 @@ export function SystemReadSyncDestinationsAwsSmNameResponseToJSONTyped(value, ig
     return {
         'connection_details': value['connectionDetails'],
         'name': value['name'],
+        'options': value['options'],
+        'purge_error': value['purgeError'],
+        'purge_initiated_at': value['purgeInitiatedAt'] == null ? undefined : ((value['purgeInitiatedAt']).toISOString()),
         'type': value['type'],
     };
 }

--- a/ui/api-client/dist/esm/models/SystemReadSyncDestinationsAzureKvNameResponse.d.ts
+++ b/ui/api-client/dist/esm/models/SystemReadSyncDestinationsAzureKvNameResponse.d.ts
@@ -28,6 +28,24 @@ export interface SystemReadSyncDestinationsAzureKvNameResponse {
      */
     name?: string;
     /**
+     * List of key value pairs of Vault configuration options.
+     * @type {object}
+     * @memberof SystemReadSyncDestinationsAzureKvNameResponse
+     */
+    options?: object;
+    /**
+     * Error message if the purge job failed.
+     * @type {string}
+     * @memberof SystemReadSyncDestinationsAzureKvNameResponse
+     */
+    purgeError?: string;
+    /**
+     * Timestamp of when a purge job was initiated when deleting a destination.
+     * @type {Date}
+     * @memberof SystemReadSyncDestinationsAzureKvNameResponse
+     */
+    purgeInitiatedAt?: Date;
+    /**
      * Type of this secrets store.
      * @type {string}
      * @memberof SystemReadSyncDestinationsAzureKvNameResponse

--- a/ui/api-client/dist/esm/models/SystemReadSyncDestinationsAzureKvNameResponse.js
+++ b/ui/api-client/dist/esm/models/SystemReadSyncDestinationsAzureKvNameResponse.js
@@ -27,6 +27,9 @@ export function SystemReadSyncDestinationsAzureKvNameResponseFromJSONTyped(json,
     return {
         'connectionDetails': json['connection_details'] == null ? undefined : json['connection_details'],
         'name': json['name'] == null ? undefined : json['name'],
+        'options': json['options'] == null ? undefined : json['options'],
+        'purgeError': json['purge_error'] == null ? undefined : json['purge_error'],
+        'purgeInitiatedAt': json['purge_initiated_at'] == null ? undefined : (new Date(json['purge_initiated_at'])),
         'type': json['type'] == null ? undefined : json['type'],
     };
 }
@@ -40,6 +43,9 @@ export function SystemReadSyncDestinationsAzureKvNameResponseToJSONTyped(value, 
     return {
         'connection_details': value['connectionDetails'],
         'name': value['name'],
+        'options': value['options'],
+        'purge_error': value['purgeError'],
+        'purge_initiated_at': value['purgeInitiatedAt'] == null ? undefined : ((value['purgeInitiatedAt']).toISOString()),
         'type': value['type'],
     };
 }

--- a/ui/api-client/dist/esm/models/SystemReadSyncDestinationsGcpSmNameResponse.d.ts
+++ b/ui/api-client/dist/esm/models/SystemReadSyncDestinationsGcpSmNameResponse.d.ts
@@ -28,6 +28,24 @@ export interface SystemReadSyncDestinationsGcpSmNameResponse {
      */
     name?: string;
     /**
+     * List of key value pairs of Vault configuration options.
+     * @type {object}
+     * @memberof SystemReadSyncDestinationsGcpSmNameResponse
+     */
+    options?: object;
+    /**
+     * Error message if the purge job failed.
+     * @type {string}
+     * @memberof SystemReadSyncDestinationsGcpSmNameResponse
+     */
+    purgeError?: string;
+    /**
+     * Timestamp of when a purge job was initiated when deleting a destination.
+     * @type {Date}
+     * @memberof SystemReadSyncDestinationsGcpSmNameResponse
+     */
+    purgeInitiatedAt?: Date;
+    /**
      * Type of this secrets store.
      * @type {string}
      * @memberof SystemReadSyncDestinationsGcpSmNameResponse

--- a/ui/api-client/dist/esm/models/SystemReadSyncDestinationsGcpSmNameResponse.js
+++ b/ui/api-client/dist/esm/models/SystemReadSyncDestinationsGcpSmNameResponse.js
@@ -27,6 +27,9 @@ export function SystemReadSyncDestinationsGcpSmNameResponseFromJSONTyped(json, i
     return {
         'connectionDetails': json['connection_details'] == null ? undefined : json['connection_details'],
         'name': json['name'] == null ? undefined : json['name'],
+        'options': json['options'] == null ? undefined : json['options'],
+        'purgeError': json['purge_error'] == null ? undefined : json['purge_error'],
+        'purgeInitiatedAt': json['purge_initiated_at'] == null ? undefined : (new Date(json['purge_initiated_at'])),
         'type': json['type'] == null ? undefined : json['type'],
     };
 }
@@ -40,6 +43,9 @@ export function SystemReadSyncDestinationsGcpSmNameResponseToJSONTyped(value, ig
     return {
         'connection_details': value['connectionDetails'],
         'name': value['name'],
+        'options': value['options'],
+        'purge_error': value['purgeError'],
+        'purge_initiated_at': value['purgeInitiatedAt'] == null ? undefined : ((value['purgeInitiatedAt']).toISOString()),
         'type': value['type'],
     };
 }

--- a/ui/api-client/dist/esm/models/SystemReadSyncDestinationsGhNameResponse.d.ts
+++ b/ui/api-client/dist/esm/models/SystemReadSyncDestinationsGhNameResponse.d.ts
@@ -28,6 +28,24 @@ export interface SystemReadSyncDestinationsGhNameResponse {
      */
     name?: string;
     /**
+     * List of key value pairs of Vault configuration options.
+     * @type {object}
+     * @memberof SystemReadSyncDestinationsGhNameResponse
+     */
+    options?: object;
+    /**
+     * Error message if the purge job failed.
+     * @type {string}
+     * @memberof SystemReadSyncDestinationsGhNameResponse
+     */
+    purgeError?: string;
+    /**
+     * Timestamp of when a purge job was initiated when deleting a destination.
+     * @type {Date}
+     * @memberof SystemReadSyncDestinationsGhNameResponse
+     */
+    purgeInitiatedAt?: Date;
+    /**
      * Type of this secrets store.
      * @type {string}
      * @memberof SystemReadSyncDestinationsGhNameResponse

--- a/ui/api-client/dist/esm/models/SystemReadSyncDestinationsGhNameResponse.js
+++ b/ui/api-client/dist/esm/models/SystemReadSyncDestinationsGhNameResponse.js
@@ -27,6 +27,9 @@ export function SystemReadSyncDestinationsGhNameResponseFromJSONTyped(json, igno
     return {
         'connectionDetails': json['connection_details'] == null ? undefined : json['connection_details'],
         'name': json['name'] == null ? undefined : json['name'],
+        'options': json['options'] == null ? undefined : json['options'],
+        'purgeError': json['purge_error'] == null ? undefined : json['purge_error'],
+        'purgeInitiatedAt': json['purge_initiated_at'] == null ? undefined : (new Date(json['purge_initiated_at'])),
         'type': json['type'] == null ? undefined : json['type'],
     };
 }
@@ -40,6 +43,9 @@ export function SystemReadSyncDestinationsGhNameResponseToJSONTyped(value, ignor
     return {
         'connection_details': value['connectionDetails'],
         'name': value['name'],
+        'options': value['options'],
+        'purge_error': value['purgeError'],
+        'purge_initiated_at': value['purgeInitiatedAt'] == null ? undefined : ((value['purgeInitiatedAt']).toISOString()),
         'type': value['type'],
     };
 }

--- a/ui/api-client/dist/esm/models/SystemReadSyncDestinationsInMemNameResponse.d.ts
+++ b/ui/api-client/dist/esm/models/SystemReadSyncDestinationsInMemNameResponse.d.ts
@@ -28,6 +28,24 @@ export interface SystemReadSyncDestinationsInMemNameResponse {
      */
     name?: string;
     /**
+     * List of key value pairs of Vault configuration options.
+     * @type {object}
+     * @memberof SystemReadSyncDestinationsInMemNameResponse
+     */
+    options?: object;
+    /**
+     * Error message if the purge job failed.
+     * @type {string}
+     * @memberof SystemReadSyncDestinationsInMemNameResponse
+     */
+    purgeError?: string;
+    /**
+     * Timestamp of when a purge job was initiated when deleting a destination.
+     * @type {Date}
+     * @memberof SystemReadSyncDestinationsInMemNameResponse
+     */
+    purgeInitiatedAt?: Date;
+    /**
      * Type of this secrets store.
      * @type {string}
      * @memberof SystemReadSyncDestinationsInMemNameResponse

--- a/ui/api-client/dist/esm/models/SystemReadSyncDestinationsInMemNameResponse.js
+++ b/ui/api-client/dist/esm/models/SystemReadSyncDestinationsInMemNameResponse.js
@@ -27,6 +27,9 @@ export function SystemReadSyncDestinationsInMemNameResponseFromJSONTyped(json, i
     return {
         'connectionDetails': json['connection_details'] == null ? undefined : json['connection_details'],
         'name': json['name'] == null ? undefined : json['name'],
+        'options': json['options'] == null ? undefined : json['options'],
+        'purgeError': json['purge_error'] == null ? undefined : json['purge_error'],
+        'purgeInitiatedAt': json['purge_initiated_at'] == null ? undefined : (new Date(json['purge_initiated_at'])),
         'type': json['type'] == null ? undefined : json['type'],
     };
 }
@@ -40,6 +43,9 @@ export function SystemReadSyncDestinationsInMemNameResponseToJSONTyped(value, ig
     return {
         'connection_details': value['connectionDetails'],
         'name': value['name'],
+        'options': value['options'],
+        'purge_error': value['purgeError'],
+        'purge_initiated_at': value['purgeInitiatedAt'] == null ? undefined : ((value['purgeInitiatedAt']).toISOString()),
         'type': value['type'],
     };
 }

--- a/ui/api-client/dist/esm/models/SystemReadSyncDestinationsVercelProjectNameResponse.d.ts
+++ b/ui/api-client/dist/esm/models/SystemReadSyncDestinationsVercelProjectNameResponse.d.ts
@@ -28,6 +28,24 @@ export interface SystemReadSyncDestinationsVercelProjectNameResponse {
      */
     name?: string;
     /**
+     * List of key value pairs of Vault configuration options.
+     * @type {object}
+     * @memberof SystemReadSyncDestinationsVercelProjectNameResponse
+     */
+    options?: object;
+    /**
+     * Error message if the purge job failed.
+     * @type {string}
+     * @memberof SystemReadSyncDestinationsVercelProjectNameResponse
+     */
+    purgeError?: string;
+    /**
+     * Timestamp of when a purge job was initiated when deleting a destination.
+     * @type {Date}
+     * @memberof SystemReadSyncDestinationsVercelProjectNameResponse
+     */
+    purgeInitiatedAt?: Date;
+    /**
      * Type of this secrets store.
      * @type {string}
      * @memberof SystemReadSyncDestinationsVercelProjectNameResponse

--- a/ui/api-client/dist/esm/models/SystemReadSyncDestinationsVercelProjectNameResponse.js
+++ b/ui/api-client/dist/esm/models/SystemReadSyncDestinationsVercelProjectNameResponse.js
@@ -27,6 +27,9 @@ export function SystemReadSyncDestinationsVercelProjectNameResponseFromJSONTyped
     return {
         'connectionDetails': json['connection_details'] == null ? undefined : json['connection_details'],
         'name': json['name'] == null ? undefined : json['name'],
+        'options': json['options'] == null ? undefined : json['options'],
+        'purgeError': json['purge_error'] == null ? undefined : json['purge_error'],
+        'purgeInitiatedAt': json['purge_initiated_at'] == null ? undefined : (new Date(json['purge_initiated_at'])),
         'type': json['type'] == null ? undefined : json['type'],
     };
 }
@@ -40,6 +43,9 @@ export function SystemReadSyncDestinationsVercelProjectNameResponseToJSONTyped(v
     return {
         'connection_details': value['connectionDetails'],
         'name': value['name'],
+        'options': value['options'],
+        'purge_error': value['purgeError'],
+        'purge_initiated_at': value['purgeInitiatedAt'] == null ? undefined : ((value['purgeInitiatedAt']).toISOString()),
         'type': value['type'],
     };
 }

--- a/ui/api-client/dist/esm/models/SystemWriteSyncDestinationsAwsSmNameResponse.d.ts
+++ b/ui/api-client/dist/esm/models/SystemWriteSyncDestinationsAwsSmNameResponse.d.ts
@@ -28,6 +28,24 @@ export interface SystemWriteSyncDestinationsAwsSmNameResponse {
      */
     name?: string;
     /**
+     * List of key value pairs of Vault configuration options.
+     * @type {object}
+     * @memberof SystemWriteSyncDestinationsAwsSmNameResponse
+     */
+    options?: object;
+    /**
+     * Error message if the purge job failed.
+     * @type {string}
+     * @memberof SystemWriteSyncDestinationsAwsSmNameResponse
+     */
+    purgeError?: string;
+    /**
+     * Timestamp of when a purge job was initiated when deleting a destination.
+     * @type {Date}
+     * @memberof SystemWriteSyncDestinationsAwsSmNameResponse
+     */
+    purgeInitiatedAt?: Date;
+    /**
      * Type of this secrets store.
      * @type {string}
      * @memberof SystemWriteSyncDestinationsAwsSmNameResponse

--- a/ui/api-client/dist/esm/models/SystemWriteSyncDestinationsAwsSmNameResponse.js
+++ b/ui/api-client/dist/esm/models/SystemWriteSyncDestinationsAwsSmNameResponse.js
@@ -27,6 +27,9 @@ export function SystemWriteSyncDestinationsAwsSmNameResponseFromJSONTyped(json, 
     return {
         'connectionDetails': json['connection_details'] == null ? undefined : json['connection_details'],
         'name': json['name'] == null ? undefined : json['name'],
+        'options': json['options'] == null ? undefined : json['options'],
+        'purgeError': json['purge_error'] == null ? undefined : json['purge_error'],
+        'purgeInitiatedAt': json['purge_initiated_at'] == null ? undefined : (new Date(json['purge_initiated_at'])),
         'type': json['type'] == null ? undefined : json['type'],
     };
 }
@@ -40,6 +43,9 @@ export function SystemWriteSyncDestinationsAwsSmNameResponseToJSONTyped(value, i
     return {
         'connection_details': value['connectionDetails'],
         'name': value['name'],
+        'options': value['options'],
+        'purge_error': value['purgeError'],
+        'purge_initiated_at': value['purgeInitiatedAt'] == null ? undefined : ((value['purgeInitiatedAt']).toISOString()),
         'type': value['type'],
     };
 }

--- a/ui/api-client/dist/esm/models/SystemWriteSyncDestinationsAzureKvNameResponse.d.ts
+++ b/ui/api-client/dist/esm/models/SystemWriteSyncDestinationsAzureKvNameResponse.d.ts
@@ -28,6 +28,24 @@ export interface SystemWriteSyncDestinationsAzureKvNameResponse {
      */
     name?: string;
     /**
+     * List of key value pairs of Vault configuration options.
+     * @type {object}
+     * @memberof SystemWriteSyncDestinationsAzureKvNameResponse
+     */
+    options?: object;
+    /**
+     * Error message if the purge job failed.
+     * @type {string}
+     * @memberof SystemWriteSyncDestinationsAzureKvNameResponse
+     */
+    purgeError?: string;
+    /**
+     * Timestamp of when a purge job was initiated when deleting a destination.
+     * @type {Date}
+     * @memberof SystemWriteSyncDestinationsAzureKvNameResponse
+     */
+    purgeInitiatedAt?: Date;
+    /**
      * Type of this secrets store.
      * @type {string}
      * @memberof SystemWriteSyncDestinationsAzureKvNameResponse

--- a/ui/api-client/dist/esm/models/SystemWriteSyncDestinationsAzureKvNameResponse.js
+++ b/ui/api-client/dist/esm/models/SystemWriteSyncDestinationsAzureKvNameResponse.js
@@ -27,6 +27,9 @@ export function SystemWriteSyncDestinationsAzureKvNameResponseFromJSONTyped(json
     return {
         'connectionDetails': json['connection_details'] == null ? undefined : json['connection_details'],
         'name': json['name'] == null ? undefined : json['name'],
+        'options': json['options'] == null ? undefined : json['options'],
+        'purgeError': json['purge_error'] == null ? undefined : json['purge_error'],
+        'purgeInitiatedAt': json['purge_initiated_at'] == null ? undefined : (new Date(json['purge_initiated_at'])),
         'type': json['type'] == null ? undefined : json['type'],
     };
 }
@@ -40,6 +43,9 @@ export function SystemWriteSyncDestinationsAzureKvNameResponseToJSONTyped(value,
     return {
         'connection_details': value['connectionDetails'],
         'name': value['name'],
+        'options': value['options'],
+        'purge_error': value['purgeError'],
+        'purge_initiated_at': value['purgeInitiatedAt'] == null ? undefined : ((value['purgeInitiatedAt']).toISOString()),
         'type': value['type'],
     };
 }

--- a/ui/api-client/dist/esm/models/SystemWriteSyncDestinationsGcpSmNameResponse.d.ts
+++ b/ui/api-client/dist/esm/models/SystemWriteSyncDestinationsGcpSmNameResponse.d.ts
@@ -28,6 +28,24 @@ export interface SystemWriteSyncDestinationsGcpSmNameResponse {
      */
     name?: string;
     /**
+     * List of key value pairs of Vault configuration options.
+     * @type {object}
+     * @memberof SystemWriteSyncDestinationsGcpSmNameResponse
+     */
+    options?: object;
+    /**
+     * Error message if the purge job failed.
+     * @type {string}
+     * @memberof SystemWriteSyncDestinationsGcpSmNameResponse
+     */
+    purgeError?: string;
+    /**
+     * Timestamp of when a purge job was initiated when deleting a destination.
+     * @type {Date}
+     * @memberof SystemWriteSyncDestinationsGcpSmNameResponse
+     */
+    purgeInitiatedAt?: Date;
+    /**
      * Type of this secrets store.
      * @type {string}
      * @memberof SystemWriteSyncDestinationsGcpSmNameResponse

--- a/ui/api-client/dist/esm/models/SystemWriteSyncDestinationsGcpSmNameResponse.js
+++ b/ui/api-client/dist/esm/models/SystemWriteSyncDestinationsGcpSmNameResponse.js
@@ -27,6 +27,9 @@ export function SystemWriteSyncDestinationsGcpSmNameResponseFromJSONTyped(json, 
     return {
         'connectionDetails': json['connection_details'] == null ? undefined : json['connection_details'],
         'name': json['name'] == null ? undefined : json['name'],
+        'options': json['options'] == null ? undefined : json['options'],
+        'purgeError': json['purge_error'] == null ? undefined : json['purge_error'],
+        'purgeInitiatedAt': json['purge_initiated_at'] == null ? undefined : (new Date(json['purge_initiated_at'])),
         'type': json['type'] == null ? undefined : json['type'],
     };
 }
@@ -40,6 +43,9 @@ export function SystemWriteSyncDestinationsGcpSmNameResponseToJSONTyped(value, i
     return {
         'connection_details': value['connectionDetails'],
         'name': value['name'],
+        'options': value['options'],
+        'purge_error': value['purgeError'],
+        'purge_initiated_at': value['purgeInitiatedAt'] == null ? undefined : ((value['purgeInitiatedAt']).toISOString()),
         'type': value['type'],
     };
 }

--- a/ui/api-client/dist/esm/models/SystemWriteSyncDestinationsGhNameResponse.d.ts
+++ b/ui/api-client/dist/esm/models/SystemWriteSyncDestinationsGhNameResponse.d.ts
@@ -28,6 +28,24 @@ export interface SystemWriteSyncDestinationsGhNameResponse {
      */
     name?: string;
     /**
+     * List of key value pairs of Vault configuration options.
+     * @type {object}
+     * @memberof SystemWriteSyncDestinationsGhNameResponse
+     */
+    options?: object;
+    /**
+     * Error message if the purge job failed.
+     * @type {string}
+     * @memberof SystemWriteSyncDestinationsGhNameResponse
+     */
+    purgeError?: string;
+    /**
+     * Timestamp of when a purge job was initiated when deleting a destination.
+     * @type {Date}
+     * @memberof SystemWriteSyncDestinationsGhNameResponse
+     */
+    purgeInitiatedAt?: Date;
+    /**
      * Type of this secrets store.
      * @type {string}
      * @memberof SystemWriteSyncDestinationsGhNameResponse

--- a/ui/api-client/dist/esm/models/SystemWriteSyncDestinationsGhNameResponse.js
+++ b/ui/api-client/dist/esm/models/SystemWriteSyncDestinationsGhNameResponse.js
@@ -27,6 +27,9 @@ export function SystemWriteSyncDestinationsGhNameResponseFromJSONTyped(json, ign
     return {
         'connectionDetails': json['connection_details'] == null ? undefined : json['connection_details'],
         'name': json['name'] == null ? undefined : json['name'],
+        'options': json['options'] == null ? undefined : json['options'],
+        'purgeError': json['purge_error'] == null ? undefined : json['purge_error'],
+        'purgeInitiatedAt': json['purge_initiated_at'] == null ? undefined : (new Date(json['purge_initiated_at'])),
         'type': json['type'] == null ? undefined : json['type'],
     };
 }
@@ -40,6 +43,9 @@ export function SystemWriteSyncDestinationsGhNameResponseToJSONTyped(value, igno
     return {
         'connection_details': value['connectionDetails'],
         'name': value['name'],
+        'options': value['options'],
+        'purge_error': value['purgeError'],
+        'purge_initiated_at': value['purgeInitiatedAt'] == null ? undefined : ((value['purgeInitiatedAt']).toISOString()),
         'type': value['type'],
     };
 }

--- a/ui/api-client/dist/esm/models/SystemWriteSyncDestinationsInMemNameResponse.d.ts
+++ b/ui/api-client/dist/esm/models/SystemWriteSyncDestinationsInMemNameResponse.d.ts
@@ -28,6 +28,24 @@ export interface SystemWriteSyncDestinationsInMemNameResponse {
      */
     name?: string;
     /**
+     * List of key value pairs of Vault configuration options.
+     * @type {object}
+     * @memberof SystemWriteSyncDestinationsInMemNameResponse
+     */
+    options?: object;
+    /**
+     * Error message if the purge job failed.
+     * @type {string}
+     * @memberof SystemWriteSyncDestinationsInMemNameResponse
+     */
+    purgeError?: string;
+    /**
+     * Timestamp of when a purge job was initiated when deleting a destination.
+     * @type {Date}
+     * @memberof SystemWriteSyncDestinationsInMemNameResponse
+     */
+    purgeInitiatedAt?: Date;
+    /**
      * Type of this secrets store.
      * @type {string}
      * @memberof SystemWriteSyncDestinationsInMemNameResponse

--- a/ui/api-client/dist/esm/models/SystemWriteSyncDestinationsInMemNameResponse.js
+++ b/ui/api-client/dist/esm/models/SystemWriteSyncDestinationsInMemNameResponse.js
@@ -27,6 +27,9 @@ export function SystemWriteSyncDestinationsInMemNameResponseFromJSONTyped(json, 
     return {
         'connectionDetails': json['connection_details'] == null ? undefined : json['connection_details'],
         'name': json['name'] == null ? undefined : json['name'],
+        'options': json['options'] == null ? undefined : json['options'],
+        'purgeError': json['purge_error'] == null ? undefined : json['purge_error'],
+        'purgeInitiatedAt': json['purge_initiated_at'] == null ? undefined : (new Date(json['purge_initiated_at'])),
         'type': json['type'] == null ? undefined : json['type'],
     };
 }
@@ -40,6 +43,9 @@ export function SystemWriteSyncDestinationsInMemNameResponseToJSONTyped(value, i
     return {
         'connection_details': value['connectionDetails'],
         'name': value['name'],
+        'options': value['options'],
+        'purge_error': value['purgeError'],
+        'purge_initiated_at': value['purgeInitiatedAt'] == null ? undefined : ((value['purgeInitiatedAt']).toISOString()),
         'type': value['type'],
     };
 }

--- a/ui/api-client/dist/esm/models/SystemWriteSyncDestinationsVercelProjectNameResponse.d.ts
+++ b/ui/api-client/dist/esm/models/SystemWriteSyncDestinationsVercelProjectNameResponse.d.ts
@@ -28,6 +28,24 @@ export interface SystemWriteSyncDestinationsVercelProjectNameResponse {
      */
     name?: string;
     /**
+     * List of key value pairs of Vault configuration options.
+     * @type {object}
+     * @memberof SystemWriteSyncDestinationsVercelProjectNameResponse
+     */
+    options?: object;
+    /**
+     * Error message if the purge job failed.
+     * @type {string}
+     * @memberof SystemWriteSyncDestinationsVercelProjectNameResponse
+     */
+    purgeError?: string;
+    /**
+     * Timestamp of when a purge job was initiated when deleting a destination.
+     * @type {Date}
+     * @memberof SystemWriteSyncDestinationsVercelProjectNameResponse
+     */
+    purgeInitiatedAt?: Date;
+    /**
      * Type of this secrets store.
      * @type {string}
      * @memberof SystemWriteSyncDestinationsVercelProjectNameResponse

--- a/ui/api-client/dist/esm/models/SystemWriteSyncDestinationsVercelProjectNameResponse.js
+++ b/ui/api-client/dist/esm/models/SystemWriteSyncDestinationsVercelProjectNameResponse.js
@@ -27,6 +27,9 @@ export function SystemWriteSyncDestinationsVercelProjectNameResponseFromJSONType
     return {
         'connectionDetails': json['connection_details'] == null ? undefined : json['connection_details'],
         'name': json['name'] == null ? undefined : json['name'],
+        'options': json['options'] == null ? undefined : json['options'],
+        'purgeError': json['purge_error'] == null ? undefined : json['purge_error'],
+        'purgeInitiatedAt': json['purge_initiated_at'] == null ? undefined : (new Date(json['purge_initiated_at'])),
         'type': json['type'] == null ? undefined : json['type'],
     };
 }
@@ -40,6 +43,9 @@ export function SystemWriteSyncDestinationsVercelProjectNameResponseToJSONTyped(
     return {
         'connection_details': value['connectionDetails'],
         'name': value['name'],
+        'options': value['options'],
+        'purge_error': value['purgeError'],
+        'purge_initiated_at': value['purgeInitiatedAt'] == null ? undefined : ((value['purgeInitiatedAt']).toISOString()),
         'type': value['type'],
     };
 }

--- a/ui/api-client/dist/models/SystemPatchSyncDestinationsAwsSmNameResponse.d.ts
+++ b/ui/api-client/dist/models/SystemPatchSyncDestinationsAwsSmNameResponse.d.ts
@@ -28,6 +28,24 @@ export interface SystemPatchSyncDestinationsAwsSmNameResponse {
      */
     name?: string;
     /**
+     * List of key value pairs of Vault configuration options.
+     * @type {object}
+     * @memberof SystemPatchSyncDestinationsAwsSmNameResponse
+     */
+    options?: object;
+    /**
+     * Error message if the purge job failed.
+     * @type {string}
+     * @memberof SystemPatchSyncDestinationsAwsSmNameResponse
+     */
+    purgeError?: string;
+    /**
+     * Timestamp of when a purge job was initiated when deleting a destination.
+     * @type {Date}
+     * @memberof SystemPatchSyncDestinationsAwsSmNameResponse
+     */
+    purgeInitiatedAt?: Date;
+    /**
      * Type of this secrets store.
      * @type {string}
      * @memberof SystemPatchSyncDestinationsAwsSmNameResponse

--- a/ui/api-client/dist/models/SystemPatchSyncDestinationsAwsSmNameResponse.js
+++ b/ui/api-client/dist/models/SystemPatchSyncDestinationsAwsSmNameResponse.js
@@ -34,6 +34,9 @@ function SystemPatchSyncDestinationsAwsSmNameResponseFromJSONTyped(json, ignoreD
     return {
         'connectionDetails': json['connection_details'] == null ? undefined : json['connection_details'],
         'name': json['name'] == null ? undefined : json['name'],
+        'options': json['options'] == null ? undefined : json['options'],
+        'purgeError': json['purge_error'] == null ? undefined : json['purge_error'],
+        'purgeInitiatedAt': json['purge_initiated_at'] == null ? undefined : (new Date(json['purge_initiated_at'])),
         'type': json['type'] == null ? undefined : json['type'],
     };
 }
@@ -47,6 +50,9 @@ function SystemPatchSyncDestinationsAwsSmNameResponseToJSONTyped(value, ignoreDi
     return {
         'connection_details': value['connectionDetails'],
         'name': value['name'],
+        'options': value['options'],
+        'purge_error': value['purgeError'],
+        'purge_initiated_at': value['purgeInitiatedAt'] == null ? undefined : ((value['purgeInitiatedAt']).toISOString()),
         'type': value['type'],
     };
 }

--- a/ui/api-client/dist/models/SystemPatchSyncDestinationsAzureKvNameResponse.d.ts
+++ b/ui/api-client/dist/models/SystemPatchSyncDestinationsAzureKvNameResponse.d.ts
@@ -28,6 +28,24 @@ export interface SystemPatchSyncDestinationsAzureKvNameResponse {
      */
     name?: string;
     /**
+     * List of key value pairs of Vault configuration options.
+     * @type {object}
+     * @memberof SystemPatchSyncDestinationsAzureKvNameResponse
+     */
+    options?: object;
+    /**
+     * Error message if the purge job failed.
+     * @type {string}
+     * @memberof SystemPatchSyncDestinationsAzureKvNameResponse
+     */
+    purgeError?: string;
+    /**
+     * Timestamp of when a purge job was initiated when deleting a destination.
+     * @type {Date}
+     * @memberof SystemPatchSyncDestinationsAzureKvNameResponse
+     */
+    purgeInitiatedAt?: Date;
+    /**
      * Type of this secrets store.
      * @type {string}
      * @memberof SystemPatchSyncDestinationsAzureKvNameResponse

--- a/ui/api-client/dist/models/SystemPatchSyncDestinationsAzureKvNameResponse.js
+++ b/ui/api-client/dist/models/SystemPatchSyncDestinationsAzureKvNameResponse.js
@@ -34,6 +34,9 @@ function SystemPatchSyncDestinationsAzureKvNameResponseFromJSONTyped(json, ignor
     return {
         'connectionDetails': json['connection_details'] == null ? undefined : json['connection_details'],
         'name': json['name'] == null ? undefined : json['name'],
+        'options': json['options'] == null ? undefined : json['options'],
+        'purgeError': json['purge_error'] == null ? undefined : json['purge_error'],
+        'purgeInitiatedAt': json['purge_initiated_at'] == null ? undefined : (new Date(json['purge_initiated_at'])),
         'type': json['type'] == null ? undefined : json['type'],
     };
 }
@@ -47,6 +50,9 @@ function SystemPatchSyncDestinationsAzureKvNameResponseToJSONTyped(value, ignore
     return {
         'connection_details': value['connectionDetails'],
         'name': value['name'],
+        'options': value['options'],
+        'purge_error': value['purgeError'],
+        'purge_initiated_at': value['purgeInitiatedAt'] == null ? undefined : ((value['purgeInitiatedAt']).toISOString()),
         'type': value['type'],
     };
 }

--- a/ui/api-client/dist/models/SystemPatchSyncDestinationsGcpSmNameResponse.d.ts
+++ b/ui/api-client/dist/models/SystemPatchSyncDestinationsGcpSmNameResponse.d.ts
@@ -28,6 +28,24 @@ export interface SystemPatchSyncDestinationsGcpSmNameResponse {
      */
     name?: string;
     /**
+     * List of key value pairs of Vault configuration options.
+     * @type {object}
+     * @memberof SystemPatchSyncDestinationsGcpSmNameResponse
+     */
+    options?: object;
+    /**
+     * Error message if the purge job failed.
+     * @type {string}
+     * @memberof SystemPatchSyncDestinationsGcpSmNameResponse
+     */
+    purgeError?: string;
+    /**
+     * Timestamp of when a purge job was initiated when deleting a destination.
+     * @type {Date}
+     * @memberof SystemPatchSyncDestinationsGcpSmNameResponse
+     */
+    purgeInitiatedAt?: Date;
+    /**
      * Type of this secrets store.
      * @type {string}
      * @memberof SystemPatchSyncDestinationsGcpSmNameResponse

--- a/ui/api-client/dist/models/SystemPatchSyncDestinationsGcpSmNameResponse.js
+++ b/ui/api-client/dist/models/SystemPatchSyncDestinationsGcpSmNameResponse.js
@@ -34,6 +34,9 @@ function SystemPatchSyncDestinationsGcpSmNameResponseFromJSONTyped(json, ignoreD
     return {
         'connectionDetails': json['connection_details'] == null ? undefined : json['connection_details'],
         'name': json['name'] == null ? undefined : json['name'],
+        'options': json['options'] == null ? undefined : json['options'],
+        'purgeError': json['purge_error'] == null ? undefined : json['purge_error'],
+        'purgeInitiatedAt': json['purge_initiated_at'] == null ? undefined : (new Date(json['purge_initiated_at'])),
         'type': json['type'] == null ? undefined : json['type'],
     };
 }
@@ -47,6 +50,9 @@ function SystemPatchSyncDestinationsGcpSmNameResponseToJSONTyped(value, ignoreDi
     return {
         'connection_details': value['connectionDetails'],
         'name': value['name'],
+        'options': value['options'],
+        'purge_error': value['purgeError'],
+        'purge_initiated_at': value['purgeInitiatedAt'] == null ? undefined : ((value['purgeInitiatedAt']).toISOString()),
         'type': value['type'],
     };
 }

--- a/ui/api-client/dist/models/SystemPatchSyncDestinationsGhNameResponse.d.ts
+++ b/ui/api-client/dist/models/SystemPatchSyncDestinationsGhNameResponse.d.ts
@@ -28,6 +28,24 @@ export interface SystemPatchSyncDestinationsGhNameResponse {
      */
     name?: string;
     /**
+     * List of key value pairs of Vault configuration options.
+     * @type {object}
+     * @memberof SystemPatchSyncDestinationsGhNameResponse
+     */
+    options?: object;
+    /**
+     * Error message if the purge job failed.
+     * @type {string}
+     * @memberof SystemPatchSyncDestinationsGhNameResponse
+     */
+    purgeError?: string;
+    /**
+     * Timestamp of when a purge job was initiated when deleting a destination.
+     * @type {Date}
+     * @memberof SystemPatchSyncDestinationsGhNameResponse
+     */
+    purgeInitiatedAt?: Date;
+    /**
      * Type of this secrets store.
      * @type {string}
      * @memberof SystemPatchSyncDestinationsGhNameResponse

--- a/ui/api-client/dist/models/SystemPatchSyncDestinationsGhNameResponse.js
+++ b/ui/api-client/dist/models/SystemPatchSyncDestinationsGhNameResponse.js
@@ -34,6 +34,9 @@ function SystemPatchSyncDestinationsGhNameResponseFromJSONTyped(json, ignoreDisc
     return {
         'connectionDetails': json['connection_details'] == null ? undefined : json['connection_details'],
         'name': json['name'] == null ? undefined : json['name'],
+        'options': json['options'] == null ? undefined : json['options'],
+        'purgeError': json['purge_error'] == null ? undefined : json['purge_error'],
+        'purgeInitiatedAt': json['purge_initiated_at'] == null ? undefined : (new Date(json['purge_initiated_at'])),
         'type': json['type'] == null ? undefined : json['type'],
     };
 }
@@ -47,6 +50,9 @@ function SystemPatchSyncDestinationsGhNameResponseToJSONTyped(value, ignoreDiscr
     return {
         'connection_details': value['connectionDetails'],
         'name': value['name'],
+        'options': value['options'],
+        'purge_error': value['purgeError'],
+        'purge_initiated_at': value['purgeInitiatedAt'] == null ? undefined : ((value['purgeInitiatedAt']).toISOString()),
         'type': value['type'],
     };
 }

--- a/ui/api-client/dist/models/SystemPatchSyncDestinationsInMemNameResponse.d.ts
+++ b/ui/api-client/dist/models/SystemPatchSyncDestinationsInMemNameResponse.d.ts
@@ -28,6 +28,24 @@ export interface SystemPatchSyncDestinationsInMemNameResponse {
      */
     name?: string;
     /**
+     * List of key value pairs of Vault configuration options.
+     * @type {object}
+     * @memberof SystemPatchSyncDestinationsInMemNameResponse
+     */
+    options?: object;
+    /**
+     * Error message if the purge job failed.
+     * @type {string}
+     * @memberof SystemPatchSyncDestinationsInMemNameResponse
+     */
+    purgeError?: string;
+    /**
+     * Timestamp of when a purge job was initiated when deleting a destination.
+     * @type {Date}
+     * @memberof SystemPatchSyncDestinationsInMemNameResponse
+     */
+    purgeInitiatedAt?: Date;
+    /**
      * Type of this secrets store.
      * @type {string}
      * @memberof SystemPatchSyncDestinationsInMemNameResponse

--- a/ui/api-client/dist/models/SystemPatchSyncDestinationsInMemNameResponse.js
+++ b/ui/api-client/dist/models/SystemPatchSyncDestinationsInMemNameResponse.js
@@ -34,6 +34,9 @@ function SystemPatchSyncDestinationsInMemNameResponseFromJSONTyped(json, ignoreD
     return {
         'connectionDetails': json['connection_details'] == null ? undefined : json['connection_details'],
         'name': json['name'] == null ? undefined : json['name'],
+        'options': json['options'] == null ? undefined : json['options'],
+        'purgeError': json['purge_error'] == null ? undefined : json['purge_error'],
+        'purgeInitiatedAt': json['purge_initiated_at'] == null ? undefined : (new Date(json['purge_initiated_at'])),
         'type': json['type'] == null ? undefined : json['type'],
     };
 }
@@ -47,6 +50,9 @@ function SystemPatchSyncDestinationsInMemNameResponseToJSONTyped(value, ignoreDi
     return {
         'connection_details': value['connectionDetails'],
         'name': value['name'],
+        'options': value['options'],
+        'purge_error': value['purgeError'],
+        'purge_initiated_at': value['purgeInitiatedAt'] == null ? undefined : ((value['purgeInitiatedAt']).toISOString()),
         'type': value['type'],
     };
 }

--- a/ui/api-client/dist/models/SystemPatchSyncDestinationsVercelProjectNameResponse.d.ts
+++ b/ui/api-client/dist/models/SystemPatchSyncDestinationsVercelProjectNameResponse.d.ts
@@ -28,6 +28,24 @@ export interface SystemPatchSyncDestinationsVercelProjectNameResponse {
      */
     name?: string;
     /**
+     * List of key value pairs of Vault configuration options.
+     * @type {object}
+     * @memberof SystemPatchSyncDestinationsVercelProjectNameResponse
+     */
+    options?: object;
+    /**
+     * Error message if the purge job failed.
+     * @type {string}
+     * @memberof SystemPatchSyncDestinationsVercelProjectNameResponse
+     */
+    purgeError?: string;
+    /**
+     * Timestamp of when a purge job was initiated when deleting a destination.
+     * @type {Date}
+     * @memberof SystemPatchSyncDestinationsVercelProjectNameResponse
+     */
+    purgeInitiatedAt?: Date;
+    /**
      * Type of this secrets store.
      * @type {string}
      * @memberof SystemPatchSyncDestinationsVercelProjectNameResponse

--- a/ui/api-client/dist/models/SystemPatchSyncDestinationsVercelProjectNameResponse.js
+++ b/ui/api-client/dist/models/SystemPatchSyncDestinationsVercelProjectNameResponse.js
@@ -34,6 +34,9 @@ function SystemPatchSyncDestinationsVercelProjectNameResponseFromJSONTyped(json,
     return {
         'connectionDetails': json['connection_details'] == null ? undefined : json['connection_details'],
         'name': json['name'] == null ? undefined : json['name'],
+        'options': json['options'] == null ? undefined : json['options'],
+        'purgeError': json['purge_error'] == null ? undefined : json['purge_error'],
+        'purgeInitiatedAt': json['purge_initiated_at'] == null ? undefined : (new Date(json['purge_initiated_at'])),
         'type': json['type'] == null ? undefined : json['type'],
     };
 }
@@ -47,6 +50,9 @@ function SystemPatchSyncDestinationsVercelProjectNameResponseToJSONTyped(value, 
     return {
         'connection_details': value['connectionDetails'],
         'name': value['name'],
+        'options': value['options'],
+        'purge_error': value['purgeError'],
+        'purge_initiated_at': value['purgeInitiatedAt'] == null ? undefined : ((value['purgeInitiatedAt']).toISOString()),
         'type': value['type'],
     };
 }

--- a/ui/api-client/dist/models/SystemReadSyncDestinationsAwsSmNameResponse.d.ts
+++ b/ui/api-client/dist/models/SystemReadSyncDestinationsAwsSmNameResponse.d.ts
@@ -28,6 +28,24 @@ export interface SystemReadSyncDestinationsAwsSmNameResponse {
      */
     name?: string;
     /**
+     * List of key value pairs of Vault configuration options.
+     * @type {object}
+     * @memberof SystemReadSyncDestinationsAwsSmNameResponse
+     */
+    options?: object;
+    /**
+     * Error message if the purge job failed.
+     * @type {string}
+     * @memberof SystemReadSyncDestinationsAwsSmNameResponse
+     */
+    purgeError?: string;
+    /**
+     * Timestamp of when a purge job was initiated when deleting a destination.
+     * @type {Date}
+     * @memberof SystemReadSyncDestinationsAwsSmNameResponse
+     */
+    purgeInitiatedAt?: Date;
+    /**
      * Type of this secrets store.
      * @type {string}
      * @memberof SystemReadSyncDestinationsAwsSmNameResponse

--- a/ui/api-client/dist/models/SystemReadSyncDestinationsAwsSmNameResponse.js
+++ b/ui/api-client/dist/models/SystemReadSyncDestinationsAwsSmNameResponse.js
@@ -34,6 +34,9 @@ function SystemReadSyncDestinationsAwsSmNameResponseFromJSONTyped(json, ignoreDi
     return {
         'connectionDetails': json['connection_details'] == null ? undefined : json['connection_details'],
         'name': json['name'] == null ? undefined : json['name'],
+        'options': json['options'] == null ? undefined : json['options'],
+        'purgeError': json['purge_error'] == null ? undefined : json['purge_error'],
+        'purgeInitiatedAt': json['purge_initiated_at'] == null ? undefined : (new Date(json['purge_initiated_at'])),
         'type': json['type'] == null ? undefined : json['type'],
     };
 }
@@ -47,6 +50,9 @@ function SystemReadSyncDestinationsAwsSmNameResponseToJSONTyped(value, ignoreDis
     return {
         'connection_details': value['connectionDetails'],
         'name': value['name'],
+        'options': value['options'],
+        'purge_error': value['purgeError'],
+        'purge_initiated_at': value['purgeInitiatedAt'] == null ? undefined : ((value['purgeInitiatedAt']).toISOString()),
         'type': value['type'],
     };
 }

--- a/ui/api-client/dist/models/SystemReadSyncDestinationsAzureKvNameResponse.d.ts
+++ b/ui/api-client/dist/models/SystemReadSyncDestinationsAzureKvNameResponse.d.ts
@@ -28,6 +28,24 @@ export interface SystemReadSyncDestinationsAzureKvNameResponse {
      */
     name?: string;
     /**
+     * List of key value pairs of Vault configuration options.
+     * @type {object}
+     * @memberof SystemReadSyncDestinationsAzureKvNameResponse
+     */
+    options?: object;
+    /**
+     * Error message if the purge job failed.
+     * @type {string}
+     * @memberof SystemReadSyncDestinationsAzureKvNameResponse
+     */
+    purgeError?: string;
+    /**
+     * Timestamp of when a purge job was initiated when deleting a destination.
+     * @type {Date}
+     * @memberof SystemReadSyncDestinationsAzureKvNameResponse
+     */
+    purgeInitiatedAt?: Date;
+    /**
      * Type of this secrets store.
      * @type {string}
      * @memberof SystemReadSyncDestinationsAzureKvNameResponse

--- a/ui/api-client/dist/models/SystemReadSyncDestinationsAzureKvNameResponse.js
+++ b/ui/api-client/dist/models/SystemReadSyncDestinationsAzureKvNameResponse.js
@@ -34,6 +34,9 @@ function SystemReadSyncDestinationsAzureKvNameResponseFromJSONTyped(json, ignore
     return {
         'connectionDetails': json['connection_details'] == null ? undefined : json['connection_details'],
         'name': json['name'] == null ? undefined : json['name'],
+        'options': json['options'] == null ? undefined : json['options'],
+        'purgeError': json['purge_error'] == null ? undefined : json['purge_error'],
+        'purgeInitiatedAt': json['purge_initiated_at'] == null ? undefined : (new Date(json['purge_initiated_at'])),
         'type': json['type'] == null ? undefined : json['type'],
     };
 }
@@ -47,6 +50,9 @@ function SystemReadSyncDestinationsAzureKvNameResponseToJSONTyped(value, ignoreD
     return {
         'connection_details': value['connectionDetails'],
         'name': value['name'],
+        'options': value['options'],
+        'purge_error': value['purgeError'],
+        'purge_initiated_at': value['purgeInitiatedAt'] == null ? undefined : ((value['purgeInitiatedAt']).toISOString()),
         'type': value['type'],
     };
 }

--- a/ui/api-client/dist/models/SystemReadSyncDestinationsGcpSmNameResponse.d.ts
+++ b/ui/api-client/dist/models/SystemReadSyncDestinationsGcpSmNameResponse.d.ts
@@ -28,6 +28,24 @@ export interface SystemReadSyncDestinationsGcpSmNameResponse {
      */
     name?: string;
     /**
+     * List of key value pairs of Vault configuration options.
+     * @type {object}
+     * @memberof SystemReadSyncDestinationsGcpSmNameResponse
+     */
+    options?: object;
+    /**
+     * Error message if the purge job failed.
+     * @type {string}
+     * @memberof SystemReadSyncDestinationsGcpSmNameResponse
+     */
+    purgeError?: string;
+    /**
+     * Timestamp of when a purge job was initiated when deleting a destination.
+     * @type {Date}
+     * @memberof SystemReadSyncDestinationsGcpSmNameResponse
+     */
+    purgeInitiatedAt?: Date;
+    /**
      * Type of this secrets store.
      * @type {string}
      * @memberof SystemReadSyncDestinationsGcpSmNameResponse

--- a/ui/api-client/dist/models/SystemReadSyncDestinationsGcpSmNameResponse.js
+++ b/ui/api-client/dist/models/SystemReadSyncDestinationsGcpSmNameResponse.js
@@ -34,6 +34,9 @@ function SystemReadSyncDestinationsGcpSmNameResponseFromJSONTyped(json, ignoreDi
     return {
         'connectionDetails': json['connection_details'] == null ? undefined : json['connection_details'],
         'name': json['name'] == null ? undefined : json['name'],
+        'options': json['options'] == null ? undefined : json['options'],
+        'purgeError': json['purge_error'] == null ? undefined : json['purge_error'],
+        'purgeInitiatedAt': json['purge_initiated_at'] == null ? undefined : (new Date(json['purge_initiated_at'])),
         'type': json['type'] == null ? undefined : json['type'],
     };
 }
@@ -47,6 +50,9 @@ function SystemReadSyncDestinationsGcpSmNameResponseToJSONTyped(value, ignoreDis
     return {
         'connection_details': value['connectionDetails'],
         'name': value['name'],
+        'options': value['options'],
+        'purge_error': value['purgeError'],
+        'purge_initiated_at': value['purgeInitiatedAt'] == null ? undefined : ((value['purgeInitiatedAt']).toISOString()),
         'type': value['type'],
     };
 }

--- a/ui/api-client/dist/models/SystemReadSyncDestinationsGhNameResponse.d.ts
+++ b/ui/api-client/dist/models/SystemReadSyncDestinationsGhNameResponse.d.ts
@@ -28,6 +28,24 @@ export interface SystemReadSyncDestinationsGhNameResponse {
      */
     name?: string;
     /**
+     * List of key value pairs of Vault configuration options.
+     * @type {object}
+     * @memberof SystemReadSyncDestinationsGhNameResponse
+     */
+    options?: object;
+    /**
+     * Error message if the purge job failed.
+     * @type {string}
+     * @memberof SystemReadSyncDestinationsGhNameResponse
+     */
+    purgeError?: string;
+    /**
+     * Timestamp of when a purge job was initiated when deleting a destination.
+     * @type {Date}
+     * @memberof SystemReadSyncDestinationsGhNameResponse
+     */
+    purgeInitiatedAt?: Date;
+    /**
      * Type of this secrets store.
      * @type {string}
      * @memberof SystemReadSyncDestinationsGhNameResponse

--- a/ui/api-client/dist/models/SystemReadSyncDestinationsGhNameResponse.js
+++ b/ui/api-client/dist/models/SystemReadSyncDestinationsGhNameResponse.js
@@ -34,6 +34,9 @@ function SystemReadSyncDestinationsGhNameResponseFromJSONTyped(json, ignoreDiscr
     return {
         'connectionDetails': json['connection_details'] == null ? undefined : json['connection_details'],
         'name': json['name'] == null ? undefined : json['name'],
+        'options': json['options'] == null ? undefined : json['options'],
+        'purgeError': json['purge_error'] == null ? undefined : json['purge_error'],
+        'purgeInitiatedAt': json['purge_initiated_at'] == null ? undefined : (new Date(json['purge_initiated_at'])),
         'type': json['type'] == null ? undefined : json['type'],
     };
 }
@@ -47,6 +50,9 @@ function SystemReadSyncDestinationsGhNameResponseToJSONTyped(value, ignoreDiscri
     return {
         'connection_details': value['connectionDetails'],
         'name': value['name'],
+        'options': value['options'],
+        'purge_error': value['purgeError'],
+        'purge_initiated_at': value['purgeInitiatedAt'] == null ? undefined : ((value['purgeInitiatedAt']).toISOString()),
         'type': value['type'],
     };
 }

--- a/ui/api-client/dist/models/SystemReadSyncDestinationsInMemNameResponse.d.ts
+++ b/ui/api-client/dist/models/SystemReadSyncDestinationsInMemNameResponse.d.ts
@@ -28,6 +28,24 @@ export interface SystemReadSyncDestinationsInMemNameResponse {
      */
     name?: string;
     /**
+     * List of key value pairs of Vault configuration options.
+     * @type {object}
+     * @memberof SystemReadSyncDestinationsInMemNameResponse
+     */
+    options?: object;
+    /**
+     * Error message if the purge job failed.
+     * @type {string}
+     * @memberof SystemReadSyncDestinationsInMemNameResponse
+     */
+    purgeError?: string;
+    /**
+     * Timestamp of when a purge job was initiated when deleting a destination.
+     * @type {Date}
+     * @memberof SystemReadSyncDestinationsInMemNameResponse
+     */
+    purgeInitiatedAt?: Date;
+    /**
      * Type of this secrets store.
      * @type {string}
      * @memberof SystemReadSyncDestinationsInMemNameResponse

--- a/ui/api-client/dist/models/SystemReadSyncDestinationsInMemNameResponse.js
+++ b/ui/api-client/dist/models/SystemReadSyncDestinationsInMemNameResponse.js
@@ -34,6 +34,9 @@ function SystemReadSyncDestinationsInMemNameResponseFromJSONTyped(json, ignoreDi
     return {
         'connectionDetails': json['connection_details'] == null ? undefined : json['connection_details'],
         'name': json['name'] == null ? undefined : json['name'],
+        'options': json['options'] == null ? undefined : json['options'],
+        'purgeError': json['purge_error'] == null ? undefined : json['purge_error'],
+        'purgeInitiatedAt': json['purge_initiated_at'] == null ? undefined : (new Date(json['purge_initiated_at'])),
         'type': json['type'] == null ? undefined : json['type'],
     };
 }
@@ -47,6 +50,9 @@ function SystemReadSyncDestinationsInMemNameResponseToJSONTyped(value, ignoreDis
     return {
         'connection_details': value['connectionDetails'],
         'name': value['name'],
+        'options': value['options'],
+        'purge_error': value['purgeError'],
+        'purge_initiated_at': value['purgeInitiatedAt'] == null ? undefined : ((value['purgeInitiatedAt']).toISOString()),
         'type': value['type'],
     };
 }

--- a/ui/api-client/dist/models/SystemReadSyncDestinationsVercelProjectNameResponse.d.ts
+++ b/ui/api-client/dist/models/SystemReadSyncDestinationsVercelProjectNameResponse.d.ts
@@ -28,6 +28,24 @@ export interface SystemReadSyncDestinationsVercelProjectNameResponse {
      */
     name?: string;
     /**
+     * List of key value pairs of Vault configuration options.
+     * @type {object}
+     * @memberof SystemReadSyncDestinationsVercelProjectNameResponse
+     */
+    options?: object;
+    /**
+     * Error message if the purge job failed.
+     * @type {string}
+     * @memberof SystemReadSyncDestinationsVercelProjectNameResponse
+     */
+    purgeError?: string;
+    /**
+     * Timestamp of when a purge job was initiated when deleting a destination.
+     * @type {Date}
+     * @memberof SystemReadSyncDestinationsVercelProjectNameResponse
+     */
+    purgeInitiatedAt?: Date;
+    /**
      * Type of this secrets store.
      * @type {string}
      * @memberof SystemReadSyncDestinationsVercelProjectNameResponse

--- a/ui/api-client/dist/models/SystemReadSyncDestinationsVercelProjectNameResponse.js
+++ b/ui/api-client/dist/models/SystemReadSyncDestinationsVercelProjectNameResponse.js
@@ -34,6 +34,9 @@ function SystemReadSyncDestinationsVercelProjectNameResponseFromJSONTyped(json, 
     return {
         'connectionDetails': json['connection_details'] == null ? undefined : json['connection_details'],
         'name': json['name'] == null ? undefined : json['name'],
+        'options': json['options'] == null ? undefined : json['options'],
+        'purgeError': json['purge_error'] == null ? undefined : json['purge_error'],
+        'purgeInitiatedAt': json['purge_initiated_at'] == null ? undefined : (new Date(json['purge_initiated_at'])),
         'type': json['type'] == null ? undefined : json['type'],
     };
 }
@@ -47,6 +50,9 @@ function SystemReadSyncDestinationsVercelProjectNameResponseToJSONTyped(value, i
     return {
         'connection_details': value['connectionDetails'],
         'name': value['name'],
+        'options': value['options'],
+        'purge_error': value['purgeError'],
+        'purge_initiated_at': value['purgeInitiatedAt'] == null ? undefined : ((value['purgeInitiatedAt']).toISOString()),
         'type': value['type'],
     };
 }

--- a/ui/api-client/dist/models/SystemWriteSyncDestinationsAwsSmNameResponse.d.ts
+++ b/ui/api-client/dist/models/SystemWriteSyncDestinationsAwsSmNameResponse.d.ts
@@ -28,6 +28,24 @@ export interface SystemWriteSyncDestinationsAwsSmNameResponse {
      */
     name?: string;
     /**
+     * List of key value pairs of Vault configuration options.
+     * @type {object}
+     * @memberof SystemWriteSyncDestinationsAwsSmNameResponse
+     */
+    options?: object;
+    /**
+     * Error message if the purge job failed.
+     * @type {string}
+     * @memberof SystemWriteSyncDestinationsAwsSmNameResponse
+     */
+    purgeError?: string;
+    /**
+     * Timestamp of when a purge job was initiated when deleting a destination.
+     * @type {Date}
+     * @memberof SystemWriteSyncDestinationsAwsSmNameResponse
+     */
+    purgeInitiatedAt?: Date;
+    /**
      * Type of this secrets store.
      * @type {string}
      * @memberof SystemWriteSyncDestinationsAwsSmNameResponse

--- a/ui/api-client/dist/models/SystemWriteSyncDestinationsAwsSmNameResponse.js
+++ b/ui/api-client/dist/models/SystemWriteSyncDestinationsAwsSmNameResponse.js
@@ -34,6 +34,9 @@ function SystemWriteSyncDestinationsAwsSmNameResponseFromJSONTyped(json, ignoreD
     return {
         'connectionDetails': json['connection_details'] == null ? undefined : json['connection_details'],
         'name': json['name'] == null ? undefined : json['name'],
+        'options': json['options'] == null ? undefined : json['options'],
+        'purgeError': json['purge_error'] == null ? undefined : json['purge_error'],
+        'purgeInitiatedAt': json['purge_initiated_at'] == null ? undefined : (new Date(json['purge_initiated_at'])),
         'type': json['type'] == null ? undefined : json['type'],
     };
 }
@@ -47,6 +50,9 @@ function SystemWriteSyncDestinationsAwsSmNameResponseToJSONTyped(value, ignoreDi
     return {
         'connection_details': value['connectionDetails'],
         'name': value['name'],
+        'options': value['options'],
+        'purge_error': value['purgeError'],
+        'purge_initiated_at': value['purgeInitiatedAt'] == null ? undefined : ((value['purgeInitiatedAt']).toISOString()),
         'type': value['type'],
     };
 }

--- a/ui/api-client/dist/models/SystemWriteSyncDestinationsAzureKvNameResponse.d.ts
+++ b/ui/api-client/dist/models/SystemWriteSyncDestinationsAzureKvNameResponse.d.ts
@@ -28,6 +28,24 @@ export interface SystemWriteSyncDestinationsAzureKvNameResponse {
      */
     name?: string;
     /**
+     * List of key value pairs of Vault configuration options.
+     * @type {object}
+     * @memberof SystemWriteSyncDestinationsAzureKvNameResponse
+     */
+    options?: object;
+    /**
+     * Error message if the purge job failed.
+     * @type {string}
+     * @memberof SystemWriteSyncDestinationsAzureKvNameResponse
+     */
+    purgeError?: string;
+    /**
+     * Timestamp of when a purge job was initiated when deleting a destination.
+     * @type {Date}
+     * @memberof SystemWriteSyncDestinationsAzureKvNameResponse
+     */
+    purgeInitiatedAt?: Date;
+    /**
      * Type of this secrets store.
      * @type {string}
      * @memberof SystemWriteSyncDestinationsAzureKvNameResponse

--- a/ui/api-client/dist/models/SystemWriteSyncDestinationsAzureKvNameResponse.js
+++ b/ui/api-client/dist/models/SystemWriteSyncDestinationsAzureKvNameResponse.js
@@ -34,6 +34,9 @@ function SystemWriteSyncDestinationsAzureKvNameResponseFromJSONTyped(json, ignor
     return {
         'connectionDetails': json['connection_details'] == null ? undefined : json['connection_details'],
         'name': json['name'] == null ? undefined : json['name'],
+        'options': json['options'] == null ? undefined : json['options'],
+        'purgeError': json['purge_error'] == null ? undefined : json['purge_error'],
+        'purgeInitiatedAt': json['purge_initiated_at'] == null ? undefined : (new Date(json['purge_initiated_at'])),
         'type': json['type'] == null ? undefined : json['type'],
     };
 }
@@ -47,6 +50,9 @@ function SystemWriteSyncDestinationsAzureKvNameResponseToJSONTyped(value, ignore
     return {
         'connection_details': value['connectionDetails'],
         'name': value['name'],
+        'options': value['options'],
+        'purge_error': value['purgeError'],
+        'purge_initiated_at': value['purgeInitiatedAt'] == null ? undefined : ((value['purgeInitiatedAt']).toISOString()),
         'type': value['type'],
     };
 }

--- a/ui/api-client/dist/models/SystemWriteSyncDestinationsGcpSmNameResponse.d.ts
+++ b/ui/api-client/dist/models/SystemWriteSyncDestinationsGcpSmNameResponse.d.ts
@@ -28,6 +28,24 @@ export interface SystemWriteSyncDestinationsGcpSmNameResponse {
      */
     name?: string;
     /**
+     * List of key value pairs of Vault configuration options.
+     * @type {object}
+     * @memberof SystemWriteSyncDestinationsGcpSmNameResponse
+     */
+    options?: object;
+    /**
+     * Error message if the purge job failed.
+     * @type {string}
+     * @memberof SystemWriteSyncDestinationsGcpSmNameResponse
+     */
+    purgeError?: string;
+    /**
+     * Timestamp of when a purge job was initiated when deleting a destination.
+     * @type {Date}
+     * @memberof SystemWriteSyncDestinationsGcpSmNameResponse
+     */
+    purgeInitiatedAt?: Date;
+    /**
      * Type of this secrets store.
      * @type {string}
      * @memberof SystemWriteSyncDestinationsGcpSmNameResponse

--- a/ui/api-client/dist/models/SystemWriteSyncDestinationsGcpSmNameResponse.js
+++ b/ui/api-client/dist/models/SystemWriteSyncDestinationsGcpSmNameResponse.js
@@ -34,6 +34,9 @@ function SystemWriteSyncDestinationsGcpSmNameResponseFromJSONTyped(json, ignoreD
     return {
         'connectionDetails': json['connection_details'] == null ? undefined : json['connection_details'],
         'name': json['name'] == null ? undefined : json['name'],
+        'options': json['options'] == null ? undefined : json['options'],
+        'purgeError': json['purge_error'] == null ? undefined : json['purge_error'],
+        'purgeInitiatedAt': json['purge_initiated_at'] == null ? undefined : (new Date(json['purge_initiated_at'])),
         'type': json['type'] == null ? undefined : json['type'],
     };
 }
@@ -47,6 +50,9 @@ function SystemWriteSyncDestinationsGcpSmNameResponseToJSONTyped(value, ignoreDi
     return {
         'connection_details': value['connectionDetails'],
         'name': value['name'],
+        'options': value['options'],
+        'purge_error': value['purgeError'],
+        'purge_initiated_at': value['purgeInitiatedAt'] == null ? undefined : ((value['purgeInitiatedAt']).toISOString()),
         'type': value['type'],
     };
 }

--- a/ui/api-client/dist/models/SystemWriteSyncDestinationsGhNameResponse.d.ts
+++ b/ui/api-client/dist/models/SystemWriteSyncDestinationsGhNameResponse.d.ts
@@ -28,6 +28,24 @@ export interface SystemWriteSyncDestinationsGhNameResponse {
      */
     name?: string;
     /**
+     * List of key value pairs of Vault configuration options.
+     * @type {object}
+     * @memberof SystemWriteSyncDestinationsGhNameResponse
+     */
+    options?: object;
+    /**
+     * Error message if the purge job failed.
+     * @type {string}
+     * @memberof SystemWriteSyncDestinationsGhNameResponse
+     */
+    purgeError?: string;
+    /**
+     * Timestamp of when a purge job was initiated when deleting a destination.
+     * @type {Date}
+     * @memberof SystemWriteSyncDestinationsGhNameResponse
+     */
+    purgeInitiatedAt?: Date;
+    /**
      * Type of this secrets store.
      * @type {string}
      * @memberof SystemWriteSyncDestinationsGhNameResponse

--- a/ui/api-client/dist/models/SystemWriteSyncDestinationsGhNameResponse.js
+++ b/ui/api-client/dist/models/SystemWriteSyncDestinationsGhNameResponse.js
@@ -34,6 +34,9 @@ function SystemWriteSyncDestinationsGhNameResponseFromJSONTyped(json, ignoreDisc
     return {
         'connectionDetails': json['connection_details'] == null ? undefined : json['connection_details'],
         'name': json['name'] == null ? undefined : json['name'],
+        'options': json['options'] == null ? undefined : json['options'],
+        'purgeError': json['purge_error'] == null ? undefined : json['purge_error'],
+        'purgeInitiatedAt': json['purge_initiated_at'] == null ? undefined : (new Date(json['purge_initiated_at'])),
         'type': json['type'] == null ? undefined : json['type'],
     };
 }
@@ -47,6 +50,9 @@ function SystemWriteSyncDestinationsGhNameResponseToJSONTyped(value, ignoreDiscr
     return {
         'connection_details': value['connectionDetails'],
         'name': value['name'],
+        'options': value['options'],
+        'purge_error': value['purgeError'],
+        'purge_initiated_at': value['purgeInitiatedAt'] == null ? undefined : ((value['purgeInitiatedAt']).toISOString()),
         'type': value['type'],
     };
 }

--- a/ui/api-client/dist/models/SystemWriteSyncDestinationsInMemNameResponse.d.ts
+++ b/ui/api-client/dist/models/SystemWriteSyncDestinationsInMemNameResponse.d.ts
@@ -28,6 +28,24 @@ export interface SystemWriteSyncDestinationsInMemNameResponse {
      */
     name?: string;
     /**
+     * List of key value pairs of Vault configuration options.
+     * @type {object}
+     * @memberof SystemWriteSyncDestinationsInMemNameResponse
+     */
+    options?: object;
+    /**
+     * Error message if the purge job failed.
+     * @type {string}
+     * @memberof SystemWriteSyncDestinationsInMemNameResponse
+     */
+    purgeError?: string;
+    /**
+     * Timestamp of when a purge job was initiated when deleting a destination.
+     * @type {Date}
+     * @memberof SystemWriteSyncDestinationsInMemNameResponse
+     */
+    purgeInitiatedAt?: Date;
+    /**
      * Type of this secrets store.
      * @type {string}
      * @memberof SystemWriteSyncDestinationsInMemNameResponse

--- a/ui/api-client/dist/models/SystemWriteSyncDestinationsInMemNameResponse.js
+++ b/ui/api-client/dist/models/SystemWriteSyncDestinationsInMemNameResponse.js
@@ -34,6 +34,9 @@ function SystemWriteSyncDestinationsInMemNameResponseFromJSONTyped(json, ignoreD
     return {
         'connectionDetails': json['connection_details'] == null ? undefined : json['connection_details'],
         'name': json['name'] == null ? undefined : json['name'],
+        'options': json['options'] == null ? undefined : json['options'],
+        'purgeError': json['purge_error'] == null ? undefined : json['purge_error'],
+        'purgeInitiatedAt': json['purge_initiated_at'] == null ? undefined : (new Date(json['purge_initiated_at'])),
         'type': json['type'] == null ? undefined : json['type'],
     };
 }
@@ -47,6 +50,9 @@ function SystemWriteSyncDestinationsInMemNameResponseToJSONTyped(value, ignoreDi
     return {
         'connection_details': value['connectionDetails'],
         'name': value['name'],
+        'options': value['options'],
+        'purge_error': value['purgeError'],
+        'purge_initiated_at': value['purgeInitiatedAt'] == null ? undefined : ((value['purgeInitiatedAt']).toISOString()),
         'type': value['type'],
     };
 }

--- a/ui/api-client/dist/models/SystemWriteSyncDestinationsVercelProjectNameResponse.d.ts
+++ b/ui/api-client/dist/models/SystemWriteSyncDestinationsVercelProjectNameResponse.d.ts
@@ -28,6 +28,24 @@ export interface SystemWriteSyncDestinationsVercelProjectNameResponse {
      */
     name?: string;
     /**
+     * List of key value pairs of Vault configuration options.
+     * @type {object}
+     * @memberof SystemWriteSyncDestinationsVercelProjectNameResponse
+     */
+    options?: object;
+    /**
+     * Error message if the purge job failed.
+     * @type {string}
+     * @memberof SystemWriteSyncDestinationsVercelProjectNameResponse
+     */
+    purgeError?: string;
+    /**
+     * Timestamp of when a purge job was initiated when deleting a destination.
+     * @type {Date}
+     * @memberof SystemWriteSyncDestinationsVercelProjectNameResponse
+     */
+    purgeInitiatedAt?: Date;
+    /**
      * Type of this secrets store.
      * @type {string}
      * @memberof SystemWriteSyncDestinationsVercelProjectNameResponse

--- a/ui/api-client/dist/models/SystemWriteSyncDestinationsVercelProjectNameResponse.js
+++ b/ui/api-client/dist/models/SystemWriteSyncDestinationsVercelProjectNameResponse.js
@@ -34,6 +34,9 @@ function SystemWriteSyncDestinationsVercelProjectNameResponseFromJSONTyped(json,
     return {
         'connectionDetails': json['connection_details'] == null ? undefined : json['connection_details'],
         'name': json['name'] == null ? undefined : json['name'],
+        'options': json['options'] == null ? undefined : json['options'],
+        'purgeError': json['purge_error'] == null ? undefined : json['purge_error'],
+        'purgeInitiatedAt': json['purge_initiated_at'] == null ? undefined : (new Date(json['purge_initiated_at'])),
         'type': json['type'] == null ? undefined : json['type'],
     };
 }
@@ -47,6 +50,9 @@ function SystemWriteSyncDestinationsVercelProjectNameResponseToJSONTyped(value, 
     return {
         'connection_details': value['connectionDetails'],
         'name': value['name'],
+        'options': value['options'],
+        'purge_error': value['purgeError'],
+        'purge_initiated_at': value['purgeInitiatedAt'] == null ? undefined : ((value['purgeInitiatedAt']).toISOString()),
         'type': value['type'],
     };
 }

--- a/ui/api-client/src/models/SystemPatchSyncDestinationsAwsSmNameResponse.ts
+++ b/ui/api-client/src/models/SystemPatchSyncDestinationsAwsSmNameResponse.ts
@@ -32,6 +32,24 @@ export interface SystemPatchSyncDestinationsAwsSmNameResponse {
      */
     name?: string;
     /**
+     * List of key value pairs of Vault configuration options.
+     * @type {object}
+     * @memberof SystemPatchSyncDestinationsAwsSmNameResponse
+     */
+    options?: object;
+    /**
+     * Error message if the purge job failed.
+     * @type {string}
+     * @memberof SystemPatchSyncDestinationsAwsSmNameResponse
+     */
+    purgeError?: string;
+    /**
+     * Timestamp of when a purge job was initiated when deleting a destination.
+     * @type {Date}
+     * @memberof SystemPatchSyncDestinationsAwsSmNameResponse
+     */
+    purgeInitiatedAt?: Date;
+    /**
      * Type of this secrets store.
      * @type {string}
      * @memberof SystemPatchSyncDestinationsAwsSmNameResponse
@@ -58,6 +76,9 @@ export function SystemPatchSyncDestinationsAwsSmNameResponseFromJSONTyped(json: 
         
         'connectionDetails': json['connection_details'] == null ? undefined : json['connection_details'],
         'name': json['name'] == null ? undefined : json['name'],
+        'options': json['options'] == null ? undefined : json['options'],
+        'purgeError': json['purge_error'] == null ? undefined : json['purge_error'],
+        'purgeInitiatedAt': json['purge_initiated_at'] == null ? undefined : (new Date(json['purge_initiated_at'])),
         'type': json['type'] == null ? undefined : json['type'],
     };
 }
@@ -75,6 +96,9 @@ export function SystemPatchSyncDestinationsAwsSmNameResponseToJSONTyped(value?: 
         
         'connection_details': value['connectionDetails'],
         'name': value['name'],
+        'options': value['options'],
+        'purge_error': value['purgeError'],
+        'purge_initiated_at': value['purgeInitiatedAt'] == null ? undefined : ((value['purgeInitiatedAt']).toISOString()),
         'type': value['type'],
     };
 }

--- a/ui/api-client/src/models/SystemPatchSyncDestinationsAzureKvNameResponse.ts
+++ b/ui/api-client/src/models/SystemPatchSyncDestinationsAzureKvNameResponse.ts
@@ -32,6 +32,24 @@ export interface SystemPatchSyncDestinationsAzureKvNameResponse {
      */
     name?: string;
     /**
+     * List of key value pairs of Vault configuration options.
+     * @type {object}
+     * @memberof SystemPatchSyncDestinationsAzureKvNameResponse
+     */
+    options?: object;
+    /**
+     * Error message if the purge job failed.
+     * @type {string}
+     * @memberof SystemPatchSyncDestinationsAzureKvNameResponse
+     */
+    purgeError?: string;
+    /**
+     * Timestamp of when a purge job was initiated when deleting a destination.
+     * @type {Date}
+     * @memberof SystemPatchSyncDestinationsAzureKvNameResponse
+     */
+    purgeInitiatedAt?: Date;
+    /**
      * Type of this secrets store.
      * @type {string}
      * @memberof SystemPatchSyncDestinationsAzureKvNameResponse
@@ -58,6 +76,9 @@ export function SystemPatchSyncDestinationsAzureKvNameResponseFromJSONTyped(json
         
         'connectionDetails': json['connection_details'] == null ? undefined : json['connection_details'],
         'name': json['name'] == null ? undefined : json['name'],
+        'options': json['options'] == null ? undefined : json['options'],
+        'purgeError': json['purge_error'] == null ? undefined : json['purge_error'],
+        'purgeInitiatedAt': json['purge_initiated_at'] == null ? undefined : (new Date(json['purge_initiated_at'])),
         'type': json['type'] == null ? undefined : json['type'],
     };
 }
@@ -75,6 +96,9 @@ export function SystemPatchSyncDestinationsAzureKvNameResponseToJSONTyped(value?
         
         'connection_details': value['connectionDetails'],
         'name': value['name'],
+        'options': value['options'],
+        'purge_error': value['purgeError'],
+        'purge_initiated_at': value['purgeInitiatedAt'] == null ? undefined : ((value['purgeInitiatedAt']).toISOString()),
         'type': value['type'],
     };
 }

--- a/ui/api-client/src/models/SystemPatchSyncDestinationsGcpSmNameResponse.ts
+++ b/ui/api-client/src/models/SystemPatchSyncDestinationsGcpSmNameResponse.ts
@@ -32,6 +32,24 @@ export interface SystemPatchSyncDestinationsGcpSmNameResponse {
      */
     name?: string;
     /**
+     * List of key value pairs of Vault configuration options.
+     * @type {object}
+     * @memberof SystemPatchSyncDestinationsGcpSmNameResponse
+     */
+    options?: object;
+    /**
+     * Error message if the purge job failed.
+     * @type {string}
+     * @memberof SystemPatchSyncDestinationsGcpSmNameResponse
+     */
+    purgeError?: string;
+    /**
+     * Timestamp of when a purge job was initiated when deleting a destination.
+     * @type {Date}
+     * @memberof SystemPatchSyncDestinationsGcpSmNameResponse
+     */
+    purgeInitiatedAt?: Date;
+    /**
      * Type of this secrets store.
      * @type {string}
      * @memberof SystemPatchSyncDestinationsGcpSmNameResponse
@@ -58,6 +76,9 @@ export function SystemPatchSyncDestinationsGcpSmNameResponseFromJSONTyped(json: 
         
         'connectionDetails': json['connection_details'] == null ? undefined : json['connection_details'],
         'name': json['name'] == null ? undefined : json['name'],
+        'options': json['options'] == null ? undefined : json['options'],
+        'purgeError': json['purge_error'] == null ? undefined : json['purge_error'],
+        'purgeInitiatedAt': json['purge_initiated_at'] == null ? undefined : (new Date(json['purge_initiated_at'])),
         'type': json['type'] == null ? undefined : json['type'],
     };
 }
@@ -75,6 +96,9 @@ export function SystemPatchSyncDestinationsGcpSmNameResponseToJSONTyped(value?: 
         
         'connection_details': value['connectionDetails'],
         'name': value['name'],
+        'options': value['options'],
+        'purge_error': value['purgeError'],
+        'purge_initiated_at': value['purgeInitiatedAt'] == null ? undefined : ((value['purgeInitiatedAt']).toISOString()),
         'type': value['type'],
     };
 }

--- a/ui/api-client/src/models/SystemPatchSyncDestinationsGhNameResponse.ts
+++ b/ui/api-client/src/models/SystemPatchSyncDestinationsGhNameResponse.ts
@@ -32,6 +32,24 @@ export interface SystemPatchSyncDestinationsGhNameResponse {
      */
     name?: string;
     /**
+     * List of key value pairs of Vault configuration options.
+     * @type {object}
+     * @memberof SystemPatchSyncDestinationsGhNameResponse
+     */
+    options?: object;
+    /**
+     * Error message if the purge job failed.
+     * @type {string}
+     * @memberof SystemPatchSyncDestinationsGhNameResponse
+     */
+    purgeError?: string;
+    /**
+     * Timestamp of when a purge job was initiated when deleting a destination.
+     * @type {Date}
+     * @memberof SystemPatchSyncDestinationsGhNameResponse
+     */
+    purgeInitiatedAt?: Date;
+    /**
      * Type of this secrets store.
      * @type {string}
      * @memberof SystemPatchSyncDestinationsGhNameResponse
@@ -58,6 +76,9 @@ export function SystemPatchSyncDestinationsGhNameResponseFromJSONTyped(json: any
         
         'connectionDetails': json['connection_details'] == null ? undefined : json['connection_details'],
         'name': json['name'] == null ? undefined : json['name'],
+        'options': json['options'] == null ? undefined : json['options'],
+        'purgeError': json['purge_error'] == null ? undefined : json['purge_error'],
+        'purgeInitiatedAt': json['purge_initiated_at'] == null ? undefined : (new Date(json['purge_initiated_at'])),
         'type': json['type'] == null ? undefined : json['type'],
     };
 }
@@ -75,6 +96,9 @@ export function SystemPatchSyncDestinationsGhNameResponseToJSONTyped(value?: Sys
         
         'connection_details': value['connectionDetails'],
         'name': value['name'],
+        'options': value['options'],
+        'purge_error': value['purgeError'],
+        'purge_initiated_at': value['purgeInitiatedAt'] == null ? undefined : ((value['purgeInitiatedAt']).toISOString()),
         'type': value['type'],
     };
 }

--- a/ui/api-client/src/models/SystemPatchSyncDestinationsInMemNameResponse.ts
+++ b/ui/api-client/src/models/SystemPatchSyncDestinationsInMemNameResponse.ts
@@ -32,6 +32,24 @@ export interface SystemPatchSyncDestinationsInMemNameResponse {
      */
     name?: string;
     /**
+     * List of key value pairs of Vault configuration options.
+     * @type {object}
+     * @memberof SystemPatchSyncDestinationsInMemNameResponse
+     */
+    options?: object;
+    /**
+     * Error message if the purge job failed.
+     * @type {string}
+     * @memberof SystemPatchSyncDestinationsInMemNameResponse
+     */
+    purgeError?: string;
+    /**
+     * Timestamp of when a purge job was initiated when deleting a destination.
+     * @type {Date}
+     * @memberof SystemPatchSyncDestinationsInMemNameResponse
+     */
+    purgeInitiatedAt?: Date;
+    /**
      * Type of this secrets store.
      * @type {string}
      * @memberof SystemPatchSyncDestinationsInMemNameResponse
@@ -58,6 +76,9 @@ export function SystemPatchSyncDestinationsInMemNameResponseFromJSONTyped(json: 
         
         'connectionDetails': json['connection_details'] == null ? undefined : json['connection_details'],
         'name': json['name'] == null ? undefined : json['name'],
+        'options': json['options'] == null ? undefined : json['options'],
+        'purgeError': json['purge_error'] == null ? undefined : json['purge_error'],
+        'purgeInitiatedAt': json['purge_initiated_at'] == null ? undefined : (new Date(json['purge_initiated_at'])),
         'type': json['type'] == null ? undefined : json['type'],
     };
 }
@@ -75,6 +96,9 @@ export function SystemPatchSyncDestinationsInMemNameResponseToJSONTyped(value?: 
         
         'connection_details': value['connectionDetails'],
         'name': value['name'],
+        'options': value['options'],
+        'purge_error': value['purgeError'],
+        'purge_initiated_at': value['purgeInitiatedAt'] == null ? undefined : ((value['purgeInitiatedAt']).toISOString()),
         'type': value['type'],
     };
 }

--- a/ui/api-client/src/models/SystemPatchSyncDestinationsVercelProjectNameResponse.ts
+++ b/ui/api-client/src/models/SystemPatchSyncDestinationsVercelProjectNameResponse.ts
@@ -32,6 +32,24 @@ export interface SystemPatchSyncDestinationsVercelProjectNameResponse {
      */
     name?: string;
     /**
+     * List of key value pairs of Vault configuration options.
+     * @type {object}
+     * @memberof SystemPatchSyncDestinationsVercelProjectNameResponse
+     */
+    options?: object;
+    /**
+     * Error message if the purge job failed.
+     * @type {string}
+     * @memberof SystemPatchSyncDestinationsVercelProjectNameResponse
+     */
+    purgeError?: string;
+    /**
+     * Timestamp of when a purge job was initiated when deleting a destination.
+     * @type {Date}
+     * @memberof SystemPatchSyncDestinationsVercelProjectNameResponse
+     */
+    purgeInitiatedAt?: Date;
+    /**
      * Type of this secrets store.
      * @type {string}
      * @memberof SystemPatchSyncDestinationsVercelProjectNameResponse
@@ -58,6 +76,9 @@ export function SystemPatchSyncDestinationsVercelProjectNameResponseFromJSONType
         
         'connectionDetails': json['connection_details'] == null ? undefined : json['connection_details'],
         'name': json['name'] == null ? undefined : json['name'],
+        'options': json['options'] == null ? undefined : json['options'],
+        'purgeError': json['purge_error'] == null ? undefined : json['purge_error'],
+        'purgeInitiatedAt': json['purge_initiated_at'] == null ? undefined : (new Date(json['purge_initiated_at'])),
         'type': json['type'] == null ? undefined : json['type'],
     };
 }
@@ -75,6 +96,9 @@ export function SystemPatchSyncDestinationsVercelProjectNameResponseToJSONTyped(
         
         'connection_details': value['connectionDetails'],
         'name': value['name'],
+        'options': value['options'],
+        'purge_error': value['purgeError'],
+        'purge_initiated_at': value['purgeInitiatedAt'] == null ? undefined : ((value['purgeInitiatedAt']).toISOString()),
         'type': value['type'],
     };
 }

--- a/ui/api-client/src/models/SystemReadSyncDestinationsAwsSmNameResponse.ts
+++ b/ui/api-client/src/models/SystemReadSyncDestinationsAwsSmNameResponse.ts
@@ -32,6 +32,24 @@ export interface SystemReadSyncDestinationsAwsSmNameResponse {
      */
     name?: string;
     /**
+     * List of key value pairs of Vault configuration options.
+     * @type {object}
+     * @memberof SystemReadSyncDestinationsAwsSmNameResponse
+     */
+    options?: object;
+    /**
+     * Error message if the purge job failed.
+     * @type {string}
+     * @memberof SystemReadSyncDestinationsAwsSmNameResponse
+     */
+    purgeError?: string;
+    /**
+     * Timestamp of when a purge job was initiated when deleting a destination.
+     * @type {Date}
+     * @memberof SystemReadSyncDestinationsAwsSmNameResponse
+     */
+    purgeInitiatedAt?: Date;
+    /**
      * Type of this secrets store.
      * @type {string}
      * @memberof SystemReadSyncDestinationsAwsSmNameResponse
@@ -58,6 +76,9 @@ export function SystemReadSyncDestinationsAwsSmNameResponseFromJSONTyped(json: a
         
         'connectionDetails': json['connection_details'] == null ? undefined : json['connection_details'],
         'name': json['name'] == null ? undefined : json['name'],
+        'options': json['options'] == null ? undefined : json['options'],
+        'purgeError': json['purge_error'] == null ? undefined : json['purge_error'],
+        'purgeInitiatedAt': json['purge_initiated_at'] == null ? undefined : (new Date(json['purge_initiated_at'])),
         'type': json['type'] == null ? undefined : json['type'],
     };
 }
@@ -75,6 +96,9 @@ export function SystemReadSyncDestinationsAwsSmNameResponseToJSONTyped(value?: S
         
         'connection_details': value['connectionDetails'],
         'name': value['name'],
+        'options': value['options'],
+        'purge_error': value['purgeError'],
+        'purge_initiated_at': value['purgeInitiatedAt'] == null ? undefined : ((value['purgeInitiatedAt']).toISOString()),
         'type': value['type'],
     };
 }

--- a/ui/api-client/src/models/SystemReadSyncDestinationsAzureKvNameResponse.ts
+++ b/ui/api-client/src/models/SystemReadSyncDestinationsAzureKvNameResponse.ts
@@ -32,6 +32,24 @@ export interface SystemReadSyncDestinationsAzureKvNameResponse {
      */
     name?: string;
     /**
+     * List of key value pairs of Vault configuration options.
+     * @type {object}
+     * @memberof SystemReadSyncDestinationsAzureKvNameResponse
+     */
+    options?: object;
+    /**
+     * Error message if the purge job failed.
+     * @type {string}
+     * @memberof SystemReadSyncDestinationsAzureKvNameResponse
+     */
+    purgeError?: string;
+    /**
+     * Timestamp of when a purge job was initiated when deleting a destination.
+     * @type {Date}
+     * @memberof SystemReadSyncDestinationsAzureKvNameResponse
+     */
+    purgeInitiatedAt?: Date;
+    /**
      * Type of this secrets store.
      * @type {string}
      * @memberof SystemReadSyncDestinationsAzureKvNameResponse
@@ -58,6 +76,9 @@ export function SystemReadSyncDestinationsAzureKvNameResponseFromJSONTyped(json:
         
         'connectionDetails': json['connection_details'] == null ? undefined : json['connection_details'],
         'name': json['name'] == null ? undefined : json['name'],
+        'options': json['options'] == null ? undefined : json['options'],
+        'purgeError': json['purge_error'] == null ? undefined : json['purge_error'],
+        'purgeInitiatedAt': json['purge_initiated_at'] == null ? undefined : (new Date(json['purge_initiated_at'])),
         'type': json['type'] == null ? undefined : json['type'],
     };
 }
@@ -75,6 +96,9 @@ export function SystemReadSyncDestinationsAzureKvNameResponseToJSONTyped(value?:
         
         'connection_details': value['connectionDetails'],
         'name': value['name'],
+        'options': value['options'],
+        'purge_error': value['purgeError'],
+        'purge_initiated_at': value['purgeInitiatedAt'] == null ? undefined : ((value['purgeInitiatedAt']).toISOString()),
         'type': value['type'],
     };
 }

--- a/ui/api-client/src/models/SystemReadSyncDestinationsGcpSmNameResponse.ts
+++ b/ui/api-client/src/models/SystemReadSyncDestinationsGcpSmNameResponse.ts
@@ -32,6 +32,24 @@ export interface SystemReadSyncDestinationsGcpSmNameResponse {
      */
     name?: string;
     /**
+     * List of key value pairs of Vault configuration options.
+     * @type {object}
+     * @memberof SystemReadSyncDestinationsGcpSmNameResponse
+     */
+    options?: object;
+    /**
+     * Error message if the purge job failed.
+     * @type {string}
+     * @memberof SystemReadSyncDestinationsGcpSmNameResponse
+     */
+    purgeError?: string;
+    /**
+     * Timestamp of when a purge job was initiated when deleting a destination.
+     * @type {Date}
+     * @memberof SystemReadSyncDestinationsGcpSmNameResponse
+     */
+    purgeInitiatedAt?: Date;
+    /**
      * Type of this secrets store.
      * @type {string}
      * @memberof SystemReadSyncDestinationsGcpSmNameResponse
@@ -58,6 +76,9 @@ export function SystemReadSyncDestinationsGcpSmNameResponseFromJSONTyped(json: a
         
         'connectionDetails': json['connection_details'] == null ? undefined : json['connection_details'],
         'name': json['name'] == null ? undefined : json['name'],
+        'options': json['options'] == null ? undefined : json['options'],
+        'purgeError': json['purge_error'] == null ? undefined : json['purge_error'],
+        'purgeInitiatedAt': json['purge_initiated_at'] == null ? undefined : (new Date(json['purge_initiated_at'])),
         'type': json['type'] == null ? undefined : json['type'],
     };
 }
@@ -75,6 +96,9 @@ export function SystemReadSyncDestinationsGcpSmNameResponseToJSONTyped(value?: S
         
         'connection_details': value['connectionDetails'],
         'name': value['name'],
+        'options': value['options'],
+        'purge_error': value['purgeError'],
+        'purge_initiated_at': value['purgeInitiatedAt'] == null ? undefined : ((value['purgeInitiatedAt']).toISOString()),
         'type': value['type'],
     };
 }

--- a/ui/api-client/src/models/SystemReadSyncDestinationsGhNameResponse.ts
+++ b/ui/api-client/src/models/SystemReadSyncDestinationsGhNameResponse.ts
@@ -32,6 +32,24 @@ export interface SystemReadSyncDestinationsGhNameResponse {
      */
     name?: string;
     /**
+     * List of key value pairs of Vault configuration options.
+     * @type {object}
+     * @memberof SystemReadSyncDestinationsGhNameResponse
+     */
+    options?: object;
+    /**
+     * Error message if the purge job failed.
+     * @type {string}
+     * @memberof SystemReadSyncDestinationsGhNameResponse
+     */
+    purgeError?: string;
+    /**
+     * Timestamp of when a purge job was initiated when deleting a destination.
+     * @type {Date}
+     * @memberof SystemReadSyncDestinationsGhNameResponse
+     */
+    purgeInitiatedAt?: Date;
+    /**
      * Type of this secrets store.
      * @type {string}
      * @memberof SystemReadSyncDestinationsGhNameResponse
@@ -58,6 +76,9 @@ export function SystemReadSyncDestinationsGhNameResponseFromJSONTyped(json: any,
         
         'connectionDetails': json['connection_details'] == null ? undefined : json['connection_details'],
         'name': json['name'] == null ? undefined : json['name'],
+        'options': json['options'] == null ? undefined : json['options'],
+        'purgeError': json['purge_error'] == null ? undefined : json['purge_error'],
+        'purgeInitiatedAt': json['purge_initiated_at'] == null ? undefined : (new Date(json['purge_initiated_at'])),
         'type': json['type'] == null ? undefined : json['type'],
     };
 }
@@ -75,6 +96,9 @@ export function SystemReadSyncDestinationsGhNameResponseToJSONTyped(value?: Syst
         
         'connection_details': value['connectionDetails'],
         'name': value['name'],
+        'options': value['options'],
+        'purge_error': value['purgeError'],
+        'purge_initiated_at': value['purgeInitiatedAt'] == null ? undefined : ((value['purgeInitiatedAt']).toISOString()),
         'type': value['type'],
     };
 }

--- a/ui/api-client/src/models/SystemReadSyncDestinationsInMemNameResponse.ts
+++ b/ui/api-client/src/models/SystemReadSyncDestinationsInMemNameResponse.ts
@@ -32,6 +32,24 @@ export interface SystemReadSyncDestinationsInMemNameResponse {
      */
     name?: string;
     /**
+     * List of key value pairs of Vault configuration options.
+     * @type {object}
+     * @memberof SystemReadSyncDestinationsInMemNameResponse
+     */
+    options?: object;
+    /**
+     * Error message if the purge job failed.
+     * @type {string}
+     * @memberof SystemReadSyncDestinationsInMemNameResponse
+     */
+    purgeError?: string;
+    /**
+     * Timestamp of when a purge job was initiated when deleting a destination.
+     * @type {Date}
+     * @memberof SystemReadSyncDestinationsInMemNameResponse
+     */
+    purgeInitiatedAt?: Date;
+    /**
      * Type of this secrets store.
      * @type {string}
      * @memberof SystemReadSyncDestinationsInMemNameResponse
@@ -58,6 +76,9 @@ export function SystemReadSyncDestinationsInMemNameResponseFromJSONTyped(json: a
         
         'connectionDetails': json['connection_details'] == null ? undefined : json['connection_details'],
         'name': json['name'] == null ? undefined : json['name'],
+        'options': json['options'] == null ? undefined : json['options'],
+        'purgeError': json['purge_error'] == null ? undefined : json['purge_error'],
+        'purgeInitiatedAt': json['purge_initiated_at'] == null ? undefined : (new Date(json['purge_initiated_at'])),
         'type': json['type'] == null ? undefined : json['type'],
     };
 }
@@ -75,6 +96,9 @@ export function SystemReadSyncDestinationsInMemNameResponseToJSONTyped(value?: S
         
         'connection_details': value['connectionDetails'],
         'name': value['name'],
+        'options': value['options'],
+        'purge_error': value['purgeError'],
+        'purge_initiated_at': value['purgeInitiatedAt'] == null ? undefined : ((value['purgeInitiatedAt']).toISOString()),
         'type': value['type'],
     };
 }

--- a/ui/api-client/src/models/SystemReadSyncDestinationsVercelProjectNameResponse.ts
+++ b/ui/api-client/src/models/SystemReadSyncDestinationsVercelProjectNameResponse.ts
@@ -32,6 +32,24 @@ export interface SystemReadSyncDestinationsVercelProjectNameResponse {
      */
     name?: string;
     /**
+     * List of key value pairs of Vault configuration options.
+     * @type {object}
+     * @memberof SystemReadSyncDestinationsVercelProjectNameResponse
+     */
+    options?: object;
+    /**
+     * Error message if the purge job failed.
+     * @type {string}
+     * @memberof SystemReadSyncDestinationsVercelProjectNameResponse
+     */
+    purgeError?: string;
+    /**
+     * Timestamp of when a purge job was initiated when deleting a destination.
+     * @type {Date}
+     * @memberof SystemReadSyncDestinationsVercelProjectNameResponse
+     */
+    purgeInitiatedAt?: Date;
+    /**
      * Type of this secrets store.
      * @type {string}
      * @memberof SystemReadSyncDestinationsVercelProjectNameResponse
@@ -58,6 +76,9 @@ export function SystemReadSyncDestinationsVercelProjectNameResponseFromJSONTyped
         
         'connectionDetails': json['connection_details'] == null ? undefined : json['connection_details'],
         'name': json['name'] == null ? undefined : json['name'],
+        'options': json['options'] == null ? undefined : json['options'],
+        'purgeError': json['purge_error'] == null ? undefined : json['purge_error'],
+        'purgeInitiatedAt': json['purge_initiated_at'] == null ? undefined : (new Date(json['purge_initiated_at'])),
         'type': json['type'] == null ? undefined : json['type'],
     };
 }
@@ -75,6 +96,9 @@ export function SystemReadSyncDestinationsVercelProjectNameResponseToJSONTyped(v
         
         'connection_details': value['connectionDetails'],
         'name': value['name'],
+        'options': value['options'],
+        'purge_error': value['purgeError'],
+        'purge_initiated_at': value['purgeInitiatedAt'] == null ? undefined : ((value['purgeInitiatedAt']).toISOString()),
         'type': value['type'],
     };
 }

--- a/ui/api-client/src/models/SystemWriteSyncDestinationsAwsSmNameResponse.ts
+++ b/ui/api-client/src/models/SystemWriteSyncDestinationsAwsSmNameResponse.ts
@@ -32,6 +32,24 @@ export interface SystemWriteSyncDestinationsAwsSmNameResponse {
      */
     name?: string;
     /**
+     * List of key value pairs of Vault configuration options.
+     * @type {object}
+     * @memberof SystemWriteSyncDestinationsAwsSmNameResponse
+     */
+    options?: object;
+    /**
+     * Error message if the purge job failed.
+     * @type {string}
+     * @memberof SystemWriteSyncDestinationsAwsSmNameResponse
+     */
+    purgeError?: string;
+    /**
+     * Timestamp of when a purge job was initiated when deleting a destination.
+     * @type {Date}
+     * @memberof SystemWriteSyncDestinationsAwsSmNameResponse
+     */
+    purgeInitiatedAt?: Date;
+    /**
      * Type of this secrets store.
      * @type {string}
      * @memberof SystemWriteSyncDestinationsAwsSmNameResponse
@@ -58,6 +76,9 @@ export function SystemWriteSyncDestinationsAwsSmNameResponseFromJSONTyped(json: 
         
         'connectionDetails': json['connection_details'] == null ? undefined : json['connection_details'],
         'name': json['name'] == null ? undefined : json['name'],
+        'options': json['options'] == null ? undefined : json['options'],
+        'purgeError': json['purge_error'] == null ? undefined : json['purge_error'],
+        'purgeInitiatedAt': json['purge_initiated_at'] == null ? undefined : (new Date(json['purge_initiated_at'])),
         'type': json['type'] == null ? undefined : json['type'],
     };
 }
@@ -75,6 +96,9 @@ export function SystemWriteSyncDestinationsAwsSmNameResponseToJSONTyped(value?: 
         
         'connection_details': value['connectionDetails'],
         'name': value['name'],
+        'options': value['options'],
+        'purge_error': value['purgeError'],
+        'purge_initiated_at': value['purgeInitiatedAt'] == null ? undefined : ((value['purgeInitiatedAt']).toISOString()),
         'type': value['type'],
     };
 }

--- a/ui/api-client/src/models/SystemWriteSyncDestinationsAzureKvNameResponse.ts
+++ b/ui/api-client/src/models/SystemWriteSyncDestinationsAzureKvNameResponse.ts
@@ -32,6 +32,24 @@ export interface SystemWriteSyncDestinationsAzureKvNameResponse {
      */
     name?: string;
     /**
+     * List of key value pairs of Vault configuration options.
+     * @type {object}
+     * @memberof SystemWriteSyncDestinationsAzureKvNameResponse
+     */
+    options?: object;
+    /**
+     * Error message if the purge job failed.
+     * @type {string}
+     * @memberof SystemWriteSyncDestinationsAzureKvNameResponse
+     */
+    purgeError?: string;
+    /**
+     * Timestamp of when a purge job was initiated when deleting a destination.
+     * @type {Date}
+     * @memberof SystemWriteSyncDestinationsAzureKvNameResponse
+     */
+    purgeInitiatedAt?: Date;
+    /**
      * Type of this secrets store.
      * @type {string}
      * @memberof SystemWriteSyncDestinationsAzureKvNameResponse
@@ -58,6 +76,9 @@ export function SystemWriteSyncDestinationsAzureKvNameResponseFromJSONTyped(json
         
         'connectionDetails': json['connection_details'] == null ? undefined : json['connection_details'],
         'name': json['name'] == null ? undefined : json['name'],
+        'options': json['options'] == null ? undefined : json['options'],
+        'purgeError': json['purge_error'] == null ? undefined : json['purge_error'],
+        'purgeInitiatedAt': json['purge_initiated_at'] == null ? undefined : (new Date(json['purge_initiated_at'])),
         'type': json['type'] == null ? undefined : json['type'],
     };
 }
@@ -75,6 +96,9 @@ export function SystemWriteSyncDestinationsAzureKvNameResponseToJSONTyped(value?
         
         'connection_details': value['connectionDetails'],
         'name': value['name'],
+        'options': value['options'],
+        'purge_error': value['purgeError'],
+        'purge_initiated_at': value['purgeInitiatedAt'] == null ? undefined : ((value['purgeInitiatedAt']).toISOString()),
         'type': value['type'],
     };
 }

--- a/ui/api-client/src/models/SystemWriteSyncDestinationsGcpSmNameResponse.ts
+++ b/ui/api-client/src/models/SystemWriteSyncDestinationsGcpSmNameResponse.ts
@@ -32,6 +32,24 @@ export interface SystemWriteSyncDestinationsGcpSmNameResponse {
      */
     name?: string;
     /**
+     * List of key value pairs of Vault configuration options.
+     * @type {object}
+     * @memberof SystemWriteSyncDestinationsGcpSmNameResponse
+     */
+    options?: object;
+    /**
+     * Error message if the purge job failed.
+     * @type {string}
+     * @memberof SystemWriteSyncDestinationsGcpSmNameResponse
+     */
+    purgeError?: string;
+    /**
+     * Timestamp of when a purge job was initiated when deleting a destination.
+     * @type {Date}
+     * @memberof SystemWriteSyncDestinationsGcpSmNameResponse
+     */
+    purgeInitiatedAt?: Date;
+    /**
      * Type of this secrets store.
      * @type {string}
      * @memberof SystemWriteSyncDestinationsGcpSmNameResponse
@@ -58,6 +76,9 @@ export function SystemWriteSyncDestinationsGcpSmNameResponseFromJSONTyped(json: 
         
         'connectionDetails': json['connection_details'] == null ? undefined : json['connection_details'],
         'name': json['name'] == null ? undefined : json['name'],
+        'options': json['options'] == null ? undefined : json['options'],
+        'purgeError': json['purge_error'] == null ? undefined : json['purge_error'],
+        'purgeInitiatedAt': json['purge_initiated_at'] == null ? undefined : (new Date(json['purge_initiated_at'])),
         'type': json['type'] == null ? undefined : json['type'],
     };
 }
@@ -75,6 +96,9 @@ export function SystemWriteSyncDestinationsGcpSmNameResponseToJSONTyped(value?: 
         
         'connection_details': value['connectionDetails'],
         'name': value['name'],
+        'options': value['options'],
+        'purge_error': value['purgeError'],
+        'purge_initiated_at': value['purgeInitiatedAt'] == null ? undefined : ((value['purgeInitiatedAt']).toISOString()),
         'type': value['type'],
     };
 }

--- a/ui/api-client/src/models/SystemWriteSyncDestinationsGhNameResponse.ts
+++ b/ui/api-client/src/models/SystemWriteSyncDestinationsGhNameResponse.ts
@@ -32,6 +32,24 @@ export interface SystemWriteSyncDestinationsGhNameResponse {
      */
     name?: string;
     /**
+     * List of key value pairs of Vault configuration options.
+     * @type {object}
+     * @memberof SystemWriteSyncDestinationsGhNameResponse
+     */
+    options?: object;
+    /**
+     * Error message if the purge job failed.
+     * @type {string}
+     * @memberof SystemWriteSyncDestinationsGhNameResponse
+     */
+    purgeError?: string;
+    /**
+     * Timestamp of when a purge job was initiated when deleting a destination.
+     * @type {Date}
+     * @memberof SystemWriteSyncDestinationsGhNameResponse
+     */
+    purgeInitiatedAt?: Date;
+    /**
      * Type of this secrets store.
      * @type {string}
      * @memberof SystemWriteSyncDestinationsGhNameResponse
@@ -58,6 +76,9 @@ export function SystemWriteSyncDestinationsGhNameResponseFromJSONTyped(json: any
         
         'connectionDetails': json['connection_details'] == null ? undefined : json['connection_details'],
         'name': json['name'] == null ? undefined : json['name'],
+        'options': json['options'] == null ? undefined : json['options'],
+        'purgeError': json['purge_error'] == null ? undefined : json['purge_error'],
+        'purgeInitiatedAt': json['purge_initiated_at'] == null ? undefined : (new Date(json['purge_initiated_at'])),
         'type': json['type'] == null ? undefined : json['type'],
     };
 }
@@ -75,6 +96,9 @@ export function SystemWriteSyncDestinationsGhNameResponseToJSONTyped(value?: Sys
         
         'connection_details': value['connectionDetails'],
         'name': value['name'],
+        'options': value['options'],
+        'purge_error': value['purgeError'],
+        'purge_initiated_at': value['purgeInitiatedAt'] == null ? undefined : ((value['purgeInitiatedAt']).toISOString()),
         'type': value['type'],
     };
 }

--- a/ui/api-client/src/models/SystemWriteSyncDestinationsInMemNameResponse.ts
+++ b/ui/api-client/src/models/SystemWriteSyncDestinationsInMemNameResponse.ts
@@ -32,6 +32,24 @@ export interface SystemWriteSyncDestinationsInMemNameResponse {
      */
     name?: string;
     /**
+     * List of key value pairs of Vault configuration options.
+     * @type {object}
+     * @memberof SystemWriteSyncDestinationsInMemNameResponse
+     */
+    options?: object;
+    /**
+     * Error message if the purge job failed.
+     * @type {string}
+     * @memberof SystemWriteSyncDestinationsInMemNameResponse
+     */
+    purgeError?: string;
+    /**
+     * Timestamp of when a purge job was initiated when deleting a destination.
+     * @type {Date}
+     * @memberof SystemWriteSyncDestinationsInMemNameResponse
+     */
+    purgeInitiatedAt?: Date;
+    /**
      * Type of this secrets store.
      * @type {string}
      * @memberof SystemWriteSyncDestinationsInMemNameResponse
@@ -58,6 +76,9 @@ export function SystemWriteSyncDestinationsInMemNameResponseFromJSONTyped(json: 
         
         'connectionDetails': json['connection_details'] == null ? undefined : json['connection_details'],
         'name': json['name'] == null ? undefined : json['name'],
+        'options': json['options'] == null ? undefined : json['options'],
+        'purgeError': json['purge_error'] == null ? undefined : json['purge_error'],
+        'purgeInitiatedAt': json['purge_initiated_at'] == null ? undefined : (new Date(json['purge_initiated_at'])),
         'type': json['type'] == null ? undefined : json['type'],
     };
 }
@@ -75,6 +96,9 @@ export function SystemWriteSyncDestinationsInMemNameResponseToJSONTyped(value?: 
         
         'connection_details': value['connectionDetails'],
         'name': value['name'],
+        'options': value['options'],
+        'purge_error': value['purgeError'],
+        'purge_initiated_at': value['purgeInitiatedAt'] == null ? undefined : ((value['purgeInitiatedAt']).toISOString()),
         'type': value['type'],
     };
 }

--- a/ui/api-client/src/models/SystemWriteSyncDestinationsVercelProjectNameResponse.ts
+++ b/ui/api-client/src/models/SystemWriteSyncDestinationsVercelProjectNameResponse.ts
@@ -32,6 +32,24 @@ export interface SystemWriteSyncDestinationsVercelProjectNameResponse {
      */
     name?: string;
     /**
+     * List of key value pairs of Vault configuration options.
+     * @type {object}
+     * @memberof SystemWriteSyncDestinationsVercelProjectNameResponse
+     */
+    options?: object;
+    /**
+     * Error message if the purge job failed.
+     * @type {string}
+     * @memberof SystemWriteSyncDestinationsVercelProjectNameResponse
+     */
+    purgeError?: string;
+    /**
+     * Timestamp of when a purge job was initiated when deleting a destination.
+     * @type {Date}
+     * @memberof SystemWriteSyncDestinationsVercelProjectNameResponse
+     */
+    purgeInitiatedAt?: Date;
+    /**
      * Type of this secrets store.
      * @type {string}
      * @memberof SystemWriteSyncDestinationsVercelProjectNameResponse
@@ -58,6 +76,9 @@ export function SystemWriteSyncDestinationsVercelProjectNameResponseFromJSONType
         
         'connectionDetails': json['connection_details'] == null ? undefined : json['connection_details'],
         'name': json['name'] == null ? undefined : json['name'],
+        'options': json['options'] == null ? undefined : json['options'],
+        'purgeError': json['purge_error'] == null ? undefined : json['purge_error'],
+        'purgeInitiatedAt': json['purge_initiated_at'] == null ? undefined : (new Date(json['purge_initiated_at'])),
         'type': json['type'] == null ? undefined : json['type'],
     };
 }
@@ -75,6 +96,9 @@ export function SystemWriteSyncDestinationsVercelProjectNameResponseToJSONTyped(
         
         'connection_details': value['connectionDetails'],
         'name': value['name'],
+        'options': value['options'],
+        'purge_error': value['purgeError'],
+        'purge_initiated_at': value['purgeInitiatedAt'] == null ? undefined : ((value['purgeInitiatedAt']).toISOString()),
         'type': value['type'],
     };
 }


### PR DESCRIPTION
### Description
This PR has generated changes to the API client with updates to sync endpoints. 

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
