### PR TITLE
Stub updates for Ent

### DIFF
--- a/changelog/30890.txt
+++ b/changelog/30890.txt
@@ -1,0 +1,3 @@
+```release-note:change
+logical/system: add ent stub for plugin catalog handling
+```

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -203,7 +203,7 @@ func NewSystemBackend(core *Core, logger log.Logger, config *logical.BackendConf
 	b.Backend.Paths = append(b.Backend.Paths, b.sealPaths()...)
 	b.Backend.Paths = append(b.Backend.Paths, b.statusPaths()...)
 	b.Backend.Paths = append(b.Backend.Paths, b.pluginsCatalogListPaths()...)
-	b.Backend.Paths = append(b.Backend.Paths, b.pluginsCatalogCRUDPath())
+	b.Backend.Paths = append(b.Backend.Paths, entWrappedPluginsCRUDPath(b)...)
 	b.Backend.Paths = append(b.Backend.Paths, b.pluginsCatalogPinsListPath())
 	b.Backend.Paths = append(b.Backend.Paths, b.pluginsCatalogPinsCRUDPath())
 	b.Backend.Paths = append(b.Backend.Paths, b.pluginsReloadPath())

--- a/vault/logical_system_stubs_oss.go
+++ b/vault/logical_system_stubs_oss.go
@@ -31,3 +31,7 @@ func (s *SystemBackend) makeSnapshotSource(ctx context.Context, _ *framework.Fie
 	}
 	return snapshots.NewManualSnapshotSource(body), nil
 }
+
+func entWrappedPluginsCRUDPath(b *SystemBackend) []*framework.Path {
+	return []*framework.Path{b.pluginsCatalogCRUDPath()}
+}

--- a/vault/plugincatalog/plugin_catalog_stubs_oss.go
+++ b/vault/plugincatalog/plugin_catalog_stubs_oss.go
@@ -1,0 +1,16 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+//go:build !enterprise
+
+package plugincatalog
+
+import (
+	"context"
+
+	"github.com/hashicorp/vault/sdk/helper/pluginutil"
+)
+
+func (c *PluginCatalog) entPrepareDownloadedPlugin(ctx context.Context, plugin pluginutil.SetPluginInput) (string, string, error) {
+	return "", "", nil
+}


### PR DESCRIPTION
### Description
What does this PR do?

Stub updates for Enterprise.

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
