### PR TITLE
UI: Address swagger invalid color contrast

### DIFF
--- a/ui/app/styles/utils/swagger.scss
+++ b/ui/app/styles/utils/swagger.scss
@@ -1,4 +1,5 @@
 @use '../utils/size_variables';
+@use '../utils/color_variables';
 
 /**
  * Copyright (c) HashiCorp, Inc.
@@ -10,6 +11,46 @@
 /* align list items with container */
 .swagger-ember .swagger-ui .wrapper {
   padding: 0;
+
+  .info a {
+    color: color_variables.$blue-700;
+  }
+
+  .title {
+    small {
+      background-color: color_variables.$ui-gray-800;
+    }
+    .version-stamp {
+      background-color: color_variables.$green-700;
+    }
+  }
+
+  .opblock-deprecated {
+    opacity: 1;
+
+    .opblock-summary-method {
+      background-color: color_variables.$ui-gray-700;
+    }
+  }
+
+  .opblock-get {
+    .opblock-summary-method {
+      background-color: color_variables.$blue-500;
+    }
+  }
+
+  .opblock-post,
+  .opblock-patch {
+    .opblock-summary-method {
+      background-color: color_variables.$green-700;
+    }
+  }
+
+  .opblock-delete {
+    .opblock-summary-method {
+      background-color: color_variables.$red-500;
+    }
+  }
 
   .opblock-summary-path-description-wrapper {
     width: min-content;
@@ -24,9 +65,9 @@
     }
   }
 
-  .copy-to-clipboard 
-  {
-    &:focus, &:focus-visible {
+  .copy-to-clipboard {
+    &:focus,
+    &:focus-visible {
       width: size_variables.$size-4;
     }
   }


### PR DESCRIPTION
### Description
This PR fixes insufficient color-contrast swagger ui page. 

Updates:
* Version badge colors
* Link text color
* `GET`, `POST`, `PATCH`, `DELETE` + `DEPRECATED` operation backgrounds

### Before:
<img width="794" alt="image" src="https://github.com/user-attachments/assets/611ee513-0a36-48b2-8151-c82f175df1da" />
<img width="801" alt="image" src="https://github.com/user-attachments/assets/7fa9161c-b8e7-474b-8746-595411f9ae43" />
<img width="801" alt="image" src="https://github.com/user-attachments/assets/15fc93db-4e47-43d2-a1a6-f44404292d7a" />

### After: 
<img width="793" alt="image" src="https://github.com/user-attachments/assets/a97b886e-5d70-4e84-8d82-785c5d280030" />
<img width="802" alt="image" src="https://github.com/user-attachments/assets/9ff756d2-74fb-463f-9268-4ac3da33b420" />
<img width="793" alt="image" src="https://github.com/user-attachments/assets/f5970c19-cb5c-4eea-b69e-3e37224bc5db" />


### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
