### PR TITLE
manual backport of docs from commit abac619 into release/1.19.x

### DIFF
--- a/website/content/api-docs/system/plugins-catalog.mdx
+++ b/website/content/api-docs/system/plugins-catalog.mdx
@@ -156,17 +156,21 @@ supplied name.
   See [/sys/plugins/runtimes/catalog](/vault/api-docs/system/plugins-runtimes-catalog) for additional information.
 
 - `version` `(string: "")` - Specifies the semantic version of the plugin. Used as the tag
-  when specifying `oci_image`, but with any leading 'v' trimmed.
+  when specifying `oci_image`, but with any leading 'v' trimmed. You can
+  omit version to register a plugin binary, but you must provide an
+  explicit version to register a plugin artifact.
 
-- `sha256` `(string: <required>)` – The SHA256 sum of a Community plugin
-  binary or the OCI image. Before a plugin is run, its SHA will be checked against this value.
-  If the actual SHA of the plugin binary and the SHA provided in `sha256` do not match, Vault will not run the plugin. The `sha256` parameter is only required for Community plugins. Enterprise plugins do not require SHA confirmation.
+- `sha256` `(string: "")` – The SHA256 sum of a plugin binary or the OCI image.
+  Before Vault runs a plugin, it checks the plugin SHA against `sha256`. If the
+  actual SHA of the plugin binary and the SHA provided in `sha256` do not match,
+  Vault will not run the plugin. You must provide `sha256` to register a plugin
+  binary, but you must leave `sha256` unset to register a plugin artifact.
 
-- `command` `(string: <required>)` - Specifies the command used to execute the
+- `command` `(string: "")` - Specifies the command used to execute the
   plugin. This is relative to the plugin directory. e.g. `"myplugin"`, or if `oci_image`
   is also specified, it is relative to the image's working directory.
-  The `command` parameter is only required for Community plugins as
-  the run command is known for Enterprise plugins.
+  You must provide `command` to register a plugin binary. Vault ignores `command`
+  when you register a plugin artifact as it already knows the associated run command.
 
 - `args` `(array: [])` – Specifies the arguments used to execute the plugin. If
   the arguments are provided here, the `command` parameter should only contain

--- a/website/content/docs/commands/plugin/register.mdx
+++ b/website/content/docs/commands/plugin/register.mdx
@@ -11,9 +11,17 @@ description: |-
 The `plugin register` command registers a new plugin in Vault's plugin catalog.
 The plugin's type of "auth", "database", or "secret" must be included.
 
+<Note>
+
+To register an Enterprise plugin, you must register with the plugin artifact, not the binary.
+Refer to the [Enterprise plugins](/vault/docs/plugins/plugin-management#enterprise-plugins) section
+of the plugin management page for Vault compatibility requirements.
+
+</Note>
+
 ## Examples
 
-Register a Community or custom plugin:
+Register a plugin binary:
 
 ```shell-session
 $ vault plugin register \
@@ -22,14 +30,7 @@ $ vault plugin register \
 Success! Registered plugin: my-custom-plugin
 ```
 
-Register an Enterprise plugin:
-
-<Note>
-
-Refer to the [Enterprise plugins](/vault/docs/plugins/plugin-management#enterprise-plugins) section
-of the Plugin management page for Vault compatibility requirements.
-
-</Note>
+Register a plugin artifact:
 
 Before registering Key Management secrets engine v0.16.0+ent for the linux/amd64 system that runs Vault Enterprise,
 `vault-plugin-secrets-keymgmt_v0.16.0+ent_linux_amd64.zip` needs to be downloaded from
@@ -44,7 +45,7 @@ $ vault plugin register
 Success! Registered plugin: vault-plugin-secrets-keymgmt
 ```
 
-Register a Community or custom plugin with custom args:
+Register a plugin binary with custom args:
 
 ```shell-session
 $ vault plugin register \
@@ -53,7 +54,7 @@ $ vault plugin register \
     auth my-custom-plugin
 ```
 
-Register an Enterprise plugin with custom args:
+Register a plugin artifact with custom args:
 
 ```shell-session
 $ vault plugin register
@@ -76,15 +77,17 @@ flags](/vault/docs/commands) included on all commands.
 
 ### Command options
 
-- `-sha256` `(string: <required>)` - SHA256 of the plugin binary or the OCI image
-  provided. This is required for all Community plugins.
-  If the plugin is Enterprise, the value is not required.
+- `sha256` `(string: "")` – The SHA256 sum of a plugin binary or the OCI image.
+  You must provide `sha256` to register a plugin binary, but you must leave
+  `sha256` unset to register a plugin artifact.
 
 - `-args` `([]string: [])` - Argument to pass to the plugin when starting. This
   flag can be specified multiple times to specify multiple args.
 
-- `-command` `(string: "")` - Command to spawn the plugin. This defaults to the
-  name of the plugin if both `-oci_image` and `-command` are unspecified.
+- `-command` `(string: "")` - Specifies the command path used to execute the
+  plugin relative to the plugin directory or OCI image directory. You must
+  provide `command` to register a plugin binary. Vault ignores `command` when
+  you register a plugin artifact as it already knows the associated run command.
 
 - `-env` `([]string: [])` - Environment variables to set for the plugin when
   starting. This flag can be specified multiple times to specify multiple
@@ -99,4 +102,6 @@ flags](/vault/docs/commands) included on all commands.
 
 - `-version` `(string: "")` - Semantic version of the plugin. Used as the tag
   when specifying `-oci_image`, but any leading 'v' will automatically be trimmed.
+   You can omit version to register a plugin binary, but you must provide
+   an explicit version to register a plugin artifact.
 

--- a/website/content/docs/plugins/register.mdx
+++ b/website/content/docs/plugins/register.mdx
@@ -17,29 +17,21 @@ Vault defaults to the manually registered plugin when you enable a new mount
 with that name.
 
 
+
 ## Before you start
 
-- **To register enterprise plugins, you have Vault v1.16.21+, 1.17.17+, 1.18.10+,
-  or 1.19.4+**.
-- **You must have admin permissions for Vault**. Specifically, you must be able
-  to run `plugin register` and the appropriate `enable` command.
-- **You must have
-  [`plugin_directory`](/vault/docs/configuration#plugin_directory) set in your
-  Vault configuration file**.
-- **For enterprise plugins, you must have the plugin `.zip` file extracted to
-  the expected location inside `plugin_directory`**.
-  For example, `vault-plugin-database-oracle_0.11.0+ent_linux_amd64.zip` must be
-  extracted to `<plugin_directory>/vault-plugin-database-oracle_0.11.0+ent_linux_amd64/`.
-- **For other plugins, you must have the plugin binary saved to the
-  location set in `plugin_directory`**.
-- **You must have [`api_addr`](/vault/docs/configuration#api_addr) set in your
-  Vault configuration file**.
+- **To register enterprise plugins, you must have Vault v1.16.21+, 1.17.17+,
+  1.18.10+, 1.19.4+, or 1.20.x+**.
 
-See [Recommendation](/vault/docs/updates/important-changes#external-enterprise-plugins)
-to register enterprise plugins on Vault v1.16.17 - v1.16.20, v1.17.13 - v1.17.16,
-v1.18.6 - v1.18.9, or v1.19.0 - v1.19.3.
+@include 'plugins/common-requirements.mdx'
 
-## Step 1: Update the plugin catalog
+
+## Step 1: Prepare the plugin
+
+@include 'plugins/prepare-plugin.mdx'
+
+
+## Step 2: Update the plugin catalog
 
 You must register your external plugin with the Vault catalog before enabling
 it. Registering plugins ensures the plugin invoked by Vault is authentic and
@@ -48,14 +40,14 @@ maintains integrity.
 @include 'plugins/register.mdx'
 
 
-## Step 2: Enable the plugin
+## Step 3: Enable the plugin
 
 Enable the plugin to make it available to clients.
 
 @include 'plugins/enable.mdx'
 
 
-## Step 3: Verify the plugin status
+## Step 4: Verify the plugin status
 
 Verify the plugin is ready for use and running the correct version.
 

--- a/website/content/docs/plugins/rollback.mdx
+++ b/website/content/docs/plugins/rollback.mdx
@@ -14,19 +14,18 @@ starting your rollback or downgrade.
 
 ## Before you start
 
-- **To register and downgrade enterprise plugins, you must have Vault v1.16.16+,
-  1.17.12+, 1.18.5+, or 1.19.x+**.
-- **You must have admin permissions for Vault**. Specifically, you must be able
-  to run `plugin register` and the appropriate `enable` command.
-- **You must have [`plugin_directory`](/vault/docs/configuration#plugin_directory)
-  set in your Vault configuration file**.
-- **You must have the new plugin binary or zip file saved to the location set in
-  `plugin_directory`**. 
-- **You must have [`api_addr`](/vault/docs/configuration#api_addr) set in your
-  Vault configuration file**.
+- **To register and downgrade enterprise plugins, you must have Vault v1.16.21+,
+  1.17.17+, 1.18.10+, 1.19.4+, or 1.20.x+**.
+
+@include 'plugins/common-requirements.mdx'
 
 
-## Step 1: Update the catalog entry
+## Step 1: Prepare the plugin
+
+@include 'plugins/prepare-plugin.mdx'
+
+
+## Step 2: Update the plugin catalog
 
 Register the replacement plugin binary or zip file with the old version number
 under the same plugin type and name as the existing plugin version.
@@ -34,7 +33,7 @@ under the same plugin type and name as the existing plugin version.
 @include 'plugins/register.mdx'
 
 
-## Step 2: Pin and reload the plugin
+## Step 3: Pin and reload the plugin
 
 Until you reload the plugin, Vault continues running the current plugin version
 on the mount path. When you trigger a reload, Vault kills the active plugin
@@ -43,6 +42,6 @@ process and start a new plugin process with the pinned version of that plugin.
 @include 'plugins/pin-and-reload.mdx'
 
 
-## Step 3: Verify the plugin status
+## Step 4: Verify the plugin status
 
 @include 'plugins/verify-status.mdx'

--- a/website/content/docs/plugins/upgrade.mdx
+++ b/website/content/docs/plugins/upgrade.mdx
@@ -22,19 +22,17 @@ unaffected by plugin upgrades.
 
 ## Before you start
 
-- **To register and upgrade enterprise plugins, you must have Vault v1.16.16+,
-  1.17.12+, 1.18.5+, or 1.19.x+**.
-- **You must have admin permissions for Vault**. Specifically, you must be able
-  to run `plugin register` and the appropriate `enable` command.
-- **You must have [`plugin_directory`](/vault/docs/configuration#plugin_directory)
-  set in your Vault configuration file**.
-- **You must have the new plugin binary or zip file saved to the location set in
-  `plugin_directory`**. 
-- **You must have [`api_addr`](/vault/docs/configuration#api_addr) set in your
-  Vault configuration file**.
+- **To register and upgrade enterprise plugins, you must have Vault v1.16.21+,
+  1.17.17+, 1.18.10+, 1.19.4+, or 1.20.x+**.
+
+@include 'plugins/common-requirements.mdx'
+
+## Step 1: Prepare the plugin
+
+@include 'plugins/prepare-plugin.mdx'
 
 
-## Step 1: Update the catalog entry
+## Step 2: Update the plugin catalog
 
 Register the new plugin binary or zip file with an updated version number under
 the same plugin type and name as the existing plugin version.
@@ -42,7 +40,7 @@ the same plugin type and name as the existing plugin version.
 @include 'plugins/register.mdx'
 
 
-## Step 2: Reload the plugin
+## Step 3: Reload the plugin
 
 Until you reload the plugin, Vault continues running the old plugin version on
 the mount path. When you trigger a reload, Vault kills the active plugin process
@@ -51,6 +49,6 @@ and start a new plugin process with the pinned version of that plugin.
 @include 'plugins/pin-and-reload.mdx'
 
 
-## Step 3: Verify the plugin status
+## Step 4: Verify the plugin status
 
 @include 'plugins/verify-status.mdx'

--- a/website/content/partials/plugins/common-requirements.mdx
+++ b/website/content/partials/plugins/common-requirements.mdx
@@ -1,0 +1,11 @@
+- **You must have admin permissions for Vault**. Specifically, you must be able
+  to run `plugin register` and the appropriate `enable` command.
+- **You must have
+  [`plugin_directory`](/vault/docs/configuration#plugin_directory) set in your
+  Vault configuration file**.
+- **You must have [`api_addr`](/vault/docs/configuration#api_addr) set in your
+  Vault configuration file**.
+- **If you plan to use an extracted `.zip` file, the plugin artifacts must be
+  compatible with the system running Vault**. Vault verifies plugin integrity
+  and checks system compatibility during the registration process for extracted
+  artifacts.

--- a/website/content/partials/plugins/prepare-plugin.mdx
+++ b/website/content/partials/plugins/prepare-plugin.mdx
@@ -1,0 +1,17 @@
+You must have the plugin set up properly in your configured plugin directory.
+Vault expects specific path structures based on the integration, license, and
+file format.
+
+If you plan to register an extracted `.zip` file, the extracted artifact
+directory name must match the official file name. For example, to register
+`vault-plugin-database-oracle_0.11.0+ent_linux_amd64.zip`, you must extract it
+to the plugin directory as `vault-plugin-database-oracle_0.11.0+ent_linux_amd64/`.
+
+Integration | License    | Source | Path structure
+----------- | ---------- | ------ | --------------
+Official    | Enterprise | `.zip` | `<plugin_directory>/<extracted-folder-name>/`
+Official    | Community  | `.zip` | `<plugin_directory>/<extracted-folder-name>/`
+Community   | N/A        | `.zip` | Not supported
+Official    | Enterprise | binary | Not supported
+Offical     | Community  | binary | `<plugin_directory>/<binary-name>`
+Community   | N/A        | binary | `<plugin_directory>/<binary-name>`

--- a/website/content/partials/plugins/register.mdx
+++ b/website/content/partials/plugins/register.mdx
@@ -1,9 +1,6 @@
-<EnterpriseAlert>
-Enterprise plugins must be compatible with the system that runs Vault and saved
-to the plugin directory unzipped with the name provided on the HashiCorp
-releases page. Vault Enterprise verifies plugin integrity, checks system
-compatibility, and unzips the plugin artifact during the registration process.
-</EnterpriseAlert>
+<Tabs>
+
+<Tab heading="Binary file" group="binary">
 
 <Tabs>
 
@@ -138,3 +135,132 @@ compatibility, and unzips the plugin artifact during the registration process.
 
 </Tabs>
 
+</Tab>
+
+<Tab heading=".zip file" group="zip">
+
+<Tabs>
+
+<Tab heading="CLI" group="cli">
+
+1. Use [`vault plugin register`](/vault/docs/commands/plugin/register) to add
+   your plugin to the catalog using `-version`. Do not provide a SHA value:
+
+    ```shell-session
+    $ vault plugin register
+        -version "<semantic_version>"
+        <plugin_type>
+        <plugin_name>
+    ```
+
+  For example, to register the `vault-plugin-secrets-keymgmt` plugin with the
+  extracted artifact directory `vault-plugin-secrets-keymgmt_0.16.0+ent_linux_amd64/`:
+
+  <CodeBlockConfig hideClipboard="true">
+
+    ```shell-session
+    $ vault plugin register     \
+        -version "v0.16.0+ent"  \
+        secret                  \
+        vault-plugin-secrets-keymgmt
+
+    Success! Registered plugin: vault-plugin-secrets-keymgmt
+    ```
+
+  </CodeBlockConfig>
+
+</Tab>
+
+<Tab heading="API" group="api">
+
+1. Save the version information for your extracted plugin folder to a JSON file:
+
+    ```shell-session
+    $ cat <<-EOF > data.json
+    {
+      "version": "<semantic_version>"
+    }
+    EOF
+    ```
+
+    For example, to create a data file for the `vault-plugin-secrets-keymgmt`
+    plugin with the extracted artifact directory
+    `vault-plugin-secrets-keymgmt_0.16.0+ent_linux_amd64/`:
+
+    <CodeBlockConfig hideClipboard="true">
+
+    ```shell-session
+    $ cat <<-EOF > data.json
+    {
+      "version": "v0.16.0+ent"
+    }
+    EOF
+    ```
+    </CodeBlockConfig>
+
+2. Call the [RegisterPlugin](/vault/api-docs/system/plugins-catalog#register-plugin)
+   endpoint to add your plugin to the catalog:
+
+    ```shell-session
+    $ curl                                      \
+      --request POST                            \
+      --header "X-Vault-Token: ${VAULT_TOKEN}"  \
+      --data @data.json                         \
+      ${VAULT_ADDR}/v1/sys/plugins/catalog/<plugin_type>/<plugin_name>
+    ```
+
+    For example, to register the `vault-plugin-secrets-keymgmt` plugin with the
+    extracted artifact directory `vault-plugin-secrets-keymgmt_0.16.0+ent_linux_amd64/`:
+
+    <CodeBlockConfig hideClipboard="true">
+
+    ```shell-session
+    $ curl                                      \
+      --request POST                            \
+      --header "X-Vault-Token: ${VAULT_TOKEN}"  \
+      --data @data.json                         \
+      ${VAULT_ADDR}/v1/sys/plugins/catalog/secret/vault-plugin-secrets-keymgmt
+    ```
+
+    </CodeBlockConfig>
+
+3. Call the [ListPlugins](/vault/api-docs/system/plugins-catalog#list-plugins)
+   endpoint to verify registration:
+    
+    ```shell-session
+    $ curl                                      \
+      --request GET                             \
+      --header "X-Vault-Token: ${VAULT_TOKEN}"  \
+      ${VAULT_ADDR}/v1/sys/plugins/catalog      \
+      | jq '.data.detailed | .[] | select(.name =="<plugin_name>")'
+    ```
+
+    For example:
+
+    <CodeBlockConfig hideClipboard="true">
+
+    ```shell-session
+    $ curl                                      \
+      --request GET                             \
+      --header "X-Vault-Token: ${VAULT_TOKEN}"  \
+      ${VAULT_ADDR}/v1/sys/plugins/catalog      \
+      | jq '.data.detailed | .[] | select(.name =="vault-plugin-secrets-keymgmt")'
+
+    {
+      "builtin": false,
+      "name": "vault-plugin-secrets-keymgmt",
+      "sha256": "95f051152c4b69c720afef2fef26469f83a2e084842bdfad0f795850047fc84f",
+      "type": "secret",
+      "version": "v0.16.0+ent"
+    }
+    ```
+
+    </CodeBlockConfig>
+
+</Tab>
+
+</Tabs>
+
+</Tab>
+
+</Tabs>


### PR DESCRIPTION
### Description

Manual backport of docs from commit abac619 into `release/1.19.x`.

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
