### PR TITLE
Backport 1.20.x: Namespace picker capabilities and duplicate selection fixes

### DIFF
--- a/changelog/31326.txt
+++ b/changelog/31326.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fix selecting multiple namespaces in the namespace picker when the path contains matching nodes
+```

--- a/ui/app/components/namespace-picker.hbs
+++ b/ui/app/components/namespace-picker.hbs
@@ -71,22 +71,19 @@
 
     <D.Footer @hasDivider={{true}} class="is-flex-center">
       <Hds::ButtonSet class="is-fullwidth">
-        {{#if this.canRefreshNamespaces}}
-          <Hds::Button
-            @color="secondary"
-            @text="Refresh list"
-            @isFullWidth={{(not this.canManageNamespaces)}}
-            @icon="reload"
-            @size="small"
-            {{on "click" this.refreshList}}
-            data-test-refresh-namespaces
-          />
-        {{/if}}
+        <Hds::Button
+          @color="secondary"
+          @text="Refresh list"
+          @isFullWidth={{not this.canManageNamespaces}}
+          @icon="reload"
+          @size="small"
+          {{on "click" this.refreshList}}
+          data-test-refresh-namespaces
+        />
         {{#if this.canManageNamespaces}}
           <Hds::Button
             @color="tertiary"
             @text="Manage"
-            @isFullWidth={{(not this.canRefreshNamespaces)}}
             @icon="settings"
             @size="small"
             @route="vault.cluster.access.namespaces"

--- a/ui/app/components/namespace-picker.hbs
+++ b/ui/app/components/namespace-picker.hbs
@@ -8,7 +8,9 @@
 
     <D.ToggleButton
       @icon="org"
-      @text={{or this.selectedNamespace.id "-"}}
+      {{! Displays the node of the current namespace context in the toggle }}
+      {{! For example, if a user navigates to 'parent/child' the toggle just displays 'child' }}
+      @text={{this.namespace.currentNamespace}}
       @isFullWidth={{true}}
       data-test-toggle-input="namespace-id"
       {{on "click" this.toggleNamespacePicker}}
@@ -58,7 +60,7 @@
       <div class="is-overflow-y-auto is-max-drawer-height" {{did-insert this.setupScrollListener}}>
         {{#each this.visibleNamespaceOptions as |option|}}
           <D.Checkmark
-            @selected={{eq option.id this.selectedNamespace.id}}
+            @selected={{eq option.path this.selectedNamespace.path}}
             {{on "click" (fn this.onChange option)}}
             data-test-namespace-link={{option.path}}
           >

--- a/ui/tests/integration/components/namespace-picker-test.js
+++ b/ui/tests/integration/components/namespace-picker-test.js
@@ -49,12 +49,12 @@ module('Integration | Component | namespace-picker', function (hooks) {
 
   test('it selects the current namespace', async function (assert) {
     await render(hbs`<NamespacePicker />`);
-    assert.dom(GENERAL.button('namespace-picker')).hasText('child1', 'it just displays the namespace node');
-    await click(GENERAL.button('namespace-picker'));
+    assert.dom(GENERAL.toggleInput('namespace-id')).hasText('child1', 'it just displays the namespace node');
+    await click(GENERAL.toggleInput('namespace-id'));
     assert
-      .dom(GENERAL.button(this.nsService.path))
+      .dom(NAMESPACE_PICKER_SELECTORS.link(this.nsService.path))
       .hasAttribute('aria-selected', 'true', 'the current namespace path is selected');
-    assert.dom(`${GENERAL.button(this.nsService.path)} ${GENERAL.icon('check')}`).exists();
+    assert.dom(`${NAMESPACE_PICKER_SELECTORS.link(this.nsService.path)} ${GENERAL.icon('check')}`).exists();
   });
 
   test('it filters namespace options based on search input', async function (assert) {
@@ -186,10 +186,10 @@ module('Integration | Component | namespace-picker', function (hooks) {
       return { data: { keys: ['parent1/', 'parent1/child1', 'anotherParent/', 'anotherParent/child1'] } };
     });
     await render(hbs`<NamespacePicker />`);
-    assert.dom(GENERAL.button('namespace-picker')).hasText('child1', 'it displays the namespace node');
-    await click(GENERAL.button('namespace-picker'));
+    assert.dom(GENERAL.toggleInput('namespace-id')).hasText('child1', 'it displays the namespace node');
+    await click(GENERAL.toggleInput('namespace-id'));
     assert
-      .dom(GENERAL.button(this.nsService.path))
+      .dom(NAMESPACE_PICKER_SELECTORS.link(this.nsService.path))
       .hasAttribute('aria-selected', 'true', 'the current namespace path is selected');
     assert.dom('[aria-selected="true"]').exists({ count: 1 }, 'only one option is selected');
     assert.dom(GENERAL.icon('check')).exists({ count: 1 }, 'only one check mark renders');

--- a/ui/tests/integration/components/namespace-picker-test.js
+++ b/ui/tests/integration/components/namespace-picker-test.js
@@ -8,36 +8,10 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render, fillIn, findAll, waitFor, click, find } from '@ember/test-helpers';
 import sinon from 'sinon';
 import hbs from 'htmlbars-inline-precompile';
-import Service from '@ember/service';
 import { NAMESPACE_PICKER_SELECTORS } from 'vault/tests/helpers/namespace-picker';
 import { GENERAL } from 'vault/tests/helpers/general-selectors';
 import { setupMirage } from 'ember-cli-mirage/test-support';
-
-class StoreService extends Service {
-  findRecord(modelType, id) {
-    return new Promise((resolve, reject) => {
-      if (modelType === 'capabilities' && id === 'sys/namespaces/') {
-        resolve(); // Simulate a successful response
-      } else {
-        reject({ httpStatus: 404, message: 'not found' }); // Simulate an error response
-      }
-    });
-  }
-}
-
-function getMockCapabilitiesModel(canList) {
-  // Mock for the Capabilities model
-  return {
-    path: 'sys/namespaces/',
-    capabilities: canList ? ['list'] : [],
-    get(property) {
-      if (property === 'canList') {
-        return this.capabilities.includes('list');
-      }
-      return undefined;
-    },
-  };
-}
+import { capabilitiesStub, overrideResponse } from 'vault/tests/helpers/stubs';
 
 module('Integration | Component | namespace-picker', function (hooks) {
   setupRenderingTest(hooks);
@@ -52,12 +26,8 @@ module('Integration | Component | namespace-picker', function (hooks) {
     // the path in the namespace service denotes the current namespace context a user is in
     this.nsService.path = 'parent1/child1';
     this.server.get('/sys/internal/ui/namespaces', () => {
-      return {
-        data: { keys: ['parent1/', 'parent1/child1/'] },
-      };
+      return { data: { keys: ['parent1/', 'parent1/child1/'] } };
     });
-
-    this.owner.register('service:store', StoreService);
   });
 
   hooks.afterEach(function () {
@@ -111,65 +81,43 @@ module('Integration | Component | namespace-picker', function (hooks) {
     );
   });
 
-  test('it shows both action buttons when canList is true', async function (assert) {
-    const storeStub = this.owner.lookup('service:store');
-    sinon.stub(storeStub, 'findRecord').callsFake((modelType, id) => {
-      if (modelType === 'capabilities' && id === 'sys/namespaces/') {
-        return Promise.resolve(getMockCapabilitiesModel(true));
-      }
-      return Promise.reject();
+  module('capabilities', function (hooks) {
+    hooks.beforeEach(function () {
+      // the capabilities service prepends the user's root namespace to API paths when checking permissions.
+      // For simplicity, test permissions from the "root" namespace context
+      this.nsService.path = '';
     });
 
-    await render(hbs`<NamespacePicker />`);
-    await click(GENERAL.toggleInput('namespace-id'));
+    test('it shows the "Manage" action when user has canList permissions', async function (assert) {
+      this.server.post('/sys/capabilities-self', () => capabilitiesStub('sys/namespaces', ['list']));
 
-    // Verify that the "Refresh List" button is visible
-    assert.dom(NAMESPACE_PICKER_SELECTORS.refreshList).exists('Refresh List button is visible');
-    assert.dom(NAMESPACE_PICKER_SELECTORS.manageButton).exists('Manage button is visible');
-  });
+      await render(hbs`<NamespacePicker />`);
+      await click(GENERAL.toggleInput('namespace-id'));
 
-  test('it hides the refresh button when canList is false', async function (assert) {
-    const storeStub = this.owner.lookup('service:store');
-    sinon.stub(storeStub, 'findRecord').callsFake((modelType, id) => {
-      if (modelType === 'capabilities' && id === 'sys/namespaces/') {
-        return Promise.resolve(getMockCapabilitiesModel(false));
-      }
-      return Promise.reject();
+      assert.dom(NAMESPACE_PICKER_SELECTORS.manageButton).exists('Manage button is visible');
     });
 
-    await render(hbs`<NamespacePicker />`);
-    await click(GENERAL.toggleInput('namespace-id'));
+    test('it hides the "Manage" button when canList is false', async function (assert) {
+      this.server.post('/sys/capabilities-self', capabilitiesStub(`sys/namespaces`, ['deny']));
+      await render(hbs`<NamespacePicker />`);
+      await click(GENERAL.toggleInput('namespace-id'));
 
-    // Verify that the buttons are hidden
-    assert.dom(NAMESPACE_PICKER_SELECTORS.refreshList).doesNotExist('Refresh List button is hidden');
-    assert.dom(NAMESPACE_PICKER_SELECTORS.manageButton).exists('Manage button is hidden');
-  });
-
-  test('it hides both action buttons when the capabilities store throws an error', async function (assert) {
-    const storeStub = this.owner.lookup('service:store');
-    sinon.stub(storeStub, 'findRecord').callsFake(() => {
-      return Promise.reject();
+      // Verify that the buttons are hidden
+      assert.dom(NAMESPACE_PICKER_SELECTORS.manageButton).doesNotExist('Manage button is hidden');
     });
 
-    await render(hbs`<NamespacePicker />`);
-    await click(GENERAL.toggleInput('namespace-id'));
+    test('it shows "Manage" button when the capabilities request throws an error', async function (assert) {
+      // It's rare for the capabilities request to fail (if it does, it's usually because the request is made in the wrong namespace context).
+      // If it fails, the UI should show resources and rely on the API to gate them appropriately.
+      this.server.post('/sys/capabilities-self', () => overrideResponse(403));
 
-    // Verify that the buttons are hidden
-    assert.dom(NAMESPACE_PICKER_SELECTORS.refreshList).doesNotExist('Refresh List button is hidden');
-    assert.dom(NAMESPACE_PICKER_SELECTORS.manageButton).doesNotExist('Manage button is hidden');
+      await render(hbs`<NamespacePicker />`);
+      await click(GENERAL.toggleInput('namespace-id'));
+      assert.dom(NAMESPACE_PICKER_SELECTORS.manageButton).exists();
+    });
   });
 
   test('it updates the namespace list after clicking "Refresh list"', async function (assert) {
-    this.owner.lookup('service:namespace').set('hasListPermissions', true);
-
-    const storeStub = this.owner.lookup('service:store');
-    sinon.stub(storeStub, 'findRecord').callsFake((modelType, id) => {
-      if (modelType === 'capabilities' && id === 'sys/namespaces/') {
-        return Promise.resolve(getMockCapabilitiesModel(true)); // Return the mock model
-      }
-      return Promise.reject();
-    });
-
     await render(hbs`<NamespacePicker />`);
     await click(GENERAL.toggleInput('namespace-id'));
 
@@ -180,7 +128,7 @@ module('Integration | Component | namespace-picker', function (hooks) {
       'Initially, three namespaces are displayed'
     );
 
-    // Re-stub request with a new namespace
+    // Re-stub request from beforeEach hook with a new namespace
     this.server.get('/sys/internal/ui/namespaces', () => {
       return {
         data: { keys: ['parent1/', 'parent1/child1/', 'new-namespace/'] },

--- a/ui/tests/integration/components/namespace-picker-test.js
+++ b/ui/tests/integration/components/namespace-picker-test.js
@@ -47,6 +47,16 @@ module('Integration | Component | namespace-picker', function (hooks) {
     );
   });
 
+  test('it selects the current namespace', async function (assert) {
+    await render(hbs`<NamespacePicker />`);
+    assert.dom(GENERAL.button('namespace-picker')).hasText('child1', 'it just displays the namespace node');
+    await click(GENERAL.button('namespace-picker'));
+    assert
+      .dom(GENERAL.button(this.nsService.path))
+      .hasAttribute('aria-selected', 'true', 'the current namespace path is selected');
+    assert.dom(`${GENERAL.button(this.nsService.path)} ${GENERAL.icon('check')}`).exists();
+  });
+
   test('it filters namespace options based on search input', async function (assert) {
     await render(hbs`<NamespacePicker/>`);
     await click(GENERAL.toggleInput('namespace-id'));
@@ -168,5 +178,20 @@ module('Integration | Component | namespace-picker', function (hooks) {
       .exists({ count: 2 }, 'namespace picker only contains 2 options');
     assert.dom(NAMESPACE_PICKER_SELECTORS.link('admin')).exists();
     assert.dom(NAMESPACE_PICKER_SELECTORS.link('admin/child1')).exists();
+  });
+
+  test('it selects the correct namespace when matching nodes exist', async function (assert) {
+    // stub response so that two namespaces have matching node names 'child1'
+    this.server.get('/sys/internal/ui/namespaces', () => {
+      return { data: { keys: ['parent1/', 'parent1/child1', 'anotherParent/', 'anotherParent/child1'] } };
+    });
+    await render(hbs`<NamespacePicker />`);
+    assert.dom(GENERAL.button('namespace-picker')).hasText('child1', 'it displays the namespace node');
+    await click(GENERAL.button('namespace-picker'));
+    assert
+      .dom(GENERAL.button(this.nsService.path))
+      .hasAttribute('aria-selected', 'true', 'the current namespace path is selected');
+    assert.dom('[aria-selected="true"]').exists({ count: 1 }, 'only one option is selected');
+    assert.dom(GENERAL.icon('check')).exists({ count: 1 }, 'only one check mark renders');
   });
 });


### PR DESCRIPTION
### Description
Manual backport combining: 
https://github.com/hashicorp/vault/pull/31308
https://github.com/hashicorp/vault/pull/31326

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.

### PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.

Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
