### PR TITLE
fix panic in HCL duplicate warning

### DIFF
--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -3682,6 +3682,9 @@ func (b *SystemBackend) handlePoliciesSet(policyType PolicyType) framework.Opera
 		}
 
 		if duplicate {
+			if resp == nil {
+				resp = &logical.Response{}
+			}
 			// TODO (HCL_DUP_KEYS_DEPRECATION): remove log and API Warning once the deprecation is done
 			b.logger.Warn("newly created HCL policy contains duplicate attributes, which will no longer be supported in a future version", "policy", policy.Name, "namespace", ns.Path)
 			resp.AddWarning("policy contains duplicate attributes, which will no longer be supported in a future version")

--- a/vault/logical_system_test.go
+++ b/vault/logical_system_test.go
@@ -2817,8 +2817,8 @@ func TestSystemBackend_writeHCLDuplicateAttributes(t *testing.T) {
 
 	// policy with duplicate attribute
 	rules := `path "foo/" { policy = "read" policy = "read" }`
-	req := logical.TestRequest(t, logical.UpdateOperation, "policy/Foo")
-	req.Data["rules"] = rules
+	req := logical.TestRequest(t, logical.UpdateOperation, "policy/foo")
+	req.Data["policy"] = rules
 	resp, err := b.HandleRequest(namespace.RootContext(nil), req)
 	// TODO (HCL_DUP_KEYS_DEPRECATION): change this test to expect an error when creating a policy with duplicate attributes
 	if err != nil {


### PR DESCRIPTION
### Description
#30386 introduced a bug where the new HCL duplicate attribute warning on policy creation would cause a panic. Tests didn't catch it because they were triggering a different warning path that already had this logic. Thanks @mpalmi for finding the issue!

### TODO only if you're a HashiCorp employee
- [-] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [-] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [-] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [-] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [-] **RFC:** If this change has an associated RFC, please link it in the description.
- [-] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
