### PR TITLE
Update Azure Auth Docs To State Required Parameters

### DIFF
--- a/website/content/api-docs/auth/azure.mdx
+++ b/website/content/api-docs/auth/azure.mdx
@@ -164,9 +164,9 @@ entities attempting to login.
 
 - `name` `(string: <required>)` - Name of the role.
 - `bound_service_principal_ids` `(array: [])` - The list of Service Principal IDs
-  that login is restricted to.
+  that login is restricted to. Either this parameter or `bound_group_ids` must be set.
 - `bound_group_ids` `(array: [])` - The list of group ids that login is restricted
-  to.
+  to. Either this parameter or `bound_service_principal_ids` must be set.
 - `bound_locations` `(array: [])` - The list of locations that login is restricted to.
 - `bound_subscription_ids` `(array: [])` - The list of subscription IDs that login
   is restricted to.
@@ -177,6 +177,8 @@ entities attempting to login.
 
 @include 'tokenfields.mdx'
 
+~> **Note:** When creating a role, you must specify either `bound_service_principal_ids` or `bound_group_ids`. These parameters are mutually exclusive - you cannot set both, but you must set one of them.
+
 ### Sample payload
 
 ```json
@@ -184,7 +186,8 @@ entities attempting to login.
   "token_policies": ["default", "dev", "prod"],
   "max_ttl": 1800000,
   "max_jwt_exp": 10000,
-  "bound_resource_groups": ["vault-dev", "vault-staging", "vault-prod"]
+  "bound_resource_groups": ["vault-dev", "vault-staging", "vault-prod"],
+  "bound_service_principal_ids": ["3cb88732-1356-4782-b671-4877166be01a"]
 }
 ```
 

--- a/website/content/docs/auth/azure.mdx
+++ b/website/content/docs/auth/azure.mdx
@@ -105,10 +105,7 @@ $ vault write auth/azure/login \
     vm_name="test-vm"
 ```
 
-The `role` and `jwt` parameters are required. When using
-`bound_service_principal_ids` and `bound_group_ids` in the token roles, all the
-information is required in the JWT (except for `vm_name`, `vmss_name`, `resource_id`). When
-using other `bound_*` parameters, calls to Azure APIs will be made and
+The `role` and `jwt` parameters are required. The JWT must contain all role binding information (except for `vm_name`, `vmss_name`, and `resource_id`). When using additional `bound_*` parameters beyond `bound_service_principal_ids` or `bound_group_ids`, Azure API calls will be made and
 `subscription_id`, `resource_group_name`, and `vm_name`/`vmss_name` are all required
 and can be obtained through instance metadata.
 
@@ -216,13 +213,25 @@ tool.
    $ vault write auth/azure/role/dev-role \
        policies="prod,dev" \
        bound_subscription_ids=6a1d5988-5917-4221-b224-904cd7e24a25 \
-       bound_resource_groups=vault
+       bound_resource_groups=vault \
+       bound_service_principal_ids=3cb88732-1356-4782-b671-4877166be01a
    ```
 
    Roles are associated with an authentication type/entity and a set of Vault
    policies. Roles are configured with constraints specific to the
    authentication type, as well as overall constraints and configuration for
    the generated auth tokens.
+
+   Note: Each role must specify either `bound_service_principal_ids` or `bound_group_ids` to restrict which Azure identities (service principals or group members) can authenticate to this role.
+   Here's an alternative example using `bound_group_ids`:
+
+   ```shell-session
+   $ vault write auth/azure/role/prod-role \
+       policies="prod" \
+       bound_subscription_ids=6a1d5988-5917-4221-b224-904cd7e24a25 \
+       bound_resource_groups=vault \
+       bound_group_ids=12345678-1234-1234-1234-123456789012
+   ```
 
    For the complete list of role options, please see the [API documentation](/vault/api-docs/auth/azure).
 


### PR DESCRIPTION
### Description
What does this PR do?

A recent update ([PR here](https://github.com/hashicorp/vault-plugin-auth-azure/pull/219)) to the Azure Auth Plugin requires that either `bound_service_principal_ids` or `bound_group_ids` be provided when creating an azure auth role in Vault. This PR updates the documentation for Vault 1.20 to accomodate this change.


### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
