### PR TITLE
Disable bench GHA

### DIFF
--- a/.github/workflows/benchmark-prevent-performance-degradations.yml
+++ b/.github/workflows/benchmark-prevent-performance-degradations.yml
@@ -1,6 +1,5 @@
 name: Bench
 
-
 on:
   # This has been disabled due to excessive flakiness. The GHA is left here for easier re-implementation in case
   # we wanted to iterate on this in the future, or if we find benchmark tests that are more stable.

--- a/.github/workflows/benchmark-prevent-performance-degradations.yml
+++ b/.github/workflows/benchmark-prevent-performance-degradations.yml
@@ -1,8 +1,13 @@
 name: Bench
 
+
 on:
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+  # This has been disabled due to excessive flakiness. The GHA is left here for easier re-implementation in case
+  # we wanted to iterate on this in the future, or if we find benchmark tests that are more stable.
+  # To re-enable, uncomment the pull request section and delete the workflow_dispatch line.
+  workflow_dispatch:
+#  pull_request:
+#    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   bench:


### PR DESCRIPTION
### Description

Disables the benchmark GHA

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
