### PR TITLE
VAULT-35087: add Open-API support for secret recovery operations

### DIFF
--- a/changelog/31331.txt
+++ b/changelog/31331.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+audit: Add OpenAPI support for secret recovery operations.
+```

--- a/changelog/31331.txt
+++ b/changelog/31331.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-audit: Add OpenAPI support for secret recovery operations.
+openapi: Add OpenAPI support for secret recovery operations.
 ```

--- a/sdk/framework/testdata/operations.json
+++ b/sdk/framework/testdata/operations.json
@@ -43,6 +43,14 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "read_snapshot_id",
+            "description": "Targets the read operation to the provided loaded snapshot Id",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -57,6 +65,16 @@
         "operationId": "kv-write-foo-id",
         "tags": [
           "secrets"
+        ],
+        "parameters": [
+          {
+            "name": "recover_snapshot_id",
+            "description": "Triggers a recover operation using the given snapshot ID. Request body is ignored when a recover operation is requested.",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
         ],
         "requestBody": {
           "required": true,
@@ -142,6 +160,14 @@
               ]
             },
             "required": true
+          },
+          {
+            "name": "read_snapshot_id",
+            "description": "Targets the read operation to the provided loaded snapshot Id",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {

--- a/vault/logical_cubbyhole.go
+++ b/vault/logical_cubbyhole.go
@@ -79,7 +79,7 @@ func (b *CubbyholeBackend) paths() []*framework.Path {
 					DisplayAttrs: &framework.DisplayAttributes{
 						OperationVerb: "write",
 					},
-					Summary: "Store a secret at the specified location.",
+					Summary: "Store a secret at the specified location, or (enterprise-only) recover it from given snapshot Id.",
 				},
 				logical.CreateOperation: &framework.PathOperation{
 					Callback: b.handleWrite,
@@ -104,10 +104,8 @@ func (b *CubbyholeBackend) paths() []*framework.Path {
 				},
 				logical.RecoverOperation: &framework.PathOperation{
 					Callback: b.handleWrite,
-					DisplayAttrs: &framework.DisplayAttributes{
-						OperationVerb: "recover",
-					},
-					Summary: "Recover a secret at the specified location.",
+					// just like CreateOperation, recover is folded into update for OpenAPI documentation purposes, so
+					// no operation verb or summary is set
 				},
 			},
 


### PR DESCRIPTION
### Description

This PR adds support to the secret recovery operations on the API explorer module.

Jira: [VAULT-35087](https://hashicorp.atlassian.net/browse/VAULT-35087)

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [-] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- - ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [-] **RFC:** If this change has an associated RFC, please link it in the description.
- [-] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.

### PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [-] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [-] If applicable, I've documented the impact of any changes to security controls.

Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.


[VAULT-35087]: https://hashicorp.atlassian.net/browse/VAULT-35087?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ