### PR TITLE
Added docs for metadata I missed

### DIFF
--- a/website/content/docs/license/product-usage-reporting.mdx
+++ b/website/content/docs/license/product-usage-reporting.mdx
@@ -211,3 +211,5 @@ HashiCorp collects the following product usage metadata as part of the `metadata
 | Metadata Name        | Description                                                          |
 |----------------------|----------------------------------------------------------------------|
 | `replication_status` | Replication status of this cluster, e.g. `perf-disabled,dr-disabled` |
+| `storage_type`       | Storage backend type, e.g. `raft` or `consul`                        |
+| `operating_system`   | Operating system of the cluster is running on.                       |

--- a/website/content/docs/license/product-usage-reporting.mdx
+++ b/website/content/docs/license/product-usage-reporting.mdx
@@ -212,4 +212,4 @@ HashiCorp collects the following product usage metadata as part of the `metadata
 |----------------------|----------------------------------------------------------------------|
 | `replication_status` | Replication status of this cluster, e.g. `perf-disabled,dr-disabled` |
 | `storage_type`       | Storage backend type, e.g. `raft` or `consul`                        |
-| `operating_system`   | Operating system of the cluster is running on.                       |
+| `operating_system`   | Operating system this cluster is running on.                       |


### PR DESCRIPTION
### Description
Added two metadata usage metrics.

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
