### PR TITLE
[VAULT-35165] CE changes for development cluster setting

### DIFF
--- a/sdk/helper/consts/replication.go
+++ b/sdk/helper/consts/replication.go
@@ -20,6 +20,7 @@ const (
 	// ids to ensure it doesn't collide.
 	CurrentReplicatedSecondaryIdentifier = ".current"
 	CoreFeatureFlagPath                  = "core/cluster/feature-flags"
+	CoreDevelopmentClusterPath           = "core/reporting/development-cluster"
 )
 
 type ReplicationState uint32

--- a/vault/census.go
+++ b/vault/census.go
@@ -29,3 +29,5 @@ func (c *Core) ReloadCensusManager(ctx context.Context, licenseChange bool) erro
 func (c *Core) parseCensusManagerConfig(conf *CoreConfig) (CensusManagerConfig, error) {
 	return CensusManagerConfig{}, nil
 }
+func (c *Core) DevelopmentCluster() bool                      { return false }
+func (c *Core) SetDevelopmentCluster(developmentCluster bool) {}

--- a/vault/census_manager.go
+++ b/vault/census_manager.go
@@ -36,6 +36,21 @@ func (c *Core) setupCensusManager(ctx context.Context) error {
 	return nil
 }
 
+// reloadDevelopmentClusterSetting is a stub on CE.
+func (c *Core) reloadDevelopmentClusterSetting() error {
+	return nil
+}
+
+// persistDevelopmentClusterSetting is a stub on CE.
+func (c *Core) persistDevelopmentClusterSetting(ctx context.Context) error {
+	return nil
+}
+
+// getDevelopmentClusterSetting is a stub on CE.
+func (c *Core) getDevelopmentClusterSetting(ctx context.Context) (bool, error) {
+	return false, nil
+}
+
 // BillingStart is a stub on CE.
 func (cm *CensusManager) BillingStart() time.Time {
 	return time.Time{}

--- a/vault/core.go
+++ b/vault/core.go
@@ -2506,6 +2506,28 @@ func (s standardUnsealStrategy) unseal(ctx context.Context, logger log.Logger, c
 		return err
 	}
 
+	if c.isPrimary() {
+		// Reload the development cluster setting from config in case the cluster is newly promoted and the setting
+		// in Census Manager is a holdover from the old primary.
+		if err := c.reloadDevelopmentClusterSetting(); err != nil {
+			return err
+		}
+		// Store the primary's development cluster setting to propagate it to any secondaries
+		if err := c.persistDevelopmentClusterSetting(ctx); err != nil {
+			return err
+		}
+	} else {
+		// If we can find a stored development cluster setting, and it is different from what was set in our config,
+		// then we need to log an error warning that the value is changing and update the census manager with the new setting.
+		developmentCluster, err := c.getDevelopmentClusterSetting(ctx)
+		if err == nil && developmentCluster != c.DevelopmentCluster() {
+			c.logger.Error("development cluster setting in config does not match that of the primary, updating to follow the primary config setting")
+			c.SetDevelopmentCluster(developmentCluster)
+		} else if err != nil {
+			return err
+		}
+	}
+
 	if !c.IsDRSecondary() {
 		// not waiting on wg to avoid changing existing behavior
 		var wg sync.WaitGroup


### PR DESCRIPTION
### Description
Corresponding CE changes to https://github.com/hashicorp/vault-enterprise/pull/7989

Jira: https://hashicorp.atlassian.net/browse/VAULT-35165
RFC: https://go.hashi.co/rfc/vlt-348

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
