### PR TITLE
VAULT-36611 remove goleak test

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -218,7 +218,6 @@ require (
 	go.opentelemetry.io/otel/sdk v1.35.0
 	go.opentelemetry.io/otel/trace v1.35.0
 	go.uber.org/atomic v1.11.0
-	go.uber.org/goleak v1.3.0
 	golang.org/x/crypto v0.38.0
 	golang.org/x/exp v0.0.0-20250531010427-b6e5de432a8b
 	golang.org/x/net v0.40.0

--- a/vault/quotas/quotas_rate_limit_test.go
+++ b/vault/quotas/quotas_rate_limit_test.go
@@ -14,10 +14,8 @@ import (
 	log "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/vault/helper/metricsutil"
 	"github.com/hashicorp/vault/sdk/helper/logging"
-	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
-	"go.uber.org/goleak"
 )
 
 type clientResult struct {
@@ -215,24 +213,6 @@ func TestRateLimitQuota_Allow_WithBlock(t *testing.T) {
 			}
 		}
 	}()
-}
-
-func TestRateLimitQuota_Update(t *testing.T) {
-	t.Skipf("See: https://hashicorp.atlassian.net/browse/VAULT-36611?focusedCommentId=746927")
-	defer goleak.VerifyNone(t)
-	qm, err := NewManager(logging.NewVaultLogger(log.Trace), nil, metricsutil.BlackholeSink(), true)
-	require.NoError(t, err)
-
-	view := &logical.InmemStorage{}
-	require.NoError(t, qm.Setup(context.Background(), view, nil))
-
-	quota := NewRateLimitQuota("quota1", "", "", "", "", GroupByIp, false, time.Second, 0, 10, 0)
-	quotaUpdate := quota.Clone()
-	require.NoError(t, qm.SetQuota(context.Background(), TypeRateLimit.String(), quota, true))
-	require.NoError(t, qm.SetQuota(context.Background(), TypeRateLimit.String(), quotaUpdate, true))
-
-	require.Nil(t, quota.close(context.Background()))
-	require.Nil(t, quotaUpdate.close(context.Background()))
 }
 
 // TestRateLimitQuota_retryAfterSeconds tests the that retryAfterSeconds rounds


### PR DESCRIPTION
### Description

This test has been sporadically failing and after some investigation we are fairly confident this is not actual issue, but just an artifact of trying to inspect go internal stuff. As we won't be putting any more time into the investigation I'm removing the test entirely, as well as the goleak library which was only used in this one test.

Another argument for removing it is that it's basically testing the library behavior, that when close is called it should stop the goroutines spawned.

Jira: [VAULT-36611](https://hashicorp.atlassian.net/browse/VAULT-36611)

### TODO only if you're a HashiCorp employee
- [-] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [-] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [-] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [-] **RFC:** If this change has an associated RFC, please link it in the description.
- [-] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.


[VAULT-36611]: https://hashicorp.atlassian.net/browse/VAULT-36611?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ