### PR TITLE
Update development cluster known issue as fixed

### DIFF
--- a/changelog/31223.txt
+++ b/changelog/31223.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+activity (enterprise): Fix `development_cluster` setting being overwritten on performance secondaries upon cluster reload.
+```

--- a/website/content/docs/updates/important-changes.mdx
+++ b/website/content/docs/updates/important-changes.mdx
@@ -153,7 +153,7 @@ None.
 | ------------ | ---------------- | --------------------
 | Known issue  | 1.20.0           | 1.20.1
 
-Users receive an error when navigating to a KV v2 secret with an underscore in the name (e.g. `my_secret`) 
+Users receive an error when navigating to a KV v2 secret with an underscore in the name (e.g. `my_secret`)
 if the user does not have policy permissions granting `read` access to the [`/subkeys` endpoint](/vault/api-docs/secret/kv/kv-v2#read-secret-subkeys).
 
 #### Recommendation
@@ -236,7 +236,7 @@ rotations on the LDAP server.
 
 | Change       | Affected version | Fixed version
 | ------------ |------------------| --------------------
-| Known issue  | 1.20.0           | N/A
+| Known issue  | 1.20.0           | 1.20.1
 
 If the Vault process receives a `SIGHUP` and reloads a secondary performance
 replication cluster, the cluster reverts to the locally configured

--- a/website/content/partials/release-notes/change-summary/1_20.mdx
+++ b/website/content/partials/release-notes/change-summary/1_20.mdx
@@ -8,8 +8,8 @@ Found  | Recommendations | Edition    | Issue
 ### Known issues
 
 Found  | Fixed  | Workaround | Edition    | Issue
------- |------- | ---------- | ---------- | -----
+------ |--------| ---------- | ---------- | -----
 1.20.0 | No     | **Yes**    | All        | [Duplicate unseal/seal wrap HSM keys](/vault/docs/v1.20.x/updates/important-changes#hsm-keys)
-1.20.0 | No     | **Yes**    | Enterprise | [Development cluster setting overwritten on secondary cluster reload](/vault/docs/v1.20.x/updates/important-changes#development-cluster-reload)
+1.20.0 | 1.20.1 | **Yes**    | Enterprise | [Development cluster setting overwritten on secondary cluster reload](/vault/docs/v1.20.x/updates/important-changes#development-cluster-reload)
 1.20.0 | No     | **Yes**    | All        | [UI login fails for auth mounts with underscores and unauthenticated listing](/vault/docs/v1.20.x/updates/important-changes#ui-login-underscore)
 1.20.0 | No     | **Yes**    | All        | [UI navigation to a KV v2 secret with an underscore errors without permissions to read subkeys](/vault/docs/v1.20.x/updates/important-changes#ui-kvv2-underscore-secrets)


### PR DESCRIPTION
### Description
Update the development cluster known issue created in 1.20.0 as fixed for 1.20.1. Also add a changelog entry. The known issue was created in https://github.com/hashicorp/vault/pull/31067. The actual fix was merged in https://github.com/hashicorp/vault-enterprise/pull/8325. 

Jira for the bug: https://hashicorp.atlassian.net/browse/VAULT-37317

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.

### PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.

Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
