### PR TITLE
Revert "Perform an immediate check when starting the seal health check. 

### DIFF
--- a/vault/seal/seal.go
+++ b/vault/seal/seal.go
@@ -112,7 +112,7 @@ func (sgi *SealGenerationInfo) Validate(existingSgi *SealGenerationInfo, hasPart
 	}
 
 	if !previousShamirConfigured && (!existingSgi.IsRewrapped() || hasPartiallyWrappedPaths) && os.Getenv("VAULT_SEAL_REWRAP_SAFETY") != "disable" {
-		return errors.New("cannot make seal config changes while seal rewrap is in progress, please revert any seal configuration changes")
+		return errors.New("cannot make seal config changes while seal re-wrap is in progress, please revert any seal configuration changes")
 	}
 
 	numSealsToAdd := 0

--- a/vault/seal_autoseal.go
+++ b/vault/seal_autoseal.go
@@ -541,7 +541,6 @@ error and restart Vault.`)
 			d.allSealsHealthy = allHealthy
 		}
 
-		check(time.Now())
 		for {
 			select {
 			case <-healthCheckStop:


### PR DESCRIPTION
Revert "Perform an immediate check when starting the seal health check. (#31030)

This reverts commit 12bd92059ed57be7eed66ca1c41ab521d3b2562a.

Reverting as there are failures in some of the back port PRs.

### Description
What does this PR do?

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
