### PR TITLE
[VAULT-38027] pipeline(active-versions): add `--github-output` support

### DIFF
--- a/tools/pipeline/internal/cmd/github.go
+++ b/tools/pipeline/internal/cmd/github.go
@@ -4,7 +4,6 @@
 package cmd
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -48,7 +47,7 @@ func newGithubCmd() *cobra.Command {
 func writeToGithubOutput(key string, bytes []byte) error {
 	devPath, ok := os.LookupEnv("GITHUB_OUTPUT")
 	if !ok {
-		return errors.New("$GITHUB_OUTPUT has not been set. Cannot write changed files to it")
+		return fmt.Errorf("$GITHUB_OUTPUT has not been set. Cannot write %s to it", key)
 	}
 
 	expanded, err := filepath.Abs(devPath)
@@ -62,7 +61,7 @@ func writeToGithubOutput(key string, bytes []byte) error {
 	}
 	defer func() { _ = dev.Close() }()
 
-	_, err = dev.Write(append([]byte(key+"="), bytes...))
+	_, err = dev.Write(append(append([]byte(key+"="), bytes...), []byte("\n")...))
 	if err != nil {
 		return fmt.Errorf("failed to write key %s to $GITHUB_OUTPUT: %w", key, err)
 	}

--- a/tools/pipeline/internal/cmd/releases_list_active_versions.go
+++ b/tools/pipeline/internal/cmd/releases_list_active_versions.go
@@ -24,6 +24,8 @@ func newReleasesListActiveVersionsCmd() *cobra.Command {
 
 	activeVersionsCmd.PersistentFlags().UintVarP(&listReleaseActiveVersionsReq.Recurse, "recurse", "r", 0, "If no path to a config file is given, recursively search backwards for it and stop at root or until we've his the configured depth.")
 
+	activeVersionsCmd.PersistentFlags().BoolVar(&listReleaseActiveVersionsReq.WriteToGithubOutput, "github-output", false, "Whether or not to write 'active-versions' to $GITHUB_OUTPUT")
+
 	return activeVersionsCmd
 }
 
@@ -48,6 +50,15 @@ func runListActiveVersionsReq(cmd *cobra.Command, args []string) error {
 		fmt.Println(string(b))
 	default:
 		fmt.Println(res.ToTable())
+	}
+
+	if listReleaseActiveVersionsReq.WriteToGithubOutput {
+		output, err := res.ToGithubOutput()
+		if err != nil {
+			return err
+		}
+
+		return writeToGithubOutput("active-versions", output)
 	}
 
 	return err


### PR DESCRIPTION
### Description
The standard JSON output of `pipeline release list active-versions --format json` returns the configuration in the same schema as `.release/versions.hcl`. While that is intended for the command, the schema itself is not easy to use with the built-in functions in Github Actions which often requires complex JQ queries to reshape the data to be useful. Instead, add a `--github-output` flag that will automatically write the active versions to `$GITHUB_OUTPUT` encoded as JSON but with multiple useful top-level keys that make utilizing it in Github Actions a breeze. This support will be utilized in future pull requests.

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [x] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.

### PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [x] If applicable, I've documented the impact of any changes to security controls.

Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
