### PR TITLE
Skip flaky rate limit quota test

### DIFF
--- a/vault/quotas/quotas_rate_limit_test.go
+++ b/vault/quotas/quotas_rate_limit_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"math"
-	"os"
 	"sync"
 	"testing"
 	"time"
@@ -219,11 +218,7 @@ func TestRateLimitQuota_Allow_WithBlock(t *testing.T) {
 }
 
 func TestRateLimitQuota_Update(t *testing.T) {
-	// This test checks for leaking goroutines, and for whatever reason that doesn't seem to interact well with the race
-	// detector, it seems to take longer than expected to clear the goroutines. Just skip it
-	if os.Getenv("VAULT_CI_GO_TEST_RACE") != "" {
-		t.Skip("skipping race test in CI as its prone to sporadic failures (false positives)")
-	}
+	t.Skipf("See: https://hashicorp.atlassian.net/browse/VAULT-36611?focusedCommentId=746927")
 	defer goleak.VerifyNone(t)
 	qm, err := NewManager(logging.NewVaultLogger(log.Trace), nil, metricsutil.BlackholeSink(), true)
 	require.NoError(t, err)


### PR DESCRIPTION
### Description
Skips the test.

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
