### PR TITLE
Backport 1.20.x UI: Update `namespace` key to `namespace_path`

### DIFF
--- a/ui/lib/config-ui/addon/components/login-settings/page/details.js
+++ b/ui/lib/config-ui/addon/components/login-settings/page/details.js
@@ -34,7 +34,7 @@ export default class LoginSettingsRuleDetails extends Component {
     defaultAuthType: 'Default method',
     backupAuthTypes: 'Backup methods',
     disableInheritance: 'Inheritance enabled',
-    namespace: 'Namespace',
+    namespacePath: 'Namespace the rule applies to',
   };
 
   displayValue = (key) => {

--- a/ui/lib/config-ui/addon/components/login-settings/page/list.hbs
+++ b/ui/lib/config-ui/addon/components/login-settings/page/list.hbs
@@ -29,7 +29,7 @@
               {{rule.name}}
             </Hds::Text::Display>
             <div class="has-top-margin-m">
-              {{rule.namespace}}
+              {{rule.namespacePath}}
               <Hds::Badge
                 @text="Inheritance {{if rule.disableInheritance 'disabled' 'enabled'}}"
                 class="has-left-margin-xxs"

--- a/ui/tests/acceptance/auth/login-settings-test.js
+++ b/ui/tests/acceptance/auth/login-settings-test.js
@@ -21,8 +21,8 @@ module('Acceptance | Enterprise | auth form custom login settings', function (ho
     await runCmd([
       `write sys/namespaces/test-ns -force`,
       `write test-ns/sys/namespaces/child -force`,
-      `write sys/config/ui/login/default-auth/root-rule backup_auth_types=token default_auth_type=okta disable_inheritance=false namespace=""`,
-      `write sys/config/ui/login/default-auth/ns-rule default_auth_type=ldap disable_inheritance=true namespace=test-ns`,
+      `write sys/config/ui/login/default-auth/root-rule backup_auth_types=token default_auth_type=okta disable_inheritance=false namespace_path=""`,
+      `write sys/config/ui/login/default-auth/ns-rule default_auth_type=ldap disable_inheritance=true namespace_path=test-ns`,
       `write sys/auth/my-oidc type=oidc`,
       `write sys/auth/my-oidc/tune listing_visibility="unauth"`,
     ]);

--- a/ui/tests/acceptance/config-ui/login-settings-test.js
+++ b/ui/tests/acceptance/config-ui/login-settings-test.js
@@ -11,6 +11,7 @@ import { GENERAL } from 'vault/tests/helpers/general-selectors';
 import { runCmd } from 'vault/tests/helpers/commands';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { overrideResponse } from 'vault/tests/helpers/stubs';
+import { v4 as uuidv4 } from 'uuid';
 
 const SELECTORS = {
   rule: (name) => (name ? `[data-test-rule="${name}"]` : '[data-test-rule]'),
@@ -22,6 +23,13 @@ module('Acceptance | Enterprise | config-ui/login-settings', function (hooks) {
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {
+    // a login rule cannot be created for a namespace that already has a rule applied.
+    // rules are deleted in the afterEach hook, but when debugging tests locally they may
+    // re-run before cleanup happens.
+    // using a uuid ensures the runCmd that creates new rules is always successful
+    // by using a different namespace_path each run.
+    this.ns1 = `ns1-${uuidv4()}`;
+    this.ns2 = `ns2-${uuidv4()}`;
     return await login();
   });
 
@@ -48,19 +56,24 @@ module('Acceptance | Enterprise | config-ui/login-settings', function (hooks) {
 
       // create login rules
       await runCmd([
-        `write sys/config/ui/login/default-auth/testRule backup_auth_types=userpass default_auth_type=okta disable_inheritance=false namespace=ns1`,
-        'write sys/config/ui/login/default-auth/testRule2 backup_auth_types=oidc default_auth_type=ldap disable_inheritance=true namespace=ns2',
+        `write sys/config/ui/login/default-auth/testRule1 backup_auth_types=userpass default_auth_type=okta disable_inheritance=false namespace_path=${this.ns1}`,
+        `write sys/config/ui/login/default-auth/testRule2 backup_auth_types=oidc default_auth_type=ldap disable_inheritance=true namespace_path=${this.ns2}`,
       ]);
     });
 
     hooks.afterEach(async function () {
+      // since the test login rules are created for namespaces that do not exist
+      // they do not affect the login view for the "root" namespace
       await login();
 
       // cleanup login rules
-      await runCmd([
-        'delete sys/config/ui/login/default-auth/testRule',
-        'delete sys/config/ui/login/default-auth/testRule2',
-      ]);
+      await runCmd(
+        [
+          'delete sys/config/ui/login/default-auth/testRule1',
+          'delete sys/config/ui/login/default-auth/testRule2',
+        ],
+        true
+      );
     });
 
     test('fetched login rule list renders', async function (assert) {
@@ -69,8 +82,8 @@ module('Acceptance | Enterprise | config-ui/login-settings', function (hooks) {
 
       // verify fetched rules are rendered in list
       assert.dom(SELECTORS.rule()).exists({ count: 2 });
-      assert.dom(SELECTORS.rule('testRule')).hasText('testRule ns1/ Inheritance enabled');
-      assert.dom(SELECTORS.rule('testRule2')).hasText('testRule2 ns2/ Inheritance disabled');
+      assert.dom(SELECTORS.rule('testRule1')).hasText(`testRule1 ${this.ns1}/ Inheritance enabled`);
+      assert.dom(SELECTORS.rule('testRule2')).hasText(`testRule2 ${this.ns2}/ Inheritance disabled`);
     });
 
     test('delete rule from list view', async function (assert) {
@@ -78,15 +91,15 @@ module('Acceptance | Enterprise | config-ui/login-settings', function (hooks) {
       await visit('vault/config-ui/login-settings');
 
       assert.dom(SELECTORS.rule()).exists({ count: 2 });
-      await click(SELECTORS.popupMenu('testRule'));
+      await click(SELECTORS.popupMenu('testRule1'));
       await click(GENERAL.menuItem('delete-rule'));
 
       assert.dom(GENERAL.confirmationModal).exists();
       await click(GENERAL.confirmButton);
 
       // verify success message from deletion
-      assert.dom(GENERAL.latestFlashContent).includesText('Successfully deleted rule testRule.');
-      assert.dom(SELECTORS.rule('testRule')).doesNotExist();
+      assert.dom(GENERAL.latestFlashContent).includesText('Successfully deleted rule testRule1.');
+      assert.dom(SELECTORS.rule('testRule1')).doesNotExist();
       assert.dom(SELECTORS.rule()).exists({ count: 1 });
     });
 
@@ -94,7 +107,7 @@ module('Acceptance | Enterprise | config-ui/login-settings', function (hooks) {
       // visit individual rule page
       await visit('vault/config-ui/login-settings');
 
-      await click(SELECTORS.popupMenu('testRule'));
+      await click(SELECTORS.popupMenu('testRule1'));
       await click(GENERAL.menuItem('view-rule'));
 
       // verify that user is redirected to the rule details page
@@ -106,7 +119,7 @@ module('Acceptance | Enterprise | config-ui/login-settings', function (hooks) {
 
       // verify fetched rule data is rendered
       assert.dom(GENERAL.infoRowValue('Default method')).hasText('okta');
-      assert.dom(GENERAL.infoRowValue('Namespace')).hasText('ns1/');
+      assert.dom(GENERAL.infoRowValue('Namespace the rule applies to')).hasText(`${this.ns1}/`);
       assert.dom(GENERAL.infoRowValue('Backup methods')).hasText('userpass');
       assert.dom(GENERAL.infoRowValue('Inheritance enabled')).hasText('Yes');
     });
@@ -121,7 +134,7 @@ module('Acceptance | Enterprise | config-ui/login-settings', function (hooks) {
       );
 
       assert.dom(GENERAL.infoRowValue('Default method')).hasText('ldap');
-      assert.dom(GENERAL.infoRowValue('Namespace')).hasText('ns2/');
+      assert.dom(GENERAL.infoRowValue('Namespace the rule applies to')).hasText(`${this.ns2}/`);
       assert.dom(GENERAL.infoRowValue('Backup methods')).hasText('oidc');
       assert.dom(GENERAL.infoRowValue('Inheritance enabled')).hasText('No');
     });


### PR DESCRIPTION
Backport for https://github.com/hashicorp/vault/pull/30848

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
