### PR TITLE
UI: Move preselected auth type logic to Auth::FormTemplate

### DIFF
--- a/ui/app/components/auth/page.hbs
+++ b/ui/app/components/auth/page.hbs
@@ -57,7 +57,7 @@
           @namespaceQueryParam={{@namespaceQueryParam}}
           @oidcProviderQueryParam={{@oidcProviderQueryParam}}
           @onSuccess={{this.onAuthResponse}}
-          @presetAuthType={{this.presetAuthType}}
+          @presetAuthType={{this.canceledMfaAuth}}
           @directLinkData={{@directLinkData}}
         />
       {{/if}}

--- a/ui/app/components/auth/page.hbs
+++ b/ui/app/components/auth/page.hbs
@@ -57,7 +57,7 @@
           @namespaceQueryParam={{@namespaceQueryParam}}
           @oidcProviderQueryParam={{@oidcProviderQueryParam}}
           @onSuccess={{this.onAuthResponse}}
-          @presetAuthType={{this.canceledMfaAuth}}
+          @canceledMfaAuth={{this.canceledMfaAuth}}
           @directLinkData={{@directLinkData}}
         />
       {{/if}}

--- a/ui/app/components/auth/page.js
+++ b/ui/app/components/auth/page.js
@@ -37,7 +37,6 @@ export const CSP_ERROR =
   "This is a standby Vault node but can't communicate with the active node via request forwarding. Sign in at the active node to use the Vault UI.";
 
 export default class AuthPage extends Component {
-  @service auth;
   @service('csp-event') csp;
 
   @tracked canceledMfaAuth = '';
@@ -62,13 +61,6 @@ export default class AuthPage extends Component {
     const isStandby = this.args.cluster.standby;
     const hasConnectionViolations = this.csp.connectionViolations.length;
     return isStandby && hasConnectionViolations ? CSP_ERROR : '';
-  }
-
-  get presetAuthType() {
-    // first canceledMfaAuth because that's from a user canceling mfa validation.
-    // then directLinkData url contains "with" query param specifying a mount path.
-    // fallback to getAuthType which is the last used auth method from local storage.
-    return this.canceledMfaAuth || this.args.directLinkData?.type || this.auth.getAuthType();
   }
 
   @action

--- a/ui/tests/integration/components/auth/form-template-test.js
+++ b/ui/tests/integration/components/auth/form-template-test.js
@@ -68,8 +68,6 @@ module('Integration | Component | auth | form template', function (hooks) {
 
   test('it selects type in the dropdown if @directLinkData data just contains type', async function (assert) {
     this.directLinkData = { type: 'oidc', hasMountData: false };
-    // set by parent (auth/page.js) component so stubbing here
-    this.presetAuthType = this.directLinkData.type;
     await this.renderComponent();
     assert.dom(GENERAL.selectByAttr('auth type')).hasValue('oidc');
     assert.dom(GENERAL.inputByAttr('role')).exists();
@@ -264,8 +262,6 @@ module('Integration | Component | auth | form template', function (hooks) {
     // if mount data exists, the mount has listing_visibility="unauth"
     test('it renders single mount view instead of tabs if @directLinkData data exists and includes mount data', async function (assert) {
       this.directLinkData = { path: 'my-oidc/', type: 'oidc', hasMountData: true };
-      // set by parent (auth/page.js) component
-      this.presetAuthType = this.directLinkData.type;
       await this.renderComponent();
       assert.dom(AUTH_FORM.preferredMethod('OIDC')).hasText('OIDC', 'it renders mount type');
       assert.dom(GENERAL.inputByAttr('role')).exists();
@@ -282,7 +278,6 @@ module('Integration | Component | auth | form template', function (hooks) {
     test('it does not render tabs if @directLinkData data exists and just includes type', async function (assert) {
       // set a type that is NOT in a visible mount because mount data exists otherwise
       this.directLinkData = { type: 'ldap', hasMountData: false };
-      this.presetAuthType = this.directLinkData.type;
       await this.renderComponent();
 
       assert.dom(GENERAL.selectByAttr('auth type')).hasValue('ldap', 'dropdown has type selected');

--- a/ui/tests/integration/components/auth/form-template-test.js
+++ b/ui/tests/integration/components/auth/form-template-test.js
@@ -34,7 +34,7 @@ module('Integration | Component | auth | form template', function (hooks) {
     this.namespaceQueryParam = '';
     this.oidcProviderQueryParam = '';
     this.onSuccess = sinon.spy();
-    this.presetAuthType = '';
+    this.canceledMfaAuth = '';
 
     this.renderComponent = () => {
       return render(hbs`
@@ -47,7 +47,7 @@ module('Integration | Component | auth | form template', function (hooks) {
           @namespaceQueryParam={{this.namespaceQueryParam}}
           @oidcProviderQueryParam={{this.oidcProviderQueryParam}}
           @onSuccess={{this.onSuccess}}
-          @presetAuthType={{this.presetAuthType}}
+          @canceledMfaAuth={{this.canceledMfaAuth}}
         />`);
     };
   });
@@ -58,8 +58,8 @@ module('Integration | Component | auth | form template', function (hooks) {
     assert.dom(GENERAL.selectByAttr('auth type')).hasValue('token');
   });
 
-  test('it selects @presetAuthType by default', async function (assert) {
-    this.presetAuthType = 'ldap';
+  test('it selects @canceledMfaAuth by default', async function (assert) {
+    this.canceledMfaAuth = 'ldap';
     await this.renderComponent();
     assert.dom(GENERAL.selectByAttr('auth type')).hasValue('ldap');
     assert.dom(GENERAL.inputByAttr('username')).exists();
@@ -241,15 +241,15 @@ module('Integration | Component | auth | form template', function (hooks) {
       assert.dom(AUTH_FORM.tabBtn('token')).hasAttribute('aria-selected', 'false');
     });
 
-    test('it preselects tab if @presetAuthType is a tab', async function (assert) {
-      this.presetAuthType = 'oidc';
+    test('it preselects tab if @canceledMfaAuth is a tab', async function (assert) {
+      this.canceledMfaAuth = 'oidc';
       await this.renderComponent();
       assert.dom(AUTH_FORM.authForm('oidc')).exists('oidc form renders');
       assert.dom(AUTH_FORM.tabBtn('oidc')).hasAttribute('aria-selected', 'true');
     });
 
-    test('if @presetAuthType is NOT a tab, dropdown renders with type selected instead of tabs', async function (assert) {
-      this.presetAuthType = 'ldap';
+    test('if @canceledMfaAuth is NOT a tab, dropdown renders with type selected instead of tabs', async function (assert) {
+      this.canceledMfaAuth = 'ldap';
       await this.renderComponent();
       assert.dom(GENERAL.selectByAttr('auth type')).hasValue('ldap');
       assert.dom(GENERAL.inputByAttr('username')).exists();

--- a/ui/tests/integration/components/auth/page-test.js
+++ b/ui/tests/integration/components/auth/page-test.js
@@ -99,6 +99,7 @@ module('Integration | Component | auth | page', function (hooks) {
   module('listing visibility', function (hooks) {
     hooks.beforeEach(function () {
       this.visibleAuthMounts = VISIBLE_MOUNTS;
+      window.localStorage.clear();
     });
 
     test('it formats tab data if visible auth mounts exist', async function (assert) {


### PR DESCRIPTION
### Description
While adding the logic for the login customization feature, it seemed like it'd eventually get confusing to have the preset type logic happen partially in the parent, moving to the child to simplify things.

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
