### PR TITLE
UI: Stabilize namespace tests

### DIFF
--- a/ui/tests/acceptance/access/namespaces/index-test.js
+++ b/ui/tests/acceptance/access/namespaces/index-test.js
@@ -147,6 +147,7 @@ module('Acceptance | Enterprise | /access/namespaces', function (hooks) {
     assert.strictEqual(currentRouteName(), 'vault.cluster.dashboard', 'navigates to the correct route');
 
     // Cleanup: Delete namespace(s) via the CLI
+    await visit('vault/dashboard'); // navigate to "root" before deleting
     await runCmd(deleteNS(testNS), false);
   });
 });

--- a/ui/tests/acceptance/auth/auth-list-test.js
+++ b/ui/tests/acceptance/auth/auth-list-test.js
@@ -159,14 +159,19 @@ module('Acceptance | auth backend list', function (hooks) {
       await settled();
       await loginNs(ns);
       // go directly to token configure route
-      await visit('/vault/settings/auth/configure/token/options');
+      await visit(`/vault/settings/auth/configure/token/options?namespace=${ns}`);
       await fillIn(GENERAL.inputByAttr('description'), 'My custom description');
       await click(GENERAL.submitButton);
-      assert.strictEqual(currentURL(), '/vault/access', 'successfully saves and navigates away');
+      assert.strictEqual(
+        currentURL(),
+        `/vault/access?namespace=${ns}`,
+        'successfully saves and navigates away'
+      );
       await click(GENERAL.linkedBlock('token'));
       assert
         .dom('[data-test-row-value="Description"]')
         .hasText('My custom description', 'description was saved');
+      await login();
       await runCmd(`delete sys/namespaces/${ns}`);
     });
   });

--- a/ui/tests/acceptance/auth/login-settings-test.js
+++ b/ui/tests/acceptance/auth/login-settings-test.js
@@ -38,8 +38,8 @@ module('Acceptance | Enterprise | auth form custom login settings', function (ho
       'delete sys/config/ui/login/default-auth/root-rule',
       'delete sys/config/ui/login/default-auth/ns-rule',
       'delete sys/auth/my_oidc',
-      'delete test-ns/sys/namespaces/child',
-      'delete sys/namespaces/test-ns',
+      'delete test-ns/sys/namespaces/child -f',
+      'delete sys/namespaces/test-ns -f',
     ]);
   });
 

--- a/ui/tests/acceptance/dashboard-test.js
+++ b/ui/tests/acceptance/dashboard-test.js
@@ -227,6 +227,9 @@ module('Acceptance | landing page dashboard', function (hooks) {
       await runCmd(createNS('world'), false);
       await visit('/vault/dashboard?namespace=world');
       assert.dom(DASHBOARD.cardName('configuration-details')).doesNotExist();
+
+      // navigate to "root" before deleting
+      await visit('vault/dashboard');
       // clean up namespace pollution
       await runCmd(deleteNS('world'));
     });
@@ -452,6 +455,9 @@ module('Acceptance | landing page dashboard', function (hooks) {
       await runCmd(createNS('blah'), false);
       await visit('/vault/dashboard?namespace=blah');
       assert.dom(DASHBOARD.cardName('replication')).doesNotExist();
+
+      // navigate to "root" before deleting
+      await visit('vault/dashboard');
       // clean up namespace pollution
       await runCmd(deleteNS('blah'));
     });

--- a/ui/tests/acceptance/enterprise-namespaces-test.js
+++ b/ui/tests/acceptance/enterprise-namespaces-test.js
@@ -156,6 +156,7 @@ module('Acceptance | Enterprise | namespaces', function (hooks) {
 
     // Verify that the namespace exists in the namespace picker
     await click(GENERAL.button('namespace-picker'));
+    await waitFor(GENERAL.button('Refresh list'));
     await click(GENERAL.button('Refresh list'));
     await fillIn(GENERAL.inputByAttr('Search namespaces'), namespace);
 

--- a/ui/tests/acceptance/enterprise-oidc-namespace-test.js
+++ b/ui/tests/acceptance/enterprise-oidc-namespace-test.js
@@ -6,7 +6,7 @@
 import { fillIn, waitFor } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
-import { runCmd } from 'vault/tests/helpers/commands';
+import { deleteNS, runCmd } from 'vault/tests/helpers/commands';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import parseURL from 'core/utils/parse-url';
 import { login, logout } from 'vault/tests/helpers/auth/auth-helpers';
@@ -17,46 +17,40 @@ module('Acceptance | Enterprise | oidc auth namespace test', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  hooks.beforeEach(async function () {
-    this.namespace = 'test-ns';
-    this.mountPath = 'ns-oidc';
-
-    this.server.post(`/auth/:path/config`, () => {});
-
-    await login();
-    await runCmd([
-      `write sys/namespaces/${this.namespace} -force`,
-      `write ${this.namespace}/sys/auth/${this.mountPath} type=oidc`,
-      `write auth/${this.mountPath}/config default_role="myrole" oidc_discovery_url="https://example.com"`,
-      // show method as tab
-      `write ${this.namespace}/sys/auth/${this.mountPath}/tune listing_visibility="unauth"`,
-    ]);
-    await logout();
-  });
-
-  hooks.afterEach(async function () {
-    // cleanup
-    await fillIn(GENERAL.inputByAttr('namespace'), ''); // clear namespace input
-    await login();
-    await runCmd([`delete sys/auth/${this.namespace}`]);
-  });
-
   test('oidc: request is made to auth_url when a namespace is inputted', async function (assert) {
     assert.expect(2);
+    const namespace = 'test-ns';
+    const mountPath = 'ns-oidc';
+
     // stubs the auth_url for the OIDC method configured in the namespace, NOT for the root namespace
     // should only be hit once when the oidc tab is selected after inputting a namespace
-    this.server.post(`/auth/${this.mountPath}/oidc/auth_url`, (schema, req) => {
+    this.server.post(`/auth/${mountPath}/oidc/auth_url`, (schema, req) => {
       const { redirect_uri } = JSON.parse(req.requestBody);
       const { pathname, search } = parseURL(redirect_uri);
       assert.strictEqual(
         pathname + search,
-        `/ui/vault/auth/${this.mountPath}/oidc/callback?namespace=${this.namespace}`,
+        `/ui/vault/auth/${mountPath}/oidc/callback?namespace=${namespace}`,
         'request made to correct auth_url when namespace is filled in'
       );
     });
 
-    await fillIn(GENERAL.inputByAttr('namespace'), this.namespace);
+    await login();
+    await runCmd([
+      `write sys/namespaces/${namespace} -force`,
+      `write ${namespace}/sys/auth/${mountPath} type=oidc`,
+      `write auth/${mountPath}/config default_role="myrole" oidc_discovery_url="https://example.com"`,
+      // show method as tab
+      `write ${namespace}/sys/auth/${mountPath}/tune listing_visibility="unauth"`,
+    ]);
+    await logout();
+
+    await fillIn(GENERAL.inputByAttr('namespace'), namespace);
     await waitFor(AUTH_FORM.tabBtn('oidc')); // no need to click because selected by default
     assert.dom(AUTH_FORM.tabBtn('oidc')).exists('renders oidc method tab for child namespace');
+
+    // cleanup
+    await fillIn(GENERAL.inputByAttr('namespace'), ''); // clear namespace input
+    await login();
+    await runCmd(deleteNS(namespace));
   });
 });

--- a/ui/tests/acceptance/reduced-disclosure-test.js
+++ b/ui/tests/acceptance/reduced-disclosure-test.js
@@ -8,7 +8,7 @@ import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { click, currentRouteName, currentURL, fillIn, settled, visit } from '@ember/test-helpers';
 import { login, loginNs, logout } from 'vault/tests/helpers/auth/auth-helpers';
-import { createTokenCmd, runCmd, tokenWithPolicyCmd } from 'vault/tests/helpers/commands';
+import { createTokenCmd, deleteNS, runCmd, tokenWithPolicyCmd } from 'vault/tests/helpers/commands';
 import { pollCluster } from 'vault/tests/helpers/poll-cluster';
 import VAULT_KEYS from 'vault/tests/helpers/vault-keys';
 import reducedDisclosureHandlers from 'vault/mirage/handlers/reduced-disclosure';
@@ -161,6 +161,11 @@ module('Acceptance | reduced disclosure test', function (hooks) {
           'shows Vault version for default policy in child namespace'
         );
       assert.dom(SELECTORS.dashboardTitle).includesText('Vault v1.');
+
+      // navigate to "root" before deleting
+      await visit('vault/dashboard');
+      // clean up namespace pollution
+      await runCmd(deleteNS(namespace));
     });
     test('login works when reduced disclosure enabled (ent)', async function (assert) {
       const namespace = 'reduced-disclosure';
@@ -191,6 +196,11 @@ module('Acceptance | reduced disclosure test', function (hooks) {
       assert
         .dom(SELECTORS.footerVersion)
         .hasText(`Vault ${this.versionSvc.version}`, 'shows Vault version for default policy in namespace');
+
+      // navigate to "root" before deleting
+      await visit('vault/dashboard');
+      // clean up namespace pollution
+      await runCmd(deleteNS(namespace));
     });
   });
 });

--- a/ui/tests/acceptance/reduced-disclosure-test.js
+++ b/ui/tests/acceptance/reduced-disclosure-test.js
@@ -162,8 +162,8 @@ module('Acceptance | reduced disclosure test', function (hooks) {
         );
       assert.dom(SELECTORS.dashboardTitle).includesText('Vault v1.');
 
-      // navigate to "root" before deleting
-      await visit('vault/dashboard');
+      // log in to "root" before deleting
+      await login();
       // clean up namespace pollution
       await runCmd(deleteNS(namespace));
     });
@@ -197,8 +197,8 @@ module('Acceptance | reduced disclosure test', function (hooks) {
         .dom(SELECTORS.footerVersion)
         .hasText(`Vault ${this.versionSvc.version}`, 'shows Vault version for default policy in namespace');
 
-      // navigate to "root" before deleting
-      await visit('vault/dashboard');
+      // log in to "root" before deleting
+      await login();
       // clean up namespace pollution
       await runCmd(deleteNS(namespace));
     });

--- a/ui/tests/acceptance/secrets/backend/kv/kv-v2-workflow-edge-cases-test.js
+++ b/ui/tests/acceptance/secrets/backend/kv/kv-v2-workflow-edge-cases-test.js
@@ -23,6 +23,7 @@ import {
   mountEngineCmd,
   runCmd,
   createTokenCmd,
+  deleteNS,
 } from 'vault/tests/helpers/commands';
 import {
   dataPolicy,
@@ -558,7 +559,7 @@ module('Acceptance | Enterprise | kv-v2 workflow | edge cases', function (hooks)
 
   hooks.afterEach(async function () {
     await login();
-    await runCmd([`delete /sys/auth/${this.namespace}`]);
+    await runCmd(deleteNS(this.namespace));
     await runCmd(deleteEngineCmd(this.backend));
     return;
   });

--- a/ui/tests/acceptance/sync/secrets/overview-test.js
+++ b/ui/tests/acceptance/sync/secrets/overview-test.js
@@ -12,7 +12,7 @@ import { login, loginNs } from 'vault/tests/helpers/auth/auth-helpers';
 import { click, waitFor, visit, currentURL } from '@ember/test-helpers';
 import { PAGE as ts } from 'vault/tests/helpers/sync/sync-selectors';
 import { GENERAL } from 'vault/tests/helpers/general-selectors';
-import { runCmd } from 'vault/tests/helpers/commands';
+import { deleteNS, runCmd } from 'vault/tests/helpers/commands';
 
 // sync is an enterprise feature but since mirage is used the enterprise label has been intentionally omitted from the module name
 module('Acceptance | sync | overview', function (hooks) {
@@ -168,6 +168,11 @@ module('Acceptance | sync | overview', function (hooks) {
         await loginNs('admin/foo');
       });
 
+      hooks.afterEach(async function () {
+        await visit('vault/dashboard');
+        await runCmd([`delete admin/sys/namespaces/foo -f`, deleteNS('admin')]);
+      });
+
       test('it should make activation-flag requests to correct namespace', async function (assert) {
         assert.expect(3);
 
@@ -195,6 +200,12 @@ module('Acceptance | sync | overview', function (hooks) {
         await click(ts.overview.optInBanner.enable);
         await click(ts.overview.activationModal.checkbox);
         await click(ts.overview.activationModal.confirm);
+
+        // During the afterEach hook cleanup endpoint is hit again which increases the assertion count (above)
+        // Re-stub here without the assertion to prep for namespace cleanup.
+        this.server.get('/sys/activation-flags', (_, req) => {
+          req.passthrough();
+        });
       });
 
       test('it should make activation-flag requests to correct namespace when managed', async function (assert) {
@@ -226,6 +237,12 @@ module('Acceptance | sync | overview', function (hooks) {
         await click(ts.overview.optInBanner.enable);
         await click(ts.overview.activationModal.checkbox);
         await click(ts.overview.activationModal.confirm);
+
+        // During the afterEach hook this endpoint is hit again which increases the assertion count (above)
+        // Re-stub here without the assertion to prep for namespace cleanup.
+        this.server.get('/sys/activation-flags', (_, req) => {
+          req.passthrough();
+        });
       });
     });
   });


### PR DESCRIPTION
### Description
✅ enterprise tests pass 

Follow-on to this PR https://github.com/hashicorp/vault/pull/31016 which added `deleteNS` commands to cleanup namespaces, however the command was not being run from the `root` namespace so the command was not actually deleting the namespace. 

I noticed this because a test failure checking for an empty state in the namespace list view returned a list of namespaces
<img width="851" alt="Screenshot 2025-06-30 at 3 12 25 PM" src="https://github.com/user-attachments/assets/e701acd0-9494-40c6-87b2-3efcc7496121" />


### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
