### PR TITLE
UI: Fix Flaky Namespace Test

### DIFF
--- a/ui/tests/acceptance/enterprise-namespaces-test.js
+++ b/ui/tests/acceptance/enterprise-namespaces-test.js
@@ -293,6 +293,7 @@ module('Acceptance | Enterprise | namespaces', function (hooks) {
     assert.dom('input[name="namespace"]').hasAttribute('placeholder', '/ (root)');
     await fillIn('input[name="namespace"]', '/foo/bar ');
     const encodedNamespace = encodeURIComponent('foo/bar');
+    await waitUntil(() => currentURL() === `/vault/auth?namespace=${encodedNamespace}`);
     assert.strictEqual(
       currentURL(),
       `/vault/auth?namespace=${encodedNamespace}`,
@@ -334,7 +335,7 @@ module('Acceptance | Enterprise | namespaces', function (hooks) {
     assert.dom(GENERAL.confirmButton).hasText('Confirm', 'Confirm namespace deletion button is shown');
     await click(GENERAL.confirmButton);
 
-    // Verify that the namespace does not exist in the nmanage namespace page
+    // Verify that the namespace does not exist in the manage namespace page
     assert.strictEqual(
       currentURL(),
       `/vault/access/namespaces?page=1&pageFilter=${namespace}`,


### PR DESCRIPTION
Wait until URL has updated before asserting. 
ent test ✅ 

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
