### PR TITLE
VAULT-36174: pipeline(go): deal with relative path issues in cache restore

### DIFF
--- a/.github/actions/set-up-go/action.yml
+++ b/.github/actions/set-up-go/action.yml
@@ -82,7 +82,7 @@ runs:
         # keeps cache upload time, download time, and storage size to a minimum.
         path: ${{ steps.metadata.outputs.cache-path }}
         key: ${{ steps.metadata.outputs.cache-key }}
-    - if: steps.cache-modules.outputs.cache-hit != 'true' && inputs.no-save != 'false'
+    - if: steps.cache-modules.outputs.cache-hit != 'true' && inputs.no-save != 'true'
       name: Download go modules
       shell: bash
       env:

--- a/.github/actions/set-up-go/action.yml
+++ b/.github/actions/set-up-go/action.yml
@@ -47,9 +47,20 @@ runs:
     - id: metadata
       shell: bash
       run: |
+        # Cache restore have some surprising relative pathing behavior we need
+        # to deal with. Since our cache-path is in $HOME (/home/runner/go/...)
+        # and $HOME can be different depending on our self-hosted vs Github
+        # hosted runners (/home/runner/actions-runner/_work vs. /home/runner/work)
+        # we need to factor in the absolute path of $HOME when creating our
+        # cache key. If we don't then cache restores will be incompatible on one
+        # or the other runner. This is because the tar restore uses relative
+        # paths backwards our our depth doesn't match on both runners.
+        #
+        # See: https://github.com/actions/cache/issues/1127
+        home_hash=$(realpath $HOME | sha256sum | head -c 8)
         {
-          echo "cache-path=$(go env GOMODCACHE)"
-          echo "cache-key=go-modules-${{ hashFiles('**/go.sum') }}"
+          echo "cache-path=$(go env GOMODCACHE)/cache"
+          echo "cache-key=go-modules-${home_hash}-${{ hashFiles('**/go.sum') }}"
         } | tee -a "$GITHUB_OUTPUT"
     - id: cache-modules
       uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0

--- a/.github/actions/set-up-go/action.yml
+++ b/.github/actions/set-up-go/action.yml
@@ -48,19 +48,19 @@ runs:
       shell: bash
       run: |
         # Cache restore have some surprising relative pathing behavior we need
-        # to deal with. Since our cache-path is in $HOME (/home/runner/go/...)
-        # and $HOME can be different depending on our self-hosted vs Github
-        # hosted runners (/home/runner/actions-runner/_work vs. /home/runner/work)
-        # we need to factor in the absolute path of $HOME when creating our
+        # to deal with. When actions/cache restores something it does it
+        # realtive to the check working directory. Since that can be different
+        # depending on our self-hosted vs Github hosted runners
+        #   /home/runner/actions-runner/_work vs. /home/runner/work
+        # we need to factor in the absolute path of our working directory in our
         # cache key. If we don't then cache restores will be incompatible on one
-        # or the other runner. This is because the tar restore uses relative
-        # paths backwards our our depth doesn't match on both runners.
+        # or the other runner.
         #
         # See: https://github.com/actions/cache/issues/1127
-        home_hash=$(realpath $HOME | sha256sum | head -c 8)
+        wd_hash=$(realpath . | sha256sum | head -c 8)
         {
           echo "cache-path=$(go env GOMODCACHE)/cache"
-          echo "cache-key=go-modules-${home_hash}-${{ hashFiles('**/go.sum') }}"
+          echo "cache-key=go-modules-${wd_hash}-${{ hashFiles('**/go.sum') }}"
         } | tee -a "$GITHUB_OUTPUT"
     - id: cache-modules
       uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0


### PR DESCRIPTION
### Description
`actions/cache/restore` has some surprising relative pathing behavior we need
 to deal with. When it restores a previously created cache it does it relative to the
checkout working directory. Since that can be different depending on our
self-hosted vs Github hosted runners:
  `home/runner/actions-runner/_work` vs. `/home/runner/work`
we need to factor in the absolute path of our working directory in our cache key.
If we don't then cache restores will be incompatible on one or the other runner
as the relative depth is different.

We also slightly change our module caches here to only get `.../mod/cache` instead
of the whole `.../mod` directory. Go is able to unzip the modules in `.../mode/cache`
faster than what it takes to download the entire directory.

This will double our module caches (in enterprise) *sigh*, but they ought to be smaller
as they only contain the module zips (1.7 GiB vs 2.3GiB).

See: https://github.com/actions/cache/issues/1127

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [x] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
