### PR TITLE
Add buildvcs=false to revert to older behavior of not embedding VCS info into Vault binary

### DIFF
--- a/changelog/30926.txt
+++ b/changelog/30926.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core: Omit automatic version control information of the main module from compiled Vault binaries 
+```

--- a/scripts/ci-helper.sh
+++ b/scripts/ci-helper.sh
@@ -124,7 +124,7 @@ function build() {
   mkdir -p out
   set -x
   go env
-  go build -v -tags "$GO_TAGS" -ldflags "$ldflags" -o dist/
+  go build -v -buildvcs=false -tags "$GO_TAGS" -ldflags "$ldflags" -o dist/
   set +x
   popd
 }

--- a/scripts/windows/build.bat
+++ b/scripts/windows/build.bat
@@ -63,7 +63,7 @@ del /f "%_GO_ENV_TMP_FILE%" 2>nul
 REM Build!
 echo ==^> Building...
 go build^
- -ldflags "-X github.com/hashicorp/vault/version.GitCommit=%_GIT_COMMIT%%_GIT_DIRTY% -X github.com/hashicorp/vault/version.BuildDate=%_BUILD_DATE%"^
+ -buildvcs=false -ldflags "-X github.com/hashicorp/vault/version.GitCommit=%_GIT_COMMIT%%_GIT_DIRTY% -X github.com/hashicorp/vault/version.BuildDate=%_BUILD_DATE%"^
  -o "bin/vault.exe"^
  .
 


### PR DESCRIPTION
### Description

Attempt to revert to the older behavior to not include the VCS information into the Vault binary for vault itself. This doesn't attempt to bake in the proper version as that issue wants us too as I believe we tag after the build so additional CI changes would be required to do this correctly.

This is the behavior I'm trying to get us back too as it appears in the 1.19.3 binary.

```
❯ go version -m vault_1.19.3
vault_1.19.3: go1.23.8
        path    github.com/hashicorp/vault
        mod     github.com/hashicorp/vault      (devel)
```

This is the 1.19.4 binary where this was reported.

```
vault_1.19.4: go1.24.3
        path    github.com/hashicorp/vault
        mod     github.com/hashicorp/vault      v0.0.0-20250514170447-322786e236e2+dirty
```

### TODO only if you're a HashiCorp employee
- [X] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [X] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
