### PR TITLE
Support recover operation for ssh roles 

### DIFF
--- a/builtin/logical/ssh/backend.go
+++ b/builtin/logical/ssh/backend.go
@@ -56,6 +56,10 @@ func Backend(conf *logical.BackendConfig) (*backend, error) {
 				caPrivateKeyStoragePath,
 				keysStoragePrefix,
 			},
+			AllowSnapshotRead: []string{
+				"roles/",
+				"roles/*",
+			},
 		},
 
 		Paths: []*framework.Path{

--- a/builtin/logical/ssh/path_config_zeroaddress.go
+++ b/builtin/logical/ssh/path_config_zeroaddress.go
@@ -92,7 +92,7 @@ func (b *backend) pathConfigZeroAddressWrite(ctx context.Context, req *logical.R
 
 	// Check if the roles listed actually exist in the backend
 	for _, item := range roles {
-		role, err := b.getRole(ctx, req.Storage, item)
+		role, err := b.getRole(ctx, req.Storage, item, false)
 		if err != nil {
 			return nil, err
 		}

--- a/builtin/logical/ssh/path_creds_create.go
+++ b/builtin/logical/ssh/path_creds_create.go
@@ -65,7 +65,7 @@ func (b *backend) pathCredsCreateWrite(ctx context.Context, req *logical.Request
 		return logical.ErrorResponse("Missing ip"), nil
 	}
 
-	role, err := b.getRole(ctx, req.Storage, roleName)
+	role, err := b.getRole(ctx, req.Storage, roleName, false)
 	if err != nil {
 		return nil, fmt.Errorf("error retrieving role: %w", err)
 	}

--- a/builtin/logical/ssh/path_issue.go
+++ b/builtin/logical/ssh/path_issue.go
@@ -86,7 +86,7 @@ be later than the role max TTL.`,
 func (b *backend) pathIssue(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
 	// Get the role
 	roleName := data.Get("role").(string)
-	role, err := b.getRole(ctx, req.Storage, roleName)
+	role, err := b.getRole(ctx, req.Storage, roleName, false)
 	if err != nil {
 		return nil, err
 	}

--- a/builtin/logical/ssh/path_sign.go
+++ b/builtin/logical/ssh/path_sign.go
@@ -74,7 +74,7 @@ func (b *backend) pathSign(ctx context.Context, req *logical.Request, data *fram
 	roleName := data.Get("role").(string)
 
 	// Get the role
-	role, err := b.getRole(ctx, req.Storage, roleName)
+	role, err := b.getRole(ctx, req.Storage, roleName, false)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### Description
This PR adds support for reading, listing, and recovering from a snapshot for an SSH role. Because roles can be automatically upgraded via this code path, we need to make sure that we don't do an upgrade (and thus try to modify storage) for a snapshot read or list.
RFC: https://go.hashi.co/rfc/vlt-347

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
