### PR TITLE
UI: Revert api service for unwrapping data

### DIFF
--- a/changelog/31287.txt
+++ b/changelog/31287.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fix mutation of unwrapped data when keys contain underscores
+```

--- a/ui/tests/acceptance/tools-test.js
+++ b/ui/tests/acceptance/tools-test.js
@@ -8,7 +8,7 @@ import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { toolsActions } from 'vault/helpers/tools-actions';
 import { login } from 'vault/tests/helpers/auth/auth-helpers';
-import { capitalize, camelize } from '@ember/string';
+import { capitalize } from '@ember/string';
 import codemirror from 'vault/tests/helpers/codemirror';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { GENERAL } from 'vault/tests/helpers/general-selectors';
@@ -166,11 +166,11 @@ module('Acceptance | tools', function (hooks) {
       await click(TS.submit);
       await waitUntil(() => find('.CodeMirror'));
 
-      const expected = Object.keys(AUTH_RESPONSE.auth).reduce((obj, auth) => {
-        obj[camelize(auth)] = AUTH_RESPONSE.auth[auth];
-        return obj;
-      }, {});
-      assert.deepEqual(expected, JSON.parse(codemirror().getValue()), 'unwrapped data equals input data');
+      assert.deepEqual(
+        JSON.parse(codemirror().getValue()),
+        AUTH_RESPONSE.auth,
+        'unwrapped data equals input data'
+      );
     });
   });
 

--- a/ui/tests/integration/components/control-group-success-test.js
+++ b/ui/tests/integration/components/control-group-success-test.js
@@ -5,7 +5,7 @@
 
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { click, fillIn, find, render } from '@ember/test-helpers';
+import { click, fillIn, find, render, waitFor } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import sinon from 'sinon';
 import { setRunOptions } from 'ember-a11y-testing/test-support';
@@ -74,10 +74,11 @@ module('Integration | Component | control group success', function (hooks) {
 
   test('it unwraps data on submit', async function (assert) {
     assert.expect(3);
+    // key has an underscore to cover a bug where the api service was returning camel-cased keys
     const data = { foo_test: 'bar' };
 
     this.server.post('sys/wrapping/unwrap', (schema, req) => {
-      assert.strictEqual(req.requestHeaders['x-vault-token'], 'token', 'header contains token');
+      assert.strictEqual(req.requestHeaders['X-Vault-Token'], 'token', 'header contains token');
       return { data };
     });
 
@@ -86,7 +87,7 @@ module('Integration | Component | control group success', function (hooks) {
 
     await fillIn(GENERAL.inputByAttr('token'), 'token');
     await click(SELECTORS.unwrap);
-
+    await waitFor(SELECTORS.jsonViewer);
     const actual = find(SELECTORS.jsonViewer).innerText;
     const expected = JSON.stringify({ foo_test: 'bar' }, null, 2);
     assert.strictEqual(actual, expected, `it renders unwrapped data: ${actual}`);

--- a/ui/tests/integration/components/tools/unwrap-test.js
+++ b/ui/tests/integration/components/tools/unwrap-test.js
@@ -47,6 +47,7 @@ module('Integration | Component | tools/unwrap', function (hooks) {
 
   test('it submits and renders falsy values', async function (assert) {
     const flashSpy = sinon.spy(this.owner.lookup('service:flash-messages'), 'success');
+    // key has an underscore to cover a bug where the api service was returning camel-cased keys
     const unwrapData = { foo_test: 'bar' };
     const data = { token: 'token.OMZFbUurY0ppT2RTMGpRa0JOSUFqUzJUaGNqdWUQ6ooG' };
     const expectedDetails = {
@@ -76,7 +77,7 @@ module('Integration | Component | tools/unwrap', function (hooks) {
     await waitUntil(() => find('.CodeMirror'));
     assert.true(flashSpy.calledWith('Unwrap was successful.'), 'it renders success flash');
     assert.dom('label').hasText('Unwrapped Data');
-    assert.strictEqual(codemirror().getValue(' '), '{   "foo": "bar" }', 'it renders unwrapped data');
+    assert.strictEqual(codemirror().getValue(' '), '{   "foo_test": "bar" }', 'it renders unwrapped data');
     assert.dom(GENERAL.hdsTab('data')).hasAttribute('aria-selected', 'true');
 
     await click(GENERAL.hdsTab('details'));

--- a/ui/tests/integration/components/tools/unwrap-test.js
+++ b/ui/tests/integration/components/tools/unwrap-test.js
@@ -47,7 +47,7 @@ module('Integration | Component | tools/unwrap', function (hooks) {
 
   test('it submits and renders falsy values', async function (assert) {
     const flashSpy = sinon.spy(this.owner.lookup('service:flash-messages'), 'success');
-    const unwrapData = { foo: 'bar' };
+    const unwrapData = { foo_test: 'bar' };
     const data = { token: 'token.OMZFbUurY0ppT2RTMGpRa0JOSUFqUzJUaGNqdWUQ6ooG' };
     const expectedDetails = {
       'Request ID': '291290a6-5602-e49a-389b-5870e6c02976',


### PR DESCRIPTION
### Description
✅ enterprise tests pass

The api service returns camel-cased keys so if a key contained an underscore unwrapping the data would return the value camel cased. Replacing the api service in calls to `sys/wrapping/unwrap` ([docs](https://developer.hashicorp.com/vault/api-docs/system/wrapping-unwrap)) for unwrapping data. This is only going in to 1.20 because for 1.21 the issue will be addressed upstream. 

Test coverage was added before the request was replaced.

### before fix
| data to wrap                                                                                                                                         | unwrapped data                                                                                                                                       |
| ---------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
| <img width="500"  alt="Screenshot 2025-07-15 at 2 20 37 PM" src="https://github.com/user-attachments/assets/30609bc5-e555-441a-b12e-1a0469d5c4d7" /> | <img width="500"  alt="Screenshot 2025-07-15 at 2 21 27 PM" src="https://github.com/user-attachments/assets/7b561e1e-5f71-42b2-8338-0838657dac0f" /> |

### after
<img width="393" height="525" alt="Screenshot 2025-07-15 at 2 23 15 PM" src="https://github.com/user-attachments/assets/9ae405e3-1b5f-4a9d-a7df-c1e41cc5b3fd" />



### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.

### PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.

Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
