### PR TITLE
enos(consul): only use versions that are CE and ENT

### DIFF
--- a/enos/enos-globals.hcl
+++ b/enos/enos-globals.hcl
@@ -17,7 +17,7 @@ globals {
   }
   config_modes    = ["env", "file"]
   consul_editions = ["ce", "ent"]
-  consul_versions = ["1.18.11", "1.19.8", "1.20.6", "1.21.0"]
+  consul_versions = ["1.18.2", "1.19.2", "1.20.6", "1.21.1"]
   distros         = ["amzn", "leap", "rhel", "sles", "ubuntu"]
   // Different distros may require different packages, or use different aliases for the same package
   distro_packages = {


### PR DESCRIPTION
### Description
Right now our logic for consul doesn't consider whether or not the version is available for ent or ce. Make sure that the versions we used are available for both.


### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
