### PR TITLE
[VAULT-37109] UI: Tackle data test toggle group selectors

### DIFF
--- a/ui/app/components/totp/key-create-toggle-groups.hbs
+++ b/ui/app/components/totp/key-create-toggle-groups.hbs
@@ -10,7 +10,7 @@
     @closedLabel={{group}}
     @onClick={{fn this.toggleGroup group}}
     class="is-block"
-    data-test-toggle-group={{group}}
+    data-test-button={{group}}
   />
   {{#if (eq this.showGroup group)}}
     <div class="box is-marginless" data-test-group={{group}}>

--- a/ui/app/templates/components/database-connection.hbs
+++ b/ui/app/templates/components/database-connection.hbs
@@ -140,7 +140,7 @@
                     @closedLabel={{group}}
                     @onClick={{fn (mut (get this prop))}}
                     class="is-block"
-                    data-test-toggle-group={{group}}
+                    data-test-button={{group}}
                   />
                   {{#if (get this prop)}}
                     <div class="box is-marginless">
@@ -270,7 +270,7 @@
                   @closedLabel={{group}}
                   @onClick={{fn (mut (get this prop))}}
                   class="is-block"
-                  data-test-toggle-group={{group}}
+                  data-test-button={{group}}
                 />
                 {{#if (get this prop)}}
                   <div class="box is-marginless">

--- a/ui/lib/core/addon/components/form-field-groups-loop.hbs
+++ b/ui/lib/core/addon/components/form-field-groups-loop.hbs
@@ -28,7 +28,7 @@
           @closedLabel={{group}}
           @onClick={{fn (mut (get @model prop))}}
           class="is-block"
-          data-test-toggle-group={{group}}
+          data-test-button={{group}}
         />
         {{#if (get @model prop)}}
           <div class="box is-marginless">

--- a/ui/lib/core/addon/components/form-field-groups.hbs
+++ b/ui/lib/core/addon/components/form-field-groups.hbs
@@ -49,7 +49,7 @@
           @closedLabel={{group}}
           @onClick={{fn this.toggleGroup group}}
           class="is-block"
-          data-test-toggle-group={{group}}
+          data-test-button={{group}}
         />
         {{#if (eq this.showGroup group)}}
           <div class="box is-marginless">

--- a/ui/lib/pki/addon/components/pki-generate-toggle-groups.hbs
+++ b/ui/lib/pki/addon/components/pki-generate-toggle-groups.hbs
@@ -10,7 +10,7 @@
     @closedLabel={{group}}
     @onClick={{fn this.toggleGroup group}}
     class="is-block"
-    data-test-toggle-group={{group}}
+    data-test-button={{group}}
   />
   {{#if (eq this.showGroup group)}}
     <div class="box is-marginless" data-test-group={{group}}>

--- a/ui/lib/pki/addon/components/pki-role-form.hbs
+++ b/ui/lib/pki/addon/components/pki-role-form.hbs
@@ -64,7 +64,7 @@
               @closedLabel={{group}}
               @onClick={{fn (mut (get @role prop))}}
               class="is-block"
-              data-test-toggle-group={{group}}
+              data-test-button={{group}}
             />
             {{#if (get @role prop)}}
               <div class="box is-tall is-marginless" data-test-toggle-div={{group}}>

--- a/ui/tests/acceptance/auth/test-helper.js
+++ b/ui/tests/acceptance/auth/test-helper.js
@@ -20,13 +20,13 @@ const assertFields = (assert, fields, customSelectors = {}) => {
   });
 };
 export default (test) => {
-  test('it renders mount fields shannontest', async function (assert) {
+  test('it renders mount fields', async function (assert) {
     await click(MOUNT_BACKEND_FORM.mountType(this.type));
     await click(GENERAL.button('Method Options'));
     assertFields(assert, this.mountFields, this.customSelectors);
   });
 
-  test('it renders tune fields shannontest', async function (assert) {
+  test('it renders tune fields', async function (assert) {
     // enable auth method to check tune fields
     await mountBackend(this.type, this.path);
     assert.strictEqual(

--- a/ui/tests/acceptance/auth/test-helper.js
+++ b/ui/tests/acceptance/auth/test-helper.js
@@ -20,13 +20,13 @@ const assertFields = (assert, fields, customSelectors = {}) => {
   });
 };
 export default (test) => {
-  test('it renders mount fields', async function (assert) {
+  test('it renders mount fields shannontest', async function (assert) {
     await click(MOUNT_BACKEND_FORM.mountType(this.type));
-    await click(GENERAL.toggleGroup('Method Options'));
+    await click(GENERAL.button('Method Options'));
     assertFields(assert, this.mountFields, this.customSelectors);
   });
 
-  test('it renders tune fields', async function (assert) {
+  test('it renders tune fields shannontest', async function (assert) {
     // enable auth method to check tune fields
     await mountBackend(this.type, this.path);
     assert.strictEqual(
@@ -39,7 +39,7 @@ export default (test) => {
 
     for (const toggle in this.tuneToggles) {
       const fields = this.tuneToggles[toggle];
-      await click(GENERAL.toggleGroup(toggle));
+      await click(GENERAL.button(toggle));
       assertFields(assert, fields, this.customSelectors);
     }
   });

--- a/ui/tests/acceptance/oidc-config/clients-test.js
+++ b/ui/tests/acceptance/oidc-config/clients-test.js
@@ -32,7 +32,7 @@ const flashMessage = create(fm);
 // in congruency with backend verbiage 'applications' are referred to as 'clients'
 // throughout the codebase and the term 'applications' only appears in the UI
 
-module('Acceptance | oidc-config clients', function (hooks) {
+module('Acceptance | oidc-config clients shannontest', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
@@ -124,7 +124,7 @@ module('Acceptance | oidc-config clients', function (hooks) {
       await visit(OIDC_BASE_URL + '/clients');
       await click('[data-test-oidc-client-create]');
       await fillIn('[data-test-input="name"]', 'client-with-test-key');
-      await click('[data-test-toggle-group="More options"]');
+      await click(GENERAL.button('More options'));
       await click('[data-test-component="search-select"] [data-test-icon="trash"]');
       await clickTrigger('#key');
       await selectChoose('[data-test-component="search-select"]#key', 'test-key');
@@ -383,7 +383,7 @@ module('Acceptance | oidc-config clients', function (hooks) {
         'navigates to create form'
       );
       await fillIn('[data-test-input="name"]', 'test-app');
-      await click('[data-test-toggle-group="More options"]');
+      await click(GENERAL.button('More options'));
       // toggle ttls to false, testing it sets correct default duration
       await click('[data-test-input="idTokenTtl"]');
       await click('[data-test-input="accessTokenTtl"]');

--- a/ui/tests/acceptance/oidc-config/clients-test.js
+++ b/ui/tests/acceptance/oidc-config/clients-test.js
@@ -32,7 +32,7 @@ const flashMessage = create(fm);
 // in congruency with backend verbiage 'applications' are referred to as 'clients'
 // throughout the codebase and the term 'applications' only appears in the UI
 
-module('Acceptance | oidc-config clients shannontest', function (hooks) {
+module('Acceptance | oidc-config clients', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 

--- a/ui/tests/acceptance/pki/pki-action-forms-test.js
+++ b/ui/tests/acceptance/pki/pki-action-forms-test.js
@@ -18,7 +18,7 @@ import { PKI_CONFIGURE_CREATE, PKI_GENERATE_ROOT } from 'vault/tests/helpers/pki
 
 const { issuerPemBundle } = CERTIFICATES;
 
-module('Acceptance | pki action forms test shannontest', function (hooks) {
+module('Acceptance | pki action forms test', function (hooks) {
   setupApplicationTest(hooks);
 
   hooks.beforeEach(async function () {

--- a/ui/tests/acceptance/pki/pki-action-forms-test.js
+++ b/ui/tests/acceptance/pki/pki-action-forms-test.js
@@ -18,7 +18,7 @@ import { PKI_CONFIGURE_CREATE, PKI_GENERATE_ROOT } from 'vault/tests/helpers/pki
 
 const { issuerPemBundle } = CERTIFICATES;
 
-module('Acceptance | pki action forms test', function (hooks) {
+module('Acceptance | pki action forms test shannontest', function (hooks) {
   setupApplicationTest(hooks);
 
   hooks.beforeEach(async function () {
@@ -193,7 +193,7 @@ module('Acceptance | pki action forms test', function (hooks) {
       await fillIn(GENERAL.inputByAttr('type'), 'internal');
       await typeIn(GENERAL.inputByAttr('commonName'), commonName);
       await typeIn(GENERAL.inputByAttr('issuerName'), issuerName);
-      await click(PKI_GENERATE_ROOT.keyParamsGroupToggle);
+      await click(GENERAL.button('Key parameters'));
       await typeIn(GENERAL.inputByAttr('keyName'), keyName);
       await click(GENERAL.submitButton);
 

--- a/ui/tests/acceptance/pki/pki-configuration-test.js
+++ b/ui/tests/acceptance/pki/pki-configuration-test.js
@@ -23,7 +23,7 @@ import {
 } from 'vault/tests/helpers/pki/pki-selectors';
 
 const { issuerPemBundle } = CERTIFICATES;
-module('Acceptance | pki configuration test', function (hooks) {
+module('Acceptance | pki configuration test shannontest', function (hooks) {
   setupApplicationTest(hooks);
 
   hooks.beforeEach(async function () {
@@ -237,7 +237,7 @@ module('Acceptance | pki configuration test', function (hooks) {
       await click(PKI_ISSUER_LIST.generateIssuerRoot);
       await fillIn(GENERAL.inputByAttr('type'), 'internal');
       await fillIn(GENERAL.inputByAttr('commonName'), 'my-certificate');
-      await click(PKI_GENERATE_ROOT.keyParamsGroupToggle);
+      await click(GENERAL.button('Key parameters'));
       await fillIn(GENERAL.inputByAttr('keyType'), 'ed25519');
       await click(GENERAL.submitButton);
 

--- a/ui/tests/acceptance/pki/pki-configuration-test.js
+++ b/ui/tests/acceptance/pki/pki-configuration-test.js
@@ -23,7 +23,7 @@ import {
 } from 'vault/tests/helpers/pki/pki-selectors';
 
 const { issuerPemBundle } = CERTIFICATES;
-module('Acceptance | pki configuration test shannontest', function (hooks) {
+module('Acceptance | pki configuration test', function (hooks) {
   setupApplicationTest(hooks);
 
   hooks.beforeEach(async function () {

--- a/ui/tests/acceptance/secrets/backend/aws/aws-configuration-test.js
+++ b/ui/tests/acceptance/secrets/backend/aws/aws-configuration-test.js
@@ -24,7 +24,7 @@ import {
   fillInAwsConfig,
 } from 'vault/tests/helpers/secret-engine/secret-engine-helpers';
 
-module('Acceptance | aws | configuration shannontest', function (hooks) {
+module('Acceptance | aws | configuration', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 

--- a/ui/tests/acceptance/secrets/backend/aws/aws-configuration-test.js
+++ b/ui/tests/acceptance/secrets/backend/aws/aws-configuration-test.js
@@ -24,7 +24,7 @@ import {
   fillInAwsConfig,
 } from 'vault/tests/helpers/secret-engine/secret-engine-helpers';
 
-module('Acceptance | aws | configuration', function (hooks) {
+module('Acceptance | aws | configuration shannontest', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
@@ -185,7 +185,7 @@ module('Acceptance | aws | configuration', function (hooks) {
       await fillIn(GENERAL.inputByAttr('roleArn'), 'foo-role');
       await fillIn(GENERAL.inputByAttr('identityTokenAudience'), 'foo-audience');
       // manually fill in non-access type specific fields on root config so we can exclude Max Retries.
-      await click(GENERAL.toggleGroup('Root config options'));
+      await click(GENERAL.button('Root config options'));
       await fillIn(GENERAL.inputByAttr('region'), 'eu-central-1');
       await click(GENERAL.submitButton);
       assert
@@ -244,7 +244,7 @@ module('Acceptance | aws | configuration', function (hooks) {
       await click(SES.configure);
       // edit root config details
       await fillIn(GENERAL.inputByAttr('accessKey'), 'not-foo');
-      await click(GENERAL.toggleGroup('Root config options'));
+      await click(GENERAL.button('Root config options'));
       await fillIn(GENERAL.inputByAttr('region'), 'ap-southeast-2');
       // add lease config details
       await fillInAwsConfig('withLease');
@@ -300,7 +300,7 @@ module('Acceptance | aws | configuration', function (hooks) {
         .dom(SES.wif.accessTypeSection)
         .doesNotExist('Access type section does not render for a community user');
       // check all the form fields are present
-      await click(GENERAL.toggleGroup('Root config options'));
+      await click(GENERAL.button('Root config options'));
       for (const key of expectedConfigKeys('aws', true)) {
         assert.dom(GENERAL.inputByAttr(key)).exists(`${key} shows for root section.`);
       }

--- a/ui/tests/acceptance/secrets/backend/azure/azure-configuration-test.js
+++ b/ui/tests/acceptance/secrets/backend/azure/azure-configuration-test.js
@@ -24,7 +24,7 @@ import {
   fillInAzureConfig,
 } from 'vault/tests/helpers/secret-engine/secret-engine-helpers';
 
-module('Acceptance | Azure | configuration shannontest', function (hooks) {
+module('Acceptance | Azure | configuration', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 

--- a/ui/tests/acceptance/secrets/backend/azure/azure-configuration-test.js
+++ b/ui/tests/acceptance/secrets/backend/azure/azure-configuration-test.js
@@ -24,7 +24,7 @@ import {
   fillInAzureConfig,
 } from 'vault/tests/helpers/secret-engine/secret-engine-helpers';
 
-module('Acceptance | Azure | configuration', function (hooks) {
+module('Acceptance | Azure | configuration shannontest', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
@@ -270,7 +270,7 @@ module('Acceptance | Azure | configuration', function (hooks) {
           return { data: { id: path, type: this.type, ...wifAttrs } };
         });
         await enablePage.enable(this.type, path);
-        GENERAL.toggleGroup('More options');
+        GENERAL.button('More options');
 
         for (const key of expectedConfigKeys('azure-wif')) {
           const responseKeyAndValue = expectedValueOfConfigKeys(this.type, key);

--- a/ui/tests/acceptance/secrets/backend/database/secret-test.js
+++ b/ui/tests/acceptance/secrets/backend/database/secret-test.js
@@ -78,7 +78,7 @@ const connectionTests = [
       assert.dom(GENERAL.inputByAttr('username')).exists(`Username field exists for ${name}`);
       assert.dom(GENERAL.inputByAttr('password')).exists(`Password field exists for ${name}`);
       assert.dom(GENERAL.inputByAttr('write_concern')).exists(`Write concern field exists for ${name}`);
-      assert.dom('[data-test-toggle-group="TLS options"]').exists('TLS options toggle exists');
+      assert.dom(GENERAL.button('TLS options')).exists('TLS options toggle exists');
       assert
         .dom(GENERAL.inputByAttr('root_rotation_statements'))
         .exists(`Root rotation statements exists for ${name}`);
@@ -123,7 +123,7 @@ const connectionTests = [
       assert
         .dom(GENERAL.inputByAttr('max_connection_lifetime'))
         .exists(`Max connection lifetime exists for ${name}`);
-      assert.dom('[data-test-toggle-group="TLS options"]').exists('TLS options toggle exists');
+      assert.dom(GENERAL.button('TLS options')).exists('TLS options toggle exists');
       assert
         .dom(GENERAL.inputByAttr('root_rotation_statements'))
         .exists(`Root rotation statements exists for ${name}`);
@@ -146,7 +146,7 @@ const connectionTests = [
       assert
         .dom(GENERAL.inputByAttr('max_connection_lifetime'))
         .exists(`Max connection lifetime exists for ${name}`);
-      assert.dom('[data-test-toggle-group="TLS options"]').exists('TLS options toggle exists');
+      assert.dom(GENERAL.button('TLS options')).exists('TLS options toggle exists');
       assert
         .dom(GENERAL.inputByAttr('root_rotation_statements'))
         .exists(`Root rotation statements exists for ${name}`);
@@ -169,7 +169,7 @@ const connectionTests = [
       assert
         .dom(GENERAL.inputByAttr('max_connection_lifetime'))
         .exists(`Max connection lifetime exists for ${name}`);
-      assert.dom('[data-test-toggle-group="TLS options"]').exists('TLS options toggle exists');
+      assert.dom(GENERAL.button('TLS options')).exists('TLS options toggle exists');
       assert
         .dom(GENERAL.inputByAttr('root_rotation_statements'))
         .exists(`Root rotation statements exists for ${name}`);
@@ -192,7 +192,7 @@ const connectionTests = [
       assert
         .dom(GENERAL.inputByAttr('max_connection_lifetime'))
         .exists(`Max connection lifetime exists for ${name}`);
-      assert.dom('[data-test-toggle-group="TLS options"]').exists('TLS options toggle exists');
+      assert.dom(GENERAL.button('TLS options')).exists('TLS options toggle exists');
       assert
         .dom(GENERAL.inputByAttr('root_rotation_statements'))
         .exists(`Root rotation statements exists for ${name}`);
@@ -227,7 +227,7 @@ const connectionTests = [
   },
 ];
 
-module('Acceptance | secrets/database/*', function (hooks) {
+module('Acceptance | secrets/database/* shannontest', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 

--- a/ui/tests/acceptance/secrets/backend/database/secret-test.js
+++ b/ui/tests/acceptance/secrets/backend/database/secret-test.js
@@ -227,7 +227,7 @@ const connectionTests = [
   },
 ];
 
-module('Acceptance | secrets/database/* shannontest', function (hooks) {
+module('Acceptance | secrets/database/*', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 

--- a/ui/tests/acceptance/secrets/backend/gcp/gcp-configuration-test.js
+++ b/ui/tests/acceptance/secrets/backend/gcp/gcp-configuration-test.js
@@ -24,7 +24,7 @@ import {
   fillInGcpConfig,
 } from 'vault/tests/helpers/secret-engine/secret-engine-helpers';
 
-module('Acceptance | GCP | configuration shannontest', function (hooks) {
+module('Acceptance | GCP | configuration', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 

--- a/ui/tests/acceptance/secrets/backend/gcp/gcp-configuration-test.js
+++ b/ui/tests/acceptance/secrets/backend/gcp/gcp-configuration-test.js
@@ -24,7 +24,7 @@ import {
   fillInGcpConfig,
 } from 'vault/tests/helpers/secret-engine/secret-engine-helpers';
 
-module('Acceptance | GCP | configuration', function (hooks) {
+module('Acceptance | GCP | configuration shannontest', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
@@ -187,7 +187,7 @@ module('Acceptance | GCP | configuration', function (hooks) {
           );
         });
 
-        await click(GENERAL.toggleGroup('More options'));
+        await click(GENERAL.button('More options'));
         await click(GENERAL.ttl.toggle('Config TTL'));
         await fillIn(GENERAL.ttl.input('Config TTL'), '10800');
         await click(GENERAL.submitButton);

--- a/ui/tests/acceptance/secrets/backend/kv/secret-test.js
+++ b/ui/tests/acceptance/secrets/backend/kv/secret-test.js
@@ -33,7 +33,7 @@ const deleteEngine = async function (enginePath, assert) {
   );
 };
 
-module('Acceptance | secrets/secret/create, read, delete', function (hooks) {
+module('Acceptance | secrets/secret/create, read, delete shannontest', function (hooks) {
   setupApplicationTest(hooks);
 
   hooks.beforeEach(async function () {
@@ -138,7 +138,7 @@ module('Acceptance | secrets/secret/create, read, delete', function (hooks) {
       await mountSecrets.visit();
       await click(MOUNT_BACKEND_FORM.mountType('kv'));
       await fillIn(GENERAL.inputByAttr('path'), this.backend);
-      await click(GENERAL.toggleGroup('Method Options'));
+      await click(GENERAL.button('Method Options'));
       await mountSecrets.version(1);
       await click(GENERAL.submitButton);
     });

--- a/ui/tests/acceptance/secrets/backend/kv/secret-test.js
+++ b/ui/tests/acceptance/secrets/backend/kv/secret-test.js
@@ -33,7 +33,7 @@ const deleteEngine = async function (enginePath, assert) {
   );
 };
 
-module('Acceptance | secrets/secret/create, read, delete shannontest', function (hooks) {
+module('Acceptance | secrets/secret/create, read, delete', function (hooks) {
   setupApplicationTest(hooks);
 
   hooks.beforeEach(async function () {

--- a/ui/tests/acceptance/secrets/backend/ssh/roles-test.js
+++ b/ui/tests/acceptance/secrets/backend/ssh/roles-test.js
@@ -30,7 +30,7 @@ import { SECRET_ENGINE_SELECTORS as SES } from 'vault/tests/helpers/secret-engin
 // There is duplication within this test suite. The duplication occurred because two test suites both testing ssh roles were merged.
 // refactoring the tests to remove the duplication would be a good next step as well as removing the tests/pages.
 
-module('Acceptance | ssh | roles', function (hooks) {
+module('Acceptance | ssh | roles shannontest', function (hooks) {
   setupApplicationTest(hooks);
 
   hooks.beforeEach(function () {
@@ -47,7 +47,7 @@ module('Acceptance | ssh | roles', function (hooks) {
       credsRoute: 'vault.cluster.secrets.backend.sign',
       async fillInCreate() {
         await click(GENERAL.inputByAttr('allowUserCertificates'));
-        await click(GENERAL.toggleGroup('Options'));
+        await click(GENERAL.button('Options'));
         // it's recommended to keep allow_empty_principals false, check for testing so we don't have to input an extra field when signing a key
         await click(GENERAL.inputByAttr('allowEmptyPrincipals'));
       },
@@ -84,7 +84,7 @@ module('Acceptance | ssh | roles', function (hooks) {
       credsRoute: 'vault.cluster.secrets.backend.credentials',
       async fillInCreate() {
         await fillIn(GENERAL.inputByAttr('defaultUser'), 'admin');
-        await click(GENERAL.toggleGroup('Options'));
+        await click(GENERAL.button('Options'));
         await fillIn(GENERAL.inputByAttr('cidrList'), '1.2.3.4/32');
       },
       async fillInGenerate() {
@@ -176,7 +176,7 @@ module('Acceptance | ssh | roles', function (hooks) {
     const createOTPRole = async (name) => {
       await fillIn(GENERAL.inputByAttr('name'), name);
       await fillIn(GENERAL.inputByAttr('keyType'), name);
-      await click(GENERAL.toggleGroup('Options'));
+      await click(GENERAL.button('Options'));
       await fillIn(GENERAL.inputByAttr('keyType'), 'otp');
       await fillIn(GENERAL.inputByAttr('defaultUser'), 'admin');
       await fillIn(GENERAL.inputByAttr('cidrList'), '0.0.0.0/0');

--- a/ui/tests/acceptance/secrets/backend/ssh/roles-test.js
+++ b/ui/tests/acceptance/secrets/backend/ssh/roles-test.js
@@ -30,7 +30,7 @@ import { SECRET_ENGINE_SELECTORS as SES } from 'vault/tests/helpers/secret-engin
 // There is duplication within this test suite. The duplication occurred because two test suites both testing ssh roles were merged.
 // refactoring the tests to remove the duplication would be a good next step as well as removing the tests/pages.
 
-module('Acceptance | ssh | roles shannontest', function (hooks) {
+module('Acceptance | ssh | roles', function (hooks) {
   setupApplicationTest(hooks);
 
   hooks.beforeEach(function () {

--- a/ui/tests/acceptance/secrets/backend/totp/key-test.js
+++ b/ui/tests/acceptance/secrets/backend/totp/key-test.js
@@ -13,7 +13,7 @@ import { login } from 'vault/tests/helpers/auth/auth-helpers';
 import { v4 as uuidv4 } from 'uuid';
 import sinon from 'sinon';
 
-module('Acceptance | totp key backend shannontest', function (hooks) {
+module('Acceptance | totp key backend', function (hooks) {
   setupApplicationTest(hooks);
 
   const createVaultKey = async (keyName, issuer, accountName, exported = true, qrSize = 200) => {

--- a/ui/tests/acceptance/secrets/backend/totp/key-test.js
+++ b/ui/tests/acceptance/secrets/backend/totp/key-test.js
@@ -13,7 +13,7 @@ import { login } from 'vault/tests/helpers/auth/auth-helpers';
 import { v4 as uuidv4 } from 'uuid';
 import sinon from 'sinon';
 
-module('Acceptance | totp key backend', function (hooks) {
+module('Acceptance | totp key backend shannontest', function (hooks) {
   setupApplicationTest(hooks);
 
   const createVaultKey = async (keyName, issuer, accountName, exported = true, qrSize = 200) => {
@@ -24,7 +24,7 @@ module('Acceptance | totp key backend', function (hooks) {
       await click(GENERAL.ttl.toggle('toggle-exported'));
     }
     if (qrSize !== 200) {
-      await click(GENERAL.toggleGroup('Provider Options'));
+      await click(GENERAL.button('Provider Options'));
       await fillIn(GENERAL.inputByAttr('qrSize'), qrSize);
     }
     await click(GENERAL.submitButton);

--- a/ui/tests/acceptance/settings-test.js
+++ b/ui/tests/acceptance/settings-test.js
@@ -15,7 +15,7 @@ import { deleteEngineCmd, mountEngineCmd, runCmd } from 'vault/tests/helpers/com
 import { GENERAL } from 'vault/tests/helpers/general-selectors';
 import { MOUNT_BACKEND_FORM } from 'vault/tests/helpers/components/mount-backend-form-selectors';
 
-module('Acceptance | secret engine mount settings shannontest', function (hooks) {
+module('Acceptance | secret engine mount settings', function (hooks) {
   setupApplicationTest(hooks);
 
   hooks.beforeEach(function () {

--- a/ui/tests/acceptance/settings-test.js
+++ b/ui/tests/acceptance/settings-test.js
@@ -15,7 +15,7 @@ import { deleteEngineCmd, mountEngineCmd, runCmd } from 'vault/tests/helpers/com
 import { GENERAL } from 'vault/tests/helpers/general-selectors';
 import { MOUNT_BACKEND_FORM } from 'vault/tests/helpers/components/mount-backend-form-selectors';
 
-module('Acceptance | secret engine mount settings', function (hooks) {
+module('Acceptance | secret engine mount settings shannontest', function (hooks) {
   setupApplicationTest(hooks);
 
   hooks.beforeEach(function () {
@@ -37,7 +37,7 @@ module('Acceptance | secret engine mount settings', function (hooks) {
     );
     await click(MOUNT_BACKEND_FORM.mountType(type));
     await fillIn(GENERAL.inputByAttr('path'), path);
-    await click(GENERAL.toggleGroup('Method Options'));
+    await click(GENERAL.button('Method Options'));
     await mountSecrets.enableDefaultTtl().defaultTTLUnit('s').defaultTTLVal(100);
     await click(GENERAL.submitButton);
 

--- a/ui/tests/acceptance/settings/mount-secret-backend-test.js
+++ b/ui/tests/acceptance/settings/mount-secret-backend-test.js
@@ -38,7 +38,7 @@ const consoleComponent = create(consoleClass);
 
 // enterprise backends are tested separately
 const BACKENDS_WITH_ENGINES = ['kv', 'pki', 'ldap', 'kubernetes'];
-module('Acceptance | settings/mount-secret-backend shannontest', function (hooks) {
+module('Acceptance | settings/mount-secret-backend', function (hooks) {
   setupApplicationTest(hooks);
 
   hooks.beforeEach(function () {

--- a/ui/tests/acceptance/settings/mount-secret-backend-test.js
+++ b/ui/tests/acceptance/settings/mount-secret-backend-test.js
@@ -38,7 +38,7 @@ const consoleComponent = create(consoleClass);
 
 // enterprise backends are tested separately
 const BACKENDS_WITH_ENGINES = ['kv', 'pki', 'ldap', 'kubernetes'];
-module('Acceptance | settings/mount-secret-backend', function (hooks) {
+module('Acceptance | settings/mount-secret-backend shannontest', function (hooks) {
   setupApplicationTest(hooks);
 
   hooks.beforeEach(function () {
@@ -61,7 +61,7 @@ module('Acceptance | settings/mount-secret-backend', function (hooks) {
     assert.strictEqual(currentRouteName(), 'vault.cluster.settings.mount-secret-backend');
     await click(MOUNT_BACKEND_FORM.mountType('kv'));
     await fillIn(GENERAL.inputByAttr('path'), path);
-    await click(GENERAL.toggleGroup('Method Options'));
+    await click(GENERAL.button('Method Options'));
     await page
       .enableDefaultTtl()
       .defaultTTLUnit('h')
@@ -89,7 +89,7 @@ module('Acceptance | settings/mount-secret-backend', function (hooks) {
     );
     await click(MOUNT_BACKEND_FORM.mountType('kv'));
     await fillIn(GENERAL.inputByAttr('path'), path);
-    await click(GENERAL.toggleGroup('Method Options'));
+    await click(GENERAL.button('Method Options'));
     await page.enableDefaultTtl().enableMaxTtl().maxTTLUnit('h').maxTTLVal(maxTTLHours);
     await click(GENERAL.submitButton);
     await configPage.visit({ backend: path });
@@ -242,7 +242,7 @@ module('Acceptance | settings/mount-secret-backend', function (hooks) {
       await click(MOUNT_BACKEND_FORM.mountType(engine.type));
       await fillIn(GENERAL.inputByAttr('path'), engine.type);
       if (engine.type === 'kv') {
-        await click(GENERAL.toggleGroup('Method Options'));
+        await click(GENERAL.button('Method Options'));
         await mountSecrets.version(1);
       }
       await click(GENERAL.submitButton);
@@ -305,7 +305,7 @@ module('Acceptance | settings/mount-secret-backend', function (hooks) {
     await mountSecrets.visit();
     await click(MOUNT_BACKEND_FORM.mountType('kv'));
     await fillIn(GENERAL.inputByAttr('path'), v1);
-    await click(GENERAL.toggleGroup('Method Options'));
+    await click(GENERAL.button('Method Options'));
     await mountSecrets.version(1);
     await click(GENERAL.submitButton);
 
@@ -324,7 +324,7 @@ module('Acceptance | settings/mount-secret-backend', function (hooks) {
 
       await page.visit();
       await click(MOUNT_BACKEND_FORM.mountType('aws')); // only testing aws of the WIF engines as the functionality for all others WIF engines in this form are the same
-      await click(GENERAL.toggleGroup('Method Options'));
+      await click(GENERAL.button('Method Options'));
       assert.dom('[data-test-search-select-with-modal]').exists('Search select with modal component renders');
       await clickTrigger('#key');
       const dropdownOptions = findAll('[data-option-index]').map((o) => o.innerText);
@@ -357,7 +357,7 @@ module('Acceptance | settings/mount-secret-backend', function (hooks) {
       await visit('/vault/settings/mount-secret-backend');
       await click(MOUNT_BACKEND_FORM.mountType(engine));
       await fillIn(GENERAL.inputByAttr('path'), path);
-      await click(GENERAL.toggleGroup('Method Options'));
+      await click(GENERAL.button('Method Options'));
       await clickTrigger('#key');
       // create new key
       await fillIn(GENERAL.searchSelect.searchInput, newKey);
@@ -399,7 +399,7 @@ module('Acceptance | settings/mount-secret-backend', function (hooks) {
       await page.visit();
       await click(MOUNT_BACKEND_FORM.mountType(engine));
       await fillIn(GENERAL.inputByAttr('path'), path);
-      await click(GENERAL.toggleGroup('Method Options'));
+      await click(GENERAL.button('Method Options'));
       // type-in fallback component to create new key
       await typeIn(GENERAL.inputSearch('key'), 'general-key');
       await click(GENERAL.submitButton);

--- a/ui/tests/helpers/general-selectors.ts
+++ b/ui/tests/helpers/general-selectors.ts
@@ -63,7 +63,6 @@ export const GENERAL = {
   radioByAttr: (attr: string) => `[data-test-radio="${attr}"]`,
   selectByAttr: (attr: string) => `[data-test-select="${attr}"]`,
   toggleInput: (attr: string) => `[data-test-toggle-input="${attr}"]`,
-  toggleGroup: (attr: string) => `[data-test-toggle-group="${attr}"]`,
   textToggle: '[data-test-text-toggle]',
   textToggleTextarea: '[data-test-text-file-textarea]',
   filter: (name: string) => `[data-test-filter="${name}"]`,

--- a/ui/tests/helpers/pki/pki-selectors.ts
+++ b/ui/tests/helpers/pki/pki-selectors.ts
@@ -47,9 +47,6 @@ export const PKI_DELETE_ALL_ISSUERS = {
 export const PKI_GENERATE_ROOT = {
   mainSectionTitle: '[data-test-generate-root-title="Root parameters"]',
   urlSectionTitle: '[data-test-generate-root-title="Issuer URLs"]',
-  keyParamsGroupToggle: '[data-test-toggle-group="Key parameters"]',
-  sanGroupToggle: '[data-test-toggle-group="Subject Alternative Name (SAN) Options"]',
-  additionalGroupToggle: '[data-test-toggle-group="Additional subject fields"]',
   toggleGroupDescription: '[data-test-toggle-group-description]',
   groupFields: (group: string) => `[data-test-group="${group}"] [data-test-field]`,
   formInvalidError: '[data-test-pki-generate-root-validation-error]',
@@ -110,22 +107,15 @@ export const PKI_NOT_VALID_AFTER = {
 };
 
 export const PKI_ROLE_FORM = {
-  domainHandling: '[data-test-toggle-group="Domain handling"]',
-  keyParams: '[data-test-toggle-group="Key parameters"]',
-  keyUsage: '[data-test-toggle-group="Key usage"]',
   digitalSignature: '[data-test-checkbox="DigitalSignature"]',
   keyAgreement: '[data-test-checkbox="KeyAgreement"]',
   keyEncipherment: '[data-test-checkbox="KeyEncipherment"]',
   any: '[data-test-checkbox="Any"]',
   serverAuth: '[data-test-checkbox="ServerAuth"]',
-  policyIdentifiers: '[data-test-toggle-group="Policy identifiers"]',
-  san: '[data-test-toggle-group="Subject Alternative Name (SAN) Options"]',
-  additionalSubjectFields: '[data-test-toggle-group="Additional subject fields"]',
 };
 
 export const PKI_ROLE_GENERATE = {
   form: '[data-test-pki-generate-cert-form]',
-  optionsToggle: '[data-test-toggle-group="Subject Alternative Name (SAN) Options"]',
   downloadButton: '[data-test-pki-cert-download-button]',
   revokeButton: '[data-test-pki-cert-revoke-button]',
 };

--- a/ui/tests/helpers/secret-engine/secret-engine-helpers.js
+++ b/ui/tests/helpers/secret-engine/secret-engine-helpers.js
@@ -173,7 +173,7 @@ export const fillInAwsConfig = async (situation = 'withAccess') => {
     await fillIn(GENERAL.inputByAttr('secretKey'), 'bar');
   }
   if (situation === 'withAccessOptions') {
-    await click(GENERAL.toggleGroup('Root config options'));
+    await click(GENERAL.button('Root config options'));
     await fillIn(GENERAL.inputByAttr('region'), 'ca-central-1');
     await fillIn(GENERAL.inputByAttr('iamEndpoint'), 'iam-endpoint');
     await fillIn(GENERAL.inputByAttr('stsEndpoint'), 'sts-endpoint');
@@ -201,7 +201,7 @@ export const fillInAzureConfig = async (withWif = false) => {
   await fillIn(GENERAL.inputByAttr('clientId'), 'client-id');
   // options may already be toggled so check before clicking
   if (!find(GENERAL.inputByAttr('environment'))) {
-    await click(GENERAL.toggleGroup('More options'));
+    await click(GENERAL.button('More options'));
   }
   await fillIn(GENERAL.inputByAttr('environment'), 'AZUREPUBLICCLOUD');
   // similarly, the root password TTL may already be toggled
@@ -228,7 +228,7 @@ export const fillInGcpConfig = async (withWif = false) => {
     await fillIn(GENERAL.ttl.input('Identity token TTL'), '7200');
     await fillIn(GENERAL.inputByAttr('serviceAccountEmail'), 'some@email.com');
   } else {
-    await click(GENERAL.toggleGroup('More options'));
+    await click(GENERAL.button('More options'));
     await click(GENERAL.ttl.toggle('Config TTL'));
     await fillIn(GENERAL.ttl.input('Config TTL'), '7200');
     await click(GENERAL.ttl.toggle('Max TTL'));

--- a/ui/tests/integration/components/mount-backend-form-test.js
+++ b/ui/tests/integration/components/mount-backend-form-test.js
@@ -18,7 +18,7 @@ import hbs from 'htmlbars-inline-precompile';
 import sinon from 'sinon';
 import SecretsEngineForm from 'vault/forms/secrets/engine';
 
-module('Integration | Component | mount backend form', function (hooks) {
+module('Integration | Component | mount backend form shannontest', function (hooks) {
   setupRenderingTest(hooks);
   setupMirage(hooks);
 
@@ -93,7 +93,7 @@ module('Integration | Component | mount backend form', function (hooks) {
         hbs`<MountBackendForm @mountModel={{this.model}} @onMountSuccess={{this.onMountSuccess}} />`
       );
       await click(MOUNT_BACKEND_FORM.mountType('github'));
-      await click(GENERAL.toggleGroup('Method Options'));
+      await click(GENERAL.button('Method Options'));
       assert
         .dom('[data-test-input="config.tokenType"]')
         .hasValue('', 'token type does not have a default value.');
@@ -216,7 +216,7 @@ module('Integration | Component | mount backend form', function (hooks) {
         );
         for (const engine of WIF_ENGINES) {
           await click(MOUNT_BACKEND_FORM.mountType(engine));
-          await click(GENERAL.toggleGroup('Method Options'));
+          await click(GENERAL.button('Method Options'));
           assert
             .dom(GENERAL.fieldByAttr('config.identityTokenKey'))
             .exists(`Identity token key field shows when type=${this.model.type}`);
@@ -225,7 +225,7 @@ module('Integration | Component | mount backend form', function (hooks) {
         for (const engine of mountableEngines().filter((e) => !WIF_ENGINES.includes(e.type))) {
           // check non-wif engine
           await click(MOUNT_BACKEND_FORM.mountType(engine.type));
-          await click(GENERAL.toggleGroup('Method Options'));
+          await click(GENERAL.button('Method Options'));
           assert
             .dom(GENERAL.fieldByAttr('config.identityTokenKey'))
             .doesNotExist(`Identity token key field hidden when type=${this.model.type}`);
@@ -244,7 +244,7 @@ module('Integration | Component | mount backend form', function (hooks) {
         );
         for (const engine of WIF_ENGINES) {
           await click(MOUNT_BACKEND_FORM.mountType(engine));
-          await click(GENERAL.toggleGroup('Method Options'));
+          await click(GENERAL.button('Method Options'));
           await typeIn(GENERAL.inputSearch('key'), `${engine}+specialKey`); // set to something else
 
           assert.strictEqual(

--- a/ui/tests/integration/components/mount-backend-form-test.js
+++ b/ui/tests/integration/components/mount-backend-form-test.js
@@ -18,7 +18,7 @@ import hbs from 'htmlbars-inline-precompile';
 import sinon from 'sinon';
 import SecretsEngineForm from 'vault/forms/secrets/engine';
 
-module('Integration | Component | mount backend form shannontest', function (hooks) {
+module('Integration | Component | mount backend form', function (hooks) {
   setupRenderingTest(hooks);
   setupMirage(hooks);
 

--- a/ui/tests/integration/components/oidc/client-form-test.js
+++ b/ui/tests/integration/components/oidc/client-form-test.js
@@ -19,7 +19,7 @@ import { GENERAL } from 'vault/tests/helpers/general-selectors';
 
 const searchSelect = create(ss);
 
-module('Integration | Component | oidc/client-form shannontest', function (hooks) {
+module('Integration | Component | oidc/client-form', function (hooks) {
   setupRenderingTest(hooks);
   setupMirage(hooks);
 

--- a/ui/tests/integration/components/oidc/client-form-test.js
+++ b/ui/tests/integration/components/oidc/client-form-test.js
@@ -15,10 +15,11 @@ import oidcConfigHandlers from 'vault/mirage/handlers/oidc-config';
 import { OIDC_BASE_URL, SELECTORS } from 'vault/tests/helpers/oidc-config';
 import { setRunOptions } from 'ember-a11y-testing/test-support';
 import { capabilitiesStub, overrideResponse } from 'vault/tests/helpers/stubs';
+import { GENERAL } from 'vault/tests/helpers/general-selectors';
 
 const searchSelect = create(ss);
 
-module('Integration | Component | oidc/client-form', function (hooks) {
+module('Integration | Component | oidc/client-form shannontest', function (hooks) {
   setupRenderingTest(hooks);
   setupMirage(hooks);
 
@@ -81,7 +82,7 @@ module('Integration | Component | oidc/client-form', function (hooks) {
         @onSave={{this.onSave}}
       />
     `);
-    await click('[data-test-toggle-group="More options"]');
+    await click(GENERAL.button('More options'));
     assert
       .dom('[data-test-oidc-client-title]')
       .hasText('Create Application', 'Form title renders correct text');
@@ -146,7 +147,7 @@ module('Integration | Component | oidc/client-form', function (hooks) {
         @onSave={{this.onSave}}
       />
     `);
-    await click('[data-test-toggle-group="More options"]');
+    await click(GENERAL.button('More options'));
     assert.dom('[data-test-oidc-client-title]').hasText('Edit Application', 'Title renders correct text');
     assert.dom(SELECTORS.clientSaveButton).hasText('Update', 'Save button has correct text');
     assert.dom('[data-test-input="name"]').isDisabled('Name input is disabled when editing');

--- a/ui/tests/integration/components/pki/pki-generate-csr-test.js
+++ b/ui/tests/integration/components/pki/pki-generate-csr-test.js
@@ -13,7 +13,7 @@ import { setRunOptions } from 'ember-a11y-testing/test-support';
 import { GENERAL } from 'vault/tests/helpers/general-selectors';
 import sinon from 'sinon';
 
-module('Integration | Component | pki-generate-csr', function (hooks) {
+module('Integration | Component | pki-generate-csr shannontest', function (hooks) {
   setupRenderingTest(hooks);
   setupEngine(hooks, 'pki');
   setupMirage(hooks);
@@ -46,7 +46,7 @@ module('Integration | Component | pki-generate-csr', function (hooks) {
   });
 
   test('it should render fields and save', async function (assert) {
-    assert.expect(9);
+    assert.expect(11);
 
     this.server.post('/pki-test/issuers/generate/intermediate/exported', (schema, req) => {
       const payload = JSON.parse(req.requestBody);
@@ -73,11 +73,15 @@ module('Integration | Component | pki-generate-csr', function (hooks) {
       assert.dom(`[data-test-input="${key}"]`).exists(`${key} form field renders`);
     });
 
-    assert.dom('[data-test-toggle-group]').exists({ count: 3 }, 'Toggle groups render');
+    assert.dom(GENERAL.button('Key parameters')).exists('Key parameters toggle renders');
+    assert.dom(GENERAL.button('Subject Alternative Name (SAN) Options')).exists('SAN options toggle renders');
+    assert
+      .dom(GENERAL.button('Additional subject fields'))
+      .exists('Additional subject fields toggle renders');
 
-    await fillIn('[data-test-input="type"]', 'exported');
-    await fillIn('[data-test-input="commonName"]', 'foo');
-    await click('[data-test-submit]');
+    await fillIn(GENERAL.inputByAttr('type'), 'exported');
+    await fillIn(GENERAL.inputByAttr('commonName'), 'foo');
+    await click(GENERAL.submitButton);
 
     const savedRecord = this.store.peekAll('pki/action')[0];
     assert.false(savedRecord.isNew, 'record is saved');
@@ -95,7 +99,7 @@ module('Integration | Component | pki-generate-csr', function (hooks) {
       }
     );
 
-    await click('[data-test-submit]');
+    await click(GENERAL.submitButton);
 
     assert
       .dom(GENERAL.validationErrorByAttr('type'))

--- a/ui/tests/integration/components/pki/pki-generate-csr-test.js
+++ b/ui/tests/integration/components/pki/pki-generate-csr-test.js
@@ -13,7 +13,7 @@ import { setRunOptions } from 'ember-a11y-testing/test-support';
 import { GENERAL } from 'vault/tests/helpers/general-selectors';
 import sinon from 'sinon';
 
-module('Integration | Component | pki-generate-csr shannontest', function (hooks) {
+module('Integration | Component | pki-generate-csr', function (hooks) {
   setupRenderingTest(hooks);
   setupEngine(hooks, 'pki');
   setupMirage(hooks);

--- a/ui/tests/integration/components/pki/pki-generate-root-test.js
+++ b/ui/tests/integration/components/pki/pki-generate-root-test.js
@@ -14,7 +14,7 @@ import { allowAllCapabilitiesStub } from 'vault/tests/helpers/stubs';
 import { GENERAL } from 'vault/tests/helpers/general-selectors';
 import { PKI_GENERATE_ROOT } from 'vault/tests/helpers/pki/pki-selectors';
 
-module('Integration | Component | pki-generate-root shannontest', function (hooks) {
+module('Integration | Component | pki-generate-root', function (hooks) {
   setupRenderingTest(hooks);
   setupMirage(hooks);
   setupEngine(hooks, 'pki');

--- a/ui/tests/integration/components/pki/pki-generate-root-test.js
+++ b/ui/tests/integration/components/pki/pki-generate-root-test.js
@@ -14,7 +14,7 @@ import { allowAllCapabilitiesStub } from 'vault/tests/helpers/stubs';
 import { GENERAL } from 'vault/tests/helpers/general-selectors';
 import { PKI_GENERATE_ROOT } from 'vault/tests/helpers/pki/pki-selectors';
 
-module('Integration | Component | pki-generate-root', function (hooks) {
+module('Integration | Component | pki-generate-root shannontest', function (hooks) {
   setupRenderingTest(hooks);
   setupMirage(hooks);
   setupEngine(hooks, 'pki');
@@ -40,7 +40,11 @@ module('Integration | Component | pki-generate-root', function (hooks) {
 
     assert.dom('h2').exists({ count: 1 }, 'One H2 title without @urls');
     assert.dom(PKI_GENERATE_ROOT.mainSectionTitle).hasText('Root parameters');
-    assert.dom('[data-test-toggle-group]').exists({ count: 3 }, '3 toggle groups shown');
+    assert.dom(GENERAL.button('Key parameters')).exists('Key parameters toggle renders');
+    assert.dom(GENERAL.button('Subject Alternative Name (SAN) Options')).exists('SAN options toggle renders');
+    assert
+      .dom(GENERAL.button('Additional subject fields'))
+      .exists('Additional subject fields toggle renders');
   });
 
   test('it shows the appropriate fields under the toggles', async function (assert) {
@@ -51,7 +55,7 @@ module('Integration | Component | pki-generate-root', function (hooks) {
       }
     );
 
-    await click(PKI_GENERATE_ROOT.additionalGroupToggle);
+    await click(GENERAL.button('Additional subject fields'));
     assert
       .dom(PKI_GENERATE_ROOT.toggleGroupDescription)
       .hasText('These fields provide more information about the client to which the certificate belongs.');
@@ -59,7 +63,7 @@ module('Integration | Component | pki-generate-root', function (hooks) {
       .dom(PKI_GENERATE_ROOT.groupFields('Additional subject fields'))
       .exists({ count: 7 }, '7 form fields under Additional Fields toggle');
 
-    await click(PKI_GENERATE_ROOT.sanGroupToggle);
+    await click(GENERAL.button('Subject Alternative Name (SAN) Options'));
     assert
       .dom(PKI_GENERATE_ROOT.toggleGroupDescription)
       .hasText(
@@ -69,7 +73,7 @@ module('Integration | Component | pki-generate-root', function (hooks) {
       .dom(PKI_GENERATE_ROOT.groupFields('Subject Alternative Name (SAN) Options'))
       .exists({ count: 6 }, '7 form fields under SANs toggle');
 
-    await click(PKI_GENERATE_ROOT.keyParamsGroupToggle);
+    await click(GENERAL.button('Key parameters'));
     assert
       .dom(PKI_GENERATE_ROOT.toggleGroupDescription)
       .hasText(
@@ -89,7 +93,7 @@ module('Integration | Component | pki-generate-root', function (hooks) {
         owner: this.engine,
       }
     );
-    await click(PKI_GENERATE_ROOT.keyParamsGroupToggle);
+    await click(GENERAL.button('Key parameters'));
     assert
       .dom(PKI_GENERATE_ROOT.groupFields('Key parameters'))
       .exists({ count: 0 }, '0 form fields under keyParams toggle');

--- a/ui/tests/integration/components/pki/pki-generate-toggle-groups-test.js
+++ b/ui/tests/integration/components/pki/pki-generate-toggle-groups-test.js
@@ -8,15 +8,9 @@ import { setupRenderingTest } from 'vault/tests/helpers';
 import { click, render, settled } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupEngine } from 'ember-engines/test-support';
+import { GENERAL } from 'vault/tests/helpers/general-selectors';
 
-const selectors = {
-  keys: '[data-test-toggle-group="Key parameters"]',
-  sanOptions: '[data-test-toggle-group="Subject Alternative Name (SAN) Options"]',
-  subjectFields: '[data-test-toggle-group="Additional subject fields"]',
-  toggleByName: (name) => `[data-test-toggle-group="${name}"]`,
-};
-
-module('Integration | Component | PkiGenerateToggleGroups', function (hooks) {
+module('Integration | Component | PkiGenerateToggleGroups shannontest', function (hooks) {
   setupRenderingTest(hooks);
   setupEngine(hooks, 'pki');
 
@@ -29,9 +23,9 @@ module('Integration | Component | PkiGenerateToggleGroups', function (hooks) {
   test('it should render key parameters', async function (assert) {
     await render(hbs`<PkiGenerateToggleGroups @model={{this.model}} />`, { owner: this.engine });
 
-    assert.dom(selectors.keys).hasText('Key parameters', 'Key parameters group renders');
+    assert.dom(GENERAL.button('Key parameters')).hasText('Key parameters', 'Key parameters group renders');
 
-    await click(selectors.keys);
+    await click(GENERAL.button('Key parameters'));
 
     assert
       .dom('[data-test-toggle-group-description]')
@@ -61,10 +55,10 @@ module('Integration | Component | PkiGenerateToggleGroups', function (hooks) {
     await render(hbs`<PkiGenerateToggleGroups @model={{this.model}} />`, { owner: this.engine });
 
     assert
-      .dom(selectors.sanOptions)
+      .dom(GENERAL.button('Subject Alternative Name (SAN) Options'))
       .hasText('Subject Alternative Name (SAN) Options', 'SAN options group renders');
 
-    await click(selectors.sanOptions);
+    await click(GENERAL.button('Subject Alternative Name (SAN) Options'));
 
     const fields = ['excludeCnFromSans', 'subjectSerialNumber', 'altNames', 'ipSans', 'uriSans', 'otherSans'];
     assert.dom('[data-test-field]').exists({ count: 6 }, `Correct number of fields render`);
@@ -90,9 +84,11 @@ module('Integration | Component | PkiGenerateToggleGroups', function (hooks) {
   test('it should render additional subject fields', async function (assert) {
     await render(hbs`<PkiGenerateToggleGroups @model={{this.model}} />`, { owner: this.engine });
 
-    assert.dom(selectors.subjectFields).hasText('Additional subject fields', 'SAN options group renders');
+    assert
+      .dom(GENERAL.button('Additional subject fields'))
+      .hasText('Additional subject fields', 'SAN options group renders');
 
-    await click(selectors.subjectFields);
+    await click(GENERAL.button('Additional subject fields'));
 
     const fields = ['ou', 'organization', 'country', 'locality', 'province', 'streetAddress', 'postalCode'];
     assert.dom('[data-test-field]').exists({ count: fields.length }, 'Correct number of fields render');
@@ -113,16 +109,16 @@ module('Integration | Component | PkiGenerateToggleGroups', function (hooks) {
       owner: this.engine,
     });
 
-    assert.dom(selectors.toggleByName('Group A')).hasText('Group A', 'First group renders');
-    assert.dom(selectors.toggleByName('Group Z')).hasText('Group Z', 'Second group renders');
+    assert.dom(GENERAL.button('Group A')).hasText('Group A', 'First group renders');
+    assert.dom(GENERAL.button('Group Z')).hasText('Group Z', 'Second group renders');
 
-    await click(selectors.toggleByName('Group A'));
+    await click(GENERAL.button('Group A'));
     assert.dom('[data-test-field]').exists({ count: fieldsA.length }, 'Correct number of fields render');
     fieldsA.forEach((key) => {
       assert.dom(`[data-test-input="${key}"]`).exists(`${key} input renders`);
     });
 
-    await click(selectors.toggleByName('Group Z'));
+    await click(GENERAL.button('Group Z'));
     assert.dom('[data-test-field]').exists({ count: fieldsZ.length }, 'Correct number of fields render');
     fieldsZ.forEach((key) => {
       assert.dom(`[data-test-input="${key}"]`).exists(`${key} input renders`);

--- a/ui/tests/integration/components/pki/pki-generate-toggle-groups-test.js
+++ b/ui/tests/integration/components/pki/pki-generate-toggle-groups-test.js
@@ -10,7 +10,7 @@ import { hbs } from 'ember-cli-htmlbars';
 import { setupEngine } from 'ember-engines/test-support';
 import { GENERAL } from 'vault/tests/helpers/general-selectors';
 
-module('Integration | Component | PkiGenerateToggleGroups shannontest', function (hooks) {
+module('Integration | Component | PkiGenerateToggleGroups', function (hooks) {
   setupRenderingTest(hooks);
   setupEngine(hooks, 'pki');
 

--- a/ui/tests/integration/components/pki/pki-role-form-test.js
+++ b/ui/tests/integration/components/pki/pki-role-form-test.js
@@ -9,12 +9,11 @@ import { render, click, fillIn } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupEngine } from 'ember-engines/test-support';
 import { GENERAL } from 'vault/tests/helpers/general-selectors';
-import { PKI_ROLE_FORM } from 'vault/tests/helpers/pki/pki-selectors';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import sinon from 'sinon';
 import { setRunOptions } from 'ember-a11y-testing/test-support';
 
-module('Integration | Component | pki-role-form', function (hooks) {
+module('Integration | Component | pki-role-form shannontest', function (hooks) {
   setupRenderingTest(hooks);
   setupMirage(hooks);
   setupEngine(hooks, 'pki'); // https://github.com/ember-engines/ember-engines/pull/653
@@ -58,13 +57,13 @@ module('Integration | Component | pki-role-form', function (hooks) {
       .dom(GENERAL.fieldByAttr('noStoreMetadata'))
       .doesNotExist('noStoreMetadata is not shown b/c not enterprise');
     assert.dom(GENERAL.inputByAttr('addBasicConstraints')).exists();
-    assert.dom(PKI_ROLE_FORM.domainHandling).exists('shows form-field group add domain handling');
-    assert.dom(PKI_ROLE_FORM.keyParams).exists('shows form-field group key params');
-    assert.dom(PKI_ROLE_FORM.keyUsage).exists('shows form-field group key usage');
-    assert.dom(PKI_ROLE_FORM.policyIdentifiers).exists('shows form-field group policy identifiers');
-    assert.dom(PKI_ROLE_FORM.san).exists('shows form-field group SAN');
+    assert.dom(GENERAL.button('Domain handling')).exists('shows form-field group add domain handling');
+    assert.dom(GENERAL.button('Key parameters')).exists('shows form-field group key params');
+    assert.dom(GENERAL.button('Key usage')).exists('shows form-field group key usage');
+    assert.dom(GENERAL.button('Policy identifiers')).exists('shows form-field group policy identifiers');
+    assert.dom(GENERAL.button('Subject Alternative Name (SAN) Options')).exists('shows form-field group SAN');
     assert
-      .dom(PKI_ROLE_FORM.additionalSubjectFields)
+      .dom(GENERAL.button('Additional subject fields'))
       .exists('shows form-field group additional subject fields');
   });
 
@@ -132,13 +131,13 @@ module('Integration | Component | pki-role-form', function (hooks) {
 
     await fillIn(GENERAL.inputByAttr('name'), 'test-role');
     await click('[data-test-input="addBasicConstraints"]');
-    await click(PKI_ROLE_FORM.domainHandling);
+    await click(GENERAL.button('Domain handling'));
     await click('[data-test-input="allowedDomainsTemplate"]');
-    await click(PKI_ROLE_FORM.policyIdentifiers);
+    await click(GENERAL.button('Policy identifiers'));
     await fillIn('[data-test-input="policyIdentifiers"] [data-test-string-list-input="0"]', 'some-oid');
-    await click(PKI_ROLE_FORM.san);
+    await click(GENERAL.button('Subject Alternative Name (SAN) Options'));
     await click('[data-test-input="allowUriSansTemplate"]');
-    await click(PKI_ROLE_FORM.additionalSubjectFields);
+    await click(GENERAL.button('Additional subject fields'));
     await fillIn(
       '[data-test-input="allowedSerialNumbers"] [data-test-string-list-input="0"]',
       'some-serial-number'
@@ -228,7 +227,7 @@ module('Integration | Component | pki-role-form', function (hooks) {
     await click(GENERAL.ttl.toggle('issuerRef-toggle'));
     await fillIn(GENERAL.selectByAttr('issuerRef'), 'issuer-1');
 
-    await click(PKI_ROLE_FORM.keyParams);
+    await click(GENERAL.button('Key parameters'));
     assert.dom(GENERAL.inputByAttr('keyType')).hasValue('rsa');
     assert
       .dom(GENERAL.inputByAttr('keyBits'))

--- a/ui/tests/integration/components/pki/pki-role-form-test.js
+++ b/ui/tests/integration/components/pki/pki-role-form-test.js
@@ -13,7 +13,7 @@ import { setupMirage } from 'ember-cli-mirage/test-support';
 import sinon from 'sinon';
 import { setRunOptions } from 'ember-a11y-testing/test-support';
 
-module('Integration | Component | pki-role-form shannontest', function (hooks) {
+module('Integration | Component | pki-role-form', function (hooks) {
   setupRenderingTest(hooks);
   setupMirage(hooks);
   setupEngine(hooks, 'pki'); // https://github.com/ember-engines/ember-engines/pull/653

--- a/ui/tests/integration/components/pki/pki-role-generate-test.js
+++ b/ui/tests/integration/components/pki/pki-role-generate-test.js
@@ -14,7 +14,7 @@ import { GENERAL } from 'vault/tests/helpers/general-selectors';
 import { PKI_ROLE_GENERATE } from 'vault/tests/helpers/pki/pki-selectors';
 import { allowAllCapabilitiesStub } from 'vault/tests/helpers/stubs';
 
-module('Integration | Component | pki-role-generate', function (hooks) {
+module('Integration | Component | pki-role-generate shannontest', function (hooks) {
   setupRenderingTest(hooks);
   setupMirage(hooks);
   setupEngine(hooks, 'pki');
@@ -45,7 +45,7 @@ module('Integration | Component | pki-role-generate', function (hooks) {
     );
     assert.dom(PKI_ROLE_GENERATE.form).exists('shows the cert generate form');
     assert.dom(GENERAL.inputByAttr('commonName')).exists('shows the common name field');
-    assert.dom(PKI_ROLE_GENERATE.optionsToggle).exists('toggle exists');
+    assert.dom(GENERAL.button('Subject Alternative Name (SAN) Options')).exists('toggle exists');
     await fillIn(GENERAL.inputByAttr('commonName'), 'example.com');
     assert.strictEqual(this.model.commonName, 'example.com', 'Filling in the form updates the model');
   });

--- a/ui/tests/integration/components/pki/pki-role-generate-test.js
+++ b/ui/tests/integration/components/pki/pki-role-generate-test.js
@@ -14,7 +14,7 @@ import { GENERAL } from 'vault/tests/helpers/general-selectors';
 import { PKI_ROLE_GENERATE } from 'vault/tests/helpers/pki/pki-selectors';
 import { allowAllCapabilitiesStub } from 'vault/tests/helpers/stubs';
 
-module('Integration | Component | pki-role-generate shannontest', function (hooks) {
+module('Integration | Component | pki-role-generate', function (hooks) {
   setupRenderingTest(hooks);
   setupMirage(hooks);
   setupEngine(hooks, 'pki');

--- a/ui/tests/integration/components/pki/pki-sign-intermediate-form-test.js
+++ b/ui/tests/integration/components/pki/pki-sign-intermediate-form-test.js
@@ -19,7 +19,7 @@ const selectors = {
   formError: '[data-test-form-error]',
   resultsContainer: '[data-test-sign-intermediate-result]',
 };
-module('Integration | Component | pki-sign-intermediate-form shannontest', function (hooks) {
+module('Integration | Component | pki-sign-intermediate-form', function (hooks) {
   setupRenderingTest(hooks);
   setupEngine(hooks, 'pki');
   setupMirage(hooks);

--- a/ui/tests/integration/components/pki/pki-sign-intermediate-form-test.js
+++ b/ui/tests/integration/components/pki/pki-sign-intermediate-form-test.js
@@ -14,16 +14,12 @@ import { GENERAL } from 'vault/tests/helpers/general-selectors';
 
 const selectors = {
   form: '[data-test-sign-intermediate-form]',
-  csrInput: '[data-test-input="csr"]',
-  toggleGroup: (group) => `[data-test-toggle-group="${group}"]`,
-  fieldByName: (name) => `[data-test-field="${name}"]`,
   saveButton: '[data-test-pki-sign-intermediate-save]',
   cancelButton: '[data-test-pki-sign-intermediate-cancel]',
-  fieldError: '[data-test-inline-alert]',
   formError: '[data-test-form-error]',
   resultsContainer: '[data-test-sign-intermediate-result]',
 };
-module('Integration | Component | pki-sign-intermediate-form', function (hooks) {
+module('Integration | Component | pki-sign-intermediate-form shannontest', function (hooks) {
   setupRenderingTest(hooks);
   setupEngine(hooks, 'pki');
   setupMirage(hooks);
@@ -51,12 +47,12 @@ module('Integration | Component | pki-sign-intermediate-form', function (hooks) 
       'Subject Alternative Name (SAN) Options',
       'Additional subject fields',
     ].forEach((group) => {
-      assert.dom(selectors.toggleGroup(group)).exists(`${group} renders`);
+      assert.dom(GENERAL.button(group)).exists(`${group} renders`);
     });
 
-    await click(selectors.toggleGroup('Signing options'));
+    await click(GENERAL.button('Signing options'));
     ['usePss', 'skid', 'signatureBits'].forEach((name) => {
-      assert.dom(selectors.fieldByName(name)).exists();
+      assert.dom(GENERAL.fieldByAttr(name)).exists();
     });
   });
 
@@ -81,10 +77,10 @@ module('Integration | Component | pki-sign-intermediate-form', function (hooks) 
     });
     await click(selectors.saveButton);
     assert.dom(selectors.formError).hasText('There is an error with this form.', 'Shows validation errors');
-    assert.dom(selectors.csrInput).hasClass('has-error-border');
-    assert.dom(selectors.fieldError).hasText('CSR is required.');
+    assert.dom(GENERAL.inputByAttr('csr')).hasClass('has-error-border');
+    assert.dom(GENERAL.inlineAlert).hasText('CSR is required.');
 
-    await fillIn(selectors.csrInput, 'example-data');
+    await fillIn(GENERAL.inputByAttr('csr'), 'example-data');
     await click(selectors.saveButton);
     [
       { label: 'Serial number' },

--- a/ui/tests/integration/components/secret-engine/configure-wif-test.js
+++ b/ui/tests/integration/components/secret-engine/configure-wif-test.js
@@ -82,9 +82,12 @@ module('Integration | Component | SecretEngine::ConfigureWif', function (hooks) 
           assert.dom(SES.configureForm).exists(`it lands on the ${type} configuration form`);
           assert.dom(SES.wif.accessType(type)).isChecked(`defaults to showing ${type} access type checked`);
           assert.dom(SES.wif.accessType('wif')).isNotChecked('wif access type is not checked');
-          // toggle grouped fields if it exists
-          const toggleGroup = document.querySelector('[data-test-toggle-group]');
-          toggleGroup ? await click(toggleGroup) : null;
+
+          let toggleGroup = GENERAL.button('More options');
+          if (type === 'aws') {
+            toggleGroup = GENERAL.button('Root config options');
+          }
+          await click(toggleGroup);
 
           for (const key of expectedConfigKeys(type, true)) {
             if (key === 'configTtl' || key === 'maxTtl') {
@@ -117,9 +120,13 @@ module('Integration | Component | SecretEngine::ConfigureWif', function (hooks) 
 
           await this.renderComponent();
           await click(SES.wif.accessType('wif'));
-          // toggle grouped fields if it exists
-          const toggleGroup = document.querySelector('[data-test-toggle-group]');
-          toggleGroup ? await click(toggleGroup) : null;
+
+          let toggleGroup = GENERAL.button('More options');
+          if (type === 'aws') {
+            toggleGroup = GENERAL.button('Root config options');
+          }
+          await click(toggleGroup);
+
           // check for the wif fields only
           for (const key of expectedConfigKeys(`${type}-wif`, true)) {
             if (key === 'Identity token TTL') {
@@ -599,9 +606,13 @@ module('Integration | Component | SecretEngine::ConfigureWif', function (hooks) 
           assert
             .dom(SES.wif.accessTypeSection)
             .doesNotExist('Access type section does not render for a community user');
-          // toggle grouped fields if it exists
-          const toggleGroup = document.querySelector('[data-test-toggle-group]');
-          toggleGroup ? await click(toggleGroup) : null;
+
+          let toggleGroup = GENERAL.button('More options');
+          if (type === 'aws') {
+            toggleGroup = GENERAL.button('Root config options');
+          }
+          await click(toggleGroup);
+
           // check all the form fields are present
           for (const key of expectedConfigKeys(type, true)) {
             if (key === 'configTtl' || key === 'maxTtl') {
@@ -781,7 +792,7 @@ module('Integration | Component | SecretEngine::ConfigureWif', function (hooks) 
             .dom(GENERAL.inputByAttr('secretKey'))
             .hasValue('**********', 'secretKey is masked on edit the value');
 
-          await click(GENERAL.toggleGroup('Root config options'));
+          await click(GENERAL.button('Root config options'));
           assert.dom(GENERAL.inputByAttr('region')).hasValue(this.form.region);
           assert.dom(GENERAL.inputByAttr('iamEndpoint')).hasValue(this.form.iamEndpoint);
           assert.dom(GENERAL.inputByAttr('stsEndpoint')).hasValue(this.form.stsEndpoint);
@@ -858,7 +869,7 @@ module('Integration | Component | SecretEngine::ConfigureWif', function (hooks) 
           const config = createConfig('gcp-generic');
           this.form = this.getForm('gcp', config);
           await this.renderComponent();
-          await click(GENERAL.toggleGroup('More options'));
+          await click(GENERAL.button('More options'));
           assert.dom(GENERAL.ttl.input('Config TTL')).hasValue('100');
           assert.dom(GENERAL.ttl.input('Max TTL')).hasValue('101');
         });
@@ -879,9 +890,13 @@ module('Integration | Component | SecretEngine::ConfigureWif', function (hooks) 
 
           await this.renderComponent();
           assert.dom(SES.wif.accessTypeSection).doesNotExist('Access type section does not render');
-          // toggle grouped fields if it exists
-          const toggleGroup = document.querySelector('[data-test-toggle-group]');
-          toggleGroup ? await click(toggleGroup) : null;
+
+          let toggleGroup = GENERAL.button('More options');
+          if (type === 'aws') {
+            toggleGroup = GENERAL.button('Root config options');
+          }
+          await click(toggleGroup);
+
           for (const key of expectedConfigKeys(type, true)) {
             if (key === 'secretKey' || key === 'clientSecret' || key === 'credentials') return; // these keys are not returned by the API
             // same issues noted in wif enterprise tests with how toggle.hbs passes in name vs how formField input passes in attr to data test selector

--- a/ui/tests/integration/components/totp/key-form-test.js
+++ b/ui/tests/integration/components/totp/key-form-test.js
@@ -10,11 +10,7 @@ import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { GENERAL } from 'vault/tests/helpers/general-selectors';
 
-const SELECTORS = {
-  toggleGroup: (name) => `[data-test-toggle-group="${name}"]`,
-};
-
-module('Integration | Component | totp/key-form', function (hooks) {
+module('Integration | Component | totp/key-form shannontest', function (hooks) {
   setupRenderingTest(hooks);
   setupMirage(hooks);
 
@@ -152,16 +148,14 @@ module('Integration | Component | totp/key-form', function (hooks) {
     `);
 
     // check generated groups
-    assert.dom(SELECTORS.toggleGroup('TOTP Code Options')).exists('Common group is shown');
-    assert.dom(SELECTORS.toggleGroup('Provider Options')).exists('Generated exclusive group is shown');
+    assert.dom(GENERAL.button('TOTP Code Options')).exists('Common group is shown');
+    assert.dom(GENERAL.button('Provider Options')).exists('Generated exclusive group is shown');
 
     // switch to non-generated form fields
     await click(GENERAL.radioByAttr('Other service'));
 
     // check non generated groups
-    assert.dom(SELECTORS.toggleGroup('TOTP Code Options')).exists('Common group is shown');
-    assert
-      .dom(SELECTORS.toggleGroup('Provider Options'))
-      .doesNotExist('Generated exclusive group is not shown');
+    assert.dom(GENERAL.button('TOTP Code Options')).exists('Common group is shown');
+    assert.dom(GENERAL.button('Provider Options')).doesNotExist('Generated exclusive group is not shown');
   });
 });

--- a/ui/tests/integration/components/totp/key-form-test.js
+++ b/ui/tests/integration/components/totp/key-form-test.js
@@ -10,7 +10,7 @@ import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { GENERAL } from 'vault/tests/helpers/general-selectors';
 
-module('Integration | Component | totp/key-form shannontest', function (hooks) {
+module('Integration | Component | totp/key-form', function (hooks) {
   setupRenderingTest(hooks);
   setupMirage(hooks);
 


### PR DESCRIPTION
### Description
What does this PR do?
Update tests to use toggle selectors as defined in `general-selectors.ts`: 
- [x] `toggleGroup` - replace `data-test-toggle-group` w/ `GENERAL.button`

Enterprise tests are passing ✅ 
> 273 tests completed in 152805 milliseconds, with 0 failed, 10 skipped, and 0 todo.
1590 assertions of 1590 passed, 0 failed.