### PR TITLE
VAULT-36902: Remove error messages when max_entry_size, max_mount_entry_size and autopilot config are empty 

### DIFF
--- a/vault/core_metrics.go
+++ b/vault/core_metrics.go
@@ -1075,7 +1075,6 @@ func (c *Core) GetAutopilotUpgradeEnabled() float64 {
 
 	config := raftBackend.AutopilotConfig()
 	if config == nil {
-		c.logger.Error("failed to get autopilot config")
 		return 0.0
 	}
 


### PR DESCRIPTION
### Description
What does this PR do?
This is OSS patch for an ENT PR here: https://github.com/hashicorp/vault-enterprise/pull/8275
[This PR removes error messages when config values for storage and autopilot metrics are empty. We should not log them as error messages as they are not technically failures in Vault. It also fixes wording in messages in the storage metric function.]

Jira: https://hashicorp.atlassian.net/browse/VAULT-36902

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
