### PR TITLE
OpenAPI Patch Endpoints

### DIFF
--- a/sdk/framework/openapi_test.go
+++ b/sdk/framework/openapi_test.go
@@ -459,6 +459,10 @@ func TestOpenAPI_Paths(t *testing.T) {
 					Summary:     "Update Summary",
 					Description: "Update Description",
 				},
+				logical.PatchOperation: &PathOperation{
+					Summary:     "Patch Summary",
+					Description: "Patch Description",
+				},
 				logical.CreateOperation: &PathOperation{
 					Summary:     "Create Summary",
 					Description: "Create Description",
@@ -711,6 +715,15 @@ func TestOpenAPI_constructOperationID(t *testing.T) {
 			operationAttributes: nil,
 			defaultPrefix:       "test",
 			expected:            "test-write-path-to-thing",
+		},
+		"simple-patch": {
+			path:                "path/to/thing",
+			pathIndex:           0,
+			pathAttributes:      nil,
+			operation:           logical.PatchOperation,
+			operationAttributes: nil,
+			defaultPrefix:       "test",
+			expected:            "test-patch-path-to-thing",
 		},
 		"operation-verb": {
 			path:                "path/to/thing",

--- a/sdk/framework/testdata/operations.json
+++ b/sdk/framework/testdata/operations.json
@@ -73,6 +73,29 @@
             "description": "OK"
           }
         }
+      },
+      "patch": {
+        "summary": "Patch Summary",
+        "description": "Patch Description",
+        "operationId": "kv-patch-foo-id",
+        "tags": [
+          "secrets"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/KvPatchFooIdRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
       }
     },
     "/foo/{id}/": {
@@ -139,6 +162,60 @@
   "components": {
     "schemas": {
       "KvWriteFooIdRequest": {
+        "type": "object",
+        "properties": {
+          "age": {
+            "type": "integer",
+            "description": "the age",
+            "enum": [
+              1,
+              2,
+              3
+            ],
+            "x-vault-displayAttrs": {
+              "name": "Age",
+              "value": 7,
+              "sensitive": true,
+              "group": "Some Group"
+            }
+          },
+          "flavors": {
+            "type": "array",
+            "description": "the flavors",
+            "items": {
+              "type": "string"
+            }
+          },
+          "format": {
+            "type": "string",
+            "description": "a query param"
+          },
+          "maximum": {
+            "type": "integer",
+            "description": "a maximum value",
+            "format": "int64"
+          },
+          "name": {
+            "type": "string",
+            "description": "the name",
+            "pattern": "\\w([\\w-.]*\\w)?",
+            "default": "Larry"
+          },
+          "x-abc-token": {
+            "type": "string",
+            "description": "a header value",
+            "enum": [
+              "a",
+              "b",
+              "c"
+            ]
+          }
+        },
+        "required": [
+          "age"
+        ]
+      },
+      "KvPatchFooIdRequest": {
         "type": "object",
         "properties": {
           "age": {

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -5428,7 +5428,7 @@ func (b *SystemBackend) pathInternalOpenAPI(ctx context.Context, req *logical.Re
 
 				// Add tags to all of the operations if necessary
 				if tag != "" {
-					for _, op := range []*framework.OASOperation{obj.Get, obj.Post, obj.Delete} {
+					for _, op := range []*framework.OASOperation{obj.Get, obj.Post, obj.Patch, obj.Delete} {
 						// TODO: a special override for identity is used used here because the backend
 						// is currently categorized as "secret", which will likely change. Also of interest
 						// is removing all tag handling here and providing the mount information to OpenAPI.


### PR DESCRIPTION
### Description
The PR adds `PATCH` endpoints to the generated OpenAPI spec.

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
