### PR TITLE
Update documentation for product usage metric

### DIFF
--- a/website/content/docs/license/product-usage-reporting.mdx
+++ b/website/content/docs/license/product-usage-reporting.mdx
@@ -165,7 +165,7 @@ All of these metrics are numerical, and contain no sensitive values or additiona
 | `vault.db.redis.plugin.count`                                       | The total number of Redis database plugin connections in Vault.                                            |
 | `vault.db.rediselasticache.plugin.count`                            | The total number of Redis Elasticache database plugin connections in Vault.                                |
 | `vault.db.snowflake.plugin.count`                                   | The total number of Snowflake database plugin connections in Vault.                                        |
-| `vault.db.unknown.plugin.count`                                     | The total number of custom or unknown database plugin connections in Vault.                              |
+| `vault.db.unknown.plugin.count`                                     | The total number of custom or unknown database plugin connections in Vault.                                |
 | `vault.secret.engine.activedirectory.count`                         | The total number of Active Directory secret engines in Vault.                                              |
 | `vault.secret.engine.alicloud.count`                                | The total number of Alicloud secret engines in Vault.                                                      |
 | `vault.secret.engine.aws.count`                                     | The total number of AWS secret engines in Vault.                                                           |
@@ -181,6 +181,7 @@ All of these metrics are numerical, and contain no sensitive values or additiona
 | `vault.secret.engine.mongodb.count`                                 | The total number of MongoDB secret engines in Vault.                                                       |
 | `vault.secret.engine.mongodbatlas.count`                            | The total number of MongoDBAtlas secret engines in Vault.                                                  |
 | `vault.secret.engine.mssql.count`                                   | The total number of MSSql secret engines in Vault.                                                         |
+| `vault.secret.engine.mysql.count`                                   | The total number of MySQL secret engines in Vault.                                                         |
 | `vault.secret.engine.postgresql.count`                              | The total number of Postgresql secret engines in Vault.                                                    |
 | `vault.secret.engine.nomad.count`                                   | The total number of Nomad secret engines in Vault.                                                         |
 | `vault.secret.engine.ldap.count`                                    | The total number of LDAP secret engines in Vault.                                                          |
@@ -198,6 +199,7 @@ All of these metrics are numerical, and contain no sensitive values or additiona
 | `vault.secretsync.destinations.count`                               | The total number of secret destinations configured for secret sync.                                        |
 | `vault.secretsync.destinations.aws-sm.count`                        | The total number of AWS-SM secret destinations configured for secret sync.                                 |
 | `vault.secretsync.destinations.azure-kv.count`                      | The total number of Azure-KV secret destinations configured for secret sync.                               |
+| `vault.secretsync.destinations.gcp-sm.count`                        | The total number of secret sync destinations to GCP-SM configured.                                         |
 | `vault.secretsync.destinations.gh.count`                            | The total number of GH secret destinations configured for secret sync.                                     |
 | `vault.secretsync.destinations.vault.count`                         | The total number of Vault secret destinations configured for secret sync.                                  |
 | `vault.secretsync.destinations.vercel-project.count`                | The total number of Vercel Project secret destinations configured for secret sync.                         |
@@ -213,6 +215,13 @@ All of these metrics are numerical, and contain no sensitive values or additiona
 | `vault.ui.custom_banners.unauthenticated`                           | How many unauthenticated custom banners have been enabled across all namespaces.                           |
 | `vault.storage.max_entry_size`                                      | The value of `max_entry_size` parameter for the storage stanza in the config.                              |
 | `vault.storage.max_mount_and_namespace_table_entry_size`            | The value of `max_mount_and_namespace_table_entry_size` parameter for the storage stanza in the config.    |
+| `vault.operator.import.kv.version2.secrets.source.vault.count`      | The total number of secrets imported from Vault using operator import command.                             |
+| `vault.operator.import.kv.version2.secrets.source.aws.count`        | The total number of secrets imported from AWS using operator import command.                               |
+| `vault.operator.import.kv.version2.secrets.source.gcp.count`        | The otal number of secrets imported from GCP using operator import command.                                |
+| `vault.operator.import.kv.version2.secrets.source.azure.count`      | The total number of secrets imported from Azure using operator import command.                             |
+| `vault.operator.import.kv.version2.secrets.count`                   | The total number of secrets imported from using operator import command.                                   |
+| `vault.telemetry.stanzas.count`                                     | The count of telemetry stanzas configured in this cluster.                                                 |
+| `vault.telemetry.filters.count`                                     | The count of metric prefix filters specified in the telemetry stanza in config file.                       |
 | `vault.replication.secret.non_local_mounts`                         | The number of replicated secret mounts on Enterprise clusters.                                             |
 | `vault.replication.secret.local_mounts`                             | The number of local secret mounts on Enterprise clusters.                                                  |
 | `vault.replication.auth.local_mounts`                               | The number of local auth mounts on Enterprise clusters.                                                    |
@@ -242,8 +251,6 @@ All of these metrics are numerical, and contain no sensitive values or additiona
 | `vault.mfa.stepup.okta.count`                                       | The count of MFA configurations using the Okta method enforced as step-up authentication.                  |
 | `vault.mfa.stepup.pingid.count`                                     | The count of MFA configurations using the PingID method enforced as step-up authentication.                |
 | `vault.mfa.stepup.duo.count`                                        | The count of MFA configurations using the Duo method enforced as step-up authentication.                   |
-| `vault.telemetry.stanzas.count`                                     | The count of telemetry stanzas configured in this cluster.                                                 |
-| `vault.telemetry.filters.count`                                     | The count of metric prefix filters specified in the telemetry stanza in config file.                       |
 ## Usage metadata list
 
 HashiCorp collects the following product usage metadata as part of the `metadata` part of the

--- a/website/content/docs/license/product-usage-reporting.mdx
+++ b/website/content/docs/license/product-usage-reporting.mdx
@@ -151,6 +151,21 @@ All of these metrics are numerical, and contain no sensitive values or additiona
 | `vault.auth.method.token.count`                                     | The total number of Token auth mounts in Vault.                                                            |
 | `vault.auth.method.userpass.count`                                  | The total number of Userpass auth mounts in Vault.                                                         |
 | `vault.auth.method.plugin.count`                                    | The total number of custom plugin auth mounts in Vault.                                                    |
+| `vault.db.cassandra.plugin.count`                                   | The total number of Cassandra database plugin connections in Vault.                                        |
+| `vault.db.couchbase.plugin.count`                                   | The total number of Couchbase database plugin connections in Vault.                                        |
+| `vault.db.elasticsearch.plugin.count`                               | The total number of Elasticsearch database plugin connections in Vault.                                    |
+| `vault.db.hana.plugin.count`                                        | The total number of Hana database plugin connections in Vault.                                             |
+| `vault.db.influxdb.plugin.count`                                    | The total number of InfluxDB database plugin connections in Vault.                                         |
+| `vault.db.mongodb.plugin.count`                                     | The total number of MongoDB database plugin connections in Vault.                                          |
+| `vault.db.mongodbatlas.plugin.count`                                | The total number of MongoDB Atlas database plugin connections in Vault.                                    |
+| `vault.db.mssql.plugin.count`                                       | The total number of MSSQL database plugin connections in Vault.                                            |
+| `vault.db.mysql.plugin.count`                                       | The total number of MySQL database plugin connections in Vault.                                            |
+| `vault.db.postgres.plugin.count`                                    | The total number of Postgres databse plugin connections in Vault.                                          |
+| `vault.db.redshift.plugin.count`                                    | The total number of Redshift database plugin connections in Vault.                                         |
+| `vault.db.redis.plugin.count`                                       | The total number of Redis database plugin connections in Vault.                                            |
+| `vault.db.rediselasticache.plugin.count`                            | The total number of Redis Elasticache database plugin connections in Vault.                                |
+| `vault.db.snowflake.plugin.count`                                   | The total number of Snowflake database plugin connections in Vault.                                        |
+| `vault.db.unknown.plugin.count`                                     | The total number of custom or unknown database plugin connections in Vault.                              |
 | `vault.secret.engine.activedirectory.count`                         | The total number of Active Directory secret engines in Vault.                                              |
 | `vault.secret.engine.alicloud.count`                                | The total number of Alicloud secret engines in Vault.                                                      |
 | `vault.secret.engine.aws.count`                                     | The total number of AWS secret engines in Vault.                                                           |

--- a/website/content/docs/license/product-usage-reporting.mdx
+++ b/website/content/docs/license/product-usage-reporting.mdx
@@ -242,6 +242,8 @@ All of these metrics are numerical, and contain no sensitive values or additiona
 | `vault.mfa.stepup.okta.count`                                       | The count of MFA configurations using the Okta method enforced as step-up authentication.                  |
 | `vault.mfa.stepup.pingid.count`                                     | The count of MFA configurations using the PingID method enforced as step-up authentication.                |
 | `vault.mfa.stepup.duo.count`                                        | The count of MFA configurations using the Duo method enforced as step-up authentication.                   |
+| `vault.telemetry.stanzas.count`                                     | The count of telemetry stanzas configured in this cluster.                                                 |
+| `vault.telemetry.filters.count`                                     | The count of metric prefix filters specified in the telemetry stanza in config file.                       |
 ## Usage metadata list
 
 HashiCorp collects the following product usage metadata as part of the `metadata` part of the


### PR DESCRIPTION
### Description
Adds new metric names related to db plugins.

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.

### PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.

Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
