### PR TITLE
UI: Revert api service request in capabilities service

### DIFF
--- a/changelog/31271.txt
+++ b/changelog/31271.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fix capability checks for api resources with underscores to properly hide actions and dropdown items a user cannot perform
+```

--- a/ui/tests/acceptance/secrets/backend/kv/kv-v2-workflow-create-test.js
+++ b/ui/tests/acceptance/secrets/backend/kv/kv-v2-workflow-create-test.js
@@ -29,7 +29,9 @@ module('Acceptance | kv-v2 workflow | secret and version create', function (hook
     this.store = this.owner.lookup('service:store');
     await login();
     await runCmd(mountEngineCmd('kv-v2', this.backend), false);
-    await writeVersionedSecret(this.backend, 'app/first', 'foo', 'bar', 2);
+    const secretPath = 'app/first_secret';
+    await writeVersionedSecret(this.backend, secretPath, 'foo', 'bar', 2);
+    this.secretUrl = (path = secretPath) => `/vault/secrets/${this.backend}/kv/${encodeURIComponent(path)}`;
   });
 
   hooks.afterEach(async function () {
@@ -61,8 +63,7 @@ module('Acceptance | kv-v2 workflow | secret and version create', function (hook
       assert.dom(`${PAGE.list.item('app/')} [data-test-path]`).hasText('app/', 'expected list item');
     });
     test('cancel on new version rolls back model (a)', async function (assert) {
-      const backend = this.backend;
-      await visit(`/vault/secrets/${backend}/kv/${encodeURIComponent('app/first')}/details`);
+      await visit(`${this.secretUrl()}/details`);
       assert.dom(PAGE.infoRowValue('foo')).exists('key has expected value');
       await click(PAGE.detail.createNewVersion);
       await fillIn(FORM.keyInput(), 'bar');
@@ -235,7 +236,7 @@ module('Acceptance | kv-v2 workflow | secret and version create', function (hook
     test('creates a secret at a sub-directory (a)', async function (assert) {
       const backend = this.backend;
       await visit(`/vault/secrets/${backend}/kv/list/app/`);
-      assert.dom(PAGE.list.item('first')).exists('Lists first sub-secret');
+      assert.dom(PAGE.list.item('first_secret')).exists('Lists first sub-secret');
       assert.dom(PAGE.list.item('new')).doesNotExist('Does not show new secret');
       await click(PAGE.list.createSecret);
       assert.strictEqual(
@@ -262,25 +263,25 @@ module('Acceptance | kv-v2 workflow | secret and version create', function (hook
     });
     test('create new version of secret from older version (a)', async function (assert) {
       const backend = this.backend;
-      await visit(`/vault/secrets/${backend}/kv/app%2Ffirst/details`);
+      await visit(`${this.secretUrl()}/details`);
       await click(PAGE.detail.versionDropdown);
       await click(`${PAGE.detail.version(1)} a`);
       assert.strictEqual(
         currentURL(),
-        `/vault/secrets/${backend}/kv/app%2Ffirst/details?version=1`,
+        `/vault/secrets/${backend}/kv/app%2Ffirst_secret/details?version=1`,
         'goes to version 1'
       );
       assert.dom(PAGE.detail.versionTimestamp).includesText('Version 1 created');
       await click(PAGE.detail.createNewVersion);
       assert.strictEqual(
         currentURL(),
-        `/vault/secrets/${backend}/kv/app%2Ffirst/details/edit?version=1`,
+        `/vault/secrets/${backend}/kv/app%2Ffirst_secret/details/edit?version=1`,
         'Goes to new version page'
       );
       assert
         .dom(FORM.versionAlert)
         .hasText(
-          'Warning You are creating a new version based on data from Version 1. The current version for app/first is Version 2.',
+          'Warning You are creating a new version based on data from Version 1. The current version for app/first_secret is Version 2.',
           'Shows version warning'
         );
       assert.dom(FORM.keyInput()).hasValue('key-1', 'Key input has old value');
@@ -291,14 +292,14 @@ module('Acceptance | kv-v2 workflow | secret and version create', function (hook
       await click(FORM.saveBtn);
       assert.strictEqual(
         currentURL(),
-        `/vault/secrets/${backend}/kv/app%2Ffirst`,
+        `/vault/secrets/${backend}/kv/app%2Ffirst_secret`,
         'goes to overview after save'
       );
 
       await click(PAGE.secretTab('Secret'));
       assert.strictEqual(
         currentURL(),
-        `/vault/secrets/${backend}/kv/app%2Ffirst/details?version=3`,
+        `/vault/secrets/${backend}/kv/app%2Ffirst_secret/details?version=3`,
         'goes to latest version 3'
       );
       await click(PAGE.infoRowToggleMasked('my-key'));
@@ -364,8 +365,7 @@ module('Acceptance | kv-v2 workflow | secret and version create', function (hook
       assert.dom(PAGE.list.item()).doesNotExist('list view still has no items');
     });
     test('cancel on new version rolls back model (dr)', async function (assert) {
-      const backend = this.backend;
-      await visit(`/vault/secrets/${backend}/kv/${encodeURIComponent('app/first')}/details`);
+      await visit(`${this.secretUrl()}/details`);
       assert.dom(PAGE.infoRowValue('foo')).exists('key has expected value');
       assert.dom(PAGE.detail.createNewVersion).doesNotExist();
     });
@@ -394,7 +394,7 @@ module('Acceptance | kv-v2 workflow | secret and version create', function (hook
         .hasText('Error 1 error occurred: * permission denied', 'API error shows on form');
 
       // Since this persona can't create a new secret, test update with existing:
-      await visit(`/vault/secrets/${backend}/kv/app%2Ffirst/details`);
+      await visit(`${this.secretUrl()}/details`);
       assert.dom(PAGE.detail.versionTimestamp).includesText('Version 2 created');
       assert.dom(PAGE.infoRow).exists({ count: 1 }, '1 row of data shows');
       assert.dom(PAGE.infoRowValue('foo')).hasText('***********');
@@ -479,8 +479,7 @@ module('Acceptance | kv-v2 workflow | secret and version create', function (hook
         .hasText('Error 1 error occurred: * permission denied', 'API error shows on form');
     });
     test('create new version of secret from older version (dr)', async function (assert) {
-      const backend = this.backend;
-      await visit(`/vault/secrets/${backend}/kv/app%2Ffirst/details?version=1`);
+      await visit(`${this.secretUrl()}/details?version=1`);
       assert.dom(PAGE.detail.versionDropdown).doesNotExist('version dropdown does not show');
       assert.dom(PAGE.detail.versionTimestamp).includesText('Version 1 created');
       assert.dom(PAGE.detail.createNewVersion).doesNotExist('cannot create new version');
@@ -514,7 +513,7 @@ module('Acceptance | kv-v2 workflow | secret and version create', function (hook
     });
     test('cancel on new version rolls back model (dlr)', async function (assert) {
       const backend = this.backend;
-      await visit(`/vault/secrets/${backend}/kv/${encodeURIComponent('app/first')}/details`);
+      await visit(`/vault/secrets/${backend}/kv/${encodeURIComponent('app/first_secret')}/details`);
       assert.dom(PAGE.infoRowValue('foo')).exists('key has expected value');
       assert.dom(PAGE.detail.createNewVersion).doesNotExist('cannot create new version');
     });
@@ -543,7 +542,7 @@ module('Acceptance | kv-v2 workflow | secret and version create', function (hook
         .hasText('Error 1 error occurred: * permission denied', 'API error shows on form');
 
       // Since this persona can't create a new secret, test update with existing:
-      await visit(`/vault/secrets/${backend}/kv/app%2Ffirst/details`);
+      await visit(`${this.secretUrl()}/details`);
       assert.dom(PAGE.detail.versionTimestamp).includesText('Version 2 created');
       assert.dom(PAGE.infoRow).exists({ count: 1 }, '1 row of data shows');
       assert.dom(PAGE.infoRowValue('foo')).hasText('***********');
@@ -628,8 +627,7 @@ module('Acceptance | kv-v2 workflow | secret and version create', function (hook
         .hasText('Error 1 error occurred: * permission denied', 'API error shows on form');
     });
     test('create new version of secret from older version (dlr)', async function (assert) {
-      const backend = this.backend;
-      await visit(`/vault/secrets/${backend}/kv/app%2Ffirst/details?version=1`);
+      await visit(`${this.secretUrl()}/details?version=1`);
       assert.dom(PAGE.detail.versionDropdown).doesNotExist('version dropdown does not show');
       assert.dom(PAGE.detail.versionTimestamp).includesText('Version 1 created');
       assert.dom(PAGE.detail.createNewVersion).doesNotExist('cannot create new version');
@@ -663,7 +661,7 @@ module('Acceptance | kv-v2 workflow | secret and version create', function (hook
     });
     test('cancel on new version rolls back model (mm)', async function (assert) {
       const backend = this.backend;
-      await visit(`/vault/secrets/${backend}/kv/${encodeURIComponent('app/first')}/details`);
+      await visit(`/vault/secrets/${backend}/kv/${encodeURIComponent('app/first_secret')}/details`);
       assert.dom(PAGE.emptyStateTitle).hasText('You do not have permission to read this secret');
       assert
         .dom(PAGE.detail.createNewVersion)
@@ -694,7 +692,7 @@ module('Acceptance | kv-v2 workflow | secret and version create', function (hook
         .hasText('Error 1 error occurred: * permission denied', 'API error shows on form');
 
       // Since this persona can't create a new secret, test update with existing:
-      await visit(`/vault/secrets/${backend}/kv/app%2Ffirst/details`);
+      await visit(`${this.secretUrl()}/details`);
       assert.dom(PAGE.detail.versionTimestamp).doesNotExist('Version created tooltip does not show');
       assert.dom(PAGE.infoRow).doesNotExist('secret data not shown');
       assert.dom(PAGE.emptyStateTitle).hasText('You do not have permission to read this secret');
@@ -716,7 +714,7 @@ module('Acceptance | kv-v2 workflow | secret and version create', function (hook
       // Add new version
       await click(PAGE.secretTab('Secret'));
       assert.dom(PAGE.detail.createNewVersion).doesNotExist('create new version button not rendered');
-      await visit(`/vault/secrets/${backend}/kv/app%2Ffirst/details/edit?version=1`);
+      await visit(`${this.secretUrl()}/details/edit?version=1`);
       assert
         .dom(FORM.noReadAlert)
         .hasText(
@@ -725,7 +723,7 @@ module('Acceptance | kv-v2 workflow | secret and version create', function (hook
         );
 
       assert.dom(FORM.inputByAttr('path')).isDisabled('path input is disabled');
-      assert.dom(FORM.inputByAttr('path')).hasValue('app/first');
+      assert.dom(FORM.inputByAttr('path')).hasValue('app/first_secret');
       assert.dom(FORM.toggleMetadata).doesNotExist('Does not show metadata toggle when creating new version');
       assert.dom(FORM.keyInput()).hasValue('', 'first row has no key');
       assert.dom(FORM.maskedValueInput()).hasValue('', 'first row has no value');
@@ -781,7 +779,7 @@ module('Acceptance | kv-v2 workflow | secret and version create', function (hook
     test('creates a secret at a sub-directory (mm)', async function (assert) {
       const backend = this.backend;
       await visit(`/vault/secrets/${backend}/kv/list/app/`);
-      assert.dom(PAGE.list.item('first')).exists('Lists first sub-secret');
+      assert.dom(PAGE.list.item('first_secret')).exists('Lists first sub-secret');
       assert.dom(PAGE.list.item('new')).doesNotExist('Does not show new secret');
       await click(PAGE.list.createSecret);
       assert.strictEqual(
@@ -799,19 +797,19 @@ module('Acceptance | kv-v2 workflow | secret and version create', function (hook
     });
     test('create new version of secret from older version (mm)', async function (assert) {
       const backend = this.backend;
-      await visit(`/vault/secrets/${backend}/kv/app%2Ffirst/details`);
+      await visit(`${this.secretUrl()}/details`);
       assert.dom(PAGE.detail.versionDropdown).hasText('Version 2');
       await click(PAGE.detail.versionDropdown);
       await click(`${PAGE.detail.version(1)} a`);
       assert.strictEqual(
         currentURL(),
-        `/vault/secrets/${backend}/kv/app%2Ffirst/details?version=1`,
+        `/vault/secrets/${backend}/kv/app%2Ffirst_secret/details?version=1`,
         'goes to version 1'
       );
       assert.dom(PAGE.detail.versionDropdown).hasText('Version 1');
       assert.dom(PAGE.detail.versionTimestamp).doesNotExist('version timestamp not shown');
       assert.dom(PAGE.detail.createNewVersion).doesNotExist('create new version button not rendered');
-      await visit(`/vault/secrets/${backend}/kv/app%2Ffirst/details/edit?version=1`);
+      await visit(`${this.secretUrl()}/details/edit?version=1`);
       assert
         .dom(FORM.noReadAlert)
         .hasText(
@@ -820,7 +818,7 @@ module('Acceptance | kv-v2 workflow | secret and version create', function (hook
         );
 
       assert.dom(FORM.inputByAttr('path')).isDisabled('path input is disabled');
-      assert.dom(FORM.inputByAttr('path')).hasValue('app/first');
+      assert.dom(FORM.inputByAttr('path')).hasValue('app/first_secret');
       assert.dom(FORM.toggleMetadata).doesNotExist('Does not show metadata toggle when creating new version');
       assert.dom(FORM.keyInput()).hasValue('', 'first row has no key');
       assert.dom(FORM.maskedValueInput()).hasValue('', 'first row has no value');
@@ -857,7 +855,7 @@ module('Acceptance | kv-v2 workflow | secret and version create', function (hook
     });
     test('cancel on new version rolls back model (sc)', async function (assert) {
       const backend = this.backend;
-      await visit(`/vault/secrets/${backend}/kv/${encodeURIComponent('app/first')}/details`);
+      await visit(`${this.secretUrl()}/details`);
       assert
         .dom(PAGE.emptyStateTitle)
         .hasText('You do not have permission to read this secret', 'no permissions state shows');
@@ -866,7 +864,7 @@ module('Acceptance | kv-v2 workflow | secret and version create', function (hook
       await click(FORM.cancelBtn);
       assert.strictEqual(
         currentURL(),
-        `/vault/secrets/${backend}/kv/${encodeURIComponent('app/first')}`,
+        `/vault/secrets/${backend}/kv/${encodeURIComponent('app/first_secret')}`,
         'cancel goes to overview'
       );
       await click(PAGE.secretTab('Secret'));
@@ -875,7 +873,7 @@ module('Acceptance | kv-v2 workflow | secret and version create', function (hook
       await click(PAGE.breadcrumbAtIdx(3));
       assert.strictEqual(
         currentURL(),
-        `/vault/secrets/${backend}/kv/${encodeURIComponent('app/first')}`,
+        `/vault/secrets/${backend}/kv/${encodeURIComponent('app/first_secret')}`,
         'breadcrumb goes to overview'
       );
     });

--- a/ui/tests/acceptance/secrets/backend/kv/kv-v2-workflow-delete-test.js
+++ b/ui/tests/acceptance/secrets/backend/kv/kv-v2-workflow-delete-test.js
@@ -42,8 +42,8 @@ module('Acceptance | kv-v2 workflow | delete, undelete, destroy', function (hook
   hooks.beforeEach(async function () {
     this.store = this.owner.lookup('service:store');
     this.backend = `kv-delete-${uuidv4()}`;
-    this.secretPath = 'bad-secret';
-    this.nestedSecretPath = 'app/nested/bad-secret';
+    this.secretPath = 'bad_secret';
+    this.nestedSecretPath = 'app/nested/bad_secret';
     await login();
     await runCmd(mountEngineCmd('kv-v2', this.backend), false);
     await writeVersionedSecret(this.backend, this.secretPath, 'foo', 'bar', 4);
@@ -171,8 +171,8 @@ module('Acceptance | kv-v2 workflow | delete, undelete, destroy', function (hook
     });
 
     test('can permanently delete all secret versions (a)', async function (assert) {
-      await writeVersionedSecret(this.backend, 'nuke', 'foo', 'bar', 2);
-      await visit(`/vault/secrets/${this.backend}/kv/nuke/metadata`);
+      await writeVersionedSecret(this.backend, 'nu_ke', 'foo', 'bar', 2);
+      await visit(`/vault/secrets/${this.backend}/kv/nu_ke/metadata`);
       assert.dom(PAGE.metadata.deleteMetadata).hasText('Permanently delete', 'shows delete metadata button');
       // delete flow
       await click(PAGE.metadata.deleteMetadata);
@@ -190,8 +190,8 @@ module('Acceptance | kv-v2 workflow | delete, undelete, destroy', function (hook
     hooks.beforeEach(async function () {
       // create and delete a secret as root user
       await login();
-      await writeVersionedSecret(this.backend, 'nuke', 'foo', 'bar', 2);
-      await runCmd(deleteLatestCmd(this.backend, 'nuke'));
+      await writeVersionedSecret(this.backend, 'nu_ke', 'foo', 'bar', 2);
+      await runCmd(deleteLatestCmd(this.backend, 'nu_ke'));
       // login as data-reader persona
       const token = await runCmd(makeToken('data-reader', this.backend, personas.dataReader));
       await login(token);
@@ -207,7 +207,7 @@ module('Acceptance | kv-v2 workflow | delete, undelete, destroy', function (hook
       assert.dom(PAGE.infoRow).exists('shows secret data');
 
       // data-reader can't delete, so check undelete with already-deleted version
-      await visit(`/vault/secrets/${this.backend}/kv/nuke/details`);
+      await visit(`/vault/secrets/${this.backend}/kv/nu_ke/details`);
       assertDeleteActions(assert, []);
       assert
         .dom(PAGE.emptyStateTitle)
@@ -231,7 +231,7 @@ module('Acceptance | kv-v2 workflow | delete, undelete, destroy', function (hook
     });
     test('cannot permanently delete all secret versions (dr)', async function (assert) {
       // go to secret details
-      await visit(`/vault/secrets/${this.backend}/kv/nuke/details`);
+      await visit(`/vault/secrets/${this.backend}/kv/nu_ke/details`);
       // Check metadata toolbar
       await click(PAGE.secretTab('Metadata'));
       assert.dom(PAGE.metadata.deleteMetadata).doesNotExist('does not show delete metadata button');
@@ -242,8 +242,8 @@ module('Acceptance | kv-v2 workflow | delete, undelete, destroy', function (hook
     hooks.beforeEach(async function () {
       // create and delete a secret as root user
       await login();
-      await writeVersionedSecret(this.backend, 'nuke', 'foo', 'bar', 2);
-      await runCmd(deleteLatestCmd(this.backend, 'nuke'));
+      await writeVersionedSecret(this.backend, 'nu_ke', 'foo', 'bar', 2);
+      await runCmd(deleteLatestCmd(this.backend, 'nu_ke'));
       // login as data-list-reader persona
       const token = await runCmd(makeToken('data-list-reader', this.backend, personas.dataListReader));
       await login(token);
@@ -295,7 +295,7 @@ module('Acceptance | kv-v2 workflow | delete, undelete, destroy', function (hook
     });
     test('cannot permanently delete all secret versions (dlr)', async function (assert) {
       // go to secret details
-      await visit(`/vault/secrets/${this.backend}/kv/nuke/details`);
+      await visit(`/vault/secrets/${this.backend}/kv/nu_ke/details`);
       // Check metadata toolbar
       await click(PAGE.secretTab('Metadata'));
       assert.dom(PAGE.metadata.deleteMetadata).doesNotExist('does not show delete metadata button');
@@ -306,8 +306,8 @@ module('Acceptance | kv-v2 workflow | delete, undelete, destroy', function (hook
     hooks.beforeEach(async function () {
       // create and delete a secret as root user
       await login();
-      await writeVersionedSecret(this.backend, 'nuke', 'foo', 'bar', 2);
-      await runCmd(deleteLatestCmd(this.backend, 'nuke'));
+      await writeVersionedSecret(this.backend, 'nu_ke', 'foo', 'bar', 2);
+      await runCmd(deleteLatestCmd(this.backend, 'nu_ke'));
       // login as metadata-maintainer persona
       const token = await runCmd(makeToken('metadata-maintainer', this.backend, personas.metadataMaintainer));
       await login(token);
@@ -328,7 +328,7 @@ module('Acceptance | kv-v2 workflow | delete, undelete, destroy', function (hook
       assert.dom(PAGE.detail.deleteOptionLatest).isDisabled('delete latest option is disabled');
 
       // Can't delete latest, try with pre-deleted secret
-      await visit(`/vault/secrets/${this.backend}/kv/nuke/details`);
+      await visit(`/vault/secrets/${this.backend}/kv/nu_ke/details`);
       assert.dom(PAGE.emptyStateTitle).hasText('You do not have permission to read this secret');
       assert.dom(PAGE.detail.versionTimestamp).doesNotExist('Version 2 timestamp not rendered');
       // updated toolbar options
@@ -397,7 +397,7 @@ module('Acceptance | kv-v2 workflow | delete, undelete, destroy', function (hook
     });
     test('cannot permanently delete all secret versions (mm)', async function (assert) {
       // go to secret details
-      await visit(`/vault/secrets/${this.backend}/kv/nuke/details`);
+      await visit(`/vault/secrets/${this.backend}/kv/nu_ke/details`);
       // Check metadata toolbar
       await click(PAGE.secretTab('Metadata'));
       assert.dom(PAGE.metadata.deleteMetadata).doesNotExist('does not show delete metadata button');
@@ -418,7 +418,7 @@ module('Acceptance | kv-v2 workflow | delete, undelete, destroy', function (hook
       // go to nested secret directory list view
       await visit(`/vault/secrets/${this.backend}/kv/list/app/nested`);
       // correct popup menu items appear on list view
-      const popupSelector = `${PAGE.list.item('bad-secret')} ${PAGE.popup}`;
+      const popupSelector = `${PAGE.list.item('bad_secret')} ${PAGE.popup}`;
       await click(popupSelector);
       assert.dom(PAGE.list.listMenuDelete).exists('shows the option to permanently delete');
     });
@@ -447,7 +447,7 @@ module('Acceptance | kv-v2 workflow | delete, undelete, destroy', function (hook
       assert.dom(PAGE.emptyStateTitle).hasText('You do not have permission to read this secret');
 
       // test with already deleted method
-      await visit(`/vault/secrets/${this.backend}/kv/nuke/details`);
+      await visit(`/vault/secrets/${this.backend}/kv/nu_ke/details`);
       assert.dom(PAGE.emptyStateTitle).hasText('You do not have permission to read this secret');
       assert.dom(PAGE.detail.versionTimestamp).doesNotExist('version timestamp not rendered');
       // updated toolbar options
@@ -469,9 +469,9 @@ module('Acceptance | kv-v2 workflow | delete, undelete, destroy', function (hook
       assertDeleteActions(assert, []);
     });
     test('can permanently delete all secret versions (sc)', async function (assert) {
-      await writeVersionedSecret(this.backend, 'nuke', 'foo', 'bar', 2);
+      await writeVersionedSecret(this.backend, 'nu_ke', 'foo', 'bar', 2);
       // go to secret details
-      await visit(`/vault/secrets/${this.backend}/kv/nuke/details`);
+      await visit(`/vault/secrets/${this.backend}/kv/nu_ke/details`);
       // Check metadata toolbar
       await click(PAGE.secretTab('Metadata'));
       assert.dom(PAGE.metadata.deleteMetadata).hasText('Permanently delete', 'shows delete metadata button');

--- a/ui/tests/acceptance/secrets/backend/kv/kv-v2-workflow-edge-cases-test.js
+++ b/ui/tests/acceptance/secrets/backend/kv/kv-v2-workflow-edge-cases-test.js
@@ -50,8 +50,8 @@ module('Acceptance | kv-v2 workflow | edge cases', function (hooks) {
   hooks.beforeEach(async function () {
     const uid = uuidv4();
     this.backend = `kv-edge-${uid}`;
-    this.rootSecret = 'root-directory';
-    this.fullSecretPath = `${this.rootSecret}/nested/child-secret`;
+    this.rootSecret = 'root_directory';
+    this.fullSecretPath = `${this.rootSecret}/nested/child_secret`;
     await login();
     await runCmd(mountEngineCmd('kv-v2', this.backend), false);
     await writeSecret(this.backend, this.fullSecretPath, 'foo', 'bar');

--- a/ui/tests/acceptance/secrets/backend/kv/kv-v2-workflow-navigation-test.js
+++ b/ui/tests/acceptance/secrets/backend/kv/kv-v2-workflow-navigation-test.js
@@ -38,9 +38,9 @@ import { GENERAL } from 'vault/tests/helpers/general-selectors';
 import { SECRET_ENGINE_SELECTORS as SES } from 'vault/tests/helpers/secret-engine/secret-engine-selectors';
 import { setupControlGroup, grantAccess } from 'vault/tests/helpers/control-groups';
 
-const secretPath = `my-#:$=?-secret`;
+const secretPath = `my-#:$=?_secret`;
 // This doesn't encode in a normal way, so hardcoding it here until we sort that out
-const secretPathUrlEncoded = `my-%23:$=%3F-secret`;
+const secretPathUrlEncoded = `my-%23:$=%3F_secret`;
 // these are rendered individually by each page component, assigning a const here for consistency
 const ALL_TABS = ['Overview', 'Secret', 'Metadata', 'Paths', 'Version History'];
 const navToBackend = async (backend) => {

--- a/ui/tests/acceptance/secrets/backend/kv/kv-v2-workflow-version-history-paths-test.js
+++ b/ui/tests/acceptance/secrets/backend/kv/kv-v2-workflow-version-history-paths-test.js
@@ -34,7 +34,7 @@ module('Acceptance | kv-v2 workflow | version history, paths', function (hooks) 
   hooks.beforeEach(async function () {
     this.store = this.owner.lookup('service:store');
     this.backend = `kv-workflow-${uuidv4()}`;
-    this.secretPath = 'app/first-secret';
+    this.secretPath = 'app/first_secret';
     this.urlPath = `${this.backend}/kv/${encodeURIComponent(this.secretPath)}`;
     this.navToSecret = async () => {
       return visit(`/vault/secrets/${this.urlPath}/details?version=4`);

--- a/ui/tests/unit/services/capabilities-test.js
+++ b/ui/tests/unit/services/capabilities-test.js
@@ -367,9 +367,9 @@ module('Unit | Service | capabilities', function (hooks) {
       const expectedPayload = [`${ns}/my/api/path`, `${ns}/another/api/path`];
 
       this.server.post('/sys/capabilities-self', (schema, req) => {
-        const nsHeader = req.requestHeaders['x-vault-namespace'];
+        const nsHeader = req.requestHeaders['X-Vault-Namespace'];
         const payload = JSON.parse(req.requestBody);
-        assert.strictEqual(nsHeader, '', 'request is made in the context of the "root" namespace');
+        assert.strictEqual(nsHeader, undefined, 'request is made in the context of the "root" namespace');
         assert.propEqual(payload.paths, expectedPayload, `paths include the relative namespace`);
         return req.passthrough();
       });
@@ -389,9 +389,9 @@ module('Unit | Service | capabilities', function (hooks) {
       const expectedPaths = ['ns1/child/my/api/path', 'ns1/child/another/api/path'];
 
       this.server.post('/sys/capabilities-self', (schema, req) => {
-        const nsHeader = req.requestHeaders['x-vault-namespace'];
+        const nsHeader = req.requestHeaders['X-Vault-Namespace'];
         const payload = JSON.parse(req.requestBody);
-        assert.strictEqual(nsHeader, '', 'request is made in the context of the "root" namespace');
+        assert.strictEqual(nsHeader, undefined, 'request is made in the context of the "root" namespace');
         assert.propEqual(payload.paths, expectedPaths, `paths include the relative namespace`);
         return req.passthrough();
       });
@@ -418,7 +418,7 @@ module('Unit | Service | capabilities', function (hooks) {
       const paths = ['my/api/path', '/another/api/path'];
 
       this.server.post('/sys/capabilities-self', (schema, req) => {
-        const nsHeader = req.requestHeaders['x-vault-namespace'];
+        const nsHeader = req.requestHeaders['X-Vault-Namespace'];
         const payload = JSON.parse(req.requestBody);
         assert.strictEqual(nsHeader, 'ns1', 'request is made in the context of the "ns1" namespace');
         assert.propEqual(
@@ -448,7 +448,7 @@ module('Unit | Service | capabilities', function (hooks) {
       const expectedPaths = ['child/my/api/path', 'child/another/api/path'];
 
       this.server.post('/sys/capabilities-self', (schema, req) => {
-        const nsHeader = req.requestHeaders['x-vault-namespace'];
+        const nsHeader = req.requestHeaders['X-Vault-Namespace'];
         const payload = JSON.parse(req.requestBody);
         assert.strictEqual(nsHeader, 'ns1', 'request is made in the context of the "ns1" namespace');
         assert.propEqual(payload.paths, expectedPaths, 'paths include the relative namespace');
@@ -473,7 +473,7 @@ module('Unit | Service | capabilities', function (hooks) {
       const paths = ['my/api/path', '/another/api/path'];
 
       this.server.post('/sys/capabilities-self', (schema, req) => {
-        const nsHeader = req.requestHeaders['x-vault-namespace'];
+        const nsHeader = req.requestHeaders['X-Vault-Namespace'];
         const payload = JSON.parse(req.requestBody);
         assert.strictEqual(
           nsHeader,


### PR DESCRIPTION
### Description
✅ enterprise tests pass

Resolves a regression introduced by https://github.com/hashicorp/vault/pull/30222 that mutated any paths containing underscores sent to the [sys/capabilities check](https://developer.hashicorp.com/vault/api-docs/system/capabilities-self) by returning them as camel-cased.

For example if the path payload was: `kvv2_admin/metadata/my_secret` the api service would return:
```js
    "data": {
        "kvv2Admin/metadata/mySecret": [
            "read"
        ],
    }
```

This means the `mapCapabilities` [method](https://github.com/hashicorp/vault/blob/main/ui/app/services/capabilities.ts#L47) incorrectly mapped permissions because it would not be able to match the original path to the mutated, camel-cased version. The result is some dropdown items and actions would display that a user may not have permissions for since our capabilities service defaults to `true` if the capability check is not found. Fortunately, the UI was not hiding any actions a user **can** perform because the fallback behavior relies on the API to gate permissions. Though this isn't ideal UX (hence the fix) the regression did not introduce any major functionality issues.



### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.

### PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.

Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
