### PR TITLE
prefix changelog filename with _ in vault-enterprise plugin update prs

### DIFF
--- a/.github/workflows/plugin-update.yml
+++ b/.github/workflows/plugin-update.yml
@@ -107,9 +107,17 @@ jobs:
           PLUGIN_SERVICE=$(echo "$PLUGIN" | cut -d- -f 4-)
           echo "::debug::plugin service: $PLUGIN_SERVICE"
 
+          # changelog filename is the PR number with a .txt extension
+          # if the repo is vault-enterprise, the filename should start with an underscore
+          CHANGELOG_FILENAME="${{ steps.pr.outputs.vault_pr_num }}.txt"
+          if [ "${{ github.repository }}" = "hashicorp/vault-enterprise" ]; then
+            CHANGELOG_FILENAME="_${{ steps.pr.outputs.vault_pr_num }}.txt"
+          fi
+          echo "::debug::changelog filename: $CHANGELOG_FILENAME"
+
           echo "\`\`\`release-note:change
           ${PLUGIN_TYPE}/${PLUGIN_SERVICE}: Update plugin to v${{ inputs.version }}
-          \`\`\`" > "changelog/${{ steps.pr.outputs.vault_pr_num }}.txt"
+          \`\`\`" > "changelog/$CHANGELOG_FILENAME"
 
           git add changelog/
           git commit -m "Add changelog"


### PR DESCRIPTION
### Description

This PR fixes a small bug in the plugin release pipeline when we open the plugin update PR for enterprise-only plugins. In an example (https://github.com/hashicorp/vault-enterprise/pull/8194), the PR opened with a changelog 8194.txt and I had to manually modify to _8194.txt. The filename should be prefixed with an underscore in the automation.

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
