### PR TITLE
Refactor security-scan workflow

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -25,18 +25,18 @@ jobs:
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-    - name: Set up Go
+    - name: Setup Go
       uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
       with:
         cache: false # save cache space for vault builds: https://github.com/hashicorp/vault/pull/21764
         go-version-file: .go-version
 
-    - name: Set up Python
+    - name: Setup Python
       uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
       with:
         python-version: 3.x
 
-    - name: Clone Security Scanner repo
+    - name: Setup Security Scanner
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         repository: hashicorp/security-scanner
@@ -44,50 +44,24 @@ jobs:
         path: security-scanner
         ref: main
 
-    - name: Install dependencies
+    - name: Install Security Scanner Semgrep Plugin Dependency
       shell: bash
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        mkdir "$HOME/.bin"
-        cd "$GITHUB_WORKSPACE/security-scanner/pkg/sdk/examples/scan-plugin-semgrep"
-        go build -o scan-plugin-semgrep .
-        mv scan-plugin-semgrep "$HOME/.bin"
-
-        cd "$GITHUB_WORKSPACE/security-scanner/pkg/sdk/examples/scan-plugin-codeql"
-        go build -o scan-plugin-codeql .
-        mv scan-plugin-codeql "$HOME/.bin"
-
-        # Semgrep
         python3 -m pip install semgrep==1.45.0
-
-        # CodeQL
-        LATEST=$(gh release list --repo https://github.com/github/codeql-action | cut -f 3 | grep codeql-bundle- | sort --version-sort | tail -n1)
-        gh release download --repo https://github.com/github/codeql-action --pattern codeql-bundle-linux64.tar.gz "$LATEST"
-        tar xf codeql-bundle-linux64.tar.gz -C "$HOME/.bin"
-
-        # Add to PATH
-        echo "$HOME/.bin" >> "$GITHUB_PATH"
-        echo "$HOME/.bin/codeql" >> "$GITHUB_PATH"
 
     - name: Scan
       id: scan
       uses: ./security-scanner
-      # env:
-        # Note: this _should_ work, but causes some issues with Semgrep.
-        # Instead, rely on filtering in the SARIF Output step.
-        #SEMGREP_BASELINE_REF: ${{ github.base_ref }}
       with:
         repository: "$PWD"
-        cache-build: true
-        cache-go-modules: false
+        plugins: "codeql semgrep"
 
-    - name: SARIF Output
+    - name: Read SARIF
       shell: bash
       run: |
-        cat results.sarif
+        cat ${{ steps.scan.outputs.sarif-file-path }}
 
-    - name: Upload SARIF file
+    - name: Upload SARIF 
       uses: github/codeql-action/upload-sarif@3096afedf9873361b2b2f65e1445b13272c83eb8  # TSCCR: could not find entry for github/codeql-action/upload-sarif
       with:
-        sarif_file: results.sarif
+        sarif_file: ${{ steps.scan.outputs.sarif-file-path }}

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -25,18 +25,18 @@ jobs:
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-    - name: Setup Go
+    - name: Set up Go
       uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
       with:
         cache: false # save cache space for vault builds: https://github.com/hashicorp/vault/pull/21764
         go-version-file: .go-version
 
-    - name: Setup Python
+    - name: Set up Python
       uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
       with:
         python-version: 3.x
 
-    - name: Setup Security Scanner
+    - name: Set up Security Scanner
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         repository: hashicorp/security-scanner


### PR DESCRIPTION
### Description
This PR refactors the security-scan GitHub Actions workflow to clean it up and take advantage of some of the newer features of the action. This primarily aims to make the workflow simpler while retaining the same functionality.

1. The `codeql` binary is installed under-the-hood by default in `scan-plugin-codeql`, so we don't need to install it manually anymore. We do not (yet?) install `semgrep` under-the-hood, so we need to still use Python for that.

2. We can customize which plugins are installed by the action using the `plugins:` option. Since we're only using CodeQL and Semgrep plugins in the `scan.hcl` file, I've set it to only install those.

    https://github.com/hashicorp/vault/blob/92362bd3dc8b345424e7e24aa0a688d093517570/scan.hcl#L13-L28

3. The `cache-*` options have been deprecated, so I've removed 'em. We no longer cache anything, and require callers of the action to handle how they want to cache resources, if they like.

4. The security-scanner action has a helpful output (`sarif-file-path`) that we can use instead of the hard-coded `results.sarif` string. This will enable us to change that name in the future, or make it customizable.

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
