### PR TITLE
CE Changes for VAULT-36172

### DIFF
--- a/command/server.go
+++ b/command/server.go
@@ -2958,7 +2958,7 @@ func createCoreConfig(c *ServerCommand, config *server.Config, backend physical.
 		DisableSSCTokens:               config.DisableSSCTokens,
 		Experiments:                    config.Experiments,
 		AdministrativeNamespacePath:    config.AdministrativeNamespacePath,
-		ObservationSystemLedgerPath:    config.ObservationSystemLedgerPath,
+		ObservationSystemConfig:        config.Observations,
 	}
 
 	if c.flagDev {

--- a/command/server/config_test.go
+++ b/command/server/config_test.go
@@ -95,6 +95,16 @@ func TestUnknownFieldValidationListenerAndStorage(t *testing.T) {
 	testUnknownFieldValidationStorageAndListener(t)
 }
 
+// Test_ObservationSystemConfig makes sure that the observation system config
+// is properly loaded.
+func Test_ObservationSystemConfig(t *testing.T) {
+	config, err := LoadConfigFile("./test-fixtures/observations.hcl")
+	require.NoError(t, err)
+	require.NotNil(t, config)
+	require.NotNil(t, config.Observations)
+	require.Equal(t, "/var/ledger.log", config.Observations.LedgerPath)
+}
+
 // TestDuplicateKeyValidationHcl checks that the server command displays a warning when the HCL config file contains duplicate keys.
 func TestDuplicateKeyValidationHcl(t *testing.T) {
 	testDuplicateKeyValidationHcl(t)

--- a/command/server/config_test_helpers.go
+++ b/command/server/config_test_helpers.go
@@ -814,7 +814,6 @@ func testConfig_Sanitized(t *testing.T) {
 		"raw_storage_endpoint":                true,
 		"introspection_endpoint":              false,
 		"disable_sentinel_trace":              true,
-		"observation_system_ledger_path":      "",
 		"detect_deadlocks":                    "",
 		"enable_ui":                           true,
 		"enable_response_header_hostname":     false,

--- a/http/sys_config_state_test.go
+++ b/http/sys_config_state_test.go
@@ -155,7 +155,6 @@ func TestSysConfigState_Sanitized(t *testing.T) {
 				"disable_sealwrap":                    false,
 				"experiments":                         nil,
 				"raw_storage_endpoint":                false,
-				"observation_system_ledger_path":      "",
 				"detect_deadlocks":                    "",
 				"introspection_endpoint":              false,
 				"disable_sentinel_trace":              false,

--- a/vault/core.go
+++ b/vault/core.go
@@ -925,8 +925,8 @@ type CoreConfig struct {
 	// only accessible in the root namespace, currently sys/audit-hash and sys/monitor.
 	AdministrativeNamespacePath string
 
-	// ObservationSystemLedgerPath is the path that the Observation System's ledger will be recorded at.
-	ObservationSystemLedgerPath string
+	// ObservationSystemConfig is the config for the Observation System
+	ObservationSystemConfig *observations.ObservationSystemConfig
 
 	NumRollbackWorkers int
 
@@ -1377,14 +1377,16 @@ func NewCore(conf *CoreConfig) (*Core, error) {
 	c.createSnapshotManager()
 
 	observationsLogger := conf.Logger.Named("observations")
-	observationSystemLedgerPath := conf.ObservationSystemLedgerPath
-	if observationSystemLedgerPath != "" {
-		observations, err := observations.NewObservationSystem(nodeID, observationSystemLedgerPath, observationsLogger)
-		if err != nil {
-			return nil, err
+	observationSystemConfig := conf.ObservationSystemConfig
+	if observationSystemConfig != nil {
+		if observationSystemConfig.LedgerPath != "" {
+			observations, err := observations.NewObservationSystem(nodeID, observationSystemConfig.LedgerPath, observationsLogger)
+			if err != nil {
+				return nil, err
+			}
+			c.observations = observations
+			c.observations.Start()
 		}
-		c.observations = observations
-		c.observations.Start()
 	}
 
 	c.clusterAddrBridge = conf.ClusterAddrBridge

--- a/vault/observations/observations.go
+++ b/vault/observations/observations.go
@@ -1,0 +1,11 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package observations
+
+// ObservationSystemConfig serves as a definition of what an observation
+// system needs from the Vault config file to start.
+type ObservationSystemConfig struct {
+	// LedgerPath is the path to the observation system's ledger.
+	LedgerPath string `json:"ledger_path" hcl:"ledger_path"`
+}

--- a/vault/testing.go
+++ b/vault/testing.go
@@ -1550,7 +1550,7 @@ func NewTestCluster(t testing.TB, base *CoreConfig, opts *TestClusterOptions) *T
 		coreConfig.ExpirationRevokeRetryBase = base.ExpirationRevokeRetryBase
 		coreConfig.PeriodicLeaderRefreshInterval = base.PeriodicLeaderRefreshInterval
 		coreConfig.ClusterAddrBridge = base.ClusterAddrBridge
-		coreConfig.ObservationSystemLedgerPath = base.ObservationSystemLedgerPath
+		coreConfig.ObservationSystemConfig = base.ObservationSystemConfig
 
 		testApplyEntBaseConfig(coreConfig, base)
 	}


### PR DESCRIPTION
### Description

CE side of https://github.com/hashicorp/vault-enterprise/pull/8157

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
