### PR TITLE
Fix issue with merging observations config

### DIFF
--- a/command/server/config.go
+++ b/command/server/config.go
@@ -447,8 +447,8 @@ func (c *Config) Merge(c2 *Config) *Config {
 		if c2.Observations.LedgerPath != "" {
 			result.Observations.LedgerPath = c2.Observations.LedgerPath
 		}
-		result.Observations.TypePrefixDenylist = append(c.Observations.TypePrefixDenylist, c2.Observations.TypePrefixDenylist...)
-		result.Observations.TypePrefixAllowlist = append(c.Observations.TypePrefixAllowlist, c2.Observations.TypePrefixAllowlist...)
+		result.Observations.TypePrefixDenylist = append(result.Observations.TypePrefixDenylist, c2.Observations.TypePrefixDenylist...)
+		result.Observations.TypePrefixAllowlist = append(result.Observations.TypePrefixAllowlist, c2.Observations.TypePrefixAllowlist...)
 		if c2.Observations.FileMode != "" {
 			result.Observations.FileMode = c2.Observations.FileMode
 		}

--- a/command/server/config_test.go
+++ b/command/server/config_test.go
@@ -139,6 +139,27 @@ func Test_ObservationSystemConfigMerge(t *testing.T) {
 	require.Equal(t, "0777", merged.Observations.FileMode)
 }
 
+// Test_ObservationSystemConfigMergeFromNoObservations checks merge for observation system config from a config
+// without an observation system defined
+func Test_ObservationSystemConfigMergeFromNoObservations(t *testing.T) {
+	config, err := LoadConfigFile("./test-fixtures/config.hcl")
+	require.NoError(t, err)
+	require.NotNil(t, config)
+
+	config2, err := LoadConfigFile("./test-fixtures/observations_allow_deny.hcl")
+	require.NoError(t, err)
+	require.NotNil(t, config2)
+
+	merged := config.Merge(config2)
+	require.NotNil(t, merged)
+	require.NotNil(t, merged.Observations)
+	require.Equal(t, "/var/ledger.log", merged.Observations.LedgerPath)
+	require.Equal(t, []string{"deny1", "deny2"}, merged.Observations.TypePrefixDenylist)
+	require.Equal(t, []string{"allow1", "allow2", "allow3"}, merged.Observations.TypePrefixAllowlist)
+	require.Equal(t, "0777", merged.Observations.FileMode)
+	require.Equal(t, true, merged.EnableUI)
+}
+
 // TestDuplicateKeyValidationHcl checks that the server command displays a warning when the HCL config file contains duplicate keys.
 func TestDuplicateKeyValidationHcl(t *testing.T) {
 	testDuplicateKeyValidationHcl(t)


### PR DESCRIPTION
### Description

Panic when first config has no observations defined.

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.

### PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.

Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
