### PR TITLE
do not fail to start if missing mlock config on systems that do not support mlock

### DIFF
--- a/command/server.go
+++ b/command/server.go
@@ -1186,7 +1186,7 @@ func (c *ServerCommand) Run(args []string) int {
 		}
 	}
 
-	// If mlockall(2) !isn't supported, show a warning. We disable this in dev
+	// If mlockall(2) isn't supported, show a warning. We disable this in dev
 	// because it is quite scary to see when first using Vault. We also disable
 	// this if the user has explicitly disabled mlock in configuration.
 	if !c.flagDev && !config.DisableMlock && !mlock.Supported() {

--- a/command/server.go
+++ b/command/server.go
@@ -1148,7 +1148,7 @@ func (c *ServerCommand) Run(args []string) int {
 	}
 
 	// ensure that the DisableMlock key is explicitly set if using integrated storage
-	if !c.flagDev && config.Storage != nil && config.Storage.Type == storageTypeRaft && !isMlockSet() {
+	if !c.flagDev && mlock.Supported() && config.Storage != nil && config.Storage.Type == storageTypeRaft && !isMlockSet() {
 
 		c.UI.Error(wrapAtLength(
 			"ERROR: disable_mlock must be configured 'true' or 'false': Mlock " +
@@ -1186,7 +1186,7 @@ func (c *ServerCommand) Run(args []string) int {
 		}
 	}
 
-	// If mlockall(2) isn't supported, show a warning. We disable this in dev
+	// If mlockall(2) !isn't supported, show a warning. We disable this in dev
 	// because it is quite scary to see when first using Vault. We also disable
 	// this if the user has explicitly disabled mlock in configuration.
 	if !c.flagDev && !config.DisableMlock && !mlock.Supported() {


### PR DESCRIPTION
### Description
Based on conversations with support, we decided to ignore the absence of `disable_mlock` in the config if a system does not support mlock.

This PR adds that check.

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
