### PR TITLE
[VAULT-36232] pipeline(changed-files): fail if we change enterprise files on ce/* branches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -136,6 +136,22 @@ jobs:
         id: changed-files
         with:
           github-token: ${{ steps.metadata.outputs.is-enterprise != 'true' && secrets.ELEVATED_GITHUB_TOKEN || steps.vault-secrets.outputs.ELEVATED_GITHUB_TOKEN }}
+      # Ensure that we have not changed any enterprise files on pull requests against ce/* branches.
+      # We do this here because we have the information, there's absolutely no reason to go
+      # further until we've resolved the issue, and we want to fail a required workflow if this
+      # issue is present.
+      - if: |
+          steps.metadata.outputs.is-enterprise == 'true' &&
+          steps.metadata.outputs.workflow-trigger == 'pull_request' &&
+          startsWith(github.event.pull_request.base.ref, 'ce/') &&
+          contains(fromJSON(steps.changed-files.outputs.changed-files).groups, 'enterprise')
+        name: Ensure that we have not changed any enterprise files on pull requests against ce/* branches.
+        run: |
+          echo "The pull request has changed files that are in enterprise groups!"
+          echo "If you believe this to be in error you will want to update the changed files checks in tools/pipeline/internal/pkg/changed"
+          echo "on our enterprise branches and backport them to ce/* before continuing with this pull request."
+          echo "See the 'changed-files' step above for a list of changed files and their associated metadata groups."
+          exit 1
       # Make sure all required Go modules are cached at this point. We don't want all of the Go
       # tests and build jobs to download modules and race to upload them to the cache.
       - uses: ./.github/actions/set-up-go


### PR DESCRIPTION
### Description
In anticipation of our reversed merge workflow we need to ensure that no enterprise files are added to `ce/` branches originally hosted in `hashicorp/vault-enterprise`. We can do that by looking at the PR changed files and their associated groups to determine if such has occurred.

This was tested on two commits on enterprise: https://github.com/hashicorp/vault-enterprise/actions/runs/16037841447/job/45253499258?pr=8404

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.

### PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [x] If applicable, I've documented the impact of any changes to security controls.

Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
