### PR TITLE
UI: Tidy up TOTP logic

### DIFF
--- a/ui/app/components/generate-credentials-totp.hbs
+++ b/ui/app/components/generate-credentials-totp.hbs
@@ -26,12 +26,10 @@
 <div class="box is-fullwidth is-sideless is-paddingless is-marginless">
   <InfoTableRow @label="Code">
     <MaskedInput @name="code" @value={{this.totpCode}} @displayOnly={{true}} @allowCopy={{true}} />
-    {{#if @totpCodePeriod}}
-      <label class="has-left-padding-s">
-        <div>Valid for {{this.remainingTime}} seconds</div>
-        <progress id="code-validity" value={{this.remainingTime}} max={{@totpCodePeriod}} />
-      </label>
-    {{/if}}
+    <label class="has-left-padding-s">
+      <div>Valid for {{this.remainingTime}} seconds</div>
+      <progress id="code-validity" value={{this.remainingTime}} max={{@totpCodePeriod}} />
+    </label>
   </InfoTableRow>
 </div>
 <div class="field is-grouped box is-fullwidth is-bottomless">

--- a/ui/app/routes/vault/cluster/secrets/backend/credentials.js
+++ b/ui/app/routes/vault/cluster/secrets/backend/credentials.js
@@ -90,7 +90,7 @@ export default Route.extend({
     } else if (backendType === 'aws') {
       awsRole = await this.getAwsRole(backendPath, role);
     } else if (backendType === 'totp') {
-      totpCodePeriod = (await this.getTotpKey(backendPath, role))?.period;
+      totpCodePeriod = (await this.getTotpKey(backendPath, role))?.period ?? 30;
       backRoute = this.backRoute;
       return { ...backendData, keyName: role, totpCodePeriod, backRoute };
     }


### PR DESCRIPTION
### Description
This PR address the remaining TODOs in the TOTP logic. If an error is encountered when retrieving the totp code's period (the time for which the code is valid), the default will be 30 seconds which is the default in the api spec. 

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
