### PR TITLE
auth/userpass: update dummy string generation

### DIFF
--- a/builtin/credential/userpass/path_login.go
+++ b/builtin/credential/userpass/path_login.go
@@ -89,7 +89,11 @@ func (b *backend) pathLogin(ctx context.Context, req *logical.Request, d *framew
 	} else {
 		// This is still acceptable as bcrypt will still make sure it takes
 		// a long time, it's just nicer to be random if possible
-		userPassword = []byte(strings.Repeat("dummy", 12))
+		var err error
+		userPassword, err = bcrypt.GenerateFromPassword([]byte("dummy"), bcrypt.DefaultCost)
+		if err != nil {
+			return logical.ErrorResponse("invalid username or password"), nil
+		}
 	}
 
 	// Check for a password match. Check for a hash collision for Vault 0.2+,


### PR DESCRIPTION
### Description
Ensures the dummy string goes through the same code path as any password
### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.

### PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.