### PR TITLE
VAULT-36229: Nonce for rekey cancellations

### DIFF
--- a/api/sys_rekey.go
+++ b/api/sys_rekey.go
@@ -147,11 +147,29 @@ func (c *Sys) RekeyCancel() error {
 	return c.RekeyCancelWithContext(context.Background())
 }
 
+func (c *Sys) RekeyCancelWithNonce(nonce string) error {
+	return c.RekeyCancelWithContextWithNonce(context.Background(), nonce)
+}
+
 func (c *Sys) RekeyCancelWithContext(ctx context.Context) error {
+	return c.RekeyCancelWithContextWithNonce(ctx, "")
+}
+
+func (c *Sys) RekeyCancelWithContextWithNonce(ctx context.Context, nonce string) error {
 	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
 	defer cancelFunc()
 
 	r := c.c.NewRequest(http.MethodDelete, "/v1/sys/rekey/init")
+	if nonce != "" {
+		body := map[string]interface{}{
+			"nonce": nonce,
+		}
+
+		if err := r.SetJSONBody(body); err != nil {
+			return err
+		}
+
+	}
 
 	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err == nil {
@@ -164,12 +182,28 @@ func (c *Sys) RekeyRecoveryKeyCancel() error {
 	return c.RekeyRecoveryKeyCancelWithContext(context.Background())
 }
 
+func (c *Sys) RekeyRecoveryKeyCancelWithNonce(nonce string) error {
+	return c.RekeyRecoveryKeyCancelWithContextWithNonce(context.Background(), nonce)
+}
+
 func (c *Sys) RekeyRecoveryKeyCancelWithContext(ctx context.Context) error {
+	return c.RekeyCancelWithContextWithNonce(ctx, "")
+}
+
+func (c *Sys) RekeyRecoveryKeyCancelWithContextWithNonce(ctx context.Context, nonce string) error {
 	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
 	defer cancelFunc()
-
 	r := c.c.NewRequest(http.MethodDelete, "/v1/sys/rekey-recovery-key/init")
 
+	if nonce != "" {
+		body := map[string]interface{}{
+			"nonce": nonce,
+		}
+
+		if err := r.SetJSONBody(body); err != nil {
+			return err
+		}
+	}
 	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err == nil {
 		defer resp.Body.Close()

--- a/changelog/30794.txt
+++ b/changelog/30794.txt
@@ -1,0 +1,3 @@
+```release-note:security
+core: require a nonce when cancelling a rekey operation that was initiated within the last 10 minutes.
+```

--- a/command/operator_rekey_test.go
+++ b/command/operator_rekey_test.go
@@ -67,6 +67,16 @@ func TestOperatorRekeyCommand_Run(t *testing.T) {
 			"incorrect number",
 			2,
 		},
+		{
+			"cancel_verify_nonce",
+			[]string{
+				"-cancel",
+				"-verify",
+				"-nonce", "abcd",
+			},
+			"The -nonce flag is not valid with the -verify flag",
+			1,
+		},
 	}
 
 	t.Run("validations", func(t *testing.T) {
@@ -152,10 +162,11 @@ func TestOperatorRekeyCommand_Run(t *testing.T) {
 		defer closer()
 
 		// Initialize a rekey
-		if _, err := client.Sys().RekeyInit(&api.RekeyInitRequest{
+		init, err := client.Sys().RekeyInit(&api.RekeyInitRequest{
 			SecretShares:    1,
 			SecretThreshold: 1,
-		}); err != nil {
+		})
+		if err != nil {
 			t.Fatal(err)
 		}
 
@@ -163,7 +174,7 @@ func TestOperatorRekeyCommand_Run(t *testing.T) {
 		cmd.client = client
 
 		code := cmd.Run([]string{
-			"-cancel",
+			"-cancel", "-nonce", init.Nonce,
 		})
 		if exp := 0; code != exp {
 			t.Errorf("expected %d to be %d", code, exp)

--- a/http/http_test.go
+++ b/http/http_test.go
@@ -32,6 +32,10 @@ func testHttpDelete(t *testing.T, token string, addr string) *http.Response {
 	return testHttpData(t, "DELETE", token, addr, "", nil, false, 0, false)
 }
 
+func testHttpDeleteData(t *testing.T, token string, addr string, body interface{}) *http.Response {
+	return testHttpData(t, "DELETE", token, addr, "", body, false, 0, false)
+}
+
 // Go 1.8+ clients redirect automatically which breaks our 307 standby testing
 func testHttpDeleteDisableRedirect(t *testing.T, token string, addr string) *http.Response {
 	return testHttpData(t, "DELETE", token, addr, "", nil, true, 0, false)

--- a/http/sys_rekey.go
+++ b/http/sys_rekey.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/hashicorp/vault/helper/pgpkeys"
 	"github.com/hashicorp/vault/sdk/helper/consts"
@@ -134,6 +135,7 @@ func handleSysRekeyInitPut(ctx context.Context, core *vault.Core, recovery bool,
 		PGPKeys:              req.PGPKeys,
 		Backup:               req.Backup,
 		VerificationRequired: req.RequireVerification,
+		Created:              time.Now().UTC(),
 	}, recovery)
 	if err != nil {
 		respondError(w, err.Code(), err)
@@ -144,7 +146,13 @@ func handleSysRekeyInitPut(ctx context.Context, core *vault.Core, recovery bool,
 }
 
 func handleSysRekeyInitDelete(ctx context.Context, core *vault.Core, recovery bool, w http.ResponseWriter, r *http.Request) {
-	if err := core.RekeyCancel(recovery); err != nil {
+	var req RekeyDeleteRequest
+	if _, err := parseJSONRequest(core.PerfStandby(), r, w, &req); err != nil {
+		respondError(w, http.StatusBadRequest, err)
+		return
+	}
+
+	if err := core.RekeyCancel(recovery, req.Nonce, 10*time.Minute); err != nil {
 		respondError(w, err.Code(), err)
 		return
 	}
@@ -411,4 +419,9 @@ type RekeyVerificationStatusResponse struct {
 type RekeyVerificationUpdateResponse struct {
 	Nonce    string `json:"nonce"`
 	Complete bool   `json:"complete"`
+}
+
+type RekeyDeleteRequest struct {
+	Nonce string `json:"nonce"`
+	Key   string `json:"key"`
 }

--- a/vault/seal_config.go
+++ b/vault/seal_config.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"encoding/base64"
 	"fmt"
+	"time"
 
 	"github.com/ProtonMail/go-crypto/openpgp"
 	"github.com/ProtonMail/go-crypto/openpgp/packet"
@@ -65,6 +66,9 @@ type SealConfig struct {
 
 	// Name is the name provided in the seal configuration to identify the seal
 	Name string `json:"name" mapstructure:"name"`
+
+	// Created is the time of creation in UTC
+	Created time.Time `json:"-"`
 }
 
 // Validate is used to sanity check the seal configuration

--- a/website/content/api-docs/system/rekey-recovery-key.mdx
+++ b/website/content/api-docs/system/rekey-recovery-key.mdx
@@ -122,7 +122,9 @@ well as any progress made. This must be called to change the parameters of the
 rekey. Note: verification is still a part of a rekey. If rekeying is canceled
 during the verification flow, the current unseal keys remain valid.
 
-This is an unauthenticated endpoint.
+<Note title="Unrestricted endpoint">
+  Clients can all the endpoint without authenticating to Vault.
+</Note>
 
 | Method   | Path                           |
 | :------- | :----------------------------- |
@@ -131,8 +133,8 @@ This is an unauthenticated endpoint.
 ### Parameters
 
 - `nonce` `(string: <optional>)` – Specifies the nonce of the rekey operation. If
-  the rekey was initialized within the last 10 minutes, the nonce is required to
-  cancel the operation.
+  the rekey was initialized within the last 10 minutes, you must provide the
+  nonce to cancel the operation.
 
 ### Sample payload
 

--- a/website/content/api-docs/system/rekey-recovery-key.mdx
+++ b/website/content/api-docs/system/rekey-recovery-key.mdx
@@ -123,7 +123,7 @@ rekey. Note: verification is still a part of a rekey. If rekeying is canceled
 during the verification flow, the current unseal keys remain valid.
 
 <Note title="Unrestricted endpoint">
-  Clients can all the endpoint without authenticating to Vault.
+  Clients can call the endpoint without authenticating to Vault.
 </Note>
 
 | Method   | Path                           |

--- a/website/content/api-docs/system/rekey-recovery-key.mdx
+++ b/website/content/api-docs/system/rekey-recovery-key.mdx
@@ -122,9 +122,25 @@ well as any progress made. This must be called to change the parameters of the
 rekey. Note: verification is still a part of a rekey. If rekeying is canceled
 during the verification flow, the current unseal keys remain valid.
 
+This is an unauthenticated endpoint.
+
 | Method   | Path                           |
 | :------- | :----------------------------- |
 | `DELETE` | `/sys/rekey-recovery-key/init` |
+
+### Parameters
+
+- `nonce` `(string: <optional>)` – Specifies the nonce of the rekey operation. If
+  the rekey was initialized within the last 10 minutes, the nonce is required to
+  cancel the operation.
+
+### Sample payload
+
+```json
+{
+  "nonce": "abcd1234..."
+}
+```
 
 ### Sample request
 
@@ -132,6 +148,7 @@ during the verification flow, the current unseal keys remain valid.
 $ curl \
     --header "X-Vault-Token: ..." \
     --request DELETE \
+    --data @payload.json \
     http://127.0.0.1:8200/v1/sys/rekey-recovery-key/init
 ```
 

--- a/website/content/api-docs/system/rekey.mdx
+++ b/website/content/api-docs/system/rekey.mdx
@@ -123,7 +123,7 @@ rekey. Note: verification is still a part of a rekey. If rekeying is canceled
 during the verification flow, the current unseal keys remain valid.
 
 <Note title="Unrestricted endpoint">
-  Clients can all the endpoint without authenticating to Vault.
+  Clients can call the endpoint without authenticating to Vault.
 </Note>
 
 | Method   | Path              |

--- a/website/content/api-docs/system/rekey.mdx
+++ b/website/content/api-docs/system/rekey.mdx
@@ -122,7 +122,9 @@ well as any progress made. This must be called to change the parameters of the
 rekey. Note: verification is still a part of a rekey. If rekeying is canceled
 during the verification flow, the current unseal keys remain valid.
 
-This is an unauthenticated endpoint.
+<Note title="Unrestricted endpoint">
+  Clients can all the endpoint without authenticating to Vault.
+</Note>
 
 | Method   | Path              |
 | :------- | :---------------- |
@@ -131,8 +133,8 @@ This is an unauthenticated endpoint.
 ### Parameters
 
 - `nonce` `(string: <optional>)` – Specifies the nonce of the rekey operation. If
-the rekey was initialized within the last 10 minutes, the nonce is required to
-cancel the operation.
+  the rekey was initialized within the last 10 minutes, you must provide the
+  nonce to cancel the operation.
 
 ### Sample payload
 

--- a/website/content/api-docs/system/rekey.mdx
+++ b/website/content/api-docs/system/rekey.mdx
@@ -122,9 +122,25 @@ well as any progress made. This must be called to change the parameters of the
 rekey. Note: verification is still a part of a rekey. If rekeying is canceled
 during the verification flow, the current unseal keys remain valid.
 
+This is an unauthenticated endpoint.
+
 | Method   | Path              |
 | :------- | :---------------- |
 | `DELETE` | `/sys/rekey/init` |
+
+### Parameters
+
+- `nonce` `(string: <optional>)` – Specifies the nonce of the rekey operation. If
+the rekey was initialized within the last 10 minutes, the nonce is required to
+cancel the operation.
+
+### Sample payload
+
+```json
+{
+  "nonce": "abcd1234..."
+}
+```
 
 ### Sample request
 
@@ -132,6 +148,7 @@ during the verification flow, the current unseal keys remain valid.
 $ curl \
     --header "X-Vault-Token: ..." \
     --request DELETE \
+    --data @payload.json \
     http://127.0.0.1:8200/v1/sys/rekey/init
 ```
 

--- a/website/content/docs/updates/important-changes.mdx
+++ b/website/content/docs/updates/important-changes.mdx
@@ -68,6 +68,20 @@ it must have a value for `disable_mlock`.
 | Performance Secondary      | Yes                      | value depends on cluster specifics. [See docs](/vault/docs/configuration#disable_mlock)
 | DR Secondary               | Yes                      | value depends on cluster specifics. [See docs](/vault/docs/configuration#disable_mlock)
 
+## Rekey cancellations use a nonce ((#rekey-cancel-nonce))
+| Change       | Affected version | Affected deployments
+| ------------ | ---------------- | --------------------
+| Breaking     | 1.20.0           | Any
+
+Vault 1.20.0 requires a nonce to cancel a [rekey](/vault/api-docs/system/rekey) or
+[rekey recovery key](/vault/api-docs/system/rekey-recovery-key) operation when
+the rekey was initialized within the last 10 minutes. If the rekey operation
+was initialized more than 10 minutes ago, the nonce is not required and the operation
+will be canceled.
+
+### Recommendation
+To cancel a rekey operation, provide the nonce value from the
+`/sys/rekey/init` response.
 
 ## Transit support for Ed25519ph and Ed25519ctx signatures ((#ed25519))
 

--- a/website/content/docs/updates/important-changes.mdx
+++ b/website/content/docs/updates/important-changes.mdx
@@ -71,9 +71,9 @@ it must have a value for `disable_mlock`.
 ## Rekey cancellations use a nonce ((#rekey-cancel-nonce))
 | Change       | Affected version | Affected deployments
 | ------------ | ---------------- | --------------------
-| Breaking     | 1.20.0           | Any
+| Breaking     | 1.20.0, 1.19.6, 1.18.11, 1.17.18, 1.16.21 | Any
 
-Vault 1.20.0 requires a nonce to cancel a [rekey](/vault/api-docs/system/rekey) or
+Vault 1.20.0, 1.19.6, 1.18.11, 1.17.18, 1.16.21 require a nonce to cancel a [rekey](/vault/api-docs/system/rekey) or
 [rekey recovery key](/vault/api-docs/system/rekey-recovery-key) operation when
 the rekey was initialized within the last 10 minutes. If the rekey operation
 was initialized more than 10 minutes ago, the nonce is not required and the operation
@@ -81,7 +81,7 @@ will be canceled.
 
 ### Recommendation
 To cancel a rekey operation, provide the nonce value from the
-`/sys/rekey/init` response.
+`/sys/rekey/init` or `sys/rekey-recovery-key/init` response.
 
 ## Transit support for Ed25519ph and Ed25519ctx signatures ((#ed25519))
 

--- a/website/content/docs/updates/important-changes.mdx
+++ b/website/content/docs/updates/important-changes.mdx
@@ -73,11 +73,11 @@ it must have a value for `disable_mlock`.
 | ------------ | ---------------- | --------------------
 | Breaking     | 1.20.0, 1.19.6, 1.18.11, 1.17.18, 1.16.21 | Any
 
-Vault 1.20.0, 1.19.6, 1.18.11, 1.17.18, 1.16.21 require a nonce to cancel a [rekey](/vault/api-docs/system/rekey) or
-[rekey recovery key](/vault/api-docs/system/rekey-recovery-key) operation when
-the rekey was initialized within the last 10 minutes. If the rekey operation
-was initialized more than 10 minutes ago, the nonce is not required and the operation
-will be canceled.
+Vault 1.20.0, 1.19.6, 1.18.11, 1.17.18, and 1.16.21 require a nonce to cancel
+[rekey](/vault/api-docs/system/rekey) and
+[rekey recovery key](/vault/api-docs/system/rekey-recovery-key) operations
+within 10 minutes of initializing a rekey request. Cancellation requests after
+the 10 minute window do not require a nonce and succeed as expected.
 
 ### Recommendation
 To cancel a rekey operation, provide the nonce value from the


### PR DESCRIPTION
### Description
This PR adds a nonce for rekey cancellations 
Enterprise PR: https://github.com/hashicorp/vault-enterprise/pull/8169

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [x] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
