### PR TITLE
[VAULT-34737] UI: move the `dateTimeLocal` block in `FormField` under the HDS block

### DIFF
--- a/ui/lib/core/addon/components/form-field.hbs
+++ b/ui/lib/core/addon/components/form-field.hbs
@@ -128,7 +128,37 @@
         </Hds::Form::Select::Field>
       {{/if}}
     {{else}}
-      {{#if (or (eq @attr.type "number") (eq @attr.type "string"))}}
+      {{#if (eq @attr.options.editType "dateTimeLocal")}}
+        <Hds::Form::TextInput::Field
+          class="is-block"
+          @type="datetime-local"
+          name={{@attr.name}}
+          @id={{@attr.name}}
+          @value={{date-format (get @model this.valuePath) "yyyy-MM-dd'T'HH:mm"}}
+          @isInvalid={{this.validationError}}
+          {{on "focusout" this.onChangeWithEvent}}
+          data-test-input={{@attr.name}}
+          as |F|
+        >
+          <F.Label data-test-form-field-label>{{this.labelString}}</F.Label>
+          {{#if this.helpTextString}}
+            <F.HelperText data-test-help-text={{@attr.options.helpText}}>{{this.helpTextString}}</F.HelperText>
+          {{/if}}
+          {{#if @attr.options.subText}}
+            <F.HelperText data-test-help-text={{@attr.options.subText}}>
+              {{@attr.options.subText}}
+              {{#if @attr.options.docLink}}
+                <DocLink @path={{@attr.options.docLink}} data-test-doc-link={{@attr.options.docLink}}>See our documentation</DocLink>
+                for help.
+              {{/if}}
+            </F.HelperText>
+          {{/if}}
+          {{#if this.validationError}}
+            <F.Error data-test-validation-error={{this.valuePath}}>{{this.validationError}}</F.Error>
+          {{/if}}
+        </Hds::Form::TextInput::Field>
+
+      {{else if (or (eq @attr.type "number") (eq @attr.type "string"))}}
         {{#if (eq @attr.options.editType "password")}}
           <Hds::Form::TextInput::Field
             @type="password"
@@ -245,18 +275,7 @@
         @docLink={{@attr.options.docLink}}
       />
     {{/unless}}
-    {{#if (eq @attr.options.editType "dateTimeLocal")}}
-      <Input
-        @type="datetime-local"
-        @value={{date-format (get @model this.valuePath) "yyyy-MM-dd'T'HH:mm"}}
-        name={{@attr.name}}
-        id={{@attr.name}}
-        data-test-input={{@attr.name}}
-        class="input has-top-margin-xs has-bottom-margin-xs is-auto-width is-block
-          {{if this.validationError 'has-error-border'}}"
-        {{on "focusout" this.onChangeWithEvent}}
-      />
-    {{else if (eq @attr.options.editType "searchSelect")}}
+    {{#if (eq @attr.options.editType "searchSelect")}}
       <div class="form-section">
         <SearchSelect
           @id={{@attr.name}}

--- a/ui/lib/core/addon/components/form-field.js
+++ b/ui/lib/core/addon/components/form-field.js
@@ -99,7 +99,9 @@ export default class FormFieldComponent extends Component {
     if (options?.possibleValues?.length > 0) {
       return true;
     } else {
-      if (type === 'number' || type === 'string') {
+      if (options?.editType === 'dateTimeLocal') {
+        return true;
+      } else if (type === 'number' || type === 'string') {
         if (options?.editType === 'password' || options?.editType === 'textarea') {
           return true;
         } else {

--- a/ui/tests/integration/components/form-field-test.js
+++ b/ui/tests/integration/components/form-field-test.js
@@ -232,23 +232,6 @@ module('Integration | Component | form field', function (hooks) {
     assert.ok(spy.calledWith('foo', expectedSeconds), 'onChange called with correct args');
   });
 
-  test('it renders: datetimelocal', async function (assert) {
-    const [model] = await setup.call(
-      this,
-      createAttr('bar', null, {
-        editType: 'dateTimeLocal',
-      })
-    );
-    assert.dom("[data-test-input='bar']").exists();
-    await fillIn(
-      "[data-test-input='bar']",
-      format(startOfDay(new Date('2023-12-17T03:24:00')), "yyyy-MM-dd'T'HH:mm")
-    );
-    // add a click label to focus out the date we filled in above
-    await click('.is-label');
-    assert.deepEqual(model.get('bar'), '2023-12-17T00:00', 'sets the value on the model');
-  });
-
   test('it renders: editType stringArray', async function (assert) {
     const [model, spy] = await setup.call(this, createAttr('foo', 'string', { editType: 'stringArray' }));
     assert.ok(component.hasStringList, 'renders the string-list component');
@@ -777,6 +760,90 @@ module('Integration | Component | form field', function (hooks) {
     this.setProperties({
       attr: createAttr('myfield', 'string', { editType: 'select', possibleValues: ['foo', 'bar', 'baz'] }),
       model: { myfield: 'bar' },
+      modelValidations: {
+        myfield: {
+          isValid: false,
+          errors: ['Error message #1', 'Error message #2'],
+          warnings: ['Warning message #1', 'Warning message #2'],
+        },
+      },
+      onChange: () => {},
+    });
+
+    await render(
+      hbs`<FormField @attr={{this.attr}} @model={{this.model}} @modelValidations={{this.modelValidations}} @onChange={{this.onChange}} />`
+    );
+    assert
+      .dom(GENERAL.validationErrorByAttr('myfield'))
+      .exists('Validation error renders')
+      .hasText('Error message #1 Error message #2', 'Validation errors are combined');
+    assert
+      .dom(GENERAL.validationWarningByAttr('myfield'))
+      .exists('Validation warning renders')
+      .hasText('Warning message #1 Warning message #2', 'Validation warnings are combined');
+  });
+
+  // ––––– editType === 'datetime-local' –––––
+
+  test('it renders: editType=dateTimeLocal - as Hds::Form::TextInput [@type=datetime-local]', async function (assert) {
+    const dateTimeValue1 = format(startOfDay(new Date('2023-12-17T03:24:00')), "yyyy-MM-dd'T'HH:mm");
+    const dateTimeValue2 = format(startOfDay(new Date('2025-05-28T16:12:00')), "yyyy-MM-dd'T'HH:mm");
+    const [model, spy] = await setup.call(
+      this,
+      createAttr('myfield', '-', { editType: 'dateTimeLocal', defaultValue: dateTimeValue1 })
+    );
+    assert
+      .dom('.field [class^="hds-form-field"] input[type="datetime-local"].hds-form-text-input')
+      .exists('renders as Hds::Form::TextInput["type=datetime-local"]');
+    assert
+      .dom(`input[type="datetime-local"]`)
+      .exists('renders input with type=datetime-local')
+      .hasAttribute(
+        'data-test-input',
+        'myfield',
+        'input[type="datetime-local"] has correct `data-test-input` attribute'
+      );
+    assert.dom(GENERAL.fieldLabel()).hasText('Myfield', 'renders the input label');
+    assert.dom(GENERAL.inputByAttr('myfield')).hasValue('2023-12-17T00:00', 'renders default value');
+    await fillIn(GENERAL.inputByAttr('myfield'), dateTimeValue2);
+    // add a click label to focus out the date we filled in above
+    await click(GENERAL.fieldLabel());
+    assert.strictEqual(model.get('myfield'), dateTimeValue2, 'sets the value on the model');
+    assert.ok(spy.calledWith('myfield', dateTimeValue2), 'onChange called with correct args');
+  });
+
+  test('it renders: editType=dateTimeLocal - with passed label, subtext, helptext, doclink', async function (assert) {
+    await setup.call(
+      this,
+      createAttr('myfield', '-', {
+        editType: 'dateTimeLocal',
+        label: 'Custom label',
+        subText: 'Some subtext',
+        helpText: 'Some helptext',
+        docLink: '/docs',
+      })
+    );
+    assert.dom(GENERAL.fieldLabel()).hasText('Custom label', 'renders the custom label from options');
+    assert
+      .dom(GENERAL.helpTextByAttr('Some subtext'))
+      .exists('renders `subText` option as HelperText')
+      .hasText(
+        'Some subtext See our documentation for help.',
+        'renders the right subtext string from options'
+      );
+    assert
+      .dom(`${GENERAL.helpTextByAttr('Some subtext')} ${GENERAL.docLinkByAttr('/docs')}`)
+      .exists('renders `docLink` option as as link inside the subtext');
+    assert
+      .dom(GENERAL.helpTextByAttr('Some helptext'))
+      .exists('renders `helptext` option as HelperText')
+      .hasText('Some helptext', 'renders the right help text string from options');
+  });
+
+  test('it renders: editType=dateTimeLocal - with validation errors and warnings', async function (assert) {
+    this.setProperties({
+      attr: createAttr('myfield', '-', { editType: 'dateTimeLocal' }),
+      model: { myfield: '2023-12-17T00:00' },
       modelValidations: {
         myfield: {
           isValid: false,


### PR DESCRIPTION
> [!IMPORTANT]
> ⚠️ Based off #30771 to minimize conflicts - Don't merge until that PR is merged in `main`

### Description
What does this PR do?

- updated logic in `isHdsFormField` of `FormField` to include the `editType === 'dateTimeLocal'` use cases
- moved template logic for `editType === 'dateTimeLocal'` in `FormField` under the `isHdsField` block

Jira ticket: https://hashicorp.atlassian.net/browse/VAULT-34737

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
