### PR TITLE
(enos) Update Vault Radar version

### DIFF
--- a/enos/modules/verify_log_secrets/main.tf
+++ b/enos/modules/verify_log_secrets/main.tf
@@ -34,7 +34,7 @@ variable "radar_license_path" {
 
 variable "radar_version" {
   description = "The version of Vault Radar to install"
-  default     = "0.24.0" # must be >= 0.17.0
+  default     = "0.29.0" # must be >= 0.17.0
   // NOTE: A `semverconstraint` validation condition would be very useful here
   // when we get around to exporting our custom enos funcs in the provider.
 }


### PR DESCRIPTION
### Description
Updates the version of Radar that Enos uses to the most recent version

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [x] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.

### PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.

Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
