### PR TITLE
VAULT-34562: Add required CE stubs

### DIFF
--- a/vault/core.go
+++ b/vault/core.go
@@ -2614,6 +2614,9 @@ func buildUnsealSetupFunctionSlice(c *Core, isActive bool) []func(context.Contex
 		func(ctx context.Context) error {
 			return c.setupHeaderHMACKey(ctx, false)
 		},
+		func(ctx context.Context) error {
+			return c.EntSetupUIDefaultAuth(ctx)
+		},
 	}
 
 	// If this server is not part of a Disaster Recovery secondary cluster,
@@ -2656,6 +2659,10 @@ func buildUnsealSetupFunctionSlice(c *Core, isActive bool) []func(context.Contex
 			return nil
 		})
 		setupFunctions = append(setupFunctions, c.loadLoginMFAConfigs)
+
+		setupFunctions = append(setupFunctions, func(ctx context.Context) error {
+			return c.EntSetupUIDefaultAuth(ctx)
+		})
 	}
 
 	return setupFunctions

--- a/vault/core_stubs_oss.go
+++ b/vault/core_stubs_oss.go
@@ -114,3 +114,5 @@ func (c *Core) ReloadReplicationCanaryWriteInterval() {}
 func (c *Core) GetReplicationLagMillisIgnoreErrs() int64 { return 0 }
 
 func (c *Core) ReloadOverloadController() {}
+
+func (c *Core) EntSetupUIDefaultAuth(ctx context.Context) error { return nil }

--- a/vault/core_test.go
+++ b/vault/core_test.go
@@ -3664,14 +3664,14 @@ func TestBuildUnsealSetupFunctionSlice(t *testing.T) {
 			core: &Core{
 				replicationState: uint32Ptr(uint32(0)),
 			},
-			expectedLength: 26,
+			expectedLength: 28,
 		},
 		{
 			name: "dr secondary core",
 			core: &Core{
 				replicationState: uint32Ptr(uint32(consts.ReplicationDRSecondary)),
 			},
-			expectedLength: 14,
+			expectedLength: 15,
 		},
 	} {
 		funcs := buildUnsealSetupFunctionSlice(testcase.core, true)


### PR DESCRIPTION
### Description
CE side change for VAULT-34562

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
