### PR TITLE
Add token_auth_metadata field for built-in Auth methods

### DIFF
--- a/builtin/credential/approle/path_role.go
+++ b/builtin/credential/approle/path_role.go
@@ -273,6 +273,10 @@ can only be set during role creation and once set, it can't be reset later.`,
 								Required:    true,
 								Description: "The maximum number of times a token may be used, a value of zero means unlimited",
 							},
+							"token_auth_metadata": {
+								Type:        framework.TypeKVPairs,
+								Description: "The metadata to be tied to generated tokens. This should be a JSON formatted string containing the metadata in key value pairs",
+							},
 							"period": {
 								Type:        framework.TypeInt64,
 								Required:    false,

--- a/builtin/credential/approle/path_role.go
+++ b/builtin/credential/approle/path_role.go
@@ -275,7 +275,7 @@ can only be set during role creation and once set, it can't be reset later.`,
 							},
 							"token_auth_metadata": {
 								Type:        framework.TypeKVPairs,
-								Description: "The metadata to be tied to generated tokens. This should be a JSON formatted string containing the metadata in key value pairs",
+								Description: "The metadata to be tied to generated tokens. This should be a list or map containing the metadata in key value pairs",
 							},
 							"period": {
 								Type:        framework.TypeInt64,

--- a/builtin/credential/aws/path_role_test.go
+++ b/builtin/credential/aws/path_role_test.go
@@ -631,11 +631,12 @@ func TestAwsEc2_RoleCrud(t *testing.T) {
 		"token_bound_cidrs":              []string{},
 		"token_no_default_policy":        false,
 		"token_num_uses":                 0,
+		"token_auth_metadata":            map[string]string{},
 		"token_type":                     "default",
 	}
 
 	if resp.Data["role_id"] == nil {
-		t.Fatal("role_id not found in repsonse")
+		t.Fatal("role_id not found in response")
 	}
 	expected["role_id"] = resp.Data["role_id"]
 	if diff := deep.Equal(expected, resp.Data); diff != nil {

--- a/builtin/credential/ldap/backend_test.go
+++ b/builtin/credential/ldap/backend_test.go
@@ -1356,6 +1356,7 @@ func TestLdapAuthBackend_ConfigUpgrade(t *testing.T) {
 		TokenParams: tokenutil.TokenParams{
 			TokenPeriod:         5 * time.Minute,
 			TokenExplicitMaxTTL: 24 * time.Hour,
+			TokenAuthMetadata:   make(map[string]string),
 		},
 		ConfigEntry: &ldaputil.ConfigEntry{
 			Url:                      cfg.Url,

--- a/changelog/31327.txt
+++ b/changelog/31327.txt
@@ -17,7 +17,7 @@ auth/okta: Add ability to specify custom Auth metadata via new role configuratio
 auth/radius: Add ability to specify custom Auth metadata via new role configuration parameter `token_auth_metadata`.
 ```
 ```release-note:improvement
-auth/scep: Add ability to specify custom Auth metadata via new role creation parameter `token_auth_metadata`.
+auth/scep (enterprise): Add ability to specify custom Auth metadata via new role creation parameter `token_auth_metadata`.
 ```
 ```release-note:improvement
 auth/cert: Add ability to specify custom Auth metadata via new CA certificate role creation parameter `token_auth_metadata`.

--- a/changelog/31327.txt
+++ b/changelog/31327.txt
@@ -1,0 +1,27 @@
+```release-note:improvement
+auth/approle: Add ability to specify custom Auth metadata via new role creation parameter `token_auth_metadata`.
+```
+```release-note:improvement
+auth/aws: Add ability to specify custom Auth metadata via new role creation parameter `token_auth_metadata`.
+```
+```release-note:improvement
+auth/github: Add ability to specify custom Auth metadata via new configuration parameter `token_auth_metadata`.
+```
+```release-note:improvement
+auth/ldap: Add ability to specify custom Auth metadata via new role configuration parameter `token_auth_metadata`.
+```
+```release-note:improvement
+auth/okta: Add ability to specify custom Auth metadata via new role configuration parameter `token_auth_metadata`.
+```
+```release-note:improvement
+auth/radius: Add ability to specify custom Auth metadata via new role configuration parameter `token_auth_metadata`.
+```
+```release-note:improvement
+auth/scep: Add ability to specify custom Auth metadata via new role creation parameter `token_auth_metadata`.
+```
+```release-note:improvement
+auth/cert: Add ability to specify custom Auth metadata via new CA certificate role creation parameter `token_auth_metadata`.
+```
+```release-note:improvement
+auth/userpass: Add ability to specify custom Auth metadata via new user creation parameter `token_auth_metadata`.
+```


### PR DESCRIPTION
### Description
Add token_auth_metadata field for built-in Auth methods.

In tokenutil.go, add support for generic Auth metadata:
  * Add a `TokenMetadata map[string]string` field to struct `TokenParams`.

  * Update method `ParseTokenFields` to populate the metadata field using request data.

  * Update method `PopulateTokenAuth` to add the metadata to field `Auth.Metadata`.

  * Update other helper methods.

The changes are described in [RFC VLT-353](https://go.hashi.co/rfc/vlt-353).
 
Please note that external Auth methods and documentation updates will be addressed in separate pull requests.

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.

### PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.

Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
