### PR TITLE
[DOCS] Add redirect to correct double versioning

### DIFF
--- a/website/redirects.js
+++ b/website/redirects.js
@@ -311,7 +311,7 @@ module.exports = [
     permanent: true,
   },
   {
-    source: '/vault/docs/v:version(1\.(?:4|5|6|7|8|9|10|11|12|13|14|15|16|17|18|19)\.x)/v:ver(1\.(?:4|5|6|7|8|9|10|11|12|13|14|15|16|17|18|19)\.x)/:slug*',
+    source: '/vault/docs/v:version(1\.*\.x)/v:ver(1\.*\.x)/:slug*',
     destination: '/vault/docs/:version/:slug',
     permanent: true,
   }

--- a/website/redirects.js
+++ b/website/redirects.js
@@ -311,7 +311,7 @@ module.exports = [
     permanent: true,
   },
   {
-    source: '/vault/docs/v:version(1\.(?:4|5|6|7|8|9|10|11|12|13|14|15|16|17|18)\.x)/v:ver(1\.(?:4|5|6|7|8|9|10|11|12|13|14|15|16|17|18)\.x)/:slug',
+    source: '/vault/docs/v:version(1\.(?:4|5|6|7|8|9|10|11|12|13|14|15|16|17|18|19)\.x)/v:ver(1\.(?:4|5|6|7|8|9|10|11|12|13|14|15|16|17|18|19)\.x)/:slug*',
     destination: '/vault/docs/:version/:slug',
     permanent: true,
   }

--- a/website/redirects.js
+++ b/website/redirects.js
@@ -309,5 +309,10 @@ module.exports = [
     source: '/vault/docs/enterprise/license/faq',
     destination: '/vault/docs/license',
     permanent: true,
+  },
+  {
+    source: '/vault/docs/v:version(1\.(?:4|5|6|7|8|9|10|11|12|13|14|15|16|17|18)\.x)/v:ver(1\.(?:4|5|6|7|8|9|10|11|12|13|14|15|16|17|18)\.x)/:slug',
+    destination: '/vault/docs/:version/:slug',
+    permanent: true,
   }
 ]


### PR DESCRIPTION
Adds a redirect for URLs with two version slugs that strips out the extra version slug