### PR TITLE
UI: update kv tooltip test

### DIFF
--- a/ui/tests/acceptance/secret-engine-list-view-test.js
+++ b/ui/tests/acceptance/secret-engine-list-view-test.js
@@ -99,9 +99,18 @@ module('Acceptance | secret-engine list view', function (hooks) {
   test('hovering over the icon of a kv engine shows engine name and version', async function (assert) {
     await visit('/vault/secrets');
 
-    await selectChoose(GENERAL.searchSelect.trigger('filter-by-engine-type'), 'kv');
+    await page.enableEngine();
+    await click(MOUNT_BACKEND_FORM.mountType('kv'));
+    await fillIn(GENERAL.inputByAttr('path'), `kv-${this.uid}`);
+    await click(GENERAL.submitButton);
+    await click(GENERAL.breadcrumbLink('Secrets'));
+
+    await selectChoose(GENERAL.searchSelect.trigger('filter-by-engine-name'), `kv-${this.uid}`);
     await triggerEvent('.hds-tooltip-button', 'mouseenter');
     assert.dom('.hds-tooltip-container').hasText('KV version 2', 'shows tooltip for kv version 2');
+
+    // cleanup
+    await runCmd(deleteEngineCmd('kv'));
   });
 
   test('enterprise: cannot view list without permissions inside namespace', async function (assert) {


### PR DESCRIPTION
### Description
What does this PR do?

Fixing failing kv tooltip test - updating to create it with uid / filter dropdown select by engine name instead of type.

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
