### PR TITLE
Backport 1.20.x: UI: Reduces margin around Sign in button

### DIFF
--- a/ui/app/components/auth/form/base.hbs
+++ b/ui/app/components/auth/form/base.hbs
@@ -18,14 +18,7 @@
 
     {{yield to="advancedSettings"}}
 
-    <Hds::Button
-      @text="Sign in"
-      @icon={{if this.login.isRunning "loading"}}
-      @isFullWidth={{true}}
-      type="submit"
-      class="has-top-margin-xl has-bottom-margin-xl"
-      data-test-auth-submit
-    />
+    <Auth::SignInButton @text="Sign in" @icon={{if this.login.isRunning "loading"}} />
 
     {{yield to="footer"}}
   </div>

--- a/ui/app/components/auth/form/oidc-jwt.hbs
+++ b/ui/app/components/auth/form/oidc-jwt.hbs
@@ -31,13 +31,9 @@
 
     {{yield to="advancedSettings"}}
 
-    <Hds::Button
+    <Auth::SignInButton
       @icon={{if this.tasksAreRunning "loading" this.icon}}
-      @isFullWidth={{true}}
       @text="Sign in {{if this.isOIDC this.providerName}}"
-      class="has-top-margin-xl has-bottom-margin-xl"
-      type="submit"
-      data-test-auth-submit
     />
 
     {{yield to="footer"}}

--- a/ui/app/components/auth/form/okta.hbs
+++ b/ui/app/components/auth/form/okta.hbs
@@ -23,14 +23,7 @@
 
       {{yield to="advancedSettings"}}
 
-      <Hds::Button
-        @text="Sign in"
-        @icon={{if this.login.isRunning "loading"}}
-        @isFullWidth={{true}}
-        type="submit"
-        class="has-top-margin-xl has-bottom-margin-xl"
-        data-test-auth-submit
-      />
+      <Auth::SignInButton @text="Sign in" @icon={{if this.login.isRunning "loading"}} />
 
       {{yield to="footer"}}
     </div>

--- a/ui/app/components/auth/form/saml.hbs
+++ b/ui/app/components/auth/form/saml.hbs
@@ -18,14 +18,7 @@
 
       {{yield to="advancedSettings"}}
 
-      <Hds::Button
-        @icon={{if this.tasksAreRunning "loading"}}
-        @isFullWidth={{true}}
-        @text="Sign in with SAML provider"
-        class="has-top-margin-xl has-bottom-margin-xl"
-        type="submit"
-        data-test-auth-submit
-      />
+      <Auth::SignInButton @text="Sign in with SAML provider" @icon={{if this.tasksAreRunning "loading"}} />
 
     {{else}}
       <Hds::Alert @type="inline" @color="warning" data-test-saml-auth-not-allowed class="has-bottom-margin-m" as |A|>

--- a/ui/app/components/auth/sign-in-button.hbs
+++ b/ui/app/components/auth/sign-in-button.hbs
@@ -1,0 +1,13 @@
+{{!
+  Copyright (c) HashiCorp, Inc.
+  SPDX-License-Identifier: BUSL-1.1
+}}
+
+<Hds::Button
+  @text={{@text}}
+  @icon={{@icon}}
+  @isFullWidth={{true}}
+  type="submit"
+  class="has-top-margin-l has-bottom-margin-l"
+  data-test-submit
+/>


### PR DESCRIPTION
### Description
Backport: https://github.com/hashicorp/vault/pull/30963

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
