### PR TITLE
Docs: Leases list API corrected required query-strings parameters.

### DIFF
--- a/website/content/api-docs/system/leases.mdx
+++ b/website/content/api-docs/system/leases.mdx
@@ -309,5 +309,5 @@ This endpoint was added in Vault 1.8.
 $ curl \
     --header "X-Vault-Token: ..." \
     --request GET \
-    http://127.0.0.1:8200/v1/sys/leases?type=irrevocable&include_child_namespaces=true
+    "http://127.0.0.1:8200/v1/sys/leases?type=irrevocable&include_child_namespaces=true"
 ```

--- a/website/content/api-docs/system/leases.mdx
+++ b/website/content/api-docs/system/leases.mdx
@@ -275,8 +275,7 @@ This endpoint was added in Vault 1.8.
 $ curl \
     --header "X-Vault-Token: ..." \
     --request GET \
-    http://127.0.0.1:8200/v1/sys/leases/count \
-    -d type=irrevocable
+    http://127.0.0.1:8200/v1/sys/leases/count?type=irrevocable
 ```
 
 ## Leases list
@@ -310,6 +309,5 @@ This endpoint was added in Vault 1.8.
 $ curl \
     --header "X-Vault-Token: ..." \
     --request GET \
-    http://127.0.0.1:8200/v1/sys/leases \
-    -d type=irrevocable
+    http://127.0.0.1:8200/v1/sys/leases?type=irrevocable&include_child_namespaces=true
 ```


### PR DESCRIPTION
The current [Sample request](https://developer.hashicorp.com/vault/api-docs/system/leases#sample-request-8) of the [API: `/sys/leases` & `/sys/leases/count`](https://developer.hashicorp.com/vault/api-docs/system/leases#lease-counts) are not correct where `-d type=irrevocable` should in fact be query-strings like: `?type=irrevocable`.