### PR TITLE
VAULT-35081: Extract query parameters for snapshot read/recover

### DIFF
--- a/http/handler.go
+++ b/http/handler.go
@@ -1460,11 +1460,12 @@ func trimPath(ns *namespace.Namespace, path string) string {
 // requiresSnapshot checks if the request requires a loaded snapshot, by
 // checking for the existence of a snapshot query parameter
 func requiresSnapshot(r *http.Request) bool {
-	switch r.Method {
-	case http.MethodGet, http.MethodPut, http.MethodPost, "LIST":
-	default:
-		return false
-	}
 	query := r.URL.Query()
-	return query.Has(VaultSnapshotReadParam) || query.Has(VaultSnapshotRecoverParam)
+	switch r.Method {
+	case http.MethodGet, "LIST":
+		return query.Has(VaultSnapshotReadParam)
+	case http.MethodPut, http.MethodPost:
+		return query.Has(VaultSnapshotRecoverParam)
+	}
+	return false
 }

--- a/http/handler_test.go
+++ b/http/handler_test.go
@@ -996,9 +996,15 @@ func Test_requiresSnapshot(t *testing.T) {
 			expected:    false,
 		},
 		{
-			name:        "put with snapshot",
+			name:        "put with read snapshot",
 			method:      http.MethodPut,
 			queryParams: map[string][]string{VaultSnapshotReadParam: {"param"}},
+			expected:    false,
+		},
+		{
+			name:        "put with recover snapshot",
+			method:      http.MethodPut,
+			queryParams: map[string][]string{VaultSnapshotRecoverParam: {"param"}},
 			expected:    true,
 		},
 		{

--- a/http/handler_test.go
+++ b/http/handler_test.go
@@ -972,3 +972,52 @@ func TestHandler_MaxRequestSize_Memory(t *testing.T) {
 	runtime.ReadMemStats(&end)
 	require.Less(t, end.TotalAlloc-start.TotalAlloc, uint64(1024*1024))
 }
+
+// Test_requiresSnapshot verifies that a request is marked as requiring a
+// snapshot when it's a read, list, or create/update and has a snapshot query
+// parameter
+func Test_requiresSnapshot(t *testing.T) {
+	testCases := []struct {
+		name        string
+		method      string
+		queryParams map[string][]string
+		expected    bool
+	}{
+		{
+			name:        "get no snapshot",
+			method:      http.MethodGet,
+			queryParams: map[string][]string{"other": {"param"}},
+			expected:    false,
+		},
+		{
+			name:        "options with snapshot",
+			method:      http.MethodOptions,
+			queryParams: map[string][]string{VaultSnapshotRecoverParam: {"param"}},
+			expected:    false,
+		},
+		{
+			name:        "put with snapshot",
+			method:      http.MethodPut,
+			queryParams: map[string][]string{VaultSnapshotReadParam: {"param"}},
+			expected:    true,
+		},
+		{
+			name:        "list with snapshot",
+			method:      "LIST",
+			queryParams: map[string][]string{VaultSnapshotReadParam: {"param"}},
+			expected:    true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := &http.Request{
+				Method: tc.method,
+				URL: &url.URL{
+					RawQuery: url.Values(tc.queryParams).Encode(),
+				},
+			}
+			require.Equal(t, tc.expected, requiresSnapshot(req))
+		})
+	}
+}

--- a/http/logical.go
+++ b/http/logical.go
@@ -202,13 +202,38 @@ func buildLogicalRequestNoAuth(perfStandby bool, ra *vault.RouterAccess, w http.
 		return nil, nil, http.StatusInternalServerError, fmt.Errorf("failed to generate identifier for the request: %w", err)
 	}
 
+	var requiredSnapshotID string
+
+	// check for a read, list, or recover from snapshot request
+	switch op {
+	case logical.ReadOperation, logical.ListOperation:
+		snapshotID, ok := data[VaultSnapshotReadParam]
+		if ok && snapshotID != "" {
+			requiredSnapshotID = snapshotID.(string)
+			delete(data, VaultSnapshotReadParam)
+			if len(data) == 0 {
+				data = nil
+			}
+		}
+	case logical.UpdateOperation:
+		queryVals := r.URL.Query()
+		if queryVals.Has(VaultSnapshotRecoverParam) {
+			snapshotID := queryVals.Get(VaultSnapshotRecoverParam)
+			if snapshotID != "" {
+				requiredSnapshotID = snapshotID
+				op = logical.RecoverOperation
+			}
+		}
+	}
+
 	req := &logical.Request{
-		ID:         requestId,
-		Operation:  op,
-		Path:       path,
-		Data:       data,
-		Connection: getConnection(r),
-		Headers:    r.Header,
+		ID:                 requestId,
+		Operation:          op,
+		Path:               path,
+		Data:               data,
+		Connection:         getConnection(r),
+		Headers:            r.Header,
+		RequiresSnapshotID: requiredSnapshotID,
 	}
 
 	if ra != nil && ra.IsLimitedPath(r.Context(), path) {

--- a/http/logical_test.go
+++ b/http/logical_test.go
@@ -1055,6 +1055,8 @@ func TestLogical_AuditEnabled_ShouldLogPluginMetadata_Secret(t *testing.T) {
 	}
 }
 
+// TestLogical_SnapshotParams checks that a request is converted into a logical
+// request correctly when it contains snapshot query parameters
 func TestLogical_SnapshotParams(t *testing.T) {
 	core, _, rootToken := vault.TestCoreUnsealed(t)
 	testCases := []struct {

--- a/http/logical_test.go
+++ b/http/logical_test.go
@@ -1054,3 +1054,87 @@ func TestLogical_AuditEnabled_ShouldLogPluginMetadata_Secret(t *testing.T) {
 		}
 	}
 }
+
+func TestLogical_SnapshotParams(t *testing.T) {
+	core, _, rootToken := vault.TestCoreUnsealed(t)
+	testCases := []struct {
+		name                   string
+		method                 string
+		url                    string
+		body                   []byte
+		wantData               map[string]interface{}
+		wantOperation          logical.Operation
+		wantRequiresSnapshotID string
+	}{
+		{
+			name:                   "normal get",
+			method:                 http.MethodGet,
+			url:                    "https://example.com",
+			body:                   nil,
+			wantOperation:          logical.ReadOperation,
+			wantRequiresSnapshotID: "",
+		},
+		{
+			name:                   "normal list",
+			method:                 http.MethodGet,
+			url:                    "https://example.com?list=true",
+			body:                   nil,
+			wantOperation:          logical.ListOperation,
+			wantRequiresSnapshotID: "",
+		},
+		{
+			name:                   "snapshot list",
+			method:                 http.MethodGet,
+			url:                    "https://example.com?list=true&read_snapshot_id=1234",
+			body:                   nil,
+			wantData:               nil,
+			wantOperation:          logical.ListOperation,
+			wantRequiresSnapshotID: "1234",
+		},
+		{
+			name:                   "snapshot read",
+			method:                 http.MethodGet,
+			url:                    "https://example.com?read_snapshot_id=1234",
+			body:                   nil,
+			wantData:               nil,
+			wantOperation:          logical.ReadOperation,
+			wantRequiresSnapshotID: "1234",
+		},
+		{
+			name:   "normal update",
+			method: http.MethodPost,
+			url:    "https://example.com",
+			body:   []byte(`{"foo":"bar"}`),
+			wantData: map[string]interface{}{
+				"foo": "bar",
+			},
+			wantOperation: logical.UpdateOperation,
+		},
+		{
+			name:   "snapshot update",
+			method: http.MethodPost,
+			url:    "https://example.com?recover_snapshot_id=1234",
+			body:   []byte(`{"other_data":"abcd"}`),
+			wantData: map[string]interface{}{
+				"other_data": "abcd",
+			},
+			wantOperation:          logical.RecoverOperation,
+			wantRequiresSnapshotID: "1234",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			req, _ := http.NewRequest(tc.method, tc.url, bytes.NewReader(tc.body))
+			req = req.WithContext(namespace.RootContext(nil))
+			req.Header.Add(consts.AuthHeaderName, rootToken)
+
+			lreq, _, status, err := buildLogicalRequest(core, nil, req, "")
+			require.NoError(t, err)
+			require.Equal(t, 0, status)
+			require.Equal(t, tc.wantOperation, lreq.Operation)
+			require.Equal(t, tc.wantData, lreq.Data)
+			require.Equal(t, tc.wantRequiresSnapshotID, lreq.RequiresSnapshotID)
+		})
+	}
+}


### PR DESCRIPTION
### Description
This PR adds support for extracting two query parameters:
* `recover_snapshot_id` (can be specified with PUT, POST)
* `read_snapshot_id` (can be specified with GET, LIST)

If the query parameter exists for a request with the correct HTTP verb, then request.RequiredSnapshotID is set to the query parameter value. 

These requests are also always forwarded to the active node, rather than being served on a perf standby.
RFC: https://go.hashi.co/prd/vlt-045

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
