### PR TITLE
Update Docs to Include Notice that Audience is Required in K8s Roles

### DIFF
--- a/website/content/api-docs/auth/kubernetes.mdx
+++ b/website/content/api-docs/auth/kubernetes.mdx
@@ -146,10 +146,10 @@ entities attempting to login.
   [LabelSelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#labelselector-v1-meta). Currently, label selectors with `matchExpressions` are not supported.
   To use label selectors, **Vault must have permission to read namespaces** on the Kubernetes
   cluster. If set with `bound_service_account_namespaces`, the conditions are `OR`ed.
-- `audience` `(string: "")` - Optional Audience claim to verify in the JWT.
+- `audience` `(string: "")` - Audience claim to verify in the JWT. Will be required in Vault 1.21+.
 - `alias_name_source` `(string: "serviceaccount_uid")` - Configures how identity aliases are generated.
   Valid choices are: `serviceaccount_uid` and `serviceaccount_name`.
-  
+
   When you specify `serviceaccount_uid`, Vault uses a machine generated UID from
   the service account as the identity alias name. Using a service account UID is
   both the default and the recommended method as it the more secure option.

--- a/website/content/docs/auth/kubernetes.mdx
+++ b/website/content/docs/auth/kubernetes.mdx
@@ -107,8 +107,12 @@ management tool.
       bound_service_account_names=myapp \
       bound_service_account_namespaces=default \
       policies=default \
+      audience=myapp \
       ttl=1h
   ```
+
+  !> **Note:** `audience` will be a required field in Vault 1.21+. This field is used
+  to verify the JWT token's audience claim.
 
   This role authorizes the "myapp" service account in the default
   namespace and it gives it the default policy.


### PR DESCRIPTION
Currently, Vault's Kubernetes authentication method does not require roles to specify an audience. As a result, an attacker could potentially craft a malicious JWT from a compromised or rogue Kubernetes cluster and use it to authenticate against Vault, especially if the associated cluster does not validate the `aud` claim.

There has been a [PR](https://github.com/hashicorp/vault-plugin-auth-kubernetes/pull/301) that logs a warning when a user creates a role without an audience and there are [plans](https://github.com/hashicorp/vault-plugin-auth-kubernetes/pull/300) to make the `audience` field required in the 1.21 release. This PR updates the docs so that users know that future versions of Vault will require the `audience` field in k8s roles.

