### PR TITLE
UI: Update Month Order to be Recent - Oldest

### DIFF
--- a/ui/app/components/clients/page/overview.ts
+++ b/ui/app/components/clients/page/overview.ts
@@ -26,7 +26,7 @@ export default class ClientsOverviewPageComponent extends ActivityComponent {
   }
 
   get months() {
-    return this.byMonthNewClients.map((m) => ({
+    return this.byMonthNewClients.reverse().map((m) => ({
       display: parseAPITimestamp(m.timestamp, 'MMMM yyyy'),
       value: m.month,
     }));

--- a/ui/tests/integration/components/clients/page/overview-test.js
+++ b/ui/tests/integration/components/clients/page/overview-test.js
@@ -154,7 +154,7 @@ module('Integration | Component | clients/page/overview', function (hooks) {
     await triggerEvent(GENERAL.selectByAttr('attribution-month'), 'change');
 
     // assert that months options in select are those of selected billing period
-    const expectedMonths = this.activity.byMonth.map((m) => m.month);
+    const expectedMonths = this.activity.byMonth.reverse().map((m) => m.month);
 
     // '' represents default state of 'Select month'
     const expectedOptions = ['', ...expectedMonths];


### PR DESCRIPTION
### Description
This updates the month options to show in order of recent -> oldest. This matches the billing period dropdown format and suits the expected use case of investigating recent activity spikes.

<img width="857" alt="image" src="https://github.com/user-attachments/assets/994a216f-21f6-430c-8b08-4840d863562b" />


### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
