### PR TITLE
Update vault-plugin-database-snowflake to v0.13.1 in release/1.19.x

### DIFF
--- a/changelog/30748.txt
+++ b/changelog/30748.txt
@@ -1,3 +1,0 @@
-```release-note:change
-database/snowflake: Update plugin to v0.14.0
-```

--- a/changelog/30775.txt
+++ b/changelog/30775.txt
@@ -1,0 +1,3 @@
+```release-note:change
+database/snowflake: Update plugin to v0.13.1
+```

--- a/go.mod
+++ b/go.mod
@@ -150,7 +150,7 @@ require (
 	github.com/hashicorp/vault-plugin-database-mongodbatlas v0.14.0
 	github.com/hashicorp/vault-plugin-database-redis v0.5.0
 	github.com/hashicorp/vault-plugin-database-redis-elasticache v0.6.0
-	github.com/hashicorp/vault-plugin-database-snowflake v0.14.0
+	github.com/hashicorp/vault-plugin-database-snowflake v0.13.1
 	github.com/hashicorp/vault-plugin-mock v0.16.1
 	github.com/hashicorp/vault-plugin-secrets-ad v0.20.1
 	github.com/hashicorp/vault-plugin-secrets-alicloud v0.19.0

--- a/go.sum
+++ b/go.sum
@@ -1592,8 +1592,8 @@ github.com/hashicorp/vault-plugin-database-redis v0.5.0 h1:p0vLmwUs6Dyiwki6ibtiz
 github.com/hashicorp/vault-plugin-database-redis v0.5.0/go.mod h1:RaY5jao0wibpMeH/1Jz0QwpH9GQ+vRay2wz5of08QsY=
 github.com/hashicorp/vault-plugin-database-redis-elasticache v0.6.0 h1:IkP+Ilb/jC2FLU4KAH9+ai0aaCP+GVmGdmIl981ZFs0=
 github.com/hashicorp/vault-plugin-database-redis-elasticache v0.6.0/go.mod h1:AxZkp+gtaDtQL5aKB4/NrTTOMpwefSIy3GTbIRQtxoM=
-github.com/hashicorp/vault-plugin-database-snowflake v0.14.0 h1:/Tx1Ibx2D/G78f2vKWymPC6eQ8wOJdW67KGAtcMxKmA=
-github.com/hashicorp/vault-plugin-database-snowflake v0.14.0/go.mod h1:8cSMM64p7/fTM02L7VeFYtPXcwo4bFGhd0oFVhTAQgU=
+github.com/hashicorp/vault-plugin-database-snowflake v0.13.1 h1:3Kc7CRdaEflXRVWckJgRaoUoSdz5z3FV6CPCXXBqGJU=
+github.com/hashicorp/vault-plugin-database-snowflake v0.13.1/go.mod h1:AGpFtf96wWxJvpqAo2Wg/2VB7Ow5NfKTH34WAz5flOc=
 github.com/hashicorp/vault-plugin-mock v0.16.1 h1:5QQvSUHxDjEEbrd2REOeacqyJnCLPD51IQzy71hx8P0=
 github.com/hashicorp/vault-plugin-mock v0.16.1/go.mod h1:83G4JKlOwUtxVourn5euQfze3ZWyXcUiLj2wqrKSDIM=
 github.com/hashicorp/vault-plugin-secrets-ad v0.20.1 h1:EC+ZwWP54cehgXk5BC8WKX8/pMYVOo7CDLDh4RPQ6TM=


### PR DESCRIPTION
### Description
Update vault-plugin-database-snowflake to v0.13.1 in release/1.19.x

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
