### PR TITLE
UI: Render line breaks for mount description in login form

### DIFF
--- a/ui/app/styles/helper-classes/general.scss
+++ b/ui/app/styles/helper-classes/general.scss
@@ -7,7 +7,9 @@
 
 // box-shadow helpers
 .has-only-top-shadow {
-  box-shadow: 0 -1px 0 -1px $grey-light, 0 -2px 0 -1px $grey-light;
+  box-shadow:
+    0 -1px 0 -1px $grey-light,
+    0 -2px 0 -1px $grey-light;
 }
 
 .is-shadowless {
@@ -15,7 +17,9 @@
 }
 
 .is-sideless {
-  box-shadow: 0 2px 0 -1px $grey-light, 0 -2px 0 -1px $grey-light;
+  box-shadow:
+    0 2px 0 -1px $grey-light,
+    0 -2px 0 -1px $grey-light;
 }
 
 // this helper needs to go after is-sideless as they are often used together and is-bottomless needs to override is-sideless (no this is not ideal).
@@ -55,6 +59,10 @@
   & svg {
     fill: currentColor;
   }
+}
+
+.white-space-pre-line {
+  white-space: pre-line;
 }
 
 // large grouped css blocks

--- a/ui/app/templates/components/auth-form.hbs
+++ b/ui/app/templates/components/auth-form.hbs
@@ -45,7 +45,7 @@
     {{#if this.selectedAuthBackend.path}}
       <div class="has-bottom-margin-s">
         <p class="is-label">{{this.selectedAuthBackend.path}}</p>
-        <span class="description has-text-grey" data-test-description={{true}}>
+        <span class="description has-text-grey white-space-pre-line" data-test-description={{true}}>
           {{this.selectedAuthBackend.mountDescription}}
         </span>
       </div>


### PR DESCRIPTION
### Description
Previously, if a mount description has a line break `\n` in it the UI ignored it. Now it doesn't. 
```
{
    "auth": {
        "userpass/": {
            "description": "this is my long description with \nline breaks\nhellloooooo",
            "options": {},
            "type": "userpass"
        }
    },
}
```
### before
<img width="450" alt="Screenshot 2025-05-21 at 12 01 35 PM" src="https://github.com/user-attachments/assets/195e2e1c-3e67-45cf-a3ca-ef57fe85bc78" />

### after
<img width="450" alt="Screenshot 2025-05-21 at 12 01 07 PM" src="https://github.com/user-attachments/assets/bc90fc5c-e840-4288-bd2c-4c015b3b81f6" />


### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
