### PR TITLE
CE-changes for ent-feature AES192-CMAC for transit.

### DIFF
--- a/builtin/logical/transit/path_byok.go
+++ b/builtin/logical/transit/path_byok.go
@@ -159,7 +159,7 @@ func getBYOKExportKey(dstP *keysutil.Policy, srcP *keysutil.Policy, key *keysuti
 
 	var targetKey interface{}
 	switch srcP.Type {
-	case keysutil.KeyType_AES128_GCM96, keysutil.KeyType_AES256_GCM96, keysutil.KeyType_ChaCha20_Poly1305, keysutil.KeyType_HMAC, keysutil.KeyType_AES128_CMAC, keysutil.KeyType_AES256_CMAC:
+	case keysutil.KeyType_AES128_GCM96, keysutil.KeyType_AES256_GCM96, keysutil.KeyType_ChaCha20_Poly1305, keysutil.KeyType_HMAC, keysutil.KeyType_AES128_CMAC, keysutil.KeyType_AES256_CMAC, keysutil.KeyType_AES192_CMAC:
 		targetKey = key.Key
 	case keysutil.KeyType_RSA2048, keysutil.KeyType_RSA3072, keysutil.KeyType_RSA4096:
 		targetKey = key.RSAKey

--- a/builtin/logical/transit/path_export.go
+++ b/builtin/logical/transit/path_export.go
@@ -289,7 +289,7 @@ func getExportKey(policy *keysutil.Policy, key *keysutil.KeyEntry, exportType st
 		return certChain, nil
 	case exportTypeCMACKey:
 		switch policy.Type {
-		case keysutil.KeyType_AES128_CMAC, keysutil.KeyType_AES256_CMAC:
+		case keysutil.KeyType_AES128_CMAC, keysutil.KeyType_AES256_CMAC, keysutil.KeyType_AES192_CMAC:
 			return strings.TrimSpace(base64.StdEncoding.EncodeToString(key.Key)), nil
 		}
 	}

--- a/builtin/logical/transit/path_import.go
+++ b/builtin/logical/transit/path_import.go
@@ -46,7 +46,8 @@ func (b *backend) pathImport() *framework.Path {
 				Default: "aes256-gcm96",
 				Description: `The type of key being imported. Currently, "aes128-gcm96" (symmetric), "aes256-gcm96" (symmetric), "ecdsa-p256"
 (asymmetric), "ecdsa-p384" (asymmetric), "ecdsa-p521" (asymmetric), "ed25519" (asymmetric), "rsa-2048" (asymmetric), "rsa-3072"
-(asymmetric), "rsa-4096" (asymmetric), "ml-dsa-44 (asymmetric)", "ml-dsa-65 (asymmetric)", "ml-dsa-87 (asymmetric)", "hmac", "aes128-cmac", "aes256-cmac" are supported.  Defaults to "aes256-gcm96".
+(asymmetric), "rsa-4096" (asymmetric), "ml-dsa-44 (asymmetric)", "ml-dsa-65 (asymmetric)", "ml-dsa-87 (asymmetric)", "hmac", "aes128-cmac", 
+"aes192-cmac", aes256-cmac" are supported.  Defaults to "aes256-gcm96".
 `,
 			},
 			"hash_function": {
@@ -219,6 +220,8 @@ func (b *backend) pathImportWrite(ctx context.Context, req *logical.Request, d *
 		polReq.KeyType = keysutil.KeyType_AES128_CMAC
 	case "aes256-cmac":
 		polReq.KeyType = keysutil.KeyType_AES256_CMAC
+	case "aes192-cmac":
+		polReq.KeyType = keysutil.KeyType_AES192_CMAC
 	default:
 		return logical.ErrorResponse(fmt.Sprintf("unknown key type: %v", keyType)), logical.ErrInvalidRequest
 	}

--- a/builtin/logical/transit/path_keys.go
+++ b/builtin/logical/transit/path_keys.go
@@ -243,6 +243,8 @@ func (b *backend) pathPolicyWrite(ctx context.Context, req *logical.Request, d *
 		polReq.KeyType = keysutil.KeyType_MANAGED_KEY
 	case "aes128-cmac":
 		polReq.KeyType = keysutil.KeyType_AES128_CMAC
+	case "aes192-cmac":
+		polReq.KeyType = keysutil.KeyType_AES192_CMAC
 	case "aes256-cmac":
 		polReq.KeyType = keysutil.KeyType_AES256_CMAC
 	case "ml-dsa":

--- a/builtin/logical/transit/path_keys_test.go
+++ b/builtin/logical/transit/path_keys_test.go
@@ -238,6 +238,10 @@ func TestTransit_CreateKey(t *testing.T) {
 			creationParams: map[string]interface{}{"type": "aes128-cmac"},
 			entOnly:        true,
 		},
+		"AES-192 CMAC": {
+			creationParams: map[string]interface{}{"type": "aes192-cmac"},
+			entOnly:        true,
+		},
 		"AES-256 CMAC": {
 			creationParams: map[string]interface{}{"type": "aes256-cmac"},
 			entOnly:        true,

--- a/builtin/logical/transit/path_sign_verify_ce.go
+++ b/builtin/logical/transit/path_sign_verify_ce.go
@@ -73,7 +73,7 @@ func _forbidEd25519EntBehavior(p *keysutil.Policy, apiArgs commonSignVerifyApiAr
 
 func _validateEntSpecificKeyType(p *keysutil.Policy) error {
 	switch p.Type {
-	case keysutil.KeyType_AES128_CMAC, keysutil.KeyType_AES256_CMAC, keysutil.KeyType_MANAGED_KEY:
+	case keysutil.KeyType_AES128_CMAC, keysutil.KeyType_AES256_CMAC, keysutil.KeyType_AES192_CMAC, keysutil.KeyType_MANAGED_KEY:
 		return fmt.Errorf("enterprise specific key type %q can not be used on CE", p.Type)
 	default:
 		return nil

--- a/sdk/helper/keysutil/lock_manager.go
+++ b/sdk/helper/keysutil/lock_manager.go
@@ -408,7 +408,7 @@ func (lm *LockManager) GetPolicy(ctx context.Context, req PolicyRequest, rand io
 				return nil, false, fmt.Errorf("key derivation and convergent encryption not supported for keys of type %v", req.KeyType)
 			}
 
-		case KeyType_AES128_CMAC, KeyType_AES256_CMAC:
+		case KeyType_AES128_CMAC, KeyType_AES256_CMAC, KeyType_AES192_CMAC:
 			if req.Derived || req.Convergent {
 				cleanup()
 				return nil, false, fmt.Errorf("key derivation and convergent encryption not supported for keys of type %v", req.KeyType)

--- a/sdk/helper/keysutil/policy_test.go
+++ b/sdk/helper/keysutil/policy_test.go
@@ -37,7 +37,7 @@ var allTestKeyTypes = []KeyType{
 	KeyType_AES256_GCM96, KeyType_ECDSA_P256, KeyType_ED25519, KeyType_RSA2048,
 	KeyType_RSA4096, KeyType_ChaCha20_Poly1305, KeyType_ECDSA_P384, KeyType_ECDSA_P521, KeyType_AES128_GCM96,
 	KeyType_RSA3072, KeyType_MANAGED_KEY, KeyType_HMAC, KeyType_AES128_CMAC, KeyType_AES256_CMAC, KeyType_ML_DSA,
-	KeyType_HYBRID,
+	KeyType_HYBRID, KeyType_AES192_CMAC,
 }
 
 func TestPolicy_KeyTypes(t *testing.T) {
@@ -67,7 +67,7 @@ func TestPolicy_HmacCmacSupported(t *testing.T) {
 			if keyType.CMACSupported() {
 				t.Fatalf("cmac should not have been be supported for keytype %s", keyType.String())
 			}
-		case KeyType_AES128_CMAC, KeyType_AES256_CMAC:
+		case KeyType_AES128_CMAC, KeyType_AES256_CMAC, KeyType_AES192_CMAC:
 			if keyType.HMACSupported() {
 				t.Fatalf("hmac should have been not be supported for keytype %s", keyType.String())
 			}


### PR DESCRIPTION
### Description
CE-changes makes AES192-CMAC work in enterprise.

### TODO only if you're a HashiCorp employee
- no backports necessary.
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying this patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files. 
-- no signature is changed by these change
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name: https://hashicorp.atlassian.net/browse/VAULT-35005
- No RFC
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
-- this is the corresponding CE PR to : https://github.com/hashicorp/vault-enterprise/pull/8126/files
-- this is a ent-feature, so changelog is in ent.