### PR TITLE
UI: Add param check to redirect hook

### DIFF
--- a/ui/app/routes/vault/cluster/auth.js
+++ b/ui/app/routes/vault/cluster/auth.js
@@ -55,13 +55,14 @@ export default class AuthRoute extends ClusterRouteBase {
     }
   }
 
-  redirect(model) {
+  redirect(model, transition) {
     if (model?.unwrapResponse) {
       // handles the transition
       return this.controllerFor('vault.cluster.auth').send('authSuccess', model.unwrapResponse);
     }
-    const invalidQueryPram = !model.directLinkData;
-    if (invalidQueryPram) {
+    const hasQueryParam = transition.to?.queryParams?.with;
+    const isInvalid = !model.directLinkData;
+    if (hasQueryParam && isInvalid) {
       // redirect user and clear out the query param if it's invalid
       this.router.replaceWith(this.routeName, { queryParams: { authMount: null } });
     }

--- a/ui/tests/acceptance/auth/auth-test.js
+++ b/ui/tests/acceptance/auth/auth-test.js
@@ -20,6 +20,7 @@ import { login, loginMethod, loginNs, logout, VISIBLE_MOUNTS } from 'vault/tests
 import { AUTH_FORM } from 'vault/tests/helpers/auth/auth-form-selectors';
 import { v4 as uuidv4 } from 'uuid';
 import { GENERAL } from 'vault/tests/helpers/general-selectors';
+import sinon from 'sinon';
 
 const ENT_AUTH_METHODS = ['saml'];
 const { rootToken } = VAULT_KEYS;
@@ -40,6 +41,14 @@ module('Acceptance | auth login form', function (hooks) {
   test('it redirects if "with" query param is not a supported auth method', async function (assert) {
     await visit('/vault/auth?with=fake');
     assert.strictEqual(currentURL(), '/vault/auth', 'invalid query param is cleared');
+  });
+
+  test('it does not refire route model if query param does not exist', async function (assert) {
+    const route = this.owner.lookup('route:vault/cluster/auth');
+    const modelSpy = sinon.spy(route, 'model');
+    await visit('/vault/auth');
+    assert.strictEqual(modelSpy.callCount, 1, 'model hook is only called once');
+    modelSpy.restore();
   });
 
   test('it clears token when changing selected auth method', async function (assert) {


### PR DESCRIPTION
### Description
The `redirect` hook was causing a double transition because `directLinkData` is `null` if no param exists. We only want to redirect if the param exists AND it's invalid. I meant to include this in https://github.com/hashicorp/vault/pull/30500 but the change got lost locally in a stash somewhere 🙃 

No changelog because it's a follow-on. 

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
