### PR TITLE
Add the new metrics to the table for census

### DIFF
--- a/website/content/docs/license/product-usage-reporting.mdx
+++ b/website/content/docs/license/product-usage-reporting.mdx
@@ -192,7 +192,7 @@ All of these metrics are numerical, and contain no sensitive values or additiona
 | `vault.pki.issuers.count`                                           | The total issuers from all PKI mounts across all namespaces.                                               |
 | `vault.identity.case_sensitive_mode`                                | Whether or not the cluster is using case-sensitive identity name matching caused by historical duplicates. |
 | `vault.identity.force_deduplication_activated`                      | Whether or not the cluster has had the force_identity_deduplication activation flag activated.             |
-| `vault.ui.enabled`                                                  | Whether the UI is enabled.                                                                                 |
+| `vault.ui.enabled`                                                  | Whether or not the UI is enabled on the cluster.                                                           |
 | `vault.ui.custom_banners.authenticated`                             | How many authenticated custom banners have been enabled across all namespaces.                             |
 | `vault.ui.custom_banners.unauthenticated`                           | How many unauthenticated custom banners have been enabled across all namespaces.                           |
 | `vault.storage.max_entry_size`                                      | The value of `max_entry_size` parameter for the storage stanza in the config.                              |
@@ -202,12 +202,18 @@ All of these metrics are numerical, and contain no sensitive values or additiona
 | `vault.replication.auth.local_mounts`                               | The number of local auth mounts on Enterprise clusters.                                                    |
 | `vault.replication.auth.non_local_mounts`                           | The number of replicated auth mounts on Enterprise clusters.                                               |
 | `vault.replication.num_nodes`                                       | The number of nodes in a HA cluster.                                                                       |
-| `vault.enterprise.aop_enabled`                                      | Whether Adaptive Overload Protection is enabled on Enterprise clusters.                                    |
-| `vault.policies.count.egp`                                          | The total number of Enterprise Governance Policies (EGP) across all namespaces in Vault.                   |
-| `vault.policies.count.rgp`                                          | The total number of Replication Governance Policies (RGP) across all namespaces in Vault.                  |
-| `vault.policies.count.acl`                                          | The total number of Access Control List (ACL) policies across all namespaces in Vault.                     |
-
-
+| `vault.adaptive_overload_protection_enabled`                        | Whether or not Adaptive Overload Protection is enabled on the cluster.                                     |
+| `vault.policies.egp.count`                                          | The total number of Enterprise Governance Policies (EGP) across all namespaces in Vault.                   |
+| `vault.policies.rgp.count`                                          | The total number of Replication Governance Policies (RGP) across all namespaces in Vault.                  |
+| `vault.policies.acl.count`                                          | The total number of Access Control List (ACL) policies across all namespaces in Vault.                     |
+| `vault.policies.acl.control_group.count`                            | The total number of control groups in this cluster.                                                        |
+| `vault.autopilot_upgrade_enabled`                                   | Whether or not Autopilot Upgrade is enabled on the cluster.                                                |
+| `vault.audit.device.file.count`                                     | The total number of audit devices of type file configured for this cluster.                                |
+| `vault.audit.device.syslog.count`                                   | The total total number of audit devices of type syslog configured for this cluster.                        |
+| `vault.audit.device.socket.udp.count`                               | The total total number of audit devices of type UDP socket configured for this cluster.                    |
+| `vault.audit.device.socket.tcp.count`                               | The total total number of audit devices of type TCP socket configured for this cluster.                    |
+| `vault.audit.device.socket.unix.count`                              | The total total number of audit devices of type UNIX socket configured for this cluster.                   |
+| `vault.audit.exclusion.stanza.count`                                | The total number of audit exclusion stanzas in the HCL configuration for this cluster.                     |
 
 ## Usage metadata list
 


### PR DESCRIPTION
### Description
What does this PR do?
This PR adds the new metrics to the table. This includes: autopilot upgrade enabled or not, audit, and control groups. There metrics were added before.


### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
