### PR TITLE
[DOCS] Add missing update info to v1.17 docs

### DIFF
--- a/website/content/docs/upgrading/upgrade-to-1.16.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.16.x.mdx
@@ -14,6 +14,26 @@ Vault 1.15. **Please read carefully**.
 
 ## Important changes
 
+### Strict validation for Azure auth login requests ((#strict-azure))
+
+| Change       | Affected version
+| ------------ | ----------------
+| New behavior | 1.16.18+
+
+Azure auth plugin requires `resource_group_name`, `vm_name`, and `vmss_name` to
+match the JWT claims on login
+
+Vault versions before 11.16.18 did not strictly validate the
+`resource_group_name`, `vm_name`, and `vmss_name` parameters against their token
+claims for clients logging in with Azure authentication.
+
+#### Recommendation
+
+Review the [Token validation](/vault/docs/auth/azure#token-validation) section
+of the Azure authN plugin guide for more information on the new validation
+requirements.
+
+
 ### External plugin variables take precedence over system variables ((#external-plugin-variables))
 
 Vault gives precedence to plugin environment variables over system environment
@@ -96,6 +116,10 @@ decides to trigger the flag. More information can be found in the
 
 ### Activity Log Changes
 
+#### Disable client counting activity
+
+License utilization cannot be reported if client counting is disabled. As of Vault Enterprise 1.16.0 and later, client counting cannot be disabled using `/sys/internal/counters/config` endpoint as manual license utilization reporting is always enabled.
+
 #### Default Activity Log Querying Period
 
 As of 1.16.13 and later, the field `default_report_months` can no longer be configured or read. Any previously set values
@@ -140,7 +164,7 @@ Attempts to set `current_billing_period` will result in the following warning fr
 
 ### Auto-rolled billing start date
 
-As of 1.16.7 and later, the billing start date (license start date if not configured) automatically rolls over to the latest billing year at the end of the last cycle. 
+As of 1.16.7 and later, the billing start date (license start date if not configured) automatically rolls over to the latest billing year at the end of the last cycle.
 
 @include 'auto-roll-billing-start.mdx'
 
@@ -189,7 +213,7 @@ kubectl exec -ti <NAME> -- wget https://github.com/moparisthebest/static-curl/re
 ### Product usage reporting
 
 As of 1.16.13, Vault will collect anonymous product usage metrics for HashiCorp. This information will be collected
-alongside client activity data, and will be sent automatically if automated reporting is configured, or added to manual
+alongside activity information, and will be sent automatically if automated reporting is configured, or added to manual
 reports if manual reporting is preferred.
 
 See the main page for [Vault product usage metrics reporting](/vault/docs/enterprise/license/product-usage-reporting) for
@@ -219,9 +243,9 @@ more details, and information about opt-out.
 
 @include 'known-issues/1_13-reload-census-panic-standby.mdx'
 
-@include 'known-issues/1_16_secrets-sync-chroot-activation.mdx'
-
 @include 'known-issues/autopilot-upgrade-upgrade-version.mdx'
+
+@include 'known-issues/1_16_secrets-sync-chroot-activation.mdx'
 
 @include 'known-issues/config_listener_proxy_protocol_behavior_issue.mdx'
 
@@ -230,7 +254,6 @@ more details, and information about opt-out.
 @include 'known-issues/duplicate-identity-groups.mdx'
 
 @include 'known-issues/manual-entity-merge-does-not-persist.mdx'
-
 
 @include 'known-issues/database-skip-static-role-rotation.mdx'
 
@@ -243,3 +266,7 @@ more details, and information about opt-out.
 @include 'known-issues/log_file_flush_issue.mdx'
 
 @include 'known-issues/azure-auth-fails-uniform-vmss.mdx'
+
+@include 'known-issues/sync-activation-flags-cache-not-updated.mdx'
+
+@include 'known-issues/enterprise-plugins.mdx'

--- a/website/content/docs/upgrading/upgrade-to-1.17.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.17.x.mdx
@@ -14,19 +14,27 @@ Vault 1.16. **Please read carefully**.
 
 ## Important changes
 
-### Azure auth plugin requires `resource_group_name`, `vm_name`, and `vmss_name` to match the JWT claims on login
+### Strict validation for Azure auth login requests ((#strict-azure))
 
-Vault versions before 1.19.1, 1.18.7, 1.17.14, and 1.16.18, do not strictly
-validate the `resource_group_name`, `vm_name`, and `vmss_name` parameters
-against their token claims during login with Azure authentication.
+| Change       | Affected version
+| ------------ | ----------------
+| New behavior | 1.17.14+
 
-Refer to the [Token validation](/vault/docs/auth/azure#token-validation) section
+Azure auth plugin requires `resource_group_name`, `vm_name`, and `vmss_name` to
+match the JWT claims on login.
+
+Vault versions before 1.17.14 did not strictly validate the
+`resource_group_name`, `vm_name`, and `vmss_name` parameters against their token
+claims for clients logging in with Azure authentication.
+
+#### Recommendation
+
+Review the [Token validation](/vault/docs/auth/azure#token-validation) section
 of the Azure authN plugin guide for more information on the new validation
 requirements.
 
-<a id="audit-headers" />
 
-### Allowed audit headers now have unremovable defaults
+### Allowed audit headers now have unremovable defaults ((#audit-headers))
 
 The [config auditing API endpoint](/vault/api-docs/system/config-auditing#create-update-audit-request-header)
 tells Vault to log incoming request headers (when present) in the audit log.
@@ -186,7 +194,7 @@ kubectl exec -ti <NAME> -- wget https://github.com/moparisthebest/static-curl/re
 ### Product usage reporting
 
 As of 1.17.9, Vault will collect anonymous product usage metrics for HashiCorp. This information will be collected
-alongside client activity data, and will be sent automatically if automated reporting is configured, or added to manual
+alongside activity information, and will be sent automatically if automated reporting is configured, or added to manual
 reports if manual reporting is preferred.
 
 See the main page for [Vault product usage metrics reporting](/vault/docs/enterprise/license/product-usage-reporting) for
@@ -229,3 +237,5 @@ more details, and information about opt-out.
 @include 'known-issues/log_file_flush_issue.mdx'
 
 @include 'known-issues/azure-auth-fails-uniform-vmss.mdx'
+
+@include 'known-issues/enterprise-plugins.mdx'

--- a/website/content/partials/known-issues/enterprise-plugins.mdx
+++ b/website/content/partials/known-issues/enterprise-plugins.mdx
@@ -1,0 +1,27 @@
+### External Enterprise plugins cannot run on a standby node when it becomes active ((#external-ent-plugins))
+
+| Change       | Affected version                 | Affected deployments
+| ------------ | -------------------------------- | --------------------
+| Bug          | 1.16.17-1.16.20, 1.17.13-1.17.16, 1.18.6-1.18.9, 1.19.0-1.19.3 | any
+
+External Enterprise plugins can't run on a standby node when it becomes active
+because standby nodes don't extract the artifact when the plugin
+is registered.
+
+#### Recommendation
+
+As a workaround, add the plugin `.zip` artifact on every node and register the plugin on the
+active node. Then, extract the contents of the zip file on the follower nodes
+similar to the following folder structure for
+`vault-plugin-secrets-keymgmt_0.16.0+ent_darwin_arm64.zip`.
+
+```text
+<plugin-directory>/vault-plugin-secrets-keymgmt_0.16.0+ent_darwin_arm64
+├── metadata.json
+├── metadata.json.sig
+└── vault-plugin-secrets-keymgmt
+```
+
+Alternatively, upgrade to one of the following Vault versions: 1.16.21+, 1.17.17+,
+1.18.10+, 1.19.4+. See [Register external plugins](/vault/docs/plugins/register)
+for more details.


### PR DESCRIPTION
### Description
What does this PR do?

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
