### PR TITLE
Inject MountPoint by SystemView, so the end user doesn't have to

### DIFF
--- a/sdk/rotation/rotation_job.go
+++ b/sdk/rotation/rotation_job.go
@@ -50,10 +50,6 @@ type RotationJobDeregisterRequest struct {
 }
 
 func (s *RotationJob) Validate() error {
-	if s.MountPoint == "" {
-		return fmt.Errorf("MountPoint is required")
-	}
-
 	if s.Path == "" {
 		return fmt.Errorf("ReqPath is required")
 	}

--- a/sdk/rotation/rotation_job_test.go
+++ b/sdk/rotation/rotation_job_test.go
@@ -19,7 +19,6 @@ func TestConfigureRotationJob(t *testing.T) {
 		{
 			name: "no rotation params",
 			req: &RotationJobConfigureRequest{
-				MountPoint:       "aws",
 				ReqPath:          "config/root",
 				RotationSchedule: "",
 				RotationWindow:   60,
@@ -28,20 +27,8 @@ func TestConfigureRotationJob(t *testing.T) {
 			expectedError: "RotationSchedule or RotationPeriod is required to set up rotation job",
 		},
 		{
-			name: "no mount point",
-			req: &RotationJobConfigureRequest{
-				MountPoint:       "",
-				ReqPath:          "config/root",
-				RotationSchedule: "",
-				RotationWindow:   60,
-				RotationPeriod:   5,
-			},
-			expectedError: "MountPoint is required",
-		},
-		{
 			name: "no req path",
 			req: &RotationJobConfigureRequest{
-				MountPoint:       "aws",
 				ReqPath:          "",
 				RotationSchedule: "",
 				RotationWindow:   60,

--- a/vault/dynamic_system_view.go
+++ b/vault/dynamic_system_view.go
@@ -362,6 +362,9 @@ func (d dynamicSystemView) RegisterRotationJob(ctx context.Context, req *rotatio
 	}
 	nsCtx := namespace.ContextWithNamespace(ctx, mountEntry.Namespace())
 
+	// set mount point
+	req.MountPoint = mountEntry.Path
+
 	job, err := rotation.ConfigureRotationJob(req)
 	if err != nil {
 		return "", fmt.Errorf("error configuring rotation job: %s", err)

--- a/vault/dynamic_system_view.go
+++ b/vault/dynamic_system_view.go
@@ -363,9 +363,7 @@ func (d dynamicSystemView) RegisterRotationJob(ctx context.Context, req *rotatio
 	nsCtx := namespace.ContextWithNamespace(ctx, mountEntry.Namespace())
 
 	// set mount point
-	if req.MountPoint == "" {
-		req.MountPoint = mountEntry.Path
-	}
+	req.MountPoint = mountEntry.Path
 
 	job, err := rotation.ConfigureRotationJob(req)
 	if err != nil {
@@ -388,9 +386,7 @@ func (d dynamicSystemView) DeregisterRotationJob(ctx context.Context, req *rotat
 	}
 	nsCtx := namespace.ContextWithNamespace(ctx, mountEntry.Namespace())
 
-	if req.MountPoint == "" {
-		req.MountPoint = mountEntry.Path
-	}
+	req.MountPoint = mountEntry.Path
 
 	return d.core.DeregisterRotationJob(nsCtx, req)
 }

--- a/vault/dynamic_system_view.go
+++ b/vault/dynamic_system_view.go
@@ -388,5 +388,9 @@ func (d dynamicSystemView) DeregisterRotationJob(ctx context.Context, req *rotat
 	}
 	nsCtx := namespace.ContextWithNamespace(ctx, mountEntry.Namespace())
 
+	if req.MountPoint == "" {
+		req.MountPoint = mountEntry.Path
+	}
+
 	return d.core.DeregisterRotationJob(nsCtx, req)
 }

--- a/vault/dynamic_system_view.go
+++ b/vault/dynamic_system_view.go
@@ -363,7 +363,9 @@ func (d dynamicSystemView) RegisterRotationJob(ctx context.Context, req *rotatio
 	nsCtx := namespace.ContextWithNamespace(ctx, mountEntry.Namespace())
 
 	// set mount point
-	req.MountPoint = mountEntry.Path
+	if req.MountPoint == "" {
+		req.MountPoint = mountEntry.Path
+	}
 
 	job, err := rotation.ConfigureRotationJob(req)
 	if err != nil {


### PR DESCRIPTION
### Description
This PR updates the RegisterRotationJob and DeregisterRotationJob to automatically supply the mount point. No component of this value is determined by the plugin, so it's really only possible for the plugin to set it incorrectly.

I also considered a version where we only override the mount point if the plugin doesn't set something, but as above, I think there's really only two possibilities if the plugin sets it - 1) it's the same as what the dynamic system view knows, or 2) wrong.

In the long run we might want to try to figure out a way for the plugin to not even see the field, but the request structure is defined in the sdk and DynamicSystemView is in core, so it's not immediately apparent a way to do that without a larger code change.

This PR wants tests, but since in CE these functions immediately run into the stub RotationManager, it might be better to put the tests in Enterprise.

I have taken the liberty of requesting review from @vinay-gopalan, who i recall running into some difficulties with getting the mountPoint to the RotationManager, and @fairclothjm who suggested this change.