### PR TITLE
Docs: Telemetery standby, leader & OSS / CE as well as ENT differences corrected in text

### DIFF
--- a/website/content/docs/configuration/telemetry.mdx
+++ b/website/content/docs/configuration/telemetry.mdx
@@ -18,6 +18,16 @@ telemetry {
 }
 ```
 
+<Tip title="Metrics from Leader vs Standby nodes">
+
+  Metrics from the telemetry end point are node specific.
+  In most cases the telemetry from the active leader node is what
+  will be of interest most times and or initially. Certian metrics are
+  **only reported by the leader** node including for example active: 
+  [`vault.identity.*` metrics](/vault/docs/internals/telemetry/metrics/all#vault-identity-entity-active-monthly).
+
+</Tip>
+
 ## `telemetry` parameters
 
 Due to the number of configurable parameters to the `telemetry` stanza,
@@ -190,8 +200,8 @@ endpoint on standby nodes by [enabling unauthenticated metrics access][telemetry
 Standby nodes will never forward a request to `/v1/sys/metrics` to the active
 node. If unauthenticated metrics access is enabled, the standby node will
 respond with its own metrics. If unauthenticated metrics access is not enabled,
-then a standby node will attempt to service the request but fail and then
-redirect the request to the active node.
+then a standby node will attempt to service the request (with Vault enterprise)
+or otherwise redirect the request to the active node (in Vault community edition).
 
 Querying `/v1/sys/metrics` with one of the following headers:
 

--- a/website/content/docs/configuration/telemetry.mdx
+++ b/website/content/docs/configuration/telemetry.mdx
@@ -197,11 +197,11 @@ These `telemetry` parameters apply to
 The `/v1/sys/metrics` endpoint is only accessible on active nodes
 and automatically disabled on standby nodes. You can enable the `/v1/sys/metrics`
 endpoint on standby nodes by [enabling unauthenticated metrics access][telemetry-tcp].
-Standby nodes will never forward a request to `/v1/sys/metrics` to the active
+Standby nodes will never forward a request to `/v1/sys/metrics` to the leader
 node. If unauthenticated metrics access is enabled, the standby node will
 respond with its own metrics. If unauthenticated metrics access is not enabled,
 then a standby node will attempt to service the request (with Vault enterprise)
-or otherwise redirect the request to the active node (in Vault community edition).
+or otherwise redirect the request to the leader node (in Vault community edition).
 
 Querying `/v1/sys/metrics` with one of the following headers:
 


### PR DESCRIPTION
Adjusted the page: `Developer/Vault/Documentation/`[Configure Vault](https://developer.hashicorp.com/vault/docs/configuration) / [**telemetry**](https://developer.hashicorp.com/vault/docs/configuration/telemetry).

Added a tip / attention area for customers to focus on metrics from leader first and foremost.

Corrected the text as regarding leader / redirect behaviour that is specific to OSS / CE (not enterprise).

<img width="998" alt="Screenshot 2025-05-28 at 13 40 33" src="https://github.com/user-attachments/assets/9b5f41b8-6a1b-4ecb-b5d9-7ffb50dca403" />

<img width="999" alt="Screenshot 2025-05-28 at 13 52 03" src="https://github.com/user-attachments/assets/5a5c72e0-78c6-4260-8e68-bab91d268cfc" />
