### PR TITLE
add context conversion for snapshot ID key

### DIFF
--- a/sdk/plugin/context.go
+++ b/sdk/plugin/context.go
@@ -1,0 +1,34 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package plugin
+
+import (
+	"context"
+
+	"github.com/hashicorp/vault/sdk/logical"
+	"google.golang.org/grpc/metadata"
+)
+
+// pbMetadataCtxToLogicalCtx extracts the snapshot ID key from an incoming GRPC
+// context and adds the logical context key to the returned context
+func pbMetadataCtxToLogicalCtx(ctx context.Context) context.Context {
+	var snapshotID string
+	snapshotIDs := metadata.ValueFromIncomingContext(ctx, snapshotIDCtxKey)
+	if len(snapshotIDs) > 0 {
+		snapshotID = snapshotIDs[0]
+	}
+	return logical.CreateContextWithSnapshotID(ctx, snapshotID)
+}
+
+// logicalCtxToPBMetadataCtx extracts the logical context snapshot ID key from
+// the context and appends it to an outgoing GRPC context
+func logicalCtxToPBMetadataCtx(ctx context.Context) context.Context {
+	snapshotID, ok := logical.ContextSnapshotIDValue(ctx)
+	if !ok {
+		return ctx
+	}
+	return metadata.AppendToOutgoingContext(ctx, snapshotIDCtxKey, snapshotID)
+}
+
+const snapshotIDCtxKey string = "snapshot_id"

--- a/sdk/plugin/grpc_backend_client.go
+++ b/sdk/plugin/grpc_backend_client.go
@@ -95,7 +95,8 @@ func (b *backendGRPCPluginClient) HandleRequest(ctx context.Context, req *logica
 		return nil, err
 	}
 
-	reply, err := b.client.HandleRequest(ctx, &pb.HandleRequestArgs{
+	reqCtx := logicalCtxToPBMetadataCtx(ctx)
+	reply, err := b.client.HandleRequest(reqCtx, &pb.HandleRequestArgs{
 		Request: protoReq,
 	}, largeMsgGRPCCallOpts...)
 	if err != nil {

--- a/sdk/plugin/grpc_backend_server.go
+++ b/sdk/plugin/grpc_backend_server.go
@@ -141,7 +141,8 @@ func (b *backendGRPCPluginServer) HandleRequest(ctx context.Context, args *pb.Ha
 
 	logicalReq.Storage = newGRPCStorageClient(brokeredClient)
 
-	resp, respErr := backend.HandleRequest(ctx, logicalReq)
+	reqCtx := pbMetadataCtxToLogicalCtx(ctx)
+	resp, respErr := backend.HandleRequest(reqCtx, logicalReq)
 
 	pbResp, err := pb.LogicalResponseToProtoResponse(resp)
 	if err != nil {
@@ -197,6 +198,7 @@ func (b *backendGRPCPluginServer) SpecialPaths(ctx context.Context, args *pb.Emp
 			WriteForwardedStorage: paths.WriteForwardedStorage,
 			Binary:                paths.Binary,
 			Limited:               paths.Limited,
+			AllowSnapshotRead:     paths.AllowSnapshotRead,
 		},
 	}, nil
 }

--- a/sdk/plugin/grpc_storage.go
+++ b/sdk/plugin/grpc_storage.go
@@ -27,6 +27,7 @@ type GRPCStorageClient struct {
 }
 
 func (s *GRPCStorageClient) List(ctx context.Context, prefix string) ([]string, error) {
+	ctx = logicalCtxToPBMetadataCtx(ctx)
 	reply, err := s.client.List(ctx, &pb.StorageListArgs{
 		Prefix: prefix,
 	}, largeMsgGRPCCallOpts...)
@@ -40,6 +41,7 @@ func (s *GRPCStorageClient) List(ctx context.Context, prefix string) ([]string, 
 }
 
 func (s *GRPCStorageClient) Get(ctx context.Context, key string) (*logical.StorageEntry, error) {
+	ctx = logicalCtxToPBMetadataCtx(ctx)
 	reply, err := s.client.Get(ctx, &pb.StorageGetArgs{
 		Key: key,
 	}, largeMsgGRPCCallOpts...)
@@ -53,6 +55,7 @@ func (s *GRPCStorageClient) Get(ctx context.Context, key string) (*logical.Stora
 }
 
 func (s *GRPCStorageClient) Put(ctx context.Context, entry *logical.StorageEntry) error {
+	ctx = logicalCtxToPBMetadataCtx(ctx)
 	reply, err := s.client.Put(ctx, &pb.StoragePutArgs{
 		Entry: pb.LogicalStorageEntryToProtoStorageEntry(entry),
 	}, largeMsgGRPCCallOpts...)
@@ -66,6 +69,7 @@ func (s *GRPCStorageClient) Put(ctx context.Context, entry *logical.StorageEntry
 }
 
 func (s *GRPCStorageClient) Delete(ctx context.Context, key string) error {
+	ctx = logicalCtxToPBMetadataCtx(ctx)
 	reply, err := s.client.Delete(ctx, &pb.StorageDeleteArgs{
 		Key: key,
 	})
@@ -88,6 +92,7 @@ func (s *GRPCStorageServer) List(ctx context.Context, args *pb.StorageListArgs) 
 	if s.impl == nil {
 		return nil, errMissingStorage
 	}
+	ctx = pbMetadataCtxToLogicalCtx(ctx)
 	keys, err := s.impl.List(ctx, args.Prefix)
 	return &pb.StorageListReply{
 		Keys: keys,
@@ -99,6 +104,7 @@ func (s *GRPCStorageServer) Get(ctx context.Context, args *pb.StorageGetArgs) (*
 	if s.impl == nil {
 		return nil, errMissingStorage
 	}
+	ctx = pbMetadataCtxToLogicalCtx(ctx)
 	storageEntry, err := s.impl.Get(ctx, args.Key)
 	if storageEntry == nil {
 		return &pb.StorageGetReply{
@@ -116,6 +122,7 @@ func (s *GRPCStorageServer) Put(ctx context.Context, args *pb.StoragePutArgs) (*
 	if s.impl == nil {
 		return nil, errMissingStorage
 	}
+	ctx = pbMetadataCtxToLogicalCtx(ctx)
 	err := s.impl.Put(ctx, pb.ProtoStorageEntryToLogicalStorageEntry(args.Entry))
 	return &pb.StoragePutReply{
 		Err: pb.ErrToString(err),
@@ -126,6 +133,7 @@ func (s *GRPCStorageServer) Delete(ctx context.Context, args *pb.StorageDeleteAr
 	if s.impl == nil {
 		return nil, errMissingStorage
 	}
+	ctx = pbMetadataCtxToLogicalCtx(ctx)
 	err := s.impl.Delete(ctx, args.Key)
 	return &pb.StorageDeleteReply{
 		Err: pb.ErrToString(err),

--- a/sdk/plugin/mock/backend.go
+++ b/sdk/plugin/mock/backend.go
@@ -67,6 +67,10 @@ func Backend() *backend {
 			Unauthenticated: []string{
 				"special",
 			},
+			AllowSnapshotRead: []string{
+				"kv/*",
+				"kv",
+			},
 		},
 		Secrets:          []*framework.Secret{},
 		Invalidate:       b.invalidate,


### PR DESCRIPTION
### Description
What does this PR do?

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
