### PR TITLE
Exclude wrapping key from list operation

### DIFF
--- a/builtin/logical/transit/path_keys.go
+++ b/builtin/logical/transit/path_keys.go
@@ -180,9 +180,9 @@ func (b *backend) pathKeysList(ctx context.Context, req *logical.Request, d *fra
 		return nil, err
 	}
 
-	// filter out partial path of wrapping key
+	// filter out partial paths
 	entries = slices.DeleteFunc(entries, func(s string) bool {
-		if s == "import/" {
+		if strings.HasSuffix(s, "/") {
 			return true
 		}
 

--- a/builtin/logical/transit/path_keys.go
+++ b/builtin/logical/transit/path_keys.go
@@ -9,6 +9,7 @@ import (
 	"encoding/base64"
 	"encoding/pem"
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -178,6 +179,15 @@ func (b *backend) pathKeysList(ctx context.Context, req *logical.Request, d *fra
 	if err != nil {
 		return nil, err
 	}
+
+	// filter out partial path of wrapping key
+	entries = slices.DeleteFunc(entries, func(s string) bool {
+		if s == "import/" {
+			return true
+		}
+
+		return false
+	})
 
 	return logical.ListResponse(entries), nil
 }

--- a/changelog/30728.txt
+++ b/changelog/30728.txt
@@ -1,0 +1,3 @@
+```release-note: improvement
+transit: Exclude the partial wrapping key path from the transit/keys LIST operation.
+```


### PR DESCRIPTION
### Description
Storing the wrapping key for BYOK is causing a key named `import/` to appear when listing keys. This PR excludes that entry from the list operation

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
