### PR TITLE
[VAULT-35162] Development Cluster setting docs

### DIFF
--- a/changelog/30659.txt
+++ b/changelog/30659.txt
@@ -1,4 +1,4 @@
 ```release-note:feature
-**Development Cluster Configuration**: Added `development_cluster` as a metadata field to the utilization reports.
+**Development Cluster Configuration** (enterprise): Added `development_cluster` as a field to Vault's utilization reports.
 The field is configurable via HCL and indicates whether the cluster is being used in a development environment, defaults to false if not set.
 ```

--- a/changelog/30659.txt
+++ b/changelog/30659.txt
@@ -1,0 +1,4 @@
+```release-note:feature
+**Development Cluster Configuration**: Added `development_cluster` as a metadata field to the utilization reports.
+The field is configurable via HCL and indicates whether the cluster is being used in a development environment, defaults to false if not set.
+```

--- a/website/content/docs/configuration/reporting.mdx
+++ b/website/content/docs/configuration/reporting.mdx
@@ -41,3 +41,7 @@ is enabled.
 page for more details.
 - `billing_start_timestamp` `(timestamp)` - The start timestamp for billing for license reporting (manual and automated).
 Defaults to the license start timestamp.
+- `development_cluster` `(boolean: false)` - Indicates whether the cluster is a development (non-production) cluster for
+license reporting (manual and automated). Defaults to false. Please see the development cluster
+  [section](/vault/docs/enterprise/license/utilization-reporting#development-cluster-setting) of the
+utilization reporting documentation for more details.

--- a/website/content/docs/configuration/reporting.mdx
+++ b/website/content/docs/configuration/reporting.mdx
@@ -43,5 +43,5 @@ page for more details.
 Defaults to the license start timestamp.
 - `development_cluster` `(boolean: false)` - Indicates whether the cluster is a development (non-production) cluster for
 license reporting (manual and automated). Defaults to false. Please see the development cluster
-  [section](/vault/docs/enterprise/license/utilization-reporting#development-cluster-setting) of the
+  [section](/vault/docs/enterprise/license/utilization-reporting#development-cluster-configuration) of the
 utilization reporting documentation for more details.

--- a/website/content/docs/license/product-usage-reporting.mdx
+++ b/website/content/docs/license/product-usage-reporting.mdx
@@ -208,8 +208,9 @@ All of these metrics are numerical, and contain no sensitive values or additiona
 HashiCorp collects the following product usage metadata as part of the `metadata` part of the
 [JSON payload that it collects for licence utilization](/vault/docs/enterprise/license/utilization-reporting#example-payloads):
 
-| Metadata Name        | Description                                                          |
-|----------------------|----------------------------------------------------------------------|
-| `replication_status` | Replication status of this cluster, e.g. `perf-disabled,dr-disabled` |
-| `storage_type`       | Storage backend type, e.g. `raft` or `consul`                        |
-| `operating_system`   | Operating system this cluster is running on.                       |
+| Metadata Name         | Description                                                                 |
+|-----------------------|-----------------------------------------------------------------------------|
+| `replication_status`  | Replication status of this cluster, e.g. `perf-disabled,dr-disabled`        |
+| `storage_type`        | Storage backend type, e.g. `raft` or `consul`                               |
+| `operating_system`    | Operating system this cluster is running on.                                |
+| `development_cluster` | Whether the cluster is operating as a development (non-production) cluster. |

--- a/website/content/docs/license/utilization/auto-reporting.mdx
+++ b/website/content/docs/license/utilization/auto-reporting.mdx
@@ -194,6 +194,46 @@ isn’t trying to send reports.
 If your configuration file and environment variable differ, the environment
 variable setting will take precedence.
 
+## Development Cluster Setting
+
+As of 1.20.0, clusters now report the `development_cluster` metadata field, which
+indicates whether the cluster is used for development (non-production) purposes. By default, the field is set to `false`,
+indicating the cluster is running in a production environment. Setting the value is done via HCL configuration by adding
+the `development_cluster` field to the `license` parameter within the `reporting` stanza.
+
+```hcl
+reporting {
+  license {
+    development_cluster = true
+  }
+}
+```
+
+#### Replication Considerations
+
+The `development_cluster` setting cannot differ across replicated clusters.
+In [performance replication](/vault/docs/enterprise/replication#performance-replication), secondary clusters inherit the
+`development_cluster` value from the primary cluster, regardless of their own HCL configuration. If the secondary cluster
+is promoted to a primary, it will begin to report its own `development_cluster` value determined by its HCL configuration.
+The reverse is also true, if the primary cluster is demoted to a secondary, it will report the `development_cluster`
+value of its new primary.
+
+[Disaster recovery](/vault/docs/enterprise/replication#disaster-recovery-dr-replication) secondaries do not send reports.
+However, if promoted to primary during failover, they will report their own `development_cluster` value based on their HCL configuration.
+
+<Warning>
+
+All clusters in a replication group must have the same `development_cluster` setting in their HCL configuration.
+In the event of a promotion or failover, the new primary cluster's HCL configuration will determine the value reported
+by all clusters in the replication group. Inconsistent configurations between clusters can lead to changes to the
+reported `development_cluster` value when the primary cluster changes.
+
+Within each cluster, each node must have the same `development_cluster` setting in its configuration to be consistent.
+In the event of leadership change, nodes will use its server configuration to determine the value to report.
+Inconsistent configuration between nodes will change the `development_cluster` setting reported upon active unseal.
+
+</Warning>
+
 ## Example payloads
 
 HashiCorp collects the following utilization data as JSON payloads:
@@ -240,6 +280,7 @@ HashiCorp collects the following utilization data as JSON payloads:
 
    - `cluster_id` - The cluster UUID as shown by `vault status` on the reporting
      cluster
+   - `development_cluster` - Whether the cluster is operating as a development (non-production) cluster.
 
 <CodeBlockConfig hideClipboard>
 
@@ -287,7 +328,8 @@ HashiCorp collects the following utilization data as JSON payloads:
   "metadata": {
     "vault": {
       "billing_start": "2023-03-01T00:00:00Z",
-      "cluster_id": "a8d95acc-ec0a-6087-d7f6-4f054ab2e7fd"
+      "cluster_id": "a8d95acc-ec0a-6087-d7f6-4f054ab2e7fd",
+      "development_cluster": "false",
     }
   }
 }

--- a/website/content/docs/license/utilization/auto-reporting.mdx
+++ b/website/content/docs/license/utilization/auto-reporting.mdx
@@ -198,7 +198,7 @@ variable setting will take precedence.
 
 As of 1.20.0, clusters now report the `development_cluster` metadata field, which
 indicates whether the cluster is used for development (non-production) purposes. By default, the field is set to `false`,
-indicating the cluster is running in a production environment. Setting the value is done via HCL configuration by adding
+indicating the cluster is running in a production environment. Changing the value is done via HCL configuration by adding
 the `development_cluster` field to the `license` parameter within the `reporting` stanza.
 
 ```hcl

--- a/website/content/docs/license/utilization/auto-reporting.mdx
+++ b/website/content/docs/license/utilization/auto-reporting.mdx
@@ -194,7 +194,7 @@ isn’t trying to send reports.
 If your configuration file and environment variable differ, the environment
 variable setting will take precedence.
 
-## Development Cluster Configuration
+## Development cluster configuration
 
 As of 1.20.0, clusters now report the `development_cluster` metadata field, which
 indicates whether the cluster is used for development (non-production) purposes. By default, the field is set to `false`,
@@ -209,7 +209,7 @@ reporting {
 }
 ```
 
-#### Replication Considerations
+#### Replication considerations
 
 The `development_cluster` configuration cannot differ across replicated clusters.
 In [performance replication](/vault/docs/enterprise/replication#performance-replication), secondary clusters inherit the

--- a/website/content/docs/license/utilization/auto-reporting.mdx
+++ b/website/content/docs/license/utilization/auto-reporting.mdx
@@ -194,7 +194,7 @@ isn’t trying to send reports.
 If your configuration file and environment variable differ, the environment
 variable setting will take precedence.
 
-## Development Cluster Setting
+## Development Cluster Configuration
 
 As of 1.20.0, clusters now report the `development_cluster` metadata field, which
 indicates whether the cluster is used for development (non-production) purposes. By default, the field is set to `false`,
@@ -211,7 +211,7 @@ reporting {
 
 #### Replication Considerations
 
-The `development_cluster` setting cannot differ across replicated clusters.
+The `development_cluster` configuration cannot differ across replicated clusters.
 In [performance replication](/vault/docs/enterprise/replication#performance-replication), secondary clusters inherit the
 `development_cluster` value from the primary cluster, regardless of their own HCL configuration. If the secondary cluster
 is promoted to a primary, it will begin to report its own `development_cluster` value determined by its HCL configuration.

--- a/website/content/docs/license/utilization/manual-reporting.mdx
+++ b/website/content/docs/license/utilization/manual-reporting.mdx
@@ -178,7 +178,8 @@ The default retention period is 400 days.
   "checksum": 6861637915450723051,
   "metadata": {
     "billing_start": "2023-05-04T00:00:00Z",
-    "cluster_id": "16d0ff5b-9d40-d7a7-384c-c9b95320c60e"
+    "cluster_id": "16d0ff5b-9d40-d7a7-384c-c9b95320c60e",
+    "development_cluster": "false"
   }
 ```
 


### PR DESCRIPTION
### Description
This PR adds the documentation for the new `development_cluster` config value and Census report metadata field. It also includes the changelog for the feature. 

Jira: https://hashicorp.atlassian.net/browse/VAULT-35162
RFC: https://go.hashi.co/rfc/vlt-348

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
