### PR TITLE
[UI] Enterprise WIF Test Failure

### DIFF
--- a/ui/tests/helpers/secret-engine/secret-engine-helpers.js
+++ b/ui/tests/helpers/secret-engine/secret-engine-helpers.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { click, fillIn } from '@ember/test-helpers';
+import { click, fillIn, find } from '@ember/test-helpers';
 import { GENERAL } from 'vault/tests/helpers/general-selectors';
 import { SECRET_ENGINE_SELECTORS as SES } from 'vault/tests/helpers/secret-engine/secret-engine-selectors';
 import { stringArrayToCamelCase } from 'vault/helpers/string-array-to-camel';
@@ -199,6 +199,16 @@ export const fillInAzureConfig = async (withWif = false) => {
   await fillIn(GENERAL.inputByAttr('subscriptionId'), 'subscription-id');
   await fillIn(GENERAL.inputByAttr('tenantId'), 'tenant-id');
   await fillIn(GENERAL.inputByAttr('clientId'), 'client-id');
+  // options may already be toggled so check before clicking
+  if (!find(GENERAL.inputByAttr('environment'))) {
+    await click(GENERAL.toggleGroup('More options'));
+  }
+  await fillIn(GENERAL.inputByAttr('environment'), 'AZUREPUBLICCLOUD');
+  // similarly, the root password TTL may already be toggled
+  if (!find(GENERAL.ttl.input('Root password TTL'))) {
+    await click(GENERAL.ttl.toggle('Root password TTL'));
+  }
+  await fillIn(GENERAL.ttl.input('Root password TTL'), '200');
 
   if (withWif) {
     await click(SES.wif.accessType('wif')); // toggle to wif
@@ -207,10 +217,6 @@ export const fillInAzureConfig = async (withWif = false) => {
     await fillIn(GENERAL.ttl.input('Identity token TTL'), '7200');
   } else {
     await fillIn(GENERAL.inputByAttr('clientSecret'), 'client-secret');
-    await click(GENERAL.toggleGroup('More options'));
-    await fillIn(GENERAL.inputByAttr('environment'), 'AZUREPUBLICCLOUD');
-    await click(GENERAL.ttl.toggle('Root password TTL'));
-    await fillIn(GENERAL.ttl.input('Root password TTL'), '200');
   }
 };
 


### PR DESCRIPTION
### Description
Fixes [this enterprise test failure](https://github.com/hashicorp/vault-enterprise/actions/runs/15692016702#summary-44209290728) that was introduced when #30829 was merged.

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
