### PR TITLE
VAULT-34527: API docs for identity-based and collective rate-limit quotas

### DIFF
--- a/website/content/api-docs/system/rate-limit-quotas.mdx
+++ b/website/content/api-docs/system/rate-limit-quotas.mdx
@@ -135,11 +135,13 @@ $ curl \
   "renewable": false,
   "data": {
     "block_interval": 300,
+    "group_by": "ip",
     "interval": 2,
     "name": "global-rate-limiter",
     "path": "",
     "rate": 897.3,
     "role": "",
+    "secondary_rate": 0,
     "type": "rate-limit"
   },
   "warnings": null

--- a/website/content/api-docs/system/rate-limit-quotas.mdx
+++ b/website/content/api-docs/system/rate-limit-quotas.mdx
@@ -51,6 +51,20 @@ the mount to restrict more specific API paths.
   the same quota will be cumulatively applied to all child namespace. The `inheritable`
   parameter cannot be set to `true` if the `path` does not specify a namespace. Only quotas
   associated with the root namespace quotas are inheritable by default.
+- `group_by` `(string: "")` – <EnterpriseAlert product="vault" inline /> Attribute by which
+  to group requests by. Valid `group_by` modes are: 1) `ip` that groups requests by their source
+  IP address (`group_by` defaults to `ip` if unset, which is the only supported mode in community
+  edition); 2) `none` that groups together all requests that match the rate limit quota rule; 3)
+  `entity_then_ip` that groups requests by their entity ID for authenticated requests that carry
+  one, or by their IP for unauthenticated requests (or requests whose authentication is not
+  connected to an entity); and 4) `entity_then_none` which also groups requests by their entity
+  ID when available, but the rest is all grouped together (i.e. unauthenticated or with
+  authentication not connected to an entity).
+- `secondary_rate` `(float: 0.0)` – <EnterpriseAlert product="vault" inline /> Can only be set
+  for the `group_by` modes `entity_then_ip` or `entity_then_none`. This is the rate limit applied
+  to the requests that fall under the "ip" or "none" groupings, while the authenticated requests
+  that contain an entity ID are subject to the `rate` field instead. Defaults to the same value
+  as `rate`.
 
 ### Sample payload
 


### PR DESCRIPTION
### Description
These are the API docs for the 2 new fields on rate limit quotas.

Jira: [VAULT-34527](https://hashicorp.atlassian.net/browse/VAULT-34527)
Main PR for feature: #30633
PR with education docs: #30717

### TODO only if you're a HashiCorp employee
- [-] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [-] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [-] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [-] **RFC:** If this change has an associated RFC, please link it in the description.
- [-] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.


[VAULT-34527]: https://hashicorp.atlassian.net/browse/VAULT-34527?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ