### PR TITLE
Manual backport of VAULT-36229 docs: Nonce for rekey cancellations into release/1.17.x

### DIFF
--- a/website/content/api-docs/system/rekey-recovery-key.mdx
+++ b/website/content/api-docs/system/rekey-recovery-key.mdx
@@ -122,9 +122,27 @@ well as any progress made. This must be called to change the parameters of the
 rekey. Note: verification is still a part of a rekey. If rekeying is canceled
 during the verification flow, the current unseal keys remain valid.
 
+<Note title="Unrestricted endpoint">
+  Clients can call the endpoint without authenticating to Vault.
+</Note>
+
 | Method   | Path                           |
 | :------- | :----------------------------- |
 | `DELETE` | `/sys/rekey-recovery-key/init` |
+
+### Parameters
+
+- `nonce` `(string: <optional>)` – Specifies the nonce of the rekey operation. If
+  the rekey was initialized within the last 10 minutes, you must provide the
+  nonce to cancel the operation.
+
+### Sample payload
+
+```json
+{
+  "nonce": "abcd1234..."
+}
+```
 
 ### Sample request
 
@@ -132,6 +150,7 @@ during the verification flow, the current unseal keys remain valid.
 $ curl \
     --header "X-Vault-Token: ..." \
     --request DELETE \
+    --data @payload.json \
     http://127.0.0.1:8200/v1/sys/rekey-recovery-key/init
 ```
 

--- a/website/content/api-docs/system/rekey.mdx
+++ b/website/content/api-docs/system/rekey.mdx
@@ -122,9 +122,27 @@ well as any progress made. This must be called to change the parameters of the
 rekey. Note: verification is still a part of a rekey. If rekeying is canceled
 during the verification flow, the current unseal keys remain valid.
 
+<Note title="Unrestricted endpoint">
+  Clients can call the endpoint without authenticating to Vault.
+</Note>
+
 | Method   | Path              |
 | :------- | :---------------- |
 | `DELETE` | `/sys/rekey/init` |
+
+### Parameters
+
+- `nonce` `(string: <optional>)` – Specifies the nonce of the rekey operation. If
+  the rekey was initialized within the last 10 minutes, you must provide the
+  nonce to cancel the operation.
+
+### Sample payload
+
+```json
+{
+  "nonce": "abcd1234..."
+}
+```
 
 ### Sample request
 
@@ -132,6 +150,7 @@ during the verification flow, the current unseal keys remain valid.
 $ curl \
     --header "X-Vault-Token: ..." \
     --request DELETE \
+    --data @payload.json \
     http://127.0.0.1:8200/v1/sys/rekey/init
 ```
 

--- a/website/content/docs/upgrading/upgrade-to-1.17.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.17.x.mdx
@@ -14,6 +14,21 @@ Vault 1.16. **Please read carefully**.
 
 ## Important changes
 
+### Rekey cancellations use a nonce ((#rekey-cancel-nonce))
+| Change       | Affected version | Affected deployments
+| ------------ | ---------------- | --------------------
+| Breaking     | 1.17.18+ | Any
+
+Vault 1.17.18 and onwards require a nonce to cancel
+[rekey](/vault/api-docs/system/rekey) and
+[rekey recovery key](/vault/api-docs/system/rekey-recovery-key) operations
+within 10 minutes of initializing a rekey request. Cancellation requests after
+the 10 minute window do not require a nonce and succeed as expected.
+
+#### Recommendation
+To cancel a rekey operation, provide the nonce value from the
+`/sys/rekey/init` or `sys/rekey-recovery-key/init` response.
+
 ### Strict validation for Azure auth login requests ((#strict-azure))
 
 | Change       | Affected version


### PR DESCRIPTION
### Description
Original PR: https://github.com/hashicorp/vault/pull/30794

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
