### PR TITLE
UI: Fix failing secret engine ENT tests with ns

### DIFF
--- a/ui/tests/acceptance/secret-engine-list-view-test.js
+++ b/ui/tests/acceptance/secret-engine-list-view-test.js
@@ -115,11 +115,14 @@ module('Acceptance | secret-engine list view', function (hooks) {
 
   test('enterprise: cannot view list without permissions inside namespace', async function (assert) {
     this.version = 'enterprise';
-    const enginePath1 = `kv-${this.uid}`;
-    await runCmd(mountEngineCmd('kv', enginePath1));
     this.namespace = `ns-${this.uid}`;
+
+    const enginePath1 = `kv-${this.uid}`;
+    const userDefault = await runCmd(createTokenCmd()); // creates default user token
+    await runCmd(mountEngineCmd('kv', enginePath1));
+
     await runCmd([`write sys/namespaces/${this.namespace} -force`]);
-    await loginNs(this.namespace, createTokenCmd());
+    await loginNs(this.namespace, userDefault);
 
     await visit('/vault/secrets');
     assert.strictEqual(currentURL(), `/vault/secrets`, 'Should be on main secret engines list page.');

--- a/ui/tests/acceptance/secret-engine-list-view-test.js
+++ b/ui/tests/acceptance/secret-engine-list-view-test.js
@@ -137,8 +137,6 @@ module('Acceptance | secret-engine list view', function (hooks) {
     await visit('/vault/secrets');
     assert.strictEqual(currentURL(), `/vault/secrets`, 'Should be on main secret engines list page.');
 
-    // await this.pauseTest();
-
     assert.dom(SES.secretsBackendLink(enginePath1)).exists();
     // cleanup
     await runCmd(deleteEngineCmd(enginePath1));

--- a/ui/tests/acceptance/secret-engine-list-view-test.js
+++ b/ui/tests/acceptance/secret-engine-list-view-test.js
@@ -137,6 +137,10 @@ module('Acceptance | secret-engine list view', function (hooks) {
       'Should be on main secret engines list page within namespace.'
     );
     assert.dom(SES.secretsBackendLink(enginePath1)).doesNotExist(); // without permissions, engine should not show for this user
+
+    // cleanup namespace
+    await login();
+    await runCmd(`delete sys/namespaces/${this.namespace}`);
   });
 
   test('enterprise: can view list with permissions inside a namespace', async function (assert) {
@@ -165,6 +169,10 @@ module('Acceptance | secret-engine list view', function (hooks) {
     );
 
     assert.dom(SES.secretsBackendLink(enginePath1)).exists(); // with permissions, able to see the engine in list
+
+    // cleanup namespace
+    await login();
+    await runCmd(`delete sys/namespaces/${this.namespace}`);
   });
 
   test('after disabling it stays on the list view', async function (assert) {


### PR DESCRIPTION
### Description
What does this PR do?

Fixes failing ENT tests with asserting secret engines being shown to a user according to namespace permission

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
