### PR TITLE
VAULT-35082: Recovery policy capability

### DIFF
--- a/vault/acl.go
+++ b/vault/acl.go
@@ -333,6 +333,9 @@ func (a *ACL) CapabilitiesAndSubscribeEventTypes(ctx context.Context, path strin
 	if capabilities&SubscribeCapabilityInt > 0 {
 		pathCapabilities = append(pathCapabilities, SubscribeCapability)
 	}
+	if capabilities&RecoverCapabilityInt > 0 {
+		pathCapabilities = append(pathCapabilities, RecoverCapability)
+	}
 
 	// If "deny" is explicitly set or if the path has no capabilities at all,
 	// set the path capabilities to "deny"
@@ -467,6 +470,9 @@ CHECK:
 	case logical.PatchOperation:
 		operationAllowed = capabilities&PatchCapabilityInt > 0
 		grantingPolicies = permissions.GrantingPoliciesMap[PatchCapabilityInt]
+	case logical.RecoverOperation:
+		operationAllowed = capabilities&RecoverCapabilityInt > 0
+		grantingPolicies = permissions.GrantingPoliciesMap[RecoverCapabilityInt]
 
 	// These three re-use UpdateCapabilityInt since that's the most appropriate
 	// capability/operation mapping
@@ -504,7 +510,7 @@ CHECK:
 
 	// Only check parameter permissions for operations that can modify
 	// parameters.
-	if op == logical.ReadOperation || op == logical.UpdateOperation || op == logical.CreateOperation || op == logical.PatchOperation {
+	if op == logical.ReadOperation || op == logical.UpdateOperation || op == logical.CreateOperation || op == logical.PatchOperation || op == logical.RecoverOperation {
 		for _, parameter := range permissions.RequiredParameters {
 			if _, ok := req.Data[strings.ToLower(parameter)]; !ok {
 				return

--- a/vault/acl_test.go
+++ b/vault/acl_test.go
@@ -267,6 +267,7 @@ func testACLSingle(t *testing.T, ns *namespace.Namespace) {
 		{logical.UpdateOperation, "1/2/3", false, false},
 		{logical.UpdateOperation, "1/2/3/4", true, false},
 		{logical.CreateOperation, "1/2/3/4/5", true, false},
+		{logical.RecoverOperation, "1/2/3/4", true, false},
 	}
 
 	for _, tc := range tcases {
@@ -899,6 +900,7 @@ func TestACLGrantingPolicies(t *testing.T) {
 		{"kv/deny", logical.ReadOperation, []*Policy{policy, merged}, nil, false},
 		{"kv/path/longer", logical.UpdateOperation, []*Policy{policy, merged}, []logical.PolicyInfo{policyInfo}, true},
 		{"kv/path/foo", logical.ReadOperation, []*Policy{policy, merged}, []logical.PolicyInfo{policyInfo, mergedInfo}, true},
+		{"ns1/kv/foo", logical.RecoverOperation, []*Policy{policy, merged}, []logical.PolicyInfo{policyInfo}, true},
 	}
 
 	for _, tc := range tcases {
@@ -945,7 +947,7 @@ path "kv/deny" {
 }
 
 path "ns1/kv/foo" {
-	capabilities = ["update", "read"]
+	capabilities = ["update", "read", "recover"]
 }
 `
 
@@ -1038,7 +1040,7 @@ path "1/2/+" {
 	capabilities = ["read"]
 }
 path "1/2/+/+" {
-	capabilities = ["update"]
+	capabilities = ["update", "recover"]
 }
 `
 

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -4482,7 +4482,6 @@ func (b *SystemBackend) handleMonitor(ctx context.Context, req *logical.Request,
 		return nil, fmt.Errorf("error trying to start a monitor that's already been started")
 	}
 
-	defer logical.IncrementResponseStatusCodeMetric(http.StatusOK)
 	w.WriteHeader(http.StatusOK)
 
 	// 0 byte write is needed before the Flush call so that if we are using
@@ -4867,7 +4866,8 @@ func hasMountAccess(ctx context.Context, acl *ACL, path string) bool {
 			perms.CapabilitiesBitmap&SudoCapabilityInt > 0,
 			perms.CapabilitiesBitmap&UpdateCapabilityInt > 0,
 			perms.CapabilitiesBitmap&PatchCapabilityInt > 0,
-			perms.CapabilitiesBitmap&SubscribeCapabilityInt > 0:
+			perms.CapabilitiesBitmap&SubscribeCapabilityInt > 0,
+			perms.CapabilitiesBitmap&RecoverCapabilityInt > 0:
 
 			aclCapabilitiesGiven = true
 
@@ -5285,6 +5285,9 @@ func (b *SystemBackend) pathInternalUIResultantACL(ctx context.Context, req *log
 		}
 		if perms.CapabilitiesBitmap&SubscribeCapabilityInt > 0 {
 			capabilities = append(capabilities, SubscribeCapability)
+		}
+		if perms.CapabilitiesBitmap&RecoverCapabilityInt > 0 {
+			capabilities = append(capabilities, RecoverCapability)
 		}
 
 		// If "deny" is explicitly set or if the path has no capabilities at all,

--- a/vault/logical_system_test.go
+++ b/vault/logical_system_test.go
@@ -720,7 +720,7 @@ path "bar/baz" {
 	capabilities = ["read", "update"]
 }
 path "bar/baz" {
-	capabilities = ["delete"]
+	capabilities = ["delete", "recover"]
 }
 `
 
@@ -828,7 +828,7 @@ func TestSystemBackend_PathCapabilities(t *testing.T) {
 		expected1 := []string{"create", "sudo", "update"}
 		expected2 := expected1
 		expected3 := []string{"update"}
-		expected4 := []string{"delete", "read", "update"}
+		expected4 := []string{"delete", "read", "recover", "update"}
 
 		if !reflect.DeepEqual(resp.Data[path1], expected1) ||
 			!reflect.DeepEqual(resp.Data[path2], expected2) ||

--- a/vault/policy.go
+++ b/vault/policy.go
@@ -32,6 +32,7 @@ const (
 	RootCapability      = "root"
 	PatchCapability     = "patch"
 	SubscribeCapability = "subscribe"
+	RecoverCapability   = "recover"
 
 	// Backwards compatibility
 	OldDenyPathPolicy  = "deny"
@@ -50,6 +51,7 @@ const (
 	SudoCapabilityInt
 	PatchCapabilityInt
 	SubscribeCapabilityInt
+	RecoverCapabilityInt
 )
 
 // Error constants for testing
@@ -93,6 +95,7 @@ var cap2Int = map[string]uint32{
 	SudoCapability:      SudoCapabilityInt,
 	PatchCapability:     PatchCapabilityInt,
 	SubscribeCapability: SubscribeCapabilityInt,
+	RecoverCapability:   RecoverCapabilityInt,
 }
 
 type egpPath struct {
@@ -451,7 +454,7 @@ func parsePaths(result *Policy, list *ast.ObjectList, performTemplating bool, en
 				pc.Capabilities = []string{DenyCapability}
 				pc.Permissions.CapabilitiesBitmap = DenyCapabilityInt
 				goto PathFinished
-			case CreateCapability, ReadCapability, UpdateCapability, DeleteCapability, ListCapability, SudoCapability, PatchCapability, SubscribeCapability:
+			case CreateCapability, ReadCapability, UpdateCapability, DeleteCapability, ListCapability, SudoCapability, PatchCapability, SubscribeCapability, RecoverCapability:
 				pc.Permissions.CapabilitiesBitmap |= cap2Int[cap]
 			default:
 				return fmt.Errorf("path %q: invalid capability %q", key, cap)

--- a/vault/policy_test.go
+++ b/vault/policy_test.go
@@ -526,3 +526,19 @@ func TestPolicy_Subscribe_EventTypes(t *testing.T) {
 		t.Fatalf("ACLPermission should reflect subscribe event types, but got %v", policy.Paths[0].Permissions.SubscribeEventTypes)
 	}
 }
+
+// TestPolicy_Recover verifies that the recover capability can be used in a
+// policy, and that the capability is set in the capabilities bitmap.
+func TestPolicy_Recover(t *testing.T) {
+	policy, err := ParseACLPolicy(namespace.RootNamespace, strings.TrimSpace(`
+	path "secret/*" {
+		capabilities = ["recover"]
+	}
+	`))
+	if err != nil {
+		t.Fatalf("Policies should be able to use 'recover' capability")
+	}
+	if policy.Paths[0].Permissions.CapabilitiesBitmap&RecoverCapabilityInt == 0 {
+		t.Fatalf("Recover capability should be present in capabilities bitmap")
+	}
+}


### PR DESCRIPTION
### Description
This PR adds a new policy capability called `recover`. The `recover` capability is required to perform a recover operation.
RFC: https://go.hashi.co/prd/vlt-045

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
