### PR TITLE
UI: add legend to Hds::Form::Radio::Group

### DIFF
--- a/ui/lib/core/addon/components/form-field.hbs
+++ b/ui/lib/core/addon/components/form-field.hbs
@@ -17,6 +17,12 @@
           data-test-input-group={{@attr.name}}
           as |G|
         >
+          {{#if @attr.options.label}}
+            <G.Legend>{{@attr.options.label}}</G.Legend>
+          {{/if}}
+          {{#if @attr.options.subText}}
+            <G.HelperText data-test-help-text>{{@attr.options.subText}}</G.HelperText>
+          {{/if}}
           {{#each (path-or-array @attr.options.possibleValues @model) as |val|}}
             <G.RadioField
               @id={{or val.id (this.radioValue val)}}

--- a/ui/tests/integration/components/form-field-test.js
+++ b/ui/tests/integration/components/form-field-test.js
@@ -383,6 +383,8 @@ module('Integration | Component | form field', function (hooks) {
     await setup.call(
       this,
       createAttr('myfield', '-', {
+        label: 'Radio group legend',
+        subText: 'Helpful legend subtext',
         editType: 'radio',
         possibleValues: [
           { value: 'foo', id: 'custom-id-1' },
@@ -392,6 +394,8 @@ module('Integration | Component | form field', function (hooks) {
         ],
       })
     );
+    assert.dom('legend').hasText('Radio group legend', 'it renders attribute label as legend');
+    assert.dom(GENERAL.helpText()).hasText('Helpful legend subtext');
     // first item should have custom ID, label `foo`, and no subText/helpText
     assert
       .dom(GENERAL.radioByAttr('custom-id-1'))


### PR DESCRIPTION
### Description
When implementing the `Hds::Form::Radio::Group` in https://github.com/hashicorp/vault/pull/30555 the legend was missed. Maps the attributes label option to the `<legend>` element 

No changelog because this issue does not exist in a released version of Vault

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
