### PR TITLE
UI: Adds custom login settings link to empty state

### DIFF
--- a/ui/lib/config-ui/addon/components/login-settings/page/list.hbs
+++ b/ui/lib/config-ui/addon/components/login-settings/page/list.hbs
@@ -70,7 +70,7 @@
     <Hds::Link::Standalone
       @icon="docs-link"
       @iconPosition="trailing"
-      @text="Login settings documentation"
+      @text="UI login settings documentation"
       @href={{doc-link "/vault/docs/ui/custom-login"}}
     />
   </EmptyState>

--- a/ui/lib/config-ui/addon/components/login-settings/page/list.hbs
+++ b/ui/lib/config-ui/addon/components/login-settings/page/list.hbs
@@ -67,8 +67,12 @@
     @title="No UI login settings yet"
     @message="Login settings can be used to customize which methods display in the web UI login form by setting a default and back up login methods. Available to be created via the CLI or HTTP API."
   >
-    {{! TODO: update href with tutorial link }}
-    {{! <Hds::Link::Standalone @icon="arrow-right" @iconPosition="trailing" @text="Learn more" @href="/" /> }}
+    <Hds::Link::Standalone
+      @icon="docs-link"
+      @iconPosition="trailing"
+      @text="Login settings documentation"
+      @href={{doc-link "/vault/docs/ui/custom-login"}}
+    />
   </EmptyState>
 {{/if}}
 


### PR DESCRIPTION
### Description
Adds docs link to login settings empty state
<img width="1068" alt="Screenshot 2025-06-09 at 3 03 08 PM" src="https://github.com/user-attachments/assets/38555a28-8caa-41df-ad7d-eeed5853638b" />

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
