### PR TITLE
[DOCS] Remove the out-dated statement about HCP Terraform

### DIFF
--- a/website/content/docs/secrets/terraform.mdx
+++ b/website/content/docs/secrets/terraform.mdx
@@ -90,11 +90,10 @@ however there are important differences to be aware of.
 
 ### Organization and team roles
 
-The HCP Terraform API limits both Organization and Team roles to **one active
-token at any given time**. Generating a new Organization or Team API token by
-reading the credentials in Vault or otherwise generating them on
-[app.terraform.io](https://app.terraform.io/session) will effectively revoke **any**
-existing API token for that Organization or Team.
+Generating a new Organization or Team API token by reading the credentials in
+Vault or otherwise generating them on
+[app.terraform.io](https://app.terraform.io/session) will effectively revoke
+**any** existing API token for that Organization or Team.
 
 Due to this behavior, Organization and Team API tokens created by Vault will be
 stored and returned on future requests, until the credentials get rotated. This


### PR DESCRIPTION
### Description

This PR removes the statement about _HCP Terraform API limits both Organization and Team roles to one active token at any given time_ since it's no longer true.

🧵 [Slack thread](https://hashicorp.slack.com/archives/C03BX0MJD27/p1747231261629569)

🔍 [Deploy preview](https://vault-git-docs-update-tf-plugin-hashicorp.vercel.app/vault/docs/secrets/terraform#organization-and-team-roles)


----
### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
