### PR TITLE
Backport Refactor release security scan config (#30597) into release/1.19.x

### DIFF
--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -2,22 +2,32 @@
 # SPDX-License-Identifier: BUSL-1.1
 
 binary {
-  secrets    = false
-  go_modules = false
-  osv        = true
-  oss_index  = true
-  nvd        = false
-}
-
-container {
-  dependencies    = true
-  alpine_security = true
-  secrets         = true
+  go_stdlib  = true // Scan the Go standard library used to build the binary.
+  go_modules = true // Scan the Go modules included in the binary.
+  osv        = true // Use the OSV vulnerability database.
+  oss_index  = true // And use OSS Index vulnerability database.
 
   triage {
     suppress {
       vulnerabilities = [
-        // We can't do anything about these two CVE's until a new Alpine container with busybox 1.38 is available.
+        "GO-2022-0635", // github.com/aws/aws-sdk-go@v1.x
+      ]
+    }
+  }
+}
+
+container {
+  dependencies = true // Scan any installed packages for vulnerabilities.
+  osv          = true // Use the OSV vulnerability database.
+
+  secrets {
+    all = true
+  }
+
+  triage {
+    suppress {
+      vulnerabilities = [
+        // We can't do anything about these two CVEs until a new Alpine container with busybox 1.38 is available.
         "CVE-2025-46394",
         "CVE-2024-58251",
         "GO-2022-0635", // github.com/aws/aws-sdk-go@v1.x


### PR DESCRIPTION
### Description
Manual backport of https://github.com/hashicorp/vault/pull/30597

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
