### PR TITLE
UI: Rename "Vault Usage Metrics" to "Client Usage"

### DIFF
--- a/ui/app/components/sidebar/nav/clients.hbs
+++ b/ui/app/components/sidebar/nav/clients.hbs
@@ -17,8 +17,8 @@
   <Nav.Link
     @route="vault.cluster.clients.counts.overview"
     @current-when="vault.cluster.clients.counts"
-    @text="Vault Usage Metrics"
-    data-test-sidebar-nav-link="Vault Usage Metrics"
+    @text="Client Usage"
+    data-test-sidebar-nav-link="Client Usage"
   />
   {{#if @canReadConfig}}
     <Nav.Link

--- a/ui/tests/acceptance/enterprise-sidebar-nav-test.js
+++ b/ui/tests/acceptance/enterprise-sidebar-nav-test.js
@@ -50,7 +50,7 @@ module('Acceptance | Enterprise | sidebar navigation', function (hooks) {
 
     await click(link('Client Count'));
     assert.dom(panel('Client Count')).exists('Client Count nav panel renders');
-    assert.dom(link('Vault Usage Metrics')).hasClass('active', 'Vault Usage Metrics link is active');
+    assert.dom(link('Client Usage')).hasClass('active', 'Client Usage link is active');
     assert.strictEqual(currentURL(), '/vault/clients/counts/overview', 'Client counts route renders');
     await click(link('Back to main navigation'));
 

--- a/ui/tests/acceptance/sidebar-nav-test.js
+++ b/ui/tests/acceptance/sidebar-nav-test.js
@@ -128,13 +128,13 @@ module('Acceptance | sidebar navigation', function (hooks) {
     await click(link('Client Count'));
     assert.dom(panel('Client Count')).exists('Client counts nav panel renders');
     assert.strictEqual(currentURL(), '/vault/clients/counts/overview', 'Top level nav link renders overview');
-    assert.dom(link('Vault Usage Metrics')).hasClass('active');
+    assert.dom(link('Client Usage')).hasClass('active');
     await click(link('Configuration'));
     assert.strictEqual(currentURL(), '/vault/clients/config', 'Clients configuration renders');
     assert.dom(link('Configuration')).hasClass('active');
-    await click(link('Vault Usage Metrics'));
+    await click(link('Client Usage'));
     assert.strictEqual(currentURL(), '/vault/clients/counts/overview', 'Sub nav link navigates to overview');
-    assert.dom(link('Vault Usage Metrics')).hasClass('active');
+    assert.dom(link('Client Usage')).hasClass('active');
   });
 
   test('it should display access nav when mounting and configuring auth methods', async function (assert) {


### PR DESCRIPTION
### Description
The introduction of the `Vault Usage` dashboard introduced a naming conflict with the client count nav link `Vault Usage Metrics`. Renaming it to `Client Usage` to more accurately align with the content.
 
### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
