### PR TITLE
UI: Render description when multiple mounts are visible

### DIFF
--- a/ui/app/components/auth/tabs.hbs
+++ b/ui/app/components/auth/tabs.hbs
@@ -14,11 +14,14 @@
         {{#if (and mounts (eq @selectedAuthMethod methodType))}}
           {{#if (gt mounts.length 1)}}
             {{! DROPDOWN for mount paths }}
-            <Hds::Form::Select::Field name="path" data-test-select="path" as |F|>
+            <Hds::Form::Select::Field name="path" data-test-select="path" {{on "change" this.setMount}} as |F|>
               <F.Label>Mount path</F.Label>
+              {{#if this.mountDescription}}
+                <F.HelperText data-test-description>{{this.mountDescription}}</F.HelperText>
+              {{/if}}
               <F.Options>
                 {{#each mounts as |mount|}}
-                  <option value={{mount.path}}>{{mount.path}}</option>
+                  <option value={{mount.path}} selected={{eq mount.path this.selectedMountPath}}>{{mount.path}}</option>
                 {{/each}}
               </F.Options>
             </Hds::Form::Select::Field>

--- a/ui/app/components/auth/tabs.ts
+++ b/ui/app/components/auth/tabs.ts
@@ -5,8 +5,10 @@
 
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
 
 import type { UnauthMountsByType } from 'vault/vault/auth/form';
+import type { HTMLElementEvent } from 'vault/forms';
 
 interface Args {
   authTabData: UnauthMountsByType;
@@ -15,6 +17,20 @@ interface Args {
 }
 
 export default class AuthTabs extends Component<Args> {
+  @tracked selectedMountPath = '';
+
+  constructor(owner: unknown, args: Args) {
+    super(owner, args);
+    this.setSelectedMountPath();
+  }
+
+  get mountDescription() {
+    const selectedAuth = this.args.selectedAuthMethod;
+    const mounts = this.args.authTabData[selectedAuth];
+    const mount = mounts?.find((m) => m.path === this.selectedMountPath);
+    return mount?.description ?? '';
+  }
+
   get tabTypes() {
     return this.args.authTabData ? Object.keys(this.args.authTabData) : [];
   }
@@ -26,7 +42,21 @@ export default class AuthTabs extends Component<Args> {
   }
 
   @action
-  onClickTab(_event: Event, idx: number) {
-    this.args.handleTabClick(this.tabTypes[idx]);
+  onClickTab(_event: HTMLElementEvent<HTMLInputElement>, idx: number) {
+    const newMethod = this.tabTypes[idx];
+    this.args.handleTabClick(newMethod);
+    // Reset selected mount path when tab changes
+    this.setSelectedMountPath();
+  }
+
+  @action
+  setMount(event: HTMLElementEvent<HTMLInputElement>) {
+    this.selectedMountPath = event.target.value;
+  }
+
+  private setSelectedMountPath() {
+    const mounts = this.args.authTabData[this.args.selectedAuthMethod];
+    const firstMount = mounts?.length ? mounts[0] : null;
+    this.selectedMountPath = firstMount?.path ?? '';
   }
 }

--- a/ui/app/styles/helper-classes/spacing.scss
+++ b/ui/app/styles/helper-classes/spacing.scss
@@ -70,20 +70,16 @@
   padding-bottom: size_variables.$spacing-24;
 }
 
-.has-top-padding-xs {
-  padding-top: size_variables.$spacing-8;
-}
-
 .top-padding-4 {
   padding-top: size_variables.$spacing-4;
 }
 
-.top-padding-10 {
-  padding-top: size_variables.$spacing-10;
+.has-top-padding-xs {
+  padding-top: size_variables.$spacing-8;
 }
 
-.has-bottom-padding-4 {
-  padding-bottom: size_variables.$spacing-4;
+.top-padding-10 {
+  padding-top: size_variables.$spacing-10;
 }
 
 .has-top-padding-s {

--- a/ui/tests/integration/components/auth/tabs-test.js
+++ b/ui/tests/integration/components/auth/tabs-test.js
@@ -5,7 +5,7 @@
 
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { click, findAll, render } from '@ember/test-helpers';
+import { click, fillIn, findAll, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import sinon from 'sinon';
 import { AUTH_FORM } from 'vault/tests/helpers/auth/auth-form-selectors';
@@ -19,13 +19,13 @@ module('Integration | Component | auth | tabs', function (hooks) {
       userpass: [
         {
           path: 'userpass/',
-          description: '',
+          description: 'platform team only',
           options: {},
           type: 'userpass',
         },
         {
           path: 'userpass2/',
-          description: '',
+          description: 'backup login method',
           options: {},
           type: 'userpass',
         },
@@ -78,12 +78,6 @@ module('Integration | Component | auth | tabs', function (hooks) {
     assert.dom(AUTH_FORM.tabBtn('userpass')).hasAttribute('aria-selected', 'true');
   });
 
-  test('it renders the mount description', async function (assert) {
-    this.selectedAuthMethod = 'token';
-    await this.renderComponent();
-    assert.dom(AUTH_FORM.description).hasText('token based credentials');
-  });
-
   test('it renders a dropdown if multiple mount paths are returned', async function (assert) {
     this.selectedAuthMethod = 'userpass';
     await this.renderComponent();
@@ -92,6 +86,54 @@ module('Integration | Component | auth | tabs', function (hooks) {
     expectedPaths.forEach((p) => {
       assert.true(dropdownOptions.includes(p), `dropdown includes path: ${p}`);
     });
+  });
+
+  test('it renders a description for the selected mount path', async function (assert) {
+    // if a method type does not have any mounts with listing_visibility="unauth" its value is `null`
+    // add a tab that has no mount data
+    this.tabData.ldap = null;
+    // update selected method and re-render component when a tab is clicked
+    this.handleTabClick = async (selection) => {
+      this.selectedAuthMethod = selection;
+      await this.renderComponent();
+    };
+    this.selectedAuthMethod = 'userpass';
+
+    await this.renderComponent();
+    assert
+      .dom(GENERAL.selectByAttr('path'))
+      .hasValue('userpass/', 'it preselects first mount for "userpass"');
+    assert.dom(AUTH_FORM.description).hasText('platform team only', 'it renders the mount description');
+    await fillIn(GENERAL.selectByAttr('path'), 'userpass2/');
+    assert.dom(GENERAL.selectByAttr('path')).hasValue('userpass2/', 'it selects the second mount');
+    assert
+      .dom(AUTH_FORM.description)
+      .hasText('backup login method', 'it renders relevant description when mount dropdown updates');
+    // select a different tab
+    await click(AUTH_FORM.tabBtn('token'));
+    assert
+      .dom(AUTH_FORM.description)
+      .hasText('token based credentials', 'it updates the mount description when a new tab is selected');
+    // select method without a description
+    await click(AUTH_FORM.tabBtn('oidc'));
+    assert.dom(AUTH_FORM.tabBtn('oidc')).hasAttribute('aria-selected', 'true');
+    assert.dom(GENERAL.inputByAttr('path')).hasValue('my_oidc/');
+    assert.dom(AUTH_FORM.description).doesNotExist();
+    // select method with no mount data
+    await click(AUTH_FORM.tabBtn('ldap'));
+    assert.dom(AUTH_FORM.tabBtn('ldap')).hasAttribute('aria-selected', 'true');
+    assert.dom(GENERAL.inputByAttr('path')).doesNotExist();
+    assert.dom(AUTH_FORM.description).doesNotExist();
+  });
+
+  test('it does not render a description if only one tab exists and it does not have mount data', async function (assert) {
+    // if a method type does not have any mounts with listing_visibility="unauth" its value is `null`
+    this.tabData = { userpass: null };
+    this.selectedAuthMethod = 'userpass';
+    await this.renderComponent();
+    assert.dom(AUTH_FORM.tabBtn('userpass')).hasAttribute('aria-selected', 'true');
+    assert.dom(GENERAL.inputByAttr('path')).doesNotExist();
+    assert.dom(AUTH_FORM.description).doesNotExist();
   });
 
   test('it renders hidden input if only one mount path is returned', async function (assert) {


### PR DESCRIPTION
### Description
Now when multiple mounts are configured with `listing_visibility="unauth"` each of their description renders as `HelperText` beneath the input label. This was was lower priority since we expect most users don't have multiple mounts tuned to be visible, but an ideal improvement to show any descriptions if they are set!

<hr>

<img width="400" alt="Screenshot 2025-06-26 at 10 37 18 AM" src="https://github.com/user-attachments/assets/9ee49fa9-e649-4bab-ba96-c9520b25b0aa" />
<img width="400" alt="Screenshot 2025-06-26 at 10 37 30 AM" src="https://github.com/user-attachments/assets/269d8080-e470-4524-b482-3297722c3aff" />


### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
