### PR TITLE
UI: Fixes kv v2 secret overview for failed subkeys policy check for secrets with underscores

### DIFF
--- a/changelog/31136.txt
+++ b/changelog/31136.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fix kv v2 overview page from erroring if a user does not have access to the /subkeys endpoint and the policy check fails.
+```

--- a/ui/lib/kv/addon/routes/secret.js
+++ b/ui/lib/kv/addon/routes/secret.js
@@ -37,7 +37,7 @@ export default class KvSecretRoute extends Route {
     return null;
   }
 
-  isPatchAllowed({ capabilities, subkeysMeta }) {
+  isPatchAllowed({ capabilities, subkeysMeta = {} }) {
     if (!this.version.isEnterprise) return false;
     const canReadSubkeys = capabilities.subkeys.canRead;
     const canPatchData = capabilities.data.canPatch;

--- a/ui/lib/kv/addon/routes/secret.js
+++ b/ui/lib/kv/addon/routes/secret.js
@@ -41,7 +41,7 @@ export default class KvSecretRoute extends Route {
     if (!this.version.isEnterprise) return false;
     const canReadSubkeys = capabilities.subkeys.canRead;
     const canPatchData = capabilities.data.canPatch;
-    if (canReadSubkeys && canPatchData) {
+    if (canReadSubkeys && canPatchData && subkeysMeta) {
       const { deletion_time, destroyed } = subkeysMeta;
       const isLatestActive = isDeleted(deletion_time) || destroyed ? false : true;
       // only the latest secret version can be patched and it must not be deleted or destroyed

--- a/ui/tests/acceptance/secrets/backend/kv/kv-v2-workflow-edge-cases-test.js
+++ b/ui/tests/acceptance/secrets/backend/kv/kv-v2-workflow-edge-cases-test.js
@@ -54,6 +54,8 @@ module('Acceptance | kv-v2 workflow | edge cases', function (hooks) {
     await writeSecret(this.backend, this.fullSecretPath, 'foo', 'bar');
     await writeSecret(this.backend, 'edge/one', 'foo', 'bar');
     await writeSecret(this.backend, 'edge/two', 'foo', 'bar');
+    // create a secret with an underscore in the path name because this
+    await writeSecret(this.backend, 'my_secret', 'foo', 'bar');
     return;
   });
 
@@ -194,6 +196,20 @@ module('Acceptance | kv-v2 workflow | edge cases', function (hooks) {
       assert.dom(PAGE.breadcrumbAtIdx(1)).hasText(backend);
       assert.dom(PAGE.secretTab('Secrets')).doesNotHaveClass('is-active');
       assert.dom(PAGE.secretTab('Configuration')).doesNotHaveClass('is-active');
+    });
+
+    // the user in the setup only has list permissions and cannot access the subkeys endpoint
+    test('it navigates to secret without access to the subkeys endpoint', async function (assert) {
+      assert.expect(2);
+      await visit(`/vault/secrets/${this.backend}/kv/list`);
+      await typeIn(PAGE.list.overviewInput, 'my_secret');
+      await click(GENERAL.submitButton);
+      assert.strictEqual(
+        currentURL(),
+        `/vault/secrets/${this.backend}/kv/my_secret`,
+        'it navigates to secret overview'
+      );
+      assert.dom(GENERAL.overviewCard.container('Paths')).exists();
     });
   });
 

--- a/ui/tests/acceptance/secrets/backend/kv/kv-v2-workflow-edge-cases-test.js
+++ b/ui/tests/acceptance/secrets/backend/kv/kv-v2-workflow-edge-cases-test.js
@@ -37,12 +37,15 @@ import { GENERAL } from 'vault/tests/helpers/general-selectors';
 import { SECRET_ENGINE_SELECTORS as SES } from 'vault/tests/helpers/secret-engine/secret-engine-selectors';
 import codemirror from 'vault/tests/helpers/codemirror';
 import { personas } from 'vault/tests/helpers/kv/policy-generator';
+import { capabilitiesStub } from 'vault/tests/helpers/stubs';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 /**
  * This test set is for testing edge cases, such as specific bug fixes or reported user workflows
  */
 module('Acceptance | kv-v2 workflow | edge cases', function (hooks) {
   setupApplicationTest(hooks);
+  setupMirage(hooks);
 
   hooks.beforeEach(async function () {
     const uid = uuidv4();
@@ -54,8 +57,6 @@ module('Acceptance | kv-v2 workflow | edge cases', function (hooks) {
     await writeSecret(this.backend, this.fullSecretPath, 'foo', 'bar');
     await writeSecret(this.backend, 'edge/one', 'foo', 'bar');
     await writeSecret(this.backend, 'edge/two', 'foo', 'bar');
-    // create a secret with an underscore in the path name because this
-    await writeSecret(this.backend, 'my_secret', 'foo', 'bar');
     return;
   });
 
@@ -198,9 +199,17 @@ module('Acceptance | kv-v2 workflow | edge cases', function (hooks) {
       assert.dom(PAGE.secretTab('Configuration')).doesNotHaveClass('is-active');
     });
 
-    // the user in the setup only has list permissions and cannot access the subkeys endpoint
-    test('it navigates to secret without access to the subkeys endpoint', async function (assert) {
+    // it's rare for a policy check to fail, but if it does we default to "true" and let the API handle gating.
+    // there was an issue with the new capabilities service incorrectly mapping permissions for secrets with underscores which surfaced this bug.
+    // The user logged in here does NOT have access to the subkeys endpoint, but we're stubbing capabilities to return true
+    // to simulate the capabilities map failing and returning a false positive.
+    test('it navigates to secret if policy check fails for the subkeys endpoint', async function (assert) {
       assert.expect(2);
+      this.server.post(
+        '/sys/capabilities-self',
+        capabilitiesStub(`${this.backend}/subkeys/my_secret`, ['read'])
+      );
+
       await visit(`/vault/secrets/${this.backend}/kv/list`);
       await typeIn(PAGE.list.overviewInput, 'my_secret');
       await click(GENERAL.submitButton);


### PR DESCRIPTION
### Description
✅ enterprise tests pass
The new api service returns capabilities camel-cased instead of matching the original path one to one so [this map](https://github.com/hashicorp/vault/blob/main/ui/app/services/capabilities.ts#L96) fails and returns a false positive that a user can read subkeys. 

It's unusual for a capability check to fail, but it's always been the pattern that if a capability check errors we return true and let the API handle permissions as a fallback. However, in this case the false positive means entering a conditional that then attempts to destructure an undefined object which is what surfaces this error. 

This does not address the larger api path manipulation, but instead adds a default for to `subkeysMeta` which should have been there all along. (This is why typescript is so nice 🥲 )

## previous error
<img width="962" alt="Screenshot 2025-06-27 at 2 25 07 PM" src="https://github.com/user-attachments/assets/fd2f719b-7d59-4702-a059-37ddf5d990e9" />


### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
