### PR TITLE
[VAULT-34486] Docs: fix broken images

### DIFF
--- a/website/content/docs/ui/namespaces.mdx
+++ b/website/content/docs/ui/namespaces.mdx
@@ -32,10 +32,9 @@ For guidance on structuring namespaces, see [Best practices for namespaces and m
 1. Click **Create namespace +**.
 1. Enter a unique name for your new namespace.
 1. Click **Save** to create the namespace.
-<figure>
-  <img src="/img/save-namespace.png" alt="Save namespace" />
-  <figcaption>Create namespace form in the Vault UI</figcaption>
-</figure>
+
+![Save namespace](/img/save-namespace.png)
+**Create namespace form in the Vault UI**
 
 ## Create a nested namespace
 
@@ -73,10 +72,9 @@ guide.
 1. Click **Confirm** on the **Delete this namespace?** confirmation modal.
 
 
-<figure>
-  <img src="/img/delete-namespace.png" alt="Delete namespace" />
-  <figcaption>Delete namespace option in the Vault GUI</figcaption>
-</figure>
+
+![Delete namespace](/img/delete-namespace.png)
+**Delete namespace option in the Vault GUI**
 
 ## Switch between namespaces from "Manage Namespace"
 
@@ -86,10 +84,9 @@ guide.
 1. Select **Switch to namespace** from the option menu to change your namespace
    context.
 
-<figure>
-  <img src="/img/switch-to-namespace.png" alt="Switch to namespace" />
-  <figcaption>Switch to namespace option in the Vault UI</figcaption>
-</figure>
+
+![Switch to namespace](/img/switch-to-namespace.png)
+**Switch to namespace option in the Vault UI**
 
 ## Switch between namespaces using the namespace picker
 
@@ -105,7 +102,6 @@ the namespace picker search bar and press <strong>Enter</strong> to switch your 
 context.
 </Tip>
 
-<figure>
-  <img src="/img/namespace-picker.png" alt="Namespace picker" />
-  <figcaption>Searching for a nested namespace path in the Namespace picker</figcaption>
-</figure>
+
+![Namespace picker](/img/namespace-picker.png)
+**Searching for a nested namespace path in the Namespace picker**


### PR DESCRIPTION
### Description
What does this PR do?
- [x] fix broken images in manage namespaces 1.20.x docs

| BEFORE | AFTER |
| -- | -- |
| ![screencapture-developer-hashicorp-vault-docs-v1-20-x-ui-namespaces-2025-06-23-14_33_04](https://github.com/user-attachments/assets/7f01394f-b79a-46fd-bf95-adfb414cca24) | ![screencapture-localhost-3000-vault-docs-v1-20-x-ui-namespaces-2025-06-23-14_33_22](https://github.com/user-attachments/assets/19e20155-4d26-409c-865c-58811f016d84) |

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
