### PR TITLE
Add missing protocol path table to CMPv2 API documentation

### DIFF
--- a/website/content/api-docs/secret/pki/issuance.mdx
+++ b/website/content/api-docs/secret/pki/issuance.mdx
@@ -681,6 +681,14 @@ for issuing and renewing leaf certificates.
 These are the CMP protocol API paths currently supported from Vault's authentication
 point of view.
 
+| Path                   | Default Path Policy | Issuer                | Role          |
+|:-----------------------|:--------------------|:----------------------|:--------------|
+| `/pki/cmp`             | `sign-verbatim`     | `default`             | Sign-Verbatim |
+| `/pki/cmp`             | `role:role_ref`     | Specified by the role | `:role_ref`   |
+| `/pki/roles/:role/cmp` | (any)               | Specified by the role | `:role`       |
+
+The Default Path Policy is specified in the [CMPv2 configuration](#set-cmpv2-configuration).
+When a role is not explicitly specified within the path, the behavior is specified by the `default_path_policy` field.
 
 ### Read CMPv2 Configuration <EnterpriseAlert inline="true" />
 


### PR DESCRIPTION
### Description

Add missing table that specifies the CMPv2 paths a client can use for Vault and what role/issuer combination will be used based on the various factors.

### TODO only if you're a HashiCorp employee
- [X] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [X] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
