### PR TITLE
[OSS PATCH] Update logging and docs around enabling and disabling product usage reporting

### DIFF
--- a/website/content/docs/license/product-usage-reporting.mdx
+++ b/website/content/docs/license/product-usage-reporting.mdx
@@ -57,12 +57,12 @@ reporting {
 </Warning>
 
 
-You will find the following entries in the server log.
+You will find the following entry in the server log.
 
 <CodeBlockConfig hideClipboard>
 
   ```
-  [DEBUG] activity: there is no reporting agent configured, skipping counts reporting
+  [DEBUG] product usage reporting is disabled; usage metrics data will not be collected
   ```
 
 </CodeBlockConfig>
@@ -94,7 +94,8 @@ You will find the following entries in the server log.
 <CodeBlockConfig hideClipboard>
 
   ```
-  [DEBUG] core: product usage reporting disabled
+  [INFO] core: product usage reporting disabled via environment variable: env=OPTOUT_PRODUCT_USAGE_REPORTING
+  [DEBUG] product usage reporting is disabled; usage metrics data will not be collected
   ```
 
 </CodeBlockConfig>


### PR DESCRIPTION
### Description
What does this PR do?
1. This PR improves debug logging around enabling and disabling product usage reporting so it is more clear when the feature is enabled vs. disabled. The message indicated in the docs, `there is no reporting agent configured, skipping counts reporting`, no longer means product usage reporting is disabled, since an agent is always created regardless of disabled feature to accommodate "always enabled" manual reporting. Please read comments on this escalation ticket for more info: https://hashicorp.atlassian.net/browse/VAULT-36896
2. It also makes messaging more consistent with the messaging around enabling and disabling automated license reporting. 
3. This PR additionally fixes a small bug by setting the value of a config field to the boolean used to determine the feature enablement - this bug surprisingly did not affect the behavior of the logic that enables and disables product usage reporting, so everything is working as expected as of now. So, it less a bug fix, but rather code quality at this point to remove further confusion in reviewing code around this feature.

Did comprehensive manual testing to ensure that enabling and disabling the product usage reporting was working as expected and works as expected after the changes of this PR.

<img width="1280" height="67" alt="Screenshot 2025-07-11 at 1 43 09 PM" src="https://github.com/user-attachments/assets/fcb276af-1c48-48e2-b7d1-2cbc49a4f9a8" />
<img width="1254" height="98" alt="Screenshot 2025-07-11 at 5 09 30 PM" src="https://github.com/user-attachments/assets/c8d6e178-7489-4ef3-a5f4-c6c6d73e87a4" />


### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.

### PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.

Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.