### PR TITLE
VAULT-35628: add missing change to fix ce-ent diff

### DIFF
--- a/vault/quotas/quotas_rate_limit.go
+++ b/vault/quotas/quotas_rate_limit.go
@@ -371,7 +371,7 @@ func (rlq *RateLimitQuota) allow(ctx context.Context, req *Request) (Response, e
 	if !resp.Allowed && rlq.purgeBlocked {
 		blockedAt := time.Now()
 		retryAfter = strconv.Itoa(int(time.Until(blockedAt.Add(rlq.BlockInterval)).Seconds()))
-		rlq.blockedClients.Store(req.ClientAddress, blockedAt)
+		rlq.blockedClients.Store(key, blockedAt)
 	}
 
 	return resp, nil


### PR DESCRIPTION
### Description

PR #30633 was missing commit b646694 from the ent PR, which fixed a bug with the new group_by modes in ent by updating this CE file. Not sure why my diff command didn't pick this one up.

Slack thread: [#feed-vault-ci-official](https://hashicorp.slack.com/archives/C05AABYEA9Y/p1747767517120989)
Jira: [VAULT-35628](https://hashicorp.atlassian.net/browse/VAULT-35643)

### TODO only if you're a HashiCorp employee
- [-] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [-] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [-] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [-] **RFC:** If this change has an associated RFC, please link it in the description.
- [-] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.


[VAULT-35628]: https://hashicorp.atlassian.net/browse/VAULT-35628?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ