### PR TITLE
Remove links and refs to using HVS

### DIFF
--- a/website/content/docs/about-vault/what-is-vault.mdx
+++ b/website/content/docs/about-vault/what-is-vault.mdx
@@ -98,7 +98,6 @@ supports backup/restore workflows, high availability, and Enterprise replication
 features without relying on third-party systems where Vault cannot verify the
 security and traceability of data access.
 
-
 ## When should I not use Vault?
 
 Vault is robust, powerful, and flexible. But it can also be overwhelming if
@@ -106,13 +105,12 @@ you have limited or simple secret management needs.
 
 If your organization is just getting started with secrets management or looking
 to simplify an existing secrets management processes, consider starting with
-[HCP Vault Secrets](/hcp/docs/vault-secrets) instead of Vault.
+[HCP Vault Dedicated](/hcp/docs/vault/what-is-hcp-vault) instead of Vault.
 
-HCP Vault Secrets is a SaaS offering on the HashiCorp cloud platform that
-provides a secure and flexible access control model. Based on the principle of
-least privilege, HCP Vault Secrets handles secret lifecycle management through a
-single platform to help mitigate the risks associated with leaked secrets.
-
+HCP Vault Dedicated is a managed offering of Vault that runs on the HashiCorp
+cloud platform. HCP Vault Dedicated provides a Vault Enterprise Cluster without
+the operational overhead of planning, deploying, and managing a self-hosted
+Vault cluster.
 
 ## How do I get Vault?
 

--- a/website/content/docs/deploy/kubernetes/vso/index.mdx
+++ b/website/content/docs/deploy/kubernetes/vso/index.mdx
@@ -7,7 +7,7 @@ description: >-
 
 # Vault Secrets Operator
 
-The Vault Secrets Operator (VSO) allows Pods to consume Vault secrets and HCP Vault Secrets Apps natively from Kubernetes Secrets.
+The Vault Secrets Operator (VSO) allows Pods to consume Vault secrets natively from Kubernetes Secrets.
 
 The Vault Secrets Operator (VSO) is a fully supported component of HashiCorp Vault.
 

--- a/website/content/docs/secrets/kv/index.mdx
+++ b/website/content/docs/secrets/kv/index.mdx
@@ -11,8 +11,6 @@ secrets within the configured physical storage for Vault. This secrets engine
 can run in one of two modes; store a single value for a key, or store a number
 of versions for each key and maintain the record of them.
 
-@include 'tips/try-hvs.mdx'
-
 ## KV version 1
 
 When running the `kv` secrets engine non-versioned, it stores the most recently

--- a/website/content/docs/sync/index.mdx
+++ b/website/content/docs/sync/index.mdx
@@ -19,12 +19,6 @@ process. If the secret value is updated in Vault, the secret is updated in the d
 from Vault, it is deleted on the external system as well. This process is asynchronous and event-based. Vault propagates
 modifications into the proper destinations automatically in a handful of seconds.
 
-<Highlight title="Sync secrets with HCP Vault Secrets">
-
-Secrets sync is a Vault Enterprise feature. For information on secrets sync with [HCP Vault Secrets](/hcp/docs/vault-secrets), refer to the HashiCorp Cloud Platform documentation for [Vault Secrets integrations](/hcp/docs/vault-secrets/integrations).
-
-</Highlight>
-
 ## Activating the feature
 
 The secrets sync feature requires manual activation through a one-time trigger. If a sync-related endpoint is called prior to


### PR DESCRIPTION
### Description
What does this PR do?

Remove links and references to using HVS as a Vault alternative. 

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
