### PR TITLE
VAULT-36903 CE Changes

### DIFF
--- a/command/server/config.go
+++ b/command/server/config.go
@@ -439,6 +439,11 @@ func (c *Config) Merge(c2 *Config) *Config {
 		if c2.Observations.LedgerPath != "" {
 			result.Observations.LedgerPath = c2.Observations.LedgerPath
 		}
+		result.Observations.TypePrefixDenylist = append(c.Observations.TypePrefixDenylist, c2.Observations.TypePrefixDenylist...)
+		result.Observations.TypePrefixAllowlist = append(c.Observations.TypePrefixAllowlist, c2.Observations.TypePrefixAllowlist...)
+		if c2.Observations.FileMode != "" {
+			result.Observations.FileMode = c2.Observations.FileMode
+		}
 	}
 
 	result.ImpreciseLeaseRoleTracking = c.ImpreciseLeaseRoleTracking

--- a/command/server/config_test.go
+++ b/command/server/config_test.go
@@ -103,6 +103,40 @@ func Test_ObservationSystemConfig(t *testing.T) {
 	require.NotNil(t, config)
 	require.NotNil(t, config.Observations)
 	require.Equal(t, "/var/ledger.log", config.Observations.LedgerPath)
+	require.Empty(t, config.Observations.TypePrefixAllowlist)
+	require.Empty(t, config.Observations.TypePrefixDenylist)
+}
+
+// Test_ObservationSystemConfigAllowDenyList makes sure that the observation system config
+// is properly loaded with an allowlist and denylist.
+func Test_ObservationSystemConfigAllowDenyList(t *testing.T) {
+	config, err := LoadConfigFile("./test-fixtures/observations_allow_deny.hcl")
+	require.NoError(t, err)
+	require.NotNil(t, config)
+	require.NotNil(t, config.Observations)
+	require.Equal(t, "/var/ledger.log", config.Observations.LedgerPath)
+	require.Equal(t, []string{"deny1", "deny2"}, config.Observations.TypePrefixDenylist)
+	require.Equal(t, []string{"allow1", "allow2", "allow3"}, config.Observations.TypePrefixAllowlist)
+	require.Equal(t, "0777", config.Observations.FileMode)
+}
+
+// Test_ObservationSystemConfigMerge checks merge for observation system config
+func Test_ObservationSystemConfigMerge(t *testing.T) {
+	config, err := LoadConfigFile("./test-fixtures/observations.hcl")
+	require.NoError(t, err)
+	require.NotNil(t, config)
+
+	config2, err := LoadConfigFile("./test-fixtures/observations_allow_deny.hcl")
+	require.NoError(t, err)
+	require.NotNil(t, config2)
+
+	merged := config.Merge(config2)
+	require.NotNil(t, merged)
+	require.NotNil(t, merged.Observations)
+	require.Equal(t, "/var/ledger.log", merged.Observations.LedgerPath)
+	require.Equal(t, []string{"deny1", "deny2"}, merged.Observations.TypePrefixDenylist)
+	require.Equal(t, []string{"allow1", "allow2", "allow3"}, merged.Observations.TypePrefixAllowlist)
+	require.Equal(t, "0777", merged.Observations.FileMode)
 }
 
 // TestDuplicateKeyValidationHcl checks that the server command displays a warning when the HCL config file contains duplicate keys.

--- a/vault/core.go
+++ b/vault/core.go
@@ -1382,7 +1382,12 @@ func NewCore(conf *CoreConfig) (*Core, error) {
 	observationSystemConfig := conf.ObservationSystemConfig
 	if observationSystemConfig != nil {
 		if observationSystemConfig.LedgerPath != "" {
-			observations, err := observations.NewObservationSystem(nodeID, observationSystemConfig.LedgerPath, observationsLogger)
+			config := &observations.NewObservationSystemConfig{
+				ObservationSystemConfig: observationSystemConfig,
+				LocalNodeId:             nodeID,
+				Logger:                  observationsLogger,
+			}
+			observations, err := observations.NewObservationSystem(config)
 			if err != nil {
 				return nil, err
 			}

--- a/vault/observations/observations.go
+++ b/vault/observations/observations.go
@@ -3,9 +3,31 @@
 
 package observations
 
+import "github.com/hashicorp/go-hclog"
+
 // ObservationSystemConfig serves as a definition of what an observation
 // system needs from the Vault config file to start.
 type ObservationSystemConfig struct {
 	// LedgerPath is the path to the observation system's ledger.
 	LedgerPath string `json:"ledger_path" hcl:"ledger_path"`
+
+	// TypePrefixDenylist will deny any observations with types with matching prefixes
+	// to be emitted to the ledger.
+	TypePrefixDenylist []string `json:"type_prefix_denylist" hcl:"type_prefix_denylist"`
+
+	// TypePrefixAllowlist will only allow observations with types with matching prefixes
+	// to be emitted to the ledger.
+	TypePrefixAllowlist []string `json:"type_prefix_allowlist" hcl:"type_prefix_allowlist"`
+
+	// FileMode will attempt to open the ledger at the ledger path with the following
+	// file mode. Specified as a string, but parsed as an octal, e.g. "0755".
+	FileMode string `json:"file_mode" hcl:"file_mode"`
+}
+
+// NewObservationSystemConfig is the config for a new Observation System, provided
+// to NewObservationSystem
+type NewObservationSystemConfig struct {
+	*ObservationSystemConfig
+	LocalNodeId string
+	Logger      hclog.Logger
 }

--- a/vault/observations/observations_consts.go
+++ b/vault/observations/observations_consts.go
@@ -4,25 +4,35 @@
 package observations
 
 const (
-	// lease
-	ObservationTypeLeaseCreationAuth    = "lease/create/auth"
+	// ObservationTypeLeaseCreationAuth is emitted when a lease connected to auth is created
+	ObservationTypeLeaseCreationAuth = "lease/create/auth"
+	// ObservationTypeLeaseCreationNonAuth is emitted when a lease NOT connected to auth is created
 	ObservationTypeLeaseCreationNonAuth = "lease/create/non-auth"
-	ObservationTypeLeaseRenewAuth       = "lease/renew/auth"
-	ObservationTypeLeaseRenewNonAuth    = "lease/renew/non-auth"
-	ObservationTypeLeaseLazyRevoke      = "lease/lazy-revoke"
-	ObservationTypeLeaseRevocation      = "lease/revoke"
+	// ObservationTypeLeaseRenewAuth is emitted when a lease connected to auth is renewed
+	ObservationTypeLeaseRenewAuth = "lease/renew/auth"
+	// ObservationTypeLeaseRenewNonAuth is emitted when a lease NOT connected to auth is renewed
+	ObservationTypeLeaseRenewNonAuth = "lease/renew/non-auth"
+	// ObservationTypeLeaseLazyRevoke is emitted when a lease is lazy-revoked
+	ObservationTypeLeaseLazyRevoke = "lease/lazy-revoke"
+	// ObservationTypeLeaseRevocation is emitted when a lease is revoked
+	ObservationTypeLeaseRevocation = "lease/revoke"
 
-	// policy
+	// ObservationTypePolicyACLEvaluation is emitted when an ACL policy is evaluated
 	ObservationTypePolicyACLEvaluation = "policy/acl/evaluation"
 
-	// mount
-	ObservationTypeMountAuthEnable     = "mount/auth/enable"
-	ObservationTypeMountAuthDisable    = "mount/auth/disable"
-	ObservationTypeMountSecretsEnable  = "mount/secrets/enable"
+	// ObservationTypeMountAuthEnable is emitted when an auth mount is enabled
+	ObservationTypeMountAuthEnable = "mount/auth/enable"
+	// ObservationTypeMountAuthDisable is emitted when an auth mount is disabled
+	ObservationTypeMountAuthDisable = "mount/auth/disable"
+	// ObservationTypeMountSecretsEnable is emitted when a secret mount is enabled
+	ObservationTypeMountSecretsEnable = "mount/secrets/enable"
+	// ObservationTypeMountSecretsDisable is emitted when a secret mount is disabled
 	ObservationTypeMountSecretsDisable = "mount/secrets/disable"
 
-	// namespace
+	// ObservationTypeNamespaceCreate is emitted when a namespace is created
 	ObservationTypeNamespaceCreate = "namespace/create"
-	ObservationTypeNamespacePatch  = "namespace/patch"
+	// ObservationTypeNamespacePatch is emitted when a namespace is patched
+	ObservationTypeNamespacePatch = "namespace/patch"
+	// ObservationTypeNamespaceDelete is emitted when a namespace is deleted
 	ObservationTypeNamespaceDelete = "namespace/delete"
 )


### PR DESCRIPTION
### Description

CE changes to go alongside https://github.com/hashicorp/vault-enterprise/pull/8389/

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
