### PR TITLE
UI: Update Swagger Title Element

### DIFF
--- a/ui/lib/open-api-explorer/addon/components/swagger-ui.js
+++ b/ui/lib/open-api-explorer/addon/components/swagger-ui.js
@@ -117,8 +117,22 @@ export default class SwaggerUiComponent extends Component {
   };
 
   // using an action to bind the correct "this" context
-  @action async swaggerInit() {
+  @action async swaggerInit(element) {
     const configSettings = this.CONFIG(SwaggerUIBundle, this);
     SwaggerUIBundle(configSettings);
+
+    // Update the title to be an h1 tag to align with a11y standards
+    setTimeout(() => {
+      const oldTitle = element.querySelector('.swagger-ui .title');
+
+      if (oldTitle) {
+        const newTitle = document.createElement('h1');
+        newTitle.innerHTML = oldTitle.innerHTML;
+
+        // this will cause the same styling to be applied
+        newTitle.className = oldTitle.className;
+        oldTitle.parentNode.replaceChild(newTitle, oldTitle);
+      }
+    }, 500);
   }
 }

--- a/ui/tests/integration/components/open-api-explorer/swagger-ui-test.js
+++ b/ui/tests/integration/components/open-api-explorer/swagger-ui-test.js
@@ -5,7 +5,7 @@
 
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'vault/tests/helpers';
-import { fillIn, render, typeIn } from '@ember/test-helpers';
+import { find, fillIn, render, typeIn, waitUntil } from '@ember/test-helpers';
 import { setupEngine } from 'ember-engines/test-support';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { hbs } from 'ember-cli-htmlbars';
@@ -18,6 +18,7 @@ const SELECTORS = {
   searchInput: 'input.operation-filter-input',
   apiPathBlock: '.opblock-post',
   operationId: '.opblock-summary-operation-id',
+  title: '.information-container .title',
 };
 
 module('Integration | Component | open-api-explorer | swagger-ui', function (hooks) {
@@ -73,6 +74,16 @@ module('Integration | Component | open-api-explorer | swagger-ui', function (hoo
     await this.renderComponent();
 
     assert.dom(SELECTORS.operationId).doesNotExist('operation ids are hidden in production environment');
+
+    envStub.restore();
+  });
+
+  test('it should replace the title h2 tag with an h1 tag for a11y', async function (assert) {
+    const envStub = sinon.stub(config, 'environment').value('production');
+
+    await this.renderComponent();
+
+    assert.ok(await waitUntil(() => find('h1.title')), 'The title element is an <h1>');
 
     envStub.restore();
   });


### PR DESCRIPTION
### Description
This PR addresses an a11y violation found in the swagger title. 
* The title element has been updated to be an `h1` tag according to a11y standards.

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
