### PR TITLE
Document prometheus follow redirection

### DIFF
--- a/website/content/docs/configuration/telemetry.mdx
+++ b/website/content/docs/configuration/telemetry.mdx
@@ -194,14 +194,14 @@ These `telemetry` parameters apply to
 - `disable_hostname` `(bool: false)` - It is recommended to also enable the option
   `disable_hostname` to avoid having prefixed metrics with hostname.
 
-The `/v1/sys/metrics` endpoint is only accessible on active nodes
-and automatically disabled on standby nodes. You can enable the `/v1/sys/metrics`
-endpoint on standby nodes by [enabling unauthenticated metrics access][telemetry-tcp].
+The `/v1/sys/metrics` endpoint is only accessible on active nodes, on standby nodes it will return
+a redirection (307) to the active node.
+Note that since version 0.55.0, prometheus automatically follows redirection, so if you configure in prometheus
+multiple vault targets, they will all return the metric of the active node.
+
+You can make standby nodes generate their own metrics by [enabling unauthenticated metrics access][telemetry-tcp].
 Standby nodes will never forward a request to `/v1/sys/metrics` to the leader
-node. If unauthenticated metrics access is enabled, the standby node will
-respond with its own metrics. If unauthenticated metrics access is not enabled,
-then a standby node will attempt to service the request (with Vault enterprise)
-or otherwise redirect the request to the leader node (in Vault community edition).
+node.
 
 Querying `/v1/sys/metrics` with one of the following headers:
 


### PR DESCRIPTION
### Description

This PR documents the fact that Prometheus, by default, follows redirection. So you end up having multiple times the same metrics if you put the different nodes inside the Prometheus configuration.

It took me some time to figure this out, so I thought updating the documentation would help the next person.