### PR TITLE
Fix auth flaky test

### DIFF
--- a/ui/app/components/section-tabs.hbs
+++ b/ui/app/components/section-tabs.hbs
@@ -10,7 +10,7 @@
         <ul>
           {{#each tabs as |tab|}}
             <li>
-              <LinkTo @route={{tab.route}} @models={{tab.routeParams}} data-test-auth-section-tab>
+              <LinkTo @route={{tab.route}} @models={{tab.routeParams}} data-test-link-to="auth-tab">
                 {{tab.label}}
               </LinkTo>
             </li>

--- a/ui/app/helpers/supported-managed-auth-backends.js
+++ b/ui/app/helpers/supported-managed-auth-backends.js
@@ -7,7 +7,7 @@ import { helper as buildHelper } from '@ember/component/helper';
 
 // The UI supports management of these auth methods (i.e. configuring roles or users)
 // otherwise only configuration of the method is supported.
-const MANAGED_AUTH_BACKENDS = ['cert', 'kubernetes', 'ldap', 'okta', 'radius', 'userpass'];
+export const MANAGED_AUTH_BACKENDS = ['cert', 'kubernetes', 'ldap', 'okta', 'radius', 'userpass'];
 
 export function supportedManagedAuthBackends() {
   return MANAGED_AUTH_BACKENDS;

--- a/ui/app/templates/components/generated-item-list.hbs
+++ b/ui/app/templates/components/generated-item-list.hbs
@@ -23,7 +23,7 @@
         <ul>
           {{#each tabs as |tab|}}
             <li>
-              <LinkTo @route={{tab.route}} @models={{tab.routeParams}} data-test-auth-section-tab>
+              <LinkTo @route={{tab.route}} @models={{tab.routeParams}} data-test-link-to="generated-tab">
                 {{tab.label}}
               </LinkTo>
             </li>

--- a/ui/app/templates/vault/cluster/access/method/section.hbs
+++ b/ui/app/templates/vault/cluster/access/method/section.hbs
@@ -18,7 +18,7 @@
 </PageHeader>
 
 {{#if (not (includes this.model.type (supported-managed-auth-backends)))}}
-  <div class="has-text-grey has-top-bottom-margin" data-test-doc-link>
+  <div class="has-text-grey has-top-bottom-margin" data-test-doc-link={{this.model.id}}>
     The Vault UI only supports configuration for this authentication method. For management, the
     <DocLink @path="/vault/api-docs">API or CLI</DocLink>
     should be used.

--- a/ui/app/templates/vault/cluster/access/methods.hbs
+++ b/ui/app/templates/vault/cluster/access/methods.hbs
@@ -50,7 +50,7 @@
   <LinkedBlock
     @params={{array "vault.cluster.access.method" method.id}}
     class="list-item-row"
-    data-test-auth-backend-link={{method.id}}
+    data-test-auth-backend-link={{or method.id method.accessor}}
   >
     <div class="level is-mobile">
       <div>

--- a/ui/tests/acceptance/access/methods-test.js
+++ b/ui/tests/acceptance/access/methods-test.js
@@ -10,6 +10,7 @@ import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { v4 as uuidv4 } from 'uuid';
 import { GENERAL } from 'vault/tests/helpers/general-selectors';
+import { AUTH_FORM } from 'vault/tests/helpers/auth/auth-form-selectors';
 import { mountAuthCmd, runCmd } from 'vault/tests/helpers/commands';
 import { login } from 'vault/tests/helpers/auth/auth-helpers';
 
@@ -44,8 +45,8 @@ module('Acceptance | auth-methods list view', function (hooks) {
     // filter by auth type
     await clickTrigger('#filter-by-auth-type');
     await click(searchSelect.option(searchSelect.optionIndex(type)));
-    let rows = findAll('[data-test-auth-backend-link]');
-    const rowsUserpass = Array.from(rows).filter((row) => row.innerText.includes('userpass'));
+    let rows = findAll('.linked-block list-item row');
+    const rowsUserpass = findAll(AUTH_FORM.linkedBlockAuth(type));
 
     assert.strictEqual(rows.length, rowsUserpass.length, 'all rows returned are userpass');
 
@@ -53,13 +54,12 @@ module('Acceptance | auth-methods list view', function (hooks) {
     await clickTrigger('#filter-by-auth-name');
     await click(searchSelect.option());
     const selectedItem = find(`#filter-by-auth-name ${searchSelect.selectedOption()}`).innerText;
-    const singleRow = findAll('[data-test-auth-backend-link]');
-
+    const singleRow = findAll('.linked-block');
     assert.strictEqual(singleRow.length, 1, 'returns only one row');
     assert.dom(singleRow[0]).includesText(selectedItem, 'shows the filtered by auth name');
     // clear filter by name
     await click(`#filter-by-auth-name ${searchSelect.removeSelected}`);
-    rows = findAll('[data-test-auth-backend-link]');
+    rows = findAll('.linked-block');
     assert.true(rows.length > 1, 'filter has been removed');
 
     // cleanup
@@ -68,24 +68,32 @@ module('Acceptance | auth-methods list view', function (hooks) {
   });
 
   test('it should show all methods in list view', async function (assert) {
+    const authPayload = {
+      'token/': { accessor: 'auth_token_263b8b4e', type: 'token' },
+      'userpass/': { accessor: 'auth_userpass_87aca1f8', type: 'userpass' },
+    };
     this.server.get('/sys/internal/ui/mounts', () => ({
       data: {
-        auth: {
-          'token/': { accessor: 'auth_token_263b8b4e', type: 'token' },
-          'userpass/': { accessor: 'auth_userpass_87aca1f8', type: 'userpass' },
-        },
+        auth: authPayload,
       },
     }));
     await visit('/vault/access/');
-    assert.dom('[data-test-auth-backend-link]').exists({ count: 2 }, 'All auth methods appear in list view');
+    for (const [key, value] of Object.entries(authPayload)) {
+      assert
+        .dom(AUTH_FORM.linkedBlockAuth(value.type))
+        .exists({ count: 1 }, `auth method ${key} appears in list view`);
+    }
 
     // verify overflow style exists on auth method name
     assert.dom('[data-test-path]').hasClass('overflow-wrap', 'auth method name has overflow class applied');
     await visit('/vault/settings/auth/enable');
-    await click('[data-test-sidebar-nav-link="OIDC Provider"]');
+    await click(GENERAL.navLink('OIDC Provider'));
     await visit('/vault/access/');
-    assert
-      .dom('[data-test-auth-backend-link]')
-      .exists({ count: 2 }, 'All auth methods appear in list view after navigating back');
+
+    for (const [key, value] of Object.entries(authPayload)) {
+      assert
+        .dom(AUTH_FORM.linkedBlockAuth(value.type))
+        .exists({ count: 1 }, `auth method ${key} appears in list view after navigating from OIDC Provider`);
+    }
   });
 });

--- a/ui/tests/acceptance/settings/auth/configure/section-test.js
+++ b/ui/tests/acceptance/settings/auth/configure/section-test.js
@@ -7,7 +7,7 @@ import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { create } from 'ember-cli-page-object';
-import { fillIn, settled } from '@ember/test-helpers';
+import { fillIn, settled, findAll } from '@ember/test-helpers';
 import { v4 as uuidv4 } from 'uuid';
 
 import enablePage from 'vault/tests/pages/settings/auth/enable';
@@ -45,11 +45,11 @@ module('Acceptance | settings/auth/configure/section', function (hooks) {
     const section = 'options';
     await enablePage.enable(type, path);
     await page.visit({ path, section });
-    await fillIn('[data-test-input="description"]', 'This is Approle!');
+    await fillIn(GENERAL.inputByAttr('description'), 'This is Approle!');
     assert
-      .dom('[data-test-input="config.tokenType"]')
+      .dom(GENERAL.inputByAttr('config.tokenType'))
       .hasValue('default-service', 'as default the token type selected is default-service.');
-    await fillIn('[data-test-input="config.tokenType"]', 'batch');
+    await fillIn(GENERAL.inputByAttr('config.tokenType'), 'batch');
     await page.save();
     assert.strictEqual(
       page.flash.latestMessage,

--- a/ui/tests/acceptance/settings/auth/configure/section-test.js
+++ b/ui/tests/acceptance/settings/auth/configure/section-test.js
@@ -16,6 +16,8 @@ import indexPage from 'vault/tests/pages/settings/auth/configure/index';
 import consolePanel from 'vault/tests/pages/components/console/ui-panel';
 import { login } from 'vault/tests/helpers/auth/auth-helpers';
 
+import { GENERAL } from 'vault/tests/helpers/general-selectors';
+
 const cli = create(consolePanel);
 
 module('Acceptance | settings/auth/configure/section', function (hooks) {
@@ -66,7 +68,8 @@ module('Acceptance | settings/auth/configure/section', function (hooks) {
       await indexPage.visit({ path });
       // aws has 4 tabs, the others will have 'Configuration' and 'Method Options' tabs
       const numTabs = type === 'aws' ? 4 : 2;
-      assert.strictEqual(page.tabs.length, numTabs, 'shows correct number of tabs');
+      const tabs = findAll(GENERAL.linkTo('auth-tab'));
+      assert.strictEqual(tabs.length, numTabs, 'shows correct number of tabs');
     });
   }
 });

--- a/ui/tests/acceptance/settings/auth/enable-test.js
+++ b/ui/tests/acceptance/settings/auth/enable-test.js
@@ -11,6 +11,7 @@ import { mountBackend } from 'vault/tests/helpers/components/mount-backend-form-
 import { login } from 'vault/tests/helpers/auth/auth-helpers';
 import { deleteAuthCmd, runCmd } from 'vault/tests/helpers/commands';
 import { GENERAL } from 'vault/tests/helpers/general-selectors';
+import { AUTH_FORM } from 'vault/tests/helpers/auth/auth-form-selectors';
 
 module('Acceptance | settings/auth/enable', function (hooks) {
   setupApplicationTest(hooks);
@@ -37,7 +38,7 @@ module('Acceptance | settings/auth/enable', function (hooks) {
     );
 
     await visit('/vault/access/');
-    assert.dom(`[data-test-auth-backend-link=${path}]`).exists('mount is present in the list');
+    assert.dom(AUTH_FORM.linkedBlockAuth(path)).exists('mount is present in the list');
 
     // cleanup
     await runCmd(deleteAuthCmd(path));

--- a/ui/tests/acceptance/sidebar-nav-test.js
+++ b/ui/tests/acceptance/sidebar-nav-test.js
@@ -10,6 +10,7 @@ import { setupMirage } from 'ember-cli-mirage/test-support';
 import { login } from 'vault/tests/helpers/auth/auth-helpers';
 import modifyPassthroughResponse from 'vault/mirage/helpers/modify-passthrough-response';
 import { setRunOptions } from 'ember-a11y-testing/test-support';
+import { AUTH_FORM } from 'vault/tests/helpers/auth/auth-form-selectors';
 
 const link = (label) => `[data-test-sidebar-nav-link="${label}"]`;
 const panel = (label) => `[data-test-sidebar-nav-panel="${label}"]`;
@@ -141,7 +142,7 @@ module('Acceptance | sidebar navigation', function (hooks) {
     await click('[data-test-auth-enable]');
     assert.dom('[data-test-sidebar-nav-panel="Access"]').exists('Access nav panel renders');
     await click(link('Authentication Methods'));
-    await click('[data-test-auth-backend-link="token"]');
+    await click(AUTH_FORM.linkedBlockAuth('token'));
     await click('[data-test-configure-link]');
     assert.dom('[data-test-sidebar-nav-panel="Access"]').exists('Access nav panel renders');
   });

--- a/ui/tests/helpers/auth/auth-form-selectors.ts
+++ b/ui/tests/helpers/auth/auth-form-selectors.ts
@@ -4,19 +4,20 @@
  */
 
 export const AUTH_FORM = {
-  selectMethod: '[data-test-select="auth type"]',
-  form: '[data-test-auth-form]',
-  login: '[data-test-auth-submit]',
-  tabs: '[data-test-auth-tab]',
-  tabBtn: (method: string) => `[data-test-auth-tab="${method}"] button`, // method is all lowercased
   description: '[data-test-description]',
+  form: '[data-test-auth-form]',
+  linkedBlockAuth: (type: string) => `[data-test-auth-backend-link="${type}"]`,
+  login: '[data-test-auth-submit]',
+  selectMethod: '[data-test-select="auth type"]',
+  tabBtn: (method: string) => `[data-test-auth-tab="${method}"] button`, // method is all lowercased
+  tabs: '[data-test-auth-tab]',
   // old form toggle, will eventually be deleted
   moreOptions: '[data-test-auth-form-options-toggle]',
   // new toggle, hds component is a button
   advancedSettings: '[data-test-auth-form-options-toggle] button',
-  managedNsRoot: '[data-test-managed-namespace-root]',
-  logo: '[data-test-auth-logo]',
-  helpText: '[data-test-auth-helptext]',
   authForm: (type: string) => `[data-test-auth-form="${type}"]`,
+  helpText: '[data-test-auth-helptext]',
+  logo: '[data-test-auth-logo]',
+  managedNsRoot: '[data-test-managed-namespace-root]',
   otherMethodsBtn: '[data-test-other-methods-button]',
 };

--- a/ui/tests/helpers/general-selectors.ts
+++ b/ui/tests/helpers/general-selectors.ts
@@ -112,9 +112,10 @@ export const GENERAL = {
     select: '[data-test-kv-suggestion-select]',
   },
   // Links and buttons
-  navLink: (label: string) => `[data-test-sidebar-nav-link="${label}"]`,
   backButton: '[data-test-back-button]',
   cancelButton: '[data-test-cancel]',
+  linkTo: (label: string) => `[data-test-link-to="${label}"]`,
+  navLink: (label: string) => `[data-test-sidebar-nav-link="${label}"]`,
   saveButton: '[data-test-save]',
   testButton: (label: string) => `[data-test-button="${label}"]`,
   // Code blocks

--- a/ui/tests/pages/settings/auth/configure/section.js
+++ b/ui/tests/pages/settings/auth/configure/section.js
@@ -3,13 +3,12 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { create, clickable, visitable, collection } from 'ember-cli-page-object';
+import { create, clickable, visitable } from 'ember-cli-page-object';
 import fields from '../../../components/form-field';
 import flashMessage from '../../../components/flash-message';
 
 export default create({
   ...fields,
-  tabs: collection('[data-test-auth-section-tab]'),
   visit: visitable('/vault/settings/auth/configure/:path/:section'),
   flash: flashMessage,
   save: clickable('[data-test-save-config]'),


### PR DESCRIPTION
### Description
Attempts to fix and clean up the flaky:
```
auth backend list > auth methods are linkable and link to correct view: userpass auth method
```

- [x] ent test pass

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
