### PR TITLE
Revert partial test changes for skipping FIPS tests for unsupported SHA3 hashes

### DIFF
--- a/sdk/helper/keysutil/policy_test.go
+++ b/sdk/helper/keysutil/policy_test.go
@@ -992,6 +992,11 @@ func Test_RSA_PSS(t *testing.T) {
 		t.Log(tabs[3], "Make an automatic signature")
 		sig, err := p.Sign(0, nil, input, hashType, sigAlgorithm, marshalingType)
 		if err != nil {
+			// A bit of a hack but FIPS go does not support some hash types
+			if isUnsupportedGoHashType(hashType, err) {
+				t.Skip(tabs[4], "skipping test as FIPS Go does not support hash type")
+				return
+			}
 			t.Fatal(tabs[4], "❌ Failed to automatically sign:", err)
 		}
 
@@ -1188,20 +1193,15 @@ func Test_RSA_PKCS1Signing(t *testing.T) {
 			input = hash.Sum(nil)
 		}
 
-		// Skip over SHA3 hash tests when running with boringcrypto as it still doesn't support it or hasn't been
-		// validated yet. Wasn't available in FIPS-140-2, but should be in FIPS-140-3 eventually?
-		if strings.Contains(runtime.Version(), "X:boringcrypto") {
-			switch hashType {
-			case HashTypeSHA3224, HashTypeSHA3256, HashTypeSHA3384, HashTypeSHA3512:
-				t.Skip(tabs[4], "boringcrypto does not support SHA3")
-				return
-			}
-		}
-
 		// 1. Make a signature with the given key size and hash algorithm.
 		t.Log(tabs[3], "Make an automatic signature")
 		sig, err := p.Sign(0, nil, input, hashType, sigAlgorithm, marshalingType)
 		if err != nil {
+			// A bit of a hack but FIPS go does not support some hash types
+			if isUnsupportedGoHashType(hashType, err) {
+				t.Skip(tabs[4], "skipping test as FIPS Go does not support hash type")
+				return
+			}
 			t.Fatal(tabs[4], "❌ Failed to automatically sign:", err)
 		}
 
@@ -1246,4 +1246,20 @@ func Test_RSA_PKCS1Signing(t *testing.T) {
 			}
 		}
 	}
+}
+
+// Normal Go builds support all the hash functions for RSA_PSS signatures but the
+// FIPS Go build does not support at this time the SHA3 hashes as FIPS 140_2 does
+// not accept them.
+func isUnsupportedGoHashType(hashType HashType, err error) bool {
+	// Skip over SHA3 hash tests when running with boringcrypto as it still doesn't support it or hasn't been
+	// validated yet. Wasn't available in FIPS-140-2, but should be in FIPS-140-3 eventually?
+	if strings.Contains(runtime.Version(), "X:boringcrypto") {
+		switch hashType {
+		case HashTypeSHA3224, HashTypeSHA3256, HashTypeSHA3384, HashTypeSHA3512:
+			return strings.Contains(err.Error(), "unsupported hash function")
+		}
+	}
+
+	return false
 }


### PR DESCRIPTION
### Description

Revert a partial fix/change had been implemented way back when we were originally looking at the 1.24 update and I missed reverting the change back then and it made it into https://github.com/hashicorp/vault/pull/30576

### TODO only if you're a HashiCorp employee
- [X] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
