### PR TITLE
fix kms config overrides

### DIFF
--- a/internalshared/configutil/kms.go
+++ b/internalshared/configutil/kms.go
@@ -267,10 +267,13 @@ func mergeKMSEnvConfig(configKMS *KMS) error {
 		}
 	} else {
 		for name, val := range envConfig {
-			var err error
-			configKMS.Config[name], err = normalizeKMSSealConfigAddrs(configKMS.Type, name, val)
-			if err != nil {
-				return err
+			// Only use environment variable if config file doesn't already have this value
+			if configKMS.Config[name] == "" {
+				var err error
+				configKMS.Config[name], err = normalizeKMSSealConfigAddrs(configKMS.Type, name, val)
+				if err != nil {
+					return err
+				}
 			}
 		}
 	}


### PR DESCRIPTION
### Description
Fix awskms config override with env vars, which cause issues when the kms key is in a different region then the current one.

