### PR TITLE
[VAULT-34827]: pipeline(actions): add workflow to trigger the enterprise pull request copier

### DIFF
--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -6,14 +6,11 @@ self-hosted-runner:
   labels:
     - small
     - medium
-    - large
     - ondemand
     - disk_gb=64
     - os=linux
     - type=m5.2xlarge
     - type=c6a.xlarge
     - type=c6a.4xlarge
-    - ubuntu-20.04
-    - custom-linux-small-vault-latest
-    - custom-linux-medium-vault-latest
+    - ubuntu-latest-x64
     - custom-linux-xl-vault-latest

--- a/.github/workflows/copy-external-contributor-pull-request-ce.yml
+++ b/.github/workflows/copy-external-contributor-pull-request-ce.yml
@@ -1,0 +1,50 @@
+name: copy-external-contributor-pull-request-ce
+
+# NOTE: Don't ever set up concurrency groups. We never want this workflow to
+# be cancelled.
+
+on:
+  #  TODO: VAULT-34830: Enable the external contributor job for community pull requests
+  #  pull_request:
+  #    types:
+  #      # We only need to trigger this on opened as it will have a manual
+  #      # deployment approval that is good for 30 days. If we exhaust that there
+  #      # are two courses of action:
+  #      #   * Close and re-open the PR and it will trigger it again.
+  #      #   * Manually run this workflow from the actions UI and provide the
+  #      #     pull request number
+  #      - opened
+  #      - reopened
+  workflow_dispatch:
+    inputs:
+      number:
+        type: string
+        description: The pull request number to copy to enterprise
+        required: true
+
+jobs:
+  copy:
+    name: Copy community contributed pull request to Vault Enterprise
+    # Only run this on pull requests that originate from a fork (community
+    # contributed) or has intentionally been dispatched.
+    if: |
+      github.repository == 'hashicorp/vault' &&
+      github.event_name == 'workflow_dispatch' ||
+      github.event.pull_request.head.repo.fork
+    # Use the community-pull-request environment so that we invoke the deployment
+    # protection rules. In this case those rules require someone in
+    # @hashicorp/github-secure-vault-core to approve the workflow.
+    # When approved we'll initiate the copy job in vault-enterprise.
+    environment: community-pull-request
+    runs-on: ubuntu-latest
+    steps:
+      - id: payload
+        run: |
+          echo 'payload={"number":"${{ github.event.number || inputs.number }}"}' | tee -a "$GITHUB_OUTPUT"
+      - name: Trigger backport for Enterprise
+        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3.0.0
+        with:
+          token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
+          repository: hashicorp/vault-enterprise
+          event-type: copy-community-pull-request
+          client-payload: ${{ steps.payload.outputs.payload }}


### PR DESCRIPTION
### Description
A follow-up to https://github.com/hashicorp/vault/pull/31095 that creates a "deployment" that will trigger the pull request copy workflow in enterprise.

As this is intended to be a `repository_dispatch` into `vault/enterprise` we'll need to hold off merging it until after the corresponding enterprise pull request has been merged. We also have two other considerations. The first is that we expect this to normally be triggered from fork PR's, but we don't actually want to turn this on until after the migration to the new workflow. That leaves us with `workflow_dispatch` as an adhoc way to test before then. However, `workflow_dispatch` jobs are required to be on main before you can run them (🐔 meet 🥚), so we have to merge this to test it 🙃.

As this will only be run on active CE branches we only need to backport it to `release/1.20.x`, which I intend to do manually as anticipate a follow-up PR to iron the kinks out.

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
