### PR TITLE
Add additional validations to the destination and properties of file audit sinks

### DIFF
--- a/audit/backend.go
+++ b/audit/backend.go
@@ -25,7 +25,7 @@ const (
 	optionFormat             = "format"
 	optionHMACAccessor       = "hmac_accessor"
 	optionLogRaw             = "log_raw"
-	optionPrefix             = "prefix"
+	OptionPrefix             = "prefix"
 
 	TypeFile   = "file"
 	TypeSocket = "socket"

--- a/audit/backend_file.go
+++ b/audit/backend_file.go
@@ -6,6 +6,7 @@ package audit
 import (
 	"fmt"
 	"reflect"
+	"strconv"
 	"strings"
 
 	"github.com/hashicorp/eventlogger"
@@ -78,6 +79,15 @@ func newFileBackend(conf *BackendConfig, headersConfig HeaderFormatter) (*fileBa
 
 	sinkOpts := []event.Option{event.WithLogger(conf.Logger)}
 	if mode, ok := conf.Config[optionMode]; ok {
+		if strings.TrimSpace(mode) != "" {
+			m, err := strconv.ParseUint(mode, 8, 32)
+			if err != nil {
+				return nil, fmt.Errorf("invalid mode: %s", mode)
+			}
+			if m&0o111 != 0 {
+				return nil, fmt.Errorf("file mode may not be executable: %s", mode)
+			}
+		}
 		sinkOpts = append(sinkOpts, event.WithFileMode(mode))
 	}
 

--- a/audit/backend_file_ce_test.go
+++ b/audit/backend_file_ce_test.go
@@ -84,7 +84,7 @@ func TestFileBackend_newFileBackend_FilterFormatterSink(t *testing.T) {
 
 	cfg := map[string]string{
 		"file_path": "/tmp/foo",
-		"mode":      "0777",
+		"mode":      "0666",
 		"format":    "json",
 		"filter":    "mount_type == \"kv\"",
 	}

--- a/audit/entry_formatter_config.go
+++ b/audit/entry_formatter_config.go
@@ -94,7 +94,7 @@ func newFormatterConfig(headerFormatter HeaderFormatter, config map[string]strin
 		opt = append(opt, withElision(v))
 	}
 
-	if prefix, ok := config[optionPrefix]; ok {
+	if prefix, ok := config[OptionPrefix]; ok {
 		opt = append(opt, withPrefix(prefix))
 	}
 

--- a/changelog/31211.txt
+++ b/changelog/31211.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+audit: Add additional verifications to the target of file audit sinks.
+```

--- a/command/server.go
+++ b/command/server.go
@@ -2945,6 +2945,7 @@ func createCoreConfig(c *ServerCommand, config *server.Config, backend physical.
 		DisableSealWrap:                config.DisableSealWrap,
 		DisablePerformanceStandby:      config.DisablePerformanceStandby,
 		DisableIndexing:                config.DisableIndexing,
+		AllowAuditLogPrefixing:         config.AllowAuditLogPrefixing,
 		AllLoggers:                     c.allLoggers,
 		BuiltinRegistry:                builtinplugins.Registry,
 		DisableKeyEncodingChecks:       config.DisablePrintableCheck,

--- a/command/server/config.go
+++ b/command/server/config.go
@@ -94,6 +94,9 @@ type Config struct {
 	DisableClustering    bool        `hcl:"-"`
 	DisableClusteringRaw interface{} `hcl:"disable_clustering,alias:DisableClustering"`
 
+	AllowAuditLogPrefixing    bool        `hcl:"-"`
+	AllowAuditLogPrefixingRaw interface{} `hcl:"allow_audit_log_prefixing,alias:AllowAuditLogPrefixing"`
+
 	DisablePerformanceStandby    bool        `hcl:"-"`
 	DisablePerformanceStandbyRaw interface{} `hcl:"disable_performance_standby,alias:DisablePerformanceStandby"`
 
@@ -400,6 +403,11 @@ func (c *Config) Merge(c2 *Config) *Config {
 	result.DisablePerformanceStandby = c.DisablePerformanceStandby
 	if c2.DisablePerformanceStandby {
 		result.DisablePerformanceStandby = c2.DisablePerformanceStandby
+	}
+
+	result.AllowAuditLogPrefixing = c.AllowAuditLogPrefixing
+	if c2.AllowAuditLogPrefixing {
+		result.AllowAuditLogPrefixing = c2.AllowAuditLogPrefixing
 	}
 
 	result.DisableSealWrap = c.DisableSealWrap
@@ -748,6 +756,12 @@ func ParseConfigCheckDuplicate(d, source string) (cfg *Config, duplicate bool, e
 
 	if result.DisablePerformanceStandbyRaw != nil {
 		if result.DisablePerformanceStandby, err = parseutil.ParseBool(result.DisablePerformanceStandbyRaw); err != nil {
+			return nil, duplicate, err
+		}
+	}
+
+	if result.AllowAuditLogPrefixingRaw != nil {
+		if result.AllowAuditLogPrefixing, err = parseutil.ParseBool(result.AllowAuditLogPrefixingRaw); err != nil {
 			return nil, duplicate, err
 		}
 	}
@@ -1377,8 +1391,8 @@ func (c *Config) Sanitized() map[string]interface{} {
 
 		"disable_sealwrap": c.DisableSealWrap,
 
-		"disable_indexing": c.DisableIndexing,
-
+		"disable_indexing":                c.DisableIndexing,
+		"allow_audit_log_prefixing":       c.AllowAuditLogPrefixing,
 		"enable_response_header_hostname": c.EnableResponseHeaderHostname,
 
 		"enable_response_header_raft_node_id": c.EnableResponseHeaderRaftNodeID,

--- a/command/server/config_test_helpers.go
+++ b/command/server/config_test_helpers.go
@@ -895,6 +895,7 @@ func testConfig_Sanitized(t *testing.T) {
 		"enable_post_unseal_trace":       true,
 		"post_unseal_trace_directory":    "/tmp",
 		"remove_irrevocable_lease_after": (30 * 24 * time.Hour) / time.Second,
+		"allow_audit_log_prefixing":      false,
 	}
 
 	addExpectedEntSanitizedConfig(expected, []string{"http"})

--- a/http/sys_config_state_test.go
+++ b/http/sys_config_state_test.go
@@ -182,6 +182,7 @@ func TestSysConfigState_Sanitized(t *testing.T) {
 				"enable_post_unseal_trace":       false,
 				"post_unseal_trace_directory":    "",
 				"remove_irrevocable_lease_after": json.Number("0"),
+				"allow_audit_log_prefixing":      false,
 			}
 
 			if tc.expectedHAStorageOutput != nil {

--- a/vault/core.go
+++ b/vault/core.go
@@ -692,6 +692,9 @@ type Core struct {
 	// disableAutopilot is used to disable the autopilot subsystem in raft storage
 	disableAutopilot bool
 
+	// allowAuditLogPrefixing must be enabled for audit devices to use a prefix (more secure without)
+	allowAuditLogPrefixing bool
+
 	// enable/disable identifying response headers
 	enableResponseHeaderHostname   bool
 	enableResponseHeaderRaftNodeID bool
@@ -906,6 +909,9 @@ type CoreConfig struct {
 	// DisableAutopilot is used to disable autopilot subsystem in raft storage
 	DisableAutopilot bool
 
+	// AllowAuditLogPrefixing must be enabled for audit devices to use a prefix (more secure without)
+	AllowAuditLogPrefixing bool
+
 	// Whether to send headers in the HTTP response showing hostname or raft node ID
 	EnableResponseHeaderHostname   bool
 	EnableResponseHeaderRaftNodeID bool
@@ -1098,6 +1104,7 @@ func CreateCore(conf *CoreConfig) (*Core, error) {
 		numExpirationWorkers:           conf.NumExpirationWorkers,
 		raftFollowerStates:             raft.NewFollowerStates(),
 		disableAutopilot:               conf.DisableAutopilot,
+		allowAuditLogPrefixing:         conf.AllowAuditLogPrefixing,
 		enableResponseHeaderHostname:   conf.EnableResponseHeaderHostname,
 		enableResponseHeaderRaftNodeID: conf.EnableResponseHeaderRaftNodeID,
 		mountMigrationTracker:          &sync.Map{},

--- a/website/content/docs/configuration/index.mdx
+++ b/website/content/docs/configuration/index.mdx
@@ -280,9 +280,6 @@ can have a negative effect on performance due to the tracking of each lock attem
   [os.TempDir()](https://pkg.go.dev/os#TempDir) (usually `/tmp` on Unix systems). This can be updated on a running Vault process
   with a SIGHUP signal.
 
-- `allow_audit_log_prefixing` `(bool: "false")` - By default, prefixing is not allowed on file audit sinks.  Setting this to 
-  true allows this for newly configured audit sinks.
-
 ### High availability parameters
 
 The following parameters are used on backends that support [high availability][high-availability].

--- a/website/content/docs/configuration/index.mdx
+++ b/website/content/docs/configuration/index.mdx
@@ -280,6 +280,9 @@ can have a negative effect on performance due to the tracking of each lock attem
   [os.TempDir()](https://pkg.go.dev/os#TempDir) (usually `/tmp` on Unix systems). This can be updated on a running Vault process
   with a SIGHUP signal.
 
+- `allow_audit_log_prefixing` `(bool: "false")` - By default, prefixing is not allowed on file audit sinks.  Setting this to 
+  true allows this for newly configured audit sinks.
+
 ### High availability parameters
 
 The following parameters are used on backends that support [high availability][high-availability].


### PR DESCRIPTION
### Description
What does this PR do?

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.

### PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.

Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.