### PR TITLE
TBD

### DIFF
--- a/vault/activity_log_util.go
+++ b/vault/activity_log_util.go
@@ -7,6 +7,7 @@ package vault
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/hashicorp/vault/helper/metricsutil"
@@ -27,7 +28,7 @@ func (c *Core) setupClientIDsUsageInfo(ctx context.Context) {
 func (a *ActivityLog) handleClientIDsInMemoryEndOfMonth(ctx context.Context, currentTime time.Time) {
 }
 
-// getStartEndTime parses input for start and end times
+// getStartEndTime gets and returns start and end times from input with any warnings if applicable
 // If the end time is after the end of last month, it is adjusted to the last month
 func getStartEndTime(d *framework.FieldData, now time.Time, billingStartTime time.Time) (time.Time, time.Time, StartEndTimesWarnings, error) {
 	warnings := StartEndTimesWarnings{}
@@ -43,6 +44,36 @@ func getStartEndTime(d *framework.FieldData, now time.Time, billingStartTime tim
 	}
 
 	return startTime, endTime, warnings, nil
+}
+
+// parseStartEndTimes parses input for start and end times
+// billing start time is a no-op for CE, therefore start time is required
+func parseStartEndTimes(d *framework.FieldData, billingStartTime time.Time) (time.Time, time.Time, error) {
+	startTime := d.Get("start_time").(time.Time)
+	endTime := d.Get("end_time").(time.Time)
+
+	// If a specific endTime is used, then respect that
+	// otherwise we want to query up until the end of the current month.
+	//
+	// Also convert any user inputs to UTC to avoid
+	// problems later.
+	if endTime.IsZero() {
+		endTime = time.Now().UTC()
+	} else {
+		endTime = endTime.UTC()
+	}
+
+	// If startTime is not specified, we return an error requiring start_time to be provided
+	if startTime.IsZero() {
+		return time.Time{}, time.Time{}, fmt.Errorf("start_time is required")
+	} else {
+		startTime = startTime.UTC()
+	}
+	if startTime.After(endTime) {
+		return time.Time{}, time.Time{}, fmt.Errorf("start_time is later than end_time")
+	}
+
+	return startTime, endTime, nil
 }
 
 // clientsGaugeCollectorCurrentBillingPeriod is no-op on CE

--- a/vault/logical_system_activity.go
+++ b/vault/logical_system_activity.go
@@ -244,35 +244,6 @@ func (b *SystemBackend) rootActivityPaths() []*framework.Path {
 	return paths
 }
 
-func parseStartEndTimes(d *framework.FieldData, billingStartTime time.Time) (time.Time, time.Time, error) {
-	startTime := d.Get("start_time").(time.Time)
-	endTime := d.Get("end_time").(time.Time)
-
-	// If a specific endTime is used, then respect that
-	// otherwise we want to query up until the end of the current month.
-	//
-	// Also convert any user inputs to UTC to avoid
-	// problems later.
-	if endTime.IsZero() {
-		endTime = time.Now().UTC()
-	} else {
-		endTime = endTime.UTC()
-	}
-
-	// If startTime is not specified, we would like to query
-	// from the beginning of the billing period
-	if startTime.IsZero() {
-		startTime = billingStartTime
-	} else {
-		startTime = startTime.UTC()
-	}
-	if startTime.After(endTime) {
-		return time.Time{}, time.Time{}, fmt.Errorf("start_time is later than end_time")
-	}
-
-	return startTime, endTime, nil
-}
-
 // This endpoint is not used by the UI. The UI's "export" feature is entirely client-side.
 func (b *SystemBackend) handleClientExport(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
 	b.Core.activityLogLock.RLock()


### PR DESCRIPTION
…ot provided

### Description
What does this PR do?

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.

### PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.

Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
