### PR TITLE
Add example policy to AWS secrets engine for AssumeRole that will still be able to rotate itself

### DIFF
--- a/website/content/docs/secrets/aws.mdx
+++ b/website/content/docs/secrets/aws.mdx
@@ -335,9 +335,9 @@ For more details on rotating root credentials in the AWS Secrets engine, refer t
 
 ## IAM permissions policy for Vault
 
-The `aws/config/root` credentials need permission to manage dynamic IAM users.
-Here is an example AWS IAM policy that grants the most commonly required
-permissions Vault needs:
+When using `credential_type=iam_user`, the `aws/config/root` credentials need
+permission to manage dynamic IAM users. Here is an example AWS IAM policy that
+grants the most commonly required permissions Vault needs:
 
 ```json
 {
@@ -419,6 +419,30 @@ where the "iam:PermissionsBoundary" condition contains the list of permissions
 boundary policies that you wish to ensure that Vault uses. This policy will
 ensure that Vault uses one of the permissions boundaries specified (not all of
 them).
+
+### Policies for STS credentials
+When using the STS `credential_type`s (`assumed_role`, `session_token`, or `federation_token`), the `aws/config/root` credentials
+do not require the above permissions to manage IAM users. However, in order for to use
+[the rotate endpoint](/vault/api-docs/secret/aws#rotate-root-iam-credentials) to rotate the credentials themselves,
+the following permissions are required:
+
+```json
+{
+  "Statement": [
+    {
+      "Action": [
+        "iam:ListAccessKeys",
+        "iam:GetUser",
+        "iam:DeleteAccessKey",
+        "iam:CreateAccessKey"
+      ],
+      "Effect": "Allow",
+      "Resource": "arn:aws:iam::590184029125:user/vault-root-admin-live-Cloud-Operations-"
+    }
+  ],
+  "Version": "2012-10-17"
+}
+```
 
 ## Plugin Workload Identity Federation (WIF)
 


### PR DESCRIPTION
### Description
Adds documentation and an example policy for STS credential types to be able to rotate themselves.

