### PR TITLE
UI: Remove capabilities check from namespace picker refresh list button

### DIFF
--- a/ui/app/components/namespace-picker.hbs
+++ b/ui/app/components/namespace-picker.hbs
@@ -72,22 +72,19 @@
 
     <D.Footer @hasDivider={{true}} class="is-flex-center">
       <Hds::ButtonSet class="is-fullwidth">
-        {{#if this.canRefreshNamespaces}}
-          <Hds::Button
-            @color="secondary"
-            @text="Refresh list"
-            @isFullWidth={{(not this.canManageNamespaces)}}
-            @icon="reload"
-            @size="small"
-            {{on "click" this.refreshList}}
-            data-test-button="Refresh list"
-          />
-        {{/if}}
+        <Hds::Button
+          @color="secondary"
+          @text="Refresh list"
+          @isFullWidth={{not this.canManageNamespaces}}
+          @icon="reload"
+          @size="small"
+          {{on "click" this.refreshList}}
+          data-test-button="Refresh list"
+        />
         {{#if this.canManageNamespaces}}
           <Hds::Button
             @color="tertiary"
             @text="Manage"
-            @isFullWidth={{(not this.canRefreshNamespaces)}}
             @icon="settings"
             @size="small"
             @route="vault.cluster.access.namespaces"

--- a/ui/app/components/namespace-picker.ts
+++ b/ui/app/components/namespace-picker.ts
@@ -8,8 +8,8 @@ import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { service } from '@ember/service';
 import keys from 'core/utils/keys';
-import { buildWaiter } from '@ember/test-waiters';
 
+import type CapabilitiesService from 'vault/services/capabilities';
 import type Router from 'vault/router';
 import type NamespaceService from 'vault/services/namespace';
 import type AuthService from 'vault/vault/services/auth';
@@ -21,8 +21,6 @@ interface NamespaceOption {
   path: string;
   label: string;
 }
-
-const waiter = buildWaiter('namespace-picker');
 
 /**
  * @module NamespacePicker
@@ -36,6 +34,7 @@ const waiter = buildWaiter('namespace-picker');
  */
 export default class NamespacePicker extends Component {
   @service declare auth: AuthService;
+  @service declare capabilities: CapabilitiesService;
   @service declare namespace: NamespaceService;
   @service declare router: Router;
   @service declare store: Store;
@@ -44,7 +43,6 @@ export default class NamespacePicker extends Component {
   @tracked batchSize = 200;
 
   @tracked canManageNamespaces = false; // Show/hide manage namespaces button
-  @tracked canRefreshNamespaces = false; // Show/hide refresh list button
   @tracked errorLoadingNamespaces = '';
   @tracked hasNamespaces = false;
   @tracked searchInput = '';
@@ -54,6 +52,7 @@ export default class NamespacePicker extends Component {
   constructor(owner: unknown, args: Record<string, never>) {
     super(owner, args);
     this.loadOptions();
+    this.fetchManageCapability();
   }
 
   get allNamespaces(): NamespaceOption[] {
@@ -184,18 +183,12 @@ export default class NamespacePicker extends Component {
   }
 
   @action
-  async fetchListCapability(): Promise<void> {
-    const waiterToken = waiter.beginAsync();
-    try {
-      const namespacePermission = await this.store.findRecord('capabilities', 'sys/namespaces/');
-      this.canRefreshNamespaces = namespacePermission.get('canList');
-      this.canManageNamespaces = true;
-    } catch (error) {
-      // If the findRecord call fails, the user lacks permissions to refresh or manage namespaces.
-      this.canRefreshNamespaces = this.canManageNamespaces = false;
-    } finally {
-      waiter.endAsync(waiterToken);
-    }
+  async fetchManageCapability(): Promise<void> {
+    // The namespace picker options are from `sys/internal/ui/namespaces` which all users have permissions to request.
+    // The UI view for managing namespaces (i.e. CRUD actions) calls `sys/namespaces` and DOES require LIST permissions.
+    // This is the capability check to hide/show the button that navigates to that route.
+    const { canList } = await this.capabilities.fetchPathCapabilities('sys/namespaces');
+    this.canManageNamespaces = canList;
   }
 
   @action
@@ -212,8 +205,6 @@ export default class NamespacePicker extends Component {
     } catch (error) {
       this.errorLoadingNamespaces = errorMessage(error);
     }
-
-    await this.fetchListCapability();
   }
 
   @action

--- a/ui/tests/integration/components/namespace-picker-test.js
+++ b/ui/tests/integration/components/namespace-picker-test.js
@@ -8,35 +8,9 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render, fillIn, findAll, click, find } from '@ember/test-helpers';
 import sinon from 'sinon';
 import hbs from 'htmlbars-inline-precompile';
-import Service from '@ember/service';
 import { GENERAL } from 'vault/tests/helpers/general-selectors';
 import { setupMirage } from 'ember-cli-mirage/test-support';
-
-class StoreService extends Service {
-  findRecord(modelType, id) {
-    return new Promise((resolve, reject) => {
-      if (modelType === 'capabilities' && id === 'sys/namespaces/') {
-        resolve(); // Simulate a successful response
-      } else {
-        reject({ httpStatus: 404, message: 'not found' }); // Simulate an error response
-      }
-    });
-  }
-}
-
-function getMockCapabilitiesModel(canList) {
-  // Mock for the Capabilities model
-  return {
-    path: 'sys/namespaces/',
-    capabilities: canList ? ['list'] : [],
-    get(property) {
-      if (property === 'canList') {
-        return this.capabilities.includes('list');
-      }
-      return undefined;
-    },
-  };
-}
+import { capabilitiesStub, overrideResponse } from 'vault/tests/helpers/stubs';
 
 const INITIALIZED_NAMESPACES = ['root', 'parent1', 'parent1/child1'];
 
@@ -53,12 +27,8 @@ module('Integration | Component | namespace-picker', function (hooks) {
     // the path in the namespace service denotes the current namespace context a user is in
     this.nsService.path = 'parent1/child1';
     this.server.get('/sys/internal/ui/namespaces', () => {
-      return {
-        data: { keys: ['parent1/', 'parent1/child1/'] },
-      };
+      return { data: { keys: ['parent1/', 'parent1/child1/'] } };
     });
-
-    this.owner.register('service:store', StoreService);
   });
 
   hooks.afterEach(function () {
@@ -110,65 +80,43 @@ module('Integration | Component | namespace-picker', function (hooks) {
     );
   });
 
-  test('it shows both "Manage" and "Refresh list" action buttons when canList is true', async function (assert) {
-    const storeStub = this.owner.lookup('service:store');
-    sinon.stub(storeStub, 'findRecord').callsFake((modelType, id) => {
-      if (modelType === 'capabilities' && id === 'sys/namespaces/') {
-        return Promise.resolve(getMockCapabilitiesModel(true));
-      }
-      return Promise.reject();
+  module('capabilities', function (hooks) {
+    hooks.beforeEach(function () {
+      // the capabilities service prepends the user's root namespace to API paths when checking permissions.
+      // For simplicity, test permissions from the "root" namespace context
+      this.nsService.path = '';
     });
 
-    await render(hbs`<NamespacePicker />`);
-    await click(GENERAL.button('namespace-picker'));
+    test('it shows the "Manage" action when user has canList permissions', async function (assert) {
+      this.server.post('/sys/capabilities-self', () => capabilitiesStub('sys/namespaces', ['list']));
 
-    // Verify that the "Refresh List" button is visible
-    assert.dom(GENERAL.button('Refresh list')).exists('Refresh List button is visible');
-    assert.dom(GENERAL.button('Manage')).exists('Manage button is visible');
-  });
+      await render(hbs`<NamespacePicker />`);
+      await click(GENERAL.button('namespace-picker'));
 
-  test('it hides the refresh button when canList is false', async function (assert) {
-    const storeStub = this.owner.lookup('service:store');
-    sinon.stub(storeStub, 'findRecord').callsFake((modelType, id) => {
-      if (modelType === 'capabilities' && id === 'sys/namespaces/') {
-        return Promise.resolve(getMockCapabilitiesModel(false));
-      }
-      return Promise.reject();
+      assert.dom(GENERAL.button('Manage')).exists('Manage button is visible');
     });
 
-    await render(hbs`<NamespacePicker />`);
-    await click(GENERAL.button('namespace-picker'));
+    test('it hides the "Manage" button when canList is false', async function (assert) {
+      this.server.post('/sys/capabilities-self', capabilitiesStub(`sys/namespaces`, ['deny']));
+      await render(hbs`<NamespacePicker />`);
+      await click(GENERAL.button('namespace-picker'));
 
-    // Verify that the buttons are hidden
-    assert.dom(GENERAL.button('Refresh list')).doesNotExist('Refresh List button is hidden');
-    assert.dom(GENERAL.button('Manage')).exists('Manage button is hidden');
-  });
-
-  test('it hides both action buttons when the capabilities store throws an error', async function (assert) {
-    const storeStub = this.owner.lookup('service:store');
-    sinon.stub(storeStub, 'findRecord').callsFake(() => {
-      return Promise.reject();
+      // Verify that the buttons are hidden
+      assert.dom(GENERAL.button('Manage')).doesNotExist('Manage button is hidden');
     });
 
-    await render(hbs`<NamespacePicker />`);
-    await click(GENERAL.button('namespace-picker'));
+    test('it shows "Manage" button when the capabilities request throws an error', async function (assert) {
+      // It's rare for the capabilities request to fail (if it does, it's usually because the request is made in the wrong namespace context).
+      // If it fails, the UI should show resources and rely on the API to gate them appropriately.
+      this.server.post('/sys/capabilities-self', () => overrideResponse(403));
 
-    // Verify that the buttons are hidden
-    assert.dom(GENERAL.button('Refresh list')).doesNotExist('Refresh List button is hidden');
-    assert.dom(GENERAL.button('Manage')).doesNotExist('Manage button is hidden');
+      await render(hbs`<NamespacePicker />`);
+      await click(GENERAL.button('namespace-picker'));
+      assert.dom(GENERAL.button('Manage')).exists();
+    });
   });
 
   test('it updates the namespace list after clicking "Refresh list"', async function (assert) {
-    this.owner.lookup('service:namespace').set('hasListPermissions', true);
-
-    const storeStub = this.owner.lookup('service:store');
-    sinon.stub(storeStub, 'findRecord').callsFake((modelType, id) => {
-      if (modelType === 'capabilities' && id === 'sys/namespaces/') {
-        return Promise.resolve(getMockCapabilitiesModel(true)); // Return the mock model
-      }
-      return Promise.reject();
-    });
-
     await render(hbs`<NamespacePicker />`);
     await click(GENERAL.button('namespace-picker'));
 
@@ -180,7 +128,7 @@ module('Integration | Component | namespace-picker', function (hooks) {
       .dom(GENERAL.button('new-namespace'))
       .doesNotExist('Namespace "new-namespace" is not displayed initially');
 
-    // Re-stub request with a new namespace
+    // Re-stub request from beforeEach hook with a new namespace
     this.server.get('/sys/internal/ui/namespaces', () => {
       return {
         data: { keys: ['parent1/', 'parent1/child1/', 'new-namespace/'] },


### PR DESCRIPTION
### Description

The [previous namespace picker](https://github.com/hashicorp/vault/pull/30490/files#diff-b5c15d9ca82ad8f80680ec98014281bf0533f7ed9da72bddfcf70a4b04890c4bL43) made a request to [sys/namespaces](https://developer.hashicorp.com/vault/api-docs/system/namespaces) and so “refresh list” was wrapped in the relevant capabilities. The new namespace picker makes a request to [sys/internal/ui/namespaces](https://developer.hashicorp.com/vault/api-docs/system/internal-ui-namespaces) which is an endpoint that any user has access to (it is not policy gated) and so these capabilities do not need to wrap that button.

<img width="284" height="228" alt="Screenshot 2025-07-16 at 4 36 45 PM" src="https://github.com/user-attachments/assets/186e1d26-d99b-4313-a4e4-75deeeaa6c02" />


### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.

### PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.

Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
