### PR TITLE
VAULT-35643: fix bug in RLQs and tests

### DIFF
--- a/vault/quotas/quotas_rate_limit.go
+++ b/vault/quotas/quotas_rate_limit.go
@@ -385,7 +385,9 @@ func (rlq *RateLimitQuota) close(ctx context.Context) error {
 	}
 
 	if rlq.store != nil {
-		return rlq.store.Close(ctx)
+		if err := rlq.store.Close(ctx); err != nil {
+			return err
+		}
 	}
 
 	return rlq.closeEnt(ctx)

--- a/vault/quotas/quotas_rate_limit_test.go
+++ b/vault/quotas/quotas_rate_limit_test.go
@@ -226,8 +226,10 @@ func TestRateLimitQuota_Update(t *testing.T) {
 	require.NoError(t, qm.Setup(context.Background(), view, nil))
 
 	quota := NewRateLimitQuota("quota1", "", "", "", "", GroupByIp, false, time.Second, 0, 10, 0)
+	quotaUpdate := quota.Clone()
 	require.NoError(t, qm.SetQuota(context.Background(), TypeRateLimit.String(), quota, true))
-	require.NoError(t, qm.SetQuota(context.Background(), TypeRateLimit.String(), quota, true))
+	require.NoError(t, qm.SetQuota(context.Background(), TypeRateLimit.String(), quotaUpdate, true))
 
 	require.Nil(t, quota.close(context.Background()))
+	require.Nil(t, quotaUpdate.close(context.Background()))
 }


### PR DESCRIPTION
### Description
This fixes a bug with the new identity-based RLQs. It also might address a possible deadlock we're sporadically seeing in this test.

Main PR: #30633

### TODO only if you're a HashiCorp employee
- [-] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [-] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [-] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [-] **RFC:** If this change has an associated RFC, please link it in the description.
- [-] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
