### PR TITLE
Known issue for UI logins with underscores and unauth listing

### DIFF
--- a/website/content/docs/updates/important-changes.mdx
+++ b/website/content/docs/updates/important-changes.mdx
@@ -15,7 +15,7 @@ valid_change_types: >-
 
 # Important changes
 
-**Last updated**: 2025-06-20
+**Last updated**: 2025-06-30
 
 Always review important or breaking changes and remediation recommendations
 before upgrading Vault.
@@ -146,6 +146,26 @@ None.
 
 
 ## Known issues
+
+### UI login fails for auth mounts with underscores and unauthenticated listing ((#ui-login-underscore))
+
+| Change       | Affected version | Fixed version
+| ------------ | ---------------- | --------------------
+| Known issue  | 1.20.0           | N/A
+
+If an auth mount is mounted at a path that includes an underscore (e.g. oidc_test)
+**and** the mount is tuned with `listing_visibility="unauth"` the login request will
+fail because the UI requests the wrong endpoint. Mounts with dashes, e.g. oidc-test
+still log in fine.
+
+#### Recommendation
+
+As a workaround, you can log in to the UI using the following steps:
+1. Navigate directly to the URL for that method’s type `${VAULT_ADDR}/ui/vault/auth?with=oidc`
+2. Click "Sign in with other methods ->"
+3. Select type from the dropdown
+4. Click "Advanced settings" and input the correct path, e.g. oidc_test
+
 
 ### Duplicate unseal/seal wrap HSM keys ((#hsm-keys)) <EnterpriseAlert inline="true" />
 


### PR DESCRIPTION
### Description
Adds a known issue to the documentation
 
### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
