### PR TITLE
test: fix CompilePlugin test helper

### DIFF
--- a/helper/testhelpers/pluginhelpers/pluginhelpers.go
+++ b/helper/testhelpers/pluginhelpers/pluginhelpers.go
@@ -76,10 +76,6 @@ func CompilePlugin(t testing.TB, typ consts.PluginType, pluginVersion string, pl
 	var pluginBytes []byte
 
 	dir := ""
-	pluginRootDir := "builtin"
-	if typ == consts.PluginTypeDatabase {
-		pluginRootDir = "plugins"
-	}
 	for {
 		// So that we can assign to dir without overshadowing the other
 		// err variables.
@@ -89,7 +85,7 @@ func CompilePlugin(t testing.TB, typ consts.PluginType, pluginVersion string, pl
 			t.Fatal(getWdErr)
 		}
 		// detect if we are in a subdirectory or the root directory and compensate
-		if _, err := os.Stat(pluginRootDir); os.IsNotExist(err) {
+		if _, err := os.Stat(pluginMain); os.IsNotExist(err) {
 			err := os.Chdir("..")
 			if err != nil {
 				t.Fatal(err)


### PR DESCRIPTION


### Description
This PR fixes CompilePlugin which would fail when run locally in certain situations based on relative directory paths. This change makes CompilePlugin perform os.Stat on the full path to the plugin's main.go file to ensure the test changes to the appropriate directory for building the plugin.

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
