### PR TITLE
 VAULT-36198: Add API/CLI support for reading, listing, recovering from a snapshot

### DIFF
--- a/command/base.go
+++ b/command/base.go
@@ -77,6 +77,8 @@ type BaseCommand struct {
 	tokenHelper    tokenhelper.TokenHelper
 	hcpTokenHelper hcpvlib.HCPTokenHelper
 
+	flagSnapshotID string
+
 	client *api.Client
 }
 
@@ -371,6 +373,7 @@ const (
 	FlagSetOutputField
 	FlagSetOutputFormat
 	FlagSetOutputDetailed
+	FlagSetSnapshot
 )
 
 // flagSet creates the flags for this command. The result is cached on the
@@ -612,6 +615,16 @@ func (c *BaseCommand) flagSet(bit FlagSetBit) *FlagSets {
 					Default: false,
 					EnvVar:  EnvVaultDetailed,
 					Usage:   "Enables additional metadata during some operations",
+				})
+			}
+
+			if bit&FlagSetSnapshot != 0 {
+				outputSet.StringVar(&StringVar{
+					Name:       "snapshot-id",
+					Target:     &c.flagSnapshotID,
+					Default:    "",
+					Completion: complete.PredictAnything,
+					Usage:      "ID of the loaded snapshot that this command will use",
 				})
 			}
 		}

--- a/command/read.go
+++ b/command/read.go
@@ -57,7 +57,7 @@ Usage: vault read [options] PATH
 }
 
 func (c *ReadCommand) Flags() *FlagSets {
-	return c.flagSet(FlagSetHTTP | FlagSetOutputField | FlagSetOutputFormat)
+	return c.flagSet(FlagSetHTTP | FlagSetOutputField | FlagSetOutputFormat | FlagSetSnapshot)
 }
 
 func (c *ReadCommand) AutocompleteArgs() complete.Predictor {
@@ -105,6 +105,13 @@ func (c *ReadCommand) Run(args []string) int {
 	if err != nil {
 		c.UI.Error(fmt.Sprintf("Failed to parse K=V data: %s", err))
 		return 1
+	}
+
+	if c.flagSnapshotID != "" {
+		if data == nil {
+			data = make(map[string][]string)
+		}
+		data["read_snapshot_id"] = []string{c.flagSnapshotID}
 	}
 
 	if Format(c.UI) != "raw" {


### PR DESCRIPTION
### Description
This PR adds:
* New methods in the api package to support read, list, and recover from a snapshot
* A -snapshot-id parameter that can be given to vault read and vault list to indicate that the data should be read/listed from a snapshot

Ent PR: https://github.com/hashicorp/vault-enterprise/pull/8101

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
