### PR TITLE
[Docs] Update the tutorial links

### DIFF
--- a/website/content/docs/plugins/index.mdx
+++ b/website/content/docs/plugins/index.mdx
@@ -152,3 +152,9 @@ You cannot use the `+builtin` string when manually registering an external
 plugin.
 
 </Note>
+
+## Tutorial
+
+Refer to the [custom secrets engines](/vault/tutorials/custom-secrets-engine)
+tutorials to build a custom secrets engine to rotate your own tokens, passwords,
+and more with Vault.

--- a/website/content/docs/secrets/databases/index.mdx
+++ b/website/content/docs/secrets/databases/index.mdx
@@ -415,10 +415,8 @@ to provision dynamic credentials capable of accessing DynamoDB.
 
 ## Tutorial
 
-Refer to the following step-by-step tutorials for more information:
-
-- [Secrets as a Service: Dynamic Secrets](/vault/tutorials/db-credentials/database-secrets)
-- [Database Root Credential Rotation](/vault/tutorials/db-credentials/database-root-rotation)
+Refer to the [database credential management](/vault/tutorials/db-credentials)
+tutorials to learn how to manage database credential lifecycle with Vault.
 
 ## API
 

--- a/website/content/docs/secrets/databases/mongodb.mdx
+++ b/website/content/docs/secrets/databases/mongodb.mdx
@@ -102,7 +102,7 @@ for more information.
 
 ## Tutorial
 
-Refer to [Database Secrets Engine tutorial](/vault/tutorials/db-credentials/database-secrets) for a
+Refer to the [database credential management](/vault/tutorials/db-credentials) tutorials for a
 step-by-step example of using the database secrets engine.
 
 ## API


### PR DESCRIPTION
### Description

This PR:
- Adds a tutorial link to the [Plugins](https://developer.hashicorp.com/vault/docs/plugins) doc page
- Update the out-dated tutorial link on the database secrets engine doc

----

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
