### PR TITLE
[VAULT-37111] UI: use general selector for textarea toggle

### DIFF
--- a/ui/lib/core/addon/components/text-file.hbs
+++ b/ui/lib/core/addon/components/text-file.hbs
@@ -41,7 +41,7 @@
       @isMultiline={{true}}
       {{on "input" this.handleTextInput}}
       aria-labelledby="text-file-input-{{this.elementId}}"
-      data-test-text-file-textarea
+      data-test-masked-input
       as |F|
     >
       <F.HelperText>

--- a/ui/tests/acceptance/pki/pki-action-forms-test.js
+++ b/ui/tests/acceptance/pki/pki-action-forms-test.js
@@ -58,7 +58,7 @@ module('Acceptance | pki action forms test', function (hooks) {
       assert.dom(GENERAL.messageError).hasText('Error please upload your PEM bundle');
       // Fill in form data
       await click(GENERAL.textToggle);
-      await fillIn(GENERAL.textToggleTextarea, this.pemBundle);
+      await fillIn(GENERAL.maskedInput, this.pemBundle);
       await click(PKI_CONFIGURE_CREATE.importSubmit);
 
       assert.strictEqual(
@@ -95,7 +95,7 @@ module('Acceptance | pki action forms test', function (hooks) {
       await click(PKI_CONFIGURE_CREATE.optionByKey('import'));
       assert.dom(PKI_CONFIGURE_CREATE.importForm).exists('import form is shown save');
       await click(GENERAL.textToggle);
-      await fillIn(GENERAL.textToggleTextarea, this.pemBundle);
+      await fillIn(GENERAL.maskedInput, this.pemBundle);
       await click(PKI_CONFIGURE_CREATE.importSubmit);
 
       assert.strictEqual(
@@ -136,7 +136,7 @@ module('Acceptance | pki action forms test', function (hooks) {
       await click(PKI_CONFIGURE_CREATE.optionByKey('import'));
       assert.dom(PKI_CONFIGURE_CREATE.importForm).exists('import form is shown save');
       await click(GENERAL.textToggle);
-      await fillIn(GENERAL.textToggleTextarea, this.pemBundle);
+      await fillIn(GENERAL.maskedInput, this.pemBundle);
       await click(PKI_CONFIGURE_CREATE.importSubmit);
 
       assert.dom(PKI_CONFIGURE_CREATE.importForm).doesNotExist('import form is hidden after save');
@@ -162,7 +162,7 @@ module('Acceptance | pki action forms test', function (hooks) {
       await click(PKI_CONFIGURE_CREATE.optionByKey('import'));
       assert.dom(PKI_CONFIGURE_CREATE.importForm).exists('import form is shown save');
       await click(GENERAL.textToggle);
-      await fillIn(GENERAL.textToggleTextarea, this.pemBundle);
+      await fillIn(GENERAL.maskedInput, this.pemBundle);
       await click(PKI_CONFIGURE_CREATE.importSubmit);
 
       assert.dom(PKI_CONFIGURE_CREATE.importForm).doesNotExist('import form is hidden after save');

--- a/ui/tests/acceptance/pki/pki-action-forms-test.js
+++ b/ui/tests/acceptance/pki/pki-action-forms-test.js
@@ -58,7 +58,7 @@ module('Acceptance | pki action forms test', function (hooks) {
       assert.dom(GENERAL.messageError).hasText('Error please upload your PEM bundle');
       // Fill in form data
       await click(GENERAL.textToggle);
-      await fillIn('[data-test-text-file-textarea]', this.pemBundle);
+      await fillIn(GENERAL.textToggleTextarea, this.pemBundle);
       await click(PKI_CONFIGURE_CREATE.importSubmit);
 
       assert.strictEqual(
@@ -95,7 +95,7 @@ module('Acceptance | pki action forms test', function (hooks) {
       await click(PKI_CONFIGURE_CREATE.optionByKey('import'));
       assert.dom(PKI_CONFIGURE_CREATE.importForm).exists('import form is shown save');
       await click(GENERAL.textToggle);
-      await fillIn('[data-test-text-file-textarea]', this.pemBundle);
+      await fillIn(GENERAL.textToggleTextarea, this.pemBundle);
       await click(PKI_CONFIGURE_CREATE.importSubmit);
 
       assert.strictEqual(
@@ -136,7 +136,7 @@ module('Acceptance | pki action forms test', function (hooks) {
       await click(PKI_CONFIGURE_CREATE.optionByKey('import'));
       assert.dom(PKI_CONFIGURE_CREATE.importForm).exists('import form is shown save');
       await click(GENERAL.textToggle);
-      await fillIn('[data-test-text-file-textarea]', this.pemBundle);
+      await fillIn(GENERAL.textToggleTextarea, this.pemBundle);
       await click(PKI_CONFIGURE_CREATE.importSubmit);
 
       assert.dom(PKI_CONFIGURE_CREATE.importForm).doesNotExist('import form is hidden after save');
@@ -162,7 +162,7 @@ module('Acceptance | pki action forms test', function (hooks) {
       await click(PKI_CONFIGURE_CREATE.optionByKey('import'));
       assert.dom(PKI_CONFIGURE_CREATE.importForm).exists('import form is shown save');
       await click(GENERAL.textToggle);
-      await fillIn('[data-test-text-file-textarea]', this.pemBundle);
+      await fillIn(GENERAL.textToggleTextarea, this.pemBundle);
       await click(PKI_CONFIGURE_CREATE.importSubmit);
 
       assert.dom(PKI_CONFIGURE_CREATE.importForm).doesNotExist('import form is hidden after save');

--- a/ui/tests/acceptance/pki/pki-cross-sign-test.js
+++ b/ui/tests/acceptance/pki/pki-cross-sign-test.js
@@ -67,7 +67,7 @@ module('Acceptance | pki/pki cross sign', function (hooks) {
     await visit(`vault/secrets/${this.intMountPath}/pki/configuration/create`);
     await click(PKI_CONFIGURE_CREATE.optionByKey('import'));
     await click(GENERAL.textToggle);
-    await fillIn('[data-test-text-file-textarea]', pemBundle);
+    await fillIn(GENERAL.textToggleTextarea, pemBundle);
     await click(PKI_CONFIGURE_CREATE.importSubmit);
     await visit(`vault/secrets/${this.intMountPath}/pki/issuers`);
     await click('[data-test-is-default]');

--- a/ui/tests/acceptance/pki/pki-cross-sign-test.js
+++ b/ui/tests/acceptance/pki/pki-cross-sign-test.js
@@ -67,7 +67,7 @@ module('Acceptance | pki/pki cross sign', function (hooks) {
     await visit(`vault/secrets/${this.intMountPath}/pki/configuration/create`);
     await click(PKI_CONFIGURE_CREATE.optionByKey('import'));
     await click(GENERAL.textToggle);
-    await fillIn(GENERAL.textToggleTextarea, pemBundle);
+    await fillIn(GENERAL.maskedInput, pemBundle);
     await click(PKI_CONFIGURE_CREATE.importSubmit);
     await visit(`vault/secrets/${this.intMountPath}/pki/issuers`);
     await click('[data-test-is-default]');

--- a/ui/tests/acceptance/pki/pki-engine-workflow-test.js
+++ b/ui/tests/acceptance/pki/pki-engine-workflow-test.js
@@ -488,7 +488,7 @@ module('Acceptance | pki workflow', function (hooks) {
       await visit(`/vault/secrets/${this.mountPath}/pki/configuration/create`);
       await click(PKI_CONFIGURE_CREATE.optionByKey('import'));
       await click(GENERAL.textToggle);
-      await fillIn('[data-test-text-file-textarea]', unsupportedPem);
+      await fillIn(GENERAL.textToggleTextarea, unsupportedPem);
       await click(PKI_CONFIGURE_CREATE.importSubmit);
       const issuerId = find(PKI_CONFIGURE_CREATE.importedIssuer).innerText;
       await click(`${PKI_CONFIGURE_CREATE.importedIssuer} a`);

--- a/ui/tests/acceptance/pki/pki-engine-workflow-test.js
+++ b/ui/tests/acceptance/pki/pki-engine-workflow-test.js
@@ -488,7 +488,7 @@ module('Acceptance | pki workflow', function (hooks) {
       await visit(`/vault/secrets/${this.mountPath}/pki/configuration/create`);
       await click(PKI_CONFIGURE_CREATE.optionByKey('import'));
       await click(GENERAL.textToggle);
-      await fillIn(GENERAL.textToggleTextarea, unsupportedPem);
+      await fillIn(GENERAL.maskedInput, unsupportedPem);
       await click(PKI_CONFIGURE_CREATE.importSubmit);
       const issuerId = find(PKI_CONFIGURE_CREATE.importedIssuer).innerText;
       await click(`${PKI_CONFIGURE_CREATE.importedIssuer} a`);

--- a/ui/tests/acceptance/secrets/backend/gcp/gcp-configuration-test.js
+++ b/ui/tests/acceptance/secrets/backend/gcp/gcp-configuration-test.js
@@ -161,7 +161,7 @@ module('Acceptance | GCP | configuration', function (hooks) {
         });
 
         await click(GENERAL.textToggle);
-        await fillIn(GENERAL.textToggleTextarea, credentials);
+        await fillIn(GENERAL.maskedInput, credentials);
         await click(GENERAL.submitButton);
         // cleanup
         await runCmd(`delete sys/mounts/${this.path}`);

--- a/ui/tests/helpers/general-selectors.ts
+++ b/ui/tests/helpers/general-selectors.ts
@@ -60,11 +60,11 @@ export const GENERAL = {
   filterInputExplicit: '[data-test-filter-input-explicit]',
   labelById: (id: string) => `label[id="${id}"]`,
   labelByGroupControlIndex: (index: number) => `.hds-form-group__control-field:nth-of-type(${index}) label`,
+  maskedInput: '[data-test-masked-input]',
   radioByAttr: (attr: string) => `[data-test-radio="${attr}"]`,
   selectByAttr: (attr: string) => `[data-test-select="${attr}"]`,
   toggleInput: (attr: string) => `[data-test-toggle-input="${attr}"]`,
   textToggle: '[data-test-text-toggle]',
-  textToggleTextarea: '[data-test-text-file-textarea]',
   filter: (name: string) => `[data-test-filter="${name}"]`,
 
   /* ────── Code Blocks / Editor ────── */

--- a/ui/tests/helpers/secret-engine/secret-engine-helpers.js
+++ b/ui/tests/helpers/secret-engine/secret-engine-helpers.js
@@ -234,7 +234,7 @@ export const fillInGcpConfig = async (withWif = false) => {
     await click(GENERAL.ttl.toggle('Max TTL'));
     await fillIn(GENERAL.ttl.input('Max TTL'), '8200');
     await click(GENERAL.textToggle);
-    await fillIn(GENERAL.textToggleTextarea, '{"some-key":"some-value"}');
+    await fillIn(GENERAL.maskedInput, '{"some-key":"some-value"}');
   }
 };
 

--- a/ui/tests/helpers/sync/sync-selectors.js
+++ b/ui/tests/helpers/sync/sync-selectors.js
@@ -92,7 +92,7 @@ export const PAGE = {
           return await click(`${GENERAL.radioByAttr('secret-key')}`);
         case 'credentials':
           await click(GENERAL.textToggle);
-          return fillIn(GENERAL.textToggleTextarea, value);
+          return fillIn(GENERAL.maskedInput, value);
         case 'customTags':
           await fillIn('[data-test-kv-key="0"]', 'foo');
           return fillIn('[data-test-kv-value="0"]', value);

--- a/ui/tests/helpers/sync/sync-selectors.js
+++ b/ui/tests/helpers/sync/sync-selectors.js
@@ -92,7 +92,7 @@ export const PAGE = {
           return await click(`${GENERAL.radioByAttr('secret-key')}`);
         case 'credentials':
           await click(GENERAL.textToggle);
-          return fillIn('[data-test-text-file-textarea]', value);
+          return fillIn(GENERAL.textToggleTextarea, value);
         case 'customTags':
           await fillIn('[data-test-kv-key="0"]', 'foo');
           return fillIn('[data-test-kv-value="0"]', value);

--- a/ui/tests/integration/components/form-field-test.js
+++ b/ui/tests/integration/components/form-field-test.js
@@ -206,7 +206,7 @@ module('Integration | Component | form field', function (hooks) {
       .dom('.hds-form-helper-text')
       .hasText(`Enter the value as text. ${subText} See our documentation for help.`, 'renders subtext');
     assert.dom('.hds-form-helper-text a').exists('renders doc link');
-    await fillIn('[data-test-text-file-textarea]', 'hello world');
+    await fillIn(GENERAL.textToggleTextarea, 'hello world');
   });
 
   test('it renders: editType ttl', async function (assert) {

--- a/ui/tests/integration/components/form-field-test.js
+++ b/ui/tests/integration/components/form-field-test.js
@@ -206,7 +206,7 @@ module('Integration | Component | form field', function (hooks) {
       .dom('.hds-form-helper-text')
       .hasText(`Enter the value as text. ${subText} See our documentation for help.`, 'renders subtext');
     assert.dom('.hds-form-helper-text a').exists('renders doc link');
-    await fillIn(GENERAL.textToggleTextarea, 'hello world');
+    await fillIn(GENERAL.maskedInput, 'hello world');
   });
 
   test('it renders: editType ttl', async function (assert) {

--- a/ui/tests/integration/components/pki/page/pki-issuer-import-test.js
+++ b/ui/tests/integration/components/pki/page/pki-issuer-import-test.js
@@ -49,7 +49,7 @@ module('Integration | Component | page/pki-issuer-import', function (hooks) {
     });
     assert.dom(GENERAL.title).hasText('Import a CA');
     await click(GENERAL.textToggle);
-    await fillIn('[data-test-text-file-textarea]', 'dummy-pem-bundle');
+    await fillIn(GENERAL.textToggleTextarea, 'dummy-pem-bundle');
     await click(PKI_CONFIGURE_CREATE.importSubmit);
     assert.dom(GENERAL.title).hasText('View imported items');
   });
@@ -64,7 +64,7 @@ module('Integration | Component | page/pki-issuer-import', function (hooks) {
     assert.dom(GENERAL.title).hasText('Import a CA');
     // Fill in
     await click(GENERAL.textToggle);
-    await fillIn('[data-test-text-file-textarea]', 'dummy-pem-bundle');
+    await fillIn(GENERAL.textToggleTextarea, 'dummy-pem-bundle');
     await click(PKI_CONFIGURE_CREATE.importSubmit);
     assert.dom(GENERAL.title).hasText('Import a CA', 'title does not change if response is unsuccessful');
   });

--- a/ui/tests/integration/components/pki/page/pki-issuer-import-test.js
+++ b/ui/tests/integration/components/pki/page/pki-issuer-import-test.js
@@ -49,7 +49,7 @@ module('Integration | Component | page/pki-issuer-import', function (hooks) {
     });
     assert.dom(GENERAL.title).hasText('Import a CA');
     await click(GENERAL.textToggle);
-    await fillIn(GENERAL.textToggleTextarea, 'dummy-pem-bundle');
+    await fillIn(GENERAL.maskedInput, 'dummy-pem-bundle');
     await click(PKI_CONFIGURE_CREATE.importSubmit);
     assert.dom(GENERAL.title).hasText('View imported items');
   });
@@ -64,7 +64,7 @@ module('Integration | Component | page/pki-issuer-import', function (hooks) {
     assert.dom(GENERAL.title).hasText('Import a CA');
     // Fill in
     await click(GENERAL.textToggle);
-    await fillIn(GENERAL.textToggleTextarea, 'dummy-pem-bundle');
+    await fillIn(GENERAL.maskedInput, 'dummy-pem-bundle');
     await click(PKI_CONFIGURE_CREATE.importSubmit);
     assert.dom(GENERAL.title).hasText('Import a CA', 'title does not change if response is unsuccessful');
   });

--- a/ui/tests/integration/components/pki/pki-import-pem-bundle-test.js
+++ b/ui/tests/integration/components/pki/pki-import-pem-bundle-test.js
@@ -46,7 +46,7 @@ module('Integration | Component | PkiImportPemBundle', function (hooks) {
     assert.dom('[data-test-pki-import-pem-bundle-form]').exists('renders form');
     assert.dom('[data-test-component="text-file"]').exists('renders text file input');
     await click(GENERAL.textToggle);
-    await fillIn('[data-test-text-file-textarea]', this.pemBundle);
+    await fillIn(GENERAL.textToggleTextarea, this.pemBundle);
     assert.strictEqual(this.model.pemBundle, this.pemBundle);
   });
 
@@ -86,7 +86,7 @@ module('Integration | Component | PkiImportPemBundle', function (hooks) {
     );
 
     await click(GENERAL.textToggle);
-    await fillIn('[data-test-text-file-textarea]', this.pemBundle);
+    await fillIn(GENERAL.textToggleTextarea, this.pemBundle);
     assert.strictEqual(this.model.pemBundle, this.pemBundle, 'PEM bundle updated on model');
     await click(PKI_CONFIGURE_CREATE.importSubmit);
   });
@@ -127,7 +127,7 @@ module('Integration | Component | PkiImportPemBundle', function (hooks) {
     );
 
     await click(GENERAL.textToggle);
-    await fillIn('[data-test-text-file-textarea]', this.pemBundle);
+    await fillIn(GENERAL.textToggleTextarea, this.pemBundle);
     assert.strictEqual(this.model.pemBundle, this.pemBundle);
     await click(PKI_CONFIGURE_CREATE.importSubmit);
   });
@@ -162,7 +162,7 @@ module('Integration | Component | PkiImportPemBundle', function (hooks) {
     );
 
     await click(GENERAL.textToggle);
-    await fillIn('[data-test-text-file-textarea]', this.pemBundle);
+    await fillIn(GENERAL.textToggleTextarea, this.pemBundle);
     await click(PKI_CONFIGURE_CREATE.importSubmit);
 
     assert

--- a/ui/tests/integration/components/pki/pki-import-pem-bundle-test.js
+++ b/ui/tests/integration/components/pki/pki-import-pem-bundle-test.js
@@ -46,7 +46,7 @@ module('Integration | Component | PkiImportPemBundle', function (hooks) {
     assert.dom('[data-test-pki-import-pem-bundle-form]').exists('renders form');
     assert.dom('[data-test-component="text-file"]').exists('renders text file input');
     await click(GENERAL.textToggle);
-    await fillIn(GENERAL.textToggleTextarea, this.pemBundle);
+    await fillIn(GENERAL.maskedInput, this.pemBundle);
     assert.strictEqual(this.model.pemBundle, this.pemBundle);
   });
 
@@ -86,7 +86,7 @@ module('Integration | Component | PkiImportPemBundle', function (hooks) {
     );
 
     await click(GENERAL.textToggle);
-    await fillIn(GENERAL.textToggleTextarea, this.pemBundle);
+    await fillIn(GENERAL.maskedInput, this.pemBundle);
     assert.strictEqual(this.model.pemBundle, this.pemBundle, 'PEM bundle updated on model');
     await click(PKI_CONFIGURE_CREATE.importSubmit);
   });
@@ -127,7 +127,7 @@ module('Integration | Component | PkiImportPemBundle', function (hooks) {
     );
 
     await click(GENERAL.textToggle);
-    await fillIn(GENERAL.textToggleTextarea, this.pemBundle);
+    await fillIn(GENERAL.maskedInput, this.pemBundle);
     assert.strictEqual(this.model.pemBundle, this.pemBundle);
     await click(PKI_CONFIGURE_CREATE.importSubmit);
   });
@@ -162,7 +162,7 @@ module('Integration | Component | PkiImportPemBundle', function (hooks) {
     );
 
     await click(GENERAL.textToggle);
-    await fillIn(GENERAL.textToggleTextarea, this.pemBundle);
+    await fillIn(GENERAL.maskedInput, this.pemBundle);
     await click(PKI_CONFIGURE_CREATE.importSubmit);
 
     assert

--- a/ui/tests/integration/components/text-file-test.js
+++ b/ui/tests/integration/components/text-file-test.js
@@ -14,7 +14,6 @@ import { GENERAL } from 'vault/tests/helpers/general-selectors';
 
 const SELECTORS = {
   label: '[data-test-text-file-label]',
-  textarea: '[data-test-text-file-textarea]',
   fileUpload: '[data-test-text-file-input]',
 };
 const { componentPemBundle } = CERTIFICATES;
@@ -55,9 +54,9 @@ module('Integration | Component | text-file', function (hooks) {
     await render(hbs`<TextFile @onChange={{this.onChange}} />`);
 
     assert.dom(SELECTORS.fileUpload).exists({ count: 1 }, 'File input shown');
-    assert.dom(SELECTORS.textarea).doesNotExist('Texarea hidden');
+    assert.dom(GENERAL.textToggleTextarea).doesNotExist('Texarea hidden');
     await click(GENERAL.textToggle);
-    assert.dom(SELECTORS.textarea).exists({ count: 1 }, 'Textarea shown');
+    assert.dom(GENERAL.textToggleTextarea).exists({ count: 1 }, 'Textarea shown');
     assert.dom(SELECTORS.fileUpload).doesNotExist('File upload hidden');
   });
 
@@ -81,7 +80,7 @@ module('Integration | Component | text-file', function (hooks) {
 
     await render(hbs`<TextFile @onChange={{this.onChange}} />`);
     await click(GENERAL.textToggle);
-    await fillIn(SELECTORS.textarea, PEM_BUNDLE);
+    await fillIn(GENERAL.textToggleTextarea, PEM_BUNDLE);
     assert.propEqual(
       this.onChange.lastCall.args[0],
       {

--- a/ui/tests/integration/components/text-file-test.js
+++ b/ui/tests/integration/components/text-file-test.js
@@ -54,9 +54,9 @@ module('Integration | Component | text-file', function (hooks) {
     await render(hbs`<TextFile @onChange={{this.onChange}} />`);
 
     assert.dom(SELECTORS.fileUpload).exists({ count: 1 }, 'File input shown');
-    assert.dom(GENERAL.textToggleTextarea).doesNotExist('Texarea hidden');
+    assert.dom(GENERAL.maskedInput).doesNotExist('Texarea hidden');
     await click(GENERAL.textToggle);
-    assert.dom(GENERAL.textToggleTextarea).exists({ count: 1 }, 'Textarea shown');
+    assert.dom(GENERAL.maskedInput).exists({ count: 1 }, 'Textarea shown');
     assert.dom(SELECTORS.fileUpload).doesNotExist('File upload hidden');
   });
 
@@ -80,7 +80,7 @@ module('Integration | Component | text-file', function (hooks) {
 
     await render(hbs`<TextFile @onChange={{this.onChange}} />`);
     await click(GENERAL.textToggle);
-    await fillIn(GENERAL.textToggleTextarea, PEM_BUNDLE);
+    await fillIn(GENERAL.maskedInput, PEM_BUNDLE);
     assert.propEqual(
       this.onChange.lastCall.args[0],
       {


### PR DESCRIPTION
### Description
What does this PR do?
- [x] Use general selector `maskedInput` for `data-test-text-file-textarea`
- [x] Enterprise tests passing ✅ 
    > 268 tests completed in 175979 milliseconds, with 0 failed, 10 skipped, and 0 todo.
1523 assertions of 1523 passed, 0 failed.