### PR TITLE
UI: Fix error handling so users are redirected to log in when token expires if using Vault as an OIDC provider

### DIFF
--- a/changelog/30838.txt
+++ b/changelog/30838.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Redirect users authenticating with Vault as an OIDC provider to log in again when token expires.
+```

--- a/ui/app/routes/vault/cluster/oidc-provider.js
+++ b/ui/app/routes/vault/cluster/oidc-provider.js
@@ -148,7 +148,8 @@ export default class VaultClusterOidcProviderRoute extends Route {
     } catch (errorRes) {
       const resp = await errorRes.json();
       const code = resp.error;
-      if (code === 'max_age_violation' || resp?.errors?.includes('permission denied')) {
+      const permissionDenied = resp?.errors?.some((str) => str.includes('permission denied'));
+      if (code === 'max_age_violation' || permissionDenied) {
         this._redirectToAuth({ ...routeParams, qp, logout: true });
       } else if (code === 'invalid_redirect_uri') {
         return {

--- a/ui/app/routes/vault/cluster/oidc-provider.js
+++ b/ui/app/routes/vault/cluster/oidc-provider.js
@@ -148,6 +148,10 @@ export default class VaultClusterOidcProviderRoute extends Route {
     } catch (errorRes) {
       const resp = await errorRes.json();
       const code = resp.error;
+      // This go-multierror package formats multiple errors as a single string:
+      // https://github.com/hashicorp/go-multierror/blob/main/format.go#L28
+      // Example: '2 errors occurred:\n\t* permission denied\n\t* invalid token\n\n'
+      // So check for substrings of "permission denied" within each full error message.
       const permissionDenied = resp?.errors?.some((str) => str.includes('permission denied'));
       if (code === 'max_age_violation' || permissionDenied) {
         this._redirectToAuth({ ...routeParams, qp, logout: true });

--- a/ui/tests/helpers/stubs.js
+++ b/ui/tests/helpers/stubs.js
@@ -70,7 +70,7 @@ export function overrideResponse(httpStatus = 200, payload = {}) {
     return new Response(
       403,
       { 'Content-Type': 'application/json' },
-      JSON.stringify({ errors: ['"1 errors occurred:\n\t* permission denied"'] })
+      JSON.stringify({ errors: ['1 errors occurred:\n\t* permission denied'] })
     );
   }
   if (httpStatus === 404) {

--- a/ui/tests/helpers/stubs.js
+++ b/ui/tests/helpers/stubs.js
@@ -66,10 +66,11 @@ export function allowAllCapabilitiesStub(capabilitiesList = ['root']) {
  */
 export function overrideResponse(httpStatus = 200, payload = {}) {
   if (httpStatus === 403) {
+    // https://pkg.go.dev/github.com/hashicorp/go-multierror
     return new Response(
       403,
       { 'Content-Type': 'application/json' },
-      JSON.stringify({ errors: ['permission denied'] })
+      JSON.stringify({ errors: ['"1 errors occurred:\n\t* permission denied"'] })
     );
   }
   if (httpStatus === 404) {

--- a/ui/tests/helpers/stubs.js
+++ b/ui/tests/helpers/stubs.js
@@ -66,11 +66,10 @@ export function allowAllCapabilitiesStub(capabilitiesList = ['root']) {
  */
 export function overrideResponse(httpStatus = 200, payload = {}) {
   if (httpStatus === 403) {
-    // https://pkg.go.dev/github.com/hashicorp/go-multierror
     return new Response(
       403,
       { 'Content-Type': 'application/json' },
-      JSON.stringify({ errors: ['1 errors occurred:\n\t* permission denied'] })
+      JSON.stringify({ errors: ['permission denied'] })
     );
   }
   if (httpStatus === 404) {


### PR DESCRIPTION
### Description
Resolves https://github.com/hashicorp/vault/issues/27772

When the error handling changed in this PR: https://github.com/hashicorp/vault/pull/25953 the error handling failed to redirect users to authenticate in the OIDC provider workflow. 

> ### Testing
> I spent a while trying to figure out a way to revoke the user's token to simulate the reported bug but with our test  architecture that's very challenging. Instead, the auth service is stubbed and rejects the authorize url with the updated error format. I confirmed the added test fails before the fix.

## Broken - Vault v1.17.2
1. revoke user's token
2. submit OIDC authorize request
3. 🐛 ❌ error is returned and user is not redirected (Ignore large `Success` message). 
> The error returned by [oidcdebugger](https://oidcdebugger.com/) is URL-encoded:
> `errors=2+errors+occurred%3A%0A%09*+permission+denied%0A%09*+invalid+token%0A%0A`
>
> When the query string is decoded and formatted as JSON it reads:
> ```
> "errors": [
> 	"2 errors occurred:\n\t* permission denied\n\t* invalid token\n\n"
> ]
>```

https://github.com/user-attachments/assets/9d20217a-5c2d-469b-b8f7-ea330828557b



## Demo with fix - Vault v1.20.0-beta1 
1. revoke user's token (instead of waiting for it to expire
2. submit OIDC authorize request
3. ✅  user is redirected to Vault UI login form to re-authenticate 

https://github.com/user-attachments/assets/05e30b47-bef0-4870-bfb4-028ba053c57c

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
