### PR TITLE
[DOCS] Add missing update info to v1.16 docs

### DIFF
--- a/website/content/docs/upgrading/upgrade-to-1.16.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.16.x.mdx
@@ -221,7 +221,6 @@ more details, and information about opt-out.
 
 ## Known issues and workarounds
 
-@include 'known-issues/1_17_audit-log-hmac.mdx'
 
 @include 'known-issues/1_16-jwt_auth_bound_audiences.mdx'
 

--- a/website/content/docs/upgrading/upgrade-to-1.16.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.16.x.mdx
@@ -232,6 +232,8 @@ more details, and information about opt-out.
 
 @include 'known-issues/1_16-default-policy-needs-to-be-updated.mdx'
 
+@include 'known-issues/duplicate-hsm-key.mdx'
+
 @include 'known-issues/1_16-default-lcq-pre-1_9-upgrade.mdx'
 
 @include 'known-issues/ocsp-redirect.mdx'

--- a/website/content/docs/upgrading/upgrade-to-1.16.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.16.x.mdx
@@ -14,15 +14,25 @@ Vault 1.15. **Please read carefully**.
 
 ## Important changes
 
-### Azure auth plugin requires `resource_group_name`, `vm_name`, and `vmss_name` to match the JWT claims on login
+### Strict validation for Azure auth login requests ((#strict-azure))
 
-Vault versions before 1.19.1, 1.18.7, 1.17.14, and 1.16.18, do not strictly
-validate the `resource_group_name`, `vm_name`, and `vmss_name` parameters
-against their token claims during login with Azure authentication.
+| Change       | Affected version
+| ------------ | ----------------
+| New behavior | 1.16.18+
 
-Refer to the [Token validation](/vault/docs/auth/azure#token-validation) section
+Azure auth plugin requires `resource_group_name`, `vm_name`, and `vmss_name` to
+match the JWT claims on login
+
+Vault versions before 11.16.18 did not strictly validate the
+`resource_group_name`, `vm_name`, and `vmss_name` parameters against their token
+claims for clients logging in with Azure authentication.
+
+#### Recommendation
+
+Review the [Token validation](/vault/docs/auth/azure#token-validation) section
 of the Azure authN plugin guide for more information on the new validation
 requirements.
+
 
 ### External plugin variables take precedence over system variables ((#external-plugin-variables))
 
@@ -71,6 +81,12 @@ If you register an external plugin called `myplugin` with `SOURCE=child`, the
 plugin process starts with `SOURCE=parent` and Vault reports a conflict for
 `myplugin`.
 
+### LDAP auth login changes
+
+Users cannot log in using LDAP unless the LDAP plugin is configured
+with an `userdn` value scoped to an organization unit (OU) where the
+user resides.
+
 ### LDAP auth entity alias names no longer include upndomain
 
 The `userattr` field on the LDAP auth config is now used as the entity alias.
@@ -99,6 +115,10 @@ decides to trigger the flag. More information can be found in the
 [secrets sync documentation](/vault/docs/sync#activating-the-feature).
 
 ### Activity Log Changes
+
+#### Disable client counting activity
+
+License utilization cannot be reported if client counting is disabled. As of Vault Enterprise 1.16.0 and later, client counting cannot be disabled using `/sys/internal/counters/config` endpoint as manual license utilization reporting is always enabled.
 
 #### Default Activity Log Querying Period
 
@@ -150,7 +170,6 @@ As of 1.16.7 and later, the billing start date (license start date if not config
 
 @include 'auto-roll-billing-start-example.mdx'
 
-=======
 ### Docker image no longer contains `curl`
 
 As of 1.16.7 and later, the `curl` binary is no longer included in the published Docker container
@@ -194,13 +213,15 @@ kubectl exec -ti <NAME> -- wget https://github.com/moparisthebest/static-curl/re
 ### Product usage reporting
 
 As of 1.16.13, Vault will collect anonymous product usage metrics for HashiCorp. This information will be collected
-alongside client activity data, and will be sent automatically if automated reporting is configured, or added to manual
+alongside activity information, and will be sent automatically if automated reporting is configured, or added to manual
 reports if manual reporting is preferred.
 
 See the main page for [Vault product usage metrics reporting](/vault/docs/enterprise/license/product-usage-reporting) for
 more details, and information about opt-out.
 
 ## Known issues and workarounds
+
+@include 'known-issues/1_17_audit-log-hmac.mdx'
 
 @include 'known-issues/1_16-jwt_auth_bound_audiences.mdx'
 
@@ -220,6 +241,10 @@ more details, and information about opt-out.
 
 @include 'known-issues/perf-standbys-revert-to-standby.mdx'
 
+@include 'known-issues/1_13-reload-census-panic-standby.mdx'
+
+@include 'known-issues/autopilot-upgrade-upgrade-version.mdx'
+
 @include 'known-issues/1_16_secrets-sync-chroot-activation.mdx'
 
 @include 'known-issues/config_listener_proxy_protocol_behavior_issue.mdx'
@@ -229,8 +254,6 @@ more details, and information about opt-out.
 @include 'known-issues/duplicate-identity-groups.mdx'
 
 @include 'known-issues/manual-entity-merge-does-not-persist.mdx'
-
-@include 'known-issues/duplicate-hsm-key.mdx'
 
 @include 'known-issues/database-skip-static-role-rotation.mdx'
 
@@ -243,3 +266,7 @@ more details, and information about opt-out.
 @include 'known-issues/log_file_flush_issue.mdx'
 
 @include 'known-issues/azure-auth-fails-uniform-vmss.mdx'
+
+@include 'known-issues/sync-activation-flags-cache-not-updated.mdx'
+
+@include 'known-issues/enterprise-plugins.mdx'

--- a/website/content/partials/known-issues/1_13-reload-census-panic-standby.mdx
+++ b/website/content/partials/known-issues/1_13-reload-census-panic-standby.mdx
@@ -1,0 +1,21 @@
+### Sending SIGHUP to vault standby node causes panic
+
+#### Affected versions
+
+- 1.13.4+
+- 1.14.0+
+- 1.15.0+
+- 1.16.0+
+
+#### Issue
+
+Sending a SIGHUP to a vault standby node running an enterprise build can cause a panic
+if there is a change to the license, or reporting configuration.
+Active and performance standby nodes will perform fine. It is recommended that operators
+stop and restart vault nodes individually if configuration changes are required.
+
+
+#### Workaround
+
+Instead of issuing a SIGHUP, users should stop individual vault nodes, update the configuration 
+or license and then restart the node. 

--- a/website/content/partials/known-issues/1_17_audit-log-hmac.mdx
+++ b/website/content/partials/known-issues/1_17_audit-log-hmac.mdx
@@ -1,0 +1,15 @@
+### Client tokens and token accessors audited in plaintext
+
+#### Affected versions
+
+- 1.16.7, 1.16.8, 1.17.3, 1.17.4 
+
+#### Issue
+
+In versions 1.16.7, 1.16.8, 1.17.3, and 1.17.4 audit logs may contain non-hmac’d values for
+client_token and accessor data in the response portion. 
+A fix has been created and is released in 1.16.9 and 1.17.5.
+
+#### Workaround
+It is recommended to avoid affected versions when upgrading.
+If you are on these versions and using the audit logging feature please upgrade promptly to 1.16.9 or 1.17.5.

--- a/website/content/partials/known-issues/autopilot-upgrade-upgrade-version.mdx
+++ b/website/content/partials/known-issues/autopilot-upgrade-upgrade-version.mdx
@@ -1,0 +1,16 @@
+### New nodes added by autopilot upgrades provisioned with the wrong version
+
+#### Affected versions
+
+- 1.15.3 - 1.15.9
+- 1.16.1 - 1.16.3
+
+#### Issue
+
+If `autopilot_upgrade_version` is not explicitly set in the Vault configuration file in the `storage` 
+section, new non-active nodes will retain their original Vault version as opposed to the new version.
+
+#### Workaround
+
+Set the desired version in the configuration file as `autopilot_upgrade_version=<version string>`. This will 
+allow all nodes to receive the proper version to upgrade to.

--- a/website/content/partials/known-issues/enterprise-plugins.mdx
+++ b/website/content/partials/known-issues/enterprise-plugins.mdx
@@ -1,0 +1,27 @@
+### External Enterprise plugins cannot run on a standby node when it becomes active ((#external-ent-plugins))
+
+| Change       | Affected version                 | Affected deployments
+| ------------ | -------------------------------- | --------------------
+| Bug          | 1.16.17-1.16.20, 1.17.13-1.17.16, 1.18.6-1.18.9, 1.19.0-1.19.3 | any
+
+External Enterprise plugins can't run on a standby node when it becomes active
+because standby nodes don't extract the artifact when the plugin
+is registered.
+
+#### Recommendation
+
+As a workaround, add the plugin `.zip` artifact on every node and register the plugin on the
+active node. Then, extract the contents of the zip file on the follower nodes
+similar to the following folder structure for
+`vault-plugin-secrets-keymgmt_0.16.0+ent_darwin_arm64.zip`.
+
+```text
+<plugin-directory>/vault-plugin-secrets-keymgmt_0.16.0+ent_darwin_arm64
+├── metadata.json
+├── metadata.json.sig
+└── vault-plugin-secrets-keymgmt
+```
+
+Alternatively, upgrade to one of the following Vault versions: 1.16.21+, 1.17.17+,
+1.18.10+, 1.19.4+. See [Register external plugins](/vault/docs/plugins/register)
+for more details.

--- a/website/content/partials/known-issues/sync-activation-flags-cache-not-updated.mdx
+++ b/website/content/partials/known-issues/sync-activation-flags-cache-not-updated.mdx
@@ -1,0 +1,23 @@
+### Cached activation flags for secrets sync on follower nodes are not updated
+
+#### Affected versions
+
+- 1.16.0 - 1.16.2
+- 1.17.0 - 1.17.5
+
+#### Issue
+
+Vault 1.16 introduced secrets sync with a one-time flag required to activate the
+feature before use. Writing the activation flag to enable secrets sync is forwarded
+to leader nodes for storage and distributed to follower nodes, but the in-memory
+cache for this flag is not updated on the followers. 
+
+This prevents any secrets sync endpoints (those starting with `sys/sync/`) from
+being usable on follower nodes in a cluster.
+
+#### Workaround
+
+The cache is force-updated on all nodes when the leader node steps down and the
+cluster promotes a new leader. First, activate the secrets sync feature as described
+in the [documentation](/vault/docs/sync#activating-the-feature). Then, have the leader node
+step down.


### PR DESCRIPTION
### Description
What does this PR do?

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
