### PR TITLE
[DOCS] Manual backport of Add example policy to AWS secrets engine for AssumeRole that will still be able to rotate itself into release/1.19.x

### DIFF
--- a/website/content/docs/secrets/aws.mdx
+++ b/website/content/docs/secrets/aws.mdx
@@ -335,9 +335,9 @@ For more details on rotating root credentials in the AWS Secrets engine, refer t
 
 ## IAM permissions policy for Vault
 
-The `aws/config/root` credentials need permission to manage dynamic IAM users.
-Here is an example AWS IAM policy that grants the most commonly required
-permissions Vault needs:
+When using `credential_type=iam_user`, the `aws/config/root` credentials need
+permission to manage dynamic IAM users. Here is an example AWS IAM policy that
+grants the most commonly required permissions Vault needs:
 
 ```json
 {
@@ -419,6 +419,35 @@ where the "iam:PermissionsBoundary" condition contains the list of permissions
 boundary policies that you wish to ensure that Vault uses. This policy will
 ensure that Vault uses one of the permissions boundaries specified (not all of
 them).
+
+### Policies for STS credentials
+
+AWS root credentials (`aws/config/root`) do not require permission to manage
+dynamic IAM users when using STS credentials like `assumed_role`, `session_token`,
+or `federation_token`.
+
+To use STS credentials with
+[the rotate endpoint](/vault/api-docs/secret/aws#rotate-root-iam-credentials)
+to rotate IAM user credentials, you must grant the following permissions on the
+IAM user itself:
+
+```json
+{
+  "Statement": [
+    {
+      "Action": [
+        "iam:ListAccessKeys",
+        "iam:GetUser",
+        "iam:DeleteAccessKey",
+        "iam:CreateAccessKey"
+      ],
+      "Effect": "Allow",
+      "Resource": "arn:aws:iam::ACCOUNT-ID-WITHOUT-HYPHENS:user/vault-iam-user"
+    }
+  ],
+  "Version": "2012-10-17"
+}
+```
 
 ## Plugin Workload Identity Federation (WIF)
 


### PR DESCRIPTION
Manual backport of changes from https://github.com/hashicorp/vault/pull/30747