### PR TITLE
UI: Yield HDS dropdown text

### DIFF
--- a/ui/app/components/secret-list/totp-list-item.hbs
+++ b/ui/app/components/secret-list/totp-list-item.hbs
@@ -32,25 +32,22 @@
         />
         {{#if @item.canRead}}
           <dd.Interactive
-            @text="Details"
             @route="vault.cluster.secrets.backend.show"
             @model={{@item.id}}
             data-test-popup-menu="details"
-          />
+          >Details</dd.Interactive>
         {{/if}}
         <dd.Interactive
-          @text="Generate Code"
           @route="vault.cluster.secrets.backend.credentials"
           @model={{@item.id}}
           data-test-popup-menu="generate code"
-        />
+        >Generate Code</dd.Interactive>
         {{#if @item.canDelete}}
           <dd.Interactive
-            @text="Delete"
             @color="critical"
             data-test-confirm-action-trigger
             {{on "click" (fn (mut this.showConfirmModal) true)}}
-          />
+          >Delete</dd.Interactive>
         {{/if}}
 
       </Hds::Dropdown>


### PR DESCRIPTION
### Description
HDS `v4.12.0` deprecated passing `@text` to `Hds::Dropdown` list items in favor of yielding. This was updated in https://github.com/hashicorp/vault/pull/28525 but the new [TOTP feature](https://github.com/hashicorp/vault/pull/29751) (which originated from a community PR based off of an older branch) still used the deprecated pattern. This PR updates it. (I came across the deprecation error while trying to update tests to run in parallel)

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
