### PR TITLE
Backport of Update Docs For Bound Audience Explanation (#30519)

### DIFF
--- a/website/content/api-docs/auth/jwt.mdx
+++ b/website/content/api-docs/auth/jwt.mdx
@@ -112,8 +112,9 @@ entities attempting to login. At least one of the bound values must be set.
 - `name` `(string: <required>)` - Name of the role.
 - `role_type` `(string: <optional>)` - Type of role, either "oidc" (default) or "jwt".
 - `bound_audiences` `(array: <optional>)` - List of `aud` claims to match against.
-  Any match is sufficient. Required for "jwt" roles if the JWT has an `aud`
-  claim. Optional for "oidc" roles.
+  The `bound_audiences` parameter is required for "jwt" roles that contain an
+  audience (typical case) and **must** match at least one of the associated JWT
+  `aud` claims.
 - `user_claim` `(string: <required>)` - The claim to use to uniquely identify
   the user; this will be used as the name for the Identity entity alias created
   due to a successful login. The claim value must be a string.

--- a/website/content/docs/auth/jwt/index.mdx
+++ b/website/content/docs/auth/jwt/index.mdx
@@ -10,8 +10,9 @@ description: >-
 @include 'x509-sha1-deprecation.mdx'
 
 ~> **Note**: Starting in Vault 1.17, if the JWT in the authentication request
-contains an `aud` claim, the associated `bound_audiences` for the "jwt" role
-must match at least one of the `aud` claims declared for the JWT. For
+contains an `aud` claim (typical case) the associated `bound_audiences` for the
+"jwt" role must **exactly** match at least one of the `aud` claims declared for
+the JWT. For
 additional details, refer to the [JWT auth method (API)](/vault/api-docs/auth/jwt)
 documentation and [1.17 Upgrade Guide](/vault/docs/upgrading/upgrade-to-1.17.x#jwt-auth-login-requires-bound-audiences-on-the-role).
 
@@ -214,7 +215,7 @@ backend instance per method at different paths.
 After verifying the JWT signatures, Vault checks the corresponding `aud` claim.
 
 If the JWT in the authentication request contains an `aud` claim, the
-associated `bound_audiences` for the role must match at least one of the `aud`
+associated `bound_audiences` for the role must **exactly** match at least one of the `aud`
 claims declared for the JWT.
 
 ### Via the CLI
@@ -324,7 +325,7 @@ In some cases there are dedicated parameters, for example `bound_subject`,
 that must match the provided `sub` claim. For roles of type "jwt":
 
 1. the `bound_audiences` parameter is required when an `aud` claim is set.
-1. the `bound_audiences` parameter must match at least one of provided `aud` claims.
+1. the `bound_audiences` parameter must **exactly** match at least one of provided `aud` claims.
 
 You can also configure roles to check an arbitrary set of claims and required
 values with the `bound_claims` map. For example, assume `bound_claims` is set to:


### PR DESCRIPTION
### Description
Backport of https://github.com/hashicorp/vault/pull/30519 into 1.18.x.

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
