### PR TITLE
UI: Move keyboard help text above code editor on ACL policy creation page

### DIFF
--- a/ui/app/components/policy-form.hbs
+++ b/ui/app/components/policy-form.hbs
@@ -73,6 +73,9 @@
           <TextFile @uploadOnly={{true}} @onChange={{this.setPolicyFromFile}} />
         </div>
       {{else}}
+        <div class="is-size-9 has-text-grey has-bottom-margin-xs has-top-margin-xs" data-test-alt-tab-message>
+          You can use Alt+Tab (Option+Tab on MacOS) in the code editor to skip to the next field.
+        </div>
         <JsonEditor
           @title="Policy"
           @showToolbar={{false}}
@@ -83,11 +86,7 @@
           data-test-policy-editor
         />
       {{/if}}
-      {{#unless this.showFileUpload}}
-        <span class="is-size-9 has-text-grey has-bottom-margin-l has-top-margin-xs" data-test-alt-tab-message>
-          You can use Alt+Tab (Option+Tab on MacOS) in the code editor to skip to the next field.
-        </span>
-      {{/unless}}
+
     </div>
     {{#each @model.additionalAttrs as |attr|}}
       <FormField data-test-field={{true}} @attr={{attr}} @model={{@model}} />


### PR DESCRIPTION
### Description
What does this PR do?

Solves a11y defect regarding [keyboard trap when creating an ACL policy](https://hashicorp.atlassian.net/jira/software/c/projects/VAULT/boards/105?assignee=712020%3A7215fde3-6180-4902-8e6d-c368b94abc78&selectedIssue=VAULT-32374)


### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
