### PR TITLE
ServiceNow Update to Yokohama work around

### DIFF
--- a/website/content/docs/platform/servicenow/configuration.mdx
+++ b/website/content/docs/platform/servicenow/configuration.mdx
@@ -99,9 +99,10 @@ In the ServiceNow UI:
 1. Choose a type from the list.
 1. Select "External credential store".
 1. Provide a fully qualified collection name (FQCN):
-    - **Yokohama or newer**: You will need to enter in the credentials `com.snc.discovery.CredentialResolver`,
-        Under Credentials from the ServiceNow Webpage, you will be required to select your credentials and click 
-        the i for the mid server under “Credential Storage Vault” then click Open Record button to add the vault resolver FQCN
+    - **Yokohama or newer**: in the **Credentials** section of the ServiceNow
+      webpage, select your credentials and click **ⓘ** for the "Credential
+      Storage Vault" mid server. Click **Open Record** to add the vault resolver
+      FQCN: `com.snc.discovery.CredentialResolver`
     - **Xanadu (Q4-2024) or newer**:  use `com.snc.discovery.CredentialResolver`
     - **Versions prior to Xanadu (Q4-2024)**: leave blank or use "None"
 1. Provide a meaningful name for the resolver.

--- a/website/content/docs/platform/servicenow/configuration.mdx
+++ b/website/content/docs/platform/servicenow/configuration.mdx
@@ -99,6 +99,9 @@ In the ServiceNow UI:
 1. Choose a type from the list.
 1. Select "External credential store".
 1. Provide a fully qualified collection name (FQCN):
+    - **Yokohama or newer**: You will need to enter in the credentials `com.snc.discovery.CredentialResolver`,
+        Under Credentials from the ServiceNow Webpage, you will be required to select your credentials and click 
+        the i for the mid server under “Credential Storage Vault” then click Open Record button to add the vault resolver FQCN
     - **Xanadu (Q4-2024) or newer**:  use `com.snc.discovery.CredentialResolver`
     - **Versions prior to Xanadu (Q4-2024)**: leave blank or use "None"
 1. Provide a meaningful name for the resolver.


### PR DESCRIPTION
Confirmed Yokohama is compatible with HashiCorp Vault, there is a work around which is listed under the In the ServiceNow UI.

### Description
What does this PR do?

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
