### PR TITLE
VAULT-35838: advance deprecation of duplicate HCL attributes to pending removal stage

### DIFF
--- a/api/cliconfig/config_test.go
+++ b/api/cliconfig/config_test.go
@@ -61,17 +61,43 @@ nope = "true"
 	}
 }
 
+// TestParseConfig_HclDuplicateKey tests the parsing of HCL files with duplicate keys.
+// TODO (HCL_DUP_KEYS_DEPRECATION): on full removal change this test to ensure that duplicate attributes cannot be parsed
+// under any circumstances.
 func TestParseConfig_HclDuplicateKey(t *testing.T) {
-	_, duplicate, err := parseConfig(`
+	t.Run("fail parsing without env var", func(t *testing.T) {
+		_, _, err := parseConfig(`
 token_helper = "/token"
 token_helper = "/token"
 `)
-	// TODO (HCL_DUP_KEYS_DEPRECATION): change this to expect an error once support for duplicate keys is fully removed
-	if err != nil {
-		t.Fatal("expected no error")
-	}
+		if err == nil {
+			t.Fatal("expected error")
+		}
+	})
 
-	if !duplicate {
-		t.Fatal("expected duplicate")
-	}
+	t.Run("fail parsing with env var set to false", func(t *testing.T) {
+		t.Setenv(allowHclDuplicatesEnvVar, "false")
+		_, _, err := parseConfig(`
+token_helper = "/token"
+token_helper = "/token"
+`)
+		if err == nil {
+			t.Fatal("expected error")
+		}
+	})
+
+	t.Run("succeed parsing with env var set to true", func(t *testing.T) {
+		t.Setenv(allowHclDuplicatesEnvVar, "true")
+		_, duplicate, err := parseConfig(`
+token_helper = "/token"
+token_helper = "/token"
+`)
+		if err != nil {
+			t.Fatal("expected no error")
+		}
+
+		if !duplicate {
+			t.Fatal("expected duplicate")
+		}
+	})
 }

--- a/api/cliconfig/hcl_dup_attr_deprecation.go
+++ b/api/cliconfig/hcl_dup_attr_deprecation.go
@@ -4,6 +4,9 @@
 package cliconfig
 
 import (
+	"fmt"
+	"os"
+	"strconv"
 	"strings"
 
 	"github.com/hashicorp/hcl"
@@ -11,13 +14,32 @@ import (
 	hclParser "github.com/hashicorp/hcl/hcl/parser"
 )
 
+// allowHclDuplicatesEnvVar is an environment variable that allows Vault to revert back to accepting HCL files with
+// duplicate attributes. It's temporary until we finish the deprecation process, at which point this will be removed
+const allowHclDuplicatesEnvVar = "VAULT_ALLOW_PENDING_REMOVAL_DUPLICATE_HCL_ATTRIBUTES"
+
 // parseAndCheckForDuplicateHclAttributes parses the input JSON/HCL file and if it is HCL it also checks
-// for duplicate keys in the HCL file, allowing callers to handle the issue accordingly. In a future release we'll
-// change the behavior to treat duplicate keys as an error and eventually remove this helper altogether.
-// TODO (HCL_DUP_KEYS_DEPRECATION): remove once not used anymore
+// for duplicate keys in the HCL file, allowing callers to handle the issue accordingly. It now only accepts duplicate
+// // keys if the environment variable VAULT_ALLOW_PENDING_REMOVAL_DUPLICATE_HCL_ATTRIBUTES is set to true. In a future
+// // release we'll remove this function entirely and there will be no way to parse HCL files with duplicate keys.
+// // TODO (HCL_DUP_KEYS_DEPRECATION): remove once not used anymore
 func parseAndCheckForDuplicateHclAttributes(input string) (res *ast.File, duplicate bool, err error) {
 	res, err = hcl.Parse(input)
 	if err != nil && strings.Contains(err.Error(), "Each argument can only be defined once") {
+		allowHclDuplicatesRaw := os.Getenv(allowHclDuplicatesEnvVar)
+		if allowHclDuplicatesRaw == "" {
+			// default is to not allow duplicates
+			return nil, false, err
+		}
+		allowHclDuplicates, envParseErr := strconv.ParseBool(allowHclDuplicatesRaw)
+		if envParseErr != nil {
+			return nil, false, fmt.Errorf("error parsing %q environment variable: %w", allowHclDuplicatesEnvVar, err)
+		}
+		if !allowHclDuplicates {
+			return nil, false, err
+		}
+
+		// if allowed by the environment variable, parse again without failing on duplicate attributes
 		duplicate = true
 		res, err = hclParser.ParseDontErrorOnDuplicateKeys([]byte(input))
 	}

--- a/api/hcl_dup_attr_deprecation.go
+++ b/api/hcl_dup_attr_deprecation.go
@@ -4,6 +4,9 @@
 package api
 
 import (
+	"fmt"
+	"os"
+	"strconv"
 	"strings"
 
 	"github.com/hashicorp/hcl"
@@ -11,13 +14,32 @@ import (
 	hclParser "github.com/hashicorp/hcl/hcl/parser"
 )
 
+// allowHclDuplicatesEnvVar is an environment variable that allows Vault to revert back to accepting HCL files with
+// duplicate attributes. It's temporary until we finish the deprecation process, at which point this will be removed
+const allowHclDuplicatesEnvVar = "VAULT_ALLOW_PENDING_REMOVAL_DUPLICATE_HCL_ATTRIBUTES"
+
 // parseAndCheckForDuplicateHclAttributes parses the input JSON/HCL file and if it is HCL it also checks
-// for duplicate keys in the HCL file, allowing callers to handle the issue accordingly. In a future release we'll
-// change the behavior to treat duplicate keys as an error and eventually remove this helper altogether.
+// for duplicate keys in the HCL file, allowing callers to handle the issue accordingly. It now only accepts duplicate
+// keys if the environment variable VAULT_ALLOW_PENDING_REMOVAL_DUPLICATE_HCL_ATTRIBUTES is set to true. In a future
+// release we'll remove this function entirely and there will be no way to parse HCL files with duplicate keys.
 // TODO (HCL_DUP_KEYS_DEPRECATION): remove once not used anymore
 func parseAndCheckForDuplicateHclAttributes(input string) (res *ast.File, duplicate bool, err error) {
 	res, err = hcl.Parse(input)
 	if err != nil && strings.Contains(err.Error(), "Each argument can only be defined once") {
+		allowHclDuplicatesRaw := os.Getenv(allowHclDuplicatesEnvVar)
+		if allowHclDuplicatesRaw == "" {
+			// default is to not allow duplicates
+			return nil, false, err
+		}
+		allowHclDuplicates, envParseErr := strconv.ParseBool(allowHclDuplicatesRaw)
+		if envParseErr != nil {
+			return nil, false, fmt.Errorf("error parsing %q environment variable: %w", allowHclDuplicatesEnvVar, err)
+		}
+		if !allowHclDuplicates {
+			return nil, false, err
+		}
+
+		// if allowed by the environment variable, parse again without failing on duplicate attributes
 		duplicate = true
 		res, err = hclParser.ParseDontErrorOnDuplicateKeys([]byte(input))
 	}

--- a/api/ssh_agent_test.go
+++ b/api/ssh_agent_test.go
@@ -14,12 +14,25 @@ import (
 
 // TestSSH_CanLoadDuplicateKeys verifies that during the deprecation process of duplicate HCL attributes this function
 // will still allow them.
+// TODO (HCL_DUP_KEYS_DEPRECATION): on full removal change this test to ensure that duplicate attributes cannot be parsed
+// under any circumstances.
 func TestSSH_CanLoadDuplicateKeys(t *testing.T) {
-	_, err := LoadSSHHelperConfig("./test-fixtures/agent_config_duplicate_keys.hcl")
-	require.NoError(t, err)
-	// TODO (HCL_DUP_KEYS_DEPRECATION): Change test to expect an error
-	// require.Error(t, err)
-	// require.Contains(t, err.Error(), "Each argument can only be defined once")
+	t.Run("fail parsing without env var", func(t *testing.T) {
+		_, err := LoadSSHHelperConfig("./test-fixtures/agent_config_duplicate_keys.hcl")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "Each argument can only be defined once")
+	})
+	t.Run("fail parsing with env var set to false", func(t *testing.T) {
+		t.Setenv(allowHclDuplicatesEnvVar, "false")
+		_, err := LoadSSHHelperConfig("./test-fixtures/agent_config_duplicate_keys.hcl")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "Each argument can only be defined once")
+	})
+	t.Run("succeed parsing with env var set to true", func(t *testing.T) {
+		t.Setenv(allowHclDuplicatesEnvVar, "true")
+		_, err := LoadSSHHelperConfig("./test-fixtures/agent_config_duplicate_keys.hcl")
+		require.NoError(t, err)
+	})
 }
 
 func TestSSH_CreateTLSClient(t *testing.T) {

--- a/changelog/31215.txt
+++ b/changelog/31215.txt
@@ -1,0 +1,5 @@
+```release-note:deprecation
+core: disallow usage of duplicate attributes in HCL configuration files and policy definitions, which were already
+deprecated. For now those errors can be suppressed back to warnings by setting the environment variable
+VAULT_ALLOW_PENDING_REMOVAL_DUPLICATE_HCL_ATTRIBUTES.
+```

--- a/command/agent_test.go
+++ b/command/agent_test.go
@@ -30,6 +30,7 @@ import (
 	credAppRole "github.com/hashicorp/vault/builtin/credential/approle"
 	"github.com/hashicorp/vault/command/agent"
 	agentConfig "github.com/hashicorp/vault/command/agent/config"
+	"github.com/hashicorp/vault/helper/random"
 	"github.com/hashicorp/vault/helper/testhelpers/minimal"
 	"github.com/hashicorp/vault/helper/useragent"
 	vaulthttp "github.com/hashicorp/vault/http"
@@ -363,6 +364,7 @@ listener "tcp" {
 	)
 	configPath := makeTempFile(t, "config.hcl", config)
 
+	t.Setenv(random.AllowHclDuplicatesEnvVar, "true")
 	// Start the agent
 	ui, cmd := testAgentCommand(t, logger)
 	cmd.client = serverClient
@@ -400,7 +402,7 @@ listener "tcp" {
 	//----------------------------------------------------
 
 	// TODO (HCL_DUP_KEYS_DEPRECATION): Eventually remove this check together with the duplicate attribute in this
-	// test's configuration, create separate test ensuring such a config is not valid
+	// test's configuration
 	require.Contains(t, ui.ErrorWriter.String(),
 		"WARNING: Duplicate keys found")
 
@@ -3115,16 +3117,37 @@ func TestAgent_Config_ReloadTls(t *testing.T) {
 }
 
 // TestAgent_Config_HclDuplicateKey checks that a log warning is printed when the agent config has duplicate attributes
+// TODO (HCL_DUP_KEYS_DEPRECATION): always expect error once deprecation is done
 func TestAgent_Config_HclDuplicateKey(t *testing.T) {
-	configFile := populateTempFile(t, "agent-config.hcl", `
+	t.Run("duplicate error with env unset", func(t *testing.T) {
+		configFile := populateTempFile(t, "agent-config.hcl", `
 log_level = "trace"
 log_level = "debug"
 `)
-	_, duplicate, err := agentConfig.LoadConfigFileCheckDuplicates(configFile.Name())
-	// TODO (HCL_DUP_KEYS_DEPRECATION): expect error on duplicates once deprecation is done
-	require.NoError(t, err)
-	require.True(t, duplicate)
-	// require.Contains(t, err.Error(), "Each argument can only be defined once")
+		_, _, err := agentConfig.LoadConfigFileCheckDuplicates(configFile.Name())
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "Each argument can only be defined once")
+	})
+	t.Run("duplicate error with env set to false", func(t *testing.T) {
+		configFile := populateTempFile(t, "agent-config.hcl", `
+log_level = "trace"
+log_level = "debug"
+`)
+		t.Setenv(random.AllowHclDuplicatesEnvVar, "false")
+		_, _, err := agentConfig.LoadConfigFileCheckDuplicates(configFile.Name())
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "Each argument can only be defined once")
+	})
+	t.Run("duplicate warning with env set to true", func(t *testing.T) {
+		configFile := populateTempFile(t, "agent-config.hcl", `
+log_level = "trace"
+log_level = "debug"
+`)
+		t.Setenv(random.AllowHclDuplicatesEnvVar, "true")
+		_, duplicate, err := agentConfig.LoadConfigFileCheckDuplicates(configFile.Name())
+		require.NoError(t, err)
+		require.True(t, duplicate)
+	})
 }
 
 // TestAgent_NonTLSListener_SIGHUP tests giving a SIGHUP signal to a listener

--- a/command/login_test.go
+++ b/command/login_test.go
@@ -16,6 +16,7 @@ import (
 	credToken "github.com/hashicorp/vault/builtin/credential/token"
 	credUserpass "github.com/hashicorp/vault/builtin/credential/userpass"
 	"github.com/hashicorp/vault/command/token"
+	"github.com/hashicorp/vault/helper/random"
 	"github.com/hashicorp/vault/helper/testhelpers"
 	"github.com/hashicorp/vault/vault"
 	"github.com/stretchr/testify/require"
@@ -639,18 +640,33 @@ token_helper = ""
 	}
 	token := secret.Auth.ClientToken
 
-	ui, cmd := testLoginCommand(t)
-	cmd.tokenHelper = nil // cause default one to be used
-	cmd.client = client
+	t.Run("fail if duplicates are not allowed", func(t *testing.T) {
+		_, cmd := testLoginCommand(t)
+		cmd.tokenHelper = nil // cause default one to be used
+		cmd.client = client
 
-	code := cmd.Run([]string{
-		token,
+		code := cmd.Run([]string{
+			token,
+		})
+		if exp := 1; code != exp {
+			t.Errorf("expected %d to be %d", code, exp)
+		}
 	})
-	if exp := 0; code != exp {
-		t.Errorf("expected %d to be %d", code, exp)
-	}
 
-	// TODO (HCL_DUP_KEYS_DEPRECATION): Instead ensure that login command fails if the config file contains duplicate keys
-	require.Contains(t, ui.ErrorWriter.String(),
-		"WARNING: Duplicate keys found in the Vault token helper configuration file, duplicate keys in HCL files are deprecated and will be forbidden in a future release.")
+	t.Run("succeed if duplicates are allowed", func(t *testing.T) {
+		t.Setenv(random.AllowHclDuplicatesEnvVar, "true")
+		ui, cmd := testLoginCommand(t)
+		cmd.tokenHelper = nil // cause default one to be used
+		cmd.client = client
+
+		code := cmd.Run([]string{
+			token,
+		})
+		if exp := 0; code != exp {
+			t.Errorf("expected %d to be %d", code, exp)
+		}
+
+		require.Contains(t, ui.ErrorWriter.String(),
+			"WARNING: Duplicate keys found in the Vault token helper configuration file, duplicate keys in HCL files are deprecated and will be forbidden in a future release.")
+	})
 }

--- a/command/proxy_test.go
+++ b/command/proxy_test.go
@@ -24,6 +24,7 @@ import (
 	credAppRole "github.com/hashicorp/vault/builtin/credential/approle"
 	"github.com/hashicorp/vault/command/agent"
 	proxyConfig "github.com/hashicorp/vault/command/proxy/config"
+	"github.com/hashicorp/vault/helper/random"
 	"github.com/hashicorp/vault/helper/testhelpers/minimal"
 	"github.com/hashicorp/vault/helper/useragent"
 	vaulthttp "github.com/hashicorp/vault/http"
@@ -313,6 +314,7 @@ auto_auth {
 	wg := &sync.WaitGroup{}
 	wg.Add(1)
 	go func() {
+		t.Setenv(random.AllowHclDuplicatesEnvVar, "true")
 		cmd.Run([]string{"-config", configPath})
 		wg.Done()
 	}()
@@ -324,7 +326,7 @@ auto_auth {
 	}
 
 	// TODO (HCL_DUP_KEYS_DEPRECATION): Eventually remove this check together with the duplicate attribute in this
-	// test's configuration, create separate test ensuring such a config is not valid
+	// test's configuration
 	require.Contains(t, ui.ErrorWriter.String(),
 		"WARNING: Duplicate keys found")
 

--- a/command/server/config.go
+++ b/command/server/config.go
@@ -640,6 +640,14 @@ func ParseConfigCheckDuplicate(d, source string) (cfg *Config, duplicate bool, e
 	// Parse!
 	obj, duplicate, err := random.ParseAndCheckForDuplicateHclAttributes(d)
 	if err != nil {
+		if strings.Contains(err.Error(), "was already set. Each argument can only be defined once") {
+			knownPossibleAttributeDupErrors := []string{"retry_join", "transform", "listener"}
+			for _, s := range knownPossibleAttributeDupErrors {
+				if strings.Contains(err.Error(), fmt.Sprintf("The argument %q at", s)) {
+					return nil, duplicate, fmt.Errorf("%w (if using the attribute syntax %s = [...], change it to the block syntax %s { ... })", err, s, s)
+				}
+			}
+		}
 		return nil, duplicate, err
 	}
 

--- a/command/server/config_test_helpers.go
+++ b/command/server/config_test_helpers.go
@@ -33,8 +33,6 @@ func boolPointer(x bool) *bool {
 
 // testConfigRaftRetryJoin decodes and normalizes retry_join stanzas.
 func testConfigRaftRetryJoin(t *testing.T) {
-	t.Parallel()
-
 	retryJoinExpected := []map[string]string{
 		// NOTE: Normalization handles IPv6 addresses and returns auto_join with
 		// sorted stable keys.
@@ -48,15 +46,49 @@ func testConfigRaftRetryJoin(t *testing.T) {
 		{"auto_join": "provider=k8s label_selector=\"app.kubernetes.io/name=vault, component=server\" namespace=vault"},
 		{"auto_join": "provider=k8s label_selector=\"app.kubernetes.io/name=vault1,component=server\" namespace=vault1"},
 	}
-	for _, cfg := range []string{
-		"attr",
-		"block",
-		"mixed",
-	} {
-		t.Run(cfg, func(t *testing.T) {
-			t.Parallel()
+	testCases := map[string]struct {
+		configFile    string
+		envVars       map[string]string
+		errorContains string
+	}{
+		"attributes_duplicate_error": {
+			configFile:    "./test-fixtures/raft_retry_join_attr.hcl",
+			errorContains: "The argument \"retry_join\" at 11:3 was already set. Each argument can only be defined once (if using the attribute syntax retry_join = [...], change it to the block syntax retry_join { ... })",
+		},
+		"attributes_allowed_with_env_var": {
+			configFile: "./test-fixtures/raft_retry_join_attr.hcl",
+			envVars: map[string]string{
+				random.AllowHclDuplicatesEnvVar: "true",
+			},
+		},
+		"blocks": {
+			configFile: "./test-fixtures/raft_retry_join_block.hcl",
+		},
+		"mixed_duplicate_error": {
+			configFile:    "./test-fixtures/raft_retry_join_mixed.hcl",
+			errorContains: "The argument \"retry_join\" at 14:3 was already set. Each argument can only be defined once (if using the attribute syntax retry_join = [...], change it to the block syntax retry_join { ... })",
+		},
+		"mixed_allowed_with_env_var": {
+			configFile: "./test-fixtures/raft_retry_join_mixed.hcl",
+			envVars: map[string]string{
+				random.AllowHclDuplicatesEnvVar: "true",
+			},
+		},
+	}
 
-			config, err := LoadConfigFile(fmt.Sprintf("./test-fixtures/raft_retry_join_%s.hcl", cfg))
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			for k, v := range tc.envVars {
+				t.Setenv(k, v)
+			}
+
+			config, err := LoadConfigFile(tc.configFile)
+			if tc.errorContains != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.errorContains)
+				return
+			}
+
 			require.NoError(t, err)
 			retryJoinJSON, err := json.Marshal(retryJoinExpected)
 			require.NoError(t, err)

--- a/vault/logical_system_test.go
+++ b/vault/logical_system_test.go
@@ -2813,21 +2813,32 @@ func TestSystemBackend_policyCRUD(t *testing.T) {
 // TestSystemBackend_writeHCLDuplicateAttributes checks that trying to create a policy with duplicate HCL attributes
 // results in a warning being returned by the API
 func TestSystemBackend_writeHCLDuplicateAttributes(t *testing.T) {
-	b := testSystemBackend(t)
-
 	// policy with duplicate attribute
 	rules := `path "foo/" { policy = "read" policy = "read" }`
 	req := logical.TestRequest(t, logical.UpdateOperation, "policy/foo")
 	req.Data["policy"] = rules
-	resp, err := b.HandleRequest(namespace.RootContext(nil), req)
-	// TODO (HCL_DUP_KEYS_DEPRECATION): change this test to expect an error when creating a policy with duplicate attributes
-	if err != nil {
-		t.Fatalf("err: %v %#v", err, resp)
-	}
-	if resp != nil && (resp.IsError() || len(resp.Data) > 0) {
-		t.Fatalf("bad: %#v", resp)
-	}
-	require.Contains(t, resp.Warnings, "policy contains duplicate attributes, which will no longer be supported in a future version")
+
+	t.Run("fails with env unset", func(t *testing.T) {
+		b := testSystemBackend(t)
+		resp, err := b.HandleRequest(namespace.RootContext(nil), req)
+		require.Error(t, err)
+		require.Error(t, resp.Error())
+		require.EqualError(t, resp.Error(), "failed to parse policy: The argument \"policy\" at 1:31 was already set. Each argument can only be defined once")
+	})
+
+	// TODO (HCL_DUP_KEYS_DEPRECATION): leave only test above once deprecation is done
+	t.Run("warning with env set", func(t *testing.T) {
+		t.Setenv(random.AllowHclDuplicatesEnvVar, "true")
+		b := testSystemBackend(t)
+		resp, err := b.HandleRequest(namespace.RootContext(nil), req)
+		if err != nil {
+			t.Fatalf("err: %v %#v", err, resp)
+		}
+		if resp != nil && (resp.IsError() || len(resp.Data) > 0) {
+			t.Fatalf("bad: %#v", resp)
+		}
+		require.Contains(t, resp.Warnings, "policy contains duplicate attributes, which will no longer be supported in a future version")
+	})
 }
 
 func TestSystemBackend_enableAudit(t *testing.T) {

--- a/vault/policy_store_test.go
+++ b/vault/policy_store_test.go
@@ -459,12 +459,15 @@ func TestPolicyStore_DuplicateAttributes(t *testing.T) {
 	ps := core.policyStore
 	dupAttrPolicy := aclPolicy + `
 path "foo" {
-	capabilities = ["deny"]
-	capabilities = ["deny"]
+	capabilities = ["list"]
+	capabilities = ["read"]
 }
 `
 	t.Setenv(random.AllowHclDuplicatesEnvVar, "true")
 	policy, err := ParseACLPolicy(namespace.RootNamespace, dupAttrPolicy)
+	require.NoError(t, err)
+	// check that "list" and "read" get concatenated
+	require.Len(t, policy.Paths[len(policy.Paths)-1].Capabilities, 2)
 	policy.Templated = true
 	require.NoError(t, err)
 	ctx := namespace.RootContext(context.Background())

--- a/website/content/docs/updates/deprecation.mdx
+++ b/website/content/docs/updates/deprecation.mdx
@@ -38,6 +38,8 @@ or raise a ticket with your support team.
 
 @include 'deprecation/snowflake-password-auth.mdx'
 
+@include 'deprecation/duplicate-hcl-attributes.mdx'
+
 </Tab>
 <Tab heading="PENDING REMOVAL">
 
@@ -46,8 +48,6 @@ or raise a ticket with your support team.
 @include 'deprecation/aws-field-change.mdx'
 
 @include 'deprecation/centrify-auth-method.mdx'
-
-@include 'deprecation/duplicate-hcl-attributes.mdx'
 
 </Tab>
 <Tab heading="REMOVED">

--- a/website/content/partials/deprecation/duplicate-hcl-attributes.mdx
+++ b/website/content/partials/deprecation/duplicate-hcl-attributes.mdx
@@ -4,7 +4,8 @@
 | :-------: | :---------------------: | :--------------: |
 | JUN 2025  | OCT 2025                | N/A
 
-The ability to duplicate attributes in HCL configuration files and policy definitions is deprecated.
+In Vault v1.20.x and v1.19.6 the ability to duplicate attributes in HCL configuration
+files and policy definitions is deprecated.
 
 To find affected policies, look for "policy contains duplicate attributes"
 warnings in the server logs. Once we remove support for duplicate attributes,

--- a/website/content/partials/deprecation/duplicate-hcl-attributes.mdx
+++ b/website/content/partials/deprecation/duplicate-hcl-attributes.mdx
@@ -4,7 +4,7 @@
 | :-------: | :---------------------: | :--------------: |
 | JUN 2025  | OCT 2025                | N/A
 
-In Vault v1.20.x and v1.19.6 the ability to duplicate attributes in HCL configuration
+In Vault v1.20.x and v1.19.6, the ability to duplicate attributes in HCL configuration
 files and policy definitions is deprecated.
 
 To find affected policies, look for "policy contains duplicate attributes"

--- a/website/content/partials/deprecation/duplicate-hcl-attributes.mdx
+++ b/website/content/partials/deprecation/duplicate-hcl-attributes.mdx
@@ -4,7 +4,7 @@
 | :-------: | :---------------------: | :--------------: |
 | JUN 2025  | OCT 2025                | N/A
 
-In Vault v1.20.x and v1.19.6, the ability to duplicate attributes in HCL configuration
+In Vault v1.20.x and v1.19.6+, the ability to duplicate attributes in HCL configuration
 files and policy definitions is deprecated.
 
 To find affected policies, look for "policy contains duplicate attributes"


### PR DESCRIPTION
### Description

This is a follow up to #30386, which went into Vault v1.20 (and backported to v1.1.6) and started to print warnings whenever Vault parsed any HCL with duplicate attributes, as well as returning some API warnings when creating policies with those duplicate attributes in their HCL definition.

Continuing to follow our deprecation process, this PR changes those warnings to be actual errors, preventing the parsing of HCL files containing duplicate attributes in Vault v1.21.x. The previous "log-only" behavior of v1.20.x can be restored in v1.21.x by setting the `VAULT_ALLOW_PENDING_REMOVAL_DUPLICATE_HCL_ATTRIBUTES` to `true`.

I'm also rectifying the deprecation notice for duplicate attributes, which was incorrectly added directly to the "pending removal" stage in #30512. As for updating it to the proper "pending removal" on v1.21.x, that will have to wait until October when we cut a branch for v1.21.x.

Also, something important to highlight is that HCL allows defining multiple blocks of the same type, putting each definition into its own object in an array with the type name, like how we expect [retry_join](https://developer.hashicorp.com/vault/docs/configuration/storage/raft#retry_join-stanza) to be used. However, the HCL library without the patch preventing duplicate attributes would also allow that same behavior to concatenate explicit list assignment. For example, a similar example to what I used in #30386
```
path "secret" {
  capabilities = ["read"]
  capabilities = ["write"]
}
```
would previously result in `capabilities = ["read", "write"]` (unlike what I previously thought, the "overwrite" behavior doesn't apply to lists), while with the patch this is forbidden. I think this outcome is still in line with the goal of reducing the potential for confusion, so I'm keeping this restriction on "implicit list concatenation via attribute assignments", and also added some improved error messages for cases where I think customers could run into this issue, instructing them to use the block syntax instead, like we already have in our docs for `retry_join`.

Jira: [VAULT-35838](https://hashicorp.atlassian.net/browse/VAULT-35838)
ADR: [VLT-006: Deprecate and remove duplicate attributes in HCL files in Vault](https://docs.google.com/document/d/1wFEjSH8wXAQYyOJf2aM3Mg8JivkyI7lqdpkcsXQFPpA/edit?tab=t.0)

### TODO only if you're a HashiCorp employee
- [-] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [-] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [-] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [-] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.

### PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [-] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [-] If applicable, I've documented the impact of any changes to security controls.

Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.


[VAULT-35838]: https://hashicorp.atlassian.net/browse/VAULT-35838?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ