### PR TITLE
apply oss patch

### DIFF
--- a/vault/core_metrics.go
+++ b/vault/core_metrics.go
@@ -1188,3 +1188,63 @@ func (c *Core) GetControlGroupCount() (int, error) {
 
 	return controlGroupCount, nil
 }
+
+func (c *Core) GetMFAConfigCountByMethod() map[string]int {
+	mfaCounts := make(map[string]int)
+	mfaCounts["login-totp"] = 0
+	mfaCounts["login-okta"] = 0
+	mfaCounts["login-pingid"] = 0
+	mfaCounts["login-duo"] = 0
+	mfaCounts["stepup-totp"] = 0
+	mfaCounts["stepup-okta"] = 0
+	mfaCounts["stepup-pingid"] = 0
+	mfaCounts["stepup-duo"] = 0
+
+	namespaces := c.collectNamespaces()
+
+	// count login MFA configs
+	if c.loginMFABackend != nil {
+		c.loginMFABackend.mfaLock.RLock()
+		defer c.loginMFABackend.mfaLock.RUnlock()
+
+		for _, ns := range namespaces {
+			nsCtx := namespace.ContextWithNamespace(context.Background(), ns)
+			keys, configInfo, err := c.loginMFABackend.mfaMethodList(nsCtx, "")
+			if err != nil && !errors.Is(err, logical.ErrUnsupportedPath) {
+				c.logger.Error("failed to retreive MFA methods implemented during login from the identity store")
+			}
+
+			for _, methodId := range keys {
+				currConfigMap := configInfo[methodId].(map[string]interface{})
+				// add the config to the count only if the namespaces match
+				if ns.ID == currConfigMap["namespace_id"].(string) {
+					mfaCounts["login-"+currConfigMap["type"].(string)]++
+				}
+			}
+		}
+	}
+
+	// count step-up MFA configs
+	if c.systemBackend != nil && c.systemBackend.mfaBackend != nil {
+		c.systemBackend.mfaBackend.mfaLock.RLock()
+		defer c.systemBackend.mfaBackend.mfaLock.RUnlock()
+
+		// list only from root namespace since step-up MFA configs cannot be created in child namespaces
+		keys, err := c.systemBarrierView.List(c.activeContext, "mfa/method/")
+		if err != nil && !errors.Is(err, logical.ErrUnsupportedPath) {
+			c.logger.Error("failed to list MFA methods enforced as step-up authentication from the system store")
+		}
+
+		for _, key := range keys {
+			config, err := c.systemBackend.mfaBackend.getMFAConfig(c.activeContext, "mfa/method/"+key, c.systemBarrierView)
+			if err != nil {
+				c.logger.Error("failed to retrieve MFA method config enforced as step-up authentication from the system store")
+				continue
+			}
+
+			mfaCounts["stepup-"+config.Type]++
+		}
+	}
+
+	return mfaCounts
+}


### PR DESCRIPTION
### Description
What does this PR do?
This PR adds usage metric related to count of MFA configs to Census.

Jira: https://hashicorp.atlassian.net/browse/VAULT-35528
ENT PR: https://github.com/hashicorp/vault-enterprise/pull/8368

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
