### PR TITLE
UI: A11y fix for disabled swagger interarctive

### DIFF
--- a/ui/lib/open-api-explorer/addon/components/swagger-ui.js
+++ b/ui/lib/open-api-explorer/addon/components/swagger-ui.js
@@ -130,12 +130,14 @@ export default class SwaggerUiComponent extends Component {
       this.observer = new MutationObserver(() => {
         this.updateCaretTabIndex();
         this.updateCopyToClipboard();
+        this.updateDisabledFields();
         this.updateTryItOutButtonDescription();
       });
       this.observer.observe(container, { childList: true, subtree: true });
       // Run once on initial load
       this.updateCaretTabIndex();
       this.updateCopyToClipboard();
+      this.updateDisabledFields();
       this.updateTryItOutButtonDescription();
     }
   }
@@ -159,6 +161,13 @@ export default class SwaggerUiComponent extends Component {
           e.preventDefault();
         }
       });
+    });
+  }
+
+  updateDisabledFields() {
+    document.querySelectorAll('.parameters :disabled').forEach((el) => {
+      el.removeAttribute('disabled');
+      el.setAttribute('readonly', true);
     });
   }
 

--- a/ui/mirage/factories/open-api-explorer.js
+++ b/ui/mirage/factories/open-api-explorer.js
@@ -36,6 +36,30 @@ export default Factory.extend({
           },
         },
       },
+      'auth/token/roles/{role_name}': {
+        description: '',
+        get: {
+          summary: '',
+          tags: ['auth'],
+          operationId: 'token-read-role',
+          parameters: [
+            {
+              name: 'role_name',
+              required: true,
+              in: 'path',
+              schema: {
+                type: 'string',
+              },
+              description: 'Name of the role',
+            },
+          ],
+          responses: {
+            200: {
+              description: 'OK',
+            },
+          },
+        },
+      },
       '/secret/data/{path}': {
         description: 'Location of a secret.',
         post: {

--- a/ui/tests/integration/components/open-api-explorer/swagger-ui-test.js
+++ b/ui/tests/integration/components/open-api-explorer/swagger-ui-test.js
@@ -16,7 +16,7 @@ import { camelize } from '@ember/string';
 const SELECTORS = {
   container: '[data-test-swagger-ui]',
   searchInput: 'input.operation-filter-input',
-  apiPathBlock: '.opblock-post',
+  apiPathBlock: '.opblock',
   operationId: '.opblock-summary-operation-id',
   controlArrowButton: '.opblock-control-arrow',
   copyButton: '.copy-to-clipboard',
@@ -105,8 +105,13 @@ module('Integration | Component | open-api-explorer | swagger-ui', function (hoo
     });
     assert.dom(SELECTORS.copyButton).hasAttribute('tabindex', '0');
 
-    await click(SELECTORS.controlArrowButton);
+    const controlArrowButton = document.querySelectorAll(SELECTORS.controlArrowButton)[1];
+    await click(controlArrowButton);
     await waitFor(SELECTORS.tryItOutButton);
+
+    const input = document.querySelector('.parameters input:read-only');
+    assert.dom(input).exists('parameter input is readonly');
+
     assert
       .dom(SELECTORS.tryItOutButton)
       .hasAttribute(
@@ -134,8 +139,12 @@ module('Integration | Component | open-api-explorer | swagger-ui', function (hoo
     });
     assert.dom(SELECTORS.copyButton).hasAttribute('tabindex', '0');
 
-    await click(SELECTORS.controlArrowButton);
+    const controlArrowButton = document.querySelectorAll(SELECTORS.controlArrowButton)[1];
+    await click(controlArrowButton);
     await waitFor(SELECTORS.tryItOutButton);
+
+    const input = document.querySelector('.parameters input:read-only');
+    assert.dom(input).exists('parameter input is readonly');
     assert
       .dom(SELECTORS.tryItOutButton)
       .hasAttribute(

--- a/ui/tests/integration/components/open-api-explorer/swagger-ui-test.js
+++ b/ui/tests/integration/components/open-api-explorer/swagger-ui-test.js
@@ -66,7 +66,7 @@ module('Integration | Component | open-api-explorer | swagger-ui', function (hoo
 
     setNativeInputValue('token');
     assert.dom(SELECTORS.searchInput).hasValue('token', 'search input has value');
-    assert.dom(SELECTORS.apiPathBlock).exists({ count: 1 }, 'renders filtered api paths');
+    assert.dom(SELECTORS.apiPathBlock).exists({ count: 2 }, 'renders filtered api paths');
   });
 
   test('it should render camelized operation ids', async function (assert) {
@@ -127,7 +127,7 @@ module('Integration | Component | open-api-explorer | swagger-ui', function (hoo
 
     await this.renderComponent();
 
-    setNativeInputValue('secret');
+    setNativeInputValue('token');
 
     await waitUntil(() => {
       return document.querySelector(SELECTORS.controlArrowButton).getAttribute('tabindex') === '0';


### PR DESCRIPTION
### Description
This PR addresses a severe accessibility concern on the swagger ui page. 

**Problem**: Parameter inputs are disabled until the `Try it out` button is clicked which makes them inaccessible to keyboard users or screen readers. 

 **Solution**: After the swagger ui completes rendering and an operation block is expanded, the parameter input's `disabled` attribute will be removed and replaced with `readonly`. This preserves the original behavior of making the inputs immutable until the `Try it out` button is clicked, but makes them accessible.

Tests have also been updated confirming these a11y fixes are applied. This will protect us in the instance that we upgrade the swagger version and an assumption we're making about the HTML breaks the a11y fixes. 

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
