### PR TITLE
[OSS PATCH] VAULT-36896: add clear logs about auto reporting disabling and enabling, update the docs

### DIFF
--- a/website/content/docs/license/utilization/auto-reporting.mdx
+++ b/website/content/docs/license/utilization/auto-reporting.mdx
@@ -59,17 +59,17 @@ You will find log entries similar to the following:
 <CodeBlockConfig hideClipboard>
 
 ```
-[DEBUG] core.reporting: beginning snapshot export
-[DEBUG] core.reporting: creating payload
-[DEBUG] core.reporting: marshalling payload to json
-[DEBUG] core.reporting: generating authentication headers
-[DEBUG] core.reporting: creating request
-[DEBUG] core.reporting: sending request
-[DEBUG] core.reporting: performing request: method=POST url=https://reporting.hashicorp.services
-[DEBUG] core.reporting: recording audit record
+[DEBUG] reporting.auto_exporter: beginning snapshot export
+[DEBUG] reporting.auto_exporter: creating bundle
+[DEBUG] reporting.auto_exporter: marshalling bundle to json
+[DEBUG] reporting.auto_exporter: creating request
+[DEBUG] reporting.auto_exporter: sending request
+[DEBUG] reporting.auto_exporter: performing request: method=POST url=https://reporting.hashicorp.services/v2
+[DEBUG] reporting.auto_exporter: recording audit record
+[DEBUG] reporting.auto_exporter: completed recording audit record
 [INFO]  core.reporting: Report sent: auditRecord="{\"payload\":{\"payload_version\":\"1\",\"license_id\":\"97afe7b4-b9c8-bf19-bf35-b89b5cc0efea\",\"product\":\"vault\",\"product_version\":\"1.14.0-rc1+ent\",\"export_timestamp\":\"2023-06-01T09:34:44.215133-04:00\",\"snapshots\":[{\"snapshot_version\":1,\"snapshot_id\":\"0001J7H7KMEDRXKM5C1QJGBXV3\",\"process_id\":\"01H1T45CZK2GN9WR22863W2K32\",\"timestamp\":\"2023-06-01T09:34:44.215001-04:00\",\"schema_version\":\"1.0.0\",\"service\":\"vault\",\"metrics\":{\"clientcount.current_month_estimate\":{\"key\":\"clientcount.current_month_estimate\",\"kind\":\"sum\",\"mode\":\"write\",\"labels\":{\"type\":{\"entity\":20,\"nonentity\":11}}},\"clientcount.previous_month_complete\":{\"key\":\"clientcount.previous_month_complete\",\"kind\":\"sum\",\"mode\":\"write\",\"labels\":{\"type\":{\"entity\":10,\"nonentity\":11}}}}}],\"metadata\":{\"vault\":{\"billing_start\":\"2023-03-01T00:00:00Z\",\"cluster_id\":\"a8d95acc-ec0a-6087-d7f6-4f054ab2e7fd\"}}}}"
-[DEBUG] core.reporting: completed recording audit record
-[DEBUG] core.reporting: export finished successfully
+[DEBUG] reporting.auto_exporter: completed recording audit record
+[DEBUG] reporting.auto_exporter: export finished successfully
 ```
 
 </CodeBlockConfig>
@@ -80,13 +80,12 @@ egress, logs will show an error.
 <CodeBlockConfig hideClipboard>
 
 ```
-[DEBUG] core.reporting: beginning snapshot export
-[DEBUG] core.reporting: creating payload
-[DEBUG] core.reporting: marshalling payload to json
-[DEBUG] core.reporting: generating authentication headers
-[DEBUG] core.reporting: creating request
-[DEBUG] core.reporting: sending request
-[DEBUG] core.reporting: performing request: method=POST url=https://reporting.hashicorp.services
+[DEBUG] reporting.auto_exporter: beginning snapshot export
+[DEBUG] reporting.auto_exporter: creating bundle
+[DEBUG] reporting.auto_exporter: marshalling bundle to json
+[DEBUG] reporting.auto_exporter: creating request
+[DEBUG] reporting.auto_exporter: sending request
+[DEBUG] reporting.auto_exporter: performing request: method=POST url=https://reporting.hashicorp.services/v2
 [DEBUG] core.reporting: error status code received: statusCode=403
 ```
 
@@ -141,14 +140,12 @@ reporting status upon active unseal.
 </Warning>
 
 
-You will find the following entries in the server log.
+You will find the following entry in the server log.
 
 <CodeBlockConfig hideClipboard>
 
 ```
-[DEBUG] core: reloading automated reporting
-[INFO]  core: opting out of automated reporting
-[DEBUG] activity: there is no reporting agent configured, skipping counts reporting
+[DEBUG] reporting: automated reporting is disabled; license utilization data will not be exported unless triggered manually
 ```
 
 </CodeBlockConfig>
@@ -181,8 +178,7 @@ You will find the following entries in the server log.
 
 ```
 [INFO]  core: automated reporting disabled via environment variable: env=OPTOUT_LICENSE_REPORTING
-[INFO]  core: opting out of automated reporting
-[DEBUG] activity: there is no reporting agent configured, skipping counts reporting
+[DEBUG] reporting: automated reporting is disabled; license utilization data will not be exported unless triggered manually
 ```
 
 </CodeBlockConfig>


### PR DESCRIPTION
### Description
What does this PR do?

This PR adds clearer logs on when the automated license utilization reporting is enabled and disabled. The PR correspondingly updates the docs. In addition, some logs from license exporter have been updated too, so the docs are updated on these logs.

Why is this PR needed?

This PR brings about the changes that remove the confusion that came about from an escalation from a customer that said the automated license reporting continues to be working even when disabled because they do no see the log `activity: there is no reporting agent configured, skipping counts reporting`. This is expected however, since the code has been updated after manual reporting has been enabled to work all the time, thus always creating an agent for census. So this message cannot be relied on to indicate that this feature is disabled. For more information, please check comments on this Jira ticket: https://hashicorp.atlassian.net/browse/VAULT-36896?focusedCommentId=764218

<img width="1440" height="263" alt="Screenshot 2025-07-11 at 12 19 41 PM" src="https://github.com/user-attachments/assets/552a371a-0316-4147-b928-567553646094" />
<img width="1390" height="169" alt="Screenshot 2025-07-11 at 12 21 02 PM" src="https://github.com/user-attachments/assets/7b0a5df5-2453-44c2-bd21-aa09328dcffb" />
<img width="1288" height="124" alt="Screenshot 2025-07-11 at 12 25 43 PM" src="https://github.com/user-attachments/assets/4c173d19-4930-4d5b-8c1d-f4031d09a62e" />
### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.

### PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.

Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
