### PR TITLE
Update vault-plugin-secrets-azure to v0.21.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -154,7 +154,7 @@ require (
 	github.com/hashicorp/vault-plugin-mock v0.16.1
 	github.com/hashicorp/vault-plugin-secrets-ad v0.20.1
 	github.com/hashicorp/vault-plugin-secrets-alicloud v0.19.0
-	github.com/hashicorp/vault-plugin-secrets-azure v0.21.3
+	github.com/hashicorp/vault-plugin-secrets-azure v0.21.4
 	github.com/hashicorp/vault-plugin-secrets-gcp v0.21.3
 	github.com/hashicorp/vault-plugin-secrets-gcpkms v0.20.0
 	github.com/hashicorp/vault-plugin-secrets-kubernetes v0.10.0

--- a/go.sum
+++ b/go.sum
@@ -1600,8 +1600,8 @@ github.com/hashicorp/vault-plugin-secrets-ad v0.20.1 h1:EC+ZwWP54cehgXk5BC8WKX8/
 github.com/hashicorp/vault-plugin-secrets-ad v0.20.1/go.mod h1:QeGpxzcU1EEZazRUiJNi4cIJ98f3JbgefhrFGkwI+h4=
 github.com/hashicorp/vault-plugin-secrets-alicloud v0.19.0 h1:XH1typO/R5RlyyW5cm65+DDAnYmiA7xEdoRGGrB9xu0=
 github.com/hashicorp/vault-plugin-secrets-alicloud v0.19.0/go.mod h1:MxfMowH1VenMCtixd/mDqq9z10CBobzOMZJOXRLi0TA=
-github.com/hashicorp/vault-plugin-secrets-azure v0.21.3 h1:9EZc8foVyvifIj0DnoVcjaIkA2RuRRg7s6CybXp/fK4=
-github.com/hashicorp/vault-plugin-secrets-azure v0.21.3/go.mod h1:fHMx++5LnKQR9oaNrLUmygWTP3O0JaEGYBT63XNk2VY=
+github.com/hashicorp/vault-plugin-secrets-azure v0.21.4 h1:nS/XXCDDdhoWXelxHexzhjUV2Wi515Z8aHLbwDPa3us=
+github.com/hashicorp/vault-plugin-secrets-azure v0.21.4/go.mod h1:LpC/rucWs/sD4zNO/mltn66q/PaDce80giZfy00NZzc=
 github.com/hashicorp/vault-plugin-secrets-gcp v0.21.3 h1:iPa0odSb6WFxOpiNOMZE+wIoyYkDGfWQtellg1NiA8A=
 github.com/hashicorp/vault-plugin-secrets-gcp v0.21.3/go.mod h1:kgg83bUN1aPOaRTTaYGsJGiKzd2CberhmjA73Er2vfM=
 github.com/hashicorp/vault-plugin-secrets-gcpkms v0.20.0 h1:gFPxVPaFJjyPUF3GE7LwgGkVkQ+BA7BE775IfdznZ5M=


### PR DESCRIPTION
### Description
What does this PR do?

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
