### PR TITLE
[VAULT-34485] UI: Internal namespace documentation updates

### DIFF
--- a/website/content/api-docs/system/internal-ui-namespaces.mdx
+++ b/website/content/api-docs/system/internal-ui-namespaces.mdx
@@ -15,7 +15,8 @@ not need to explicitly grant capabilities on the `/sys/internal/ui/namespaces`
 path in your policy. For more information about namespace policies, see the
 [sys/namespaces API documentation](/vault/api-docs/system/namespaces).
 
-Due to the nature of its intended usage, there is no guarantee on backwards compatibility for this endpoint.
+Internal endpoints are not intended for general use and make no guarantees on
+backwards compatibility over time.
 
 ## Get namespaces
 

--- a/website/content/api-docs/system/internal-ui-namespaces.mdx
+++ b/website/content/api-docs/system/internal-ui-namespaces.mdx
@@ -9,7 +9,11 @@ description: >-
 
 The `/sys/internal/ui/namespaces` endpoint returns the namespaces that the current user has access to.
 
-This endpoint is used internally by the GUI and is an authenticated endpoint (requires a valid Vault token). You do not need to explicitly grant capabilities on the `/sys/internal/ui/namespaces` path in your policy. If your token has any access to a namespace, that namespace will be included in the response. For more information about namespace policies, see the [sys/namespaces API documentation](/vault/api-docs/system/namespaces).
+The namespaces endpoint is an authenticated endpoint used internally by the
+Vault GUI to return all namespaces associated with the provided toekn. You do
+not need to explicitly grant capabilities on the `/sys/internal/ui/namespaces`
+path in your policy. For more information about namespace policies, see the
+[sys/namespaces API documentation](/vault/api-docs/system/namespaces).
 
 Due to the nature of its intended usage, there is no guarantee on backwards compatibility for this endpoint.
 

--- a/website/content/api-docs/system/internal-ui-namespaces.mdx
+++ b/website/content/api-docs/system/internal-ui-namespaces.mdx
@@ -20,7 +20,7 @@ backwards compatibility over time.
 
 ## Get namespaces
 
-This endpoint lists the namespaces relevant to the GUI.
+List namespaces associated with the provided Vault token for use in the GUI.
 
 | Method | Path                             |
 | :----- | :------------------------------- |

--- a/website/content/api-docs/system/internal-ui-namespaces.mdx
+++ b/website/content/api-docs/system/internal-ui-namespaces.mdx
@@ -2,17 +2,16 @@
 layout: api
 page_title: /sys/internal/ui/namespaces - HTTP API
 description: >-
-  The `/sys/internal/ui/namespaces` endpoint exposes namespaces to the UI.
+  The `/sys/internal/ui/namespaces` endpoint exposes namespaces to the GUI.
 ---
 
 # `/sys/internal/ui/namespaces`
 
-The `/sys/internal/ui/namespaces` endpoint is used to expose namespaces
-to the GUI so that it can change its behavior in response, even before a user logs in.
+The `/sys/internal/ui/namespaces` endpoint returns the namespaces that the current user has access to.
 
-This is currently only being used internally for the UI and is
-an unauthenticated endpoint. Due to the nature of its intended usage, there is no
-guarantee on backwards compatibility for this endpoint.
+This endpoint is used internally by the GUI and is an authenticated endpoint (requires a valid Vault token). You do not need to explicitly grant capabilities on the `/sys/internal/ui/namespaces` path in your policy. If your token has any access to a namespace, that namespace will be included in the response. For more information about namespace policies, see the [sys/namespaces API documentation](https://developer.hashicorp.com/vault/api-docs/system/namespaces).
+
+Due to the nature of its intended usage, there is no guarantee on backwards compatibility for this endpoint.
 
 ## Get namespaces
 

--- a/website/content/api-docs/system/internal-ui-namespaces.mdx
+++ b/website/content/api-docs/system/internal-ui-namespaces.mdx
@@ -40,10 +40,11 @@ $ curl \
     "lease_duration": 0,
     "data": {
         "keys": [
-            "parent/",
-            "parent/child/",
-            "parent/child/grandchild/",
-            "parent2/"
+            "software/",
+            "software/eng/",
+            "software/eng/dev/",
+            "software/eng/qc/",
+            "devops/"
         ]
     },
     "wrap_info": null,
@@ -56,9 +57,10 @@ $ curl \
 The `keys` array in the response lists all available namespaces, with each entry representing a namespace path.
 
 In the sample response above:
-- `parent/` is a namespace that contains a nested namespace `child/`.
-- `parent/child/` is a nested namespace under `parent/` and contains its own nested namespace `grandchild/`.
-- `parent/child/grandchild/` is a nested namespace under `parent/child/`.
-- `parent2/` is a namespace that does not have any nested namespaces.
+- `software/` is a namespace that contains a nested namespace `eng/`.
+- `software/eng/` is a nested namespace under `software/` and contains its own nested namespaces `dev/` and `qc/`.
+- `software/eng/dev/` is a nested namespace under `software/eng/`.
+- `software/eng/qc/` is a nested namespace under `software/eng/`.
+- `devops/` is a namespace that does not have any nested namespaces.
 
 > **Note:** The `root` namespace is never included in this list of namespaces.

--- a/website/content/api-docs/system/internal-ui-namespaces.mdx
+++ b/website/content/api-docs/system/internal-ui-namespaces.mdx
@@ -10,7 +10,7 @@ description: >-
 The `/sys/internal/ui/namespaces` endpoint returns the namespaces that the current user has access to.
 
 The namespaces endpoint is an authenticated endpoint used internally by the
-Vault GUI to return all namespaces associated with the provided toekn. You do
+Vault GUI to return all namespaces associated with the provided token. You do
 not need to explicitly grant capabilities on the `/sys/internal/ui/namespaces`
 path in your policy. For more information about namespace policies, see the
 [sys/namespaces API documentation](/vault/api-docs/system/namespaces).

--- a/website/content/api-docs/system/internal-ui-namespaces.mdx
+++ b/website/content/api-docs/system/internal-ui-namespaces.mdx
@@ -8,7 +8,7 @@ description: >-
 # `/sys/internal/ui/namespaces`
 
 The `/sys/internal/ui/namespaces` endpoint is used to expose namespaces
-to the UI so that it can change its behavior in response, even before a user logs in.
+to the GUI so that it can change its behavior in response, even before a user logs in.
 
 This is currently only being used internally for the UI and is
 an unauthenticated endpoint. Due to the nature of its intended usage, there is no
@@ -16,7 +16,7 @@ guarantee on backwards compatibility for this endpoint.
 
 ## Get namespaces
 
-This endpoint lists the namespaces relevant to the UI.
+This endpoint lists the namespaces relevant to the GUI.
 
 | Method | Path                             |
 | :----- | :------------------------------- |
@@ -26,6 +26,8 @@ This endpoint lists the namespaces relevant to the UI.
 
 ```shell-session
 $ curl \
+    --header "X-Vault-Token: ..." \
+    --request GET \
     http://127.0.0.1:8200/v1/sys/internal/ui/namespaces
 ```
 
@@ -33,6 +35,31 @@ $ curl \
 
 ```json
 {
-  "namespaces": []
+    "request_id": "28a1ca80-cc97-913d-8ed2-844ea501ae0d",
+    "lease_id": "",
+    "renewable": false,
+    "lease_duration": 0,
+    "data": {
+        "keys": [
+            "parent/",
+            "parent/child/",
+            "parent/child/grandchild/",
+            "parent2/"
+        ]
+    },
+    "wrap_info": null,
+    "warnings": null,
+    "auth": null,
+    "mount_type": ""
 }
 ```
+
+The `keys` array in the response lists all available namespaces, with each entry representing a namespace path.
+
+In the sample response above:
+- `parent/` is a namespace that contains a nested namespace `child/`.
+- `parent/child/` is a nested namespace under `parent/` and contains its own nested namespace `grandchild/`.
+- `parent/child/grandchild/` is a nested namespace under `parent/child/`.
+- `parent2/` is a namespace that does not have any nested namespaces.
+
+> **Note:** The `root` namespace is never included in this list of namespaces.

--- a/website/content/api-docs/system/internal-ui-namespaces.mdx
+++ b/website/content/api-docs/system/internal-ui-namespaces.mdx
@@ -9,7 +9,7 @@ description: >-
 
 The `/sys/internal/ui/namespaces` endpoint returns the namespaces that the current user has access to.
 
-This endpoint is used internally by the GUI and is an authenticated endpoint (requires a valid Vault token). You do not need to explicitly grant capabilities on the `/sys/internal/ui/namespaces` path in your policy. If your token has any access to a namespace, that namespace will be included in the response. For more information about namespace policies, see the [sys/namespaces API documentation](https://developer.hashicorp.com/vault/api-docs/system/namespaces).
+This endpoint is used internally by the GUI and is an authenticated endpoint (requires a valid Vault token). You do not need to explicitly grant capabilities on the `/sys/internal/ui/namespaces` path in your policy. If your token has any access to a namespace, that namespace will be included in the response. For more information about namespace policies, see the [sys/namespaces API documentation](/vault/api-docs/system/namespaces).
 
 Due to the nature of its intended usage, there is no guarantee on backwards compatibility for this endpoint.
 


### PR DESCRIPTION
![screencapture-localhost-3000-vault-api-docs-system-internal-ui-namespaces-2025-06-24-11_30_32](https://github.com/user-attachments/assets/1c82c1bc-9a8d-40e9-bf54-c6c42f394c7d)
