### PR TITLE
Change the column name in the Export API response from "timestamp" to "token_creation_time" CE changes

### DIFF
--- a/vault/activity_log.go
+++ b/vault/activity_log.go
@@ -288,8 +288,8 @@ type ActivityLogExportRecord struct {
 	// MountPath is the path of the auth mount associated with the token used
 	MountPath string `json:"mount_path" mapstructure:"mount_path"`
 
-	// Timestamp denotes the time at which the activity occurred formatted using RFC3339
-	Timestamp string `json:"timestamp" mapstructure:"timestamp"`
+	// TokenCreationTime denotes the time at which the activity occurred formatted using RFC3339
+	TokenCreationTime string `json:"token_creation_time" mapstructure:"token_creation_time"`
 
 	// Policies are the list of policy names attached to the token used
 	Policies []string `json:"policies" mapstructure:"policies"`
@@ -3192,12 +3192,12 @@ func (a *ActivityLog) writeExport(ctx context.Context, rw http.ResponseWriter, f
 			ts := time.Unix(e.Timestamp, 0)
 
 			record := &ActivityLogExportRecord{
-				ClientID:      e.ClientID,
-				ClientType:    e.ClientType,
-				NamespaceID:   e.NamespaceID,
-				NamespacePath: nsDisplayPath,
-				Timestamp:     ts.UTC().Format(time.RFC3339),
-				MountAccessor: e.MountAccessor,
+				ClientID:          e.ClientID,
+				ClientType:        e.ClientType,
+				NamespaceID:       e.NamespaceID,
+				NamespacePath:     nsDisplayPath,
+				TokenCreationTime: ts.UTC().Format(time.RFC3339),
+				MountAccessor:     e.MountAccessor,
 
 				// Default following to empty versus nil, will be overwritten if necessary
 				Policies:                  []string{},
@@ -3481,7 +3481,7 @@ func baseActivityExportCSVHeader() []string {
 		"mount_accessor",
 		"mount_path",
 		"mount_type",
-		"timestamp",
+		"token_creation_time",
 	}
 }
 

--- a/vault/activity_log_test.go
+++ b/vault/activity_log_test.go
@@ -5010,12 +5010,12 @@ func TestActivityLog_partialMonthClientCountUsingWriteExport(t *testing.T) {
 	expectedCurrentMonthClients := expectedClients[1:]
 
 	type record struct {
-		ClientID      string `json:"client_id"`
-		NamespaceID   string `json:"namespace_id"`
-		Timestamp     string `json:"timestamp"`
-		NonEntity     bool   `json:"non_entity"`
-		MountAccessor string `json:"mount_accessor"`
-		ClientType    string `json:"client_type"`
+		ClientID          string `json:"client_id"`
+		NamespaceID       string `json:"namespace_id"`
+		TokenCreationTime string `json:"token_creation_time"`
+		NonEntity         bool   `json:"non_entity"`
+		MountAccessor     string `json:"mount_accessor"`
+		ClientType        string `json:"client_type"`
 	}
 
 	startOfMonth := timeutil.StartOfMonth(now)
@@ -5069,7 +5069,7 @@ func TestActivityLog_partialMonthClientCountUsingWriteExport(t *testing.T) {
 
 			// Compare expectedClients with actualClients
 			for i := range expectedCurrentMonthClients {
-				resultTimeStamp, err := time.Parse(time.RFC3339, results[i].Timestamp)
+				resultTimeStamp, err := time.Parse(time.RFC3339, results[i].TokenCreationTime)
 				require.NoError(t, err)
 				require.Equal(t, expectedCurrentMonthClients[i].ClientID, results[i].ClientID)
 				require.Equal(t, expectedCurrentMonthClients[i].NamespaceID, results[i].NamespaceID)


### PR DESCRIPTION
### Description
What does this PR do?
Jira: https://hashicorp.atlassian.net/browse/VAULT-36265
Approved ent PR: https://github.com/hashicorp/vault-enterprise/pull/8374

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
