### PR TITLE
Development cluster known issue

### DIFF
--- a/website/content/docs/updates/important-changes.mdx
+++ b/website/content/docs/updates/important-changes.mdx
@@ -157,3 +157,18 @@ confusion interpreting audit logs.
 
 Send check-in requests directly to the active node of the primary cluster to prevent duplicate password
 rotations on the LDAP server.
+
+### Development Cluster Setting Overwritten on Secondary Cluster Reload
+
+| Change       | Affected version | Fixed version
+| ------------ |------------------| --------------------
+| Known issue  | 1.20.0           | N/A
+
+If a performance replication secondary is reloaded by sending a `SIGHUP` to the Vault process, the cluster will start
+to use the `development_cluster` value set in its HCL configuration when reporting license utilization, instead of following
+the value configured on the primary as expected.
+
+#### Recommendation:
+
+Ensure all clusters in a performance replication group have the same `development_cluster` value configured in HCL to
+prevent unexpected changes to the reported value.

--- a/website/content/docs/updates/important-changes.mdx
+++ b/website/content/docs/updates/important-changes.mdx
@@ -158,7 +158,7 @@ confusion interpreting audit logs.
 Send check-in requests directly to the active node of the primary cluster to prevent duplicate password
 rotations on the LDAP server.
 
-### Development Cluster Setting Overwritten on Secondary Cluster Reload
+### Development Cluster Setting Overwritten on Secondary Cluster Reload ((#development-cluster-reload))
 
 | Change       | Affected version | Fixed version
 | ------------ |------------------| --------------------

--- a/website/content/partials/release-notes/change-summary/1_20.mdx
+++ b/website/content/partials/release-notes/change-summary/1_20.mdx
@@ -10,3 +10,4 @@ Found  | Recommendations | Edition    | Issue
 Found  | Fixed  | Workaround | Edition    | Issue
 ------ |------- | ---------- | ---------- | -----
 1.20.0 | No     | **Yes**    | All        | [Duplicate unseal/seal wrap HSM keys](/vault/docs/v1.20.x/updates/important-changes#hsm-keys)
+1.20.0 | No     | **Yes**    | Enterprise | [Development cluster setting overwritten on secondary cluster reload](/vault/docs/v1.20.x/updates/important-changes#development-cluster-reload)


### PR DESCRIPTION
### Description
Add a known issue for https://hashicorp.atlassian.net/browse/VAULT-37317 for 1.20.0. Note this is already fixed in https://github.com/hashicorp/vault-enterprise/pull/8325. 

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
