### PR TITLE
UI: Fix login settings list view if names include an underscore

### DIFF
--- a/changelog/31150.txt
+++ b/changelog/31150.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fixes UI login settings list page which was not rendering rules with an underscore in the name.
+```

--- a/ui/app/app.js
+++ b/ui/app/app.js
@@ -24,6 +24,7 @@ export default class App extends Application {
           'version',
           'custom-messages',
           'api',
+          'store',
           'capabilities',
         ],
       },

--- a/ui/app/components/secret-list/totp-list-item.hbs
+++ b/ui/app/components/secret-list/totp-list-item.hbs
@@ -32,25 +32,22 @@
         />
         {{#if @item.canRead}}
           <dd.Interactive
-            @text="Details"
             @route="vault.cluster.secrets.backend.show"
             @model={{@item.id}}
             data-test-popup-menu="details"
-          />
+          >Details</dd.Interactive>
         {{/if}}
         <dd.Interactive
-          @text="Generate Code"
           @route="vault.cluster.secrets.backend.credentials"
           @model={{@item.id}}
           data-test-popup-menu="generate code"
-        />
+        >Generate Code</dd.Interactive>
         {{#if @item.canDelete}}
           <dd.Interactive
-            @text="Delete"
             @color="critical"
             data-test-confirm-action-trigger
             {{on "click" (fn (mut this.showConfirmModal) true)}}
-          />
+          >Delete</dd.Interactive>
         {{/if}}
 
       </Hds::Dropdown>

--- a/ui/lib/config-ui/addon/components/login-settings/page/list.hbs
+++ b/ui/lib/config-ui/addon/components/login-settings/page/list.hbs
@@ -29,9 +29,9 @@
               {{rule.name}}
             </Hds::Text::Display>
             <div class="has-top-margin-m">
-              {{rule.namespacePath}}
+              {{rule.namespace_path}}
               <Hds::Badge
-                @text="Inheritance {{if rule.disableInheritance 'disabled' 'enabled'}}"
+                @text="Inheritance {{if rule.disable_inheritance 'disabled' 'enabled'}}"
                 class="has-left-margin-xxs"
               />
             </div>

--- a/ui/lib/config-ui/addon/engine.js
+++ b/ui/lib/config-ui/addon/engine.js
@@ -25,6 +25,7 @@ export default class ConfigUiEngine extends Engine {
       'version',
       'custom-messages',
       'api',
+      'store',
       'capabilities',
     ],
   };

--- a/ui/tests/acceptance/config-ui/login-settings-test.js
+++ b/ui/tests/acceptance/config-ui/login-settings-test.js
@@ -47,7 +47,11 @@ module('Acceptance | Enterprise | config-ui/login-settings', function (hooks) {
   test('it falls back error template if no permission', async function (assert) {
     this.server.get('/sys/config/ui/login/default-auth', () => overrideResponse(403));
     await visit('vault/config-ui/login-settings');
-    assert.dom(GENERAL.pageError.error).hasText('Error permission denied');
+    assert
+      .dom(GENERAL.pageError.error)
+      .hasText(
+        'Not authorized You are not authorized to access content at /v1/sys/config/ui/login/default-auth.'
+      );
   });
 
   module('list, read and delete', function (hooks) {


### PR DESCRIPTION
### Description
Reverts the use of the api service in the login settings list view. The api service camelizes keys which mutates the server response. This means the `key_info` would not properly map to the key in the `keys` array. Until we resolve this in the api service itself, reverting the use in the login settings list view.

**actual**
```
{
    "key_info": {
        "test_rule": {
            "name": "test_rule",
            "namespace_path": "fake/",
            "disable_inheritance": false
        }
    },
    "keys": [
        "test_rule"
    ]
}
```

**response from request made via api service**
```
{
    "keyInfo": {
        "testRule": {
            "name": "test_rule",
            "namespacePath": "fake/",
            "disableInheritance": false
        }
    },
    "keys": [
        "test_rule"
    ]
}
```


### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
