### PR TITLE
[VAULT-36594] UI: add missing integration tests for `FormField` component

### DIFF
--- a/ui/lib/core/addon/components/form-field.hbs
+++ b/ui/lib/core/addon/components/form-field.hbs
@@ -141,8 +141,8 @@
             @hasVisibilityToggle={{false}}
             @value={{get @model this.valuePath}}
             @isInvalid={{this.validationError}}
-            {{! Prevents browsers from auto-filling }}
             placeholder={{@attr.options.placeholder}}
+            {{! Prevents browsers from auto-filling }}
             autocomplete="new-password"
             spellcheck="false"
             {{on "input" this.onChangeWithEvent}}

--- a/ui/tests/integration/components/form-field-test.js
+++ b/ui/tests/integration/components/form-field-test.js
@@ -545,6 +545,7 @@ module('Integration | Component | form field', function (hooks) {
         .dom(inputs[index])
         .hasAttribute('id', possibleValue, 'input[type="checkbox"] has correct `id` attribute')
         .hasAttribute('name', 'myfield', 'input[type="checkbox"] has correct `name` attribute')
+        .hasAttribute('value', possibleValue, 'input[type="checkbox"] has correct `value` attribute')
         .hasAttribute(
           'data-test-checkbox',
           possibleValue,

--- a/ui/tests/integration/components/form-field-test.js
+++ b/ui/tests/integration/components/form-field-test.js
@@ -650,6 +650,8 @@ module('Integration | Component | form field', function (hooks) {
       .exists('renders as Hds::Form::Select');
     assert
       .dom('select')
+      .hasAttribute('id', 'myfield', 'select has correct `id` attribute')
+      .hasAttribute('name', 'myfield', 'select has correct `name` attribute')
       .hasAttribute('data-test-input', 'myfield', 'select has correct `data-test-input` attribute');
     assert.dom(GENERAL.fieldLabel()).hasText('Myfield', 'renders the select label');
     assert.dom(GENERAL.inputByAttr('myfield')).hasValue('foo', 'has first option value');

--- a/ui/tests/integration/components/form-field-test.js
+++ b/ui/tests/integration/components/form-field-test.js
@@ -325,6 +325,7 @@ module('Integration | Component | form field', function (hooks) {
         .dom(inputs[index])
         .hasAttribute('id', possibleValue, 'input[type="radio"] has correct `id` attribute')
         .hasAttribute('name', 'myfield', 'input[type="radio"] has correct `name` attribute')
+        .hasAttribute('value', possibleValue, 'input[type="radio"] has correct `value` attribute')
         .hasAttribute(
           'data-test-radio',
           possibleValue,

--- a/ui/tests/integration/components/form-field-test.js
+++ b/ui/tests/integration/components/form-field-test.js
@@ -543,7 +543,8 @@ module('Integration | Component | form field', function (hooks) {
         .hasText(possibleValue, 'label has correct text');
       assert
         .dom(inputs[index])
-        .hasAttribute('id', possibleValue, 'input[type="checkbox"] has correct id')
+        .hasAttribute('id', possibleValue, 'input[type="checkbox"] has correct `id` attribute')
+        .hasAttribute('name', 'myfield', 'input[type="checkbox"] has correct `name` attribute')
         .hasAttribute(
           'data-test-checkbox',
           possibleValue,

--- a/ui/tests/integration/components/form-field-test.js
+++ b/ui/tests/integration/components/form-field-test.js
@@ -497,6 +497,25 @@ module('Integration | Component | form field', function (hooks) {
       .hasText('Some subtext 4', 'renders the right subtext string for `qux` from options');
   });
 
+  // note: this test is not a duplicate of the one above, but is meant to test the condition
+  // where there is a `helpText` provided for one of the controls, but no `subText` for any of them
+  // in which case the template logic for the `HelperText` block of the inputs hits the `else` block
+  test('it renders: editType=radio / possibleValues - with passed helptext and subtext not defined', async function (assert) {
+    await setup.call(
+      this,
+      createAttr('myfield', '-', {
+        editType: 'radio',
+        possibleValues: [{ value: 'foo' }, { value: 'bar', helpText: 'Some helptext 2' }],
+      })
+    );
+    // first item should not have helpText
+    assert.dom(GENERAL.helpTextByGroupControlIndex(1)).doesNotExist('does not render helptext for `foo`');
+    // second item should have helpText
+    assert
+      .dom(GENERAL.helpTextByGroupControlIndex(2))
+      .hasText('Some helptext 2', 'renders the right helptext string for `bar` from options');
+  });
+
   test('it renders: editType=radio / possibleValues - with validation errors and warnings', async function (assert) {
     this.setProperties({
       attr: createAttr('myfield', '-', { editType: 'radio', possibleValues: ['foo', 'bar', 'baz'] }),

--- a/ui/tests/integration/components/form-field-test.js
+++ b/ui/tests/integration/components/form-field-test.js
@@ -323,7 +323,8 @@ module('Integration | Component | form field', function (hooks) {
         .hasText(possibleValue, 'label has correct text');
       assert
         .dom(inputs[index])
-        .hasAttribute('id', possibleValue, 'input[type="radio"] has correct id')
+        .hasAttribute('id', possibleValue, 'input[type="radio"] has correct `id` attribute')
+        .hasAttribute('name', 'myfield', 'input[type="radio"] has correct `name` attribute')
         .hasAttribute(
           'data-test-radio',
           possibleValue,

--- a/ui/tests/integration/components/form-field-test.js
+++ b/ui/tests/integration/components/form-field-test.js
@@ -395,6 +395,23 @@ module('Integration | Component | form field', function (hooks) {
     assert.ok(spy.calledWith('myfield', 'foo'), 'onChange called with correct args');
   });
 
+  test('it renders: editType=radio / possibleValues - disabled inputs', async function (assert) {
+    const possibleValues = ['foo', 'bar', 'baz'];
+    await setup.call(
+      this,
+      createAttr('myfield', '-', {
+        editType: 'radio',
+        editDisabled: true,
+        possibleValues: ['foo', 'bar', 'baz'],
+        defaultValue: 'baz',
+      })
+    );
+    const inputs = findAll(`${GENERAL.inputGroupByAttr('myfield')} input[type="radio"]`);
+    possibleValues.forEach((possibleValue, index) => {
+      assert.dom(inputs[index]).hasAttribute('disabled', '', 'input[type="radio"] has `disabled` attribute');
+    });
+  });
+
   test('it renders: editType=radio / possibleValues - with `true/false` boolean values', async function (assert) {
     const [model, spy] = await setup.call(
       this,

--- a/ui/tests/integration/components/form-field-test.js
+++ b/ui/tests/integration/components/form-field-test.js
@@ -332,6 +332,42 @@ module('Integration | Component | form field', function (hooks) {
     });
   });
 
+  test('it renders: editType=radio / possibleValues - horizontal layout (no `subText/helpText`)', async function (assert) {
+    await setup.call(
+      this,
+      createAttr('myfield', '-', { editType: 'radio', possibleValues: ['foo', 'bar', 'baz'] })
+    );
+    assert
+      .dom('.field fieldset[class^="hds-form-group"].hds-form-group--layout-horizontal')
+      .exists('renders the Hds::Form::Radio::Group with an horizontal layout');
+  });
+
+  test('it renders: editType=radio / possibleValues - vertical layout (with `subText`)', async function (assert) {
+    await setup.call(
+      this,
+      createAttr('myfield', '-', {
+        editType: 'radio',
+        possibleValues: [{ value: 'foo', subText: 'Some subtext' }, { value: 'bar' }, { value: 'baz' }],
+      })
+    );
+    assert
+      .dom('.field fieldset[class^="hds-form-group"].hds-form-group--layout-vertical')
+      .exists('renders the Hds::Form::Radio::Group with a vertical layout');
+  });
+
+  test('it renders: editType=radio / possibleValues - vertical layout (with `helpText`)', async function (assert) {
+    await setup.call(
+      this,
+      createAttr('myfield', '-', {
+        editType: 'radio',
+        possibleValues: [{ value: 'foo', helpText: 'Some help text' }, { value: 'bar' }, { value: 'baz' }],
+      })
+    );
+    assert
+      .dom('.field fieldset[class^="hds-form-group"].hds-form-group--layout-vertical')
+      .exists('renders the Hds::Form::Radio::Group with a vertical layout');
+  });
+
   test('it renders: editType=radio / possibleValues - with no selected radio', async function (assert) {
     const possibleValues = ['foo', 'bar', 'baz'];
     await setup.call(this, createAttr('myfield', '-', { editType: 'radio', possibleValues }));

--- a/ui/tests/integration/components/form-field-test.js
+++ b/ui/tests/integration/components/form-field-test.js
@@ -764,6 +764,17 @@ module('Integration | Component | form field', function (hooks) {
     assert
       .dom(`input[type="password"]`)
       .exists('renders input with type=password')
+      .hasAttribute('name', 'myfield', 'input[type="password"] has correct `id` attribute')
+      .doesNotHaveAttribute(
+        'placeholder',
+        'input[type="password"] does not have `placeholder` attribute by default'
+      )
+      .hasAttribute(
+        'autocomplete',
+        'new-password',
+        'input[type="password"] has correct `autocomplete` attribute'
+      )
+      .hasAttribute('spellcheck', 'false', 'input[type="password"] has correct `spellcheck` attribute')
       .hasAttribute(
         'data-test-input',
         'myfield',


### PR DESCRIPTION
### Description
What does this PR do?

- It mainly adds new integration tests for some of the form fields, that were missed when migrated to HDS components (see single commits descriptions for details).
- it also brings back a test that was removed in #30768 (see [thread here](https://github.com/hashicorp/vault/pull/30768/files#r2112332572)) 

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
