### PR TITLE
VAULT-35083: CE changes for recover, read, list from snapshot

### DIFF
--- a/vault/logical_cubbyhole.go
+++ b/vault/logical_cubbyhole.go
@@ -25,6 +25,9 @@ func CubbyholeBackendFactory(ctx context.Context, conf *logical.BackendConfig) (
 	}
 
 	b.Backend.Paths = append(b.Backend.Paths, b.paths()...)
+	b.Backend.PathsSpecial = &logical.Paths{
+		AllowSnapshotRead: []string{"*"},
+	}
 
 	if conf == nil {
 		return nil, fmt.Errorf("configuration passed into backend is nil")
@@ -98,6 +101,13 @@ func (b *CubbyholeBackend) paths() []*framework.Path {
 					},
 					Summary:     "List secret entries at the specified location.",
 					Description: "Folders are suffixed with /. The input must be a folder; list on a file will not return a value. The values themselves are not accessible via this command.",
+				},
+				logical.RecoverOperation: &framework.PathOperation{
+					Callback: b.handleWrite,
+					DisplayAttrs: &framework.DisplayAttributes{
+						OperationVerb: "recover",
+					},
+					Summary: "Recover a secret at the specified location.",
 				},
 			},
 

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -677,8 +677,12 @@ func (c *Core) mountInternal(ctx context.Context, entry *MountEntry, updateStora
 		return fmt.Errorf("error creating forwarded writer: %v", err)
 	}
 
+	// add the snapshot storage router, which will use the context to determine
+	// whether a read will be from a snapshot or from the normal barrier storage
+	router := newSnapshotStorageRouter(c, forwarded)
+
 	viewPath := entry.ViewPath()
-	view := NewBarrierView(forwarded, viewPath)
+	view := NewBarrierView(router, viewPath)
 
 	// Singleton mounts cannot be filtered manually on a per-secondary basis
 	// from replication.
@@ -1525,8 +1529,10 @@ func (c *Core) setupMounts(ctx context.Context) error {
 			return fmt.Errorf("error creating forwarded writer: %v", err)
 		}
 
+		storageRouter := newSnapshotStorageRouter(c, forwarded)
+
 		// Create a barrier storage view using the UUID
-		view := NewBarrierView(forwarded, barrierPath)
+		view := NewBarrierView(storageRouter, barrierPath)
 
 		// Singleton mounts cannot be filtered manually on a per-secondary basis
 		// from replication

--- a/vault/mount_util.go
+++ b/vault/mount_util.go
@@ -76,3 +76,7 @@ func (c *Core) mountEntrySysView(entry *MountEntry) extendedSystemView {
 func (c *Core) entBuiltinPluginMetrics(ctx context.Context, entry *MountEntry, val float32) error {
 	return nil
 }
+
+func newSnapshotStorageRouter(c *Core, storage logical.Storage) logical.Storage {
+	return storage
+}

--- a/vault/plugin_reload.go
+++ b/vault/plugin_reload.go
@@ -288,6 +288,11 @@ func (c *Core) reloadBackendCommon(ctx context.Context, entry *MountEntry, isAut
 				return err
 			}
 			re.binaryPaths.Store(binaryPathsEntry)
+			allowSnapshotReadPathsEntry, err := parseUnauthenticatedPaths(paths.AllowSnapshotRead)
+			if err != nil {
+				return err
+			}
+			re.allowSnapshotReadPaths.Store(allowSnapshotReadPathsEntry)
 		}
 	}
 

--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -633,6 +633,19 @@ func (c *Core) handleCancelableRequest(ctx context.Context, req *logical.Request
 	var entry *MountEntry
 	req.MountPoint, entry = c.router.MatchingMountAndEntry(ctx, req.Path)
 
+	// If the request requires a snapshot ID, we need to perform checks to
+	// ensure the request is valid and lock the snapshot, so it doesn't get
+	// unloaded while the request is being processed.
+	if req.RequiresSnapshotID != "" {
+		if c.perfStandby {
+			return nil, logical.ErrPerfStandbyPleaseForward
+		}
+		unlockSnapshot, err := c.lockSnapshotForRequest(ctx, req, entry)
+		if err != nil {
+			return logical.ErrorResponse("unable to lock snapshot: " + err.Error()), err
+		}
+		defer unlockSnapshot()
+	}
 	// Allowing writing to a path ending in / makes it extremely difficult to
 	// understand user intent for the filesystem-like backends (kv,
 	// cubbyhole) -- did they want a key named foo/ or did they want to write
@@ -642,7 +655,8 @@ func (c *Core) handleCancelableRequest(ctx context.Context, req *logical.Request
 	if strings.HasSuffix(req.Path, "/") &&
 		(req.Operation == logical.UpdateOperation ||
 			req.Operation == logical.CreateOperation ||
-			req.Operation == logical.PatchOperation) {
+			req.Operation == logical.PatchOperation ||
+			req.Operation == logical.RecoverOperation) {
 		if entry == nil || !entry.Config.TrimRequestTrailingSlashes {
 			return logical.ErrorResponse("cannot write to a path ending in '/'"), nil
 		} else {
@@ -1186,6 +1200,34 @@ func (c *Core) handleRequest(ctx context.Context, req *logical.Request) (retResp
 		}
 	}()
 
+	// This context value will be empty if it's a request that doesn't require a
+	// snapshot. This is done on purpose and handled in the
+	// SnapshotStorageRouter
+	ctx = logical.CreateContextWithSnapshotID(ctx, req.RequiresSnapshotID)
+
+	// recover operations require 2 steps
+	if req.Operation == logical.RecoverOperation {
+		// first do a read operation
+		// this will use the snapshot's storage
+		req.Operation = logical.ReadOperation
+		resp, err := c.doRouting(ctx, req)
+		if err != nil {
+			return nil, auth, err
+		}
+		if resp == nil {
+			return logical.ErrorResponse("no data in the snapshot"), auth, err
+		}
+		if resp.IsError() {
+			return resp, auth, err
+		}
+		// use the response as the data in a recover operation
+		// set the snapshot ID context value to the empty string to ensure that
+		// the write goes to the real storage
+		req.Operation = logical.RecoverOperation
+		req.Data = resp.Data
+		ctx = logical.CreateContextWithSnapshotID(ctx, "")
+	}
+
 	// Route the request
 	resp, routeErr := c.doRouting(ctx, req)
 	if resp != nil {
@@ -1270,18 +1312,24 @@ func (c *Core) handleRequest(ctx context.Context, req *logical.Request) (retResp
 			} else if matchingMountEntry.Options == nil || matchingMountEntry.Options["leased_passthrough"] != "true" {
 				registerLease = false
 				resp.Secret.Renewable = false
+			} else if req.IsSnapshotReadOrList() {
+				registerLease = false
+				resp.Secret.Renewable = false
 			}
 
 		case "plugin":
 			// If we are a plugin type and the plugin name is "kv" check the
 			// mount entry options.
-			if matchingMountEntry.Config.PluginName == "kv" && (matchingMountEntry.Options == nil || matchingMountEntry.Options["leased_passthrough"] != "true") {
+			if matchingMountEntry.Config.PluginName == "kv" && (matchingMountEntry.Options == nil || matchingMountEntry.Options["leased_passthrough"] != "true" || req.IsSnapshotReadOrList()) {
 				registerLease = false
 				resp.Secret.Renewable = false
 			}
 		}
 
 		if registerLease {
+			if req.IsSnapshotReadOrList() {
+				return logical.ErrorResponse("cannot register lease for snapshot read or list"), nil, ErrInternalError
+			}
 			sysView := c.router.MatchingSystemView(ctx, req.Path)
 			if sysView == nil {
 				c.logger.Error("unable to look up sys view for login path", "request_path", req.Path)

--- a/vault/request_handling_util.go
+++ b/vault/request_handling_util.go
@@ -7,6 +7,7 @@ package vault
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"time"
 
@@ -83,4 +84,8 @@ func possiblyForwardSaveCachedAuthResponse(ctx context.Context, c *Core, respAut
 
 func forwardCreateTokenRegisterAuth(ctx context.Context, c *Core, te *logical.TokenEntry, roleName string, renewable bool, periodToUse, explicitMaxTTLToUse time.Duration) (*logical.TokenEntry, error) {
 	return nil, nil
+}
+
+func (c *Core) lockSnapshotForRequest(ctx context.Context, req *logical.Request, entry *MountEntry) (func(), error) {
+	return nil, errors.New("loaded snapshots not supported")
 }

--- a/vault/wrapping.go
+++ b/vault/wrapping.go
@@ -130,6 +130,13 @@ DONELISTHANDLING:
 		}
 	}
 
+	// If the response is from a snapshot read or list, we need to make sure
+	// that hte wrapped value is written to real storage, not to the snapshot
+	// storage
+	if req.IsSnapshotReadOrList() {
+		ctx = logical.CreateContextWithSnapshotID(ctx, "")
+	}
+
 	// If we are wrapping, the first part (performed in this functions) happens
 	// before auditing so that resp.WrapInfo.Token can contain the HMAC'd
 	// wrapping token ID in the audit logs, so that it can be determined from


### PR DESCRIPTION
### Description
This PR adds the CE changes needed to support snapshot operations

Ent PR: https://github.com/hashicorp/vault-enterprise/pull/8110

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
