### PR TITLE
Add 192 to the list of key sizes supported in the docs.

### DIFF
--- a/website/content/api-docs/secret/transit.mdx
+++ b/website/content/api-docs/secret/transit.mdx
@@ -66,6 +66,7 @@ values set here cannot be changed after key creation.
   - `hmac` - HMAC (HMAC generation, verification)
   - `managed_key` - External key configured via the [Managed Keys](/vault/docs/enterprise/managed-keys) feature (enterprise only)
   - `aes128-cmac` - AES-128 CMAC (CMAC generation, verification) <EnterpriseAlert inline="true" />
+  - `aes192-cmac` - AES-192 CMAC (CMAC generation, verification) <EnterpriseAlert inline="true" />
   - `aes256-cmac` - AES-256 CMAC (CMAC generation, verification) <EnterpriseAlert inline="true" />
   - `ml-dsa` - ML-DSA (asymmetric) (experimental) <EnterpriseAlert inline="true" />
   - `hybrid` - hybrid signatures combining a post-quantum algorithm and an elliptic curve algorithm (asymmetric) (experimental) <EnterpriseAlert inline="true" />
@@ -183,6 +184,7 @@ the hash function defaults to SHA256.
   - `rsa-3072` - RSA with bit size of 3072 (asymmetric)
   - `rsa-4096` - RSA with bit size of 4096 (asymmetric)
   - `aes128-cmac` - AES-128 CMAC (CMAC generation, verification) <EnterpriseAlert inline="true" />
+  - `aes192-cmac` - AES-192 CMAC (CMAC generation, verification) <EnterpriseAlert inline="true" />
   - `aes256-cmac` - AES-256 CMAC (CMAC generation, verification) <EnterpriseAlert inline="true" />
 
 - `public_key` `(string: "", optional)` - A plaintext PEM public key to be

--- a/website/content/docs/secrets/transit/index.mdx
+++ b/website/content/docs/secrets/transit/index.mdx
@@ -89,6 +89,7 @@ types also generate separate HMAC keys):
   backing key management solution. See [Managed Keys](/vault/docs/enterprise/managed-keys)
   for more information. <EnterpriseAlert inline="true" />
 - `aes128-cmac`: CMAC with a 128-bit AES key; supporting CMAC generation and verification. <EnterpriseAlert inline="true" />
+- `aes192-cmac`: CMAC with a 192-bit AES key; supporting CMAC generation and verification. <EnterpriseAlert inline="true" />
 - `aes256-cmac`: CMAC with a 256-bit AES key; supporting CMAC generation and verification. <EnterpriseAlert inline="true" />
 - `ml-dsa` - ML-DSA; supports signing and signature verification (experimental) <EnterpriseAlert inline="true" />
 - `hybrid` - combination of two signature algorithms; supports signing and signature verification (experimental) <EnterpriseAlert inline="true" />


### PR DESCRIPTION
### Description
Docs update, based on work: https://github.com/hashicorp/vault-enterprise/pull/8126

### TODO only if you're a HashiCorp employee
- Not a backported change, so no need to backport docs
- Doesn't touch any functions - backported or not
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name: https://hashicorp.atlassian.net/browse/VAULT-35005
- No RFC
- ? **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR. - not sure why the changelog would be here - this is entirely an ent change: https://github.com/hashicorp/vault-enterprise/pull/8126
