### PR TITLE
UI: Fixes issue where backup tab was selected if they included default type

### DIFF
--- a/ui/app/components/auth/page.ts
+++ b/ui/app/components/auth/page.ts
@@ -218,15 +218,17 @@ export default class AuthPage extends Component<Args> {
 
   get initialFormState() {
     const { defaultView, alternateView } = this.formViews;
-    const hasTab = (tabData: object) => Object.keys(tabData).includes(this.initialAuthType);
+    // Helper to check if passed tabs include initialAuthType to render
+    const hasTab = (tabs: object) => Object.keys(tabs).includes(this.initialAuthType);
     const authIsNotDefaultTab = !hasTab(defaultView?.tabData || {});
     const hasAlternateView = !!alternateView;
     const authIsAlternateTab = hasTab(alternateView?.tabData || {});
 
-    // In rare cases, pre-toggle the form to the fallback dropdown if the selected method is not in the alternate view.
-    // This could happen if tabs render for visible mounts and the "with" query param references a type that isn't a tab.
-    // Or auth type is preset from canceled MFA or local storage and is not in the default view.
-    const showAlternate = (authIsNotDefaultTab && hasAlternateView) || authIsAlternateTab;
+    // In rare cases, pre-toggle the form to the fallback dropdown or backup tabs, if an alternate view exists.
+    // This is only possible in a couple scenarios:
+    // - The default view renders tabs for visible mounts and the "with" query param references a type that is not a tab.
+    // - Auth type is preset from canceled MFA verification or local storage and it is not in the default (initial) view
+    const showAlternate = authIsNotDefaultTab && (hasAlternateView || authIsAlternateTab);
 
     return { initialAuthType: this.initialAuthType, showAlternate };
   }

--- a/ui/tests/acceptance/config-ui/login-settings-test.js
+++ b/ui/tests/acceptance/config-ui/login-settings-test.js
@@ -32,7 +32,7 @@ module('Acceptance | Enterprise | config-ui/login-settings', function (hooks) {
     assert
       .dom(GENERAL.emptyStateMessage)
       .hasText(
-        'Login rules can be used to select default and back up login methods and customize which methods display in the web UI login form. Available to be created via the CLI or HTTP API.'
+        'Login settings can be used to customize which methods display in the web UI login form by setting a default and back up login methods. Available to be created via the CLI or HTTP API.'
       );
   });
 

--- a/ui/tests/integration/components/auth/page-test.js
+++ b/ui/tests/integration/components/auth/page-test.js
@@ -392,6 +392,26 @@ module('Integration | Component | auth | page', function (hooks) {
       await this.assertPathInput(assert);
     });
 
+    test('(default+backups): it initially renders default type if backup types include the default method', async function (assert) {
+      this.loginSettings = {
+        defaultType: 'userpass',
+        backupTypes: ['ldap', 'userpass', 'oidc'],
+      };
+      await this.renderComponent();
+      assert.dom(GENERAL.backButton).doesNotExist('it renders default view');
+      assert.dom(AUTH_FORM.tabBtn('userpass')).hasText('Userpass', 'it renders default method');
+      assert
+        .dom(AUTH_FORM.tabs)
+        .exists({ count: 1 }, 'it is rendering the default view because only one tab renders');
+
+      await click(AUTH_FORM.otherMethodsBtn);
+      assert.dom(GENERAL.backButton).exists('it toggles to backup method view');
+      assert.dom(AUTH_FORM.tabs).exists({ count: 3 }, 'it renders 3 backup type tabs');
+      assert
+        .dom(AUTH_FORM.tabBtn('ldap'))
+        .hasAttribute('aria-selected', 'true', 'it selects the first backup type');
+    });
+
     test('(default only): it renders default type without backup methods', async function (assert) {
       this.loginSettings.backupTypes = null;
       await this.renderComponent();


### PR DESCRIPTION
### Description
No changelog because follow-on to https://github.com/hashicorp/vault/pull/30700

Fixes a bug where the form rendered the alternate view (backup tabs) if `backup_auth_types` included `default_auth_type`.

```
#  see `token` is a backup and the default. 

vault write sys/config/ui/login/default-auth/root-rule \
 default_auth_type=token \
 backup_auth_types=userpass \
 backup_auth_types=oidc \
 backup_auth_types=token \
 disable_inheritance=false \
 namespace=""
 ```

Now the form properly renders the default (initial) view and does not pre-toggle the form.

## initial view before fix
<img width="620" alt="Screenshot 2025-06-02 at 9 53 26 AM" src="https://github.com/user-attachments/assets/4d653188-568e-4ce7-b2ee-3c1002adec63" />


## initial view after fix 
<img width="642" alt="Screenshot 2025-06-02 at 9 53 01 AM" src="https://github.com/user-attachments/assets/136052eb-f49b-46fc-aa67-6b260f1444eb" />


### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
