### PR TITLE
[VAULT-35871] UI: Address design UI feedback on namespace picker

### DIFF
--- a/ui/app/components/namespace-picker.hbs
+++ b/ui/app/components/namespace-picker.hbs
@@ -3,7 +3,7 @@
   SPDX-License-Identifier: BUSL-1.1
 }}
 
-<div class="has-side-padding-4" ...attributes>
+<div class="namespace-picker has-side-padding-4" ...attributes>
   <Hds::Dropdown @enableCollisionDetection={{true}} as |D|>
 
     <D.ToggleButton @icon="org" @text={{or this.selected.id "-"}} @isFullWidth={{true}} data-test-namespace-toggle />

--- a/ui/app/components/namespace-picker.hbs
+++ b/ui/app/components/namespace-picker.hbs
@@ -3,7 +3,7 @@
   SPDX-License-Identifier: BUSL-1.1
 }}
 
-<div class="namespace-picker has-side-padding-4" ...attributes>
+<div class="namespace-picker side-padding-4" ...attributes>
   <Hds::Dropdown @enableCollisionDetection={{true}} as |D|>
 
     <D.ToggleButton @icon="org" @text={{or this.selected.id "-"}} @isFullWidth={{true}} data-test-namespace-toggle />
@@ -32,12 +32,12 @@
 
       <D.Header class="is-paddingless">
         {{#if (and this.hasSearchInput (not this.showNoNamespacesMessage))}}
-          <div class="sub-text is-marginless has-top-padding-xs has-left-padding-16" {{did-insert this.adjustElementWidth}}>
+          <div class="sub-text is-marginless has-top-padding-xs left-padding-16" {{did-insert this.adjustElementWidth}}>
             {{this.searchInputHelpText}}
           </div>
         {{/if}}
 
-        <div class="is-size-8 has-text-black has-text-weight-semibold has-left-padding-16 top-padding-10">
+        <div class="is-size-8 has-text-black has-text-weight-semibold left-padding-16 top-padding-10">
           {{this.namespaceLabel}}
           <Hds::BadgeCount @text={{or this.namespaceCount 0}} />
         </div>
@@ -56,7 +56,7 @@
             {{on "click" (fn this.onChange option)}}
             data-test-namespace-link={{option.path}}
           >
-            <span class="is-fullwidth is-word-break has-right-padding-4">{{option.label}}</span>
+            <span class="is-fullwidth is-word-break right-padding-4">{{option.label}}</span>
           </D.Checkmark>
         {{/each}}
       </div>
@@ -70,6 +70,7 @@
             @color="secondary"
             @text="Refresh list"
             @isFullWidth={{(not this.canManageNamespaces)}}
+            @icon="reload"
             {{on "click" this.refreshList}}
             data-test-refresh-namespaces
           />

--- a/ui/app/components/namespace-picker.hbs
+++ b/ui/app/components/namespace-picker.hbs
@@ -71,16 +71,18 @@
             @text="Refresh list"
             @isFullWidth={{(not this.canManageNamespaces)}}
             @icon="reload"
+            @size="small"
             {{on "click" this.refreshList}}
             data-test-refresh-namespaces
           />
         {{/if}}
         {{#if this.canManageNamespaces}}
           <Hds::Button
-            @color="secondary"
+            @color="tertiary"
             @text="Manage"
             @isFullWidth={{(not this.canRefreshNamespaces)}}
             @icon="settings"
+            @size="small"
             @route="vault.cluster.access.namespaces"
             data-test-manage-namespaces
           />

--- a/ui/app/components/namespace-picker.hbs
+++ b/ui/app/components/namespace-picker.hbs
@@ -3,20 +3,20 @@
   SPDX-License-Identifier: BUSL-1.1
 }}
 
-<div class="top-padding-4 has-bottom-padding-4 has-side-padding-8" ...attributes>
+<div class="has-side-padding-4" ...attributes>
   <Hds::Dropdown @enableCollisionDetection={{true}} as |D|>
 
     <D.ToggleButton @icon="org" @text={{or this.selected.id "-"}} @isFullWidth={{true}} data-test-namespace-toggle />
 
     {{#if this.errorLoadingNamespaces}}
 
-      <D.Header>
+      <D.Header class="is-paddingless">
         <MessageError @errorMessage={{this.errorLoadingNamespaces}} />
       </D.Header>
 
     {{else}}
 
-      <D.Header @hasDivider={{true}}>
+      <D.Header class="is-paddingless" @hasDivider={{true}}>
         <div class="has-padding-8">
           <Hds::Form::TextInput::Field
             @value={{this.searchInput}}
@@ -30,21 +30,21 @@
         </div>
       </D.Header>
 
-      <D.Header>
+      <D.Header class="is-paddingless">
         {{#if (and this.hasSearchInput (not this.showNoNamespacesMessage))}}
-          <div class="sub-text has-padding-8">
+          <div class="sub-text is-marginless has-top-padding-xs has-left-padding-16">
             {{this.searchInputHelpText}}
           </div>
         {{/if}}
 
-        <div class="is-size-8 has-text-black has-text-weight-semibold has-padding-8">
+        <div class="is-size-8 has-text-black has-text-weight-semibold has-left-padding-16 top-padding-10">
           {{this.namespaceLabel}}
           <Hds::BadgeCount @text={{or this.namespaceCount 0}} />
         </div>
       </D.Header>
 
       {{#if this.showNoNamespacesMessage}}
-        <D.Generic class="sub-text">
+        <D.Generic class="sub-text is-marginless">
           {{this.noNamespacesMessage}}
         </D.Generic>
       {{/if}}

--- a/ui/app/components/namespace-picker.hbs
+++ b/ui/app/components/namespace-picker.hbs
@@ -10,7 +10,7 @@
 
     {{#if this.errorLoadingNamespaces}}
 
-      <D.Header class="is-paddingless">
+      <D.Header>
         <MessageError @errorMessage={{this.errorLoadingNamespaces}} />
       </D.Header>
 
@@ -32,7 +32,7 @@
 
       <D.Header class="is-paddingless">
         {{#if (and this.hasSearchInput (not this.showNoNamespacesMessage))}}
-          <div class="sub-text is-marginless has-top-padding-xs has-left-padding-16">
+          <div class="sub-text is-marginless has-top-padding-xs has-left-padding-16" {{did-insert this.adjustElementWidth}}>
             {{this.searchInputHelpText}}
           </div>
         {{/if}}
@@ -44,7 +44,7 @@
       </D.Header>
 
       {{#if this.showNoNamespacesMessage}}
-        <D.Generic class="sub-text is-marginless">
+        <D.Generic class="sub-text is-marginless" {{did-insert this.adjustElementWidth}}>
           {{this.noNamespacesMessage}}
         </D.Generic>
       {{/if}}
@@ -56,7 +56,7 @@
             {{on "click" (fn this.onChange option)}}
             data-test-namespace-link={{option.path}}
           >
-            {{option.label}}
+            <span class="is-fullwidth is-word-break has-right-padding-4">{{option.label}}</span>
           </D.Checkmark>
         {{/each}}
       </div>

--- a/ui/app/components/namespace-picker.ts
+++ b/ui/app/components/namespace-picker.ts
@@ -140,6 +140,22 @@ export default class NamespacePicker extends Component {
   }
 
   @action
+  adjustElementWidth(element: HTMLElement): void {
+    const namespaceLinks = document.querySelectorAll('[data-test-namespace-link]');
+
+    let maxWidth = 240; // Default minimum width
+    namespaceLinks.forEach((checkmark: Element) => {
+      const width = (checkmark as HTMLElement).offsetWidth;
+      if (width > maxWidth) {
+        maxWidth = width;
+      }
+    });
+
+    // Set the width of the target element
+    element.style.width = `${maxWidth}px`;
+  }
+
+  @action
   async fetchListCapability(): Promise<void> {
     try {
       const namespacePermission = await this.store.findRecord('capabilities', 'sys/namespaces/');

--- a/ui/app/components/namespace-picker.ts
+++ b/ui/app/components/namespace-picker.ts
@@ -141,9 +141,11 @@ export default class NamespacePicker extends Component {
 
   @action
   adjustElementWidth(element: HTMLElement): void {
-    const namespaceLinks = document.querySelectorAll('[data-test-namespace-link]');
+    // Hide the element so that it doesn't affect the layout
+    element.style.display = 'none';
 
     let maxWidth = 240; // Default minimum width
+    const namespaceLinks = document.querySelectorAll('[data-test-namespace-link]');
     namespaceLinks.forEach((checkmark: Element) => {
       const width = (checkmark as HTMLElement).offsetWidth;
       if (width > maxWidth) {
@@ -153,6 +155,9 @@ export default class NamespacePicker extends Component {
 
     // Set the width of the target element
     element.style.width = `${maxWidth}px`;
+
+    // Show the element once the width is set
+    element.style.display = '';
   }
 
   @action

--- a/ui/app/styles/components/namespace-picker.scss
+++ b/ui/app/styles/components/namespace-picker.scss
@@ -1,3 +1,8 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
 @use '../helper-classes/general';
 
 .namespace-picker {

--- a/ui/app/styles/components/namespace-picker.scss
+++ b/ui/app/styles/components/namespace-picker.scss
@@ -13,7 +13,7 @@
   }
 
   .hds-button-set {
-    @extend .flex.space-between;
+    @extend .is-flex-between;
 
     .hds-button {
       @extend .is-flex-grow-1;

--- a/ui/app/styles/components/namespace-picker.scss
+++ b/ui/app/styles/components/namespace-picker.scss
@@ -7,6 +7,10 @@
 @use '../helper-classes/flexbox-and-grid';
 
 .namespace-picker {
+  .hds-dropdown__content {
+    min-width: 239px;
+  }
+
   .hds-dropdown-toggle-button__text {
     @extend .truncate-second-line, .is-word-break;
     white-space: normal;

--- a/ui/app/styles/components/namespace-picker.scss
+++ b/ui/app/styles/components/namespace-picker.scss
@@ -1,0 +1,8 @@
+@use '../helper-classes/general';
+
+.namespace-picker {
+  .hds-dropdown-toggle-button__text {
+    @extend .truncate-second-line, .is-word-break;
+    white-space: normal;
+  }
+}

--- a/ui/app/styles/components/namespace-picker.scss
+++ b/ui/app/styles/components/namespace-picker.scss
@@ -4,10 +4,19 @@
  */
 
 @use '../helper-classes/general';
+@use '../helper-classes/flexbox-and-grid';
 
 .namespace-picker {
   .hds-dropdown-toggle-button__text {
     @extend .truncate-second-line, .is-word-break;
     white-space: normal;
+  }
+
+  .hds-button-set {
+    @extend .flex.space-between;
+
+    .hds-button {
+      @extend .is-flex-grow-1;
+    }
   }
 }

--- a/ui/app/styles/core.scss
+++ b/ui/app/styles/core.scss
@@ -75,6 +75,7 @@
 @use 'components/list-item-row';
 @use 'components/loader';
 @use 'components/masked-input';
+@use 'components/namespace-picker';
 @use 'components/namespace-reminder';
 @use 'components/navigate-input';
 @use 'components/overview-card';

--- a/ui/app/styles/helper-classes/spacing.scss
+++ b/ui/app/styles/helper-classes/spacing.scss
@@ -38,11 +38,6 @@
   padding-right: size_variables.$spacing-12;
 }
 
-.has-side-padding-14 {
-  padding-left: size_variables.$spacing-14;
-  padding-right: size_variables.$spacing-14;
-}
-
 .has-padding-8 {
   padding: size_variables.$spacing-8;
 }

--- a/ui/app/styles/helper-classes/spacing.scss
+++ b/ui/app/styles/helper-classes/spacing.scss
@@ -23,6 +23,11 @@
   padding: size_variables.$spacing-36;
 }
 
+.has-side-padding-4 {
+  padding-left: size_variables.$spacing-4;
+  padding-right: size_variables.$spacing-4;
+}
+
 .has-side-padding-8 {
   padding-left: size_variables.$spacing-8;
   padding-right: size_variables.$spacing-8;
@@ -31,6 +36,11 @@
 .has-side-padding-s {
   padding-left: size_variables.$spacing-12;
   padding-right: size_variables.$spacing-12;
+}
+
+.has-side-padding-14 {
+  padding-left: size_variables.$spacing-14;
+  padding-right: size_variables.$spacing-14;
 }
 
 .has-padding-8 {
@@ -73,6 +83,10 @@
   padding-top: size_variables.$spacing-4;
 }
 
+.top-padding-10 {
+  padding-top: size_variables.$spacing-10;
+}
+
 .has-bottom-padding-4 {
   padding-bottom: size_variables.$spacing-4;
 }
@@ -95,6 +109,10 @@
 
 .has-left-padding-s {
   padding-left: size_variables.$spacing-12;
+}
+
+.has-left-padding-16 {
+  padding-left: size_variables.$spacing-16;
 }
 
 .has-left-padding-l {

--- a/ui/app/styles/helper-classes/spacing.scss
+++ b/ui/app/styles/helper-classes/spacing.scss
@@ -114,6 +114,10 @@
   padding-left: size_variables.$spacing-24;
 }
 
+.has-right-padding-4 {
+  padding-right: size_variables.$spacing-4;
+}
+
 .has-top-padding-xxl {
   padding-top: size_variables.$spacing-48;
 }

--- a/ui/app/styles/helper-classes/spacing.scss
+++ b/ui/app/styles/helper-classes/spacing.scss
@@ -23,7 +23,7 @@
   padding: size_variables.$spacing-36;
 }
 
-.has-side-padding-4 {
+.side-padding-4 {
   padding-left: size_variables.$spacing-4;
   padding-right: size_variables.$spacing-4;
 }
@@ -106,7 +106,7 @@
   padding-left: size_variables.$spacing-12;
 }
 
-.has-left-padding-16 {
+.left-padding-16 {
   padding-left: size_variables.$spacing-16;
 }
 
@@ -114,7 +114,7 @@
   padding-left: size_variables.$spacing-24;
 }
 
-.has-right-padding-4 {
+.right-padding-4 {
   padding-right: size_variables.$spacing-4;
 }
 


### PR DESCRIPTION
### Description
Address design UI feedback on namespace picker:
- [x] Namespace picker width should be determined by the longest namespace name, not help/error messages.
- [x] Enterprise tests passing ✅ 
  > 249 tests completed in 138252 milliseconds, with 0 failed, 10 skipped, and 0 todo.
1464 assertions of 1464 passed, 0 failed.

Screenshots:
| Narrow | Expanded | 
| -- | -- |
| ![Screenshot 2025-05-12 at 3 41 45 PM](https://github.com/user-attachments/assets/1f913ea7-2210-4a99-bcf9-f89f2cf08253) | ![Screenshot 2025-05-12 at 3 42 39 PM](https://github.com/user-attachments/assets/5a1d9c73-ef9e-49ee-b47a-37a4af5d6cbc) |
| ![Screenshot 2025-05-12 at 3 44 20 PM](https://github.com/user-attachments/assets/2523cacb-e5eb-4de1-9261-18f92e87e8ae) | |