### PR TITLE
Backport of UI: Fix failing secret engine ENT tests with ns (#31099)

### DIFF
--- a/ui/tests/acceptance/secret-engine-list-view-test.js
+++ b/ui/tests/acceptance/secret-engine-list-view-test.js
@@ -11,8 +11,14 @@ import { v4 as uuidv4 } from 'uuid';
 
 import { GENERAL } from 'vault/tests/helpers/general-selectors';
 import { SECRET_ENGINE_SELECTORS as SES } from 'vault/tests/helpers/secret-engine/secret-engine-selectors';
-import { deleteEngineCmd, mountEngineCmd, runCmd } from 'vault/tests/helpers/commands';
-import { login, loginNs, logout } from 'vault/tests/helpers/auth/auth-helpers';
+import {
+  createTokenCmd,
+  deleteEngineCmd,
+  mountEngineCmd,
+  runCmd,
+  tokenWithPolicyCmd,
+} from 'vault/tests/helpers/commands';
+import { login, loginNs } from 'vault/tests/helpers/auth/auth-helpers';
 import { MOUNT_BACKEND_FORM } from '../helpers/components/mount-backend-form-selectors';
 import page from 'vault/tests/pages/settings/mount-secret-backend';
 
@@ -80,28 +86,60 @@ module('Acceptance | secret-engine list view', function (hooks) {
     await runCmd(deleteEngineCmd('aws'));
   });
 
-  test('enterprise: cannot view list without permissions inside namespace', async function (assert) {
-    this.version = 'enterprise';
-    this.backend = `bk-${this.uid}`;
+  test('enterprise: cannot view list without permissions inside a namespace', async function (assert) {
     this.namespace = `ns-${this.uid}`;
-    await runCmd([`write sys/namespaces/${this.namespace} -force`]);
-    await loginNs(this.namespace, ' ');
+    const enginePath1 = `kv-t1-${this.uid}`;
+    const userDefault = await runCmd(createTokenCmd()); // creates a default user token
 
-    await visit('/vault/secrets');
-    assert.dom(SES.secretsBackendLink('cubbyhole')).doesNotExist();
+    await runCmd([`write sys/namespaces/${this.namespace} -force`]); // creates a namespace
+    await loginNs(this.namespace); //logs into namespace with root token
+    await runCmd(mountEngineCmd('kv', enginePath1)); // mounts a kv engine in namespace
 
-    await logout();
+    await loginNs(this.namespace, userDefault); // logs into that same namespace with a default user token
+
+    await visit(`/vault/secrets?namespace=${this.namespace}`); // nav to specified namespace list
+    assert.strictEqual(
+      currentURL(),
+      `/vault/secrets?namespace=${this.namespace}`,
+      'Should be on main secret engines list page within namespace.'
+    );
+    assert.dom(SES.secretsBackendLink(enginePath1)).doesNotExist(); // without permissions, engine should not show for this user
+
+    // cleanup namespace
+    await login();
+    await runCmd(`delete sys/namespaces/${this.namespace}`);
   });
 
-  test('enterprise: can view list with permissions inside namespace', async function (assert) {
-    this.version = 'enterprise';
-    this.backend = `bk-${this.uid}`;
+  test('enterprise: can view list with permissions inside a namespace', async function (assert) {
     this.namespace = `ns-${this.uid}`;
-    await runCmd([`write sys/namespaces/${this.namespace} -force`]);
-    await loginNs(this.namespace);
-    await visit('/vault/secrets');
+    const enginePath1 = `kv-t2-${this.uid}`;
+    const userToken = await runCmd(
+      tokenWithPolicyCmd(
+        'policy',
+        `path "${this.namespace}/sys/*" {
+          capabilities = ["create", "read", "update", "delete", "list"]
+        }`
+      )
+    );
 
-    assert.dom(SES.secretsBackendLink('cubbyhole')).exists();
+    await runCmd([`write sys/namespaces/${this.namespace} -force`]);
+    await loginNs(this.namespace, userToken); // logs into namespace with user token
+    await runCmd(mountEngineCmd('kv', enginePath1)); // mount kv engine as user
+
+    await loginNs(this.namespace); // logs into namespace with root token
+
+    await visit(`/vault/secrets?namespace=${this.namespace}`); // nav to specified namespace list
+    assert.strictEqual(
+      currentURL(),
+      `/vault/secrets?namespace=${this.namespace}`,
+      'Should be on main secret engines list page within namespace.'
+    );
+
+    assert.dom(SES.secretsBackendLink(enginePath1)).exists(); // with permissions, able to see the engine in list
+
+    // cleanup namespace
+    await login();
+    await runCmd(`delete sys/namespaces/${this.namespace}`);
   });
 
   test('after disabling it stays on the list view', async function (assert) {


### PR DESCRIPTION
Manual backport of #31099 

