### PR TITLE
[VAULT-36271] UI: Add refresh namespaces button and breadcrumb to manage namespace page

### DIFF
--- a/changelog/30692.txt
+++ b/changelog/30692.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: Add 'Refresh list' button to the namespace list page.
+```

--- a/ui/app/controllers/vault/cluster/access/namespaces/index.js
+++ b/ui/app/controllers/vault/cluster/access/namespaces/index.js
@@ -80,7 +80,7 @@ export default class ManageNamespacesController extends Controller {
     }
   }
 
-  // Refresh the namespace list
+  @action
   async refreshNamespaceList() {
     try {
       // Await the async operation to complete

--- a/ui/app/templates/vault/cluster/access/namespaces/index.hbs
+++ b/ui/app/templates/vault/cluster/access/namespaces/index.hbs
@@ -6,7 +6,7 @@
 {{#if (has-feature "Namespaces")}}
   <PageHeader as |p|>
     <p.top>
-      <Hds::Breadcrumb data-test-breadcrumbs>
+      <Hds::Breadcrumb>
         <Hds::Breadcrumb::Item @text="Namespaces" @current={{true}} />
       </Hds::Breadcrumb>
     </p.top>

--- a/ui/app/templates/vault/cluster/access/namespaces/index.hbs
+++ b/ui/app/templates/vault/cluster/access/namespaces/index.hbs
@@ -6,7 +6,7 @@
 {{#if (has-feature "Namespaces")}}
   <PageHeader as |p|>
     <p.top>
-      <Hds::Breadcrumb>
+      <Hds::Breadcrumb data-test-breadcrumbs>
         <Hds::Breadcrumb::Item @text="Namespaces" @current={{true}} />
       </Hds::Breadcrumb>
     </p.top>
@@ -36,8 +36,9 @@
         @iconPosition="trailing"
         @text="Refresh list"
         {{on "click" this.refreshNamespaceList}}
+        data-test-button="refresh-namespace-list"
       />
-      <ToolbarLink @route="vault.cluster.access.namespaces.create" @type="add">
+      <ToolbarLink @route="vault.cluster.access.namespaces.create" @type="add" data-test-link-to="create-namespace">
         Create namespace
       </ToolbarLink>
     </ToolbarActions>

--- a/ui/app/templates/vault/cluster/access/namespaces/index.hbs
+++ b/ui/app/templates/vault/cluster/access/namespaces/index.hbs
@@ -5,6 +5,12 @@
 
 {{#if (has-feature "Namespaces")}}
   <PageHeader as |p|>
+    <p.top>
+      <Hds::Breadcrumb data-test-breadcrumbs>
+        <Hds::Breadcrumb::Item @text="Namespaces" @current={{true}} />
+      </Hds::Breadcrumb>
+    </p.top>
+
     <p.levelLeft>
       <h1 class="title is-3">
         Namespaces
@@ -23,6 +29,14 @@
       />
     </ToolbarFilters>
     <ToolbarActions>
+      <Hds::Button
+        class="has-right-margin-4"
+        @color="secondary"
+        @icon="reload"
+        @iconPosition="trailing"
+        @text="Refresh list"
+        {{on "click" this.refreshNamespaceList}}
+      />
       <ToolbarLink @route="vault.cluster.access.namespaces.create" @type="add">
         Create namespace
       </ToolbarLink>

--- a/ui/tests/acceptance/access/namespaces/index-test.js
+++ b/ui/tests/acceptance/access/namespaces/index-test.js
@@ -33,8 +33,8 @@ module('Acceptance | Enterprise | /access/namespaces', function (hooks) {
 
   test('it displays the breadcrumb trail', async function (assert) {
     await visit('/vault/access/namespaces');
-    assert.dom('.hds-breadcrumb__text').exists({ count: 1 }, 'Only one breadcrumb is displayed');
-    assert.dom('.hds-breadcrumb__text').hasText('Namespaces', 'Breadcrumb trail is displayed correctly');
+    assert.dom(GENERAL.breadcrumb).exists({ count: 1 }, 'Only one breadcrumb is displayed');
+    assert.dom(GENERAL.breadcrumb).hasText('Namespaces', 'Breadcrumb trail is displayed correctly');
   });
 
   test('it should render correct number of namespaces', async function (assert) {
@@ -49,6 +49,7 @@ module('Acceptance | Enterprise | /access/namespaces', function (hooks) {
 
   test('it should show button to refresh namespace list', async function (assert) {
     let refreshNetworkRequestTriggered;
+    const refreshNamespaceButton = GENERAL.testButton('refresh-namespace-list');
 
     this.server.get('/sys/internal/ui/namespaces', () => {
       refreshNetworkRequestTriggered = true;
@@ -56,11 +57,11 @@ module('Acceptance | Enterprise | /access/namespaces', function (hooks) {
     });
 
     await visit('/vault/access/namespaces');
-    const refreshListButton = 'nav.toolbar-actions .hds-button';
-    assert.dom(refreshListButton).hasText('Refresh list', 'Refresh button is rendered correctly');
+
+    assert.dom(refreshNamespaceButton).hasText('Refresh list', 'Refresh button is rendered correctly');
 
     refreshNetworkRequestTriggered = false;
-    await click(refreshListButton);
+    await click(refreshNamespaceButton);
     assert.true(
       refreshNetworkRequestTriggered,
       'Get namespaces network request was made when refresh button was clicked'
@@ -68,13 +69,15 @@ module('Acceptance | Enterprise | /access/namespaces', function (hooks) {
   });
 
   test('it should show button to create new namespace', async function (assert) {
+    const createNamespaceLink = GENERAL.linkTo('create-namespace');
+
     await visit('/vault/access/namespaces');
-    const createNamespaceButton = 'nav.toolbar-actions a.toolbar-link';
+
     assert
-      .dom(createNamespaceButton)
+      .dom(createNamespaceLink)
       .hasText('Create namespace', 'Create namespace button is rendered correctly');
     assert
-      .dom(createNamespaceButton)
+      .dom(createNamespaceLink)
       .hasAttribute(
         'href',
         '/ui/vault/access/namespaces/create',

--- a/ui/tests/acceptance/access/namespaces/index-test.js
+++ b/ui/tests/acceptance/access/namespaces/index-test.js
@@ -31,6 +31,12 @@ module('Acceptance | Enterprise | /access/namespaces', function (hooks) {
     );
   });
 
+  test('it displays the breadcrumb trail', async function (assert) {
+    await visit('/vault/access/namespaces');
+    assert.dom('.hds-breadcrumb__text').exists({ count: 1 }, 'Only one breadcrumb is displayed');
+    assert.dom('.hds-breadcrumb__text').hasText('Namespaces', 'Breadcrumb trail is displayed correctly');
+  });
+
   test('it should render correct number of namespaces', async function (assert) {
     assert.expect(3);
     await visit('/vault/access/namespaces');
@@ -39,6 +45,26 @@ module('Acceptance | Enterprise | /access/namespaces', function (hooks) {
     assert.strictEqual(store.peekAll('namespace').length, 15, 'Store has 15 namespaces records');
     assert.dom('.list-item-row').exists({ count: 15 }, 'Should display 15 namespaces');
     assert.dom('.hds-pagination').exists();
+  });
+
+  test('it should show button to refresh namespace list', async function (assert) {
+    let refreshNetworkRequestTriggered;
+
+    this.server.get('/sys/internal/ui/namespaces', () => {
+      refreshNetworkRequestTriggered = true;
+      return;
+    });
+
+    await visit('/vault/access/namespaces');
+    const refreshListButton = 'nav.toolbar-actions .hds-button';
+    assert.dom(refreshListButton).hasText('Refresh list', 'Refresh button is rendered correctly');
+
+    refreshNetworkRequestTriggered = false;
+    await click(refreshListButton);
+    assert.true(
+      refreshNetworkRequestTriggered,
+      'Get namespaces network request was made when refresh button was clicked'
+    );
   });
 
   test('it should show button to create new namespace', async function (assert) {


### PR DESCRIPTION
### Description
What does this PR do?
- [x] Added breadcrumb to Namespace list page for consistency with other pages
- [x] Added refresh list button to Namespace list page to manually refresh list as needed
- [x] Added test coverage
- [x] Enterprise tests passing ✅  
  > 258 tests completed in 148164 milliseconds, with 0 failed, 10 skipped, and 0 todo.
1492 assertions of 1492 passed, 0 failed.

<img width="1726" alt="Screenshot 2025-05-20 at 10 37 38 AM" src="https://github.com/user-attachments/assets/207c007f-3f44-4ecf-b36e-1d8dc2e4cb32" />


### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
