### PR TITLE
[VAULT-34798] UI: move the `boolean` block in `FormField` under the HDS block

### DIFF
--- a/ui/lib/core/addon/components/form-field.hbs
+++ b/ui/lib/core/addon/components/form-field.hbs
@@ -194,10 +194,9 @@
       {{else if (or (eq @attr.type "boolean") (eq @attr.options.editType "boolean"))}}
         <Hds::Form::Checkbox::Field
           name={{@attr.name}}
-          id={{@attr.name}}
+          @id={{@attr.name}}
           checked={{get @model @attr.name}}
           disabled={{this.disabled}}
-          @isInvalid={{this.validationError}}
           {{on "change" this.onChangeWithEvent}}
           data-test-input={{@attr.name}}
           as |F|

--- a/ui/lib/core/addon/components/form-field.hbs
+++ b/ui/lib/core/addon/components/form-field.hbs
@@ -191,6 +191,39 @@
             {{/if}}
           </Hds::Form::Textarea::Field>
         {{/if}}
+      {{else if (or (eq @attr.type "boolean") (eq @attr.options.editType "boolean"))}}
+        <Hds::Form::Checkbox::Field
+          name={{@attr.name}}
+          id={{@attr.name}}
+          checked={{get @model @attr.name}}
+          disabled={{this.disabled}}
+          @isInvalid={{this.validationError}}
+          {{on "change" this.onChangeWithEvent}}
+          data-test-input={{@attr.name}}
+          as |F|
+        >
+          {{#if this.labelString}}
+            <F.Label data-test-form-field-label>{{this.labelString}}</F.Label>
+          {{/if}}
+          {{#if (or this.helpTextString @attr.options.subText)}}
+            <F.HelperText>
+              {{#if this.helpTextString}}
+                <span data-test-help-text={{@attr.options.helpText}}>{{this.helpTextString}}</span>
+              {{/if}}
+              {{#if @attr.options.subText}}
+                <span data-test-help-text={{@attr.options.subText}}>
+                  {{@attr.options.subText}}
+                  {{#if @attr.options.docLink}}
+                    <DocLink @path={{@attr.options.docLink}} data-test-doc-link={{@attr.options.docLink}}>Learn more here.</DocLink>
+                  {{/if}}
+                </span>
+              {{/if}}
+            </F.HelperText>
+          {{/if}}
+          {{#if this.validationError}}
+            <F.Error data-test-validation-error={{this.valuePath}}>{{this.validationError}}</F.Error>
+          {{/if}}
+        </Hds::Form::Checkbox::Field>
       {{/if}}
     {{/if}}
     {{! •••••••••••••••••••••••••••••••••••••••••••••••••••••••• }}
@@ -444,34 +477,6 @@
             class="input {{if this.validationError 'has-error-border'}}"
             maxLength={{@attr.options.characterLimit}}
           />
-        {{/if}}
-      </div>
-    {{else if (or (eq @attr.type "boolean") (eq @attr.options.editType "boolean"))}}
-      <div class="b-checkbox">
-        <input
-          disabled={{this.disabled}}
-          type="checkbox"
-          id={{@attr.name}}
-          class="styled"
-          checked={{get @model @attr.name}}
-          onchange={{this.onChangeWithEvent}}
-          data-test-input={{@attr.name}}
-        />
-        <label for={{@attr.name}} class="is-label" data-test-form-field-label>
-          {{this.labelString}}
-          {{#if this.helpTextString}}
-            <InfoTooltip>{{this.helpTextString}}</InfoTooltip>
-          {{/if}}
-        </label>
-        {{#if @attr.options.subText}}
-          <p class="sub-text">
-            {{@attr.options.subText}}
-            {{#if @attr.options.docLink}}
-              <DocLink @path={{@attr.options.docLink}} data-test-doc-link={{@attr.options.docLink}}>
-                Learn more here.
-              </DocLink>
-            {{/if}}
-          </p>
         {{/if}}
       </div>
     {{else if (eq @attr.type "object")}}

--- a/ui/lib/core/addon/components/form-field.hbs
+++ b/ui/lib/core/addon/components/form-field.hbs
@@ -201,9 +201,7 @@
           data-test-input={{@attr.name}}
           as |F|
         >
-          {{#if this.labelString}}
-            <F.Label data-test-form-field-label>{{this.labelString}}</F.Label>
-          {{/if}}
+          <F.Label data-test-form-field-label>{{this.labelString}}</F.Label>
           {{#if (or this.helpTextString @attr.options.subText)}}
             <F.HelperText>
               {{#if this.helpTextString}}

--- a/ui/lib/core/addon/components/form-field.hbs
+++ b/ui/lib/core/addon/components/form-field.hbs
@@ -195,7 +195,7 @@
         <Hds::Form::Checkbox::Field
           name={{@attr.name}}
           @id={{@attr.name}}
-          checked={{get @model @attr.name}}
+          checked={{get @model this.valuePath}}
           disabled={{this.disabled}}
           {{on "change" this.onChangeWithEvent}}
           data-test-input={{@attr.name}}

--- a/ui/lib/core/addon/components/form-field.js
+++ b/ui/lib/core/addon/components/form-field.js
@@ -56,7 +56,6 @@ import { get } from '@ember/object';
 export default class FormFieldComponent extends Component {
   emptyData = '{\n}';
   shouldHideLabel = [
-    'boolean',
     'file',
     'json',
     'kv',
@@ -107,6 +106,8 @@ export default class FormFieldComponent extends Component {
         } else {
           return false;
         }
+      } else if (type === 'boolean' || options?.editType === 'boolean') {
+        return true;
       } else {
         // we leave these fields as they are (for now)
         return false;
@@ -126,7 +127,7 @@ export default class FormFieldComponent extends Component {
 
   get hideLabel() {
     const { type, options } = this.args.attr;
-    if (type === 'boolean' || type === 'object' || options?.isSectionHeader) {
+    if (type === 'object' || options?.isSectionHeader) {
       return true;
     }
     // falsey values render a <FormFieldLabel>

--- a/ui/lib/core/addon/components/form-field.js
+++ b/ui/lib/core/addon/components/form-field.js
@@ -96,20 +96,38 @@ export default class FormFieldComponent extends Component {
   get isHdsFormField() {
     const { type, options } = this.args.attr;
 
-    // here we replicate the logic in the template, to make sure we don't change the order in which the "ifs" are evaluated
+    // here we replicate the logic in the `form-field.hbs` template, as it was at the beginning of the migation to HDS
+    // to make sure we don't change the order in which the "ifs" are evaluated
+    // see: https://github.com/hashicorp/vault/blob/e99c06a0249f1ecde02c5b48990cb0e91e4ec575/ui/lib/core/addon/components/form-field.hbs
     if (options?.possibleValues?.length > 0) {
       return true;
     } else {
-      if (type === 'number' || type === 'string') {
-        if (options?.editType === 'password' || options?.editType === 'textarea') {
+      if (
+        options?.editType === 'dateTimeLocal' ||
+        options?.editType === 'searchSelect' ||
+        options?.editType === 'mountAccessor' ||
+        options?.editType === 'kv' ||
+        options?.editType === 'file' ||
+        options?.editType === 'ttl' ||
+        options?.editType === 'regex' ||
+        options?.editType === 'toggleButton' ||
+        options?.editType === 'optionalText' ||
+        options?.editType === 'stringArray' ||
+        options?.sensitive === true
+      ) {
+        return false;
+      } else if (type === 'number' || type === 'string') {
+        if (options?.editType === 'textarea' || options?.editType === 'password') {
           return true;
         } else {
           return false;
         }
       } else if (type === 'boolean' || options?.editType === 'boolean') {
         return true;
+      } else if (type === 'object' || options?.editType === 'yield') {
+        return false;
       } else {
-        // we leave these fields as they are (for now)
+        // fallback, just in case
         return false;
       }
     }

--- a/ui/tests/acceptance/secrets/backend/ssh/configuration-test.js
+++ b/ui/tests/acceptance/secrets/backend/ssh/configuration-test.js
@@ -105,7 +105,7 @@ module('Acceptance | ssh | configuration', function (hooks) {
     await click(GENERAL.inputByAttr('generateSigningKey'));
     await click(GENERAL.submitButton);
     assert
-      .dom(GENERAL.inlineError)
+      .dom(GENERAL.validationErrorByAttr('generateSigningKey'))
       .hasText('Provide a Public and Private key or set "Generate Signing Key" to true.');
     // visit the details page and confirm the public key is not shown
     await visit(`/vault/secrets/${path}/configuration`);

--- a/ui/tests/acceptance/secrets/backend/totp/key-test.js
+++ b/ui/tests/acceptance/secrets/backend/totp/key-test.js
@@ -21,7 +21,7 @@ module('Acceptance | totp key backend', function (hooks) {
     await fillIn(GENERAL.inputByAttr('issuer'), issuer);
     await fillIn(GENERAL.inputByAttr('accountName'), accountName);
     if (!exported) {
-      await click(GENERAL.inputByAttr('exported'));
+      await click(GENERAL.toggleInput('toggle-exported'));
     }
     if (qrSize !== 200) {
       await click(GENERAL.button('Provider Options'));

--- a/ui/tests/acceptance/secrets/backend/totp/key-test.js
+++ b/ui/tests/acceptance/secrets/backend/totp/key-test.js
@@ -21,7 +21,7 @@ module('Acceptance | totp key backend', function (hooks) {
     await fillIn(GENERAL.inputByAttr('issuer'), issuer);
     await fillIn(GENERAL.inputByAttr('accountName'), accountName);
     if (!exported) {
-      await click(GENERAL.ttl.toggle('toggle-exported'));
+      await click(GENERAL.inputByAttr('exported'));
     }
     if (qrSize !== 200) {
       await click(GENERAL.button('Provider Options'));

--- a/ui/tests/integration/components/form-field-test.js
+++ b/ui/tests/integration/components/form-field-test.js
@@ -1086,7 +1086,7 @@ module('Integration | Component | form field', function (hooks) {
     assert.dom(GENERAL.inputByAttr('myfield')).isChecked('input[type="checkbox"] is checked');
     await click(GENERAL.inputByAttr('myfield'));
     assert.false(model.get('myfield'));
-    assert.ok(spy.calledWith('myfield', false), 'onChange called with correct args');
+    assert.true(spy.calledWith('myfield', false), 'onChange called with correct args');
   });
 
   test('it renders: editType=boolean - with passed label, subtext, helptext, doclink', async function (assert) {

--- a/ui/tests/integration/components/form-field-test.js
+++ b/ui/tests/integration/components/form-field-test.js
@@ -118,17 +118,6 @@ module('Integration | Component | form field', function (hooks) {
     assert.ok(spy.calledWith('foo', 'bar'), 'onChange called with correct args');
   });
 
-  test('it renders: boolean', async function (assert) {
-    const [model, spy] = await setup.call(this, createAttr('foo', 'boolean', { defaultValue: false }));
-    assert.strictEqual(component.fields.objectAt(0).labelValue, 'Foo', 'renders a label');
-    assert.notOk(component.fields.objectAt(0).inputChecked, 'renders default value');
-    assert.ok(component.hasCheckbox, 'renders a checkbox for boolean');
-    await component.fields.objectAt(0).clickLabel();
-
-    assert.true(model.get('foo'));
-    assert.ok(spy.calledWith('foo', true), 'onChange called with correct args');
-  });
-
   test('it renders: number', async function (assert) {
     const [model, spy] = await setup.call(this, createAttr('foo', 'number', { defaultValue: 5 }));
     assert.strictEqual(component.fields.objectAt(0).labelValue, 'Foo', 'renders a label');
@@ -1027,6 +1016,108 @@ module('Integration | Component | form field', function (hooks) {
     this.setProperties({
       attr: createAttr('myfield', 'string', { editType: 'textarea' }),
       model: { myfield: 'bar' },
+      modelValidations: {
+        myfield: {
+          isValid: false,
+          errors: ['Error message #1', 'Error message #2'],
+          warnings: ['Warning message #1', 'Warning message #2'],
+        },
+      },
+      onChange: () => {},
+    });
+
+    await render(
+      hbs`<FormField @attr={{this.attr}} @model={{this.model}} @modelValidations={{this.modelValidations}} @onChange={{this.onChange}} />`
+    );
+    assert
+      .dom(GENERAL.validationErrorByAttr('myfield'))
+      .exists('Validation error renders')
+      .hasText('Error message #1 Error message #2', 'Validation errors are combined');
+    assert
+      .dom(GENERAL.validationWarningByAttr('myfield'))
+      .exists('Validation warning renders')
+      .hasText('Warning message #1 Warning message #2', 'Validation warnings are combined');
+  });
+
+  // ––––– type/editType === 'boolean' –––––
+
+  test('it renders: type=boolean - as Hds::Form::Checkbox', async function (assert) {
+    await setup.call(this, createAttr('myfield', 'boolean', { defaultValue: 'false' }));
+    assert
+      .dom('.field [class^="hds-form-field"] input[type="checkbox"].hds-form-checkbox')
+      .exists('renders as Hds::Form::Checkbox::Field');
+    assert
+      .dom(`input[type=checkbox]`)
+      .exists('renders input[type="checkbox"]')
+      .hasAttribute(
+        'data-test-input',
+        'myfield',
+        'input[type="checkbox"] has correct `data-test-input` attribute'
+      );
+    assert.dom(GENERAL.fieldLabel()).hasText('Myfield', 'renders the input[type="checkbox"] label');
+  });
+
+  test('it renders: editType=boolean - as Hds::Form::Checkbox', async function (assert) {
+    await setup.call(this, createAttr('myfield', '-', { editType: 'boolean', defaultValue: 'false' }));
+    assert
+      .dom('.field [class^="hds-form-field"] input[type="checkbox"].hds-form-checkbox')
+      .exists('renders as Hds::Form::Checkbox::Field');
+    assert
+      .dom(`input[type=checkbox]`)
+      .exists('renders input[type="checkbox"]')
+      .hasAttribute(
+        'data-test-input',
+        'myfield',
+        'input[type="checkbox"] has correct `data-test-input` attribute'
+      );
+    assert.dom(GENERAL.fieldLabel()).hasText('Myfield', 'renders the input[type="checkbox"] label');
+  });
+
+  test('it renders: editType=boolean - unselected by default', async function (assert) {
+    await setup.call(this, createAttr('myfield', '-', { editType: 'boolean' }));
+    assert.dom(GENERAL.inputByAttr('myfield')).isNotChecked('input[type="checkbox"] is not checked');
+  });
+
+  test('it renders: editType=boolean - selected and changes it', async function (assert) {
+    const [model, spy] = await setup.call(
+      this,
+      createAttr('myfield', '-', { editType: 'boolean', defaultValue: 'true' })
+    );
+    assert.dom(GENERAL.inputByAttr('myfield')).isChecked('input[type="checkbox"] is checked');
+    await click(GENERAL.inputByAttr('myfield'));
+    assert.false(model.get('myfield'));
+    assert.ok(spy.calledWith('myfield', false), 'onChange called with correct args');
+  });
+
+  test('it renders: editType=boolean - with passed label, subtext, helptext, doclink', async function (assert) {
+    await setup.call(
+      this,
+      createAttr('myfield', '-', {
+        editType: 'boolean',
+        label: 'Custom label',
+        subText: 'Some subtext',
+        helpText: 'Some helptext',
+        docLink: '/docs',
+      })
+    );
+    assert.dom(GENERAL.fieldLabel()).hasText('Custom label', 'renders the custom label from options');
+    assert
+      .dom(GENERAL.helpTextByAttr('Some subtext'))
+      .exists('renders `subText` option as HelperText')
+      .hasText('Some subtext Learn more here.', 'renders the right subtext string from options');
+    assert
+      .dom(`${GENERAL.helpTextByAttr('Some subtext')} ${GENERAL.docLinkByAttr('/docs')}`)
+      .exists('renders `docLink` option as as link inside the subtext');
+    assert
+      .dom(GENERAL.helpTextByAttr('Some helptext'))
+      .exists('renders `helptext` option as HelperText')
+      .hasText('Some helptext', 'renders the right help text string from options');
+  });
+
+  test('it renders: editType=boolean - with validation errors and warnings', async function (assert) {
+    this.setProperties({
+      attr: createAttr('myfield', '-', { editType: 'boolean' }),
+      model: { myfield: false },
       modelValidations: {
         myfield: {
           isValid: false,


### PR DESCRIPTION
### Description
What does this PR do?

- updated logic in `isHdsFormField` of `FormField` to include the `type|editType === 'boolean'` use cases
- moved template logic for `type|editType === 'boolean'` in `FormField` under the `isHdsField` block
- fix a couple of failing tests by updating the selectors to match the new DOM structure

Jira ticket: https://hashicorp.atlassian.net/browse/VAULT-34798


### Screenshots

**Before**:
<img width="1791" alt="screenshot_5051" src="https://github.com/user-attachments/assets/7bce0910-d68e-4864-be9f-7a32697ba35a" />

**After**:
<img width="1791" alt="screenshot_5050" src="https://github.com/user-attachments/assets/7cb9fa43-844f-4e8a-9943-20600adbce93" />

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
