### PR TITLE
UI: Improve namespace input UX 

### DIFF
--- a/ui/app/components/auth/form-template.hbs
+++ b/ui/app/components/auth/form-template.hbs
@@ -13,14 +13,7 @@
       @onSuccess={{@onSuccess}}
     >
       <:namespace>
-        {{#if (has-feature "Namespaces")}}
-          <Auth::NamespaceInput
-            @disabled={{@oidcProviderQueryParam}}
-            @hvdManagedNamespace={{this.flags.hvdManagedNamespaceRoot}}
-            @namespaceValue={{this.namespaceInput}}
-            @updateNamespace={{this.handleNamespaceUpdate}}
-          />
-        {{/if}}
+        {{yield}}
       </:namespace>
 
       <:back>

--- a/ui/app/components/auth/namespace-input.hbs
+++ b/ui/app/components/auth/namespace-input.hbs
@@ -4,14 +4,14 @@
 }}
 
 <div class="background-neutral-50 has-padding-l">
-  {{#if @hvdManagedNamespace}}
+  {{#if this.flags.hvdManagedNamespaceRoot}}
     <Hds::Form::Field @layout="vertical" disabled={{@disabled}} as |F|>
       <F.Label>Namespace</F.Label>
       <F.Control>
         <Hds::SegmentedGroup class="is-fullwidth" as |SG|>
           <SG.TextInput
             @type="text"
-            @value="/{{@hvdManagedNamespace}}"
+            @value="/{{this.flags.hvdManagedNamespaceRoot}}"
             aria-label="Root namespace for H-C-P managed cluster"
             class="one-fourth-width"
             name="hvd-root-namespace"
@@ -19,8 +19,8 @@
             data-test-managed-namespace-root
           />
           <SG.TextInput
-            {{on "input" @updateNamespace}}
-            @value={{@namespaceValue}}
+            {{on "input" this.handleInput}}
+            @value={{this.namespaceInput}}
             autocomplete="off"
             disabled={{@disabled}}
             name="namespace"
@@ -32,8 +32,8 @@
     </Hds::Form::Field>
   {{else}}
     <Hds::Form::TextInput::Field
-      {{on "input" @updateNamespace}}
-      @value={{@namespaceValue}}
+      {{on "input" this.handleInput}}
+      @value={{this.namespaceInput}}
       autocomplete="off"
       disabled={{@disabled}}
       name="namespace"

--- a/ui/app/components/auth/namespace-input.ts
+++ b/ui/app/components/auth/namespace-input.ts
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { getRelativePath } from 'core/utils/sanitize-path';
+import { restartableTask, timeout } from 'ember-concurrency';
+import { service } from '@ember/service';
+
+import type { HTMLElementEvent } from 'vault/forms';
+import type ApiService from 'vault/services/api';
+import type FlagsService from 'vault/services/flags';
+
+/**
+ * @module Auth::NamespaceInput
+ * Renders the namespace input for the login form. As a user types, the updateNamespace callback fires in the controller to update the query param in the URL.
+ * When a namespace is updated, the controller sets `shouldRefocusNamespaceInput = true` which refocuses the input after the route refreshes.
+ * For HVD managed clusters the input prepends the administrative namespace: `admin/`. The input is disabled if the url has and OIDC query param: "?o=someprovider"
+ *
+ * @param {boolean} disabled - determines whether or not the namespace input is disabled
+ * @param {function} handleNamespaceUpdate - fires updateNamespace callback in controller
+ * @param {string} namespaceQueryParam - namespace query param from the url
+ * @param {boolean} shouldRefocusNamespaceInput - if true, refocuses the input on `{{did-insert}}`
+ * */
+
+interface Args {
+  handleNamespaceUpdate: CallableFunction;
+  namespaceQueryParam: string;
+  shouldRefocusNamespaceInput: boolean;
+}
+
+export default class AuthNamespaceInput extends Component<Args> {
+  @service declare readonly api: ApiService;
+  @service declare readonly flags: FlagsService;
+
+  get namespaceInput() {
+    const namespaceQueryParam = this.args.namespaceQueryParam;
+    if (this.flags.hvdManagedNamespaceRoot) {
+      // When managed, the user isn't allowed to edit the prefix `admin/`
+      // so prefill just the relative path in the namespace input
+      const path = getRelativePath(namespaceQueryParam, this.flags.hvdManagedNamespaceRoot);
+      return path ? `/${path}` : '';
+    }
+    return namespaceQueryParam;
+  }
+
+  @action
+  async handleInput(event: HTMLElementEvent<HTMLInputElement>) {
+    // user has typed something, so input should be refocused
+    const value = event.target.value;
+    this.updateNamespace.perform(value);
+  }
+
+  updateNamespace = restartableTask(async (namespace) => {
+    await timeout(500);
+    await this.args.handleNamespaceUpdate(namespace);
+  });
+}

--- a/ui/app/components/auth/page.hbs
+++ b/ui/app/components/auth/page.hbs
@@ -53,13 +53,19 @@
           @alternateView={{this.formViews.alternateView}}
           @cluster={{@cluster}}
           @defaultView={{this.formViews.defaultView}}
-          @handleNamespaceUpdate={{@onNamespaceUpdate}}
           @initialFormState={{this.initialFormState}}
-          @namespaceQueryParam={{@namespaceQueryParam}}
-          @oidcProviderQueryParam={{@oidcProviderQueryParam}}
           @onSuccess={{this.onAuthResponse}}
           @visibleMountTypes={{this.visibleMountTypes}}
-        />
+        >
+          {{! yielded for accessibility so namespace submits as an input of the <form> element }}
+          {{#if (has-feature "Namespaces")}}
+            <Auth::NamespaceInput
+              @disabled={{if @oidcProviderQueryParam true false}}
+              @handleNamespaceUpdate={{@onNamespaceUpdate}}
+              @namespaceQueryParam={{@namespaceQueryParam}}
+            />
+          {{/if}}
+        </Auth::FormTemplate>
       {{/if}}
     </:content>
 

--- a/ui/app/controllers/vault/cluster/auth.js
+++ b/ui/app/controllers/vault/cluster/auth.js
@@ -5,7 +5,7 @@
 import { service } from '@ember/service';
 import { alias } from '@ember/object/computed';
 import Controller, { inject as controller } from '@ember/controller';
-import { task, timeout } from 'ember-concurrency';
+import { task } from 'ember-concurrency';
 import { sanitizePath } from 'core/utils/sanitize-path';
 
 export default Controller.extend({
@@ -36,12 +36,11 @@ export default Controller.extend({
   },
 
   updateNamespace: task(function* (value) {
-    // debounce
-    yield timeout(500);
     const ns = this.fullNamespaceFromInput(value);
     this.namespaceService.setNamespace(ns, true);
-    this.customMessages.fetchMessages();
+    yield this.customMessages.fetchMessages();
     this.set('namespaceQueryParam', ns);
+    // if user is inputting a namespace, maintain input focus as the param updates
   }).restartable(),
 
   actions: {

--- a/ui/app/routes/vault/cluster/auth.js
+++ b/ui/app/routes/vault/cluster/auth.js
@@ -120,7 +120,7 @@ export default class AuthRoute extends ClusterRouteBase {
       // return a falsy value if the object is empty
       return isEmptyValue(resp.auth) ? null : resp.auth;
     } catch {
-      // swallow the error if there's an error fetching mount data (i.e. invalid namespace)
+      // catch error if there's a problem fetching mount data (i.e. invalid namespace)
       return null;
     }
   }

--- a/ui/tests/integration/components/auth/namespace-input-test.js
+++ b/ui/tests/integration/components/auth/namespace-input-test.js
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, typeIn } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import sinon from 'sinon';
+import { AUTH_FORM } from 'vault/tests/helpers/auth/auth-form-selectors';
+import { GENERAL } from 'vault/tests/helpers/general-selectors';
+
+module('Integration | Component | auth | namespace input', function (hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function () {
+    this.disabled = false;
+    this.oidcProviderQueryParam = '';
+    this.handleNamespaceUpdate = sinon.spy();
+
+    this.renderComponent = () => {
+      return render(hbs`
+      <Auth::NamespaceInput
+        @disabled={{this.disabled}}
+        @handleNamespaceUpdate={{this.handleNamespaceUpdate}}
+        @namespaceQueryParam={{this.namespaceQueryParam}}
+      />`);
+    };
+  });
+
+  test('it calls handleNamespaceUpdate', async function (assert) {
+    assert.expect(1);
+    await this.renderComponent();
+    await typeIn(GENERAL.inputByAttr('namespace'), 'ns-1');
+    const [actual] = this.handleNamespaceUpdate.lastCall.args;
+    assert.strictEqual(actual, 'ns-1', `handleNamespaceUpdate called with: ${actual}`);
+  });
+
+  test('it disables the input if @disabled is true', async function (assert) {
+    this.disabled = true;
+    await this.renderComponent();
+    assert.dom(GENERAL.inputByAttr('namespace')).isDisabled();
+  });
+
+  module('HVD managed', function (hooks) {
+    hooks.beforeEach(function () {
+      this.owner.lookup('service:flags').featureFlags = ['VAULT_CLOUD_ADMIN_NAMESPACE'];
+    });
+
+    test('it sets namespace', async function (assert) {
+      this.namespaceQueryParam = 'admin/west-coast';
+      await this.renderComponent();
+      assert.dom(AUTH_FORM.managedNsRoot).hasValue('/admin');
+      assert.dom(AUTH_FORM.managedNsRoot).hasAttribute('readonly');
+      assert.dom(GENERAL.inputByAttr('namespace')).hasValue('/west-coast');
+    });
+
+    test('it calls onNamespaceUpdate', async function (assert) {
+      assert.expect(2);
+      this.namespaceQueryParam = 'admin';
+      await this.renderComponent();
+
+      assert.dom(GENERAL.inputByAttr('namespace')).hasValue('');
+      await typeIn(GENERAL.inputByAttr('namespace'), 'ns-1');
+      const [actual] = this.handleNamespaceUpdate.lastCall.args;
+      assert.strictEqual(actual, 'ns-1', `handleNamespaceUpdate called with: ${actual}`);
+    });
+  });
+});


### PR DESCRIPTION
### Description
Updating the namespace refreshes the login form because a new request must be made to `sys/internal/ui/mounts.` There is currently a `debounce` in the controller but it should really happen in the component. The debounce is only half a second, so if the user makes a typo or pauses while typing the form refreshes and the namespace input loses focus. 

This PR
- Moves the debounce to the input so the tasks restarts as the user types, not when the url is being updated
- Refocuses the input if the user has made any changes to the namespace input so it’s already focused if the route refreshes while the user is typing.  
- Separates concerns better by moving the `Auth::NamespaceInput` up to the `Auth::Page` component. (I don't know why I didn't put it there before... 🙃 )

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
