### PR TITLE
[DOCS] Manual backport of LTS upgrade summary (#30981) to 1.19

### DIFF
--- a/website/content/docs/upgrade/lts-upgrade.mdx
+++ b/website/content/docs/upgrade/lts-upgrade.mdx
@@ -1,0 +1,29 @@
+---
+layout: docs
+page_title: LTS Vault upgrades
+description: >-
+  General guidance for LTS upgrades
+---
+
+# Long-term support Vault upgrades
+
+[Long-term support](/vault/docs/enterprise/) offers extended maintenance through
+minor releases for select, major Vault Enterprise versions.
+
+Current LTS release | Extended maintenance release
+------------------- | ----------------------------
+1.19.x              | 1.16.x
+
+Before you perform a direct LTS upgrade from an extended maintenance release to
+the current LTS release, we recommend reviewing the following summary of
+functional changes and known issues to determine the likely impact on your Vault
+deployment.
+
+Functional changes affect how Vault works including new requirements, new
+defaults, new behavior, and breaking changes. In some cases, we recommend specific
+actions before or after upgrading to mitigate the impact of a functional change.
+
+Unresolved nown issues may have suggested workarounds or mitagation stratagies
+you should consider before upgrading.
+
+@include 'release-notes/change-summary/lts/1_16-to-1_19.mdx'

--- a/website/content/partials/release-notes/change-summary/lts/1_16-to-1_19.mdx
+++ b/website/content/partials/release-notes/change-summary/lts/1_16-to-1_19.mdx
@@ -1,0 +1,39 @@
+## Breaking changes
+
+Introduced | Recommendations | Change
+---------- | --------------- | -------
+1.17.x     | **Yes**         | [Rekey cancellations use a nonce](/vault/docs/v1.17.x/updates/important-changes#rekey-cancel-nonce)
+1.19.x     | **Yes**         | [Security improvement for LDAP user DN search with upndomain](/vault/docs/v1.19.x/updates/important-changes#ldap)
+1.19.x     | **Yes**         | [Rekey cancellations use a nonce](/vault/docs/v1.20.x/updates/important-changes#rekey-cancel-nonce)
+
+
+## New behavior
+
+Introduced | Recommendations | Change
+---------- | --------------- | -------
+1.17.x     | No              | [Allowed audit headers now have unremovable defaults](/vault/docs/v1.17.x/updates/important-changes#audit-headers)
+1.17.x     | **Yes**         | [JWT auth login requires `bound_audiences` parameter on role](/vault/docs/v1.17.x/updates/important-changes#jwt-auth-login-requires-bound-audiences-on-the-role)
+1.17.x     | No              | [Strict validation for Azure auth login requests](/vault/docs/v1.17.x/updates/important-changes#strict-azure)
+1.17.x     | **Yes**         | [Secrets Sync SSRF Protection May Block Private Endpoints](/vault/docs/v1.17.x/updates/important-changes#secrets-sync-ssrf-protection-may-block-private-endpoints)
+1.17.x     | No              | [Default report months deprecated for `sys/internal/counters`](/vault/docs/v1.17.x/updates/important-changes#activity-log-changes)
+1.17.x     | **Yes**         | [Vault product usage metrics reporting](/vault/docs/v1.17.x/updates/important-changes#product-usage-reporting)
+1.18.x     | No              | [Activity log changes](/vault/docs/v1.18.x/updates/important-changes#default-activity-log-querying-period)
+1.18.x     | **Yes**         | [Docker image no longer contains curl](/vault/docs/v1.18.x/updates/important-changes#docker-image-no-longer-contains-curl)
+1.18.x     | **Yes**         | [Anonymous product usage metrics collection](/vault/docs/v1.18.x/updates/important-changes#product-usage-reporting)
+1.18.x     | No              | [Strict validation for Azure auth login requests](/vault/docs/v1.18.x/updates/important-changes#azure-auth-plugin-requires-resource_group_name-vm_name-and-vmss_name-to-match-the-jwt-claims-on-login)
+1.19.x     | No              | [Anonymized cluster data returned with license utilization](/vault/docs/v1.19.x/updates/important-changes#anon-data)
+1.19.x     | **Yes**         | [Identity system duplicate cleanup](/vault/docs/v1.19.x/updates/important-changes#dedupe)
+1.19.x     | No              | [RADIUS authentication is no longer case sensitive](/vault/docs/v1.19.x/updates/important-changes#case-sensitive)
+1.19.x     | No              | [Transit support for Ed25519ph and Ed25519ctx signatures](/vault/docs/v1.19.x/updates/important-changes#ed25519)
+1.19.x     | **Yes**         | [Strict validation for Azure auth login requests](/vault/docs/v1.19.x/updates/important-changes#strict-azure)
+
+
+## Known issues
+
+Workaround | Issue
+---------- | -----
+**Yes**    | [Duplicate unseal/seal wrap HSM keys](/vault/docs/v1.19.x/updates/important-changes#hsm-keys)
+**Yes**    | [Duplicate identity groups created when concurrent requests sent to the primary and PR secondary cluster](/vault/docs/v1.17.x/updates/important-changes#duplicate-identity-groups-created-when-concurrent-requests-sent-to-the-primary-and-pr-secondary-cluster)
+**Yes**    | [Manual entity merges sent to a PR secondary cluster are not persisted to storage](/vault/docs/v1.17.x/updates/important-changes#manual-entity-merges-sent-to-a-pr-secondary-cluster-are-not-persisted-to-storage)
+**Yes**    | [PKI OCSP GET requests can return HTTP redirect responses](/vault/docs/v1.17.x/updates/important-changes#pki-ocsp)
+No         | [Authorization failure with Azure federated identity credentials](/vault/docs/v1.17.x/updates/important-changes#authorization-failures-using-azure-federated-identity-credentials)

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -938,6 +938,10 @@
         "path": "upgrade/replicated-deployment"
       },
       {
+        "title": "LTS Vault upgrades",
+        "path": "upgrade/lts-upgrade"
+      },
+      {
         "title": "Rollback an upgrade",
         "path": "upgrade/rollback"
       },


### PR DESCRIPTION
* draft lts summary

* tweak language to avoid specific version numbers

* markdown cleanup

* tweak language

* break up tables

* another language tweak

### Description
What does this PR do?

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
