### PR TITLE
UI: Known issue for KV v2 secrets containing underscores if no `read` permissions for the `subkeys` endpoint

### DIFF
--- a/ui/app/components/secret-list/totp-list-item.hbs
+++ b/ui/app/components/secret-list/totp-list-item.hbs
@@ -32,25 +32,22 @@
         />
         {{#if @item.canRead}}
           <dd.Interactive
-            @text="Details"
             @route="vault.cluster.secrets.backend.show"
             @model={{@item.id}}
             data-test-popup-menu="details"
-          />
+          >Details</dd.Interactive>
         {{/if}}
         <dd.Interactive
-          @text="Generate Code"
           @route="vault.cluster.secrets.backend.credentials"
           @model={{@item.id}}
           data-test-popup-menu="generate code"
-        />
+        >Generate Code</dd.Interactive>
         {{#if @item.canDelete}}
           <dd.Interactive
-            @text="Delete"
             @color="critical"
             data-test-confirm-action-trigger
             {{on "click" (fn (mut this.showConfirmModal) true)}}
-          />
+          >Delete</dd.Interactive>
         {{/if}}
 
       </Hds::Dropdown>

--- a/website/content/docs/updates/important-changes.mdx
+++ b/website/content/docs/updates/important-changes.mdx
@@ -147,6 +147,26 @@ None.
 
 ## Known issues
 
+### UI KV v2 overview for secret paths containing underscores ((#ui-kvv2-underscore-secrets))
+
+| Change       | Affected version | Fixed version
+| ------------ | ---------------- | --------------------
+| Known issue  | 1.20.0           | 1.20.1
+
+Navigating to a KV v2 secret with an underscore in the name (e.g. `my_secret`) errors if a user does not have
+policy permissions granting `read` access to the [`/subkeys` endpoint](/vault/api-docs/secret/kv/kv-v2#read-secret-subkeys).
+
+#### Recommendation
+
+As a workaround, the [GUI CLI emulator](/vault/docs/ui/web-cli) can be used to read secret data or metadata.
+
+The API Explorer can be used to make any HTTP request.
+1. Select **Tools** from the Vault UI sidebar and click **API Explorer**
+1. Input the KV v2 plugin mount path in the search bar with the placeholder "Filter by tag"
+1. Expand the endpoint for the action you wish to perform and click **Try it out**
+1. Fill in any additional parameters, if applicable. For example, to read a KV v2 secret the `path` must be provided.
+1. Click **Execute** to perform the HTTP request.
+
 ### Duplicate unseal/seal wrap HSM keys ((#hsm-keys)) <EnterpriseAlert inline="true" />
 
 | Change      | Status | Affected version                       | Fixed version

--- a/website/content/docs/updates/important-changes.mdx
+++ b/website/content/docs/updates/important-changes.mdx
@@ -153,18 +153,21 @@ None.
 | ------------ | ---------------- | --------------------
 | Known issue  | 1.20.0           | 1.20.1
 
-Navigating to a KV v2 secret with an underscore in the name (e.g. `my_secret`) errors if a user does not have
-policy permissions granting `read` access to the [`/subkeys` endpoint](/vault/api-docs/secret/kv/kv-v2#read-secret-subkeys).
+Users receive an error when navigating to a KV v2 secret with an underscore in the name (e.g. `my_secret`) 
+if the user does not have policy permissions granting `read` access to the [`/subkeys` endpoint](/vault/api-docs/secret/kv/kv-v2#read-secret-subkeys).
 
 #### Recommendation
 
-As a workaround, the [GUI CLI emulator](/vault/docs/ui/web-cli) can be used to read secret data or metadata.
+As a workaround, you can use the [GUI CLI emulator](/vault/docs/ui/web-cli) to read secret data or metadata.
 
-The API Explorer can be used to make any HTTP request.
-1. Select **Tools** from the Vault UI sidebar and click **API Explorer**
-1. Input the KV v2 plugin mount path in the search bar with the placeholder "Filter by tag"
-1. Expand the endpoint for the action you wish to perform and click **Try it out**
-1. Fill in any additional parameters, if applicable. For example, to read a KV v2 secret the `path` must be provided.
+You can also use the API explorer to make any HTTP request:
+
+1. Select **Tools** from the Vault GUI sidebar.
+1. Click **API Explorer**.
+1. Enter the KV v2 plugin mount path in the "Filter by tag" search bar.
+1. Expand the endpoint for the action you wish to perform and click **Try it out**.
+1. Provide the required parameters. For example, to read a KV v2 secret the `path` must be provided.
+1. Provide any optional parameters desired.
 1. Click **Execute** to perform the HTTP request.
 
 ### UI login fails for auth mounts with underscores and unauthenticated listing ((#ui-login-underscore))

--- a/website/content/partials/release-notes/change-summary/1_20.mdx
+++ b/website/content/partials/release-notes/change-summary/1_20.mdx
@@ -12,3 +12,4 @@ Found  | Fixed  | Workaround | Edition    | Issue
 1.20.0 | No     | **Yes**    | All        | [Duplicate unseal/seal wrap HSM keys](/vault/docs/v1.20.x/updates/important-changes#hsm-keys)
 1.20.0 | No     | **Yes**    | Enterprise | [Development cluster setting overwritten on secondary cluster reload](/vault/docs/v1.20.x/updates/important-changes#development-cluster-reload)
 1.20.0 | No     | **Yes**    | All        | [UI login fails for auth mounts with underscores and unauthenticated listing](/vault/docs/v1.20.x/updates/important-changes#ui-login-underscore)
+1.20.0 | No     | **Yes**    | All        | [UI view KV v2 secret errors without permissions to read subkeys](/vault/docs/v1.20.x/updates/important-changes#ui-kvv2-underscore-secrets)


### PR DESCRIPTION
### Description
Adds a known issue to the docs

(Issue fixed by PR: https://github.com/hashicorp/vault/pull/31136)

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
