### PR TITLE
update user pass dummy string

### DIFF
--- a/builtin/credential/userpass/path_login.go
+++ b/builtin/credential/userpass/path_login.go
@@ -89,11 +89,7 @@ func (b *backend) pathLogin(ctx context.Context, req *logical.Request, d *framew
 	} else {
 		// This is still acceptable as bcrypt will still make sure it takes
 		// a long time, it's just nicer to be random if possible
-		var err error
-		userPassword, err = bcrypt.GenerateFromPassword([]byte("dummy"), bcrypt.DefaultCost)
-		if err != nil {
-			return logical.ErrorResponse("invalid username or password"), nil
-		}
+		userPassword = []byte("$2a$10$/rzAjBPX3APZv8DesvsjB.OKdMif2xomluDfaxQ.OZcF06EuECsVG")
 	}
 
 	// Check for a password match. Check for a hash collision for Vault 0.2+,


### PR DESCRIPTION
### Description

follow up to #31318 which did not have the intended effect

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [x] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.

### PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
