### PR TITLE
Manual backport - update vault-plugin-auth-jwt plugin to 0.24.1

### DIFF
--- a/changelog/30876.txt
+++ b/changelog/30876.txt
@@ -1,0 +1,3 @@
+```release-note:change
+auth/jwt: Update plugin to v0.24.1
+```

--- a/go.mod
+++ b/go.mod
@@ -140,8 +140,8 @@ require (
 	github.com/hashicorp/vault-plugin-auth-alicloud v0.21.0
 	github.com/hashicorp/vault-plugin-auth-azure v0.20.4
 	github.com/hashicorp/vault-plugin-auth-cf v0.21.0
-	github.com/hashicorp/vault-plugin-auth-gcp v0.20.2
-	github.com/hashicorp/vault-plugin-auth-jwt v0.23.2
+	github.com/hashicorp/vault-plugin-auth-gcp v0.21.0
+	github.com/hashicorp/vault-plugin-auth-jwt v0.24.1
 	github.com/hashicorp/vault-plugin-auth-kerberos v0.15.0
 	github.com/hashicorp/vault-plugin-auth-kubernetes v0.22.1
 	github.com/hashicorp/vault-plugin-auth-oci v0.19.0

--- a/go.sum
+++ b/go.sum
@@ -1593,10 +1593,10 @@ github.com/hashicorp/vault-plugin-auth-azure v0.20.4 h1:Y10r6GMnnwuWVTbIi5BWuRN9
 github.com/hashicorp/vault-plugin-auth-azure v0.20.4/go.mod h1:xJ9/bjEfllNnlZtjUX1fltRxZz08h5HnWpftwmwcu+c=
 github.com/hashicorp/vault-plugin-auth-cf v0.21.0 h1:yELepQ3qV/QtbhtbfnhArTjYG4f6a5RyRVDsQV/+Y8g=
 github.com/hashicorp/vault-plugin-auth-cf v0.21.0/go.mod h1:cwskmYdDcdF71m+Wsz7Vq0oWDef+gMHZViXkCAHGoTM=
-github.com/hashicorp/vault-plugin-auth-gcp v0.20.2 h1:M1gWdAo/WTu9PR8j8kfnDwDEqlgJKUDgEla/aB5IaZk=
-github.com/hashicorp/vault-plugin-auth-gcp v0.20.2/go.mod h1:FEXGIQPbjjc3Dzf3FEwRzj4qK7YfzwELd6ZHHsFXXM4=
-github.com/hashicorp/vault-plugin-auth-jwt v0.23.2 h1:5QDHC0u5HsqjE2YJPVUQJIede9UTbPTfV8PPuEY4K7o=
-github.com/hashicorp/vault-plugin-auth-jwt v0.23.2/go.mod h1:jO/11eygPDdg/OmUmvL/N7Vxbv2tbQTdGuKoQ/0uLf4=
+github.com/hashicorp/vault-plugin-auth-gcp v0.21.0 h1:KRCGEEAP9mwxRTOOWJpQk/mi6Twxi1PHtfRAJfLEse4=
+github.com/hashicorp/vault-plugin-auth-gcp v0.21.0/go.mod h1:wzBCdw8cRPVQvhbbnhEi65y46vXMfuP1EP2mdByh4eQ=
+github.com/hashicorp/vault-plugin-auth-jwt v0.24.1 h1:SsSHcbmoMFz3cZDr+HyVZ1oppPFOjfjSHt+U10gT1p0=
+github.com/hashicorp/vault-plugin-auth-jwt v0.24.1/go.mod h1:d0aS4WgdsuEOAKmRxZJFD0t/WkejqbiRAFu3ChLmYpQ=
 github.com/hashicorp/vault-plugin-auth-kerberos v0.15.0 h1:e+y3RAe3WgvQ6zblWPqEfa1MtlS9f6Nduw1UxfhUxM8=
 github.com/hashicorp/vault-plugin-auth-kerberos v0.15.0/go.mod h1:VJn5xKHXzRmOosi97aBD2OK4JozHuEwg5vXfnkVczMg=
 github.com/hashicorp/vault-plugin-auth-kubernetes v0.22.1 h1:v7ZkGy70CTHgLsor5+kc9A/66PJyEoVpWpLSLXUysIE=


### PR DESCRIPTION
Manually backports commit to update vault-plugin-auth-jwt plugin to 0.24.1