### PR TITLE
Audit: Support audit log file rotation

### DIFF
--- a/audit/backend_file.go
+++ b/audit/backend_file.go
@@ -17,8 +17,11 @@ const (
 	stdout  = "stdout"
 	discard = "discard"
 
-	optionFilePath = "file_path"
-	optionMode     = "mode"
+	optionFilePath    = "file_path"
+	optionMode        = "mode"
+	optionMaxFiles    = "max_files"
+	optionMaxBytes    = "max_bytes"
+	optionMaxDuration = "max_duration"
 )
 
 var _ Backend = (*fileBackend)(nil)
@@ -89,6 +92,15 @@ func newFileBackend(conf *BackendConfig, headersConfig HeaderFormatter) (*fileBa
 			}
 		}
 		sinkOpts = append(sinkOpts, event.WithFileMode(mode))
+	}
+	if maxFiles, ok := conf.Config[optionMaxFiles]; ok {
+		sinkOpts = append(sinkOpts, event.WithMaxFiles(maxFiles))
+	}
+	if maxBytes, ok := conf.Config[optionMaxBytes]; ok {
+		sinkOpts = append(sinkOpts, event.WithMaxBytes(maxBytes))
+	}
+	if maxDuration, ok := conf.Config[optionMaxDuration]; ok {
+		sinkOpts = append(sinkOpts, event.WithMaxDurationFile(maxDuration))
 	}
 
 	err = b.configureSinkNode(conf.MountPath, filePath, cfg.requiredFormat, sinkOpts...)

--- a/changelog/31213.txt
+++ b/changelog/31213.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+core/audit: Support audit log file rotation.
+```

--- a/internal/observability/event/errors.go
+++ b/internal/observability/event/errors.go
@@ -7,4 +7,7 @@ import (
 	"errors"
 )
 
-var ErrInvalidParameter = errors.New("invalid parameter")
+var (
+	ErrInvalidParameter = errors.New("invalid parameter")
+	ErrExternalOptions  = errors.New("invalid configuration")
+)

--- a/internal/observability/event/options_test.go
+++ b/internal/observability/event/options_test.go
@@ -107,6 +107,9 @@ func TestOptions_Default(t *testing.T) {
 	require.Equal(t, "AUTH", opts.withFacility)
 	require.Equal(t, "vault", opts.withTag)
 	require.Equal(t, 2*time.Second, opts.withMaxDuration)
+	require.Equal(t, 0, opts.withMaxFiles)
+	require.Equal(t, int64(0), opts.withMaxBytes)
+	require.Equal(t, 24*time.Hour, opts.withMaxDurationFile)
 }
 
 // TestOptions_Opts exercises getOpts with various Option values.
@@ -357,6 +360,160 @@ func TestOptions_WithMaxDuration(t *testing.T) {
 			default:
 				require.NoError(t, err)
 				require.Equal(t, tc.ExpectedValue, opts.withMaxDuration)
+			}
+		})
+	}
+}
+
+// TestOptions_WithMaxFiles exercises WithMaxFiles Option to ensure it performs as expected.
+func TestOptions_WithMaxFiles(t *testing.T) {
+	tests := map[string]struct {
+		Value                string
+		ExpectedValue        int
+		IsErrorExpected      bool
+		ExpectedErrorMessage string
+	}{
+		"empty-gives-default": {
+			Value: "",
+		},
+		"whitespace-give-default": {
+			Value: "    ",
+		},
+		"bad-value": {
+			Value:                "juan",
+			IsErrorExpected:      true,
+			ExpectedErrorMessage: "unable to parse max files: invalid configuration",
+		},
+		"bad-spacey-value": {
+			Value:                "   juan   ",
+			IsErrorExpected:      true,
+			ExpectedErrorMessage: "unable to parse max files: invalid configuration",
+		},
+		"maxFiles-2": {
+			Value:         "2",
+			ExpectedValue: 2,
+		},
+	}
+
+	for name, tc := range tests {
+		name := name
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			opts := &options{}
+			applyOption := WithMaxFiles(tc.Value)
+			err := applyOption(opts)
+			switch {
+			case tc.IsErrorExpected:
+				require.Error(t, err)
+				require.EqualError(t, err, tc.ExpectedErrorMessage)
+			default:
+				require.NoError(t, err)
+				require.Equal(t, tc.ExpectedValue, opts.withMaxFiles)
+			}
+		})
+	}
+}
+
+// TestOptions_WithMaxBytes exercises WithMaxBytes Option to ensure it performs as expected.
+func TestOptions_WithMaxBytes(t *testing.T) {
+	tests := map[string]struct {
+		Value                string
+		ExpectedValue        int64
+		IsErrorExpected      bool
+		ExpectedErrorMessage string
+	}{
+		"empty-gives-default": {
+			Value: "",
+		},
+		"whitespace-give-default": {
+			Value: "    ",
+		},
+		"bad-value": {
+			Value:                "juan",
+			IsErrorExpected:      true,
+			ExpectedErrorMessage: "unable to parse max file bytes: invalid configuration",
+		},
+		"bad-spacey-value": {
+			Value:                "   juan   ",
+			IsErrorExpected:      true,
+			ExpectedErrorMessage: "unable to parse max file bytes: invalid configuration",
+		},
+		"maxBytes-2": {
+			Value:         "2",
+			ExpectedValue: 2,
+		},
+	}
+
+	for name, tc := range tests {
+		name := name
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			opts := &options{}
+			applyOption := WithMaxBytes(tc.Value)
+			err := applyOption(opts)
+			switch {
+			case tc.IsErrorExpected:
+				require.Error(t, err)
+				require.EqualError(t, err, tc.ExpectedErrorMessage)
+			default:
+				require.NoError(t, err)
+				require.Equal(t, tc.ExpectedValue, opts.withMaxBytes)
+			}
+		})
+	}
+}
+
+// TestOptions_WithMaxDurationFile exercises WithMaxDurationFile Option to ensure it performs as expected.
+func TestOptions_WithMaxDurationFile(t *testing.T) {
+	tests := map[string]struct {
+		Value                string
+		ExpectedValue        time.Duration
+		IsErrorExpected      bool
+		ExpectedErrorMessage string
+	}{
+		"empty-gives-default": {
+			Value: "",
+		},
+		"whitespace-give-default": {
+			Value: "    ",
+		},
+		"bad-value": {
+			Value:                "juan",
+			IsErrorExpected:      true,
+			ExpectedErrorMessage: "unable to parse max file duration: invalid configuration: time: invalid duration \"juan\"",
+		},
+		"bad-spacey-value": {
+			Value:                "   juan   ",
+			IsErrorExpected:      true,
+			ExpectedErrorMessage: "unable to parse max file duration: invalid configuration: time: invalid duration \"juan\"",
+		},
+		"duration-2s": {
+			Value:         "2s",
+			ExpectedValue: 2 * time.Second,
+		},
+		"duration-2m": {
+			Value:         "2m",
+			ExpectedValue: 2 * time.Minute,
+		},
+	}
+
+	for name, tc := range tests {
+		name := name
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			opts := &options{}
+			applyOption := WithMaxDurationFile(tc.Value)
+			err := applyOption(opts)
+			switch {
+			case tc.IsErrorExpected:
+				require.Error(t, err)
+				require.EqualError(t, err, tc.ExpectedErrorMessage)
+			default:
+				require.NoError(t, err)
+				require.Equal(t, tc.ExpectedValue, opts.withMaxDurationFile)
 			}
 		})
 	}

--- a/internal/observability/event/sink_file.go
+++ b/internal/observability/event/sink_file.go
@@ -6,12 +6,15 @@ package event
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/hashicorp/eventlogger"
 	"github.com/hashicorp/go-hclog"
@@ -21,6 +24,8 @@ import (
 // defaultFileMode is the default file permissions (read/write for everyone).
 const (
 	defaultFileMode = 0o600
+	stdout          = "/dev/stdout"
+	stderr          = "/dev/stderr"
 	devnull         = "/dev/null"
 )
 
@@ -34,6 +39,11 @@ type FileSink struct {
 	fileMode       os.FileMode
 	path           string
 	requiredFormat string
+	maxFiles       int
+	maxBytes       int64
+	maxDuration    time.Duration
+	bytesWritten   int64
+	lastCreated    time.Time
 	logger         hclog.Logger
 }
 
@@ -55,7 +65,7 @@ func NewFileSink(path string, format string, opt ...Option) (*FileSink, error) {
 	// If we got an optional file mode supplied and our path isn't a special keyword
 	// then we should use the supplied file mode, or maintain the existing file mode.
 	switch {
-	case path == devnull:
+	case path == stdout || path == stderr || path == devnull:
 	case opts.withFileMode == nil:
 	case *opts.withFileMode == 0: // Maintain the existing file's mode when set to "0000".
 		fileInfo, err := os.Stat(path)
@@ -72,6 +82,11 @@ func NewFileSink(path string, format string, opt ...Option) (*FileSink, error) {
 		fileMode:       mode,
 		requiredFormat: format,
 		path:           p,
+		maxFiles:       opts.withMaxFiles,
+		maxBytes:       opts.withMaxBytes,
+		maxDuration:    opts.withMaxDurationFile,
+		bytesWritten:   0,
+		lastCreated:    time.Time{},
 		logger:         opts.withLogger,
 	}
 
@@ -121,8 +136,8 @@ func (s *FileSink) Process(ctx context.Context, e *eventlogger.Event) (_ *eventl
 		return nil, fmt.Errorf("event is nil: %w", ErrInvalidParameter)
 	}
 
-	// '/dev/null' path means we just do nothing and pretend we're done.
-	if s.path == devnull {
+	// '/dev/stdout', '/dev/stderr', '/dev/null' paths mean we just do nothing and pretend we're done.
+	if s.path == stdout || s.path == stderr || s.path == devnull {
 		return nil, nil
 	}
 
@@ -142,8 +157,8 @@ func (s *FileSink) Process(ctx context.Context, e *eventlogger.Event) (_ *eventl
 
 // Reopen handles closing and reopening the file.
 func (s *FileSink) Reopen() error {
-	// '/dev/null' path means we just do nothing and pretend we're done.
-	if s.path == devnull {
+	// '/dev/stdout', '/dev/stderr', '/dev/null' paths mean we just do nothing and pretend we're done.
+	if s.path == stdout || s.path == stderr || s.path == devnull {
 		return nil
 	}
 
@@ -184,25 +199,28 @@ func (s *FileSink) open() error {
 		return fmt.Errorf("unable to create file %q: %w", s.path, err)
 	}
 
-	var err error
-	s.file, err = os.OpenFile(s.path, os.O_APPEND|os.O_WRONLY|os.O_CREATE, s.fileMode)
+	createTime := time.Now()
+	filePointer, err := os.OpenFile(s.path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, s.fileMode)
 	if err != nil {
 		return fmt.Errorf("unable to open file for sink %q: %w", s.path, err)
 	}
 
 	// Change the file mode in case the log file already existed.
-	// We special case '/dev/null' since we can't chmod it, and bypass if the mode is zero.
+	// We special case '/dev/stdout', '/dev/stderr', '/dev/null' since we can't chmod them, and bypass if the mode is zero.
 	switch s.path {
-	case devnull:
+	case stdout, stderr, devnull:
 	default:
 		if s.fileMode != 0 {
-			err = os.Chmod(s.path, s.fileMode)
-			if err != nil {
+			if err = os.Chmod(s.path, s.fileMode); err != nil {
 				return fmt.Errorf("unable to change file permissions '%v' for sink %q: %w", s.fileMode, s.path, err)
 			}
 		}
 	}
 
+	// New file, new bytes tracker, new creation time :)
+	s.file = filePointer
+	s.lastCreated = createTime
+	s.bytesWritten = 0
 	return nil
 }
 
@@ -227,13 +245,18 @@ func (s *FileSink) log(ctx context.Context, data []byte) error {
 		return fmt.Errorf("unable to open file for sink %q: %w", s.path, err)
 	}
 
-	if _, err := reader.WriteTo(s.file); err == nil {
+	// Check for last contact, rotate if necessary and able.
+	if err := s.rotate(); err != nil {
+		return fmt.Errorf("unable to rotate file for sink %q: %w", s.path, err)
+	}
+
+	if n, err := reader.WriteTo(s.file); err == nil {
+		s.bytesWritten += n
 		return nil
 	}
 
 	// Otherwise, opportunistically try to re-open the FD, once per call (1 retry attempt).
-	err := s.file.Close()
-	if err != nil {
+	if err := s.file.Close(); err != nil {
 		return fmt.Errorf("unable to close file for sink %q: %w", s.path, err)
 	}
 
@@ -243,15 +266,95 @@ func (s *FileSink) log(ctx context.Context, data []byte) error {
 		return fmt.Errorf("unable to re-open file for sink %q: %w", s.path, err)
 	}
 
-	_, err = reader.Seek(0, io.SeekStart)
-	if err != nil {
+	if _, err := reader.Seek(0, io.SeekStart); err != nil {
 		return fmt.Errorf("unable to seek to start of file for sink %q: %w", s.path, err)
 	}
 
-	_, err = reader.WriteTo(s.file)
-	if err != nil {
+	if _, err := reader.WriteTo(s.file); err != nil {
 		return fmt.Errorf("unable to re-write to file for sink %q: %w", s.path, err)
 	}
 
 	return nil
+}
+
+func (s *FileSink) rotate() error {
+	switch s.path {
+	case stdout, stderr, devnull:
+		return nil
+	}
+
+	// Get the time from the last point of contact.
+	timeElapsed := time.Since(s.lastCreated)
+	// Rotate if we hit the byte file limit or the time limit.
+	if (s.bytesWritten >= s.maxBytes && s.maxBytes > 0) ||
+		(timeElapsed >= s.maxDuration && s.maxDuration > 0) {
+
+		// Clean up the existing file.
+		if err := s.file.Close(); err != nil {
+			return err
+		}
+		s.file = nil
+
+		// Move current log file to a timestamped file.
+		rotateTime := time.Now().UnixNano()
+		rotateFileName := fmt.Sprintf(s.fileNamePattern("-%d"), rotateTime)
+		newPath := filepath.Join(filepath.Dir(s.path), rotateFileName)
+		if err := os.Rename(s.path, newPath); err != nil {
+			return fmt.Errorf("failed to rotate log file: %v", err)
+		}
+
+		if err := s.pruneFiles(); err != nil {
+			return fmt.Errorf("failed to prune log files: %w", err)
+		}
+		return s.open()
+	}
+
+	return nil
+}
+
+func (s *FileSink) pruneFiles() error {
+	switch {
+	case s.path == stdout, s.path == stderr, s.path == devnull:
+		return nil
+	case s.maxFiles == 0:
+		return nil
+	}
+
+	pattern := filepath.Join(filepath.Dir(s.path), fmt.Sprintf(s.fileNamePattern("-%s"), "*"))
+	matches, err := filepath.Glob(pattern)
+	if err != nil {
+		return err
+	}
+
+	switch {
+	case s.maxFiles < 0:
+		return removeFiles(matches)
+	case len(matches) < s.maxFiles:
+		return nil
+	}
+
+	sort.Strings(matches)
+	stale := len(matches) - s.maxFiles
+	return removeFiles(matches[:stale])
+}
+
+func removeFiles(files []string) (err error) {
+	for _, file := range files {
+		if fileError := os.Remove(file); fileError != nil {
+			err = errors.Join(err, fmt.Errorf("error removing file %s: %v", file, fileError))
+		}
+	}
+	return err
+}
+
+func (s *FileSink) fileNamePattern(format string) string {
+	fileName := filepath.Base(s.path)
+	// Extract the file extension.
+	fileExt := filepath.Ext(fileName)
+	// If we have no file extension we append .log.
+	if fileExt == "" {
+		fileExt = ".log"
+	}
+	// Add format string between file and extension.
+	return strings.TrimSuffix(fileName, fileExt) + format + fileExt
 }

--- a/internal/observability/event/sink_file_test.go
+++ b/internal/observability/event/sink_file_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"sort"
 	"testing"
 	"time"
 
@@ -135,8 +136,18 @@ func TestFileSink_Reopen(t *testing.T) {
 		ExpectedFileMode      os.FileMode
 	}{
 		// Should be ignored by Reopen
+		"stdout": {
+			Path:                  stdout,
+			ShouldUseAbsolutePath: true,
+			ShouldIgnoreFileMode:  true,
+		},
+		"stderr": {
+			Path:                  stderr,
+			ShouldUseAbsolutePath: true,
+			ShouldIgnoreFileMode:  true,
+		},
 		"devnull": {
-			Path:                  "/dev/null",
+			Path:                  devnull,
 			ShouldUseAbsolutePath: true,
 			ShouldIgnoreFileMode:  true,
 		},
@@ -214,6 +225,20 @@ func TestFileSink_Process(t *testing.T) {
 		IsErrorExpected       bool
 		ExpectedErrorMessage  string
 	}{
+		"stdout": {
+			ShouldUseAbsolutePath: true,
+			Path:                  stdout,
+			Format:                "json",
+			Data:                  "foo",
+			IsErrorExpected:       false,
+		},
+		"stderr": {
+			ShouldUseAbsolutePath: true,
+			Path:                  stderr,
+			Format:                "json",
+			Data:                  "foo",
+			IsErrorExpected:       false,
+		},
 		"devnull": {
 			ShouldUseAbsolutePath: true,
 			Path:                  devnull,
@@ -376,4 +401,238 @@ func TestFileSink_log_timeoutWhileWaitingForPermit(t *testing.T) {
 	case <-time.After(500 * time.Millisecond):
 		t.Fatal("sink.log did not return promptly while waiting on permit")
 	}
+}
+
+func TestFileSink_Rotation_MaxDuration(t *testing.T) {
+	tempDir := t.TempDir()
+	tempPath := filepath.Join(tempDir, "vault.log")
+	options := []Option{WithMaxDurationFile("50ms")}
+
+	sink, err := NewFileSink(tempPath, "json", options...)
+	require.NoError(t, err)
+	require.NotNil(t, sink)
+
+	ctx := namespace.RootContext(nil)
+
+	event := &eventlogger.Event{
+		Formatted: map[string][]byte{"json": []byte("first entry")},
+	}
+	_, err = sink.Process(ctx, event)
+	require.NoError(t, err, "error writing rotation max duration part 1")
+
+	time.Sleep(3 * sink.maxDuration)
+
+	event = &eventlogger.Event{
+		Formatted: map[string][]byte{"json": []byte("second entry")},
+	}
+	_, err = sink.Process(ctx, event)
+	require.NoError(t, err, "error writing rotation max duration part 2")
+
+	logFiles := listDir(t, tempDir)
+	require.Len(t, logFiles, 2)
+	require.Equal(t, "vault.log", logFiles[1])
+
+	content, err := os.ReadFile(filepath.Join(tempDir, logFiles[0]))
+	require.NoError(t, err)
+	require.Equal(t, []byte("first entry"), content)
+
+	content, err = os.ReadFile(filepath.Join(tempDir, logFiles[1]))
+	require.NoError(t, err)
+	require.Equal(t, []byte("second entry"), content)
+}
+
+func TestFileSink_Rotation_MaxBytes(t *testing.T) {
+	tempDir := t.TempDir()
+	tempPath := filepath.Join(tempDir, "vault.log")
+	options := []Option{WithMaxBytes("10"), WithMaxDurationFile("1d")}
+
+	sink, err := NewFileSink(tempPath, "json", options...)
+	require.NoError(t, err)
+	require.NotNil(t, sink)
+
+	ctx := namespace.RootContext(nil)
+
+	event := &eventlogger.Event{
+		Formatted: map[string][]byte{"json": []byte("first entry")},
+	}
+	_, err = sink.Process(ctx, event)
+	require.NoError(t, err, "error writing rotation max bytes part 1")
+
+	event = &eventlogger.Event{
+		Formatted: map[string][]byte{"json": []byte("second entry")},
+	}
+	_, err = sink.Process(ctx, event)
+	require.NoError(t, err, "error writing rotation max bytes part 2")
+
+	logFiles := listDir(t, tempDir)
+	require.Len(t, logFiles, 2)
+	require.Equal(t, "vault.log", logFiles[1])
+
+	content, err := os.ReadFile(filepath.Join(tempDir, logFiles[0]))
+	require.NoError(t, err)
+	require.Equal(t, []byte("first entry"), content)
+
+	content, err = os.ReadFile(filepath.Join(tempDir, logFiles[1]))
+	require.NoError(t, err)
+	require.Equal(t, []byte("second entry"), content)
+}
+
+func TestFileSink_PruneFiles(t *testing.T) {
+	tempDir := t.TempDir()
+	tempPath := filepath.Join(tempDir, "vault.log")
+	options := []Option{WithMaxFiles("1"), WithMaxBytes("10"), WithMaxDurationFile("1d")}
+
+	sink, err := NewFileSink(tempPath, "json", options...)
+	require.NoError(t, err)
+	require.NotNil(t, sink)
+
+	ctx := namespace.RootContext(nil)
+
+	event := &eventlogger.Event{
+		Formatted: map[string][]byte{"json": []byte("first entry")},
+	}
+	_, err = sink.Process(ctx, event)
+	require.NoError(t, err, "error writing during prune files test part 1")
+
+	event = &eventlogger.Event{
+		Formatted: map[string][]byte{"json": []byte("second entry")},
+	}
+	_, err = sink.Process(ctx, event)
+	require.NoError(t, err, "error writing during prune files test part 2")
+
+	event = &eventlogger.Event{
+		Formatted: map[string][]byte{"json": []byte("third entry")},
+	}
+	_, err = sink.Process(ctx, event)
+	require.NoError(t, err, "error writing during prune files test part 3")
+
+	logFiles := listDir(t, tempDir)
+	require.Len(t, logFiles, 2)
+	require.Equal(t, "vault.log", logFiles[1])
+
+	content, err := os.ReadFile(filepath.Join(tempDir, logFiles[0]))
+	require.NoError(t, err)
+	require.Equal(t, []byte("second entry"), content)
+
+	content, err = os.ReadFile(filepath.Join(tempDir, logFiles[1]))
+	require.NoError(t, err)
+	require.Equal(t, []byte("third entry"), content)
+}
+
+func TestFileSink_PruneFiles_Disabled(t *testing.T) {
+	tempDir := t.TempDir()
+	tempPath := filepath.Join(tempDir, "vault.log")
+	options := []Option{WithMaxFiles("0"), WithMaxBytes("10"), WithMaxDurationFile("1d")}
+
+	sink, err := NewFileSink(tempPath, "json", options...)
+	require.NoError(t, err)
+	require.NotNil(t, sink)
+
+	ctx := namespace.RootContext(nil)
+
+	event := &eventlogger.Event{
+		Formatted: map[string][]byte{"json": []byte("first entry")},
+	}
+	_, err = sink.Process(ctx, event)
+	require.NoError(t, err, "error writing during prune files - disabled test part 1")
+
+	event = &eventlogger.Event{
+		Formatted: map[string][]byte{"json": []byte("second entry")},
+	}
+	_, err = sink.Process(ctx, event)
+	require.NoError(t, err, "error writing during prune files - disabled test part 2")
+
+	event = &eventlogger.Event{
+		Formatted: map[string][]byte{"json": []byte("third entry")},
+	}
+	_, err = sink.Process(ctx, event)
+	require.NoError(t, err, "error writing during prune files - disabled test part 3")
+
+	require.Len(t, listDir(t, tempDir), 3)
+}
+
+func TestFileSink_PruneFiles_Always(t *testing.T) {
+	tempDir := t.TempDir()
+	tempPath := filepath.Join(tempDir, "vault.log")
+	options := []Option{WithMaxFiles("-1"), WithMaxBytes("10"), WithMaxDurationFile("1d")}
+
+	sink, err := NewFileSink(tempPath, "json", options...)
+	require.NoError(t, err)
+	require.NotNil(t, sink)
+
+	ctx := namespace.RootContext(nil)
+
+	event := &eventlogger.Event{
+		Formatted: map[string][]byte{"json": []byte("first entry")},
+	}
+	_, err = sink.Process(ctx, event)
+	require.NoError(t, err, "error writing during prune files - always test part 1")
+
+	event = &eventlogger.Event{
+		Formatted: map[string][]byte{"json": []byte("second entry")},
+	}
+	_, err = sink.Process(ctx, event)
+	require.NoError(t, err, "error writing during prune files - always test part 2")
+
+	event = &eventlogger.Event{
+		Formatted: map[string][]byte{"json": []byte("third entry")},
+	}
+	_, err = sink.Process(ctx, event)
+	require.NoError(t, err, "error writing during prune files - always test part 3")
+
+	logFiles := listDir(t, tempDir)
+	require.Len(t, logFiles, 1)
+	require.Equal(t, "vault.log", logFiles[0])
+
+	content, err := os.ReadFile(filepath.Join(tempDir, logFiles[0]))
+	require.NoError(t, err)
+	require.Equal(t, []byte("third entry"), content)
+}
+
+func TestFileSink_FileRotation_Disabled(t *testing.T) {
+	tempDir := t.TempDir()
+	tempPath := filepath.Join(tempDir, "vault.log")
+	options := []Option{WithMaxFiles("0"), WithMaxBytes("0"), WithMaxDurationFile("0")}
+
+	sink, err := NewFileSink(tempPath, "json", options...)
+	require.NoError(t, err)
+	require.NotNil(t, sink)
+
+	ctx := namespace.RootContext(nil)
+
+	event := &eventlogger.Event{
+		Formatted: map[string][]byte{"json": []byte("first entry")},
+	}
+	_, err = sink.Process(ctx, event)
+	require.NoError(t, err, "error writing during rotation - disabled test part 1")
+
+	event = &eventlogger.Event{
+		Formatted: map[string][]byte{"json": []byte("second entry")},
+	}
+	_, err = sink.Process(ctx, event)
+	require.NoError(t, err, "error writing during rotation - disabled test part 2")
+
+	event = &eventlogger.Event{
+		Formatted: map[string][]byte{"json": []byte("third entry")},
+	}
+	_, err = sink.Process(ctx, event)
+	require.NoError(t, err, "error writing during rotation - disabled test part 3")
+
+	logFiles := listDir(t, tempDir)
+	require.Len(t, logFiles, 1)
+	require.Equal(t, "vault.log", logFiles[0])
+
+	content, err := os.ReadFile(filepath.Join(tempDir, logFiles[0]))
+	require.NoError(t, err)
+	require.Equal(t, []byte("first entrysecond entrythird entry"), content)
+}
+
+func listDir(t *testing.T, name string) []string {
+	t.Helper()
+	fh, err := os.Open(name)
+	require.NoError(t, err)
+	files, err := fh.Readdirnames(100)
+	require.NoError(t, err)
+	sort.Strings(files)
+	return files
 }


### PR DESCRIPTION
### Description
Allow to natively configure Vault file audit device log file rotation with the `audit enable` command by adding 3 new options to the file backend. These 3 new options and their default values are as follows:

- `max_files` : `(int: 0)` - The maximum number of older audit log file archives to keep. Defaults to `0` (no files are ever deleted). Set to `-1` to discard old audit log files when a new one is created.
- `max_bytes` : `(int: 0)` - The number of bytes that should be written to an audit log file before it needs to be rotated. Unless specified, there is no limit to the number of bytes that can be written to a log file.
- `max_duration` : `(string: "24h")` - The maximum duration an audit log file should be written to before it needs to be rotated. Must be a duration value such as `"30s"`. Defaults to `"24h"`. If no time unit is specified, the time duration number is assumed to be in seconds. Set to `0` to disable time-based log file rotation.

By default, audit log file rotation is set to occur every 24 hours, with no older log file ever removed. New behavior, as well as the new options, are reflected in the documentation.

In order to revert to previous behavior, where log rotation was not handled by the Vault, the `max_duration` option must be set to `0`, as all other new options are already set to `0` by default.

Resolves #21847 

### PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [x] If applicable, I've documented the impact of any changes to security controls.

Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
