### PR TITLE
[DOCS] Add redirect to remove double version slug

### DIFF
--- a/website/redirects.js
+++ b/website/redirects.js
@@ -324,5 +324,10 @@ module.exports = [
     source: '/vault/docs/concepts/client-count/usage-metrics',
     destination: '/vault/docs/concepts/client-count/client-usage',
     permanent: true,
+  },
+  {
+    source: '/vault/docs/v:version(1\.*\.x)/v:ver(1\.*\.x)/:slug*',
+    destination: '/vault/docs/:version/:slug',
+    permanent: true,
   }
 ]


### PR DESCRIPTION
Adds a redirect for URLs with two version slugs that strips out the extra version slug