### PR TITLE
UI: Fix namespace picker selecting all namespaces with matching nodes

### DIFF
--- a/changelog/31326.txt
+++ b/changelog/31326.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fix selecting multiple namespaces in the namespace picker when the path contains matching nodes
+```

--- a/ui/app/components/namespace-picker.hbs
+++ b/ui/app/components/namespace-picker.hbs
@@ -8,7 +8,9 @@
 
     <D.ToggleButton
       @icon="org"
-      @text={{or this.selectedNamespace.id "-"}}
+      {{! Displays the node of the current namespace context in the toggle }}
+      {{! For example, if a user navigates to 'parent/child' the toggle just displays 'child' }}
+      @text={{this.namespace.currentNamespace}}
       @isFullWidth={{true}}
       data-test-button="namespace-picker"
       {{on "click" this.toggleNamespacePicker}}
@@ -59,7 +61,7 @@
       <div class="is-overflow-y-auto is-max-drawer-height" {{did-insert this.setupScrollListener}}>
         {{#each this.visibleNamespaceOptions as |option|}}
           <D.Checkmark
-            @selected={{eq option.id this.selectedNamespace.id}}
+            @selected={{eq option.path this.selectedNamespace.path}}
             {{on "click" (fn this.onChange option)}}
             data-test-button={{option.label}}
           >

--- a/ui/tests/integration/components/namespace-picker-test.js
+++ b/ui/tests/integration/components/namespace-picker-test.js
@@ -48,6 +48,16 @@ module('Integration | Component | namespace-picker', function (hooks) {
     );
   });
 
+  test('it selects the current namespace', async function (assert) {
+    await render(hbs`<NamespacePicker />`);
+    assert.dom(GENERAL.button('namespace-picker')).hasText('child1', 'it just displays the namespace node');
+    await click(GENERAL.button('namespace-picker'));
+    assert
+      .dom(GENERAL.button(this.nsService.path))
+      .hasAttribute('aria-selected', 'true', 'the current namespace path is selected');
+    assert.dom(`${GENERAL.button(this.nsService.path)} ${GENERAL.icon('check')}`).exists();
+  });
+
   test('it filters namespace options based on search input', async function (assert) {
     await render(hbs`<NamespacePicker/>`);
     await click(GENERAL.button('namespace-picker'));
@@ -159,5 +169,20 @@ module('Integration | Component | namespace-picker', function (hooks) {
     assert.dom(`li ${GENERAL.button()}`).exists({ count: 2 }, 'namespace picker only contains 2 options');
     assert.dom(GENERAL.button('admin')).exists();
     assert.dom(GENERAL.button('admin/child1')).exists();
+  });
+
+  test('it selects the correct namespace when matching nodes exist', async function (assert) {
+    // stub response so that two namespaces have matching node names 'child1'
+    this.server.get('/sys/internal/ui/namespaces', () => {
+      return { data: { keys: ['parent1/', 'parent1/child1', 'anotherParent/', 'anotherParent/child1'] } };
+    });
+    await render(hbs`<NamespacePicker />`);
+    assert.dom(GENERAL.button('namespace-picker')).hasText('child1', 'it displays the namespace node');
+    await click(GENERAL.button('namespace-picker'));
+    assert
+      .dom(GENERAL.button(this.nsService.path))
+      .hasAttribute('aria-selected', 'true', 'the current namespace path is selected');
+    assert.dom('[aria-selected="true"]').exists({ count: 1 }, 'only one option is selected');
+    assert.dom(GENERAL.icon('check')).exists({ count: 1 }, 'only one check mark renders');
   });
 });


### PR DESCRIPTION
### Description
The namespace picker was using the node as the `id` key (the segment of the current namespace context) which was used to select a namespace. However, a namespace path could have matching nodes so it may not be a unique value. Updated the namespace picker select a namespace by the full path which is unique.

## before fix
<img width="200" height="734" alt="image" src="https://github.com/user-attachments/assets/c2533f0e-f765-4917-b65b-20b09776117d" />


### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.

### PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.

Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
