### PR TITLE
login/mfa: update loginmfa cache and tests

### DIFF
--- a/vault/external_tests/identity/login_mfa_totp_test.go
+++ b/vault/external_tests/identity/login_mfa_totp_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -92,7 +93,7 @@ func TestLoginMfaGenerateTOTPTestAuditIncluded(t *testing.T) {
 	// Creating two users in the userpass auth mount
 	userClient1, entityID1, _ := testhelpers.CreateEntityAndAlias(t, client, mountAccessor, entity1, testuser1)
 	userClient2, entityID2, _ := testhelpers.CreateEntityAndAlias(t, client, mountAccessor, entity2, testuser2)
-	waitPeriod := 5
+	waitPeriod := 3
 	totpConfig := map[string]interface{}{
 		"issuer":                  "yCorp",
 		"period":                  waitPeriod,
@@ -281,10 +282,24 @@ func TestLoginMfaGenerateTOTPTestAuditIncluded(t *testing.T) {
 	if err == nil {
 		t.Fatalf("MFA succeeded with an already used passcode")
 	}
-	if !strings.Contains(err.Error(), "code already used") {
-		t.Fatalf("got: %+v, expected: code already used", err.Error())
+	if !strings.Contains(err.Error(), "failed to validate TOTP passcode") {
+		t.Fatalf("got: %+v, expected: failed to validate TOTP passcode", err.Error())
 	}
 
+	for _, possibleCode := range []string{totpPasscode1 + " ", "  " + totpPasscode1} {
+		_, err = userClient1.Logical().WriteWithContext(context.Background(), "sys/mfa/validate", map[string]interface{}{
+			"mfa_request_id": secret.Auth.MFARequirement.MFARequestID,
+			"mfa_payload": map[string][]string{
+				methodID: {possibleCode},
+			},
+		})
+		if err == nil {
+			t.Fatalf("MFA succeeded with an already used passcode")
+		}
+		if !strings.Contains(err.Error(), "failed to validate TOTP passcode") {
+			t.Fatalf("got: %+v, expected: failed to validate TOTP passcode", err.Error())
+		}
+	}
 	// check for reaching max failed validation requests
 	secret, err = userClient1.Logical().WriteWithContext(context.Background(), userpassPath, map[string]interface{}{
 		"password": "testpassword",
@@ -300,7 +315,7 @@ func TestLoginMfaGenerateTOTPTestAuditIncluded(t *testing.T) {
 		_, maxErr = userClient1.Logical().WriteWithContext(context.Background(), "sys/mfa/validate", map[string]interface{}{
 			"mfa_request_id": secret.Auth.MFARequirement.MFARequestID,
 			"mfa_payload": map[string][]string{
-				methodID: {fmt.Sprintf("%d", i)},
+				methodID: {fmt.Sprintf("%s", strings.Repeat(strconv.Itoa(i), len(totpPasscode1)))},
 			},
 		})
 		if maxErr == nil {
@@ -314,8 +329,8 @@ func TestLoginMfaGenerateTOTPTestAuditIncluded(t *testing.T) {
 	// let's make sure the configID is not blocked for other users
 	doTwoPhaseLogin(t, userClient2, enginePath2, methodID, testuser2)
 
-	// let's see if user1 is able to login after 5 seconds
-	time.Sleep(5 * time.Second)
+	// let's see if user1 is able to login after 3 + 3*2 = 9 seconds
+	time.Sleep(9 * time.Second)
 	doTwoPhaseLogin(t, userClient1, enginePath1, methodID, testuser1)
 
 	// Destroy the secret so that the token can self generate

--- a/vault/login_mfa.go
+++ b/vault/login_mfa.go
@@ -2332,17 +2332,20 @@ func (c *Core) validateTOTP(ctx context.Context, mfaFactors *MFAFactor, entityMe
 		return fmt.Errorf("entity does not contain the TOTP secret")
 	}
 
+	if len(passcode) != int(totpSecret.GetDigits()) {
+		return fmt.Errorf("failed to validate TOTP passcode")
+	}
+
 	usedName := fmt.Sprintf("%s_%s", configID, passcode)
 
 	_, ok := usedCodes.Get(usedName)
 	if ok {
-		return fmt.Errorf("code already used; new code is available in %v seconds", totpSecret.Period)
+		return fmt.Errorf("failed to validate TOTP passcode")
 	}
 
 	// The duration in which a passcode is stored in cache to enforce
 	// rate limit on failed totp passcode validation
-	passcodeTTL := time.Duration(int64(time.Second) * int64(totpSecret.Period))
-
+	passcodeTTL := time.Duration(int64(time.Second) * int64(totpSecret.Period) * int64(2*totpSecret.Skew))
 	// Enforcing rate limit per MethodID per EntityID
 	rateLimitID := fmt.Sprintf("%s_%s", configID, entityID)
 


### PR DESCRIPTION
### Description
normalizes the loginmfa totp code and adjusts the used code cache duration

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.

### PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.

Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
