### PR TITLE
UI: Fix flaky secrets-sync test with optional chaining

### DIFF
--- a/ui/app/services/flags.ts
+++ b/ui/app/services/flags.ts
@@ -57,7 +57,7 @@ export default class FlagsService extends Service {
   }
 
   get secretsSyncIsActivated(): boolean {
-    return this.activatedFlags.includes('secrets-sync');
+    return this.activatedFlags?.includes('secrets-sync');
   }
 
   getActivatedFlags = keepLatestTask(async () => {

--- a/ui/app/services/flags.ts
+++ b/ui/app/services/flags.ts
@@ -57,7 +57,7 @@ export default class FlagsService extends Service {
   }
 
   get secretsSyncIsActivated(): boolean {
-    return this.activatedFlags?.includes('secrets-sync');
+    return this.activatedFlags.includes('secrets-sync');
   }
 
   getActivatedFlags = keepLatestTask(async () => {

--- a/ui/tests/acceptance/sync/secrets/overview-test.js
+++ b/ui/tests/acceptance/sync/secrets/overview-test.js
@@ -168,11 +168,6 @@ module('Acceptance | sync | overview', function (hooks) {
         await loginNs('admin/foo');
       });
 
-      hooks.afterEach(async function () {
-        await visit('vault/dashboard');
-        await runCmd([`delete admin/sys/namespaces/foo -f`, deleteNS('admin')]);
-      });
-
       test('it should make activation-flag requests to correct namespace', async function (assert) {
         assert.expect(3);
 
@@ -201,9 +196,16 @@ module('Acceptance | sync | overview', function (hooks) {
         await click(ts.overview.activationModal.checkbox);
         await click(ts.overview.activationModal.confirm);
 
-        // During the afterEach hook cleanup endpoint is hit again which increases the assertion count (above)
-        // Re-stub here without the assertion to prep for namespace cleanup.
-        this.server.get('/sys/activation-flags', (_, req) => req.passthrough());
+        // During the namespace cleanup in the afterEach hook this endpoint is hit again which increases the assertion count (above)
+        // Re-stub here without the assertion to reduce unnecessary assertions.
+        this.server.get('/sys/activation-flags', () => {
+          return {
+            activated: ['secrets-sync'],
+            unactivated: [],
+          };
+        });
+        await visit('vault/dashboard');
+        await runCmd([`delete admin/sys/namespaces/foo -f`, deleteNS('admin')]);
       });
 
       test('it should make activation-flag requests to correct namespace when managed', async function (assert) {
@@ -236,9 +238,16 @@ module('Acceptance | sync | overview', function (hooks) {
         await click(ts.overview.activationModal.checkbox);
         await click(ts.overview.activationModal.confirm);
 
-        // During the afterEach hook this endpoint is hit again which increases the assertion count (above)
-        // Re-stub here without the assertion to prep for namespace cleanup.
-        this.server.get('/sys/activation-flags', (_, req) => req.passthrough());
+        // During the namespace cleanup in the afterEach hook this endpoint is hit again which increases the assertion count (above)
+        // Re-stub here without the assertion to reduce unnecessary assertions.
+        this.server.get('/sys/activation-flags', () => {
+          return {
+            activated: ['secrets-sync'],
+            unactivated: [],
+          };
+        });
+        await visit('vault/dashboard');
+        await runCmd([`delete admin/sys/namespaces/foo -f`, deleteNS('admin')]);
       });
     });
   });


### PR DESCRIPTION
### Description

 There seem to be some timing issues with cleanup in the `afterEach` hook and the stubbed mirage endpoint. `req.passthrough()` didn't consistently return a response in time so the `.includes()` check here would fail because `this.activatedFlags` would return undefined ([here](https://github.com/hashicorp/vault/blob/3f7b8a66714b10080ccd0b50e6953de8fc7676bf/ui/app/services/flags.ts#L60))

Moving the cleanup directly into the test and manually stubbing the response _seems_ to have resolved the flakiness 🤞 

 

- [x] fix flaky secrets-sync test w/ optional chaining to prevent TypeError: 
> [vault] not ok 1 Chrome 128.0 - [2333 ms] - Acceptance | sync | overview > when feature is not activated > enterprise with namespaces: it should make activation-flag requests to correct namespace when managed
[vault]     ---
[vault]         stack: >
[vault]             TypeError: Cannot read properties of undefined (reading 'includes')
[vault]                 at get secretsSyncIsActivated 
