### PR TITLE
 Update ENOS to test upgrades from fips1402 -> fips1403

### DIFF
--- a/enos/enos-scenario-autopilot.hcl
+++ b/enos/enos-scenario-autopilot.hcl
@@ -268,7 +268,7 @@ scenario "autopilot" {
       packages             = concat(global.packages, global.distro_packages[matrix.distro][global.distro_version[matrix.distro]])
       release = {
         edition = strcontains(matrix.edition, "fips1403") ? (
-          semverconstraint(var.vault_upgrade_initial_version, ">=1.19.4-0 || >=1.18.10-0,<1.19.0-0 || >=1.17.17-0,<1.18.0-0 || >=1.16.21-0,<1.17.0-0")
+          semverconstraint(var.vault_upgrade_initial_version, "<1.19.4-0,>=1.19.0-0 || <1.18.10-0,>=1.18.0-0 || <1.17.17-0,>=1.17.0-0 || <1.16.21-0")
           ? replace(matrix.edition, "fips1403", "fips1402")
           : matrix.edition
         ) : matrix.edition

--- a/enos/enos-scenario-upgrade.hcl
+++ b/enos/enos-scenario-upgrade.hcl
@@ -322,7 +322,7 @@ scenario "upgrade" {
       packages             = concat(global.packages, global.distro_packages[matrix.distro][global.distro_version[matrix.distro]])
       release = {
         edition = strcontains(matrix.edition, "fips1403") ? (
-          semverconstraint(var.vault_upgrade_initial_version, ">=1.19.4-0 || >=1.18.10-0,<1.19.0-0 || >=1.17.17-0,<1.18.0-0 || >=1.16.21-0,<1.17.0-0")
+          semverconstraint(var.vault_upgrade_initial_version, "<1.19.4-0,>=1.19.0-0 || <1.18.10-0,>=1.18.0-0 || <1.17.17-0,>=1.17.0-0 || <1.16.21-0")
           ? replace(matrix.edition, "fips1403", "fips1402")
           : matrix.edition
         ) : matrix.edition


### PR DESCRIPTION
### Description
CE Version of ENT PRs ([#8012](https://github.com/hashicorp/vault-enterprise/pull/8012) and [#8037](https://github.com/hashicorp/vault-enterprise/pull/8037))

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
