### PR TITLE
[UI] Ember Data Migration - Secrets Engine Resource

### DIFF
--- a/ui/app/components/dashboard/secrets-engines-card.ts
+++ b/ui/app/components/dashboard/secrets-engines-card.ts
@@ -4,7 +4,8 @@
  */
 
 import Component from '@glimmer/component';
-import type SecretEngineModel from 'vault/models/secret-engine';
+
+import type SecretsEngineResource from 'vault/resources/secrets/engine';
 
 /**
  * @module DashboardSecretsEnginesCard
@@ -18,7 +19,7 @@ import type SecretEngineModel from 'vault/models/secret-engine';
  */
 
 interface Args {
-  secretsEngines: SecretEngineModel[];
+  secretsEngines: SecretsEngineResource[];
 }
 
 export default class DashboardSecretsEnginesCard extends Component<Args> {

--- a/ui/app/components/dashboard/vault-configuration-details-card.hbs
+++ b/ui/app/components/dashboard/vault-configuration-details-card.hbs
@@ -10,17 +10,17 @@
     <:body as |B|>
       <B.Tr>
         <B.Td>API_ADDR</B.Td>
-        <B.Td data-test-vault-config-details="api_addr">{{or @vaultConfiguration.api_addr "None"}}</B.Td>
+        <B.Td data-test-vault-config-details="api_addr">{{or @vaultConfiguration.apiAddr "None"}}</B.Td>
       </B.Tr>
       <B.Tr>
         <B.Td>Default lease TTL</B.Td>
         <B.Td data-test-vault-config-details="default_lease_ttl">{{format-duration
-            @vaultConfiguration.default_lease_ttl
+            @vaultConfiguration.defaultLeaseTtl
           }}</B.Td>
       </B.Tr>
       <B.Tr>
         <B.Td>Max lease TTL</B.Td>
-        <B.Td data-test-vault-config-details="max_lease_ttl">{{format-duration @vaultConfiguration.max_lease_ttl}}</B.Td>
+        <B.Td data-test-vault-config-details="max_lease_ttl">{{format-duration @vaultConfiguration.maxLeaseTtl}}</B.Td>
       </B.Tr>
       <B.Tr>
         <B.Td>TLS</B.Td>
@@ -28,11 +28,11 @@
       </B.Tr>
       <B.Tr>
         <B.Td>Log format</B.Td>
-        <B.Td data-test-vault-config-details="log_format">{{or @vaultConfiguration.log_format "None"}}</B.Td>
+        <B.Td data-test-vault-config-details="log_format">{{or @vaultConfiguration.logFormat "None"}}</B.Td>
       </B.Tr>
       <B.Tr>
         <B.Td>Log level</B.Td>
-        <B.Td data-test-vault-config-details="log_level">{{@vaultConfiguration.log_level}}</B.Td>
+        <B.Td data-test-vault-config-details="log_level">{{@vaultConfiguration.logLevel}}</B.Td>
       </B.Tr>
       <B.Tr>
         <B.Td>Storage type</B.Td>

--- a/ui/app/components/dashboard/vault-configuration-details-card.js
+++ b/ui/app/components/dashboard/vault-configuration-details-card.js
@@ -18,11 +18,11 @@ import Component from '@glimmer/component';
 
 export default class DashboardSecretsEnginesCard extends Component {
   get tls() {
-    // since the default for tls_disable is false it may not be in the config
-    // consider tls enabled if tls_disable is undefined or false AND both tls_cert_file and tls_key_file are defined
+    // since the default for tlsDisable is false it may not be in the config
+    // consider tls enabled if tlsDisable is undefined or false AND both tlsCertFile and tlsKeyFile are defined
     const tlsListener = this.args.vaultConfiguration?.listeners.find((listener) => {
-      const { tls_disable, tls_cert_file, tls_key_file } = listener.config || {};
-      return !tls_disable && tls_cert_file && tls_key_file;
+      const { tlsDisable, tlsCertFile, tlsKeyFile } = listener.config || {};
+      return !tlsDisable && tlsCertFile && tlsKeyFile;
     });
 
     return tlsListener ? 'Enabled' : 'Disabled';

--- a/ui/app/components/secret-engine/configuration-details.hbs
+++ b/ui/app/components/secret-engine/configuration-details.hbs
@@ -7,7 +7,7 @@
   {{#each this.displayFields as |field|}}
     {{! public key while not sensitive when editing/creating, should be hidden by default on viewing }}
     {{#if (eq field "publicKey")}}
-      <InfoTableRow alwaysRender={{not (is-empty-value @config.publicKey)}} @label="Public key" @value={{@config.publicKey}}>
+      <InfoTableRow @label="Public key" @value={{@config.publicKey}}>
         <MaskedInput @value={{@config.publicKey}} @name={{field}} @displayOnly={{true}} @allowCopy={{true}} />
       </InfoTableRow>
     {{else}}

--- a/ui/app/components/secret-engine/configuration-details.hbs
+++ b/ui/app/components/secret-engine/configuration-details.hbs
@@ -3,23 +3,19 @@
   SPDX-License-Identifier: BUSL-1.1
 }}
 
-{{#each @configModels as |configModel|}}
-  {{#each configModel.displayAttrs as |attr|}}
+{{#if @config}}
+  {{#each this.displayFields as |field|}}
     {{! public key while not sensitive when editing/creating, should be hidden by default on viewing }}
-    {{#if (or attr.options.sensitive (eq attr.name "publicKey"))}}
-      <InfoTableRow
-        alwaysRender={{not (is-empty-value (get configModel attr.name))}}
-        @label={{or attr.options.label (to-label attr.name)}}
-        @value={{get configModel (or attr.options.fieldValue attr.name)}}
-      >
-        <MaskedInput @value={{get configModel attr.name}} @name={{attr.name}} @displayOnly={{true}} @allowCopy={{true}} />
+    {{#if (eq field "publicKey")}}
+      <InfoTableRow alwaysRender={{not (is-empty-value @config.publicKey)}} @label="Public key" @value={{@config.publicKey}}>
+        <MaskedInput @value={{@config.publicKey}} @name={{field}} @displayOnly={{true}} @allowCopy={{true}} />
       </InfoTableRow>
     {{else}}
       <InfoTableRow
-        @alwaysRender={{not (is-empty-value (get @model attr.name))}}
-        @label={{or attr.options.label (to-label attr.name)}}
-        @value={{get configModel (or attr.options.fieldValue attr.name)}}
-        @formatTtl={{eq attr.options.editType "ttl"}}
+        @alwaysRender={{not (is-empty-value (get @config field))}}
+        @label={{this.label field}}
+        @value={{get @config field}}
+        @formatTtl={{this.isDuration field}}
       />
     {{/if}}
   {{/each}}
@@ -38,4 +34,4 @@
       @model={{@id}}
     />
   </EmptyState>
-{{/each}}
+{{/if}}

--- a/ui/app/components/secret-engine/configuration-details.ts
+++ b/ui/app/components/secret-engine/configuration-details.ts
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import Component from '@glimmer/component';
+import { toLabel } from 'core/helpers/to-label';
+
+import type { AwsConfig, AzureConfig, GcpConfig, SshConfig } from 'vault/vault/secrets/engine';
+
+type Args = {
+  config: AwsConfig | AzureConfig | GcpConfig | SshConfig;
+  typeDisplay: string;
+};
+
+export default class ConfigurationDetails extends Component<Args> {
+  awsFields = [
+    'roleArn',
+    'identityTokenAudience',
+    'identityTokenTtl',
+    'accessKey',
+    'region',
+    'iamEndpoint',
+    'stsEndpoint',
+    'maxRetries',
+    'lease',
+    'leaseMax',
+    'issuer',
+  ];
+
+  azureFields = [
+    'subscriptionId',
+    'tenantId',
+    'clientId',
+    'identityTokenAudience',
+    'identityTokenTtl',
+    'rootPasswordTtl',
+    'environment',
+    'issuer',
+  ];
+
+  gcpFields = ['serviceAccountEmail', 'ttl', 'maxTtl', 'identityTokenAudience', 'identityTokenTtl', 'issuer'];
+
+  sshFields = ['publicKey', 'generateSigningKey'];
+
+  get displayFields() {
+    switch (this.args.typeDisplay) {
+      case 'AWS':
+        return this.awsFields;
+      case 'Azure':
+        return this.azureFields;
+      case 'Google Cloud':
+        return this.gcpFields;
+      case 'SSH':
+        return this.sshFields;
+      default:
+        return [];
+    }
+  }
+
+  label = (field: string) => {
+    const label = toLabel([field]);
+    // convert words like id and ttl to uppercase
+    const formattedLabel = label.replace(/(id|ttl)/g, (match: string) => match.toUpperCase());
+    // map specific fields to custom labels
+    return (
+      {
+        lease: 'Default Lease TTL',
+        leaseMax: 'Max Lease TTL',
+      }[field] || formattedLabel
+    );
+  };
+
+  isDuration = (field: string) => {
+    return ['identityTokenTtl', 'rootPasswordTtl', 'lease', 'leaseMax', 'ttl', 'maxTtl'].includes(field);
+  };
+}

--- a/ui/app/components/secret-engine/configuration-details.ts
+++ b/ui/app/components/secret-engine/configuration-details.ts
@@ -73,6 +73,7 @@ export default class ConfigurationDetails extends Component<Args> {
       {
         lease: 'Default Lease TTL',
         leaseMax: 'Max Lease TTL',
+        ttl: 'Config TTL',
       }[field] || formattedLabel
     );
   };

--- a/ui/app/components/secret-engine/configuration-details.ts
+++ b/ui/app/components/secret-engine/configuration-details.ts
@@ -61,7 +61,13 @@ export default class ConfigurationDetails extends Component<Args> {
   label = (field: string) => {
     const label = toLabel([field]);
     // convert words like id and ttl to uppercase
-    const formattedLabel = label.replace(/(id|ttl)/g, (match: string) => match.toUpperCase());
+    const formattedLabel = label
+      .split(' ')
+      .map((word: string) => {
+        const acronyms = ['id', 'ttl', 'arn', 'iam', 'sts'];
+        return acronyms.includes(word.toLowerCase()) ? word.toUpperCase() : word;
+      })
+      .join(' ');
     // map specific fields to custom labels
     return (
       {

--- a/ui/app/controllers/vault/cluster/secrets/backend/configuration/index.js
+++ b/ui/app/controllers/vault/cluster/secrets/backend/configuration/index.js
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import Controller from '@ember/controller';
+import { WIF_ENGINES } from 'vault/helpers/mountable-secret-engines';
+import { toLabel } from 'core/helpers/to-label';
+
+export default class SecretsBackendConfigurationController extends Controller {
+  get displayFields() {
+    const { engineType } = this.model.secretsEngine;
+    const fields = ['type', 'path', 'description', 'accessor', 'local', 'sealWrap'];
+    // no ttl options for keymgmt
+    if (engineType !== 'keymgmt') {
+      fields.push('config.defaultLeaseTtl', 'config.maxLeaseTtl');
+    }
+    fields.push(
+      'config.allowedManagedKeys',
+      'config.auditNonHmacRequestKeys',
+      'config.auditNonHmacResponseKeys',
+      'config.passthroughRequestHeaders',
+      'config.allowedResponseHeaders'
+    );
+    if (engineType === 'kv' || engineType === 'generic') {
+      fields.push('version');
+    }
+    // For WIF Secret engines, allow users to set the identity token key when mounting the engine.
+    if (WIF_ENGINES.includes(engineType)) {
+      fields.push('config.identityTokenKey');
+    }
+    return fields;
+  }
+
+  label = (field) => {
+    const key = field.replace('config.', '');
+    const label = toLabel([key]);
+    // map specific fields to custom labels
+    return (
+      {
+        defaultLeaseTtl: 'Default Lease TTL',
+        maxLeaseTtl: 'Max Lease TTL',
+        auditNonHmacRequestKeys: 'Request keys excluded from HMACing in audit',
+        auditNonHmacResponseKeys: 'Response keys excluded from HMACing in audit',
+        passthroughRequestHeaders: 'Allowed passthrough request headers',
+      }[key] || label
+    );
+  };
+}

--- a/ui/app/resources/base-factory.ts
+++ b/ui/app/resources/base-factory.ts
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+abstract class BaseResource<T> {
+  // pass data that the resource should represent (typically from an API response) to constructor
+  // object properties will be assigned to class instance
+  // extending classes can define getters and additional properties/methods that are required widely across the app
+  constructor(readonly data: T) {
+    Object.assign(this, data) as T;
+  }
+}
+
+// factory that allows for the BaseResource class to be casted to the specific type provided
+// without this the compiler is not aware of the properties set on the class via Object.assign
+// example usage -> export default class SecretsEngineResource extends baseResourceFactory<SecretsEngine>() { ... }
+export function baseResourceFactory<T>() {
+  return BaseResource as new (data: T) => T;
+}

--- a/ui/app/resources/secrets/engine.ts
+++ b/ui/app/resources/secrets/engine.ts
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import { baseResourceFactory } from 'vault/resources/base-factory';
+import { isAddonEngine, allEngines } from 'vault/helpers/mountable-secret-engines';
+import { supportedSecretBackends } from 'vault/helpers/supported-secret-backends';
+
+import type { SecretsEngine } from 'vault/secrets/engine';
+
+export default class SecretsEngineResource extends baseResourceFactory<SecretsEngine>() {
+  id: string;
+
+  #LIST_EXCLUDED_BACKENDS = ['system', 'identity'];
+
+  constructor(data: SecretsEngine) {
+    super(data);
+    // strip trailing slash from path for id since it is used in routing
+    this.id = data.path.replace(/\/$/, '');
+  }
+
+  get version() {
+    const { version } = this.options || {};
+    return version ? Number(version) : undefined;
+  }
+
+  get engineType() {
+    return (this.type || '').replace(/^ns_/, '');
+  }
+
+  get icon() {
+    const engineData = allEngines().find((engine) => engine.type === this.engineType);
+
+    return engineData?.glyph || 'lock';
+  }
+
+  get isV2KV() {
+    return this.version === 2 && (this.engineType === 'kv' || this.engineType === 'generic');
+  }
+
+  get shouldIncludeInList() {
+    return !this.#LIST_EXCLUDED_BACKENDS.includes(this.engineType);
+  }
+
+  get isSupportedBackend() {
+    return supportedSecretBackends().includes(this.engineType);
+  }
+
+  get backendLink() {
+    if (this.engineType === 'database') {
+      return 'vault.cluster.secrets.backend.overview';
+    }
+    if (isAddonEngine(this.engineType, this.version)) {
+      const engine = allEngines().find((engine) => engine.type === this.engineType);
+      if (engine?.engineRoute) {
+        return `vault.cluster.secrets.backend.${engine.engineRoute}`;
+      }
+    }
+    if (this.isV2KV) {
+      // if it's KV v2 but not registered as an addon, it's type generic
+      return 'vault.cluster.secrets.backend.kv.list';
+    }
+    return `vault.cluster.secrets.backend.list-root`;
+  }
+
+  get backendConfigurationLink() {
+    if (isAddonEngine(this.engineType, this.version)) {
+      return `vault.cluster.secrets.backend.${this.engineType}.configuration`;
+    }
+    return `vault.cluster.secrets.backend.configuration`;
+  }
+
+  get localDisplay() {
+    return this.local ? 'local' : 'replicated';
+  }
+}

--- a/ui/app/resources/secrets/engine.ts
+++ b/ui/app/resources/secrets/engine.ts
@@ -22,7 +22,7 @@ export default class SecretsEngineResource extends baseResourceFactory<SecretsEn
 
   get version() {
     const { version } = this.options || {};
-    return version ? Number(version) : undefined;
+    return version ? Number(version) : 1;
   }
 
   get engineType() {

--- a/ui/app/routes/vault/cluster/dashboard.js
+++ b/ui/app/routes/vault/cluster/dashboard.js
@@ -5,29 +5,30 @@
 
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
-import { hash } from 'rsvp';
 // eslint-disable-next-line ember/no-mixins
 import ClusterRoute from 'vault/mixins/cluster-route';
 import { action } from '@ember/object';
+import SecretsEngineResource from 'vault/resources/secrets/engine';
 
 export default class VaultClusterDashboardRoute extends Route.extend(ClusterRoute) {
   @service store;
   @service namespace;
   @service version;
+  @service api;
 
-  async getVaultConfiguration() {
+  async getVaultConfiguration(hasChroot) {
     try {
-      if (!this.namespace.inRootNamespace) return null;
-
-      const adapter = this.store.adapterFor('application');
-      const configState = await adapter.ajax('/v1/sys/config/state/sanitized', 'GET');
-      return configState.data;
+      if (!this.namespace.inRootNamespace || hasChroot) {
+        return null;
+      }
+      const { data } = await this.api.sys.readSanitizedConfigurationState();
+      return data;
     } catch (e) {
       return null;
     }
   }
 
-  model() {
+  async model() {
     const clusterModel = this.modelFor('vault.cluster');
     const hasChroot = clusterModel?.hasChrootNamespace;
     const replication =
@@ -37,13 +38,22 @@ export default class VaultClusterDashboardRoute extends Route.extend(ClusterRout
             dr: clusterModel.dr,
             performance: clusterModel.performance,
           };
-    return hash({
+    const requests = [
+      this.getVaultConfiguration(hasChroot),
+      this.api.sys.internalUiListEnabledVisibleMounts(),
+    ];
+    const [vaultConfiguration, { secret }] = await Promise.all(requests);
+    const secretsEngines = this.api
+      .responseObjectToArray(secret, 'path')
+      .map((engine) => new SecretsEngineResource(engine));
+
+    return {
       replication,
-      secretsEngines: this.store.query('secret-engine', {}),
+      secretsEngines,
       isRootNamespace: this.namespace.inRootNamespace && !hasChroot,
       version: this.version,
-      vaultConfiguration: hasChroot ? null : this.getVaultConfiguration(),
-    });
+      vaultConfiguration,
+    };
   }
 
   @action

--- a/ui/app/routes/vault/cluster/dashboard.js
+++ b/ui/app/routes/vault/cluster/dashboard.js
@@ -40,7 +40,7 @@ export default class VaultClusterDashboardRoute extends Route.extend(ClusterRout
           };
     const requests = [
       this.getVaultConfiguration(hasChroot),
-      this.api.sys.internalUiListEnabledVisibleMounts(),
+      this.api.sys.internalUiListEnabledVisibleMounts().catch(() => ({})),
     ];
     const [vaultConfiguration, { secret }] = await Promise.all(requests);
     const secretsEngines = this.api

--- a/ui/app/routes/vault/cluster/secrets/backend.js
+++ b/ui/app/routes/vault/cluster/secrets/backend.js
@@ -19,8 +19,18 @@ export default Route.extend({
     const { backend } = params;
     this.secretMountPath.update(backend);
 
-    const secretsEngine = await this.api.sys.mountsReadConfiguration(backend);
-    return new SecretsEngineResource({ ...secretsEngine, path: `${backend}/` });
+    try {
+      const secretsEngine = await this.api.sys.internalUiReadMountInformation(backend);
+      return new SecretsEngineResource({ ...secretsEngine, path: `${backend}/` });
+    } catch (e) {
+      // the backend.error template is expecting additional data so for now we will catch and rethrow
+      const error = await this.api.parseError(e);
+      throw {
+        backend,
+        httpStatus: error.status,
+        ...error,
+      };
+    }
   },
 
   afterModel(model, transition) {

--- a/ui/app/routes/vault/cluster/secrets/backend.js
+++ b/ui/app/routes/vault/cluster/secrets/backend.js
@@ -5,25 +5,22 @@
 
 import { service } from '@ember/service';
 import Route from '@ember/routing/route';
+import SecretsEngineResource from 'vault/resources/secrets/engine';
+
 export default Route.extend({
   flashMessages: service(),
   router: service(),
   secretMountPath: service(),
-  store: service(),
+  api: service(),
+
   oldModel: null,
 
-  model(params) {
+  async model(params) {
     const { backend } = params;
     this.secretMountPath.update(backend);
-    return this.store
-      .query('secret-engine', {
-        path: backend,
-      })
-      .then((model) => {
-        if (model) {
-          return model[0];
-        }
-      });
+
+    const secretsEngine = await this.api.sys.mountsReadConfiguration(backend);
+    return new SecretsEngineResource({ ...secretsEngine, path: `${backend}/` });
   },
 
   afterModel(model, transition) {

--- a/ui/app/routes/vault/cluster/secrets/backend/configuration/index.js
+++ b/ui/app/routes/vault/cluster/secrets/backend/configuration/index.js
@@ -121,7 +121,7 @@ export default class SecretsBackendConfigurationRoute extends Route {
 
   async checkIssuer(config, fields) {
     // issuer is an enterprise only related feature
-    // issuer is also a global endpoint that doesn't mean anything in the AWS secret details context if WIF related fields on the rootConfig have not been set.
+    // issuer is also a global endpoint that doesn't mean anything in the secret details context if WIF related fields on the engine's config have not been set.
     if (this.version.isEnterprise && config) {
       const shouldFetchIssuer = fields.some((field) => config[field]);
 

--- a/ui/app/routes/vault/cluster/secrets/backend/configuration/index.js
+++ b/ui/app/routes/vault/cluster/secrets/backend/configuration/index.js
@@ -142,7 +142,7 @@ export default class SecretsBackendConfigurationRoute extends Route {
     return {
       backend,
       httpStatus: error.status,
-      ...error,
+      ...error.response,
     };
   }
 

--- a/ui/app/routes/vault/cluster/secrets/backend/list.js
+++ b/ui/app/routes/vault/cluster/secrets/backend/list.js
@@ -81,7 +81,7 @@ export default Route.extend({
     const secret = this.secretParam();
     const backend = this.enginePathParam();
     const { tab } = this.paramsFor('vault.cluster.secrets.backend.list-root');
-    const secretEngine = this.store.peekRecord('secret-engine', backend);
+    const secretEngine = this.modelFor('vault.cluster.secrets.backend');
     const type = secretEngine?.engineType;
     assert('secretEngine.engineType is not defined', !!type);
     // if configuration only, redirect to configuration route
@@ -105,15 +105,13 @@ export default Route.extend({
       // if it's KV v2 but not registered as an addon, it's type generic
       return this.router.transitionTo('vault.cluster.secrets.backend.kv.list', backend);
     }
-    const modelType = this.getModelType(backend, tab);
+    const modelType = this.getModelType(secretEngine.type, tab);
     return this.pathHelp.hydrateModel(modelType, backend).then(() => {
       this.store.unloadAll('capabilities');
     });
   },
 
-  getModelType(backend, tab) {
-    const secretEngine = this.store.peekRecord('secret-engine', backend);
-    const type = secretEngine.engineType;
+  getModelType(type, tab) {
     const types = {
       database: tab === 'role' ? 'database/role' : 'database/connection',
       transit: 'transit-key',
@@ -165,7 +163,7 @@ export default Route.extend({
     const secret = resolvedModel.secret;
     const model = resolvedModel.secrets;
     const backend = this.enginePathParam();
-    const backendModel = this.store.peekRecord('secret-engine', backend);
+    const backendModel = this.modelFor('vault.cluster.secrets.backend');
     const has404 = this.has404;
     // only clear store cache if this is a new model
     if (secret !== controller?.baseKey?.id) {

--- a/ui/app/routes/vault/cluster/secrets/backend/list.js
+++ b/ui/app/routes/vault/cluster/secrets/backend/list.js
@@ -131,7 +131,7 @@ export default Route.extend({
     const secret = this.secretParam() || '';
     const backend = this.enginePathParam();
     const backendModel = this.modelFor('vault.cluster.secrets.backend');
-    const modelType = this.getModelType(backend, params.tab);
+    const modelType = this.getModelType(backendModel.type, params.tab);
 
     return hash({
       secret,

--- a/ui/app/routes/vault/cluster/secrets/backends.ts
+++ b/ui/app/routes/vault/cluster/secrets/backends.ts
@@ -5,13 +5,15 @@
 
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
+import SecretsEngineResource from 'vault/resources/secrets/engine';
 
-import type Store from '@ember-data/store';
+import type ApiService from 'vault/services/api';
 
 export default class SecretsBackends extends Route {
-  @service declare readonly store: Store;
+  @service declare readonly api: ApiService;
 
-  model() {
-    return this.store.query('secret-engine', {});
+  async model() {
+    const { secret } = await this.api.sys.internalUiListEnabledVisibleMounts();
+    return this.api.responseObjectToArray(secret, 'path').map((engine) => new SecretsEngineResource(engine));
   }
 }

--- a/ui/app/services/api.ts
+++ b/ui/app/services/api.ts
@@ -200,4 +200,21 @@ export default class ApiService extends Service {
       [] as Record<string, unknown>[]
     );
   }
+
+  // some responses return an object with a uuid as the key rather than an array
+  // in most cases it is easier to work with an array with the uuid set as a property on the object
+  // for example, internalUiListEnabledVisibleMounts returns an object like: { secret: { '/path/to/secret': { ... } } }
+  // usage for above example -> this.api.objectToArray(response.secret, 'path');
+  // this would return an array of objects like: [{ path: '/path/to/secret', ... }]
+  responseObjectToArray<T extends object>(obj?: T, uuidKey?: string) {
+    if (obj) {
+      return Object.entries(obj).map(([key, value]) => {
+        if (uuidKey) {
+          return { [uuidKey]: key, ...value };
+        }
+        return { ...value };
+      });
+    }
+    return [];
+  }
 }

--- a/ui/app/services/api.ts
+++ b/ui/app/services/api.ts
@@ -65,8 +65,9 @@ export default class ApiService extends Service {
     const headers = new Headers(init.headers);
     // unauthenticated or clientToken requests should set the header in initOverrides
     // unauthenticated value should be empty string, not undefined or null
-    if (!headers.has('X-Vault-Token')) {
-      headers.set('X-Vault-Token', this.authService.currentToken);
+    const { currentToken } = this.authService;
+    if (!headers.has('X-Vault-Token') && currentToken) {
+      headers.set('X-Vault-Token', currentToken);
     }
     if (init.method === 'PATCH') {
       headers.set('Content-Type', 'application/merge-patch+json');

--- a/ui/app/templates/vault/cluster/secrets/backend/configuration/index.hbs
+++ b/ui/app/templates/vault/cluster/secrets/backend/configuration/index.hbs
@@ -3,14 +3,14 @@
   SPDX-License-Identifier: BUSL-1.1
 }}
 
-<SecretListHeader @model={{this.model.secretEngineModel}} @isConfigure={{true}} />
+<SecretListHeader @model={{this.model.secretsEngine}} @isConfigure={{true}} />
 
 {{#if this.isConfigurable}}
   <Toolbar>
     <ToolbarActions>
       <ToolbarLink
         @route="vault.cluster.secrets.backend.configuration.edit"
-        @model={{this.model.secretEngineModel.id}}
+        @model={{this.model.secretsEngine.id}}
         data-test-secret-backend-configure
       >
         Configure
@@ -18,38 +18,23 @@
     </ToolbarActions>
   </Toolbar>
 
-  <SecretEngine::ConfigurationDetails
-    @configModels={{this.model.configModels}}
-    @typeDisplay={{this.typeDisplay}}
-    @id={{this.modelId}}
-  />
+  <SecretEngine::ConfigurationDetails @config={{this.model.config}} @typeDisplay={{this.typeDisplay}} @id={{this.modelId}} />
 
   <SecretsEngineMountConfig
-    @model={{this.model.secretEngineModel}}
+    @secretsEngine={{this.model.secretsEngine}}
     class="has-top-margin-xl has-bottom-margin-xl"
     data-test-mount-config
   />
 
 {{else}}
   <div class="box is-fullwidth is-sideless is-paddingless is-marginless">
-    {{#each this.model.secretEngineModel.attrs as |attr|}}
-      {{#if (eq attr.type "object")}}
-        <InfoTableRow
-          @alwaysRender={{not (is-empty-value (get this.model.secretEngineModel attr.name))}}
-          @label={{or attr.options.label (to-label attr.name)}}
-          @value={{stringify (get this.model.secretEngineModel (or attr.options.fieldValue attr.name))}}
-        />
-      {{else}}
-        <InfoTableRow
-          @alwaysRender={{and
-            (not (is-empty-value (get this.model.secretEngineModel attr.name)))
-            (not-eq attr.name "version")
-          }}
-          @formatTtl={{eq attr.options.editType "ttl"}}
-          @label={{or attr.options.label (to-label attr.name)}}
-          @value={{get this.model.secretEngineModel (or attr.options.fieldValue attr.name)}}
-        />
-      {{/if}}
+    {{#each this.displayFields as |field|}}
+      <InfoTableRow
+        @alwaysRender={{and (not (is-empty-value (get this.model.secretsEngine field))) (not-eq field "version")}}
+        @formatTtl={{includes field (array "config.defaultLeaseTtl" "config.maxLeaseTtl")}}
+        @label={{this.label field}}
+        @value={{get this.model.secretsEngine field}}
+      />
     {{/each}}
   </div>
 {{/if}}

--- a/ui/app/templates/vault/cluster/secrets/backends.hbs
+++ b/ui/app/templates/vault/cluster/secrets/backends.hbs
@@ -11,4 +11,4 @@
   </p.levelLeft>
 </PageHeader>
 
-<SecretEngine::List @secretEngineModels={{this.model}} />
+<SecretEngine::List @secretEngines={{this.model}} />

--- a/ui/lib/core/addon/components/secrets-engine-mount-config.hbs
+++ b/ui/lib/core/addon/components/secrets-engine-mount-config.hbs
@@ -4,14 +4,16 @@
 }}
 
 <div ...attributes>
-  <ToggleButton
-    @isOpen={{this.showConfig}}
-    @openLabel="Hide mount configuration"
-    @closedLabel="Show mount configuration"
-    @onClick={{fn (mut this.showConfig) (not this.showConfig)}}
-    class="is-block"
-    data-test-mount-config-toggle
-  />
+  {{#unless @hideToggle}}
+    <ToggleButton
+      @isOpen={{this.showConfig}}
+      @openLabel="Hide mount configuration"
+      @closedLabel="Show mount configuration"
+      @onClick={{fn (mut this.showConfig) (not this.showConfig)}}
+      class="is-block"
+      data-test-mount-config-toggle
+    />
+  {{/unless}}
   {{#if this.showConfig}}
     {{#each this.fields as |field|}}
       <InfoTableRow @label={{field.label}} @value={{field.value}} data-test-mount-config-field={{field.label}} />

--- a/ui/lib/core/addon/components/secrets-engine-mount-config.hbs
+++ b/ui/lib/core/addon/components/secrets-engine-mount-config.hbs
@@ -4,16 +4,14 @@
 }}
 
 <div ...attributes>
-  {{#unless @hideToggle}}
-    <ToggleButton
-      @isOpen={{this.showConfig}}
-      @openLabel="Hide mount configuration"
-      @closedLabel="Show mount configuration"
-      @onClick={{fn (mut this.showConfig) (not this.showConfig)}}
-      class="is-block"
-      data-test-mount-config-toggle
-    />
-  {{/unless}}
+  <ToggleButton
+    @isOpen={{this.showConfig}}
+    @openLabel="Hide mount configuration"
+    @closedLabel="Show mount configuration"
+    @onClick={{fn (mut this.showConfig) (not this.showConfig)}}
+    class="is-block"
+    data-test-mount-config-toggle
+  />
   {{#if this.showConfig}}
     {{#each this.fields as |field|}}
       <InfoTableRow @label={{field.label}} @value={{field.value}} data-test-mount-config-field={{field.label}} />

--- a/ui/lib/core/addon/components/secrets-engine-mount-config.ts
+++ b/ui/lib/core/addon/components/secrets-engine-mount-config.ts
@@ -7,20 +7,20 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { duration } from 'core/helpers/format-duration';
 
-import type SecretEngineModel from 'vault/models/secret-engine';
+import type SecretsEngineResource from 'vault/resources/secrets/engine';
 
 /**
  * @module SecretsEngineMountConfig
  * SecretsEngineMountConfig component is used to display a "Show mount configuration" toggle section. It is generally used alongside the fetch-secret-engine-config decorator which displays the engine configuration above this component. Mount configuration is always available for display but is hidden by default behind a toggle.
  *
  * @example
- * <SecretsEngineMountConfig @model={{model}} />
+ * <SecretsEngineMountConfig @secretsEngine={{this.model}} />
  *
- * @param {Model} model- The secret engines model, generated via the secret-engine model and a belongsTo relationship connecting to the mount-config model.
+ * @param {SecretsEngineResource} secretsEngine - the secrets engine resource containing the mount configuration details
  */
 
 interface Args {
-  model: SecretEngineModel;
+  secretsEngine: SecretsEngineResource;
 }
 interface Field {
   label: string;
@@ -31,16 +31,16 @@ export default class SecretsEngineMountConfig extends Component<Args> {
   @tracked showConfig = false;
 
   get fields(): Array<Field> {
-    const { model } = this.args;
+    const { secretsEngine } = this.args;
     return [
-      { label: 'Secret Engine Type', value: model.engineType },
-      { label: 'Path', value: model.path },
-      { label: 'Accessor', value: model.accessor },
-      { label: 'Local', value: model.local },
-      { label: 'Seal Wrap', value: model.sealWrap },
-      { label: 'Default Lease TTL', value: duration([model.config.defaultLeaseTtl]) },
-      { label: 'Max Lease TTL', value: duration([model.config.maxLeaseTtl]) },
-      { label: 'Identity Token Key', value: model.config.identityTokenKey },
+      { label: 'Secret Engine Type', value: secretsEngine.engineType },
+      { label: 'Path', value: secretsEngine.path },
+      { label: 'Accessor', value: secretsEngine.accessor },
+      { label: 'Local', value: secretsEngine.local },
+      { label: 'Seal Wrap', value: secretsEngine.sealWrap },
+      { label: 'Default Lease TTL', value: duration([secretsEngine.config.defaultLeaseTtl]) },
+      { label: 'Max Lease TTL', value: duration([secretsEngine.config.maxLeaseTtl]) },
+      { label: 'Identity Token Key', value: secretsEngine.config.identityTokenKey },
     ];
   }
 }

--- a/ui/lib/kubernetes/addon/components/page/configuration.hbs
+++ b/ui/lib/kubernetes/addon/components/page/configuration.hbs
@@ -30,4 +30,8 @@
   <ConfigCta />
 {{/if}}
 
-<SecretsEngineMountConfig @model={{@backend}} class="has-top-margin-xl has-bottom-margin-xl" data-test-mount-config />
+<SecretsEngineMountConfig
+  @secretsEngine={{@backend}}
+  class="has-top-margin-xl has-bottom-margin-xl"
+  data-test-mount-config
+/>

--- a/ui/lib/kv/addon/routes/configuration.js
+++ b/ui/lib/kv/addon/routes/configuration.js
@@ -13,7 +13,7 @@ export default class KvConfigurationRoute extends Route {
   model() {
     const backend = this.modelFor('application');
     return hash({
-      mountConfig: backend,
+      mountConfig: this.store.findRecord('secret-engine', backend.id),
       engineConfig: this.store.findRecord('kv/config', backend.id).catch(() => {
         // return an empty record so we have access to model capabilities
         return this.store.createRecord('kv/config', { backend: backend.id });

--- a/ui/lib/kv/addon/routes/configuration.js
+++ b/ui/lib/kv/addon/routes/configuration.js
@@ -13,7 +13,7 @@ export default class KvConfigurationRoute extends Route {
   model() {
     const backend = this.modelFor('application');
     return hash({
-      mountConfig: this.store.findRecord('secret-engine', backend.id),
+      mountConfig: this.store.query('secret-engine', { path: backend.id }).then((models = []) => models[0]),
       engineConfig: this.store.findRecord('kv/config', backend.id).catch(() => {
         // return an empty record so we have access to model capabilities
         return this.store.createRecord('kv/config', { backend: backend.id });

--- a/ui/lib/ldap/addon/components/page/configuration.hbs
+++ b/ui/lib/ldap/addon/components/page/configuration.hbs
@@ -41,4 +41,8 @@
   <ConfigCta />
 {{/if}}
 
-<SecretsEngineMountConfig @model={{@backendModel}} class="has-top-margin-xl has-bottom-margin-xl" data-test-mount-config />
+<SecretsEngineMountConfig
+  @secretsEngine={{@backendModel}}
+  class="has-top-margin-xl has-bottom-margin-xl"
+  data-test-mount-config
+/>

--- a/ui/lib/pki/addon/templates/configuration/index.hbs
+++ b/ui/lib/pki/addon/templates/configuration/index.hbs
@@ -35,7 +35,7 @@
 {{/if}}
 
 <SecretsEngineMountConfig
-  @model={{this.model.mountConfig}}
+  @secretsEngine={{this.model.mountConfig}}
   class="has-top-margin-m has-bottom-margin-xl"
   data-test-mount-config
 />

--- a/ui/tests/acceptance/dashboard-test.js
+++ b/ui/tests/acceptance/dashboard-test.js
@@ -121,46 +121,46 @@ module('Acceptance | landing page dashboard', function (hooks) {
   module('configuration details card', function (hooks) {
     hooks.beforeEach(async function () {
       this.data = {
-        api_addr: 'http://127.0.0.1:8200',
-        cache_size: 0,
-        cluster_addr: 'https://127.0.0.1:8201',
-        cluster_cipher_suites: '',
-        cluster_name: '',
-        default_lease_ttl: 0,
-        default_max_request_duration: 0,
-        detect_deadlocks: '',
-        disable_cache: false,
-        disable_clustering: false,
-        disable_indexing: false,
-        disable_mlock: true,
-        disable_performance_standby: false,
-        disable_printable_check: false,
-        disable_sealwrap: false,
-        disable_sentinel_trace: false,
-        enable_response_header_hostname: false,
-        enable_response_header_raft_node_id: false,
-        enable_ui: true,
+        apiAddr: 'http://127.0.0.1:8200',
+        cacheSize: 0,
+        clusterAddr: 'https://127.0.0.1:8201',
+        clusterCipherSuites: '',
+        clusterName: '',
+        defaultLeaseTtl: 0,
+        defaultMaxRequestDuration: 0,
+        detectDeadlocks: '',
+        disableCache: false,
+        disableClustering: false,
+        disableIndexing: false,
+        disableMlock: true,
+        disablePerformanceStandby: false,
+        disablePrintableCheck: false,
+        disableSealwrap: false,
+        disableSentinelTrace: false,
+        enableResponseHeaderHostname: false,
+        enableResponseHeaderRaftNodeId: false,
+        enableUi: true,
         experiments: null,
-        introspection_endpoint: false,
+        introspectionEndpoint: false,
         listeners: [
           {
             config: {
               address: '0.0.0.0:8200',
-              cluster_address: '0.0.0.0:8201',
-              tls_disable: true,
+              clusterAddress: '0.0.0.0:8201',
+              tlsDisable: true,
             },
             type: 'tcp',
           },
         ],
-        log_format: '',
-        log_level: 'debug',
-        log_requests_level: '',
-        max_lease_ttl: '48h',
-        pid_file: '',
-        plugin_directory: '',
-        plugin_file_permissions: 0,
-        plugin_file_uid: 0,
-        raw_storage_endpoint: true,
+        logFormat: '',
+        logLevel: 'debug',
+        logRequestsLevel: '',
+        maxLeaseTtl: '48h',
+        pidFile: '',
+        pluginDirectory: '',
+        pluginFilePermissions: 0,
+        pluginFileUid: 0,
+        rawStorageEndpoint: true,
         seals: [
           {
             disabled: false,
@@ -168,44 +168,44 @@ module('Acceptance | landing page dashboard', function (hooks) {
           },
         ],
         storage: {
-          cluster_addr: 'https://127.0.0.1:8201',
-          disable_clustering: false,
+          clusterAddr: 'https://127.0.0.1:8201',
+          disableClustering: false,
           raft: {
-            max_entry_size: '',
+            maxEntrySize: '',
           },
-          redirect_addr: 'http://127.0.0.1:8200',
+          redirectAddr: 'http://127.0.0.1:8200',
           type: 'raft',
         },
         telemetry: {
-          add_lease_metrics_namespace_labels: false,
-          circonus_api_app: '',
-          circonus_api_token: '',
-          circonus_api_url: '',
-          circonus_broker_id: '',
-          circonus_broker_select_tag: '',
-          circonus_check_display_name: '',
-          circonus_check_force_metric_activation: '',
-          circonus_check_id: '',
-          circonus_check_instance_id: '',
-          circonus_check_search_tag: '',
-          circonus_check_tags: '',
-          circonus_submission_interval: '',
-          circonus_submission_url: '',
-          disable_hostname: true,
-          dogstatsd_addr: '',
-          dogstatsd_tags: null,
-          lease_metrics_epsilon: 3600000000000,
-          maximum_gauge_cardinality: 500,
-          metrics_prefix: '',
-          num_lease_metrics_buckets: 168,
-          prometheus_retention_time: 86400000000000,
-          stackdriver_debug_logs: false,
-          stackdriver_location: '',
-          stackdriver_namespace: '',
-          stackdriver_project_id: '',
-          statsd_address: '',
-          statsite_address: '',
-          usage_gauge_period: 5000000000,
+          addLeaseMetricsNamespaceLabels: false,
+          circonusApiApp: '',
+          circonusApiToken: '',
+          circonusApiUrl: '',
+          circonusBrokerId: '',
+          circonusBrokerSelectTag: '',
+          circonusCheckDisplayName: '',
+          circonusCheckForceMetricActivation: '',
+          circonusCheckId: '',
+          circonusCheckInstanceId: '',
+          circonusCheckSearchTag: '',
+          circonusCheckTags: '',
+          circonusSubmissionInterval: '',
+          circonusSubmissionUrl: '',
+          disableHostname: true,
+          dogstatsdAddr: '',
+          dogstatsdTags: null,
+          leaseMetricsEpsilon: 3600000000000,
+          maximumGaugeCardinality: 500,
+          metricsPrefix: '',
+          numLeaseMetricsBuckets: 168,
+          prometheusRetentionTime: 86400000000000,
+          stackdriverDebugLogs: false,
+          stackdriverLocation: '',
+          stackdriverNamespace: '',
+          stackdriverProjectId: '',
+          statsdAddress: '',
+          statsiteAddress: '',
+          usageGaugePeriod: 5000000000,
         },
       };
 
@@ -247,9 +247,9 @@ module('Acceptance | landing page dashboard', function (hooks) {
 
     test('it should show tls as enabled if tls_disable, tls_cert_file and tls_key_file are in the config', async function (assert) {
       assert.expect(1);
-      this.data.listeners[0].config.tls_disable = false;
-      this.data.listeners[0].config.tls_cert_file = './cert.pem';
-      this.data.listeners[0].config.tls_key_file = './key.pem';
+      this.data.listeners[0].config.tlsDisable = false;
+      this.data.listeners[0].config.tlsCertFile = './cert.pem';
+      this.data.listeners[0].config.tlsKeyFile = './key.pem';
 
       await login();
       await visit('/vault/dashboard');
@@ -258,9 +258,9 @@ module('Acceptance | landing page dashboard', function (hooks) {
 
     test('it should show tls as enabled if only cert and key exist in config', async function (assert) {
       assert.expect(1);
-      delete this.data.listeners[0].config.tls_disable;
-      this.data.listeners[0].config.tls_cert_file = './cert.pem';
-      this.data.listeners[0].config.tls_key_file = './key.pem';
+      delete this.data.listeners[0].config.tlsDisable;
+      this.data.listeners[0].config.tlsCertFile = './cert.pem';
+      this.data.listeners[0].config.tlsKeyFile = './key.pem';
       await login();
       await visit('/vault/dashboard');
       assert.dom(DASHBOARD.vaultConfigurationCard.configDetailsField('tls')).hasText('Enabled');

--- a/ui/tests/acceptance/secrets/backend/aws/aws-configuration-test.js
+++ b/ui/tests/acceptance/secrets/backend/aws/aws-configuration-test.js
@@ -37,6 +37,15 @@ module('Acceptance | aws | configuration', function (hooks) {
     this.flashDangerSpy = spy(flash, 'danger');
     this.version = this.owner.lookup('service:version');
     this.uid = uuidv4();
+    this.awsRootConfigResponse = {
+      data: {
+        region: 'us-west-2',
+        access_key: '123-key',
+        iam_endpoint: 'iam-endpoint',
+        sts_endpoint: 'sts-endpoint',
+        max_retries: 1,
+      },
+    };
     return login();
   });
 
@@ -129,16 +138,16 @@ module('Acceptance | aws | configuration', function (hooks) {
     test('it should not show issuer if no root WIF configuration data is returned', async function (assert) {
       const path = `aws-${this.uid}`;
       const type = 'aws';
-      this.server.get(`${path}/config/root`, (schema, req) => {
-        const payload = JSON.parse(req.requestBody);
+
+      this.server.get(`${path}/config/root`, () => {
         assert.true(true, 'request made to config/root when navigating to the configuration page.');
-        return { data: { id: path, type, attributes: payload } };
+        return this.awsRootConfigResponse;
       });
       this.server.get(`identity/oidc/config`, () => {
         throw new Error(`Request was made to return the issuer when it should not have been.`);
       });
+
       await enablePage.enable(type, path);
-      createConfig(this.store, path, type); // create the aws root config in the store
       await click(SES.configTab);
       assert.dom(GENERAL.infoRowLabel('Issuer')).doesNotExist(`Issuer does not exists on config details.`);
       assert.dom(GENERAL.infoRowLabel('Access key')).exists(`Access key does exists on config details.`);
@@ -199,11 +208,12 @@ module('Acceptance | aws | configuration', function (hooks) {
     test('it shows AWS mount configuration details', async function (assert) {
       const path = `aws-${this.uid}`;
       const type = 'aws';
-      this.server.get(`${path}/config/root`, (schema, req) => {
-        const payload = JSON.parse(req.requestBody);
+
+      this.server.get(`${path}/config/root`, () => {
         assert.true(true, 'request made to config/root when navigating to the configuration page.');
-        return { data: { id: path, type, attributes: payload } };
+        return this.awsRootConfigResponse;
       });
+
       await enablePage.enable(type, path);
       createConfig(this.store, path, type); // create the aws root config in the store
       await click(SES.configTab);

--- a/ui/tests/acceptance/secrets/backend/azure/azure-configuration-test.js
+++ b/ui/tests/acceptance/secrets/backend/azure/azure-configuration-test.js
@@ -21,7 +21,6 @@ import {
   expectedConfigKeys,
   expectedValueOfConfigKeys,
   configUrl,
-  createConfig,
   fillInAzureConfig,
 } from 'vault/tests/helpers/secret-engine/secret-engine-helpers';
 
@@ -31,7 +30,6 @@ module('Acceptance | Azure | configuration', function (hooks) {
 
   hooks.beforeEach(function () {
     const flash = this.owner.lookup('service:flash-messages');
-    this.store = this.owner.lookup('service:store');
     this.flashSuccessSpy = spy(flash, 'success');
     this.flashDangerSpy = spy(flash, 'danger');
     this.flashInfoSpy = spy(flash, 'info');
@@ -299,7 +297,6 @@ module('Acceptance | Azure | configuration', function (hooks) {
         this.server.get(`identity/oidc/config`, () => {
           throw new Error(`Request was made to return the issuer when it should not have been.`);
         });
-        await createConfig(this.store, path, this.type); // create the azure account config in the store
         await enablePage.enable(this.type, path);
         await click(SES.configTab);
 
@@ -385,7 +382,7 @@ module('Acceptance | Azure | configuration', function (hooks) {
         const oldIssuer = 'http://old.issuer';
         await enablePage.enable(this.type, path);
         this.server.get('/identity/oidc/config', () => {
-          return { issuer: 'http://old.issuer' };
+          return { data: { issuer: 'http://old.issuer' } };
         });
         this.server.post('/identity/oidc/config', () => {
           return overrideResponse(400, { errors: ['bad request'] });
@@ -427,7 +424,7 @@ module('Acceptance | Azure | configuration', function (hooks) {
         const oldIssuer = 'http://old.issuer';
         await enablePage.enable(this.type, path);
         this.server.get('/identity/oidc/config', () => {
-          return { issuer: oldIssuer };
+          return { data: { issuer: oldIssuer } };
         });
         this.server.post(configUrl(this.type, path), () => {
           return overrideResponse(400, { errors: ['bad request'] });

--- a/ui/tests/helpers/secret-engine/secret-engine-helpers.js
+++ b/ui/tests/helpers/secret-engine/secret-engine-helpers.js
@@ -8,6 +8,7 @@ import { GENERAL } from 'vault/tests/helpers/general-selectors';
 import { SECRET_ENGINE_SELECTORS as SES } from 'vault/tests/helpers/secret-engine/secret-engine-selectors';
 import { stringArrayToCamelCase } from 'vault/helpers/string-array-to-camel';
 import { v4 as uuidv4 } from 'uuid';
+import SecretsEngineResource from 'vault/resources/secrets/engine';
 
 /* Secret Create/Edit methods */
 // ARG TODO unsure if should be moved to another file
@@ -20,16 +21,23 @@ export async function createSecret(path, key, value) {
 }
 
 export const createSecretsEngine = (store, type, path) => {
-  store.pushPayload('secret-engine', {
-    modelName: 'secret-engine',
-    id: path,
-    path: `${path}/`,
-    type: type,
-    data: {
+  if (store) {
+    store.pushPayload('secret-engine', {
+      modelName: 'secret-engine',
+      id: path,
+      path: `${path}/`,
       type: type,
-    },
+      data: {
+        type: type,
+      },
+    });
+    return store.peekRecord('secret-engine', path);
+  }
+
+  return new SecretsEngineResource({
+    path: `${path}/`,
+    type,
   });
-  return store.peekRecord('secret-engine', path);
 };
 /* Create configurations methods
  * for each configuration we create the record and then push it to the store.

--- a/ui/tests/integration/components/list-test.js
+++ b/ui/tests/integration/components/list-test.js
@@ -27,7 +27,6 @@ module('Integration | Component | secret-engine/list', function (hooks) {
         capabilities: ['root'],
       },
     }));
-    this.store = this.owner.lookup('service:store');
     this.version = this.owner.lookup('service:version');
     this.flashMessages = this.owner.lookup('service:flash-messages');
     this.flashMessages.registerTypes(['success', 'danger']);
@@ -36,21 +35,21 @@ module('Integration | Component | secret-engine/list', function (hooks) {
     this.uid = uuidv4();
     // generate a model of cubbyhole, kv2, and nomad
     this.secretEngineModels = [
-      createSecretsEngine(this.store, 'cubbyhole', 'cubbyhole-test'),
-      createSecretsEngine(this.store, 'kv', 'kv2-test'),
-      createSecretsEngine(this.store, 'aws', 'aws-1'),
-      createSecretsEngine(this.store, 'aws', 'aws-2'),
-      createSecretsEngine(this.store, 'nomad', 'nomad-test'),
+      createSecretsEngine(undefined, 'cubbyhole', 'cubbyhole-test'),
+      createSecretsEngine(undefined, 'kv', 'kv2-test'),
+      createSecretsEngine(undefined, 'aws', 'aws-1'),
+      createSecretsEngine(undefined, 'aws', 'aws-2'),
+      createSecretsEngine(undefined, 'nomad', 'nomad-test'),
     ];
   });
 
   test('it allows you to disable an engine', async function (assert) {
     const enginePath = 'kv2-test';
     this.server.delete(`sys/mounts/${enginePath}`, () => {
-      assert.true(true, 'Destroy record is called and deletes the engine');
+      assert.true(true, 'Request is made to delete engine');
       return overrideResponse(204);
     });
-    await render(hbs`<SecretEngine::List @secretEngineModels={{this.secretEngineModels}} />`);
+    await render(hbs`<SecretEngine::List @secretEngines={{this.secretEngineModels}} />`);
 
     assert.dom(SES.secretsBackendLink(enginePath)).exists('shows the link for the kvv2 secrets engine');
     const row = SES.secretsBackendLink(enginePath);
@@ -65,7 +64,7 @@ module('Integration | Component | secret-engine/list', function (hooks) {
   });
 
   test('it adds disabled css styling to unsupported secret engines', async function (assert) {
-    await render(hbs`<SecretEngine::List @secretEngineModels={{this.secretEngineModels}} />`);
+    await render(hbs`<SecretEngine::List @secretEngines={{this.secretEngineModels}} />`);
     assert
       .dom(SES.secretsBackendLink('nomad-test'))
       .doesNotHaveClass(
@@ -79,7 +78,7 @@ module('Integration | Component | secret-engine/list', function (hooks) {
   });
 
   test('it filters by name and engine type', async function (assert) {
-    await render(hbs`<SecretEngine::List @secretEngineModels={{this.secretEngineModels}} />`);
+    await render(hbs`<SecretEngine::List @secretEngines={{this.secretEngineModels}} />`);
     // filter by type
     await clickTrigger('#filter-by-engine-type');
     await click(GENERAL.searchSelect.option());
@@ -103,7 +102,7 @@ module('Integration | Component | secret-engine/list', function (hooks) {
   });
 
   test('it applies overflow styling', async function (assert) {
-    await render(hbs`<SecretEngine::List @secretEngineModels={{this.secretEngineModels}} />`);
+    await render(hbs`<SecretEngine::List @secretEngines={{this.secretEngineModels}} />`);
     // not using the secret-engine-selector "secretPath" because I want to return the first node of a querySelectorAll
     const firstSecretEngine = document.querySelectorAll('[data-test-secret-path]')[0];
     assert.dom(firstSecretEngine).hasClass('overflow-wrap', 'secret engine name has overflow class ');

--- a/ui/tests/integration/components/secret-engine/configuration-details-test.js
+++ b/ui/tests/integration/components/secret-engine/configuration-details-test.js
@@ -11,7 +11,6 @@ import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { CONFIGURABLE_SECRET_ENGINES } from 'vault/helpers/mountable-secret-engines';
 import {
-  createConfig,
   expectedConfigKeys,
   expectedValueOfConfigKeys,
 } from 'vault/tests/helpers/secret-engine/secret-engine-helpers';
@@ -22,8 +21,32 @@ module('Integration | Component | SecretEngine::ConfigurationDetails', function 
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function () {
-    this.store = this.owner.lookup('service:store');
-    this.configModels = [];
+    this.configs = {
+      aws: {
+        region: 'us-west-2',
+        accessKey: '123-key',
+        iamEndpoint: 'iam-endpoint',
+        stsEndpoint: 'sts-endpoint',
+        maxRetries: 1,
+      },
+      azure: {
+        clientSecret: 'client-secret',
+        subscriptionId: 'subscription-id',
+        tenantId: 'tenant-id',
+        clientId: 'client-id',
+        rootPasswordTtl: '1800000s',
+        environment: 'AZUREPUBLICCLOUD',
+      },
+      gcp: {
+        credentials: '{"some-key":"some-value"}',
+        ttl: '100s',
+        maxTtl: '101s',
+      },
+      ssh: {
+        publicKey: 'public-key',
+        generateSigningKey: true,
+      },
+    };
   });
 
   test('it shows prompt message if no config models are passed in', async function (assert) {
@@ -39,12 +62,11 @@ module('Integration | Component | SecretEngine::ConfigurationDetails', function 
 
   for (const type of CONFIGURABLE_SECRET_ENGINES) {
     test(`${type}: it shows config details if configModel(s) are passed in`, async function (assert) {
-      const backend = `test-${type}`;
-      this.configModels = createConfig(this.store, backend, type);
+      this.config = this.configs[type];
       this.typeDisplay = allEnginesArray.find((engine) => engine.type === type).displayName;
 
       await render(
-        hbs`<SecretEngine::ConfigurationDetails @configModels={{array this.configModels}} @typeDisplay={{this.typeDisplay}}/>`
+        hbs`<SecretEngine::ConfigurationDetails @config={{this.config}} @typeDisplay={{this.typeDisplay}}/>`
       );
 
       for (const key of expectedConfigKeys(type)) {

--- a/ui/tests/integration/components/secret-engine/configure-ssh-test.js
+++ b/ui/tests/integration/components/secret-engine/configure-ssh-test.js
@@ -9,7 +9,6 @@ import { render, click, fillIn } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { GENERAL } from 'vault/tests/helpers/general-selectors';
 import { SECRET_ENGINE_SELECTORS as SES } from 'vault/tests/helpers/secret-engine/secret-engine-selectors';
-import { createConfig } from 'vault/tests/helpers/secret-engine/secret-engine-helpers';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import sinon from 'sinon';
 
@@ -29,9 +28,9 @@ module('Integration | Component | SecretEngine/configure-ssh', function (hooks) 
   test('it shows create fields if not configured', async function (assert) {
     await render(hbs`
       <SecretEngine::ConfigureSsh
-    @model={{this.model}}
-    @id={{this.id}}
-  />
+        @model={{this.model}}
+        @id={{this.id}}
+      />
     `);
     assert.dom(GENERAL.inputByAttr('privateKey')).hasNoText('Private key is empty and reset');
     assert.dom(GENERAL.inputByAttr('publicKey')).hasNoText('Public key is empty and reset');
@@ -43,9 +42,9 @@ module('Integration | Component | SecretEngine/configure-ssh', function (hooks) 
   test('it should go back to parent route on cancel', async function (assert) {
     await render(hbs`
       <SecretEngine::ConfigureSsh
-    @model={{this.model}}
-    @id={{this.id}}
-  />
+        @model={{this.model}}
+        @id={{this.id}}
+      />
     `);
 
     await click(SES.ssh.cancel);
@@ -59,9 +58,9 @@ module('Integration | Component | SecretEngine/configure-ssh', function (hooks) 
   test('it should validate form fields', async function (assert) {
     await render(hbs`
       <SecretEngine::ConfigureSsh
-    @model={{this.model}}
-    @id={{this.id}}
-  />
+        @model={{this.model}}
+        @id={{this.id}}
+      />
     `);
     await fillIn(GENERAL.inputByAttr('publicKey'), 'hello');
     await click(SES.ssh.save);
@@ -94,9 +93,9 @@ module('Integration | Component | SecretEngine/configure-ssh', function (hooks) 
     });
     await render(hbs`
       <SecretEngine::ConfigureSsh
-    @model={{this.model}}
-    @id={{this.id}}
-  />
+        @model={{this.model}}
+        @id={{this.id}}
+      />
     `);
 
     await click(SES.ssh.save);
@@ -106,15 +105,24 @@ module('Integration | Component | SecretEngine/configure-ssh', function (hooks) 
   module('editing', function (hooks) {
     hooks.beforeEach(function () {
       this.editId = 'ssh-edit-me';
-      this.editModel = createConfig(this.store, 'ssh-edit-me', 'ssh');
+      this.store.pushPayload('ssh/ca-config', {
+        id: this.editId,
+        modelName: 'ssh/ca-config',
+        data: {
+          backend: this.editId,
+          public_key: 'public-key',
+          generate_signing_key: true,
+        },
+      });
+      this.editModel = this.store.peekRecord('ssh/ca-config', this.editId);
     });
     test('it populates fields when editing', async function (assert) {
       await render(hbs`
-      <SecretEngine::ConfigureSsh
-    @model={{this.editModel}}
-    @id={{this.editId}}
-  />
-    `);
+        <SecretEngine::ConfigureSsh
+          @model={{this.editModel}}
+          @id={{this.editId}}
+        />
+      `);
       assert
         .dom(SES.ssh.editConfigSection)
         .exists('renders the edit configuration section of the form and not the create part');
@@ -131,11 +139,11 @@ module('Integration | Component | SecretEngine/configure-ssh', function (hooks) 
         assert.true(true, 'DELETE request made to ca-config with correct properties');
       });
       await render(hbs`
-      <SecretEngine::ConfigureSsh
-    @model={{this.editModel}}
-    @id={{this.editId}}
-  />
-    `);
+        <SecretEngine::ConfigureSsh
+          @model={{this.editModel}}
+          @id={{this.editId}}
+        />
+      `);
       // delete Public key
       await click(SES.ssh.delete);
       assert.dom(GENERAL.confirmMessage).hasText('Confirming will remove the CA certificate information.');

--- a/ui/tests/integration/components/secrets-engine-mount-config-test.js
+++ b/ui/tests/integration/components/secrets-engine-mount-config-test.js
@@ -8,6 +8,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render, click } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { GENERAL } from 'vault/tests/helpers/general-selectors';
+import SecretsEngineResource from 'vault/resources/secrets/engine';
 
 const selectors = {
   toggle: '[data-test-mount-config-toggle]',
@@ -18,27 +19,22 @@ module('Integration | Component | secrets-engine-mount-config', function (hooks)
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function () {
-    const store = this.owner.lookup('service:store');
-    store.pushPayload('secret-engine', {
-      modelName: 'secret-engine',
-      data: {
-        path: 'ldap-test/',
-        type: 'ldap',
-        accessor: 'ldap_7e838627',
-        local: false,
-        seal_wrap: true,
-        config: {
-          id: 'foo',
-          default_lease_ttl: 0,
-          max_lease_ttl: 10000,
-        },
+    this.secretsEngine = new SecretsEngineResource({
+      path: 'ldap-test/',
+      type: 'ldap',
+      accessor: 'ldap_7e838627',
+      local: false,
+      sealWrap: true,
+      config: {
+        id: 'foo',
+        defaultLeaseTtl: 0,
+        maxLeaseTtl: 10000,
       },
     });
-    this.model = store.peekRecord('secret-engine', 'ldap-test');
   });
 
   test('it should toggle config fields visibility', async function (assert) {
-    await render(hbs`<SecretsEngineMountConfig @model={{this.model}} />`);
+    await render(hbs`<SecretsEngineMountConfig @secretsEngine={{this.secretsEngine}} />`);
 
     assert
       .dom(selectors.toggle)
@@ -52,14 +48,14 @@ module('Integration | Component | secrets-engine-mount-config', function (hooks)
   });
 
   test('it should render correct config fields', async function (assert) {
-    await render(hbs`<SecretsEngineMountConfig @model={{this.model}} />`);
+    await render(hbs`<SecretsEngineMountConfig @secretsEngine={{this.secretsEngine}} />`);
     await click(selectors.toggle);
 
     assert
       .dom(GENERAL.infoRowValue('Secret Engine Type'))
-      .hasText(this.model.engineType, 'Secret engine type renders');
-    assert.dom(GENERAL.infoRowValue('Path')).hasText(this.model.path, 'Path renders');
-    assert.dom(GENERAL.infoRowValue('Accessor')).hasText(this.model.accessor, 'Accessor renders');
+      .hasText(this.secretsEngine.engineType, 'Secret engine type renders');
+    assert.dom(GENERAL.infoRowValue('Path')).hasText(this.secretsEngine.path, 'Path renders');
+    assert.dom(GENERAL.infoRowValue('Accessor')).hasText(this.secretsEngine.accessor, 'Accessor renders');
     assert.dom(GENERAL.infoRowValue('Local')).includesText('No', 'Local renders');
     assert.dom(GENERAL.infoRowValue('Seal Wrap')).includesText('Yes', 'Seal wrap renders');
     assert.dom(GENERAL.infoRowValue('Default Lease TTL')).includesText('0', 'Default Lease TTL renders');
@@ -70,7 +66,7 @@ module('Integration | Component | secrets-engine-mount-config', function (hooks)
 
   test('it should yield block for additional fields', async function (assert) {
     await render(hbs`
-      <SecretsEngineMountConfig @model={{this.model}}>
+      <SecretsEngineMountConfig @secretsEngine={{this.secretsEngine}}>
         <span data-test-yield>It Yields!</span>
       </SecretsEngineMountConfig>
     `);

--- a/ui/types/vault/secrets/engine.d.ts
+++ b/ui/types/vault/secrets/engine.d.ts
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+export type EngineConfig = {
+  forceNoCache: boolean;
+  listingVisibility: string;
+  defaultLeaseTtl: number;
+  maxLeaseTtl: number;
+  allowedManagedKeys?: string[];
+  auditNonHmacRequestKeys?: string[];
+  auditNonHmacResponseKeys?: string[];
+  passthroughRequestHeaders?: string[];
+  allowedResponseHeaders?: string[];
+  identityTokenKey?: string;
+};
+
+export type EngineOptions = {
+  version: string;
+};
+
+export type SecretsEngine = {
+  path: string;
+  accessor: string;
+  config: EngineConfig;
+  description: string;
+  externalEntropyAccess: boolean;
+  local: boolean;
+  options?: EngineOptions;
+  pluginVersion: string;
+  runningPluginVersion: string;
+  runningSha256: string;
+  sealWrap: boolean;
+  type: string;
+  uuid: string;
+};
+
+type CommonConfigParams = {
+  rotationPeriod: number;
+  rotationSchedule: string;
+  rotationWindow: number;
+  identityTokenAudience: string;
+  identityTokenTtl: number;
+  disableAutomatedRotation: boolean;
+  issuer?: string;
+};
+
+export type AwsConfig = CommonConfigParams & {
+  accessKey: string;
+  iamEndpoint: string;
+  maxRetries: number;
+  region: string;
+  roleArn: string;
+  stsEndpoint: string;
+  stsFallbackEndpoints: string[];
+  stsFallbackRegions: string[];
+  stsRegion: string;
+  usernameTemplate: string;
+  lease?: string;
+  leaseMax?: string;
+};
+
+export type AzureConfig = CommonConfigParams & {
+  clientId: string;
+  environment: string;
+  subscriptionId: string;
+  tenantId: string;
+};
+
+export type GcpConfig = CommonConfigParams & {
+  maxTtl: number;
+  serviceAccountEmail: string;
+  ttl: number;
+};
+
+export type SshConfig = {
+  publicKey: string;
+  generateSigningKey: boolean;
+};


### PR DESCRIPTION
### Description
This PR adds a secrets engine resource to help migrate away from the Ember Data models and updates routes that fetch internal mounts and configuration to use the api service.

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
