### PR TITLE
UI Bug Fix: Skip analytics init on DR secondary clusters due to async breaking the DR transition flow

### DIFF
--- a/changelog/31359.txt
+++ b/changelog/31359.txt
@@ -1,0 +1,3 @@
+```release-note:change
+ui: Fixes UI DR Secondary view from not loading/transitioning.
+```

--- a/ui/app/routes/vault/cluster.js
+++ b/ui/app/routes/vault/cluster.js
@@ -128,6 +128,7 @@ export default Route.extend(ModelBoundaryRoute, ClusterRoute, {
     .cancelOn('deactivate')
     .keepLatest(),
 
+  // Note: do not make this afterModel hook async, it will break the DR secondary flow.
   afterModel(model, transition) {
     this._super(...arguments);
 

--- a/ui/app/routes/vault/cluster.js
+++ b/ui/app/routes/vault/cluster.js
@@ -128,36 +128,6 @@ export default Route.extend(ModelBoundaryRoute, ClusterRoute, {
     .cancelOn('deactivate')
     .keepLatest(),
 
-  async addAnalyticsService(model) {
-    // identify user for analytics service
-    if (this.analytics.activated) {
-      if (model.dr.isSecondary) return;
-      let licenseId = '';
-      try {
-        const licenseStatus = await this.api.sys.systemReadLicenseStatus();
-        licenseId = licenseStatus?.data?.autoloaded?.licenseId;
-      } catch (e) {
-        // license is not retrievable
-        licenseId = '';
-      }
-      try {
-        const entity_id = this.auth.authData?.entityId;
-        const entity = entity_id ? entity_id : `root_${uuidv4()}`;
-        this.analytics.identifyUser(entity, {
-          licenseId: licenseId,
-          licenseState: model.license?.state || 'community',
-          version: model.version.version,
-          storageType: model.storageType,
-          replicationMode: model.replicationMode,
-          isEnterprise: Boolean(model.license),
-        });
-      } catch (e) {
-        // eslint-disable-next-line no-console
-        console.log('unable to start analytics', e);
-      }
-    }
-  },
-
   afterModel(model, transition) {
     this._super(...arguments);
 
@@ -184,6 +154,35 @@ export default Route.extend(ModelBoundaryRoute, ClusterRoute, {
     this.addAnalyticsService(model);
 
     return this.transitionToTargetRoute(transition);
+  },
+
+  async addAnalyticsService(model) {
+    // identify user for analytics service
+    if (this.analytics.activated) {
+      let licenseId = '';
+      try {
+        const licenseStatus = await this.api.sys.systemReadLicenseStatus();
+        licenseId = licenseStatus?.data?.autoloaded?.licenseId;
+      } catch (e) {
+        // license is not retrievable
+        licenseId = '';
+      }
+      try {
+        const entity_id = this.auth.authData?.entityId;
+        const entity = entity_id ? entity_id : `root_${uuidv4()}`;
+        this.analytics.identifyUser(entity, {
+          licenseId: licenseId,
+          licenseState: model.license?.state || 'community',
+          version: model.version.version,
+          storageType: model.storageType,
+          replicationMode: model.replicationMode,
+          isEnterprise: Boolean(model.license),
+        });
+      } catch (e) {
+        // eslint-disable-next-line no-console
+        console.log('unable to start analytics', e);
+      }
+    }
   },
 
   setupController() {

--- a/ui/app/routes/vault/cluster.js
+++ b/ui/app/routes/vault/cluster.js
@@ -160,6 +160,7 @@ export default Route.extend(ModelBoundaryRoute, ClusterRoute, {
     // identify user for analytics service
     if (this.analytics.activated) {
       let licenseId = '';
+
       try {
         const licenseStatus = await this.api.sys.systemReadLicenseStatus();
         licenseId = licenseStatus?.data?.autoloaded?.licenseId;
@@ -167,6 +168,7 @@ export default Route.extend(ModelBoundaryRoute, ClusterRoute, {
         // license is not retrievable
         licenseId = '';
       }
+
       try {
         const entity_id = this.auth.authData?.entityId;
         const entity = entity_id ? entity_id : `root_${uuidv4()}`;

--- a/ui/app/routes/vault/cluster.js
+++ b/ui/app/routes/vault/cluster.js
@@ -112,6 +112,7 @@ export default Route.extend(ModelBoundaryRoute, ClusterRoute, {
     while (true) {
       // when testing, the polling loop causes promises to never settle so acceptance tests hang
       // to get around that, we just disable the poll in tests
+      // if you rely on the cluster status changing, e.g. replication modes, you will need to manually poll the cluster, using pollCluster from 'vault/tests/helpers/poll-cluster'
       if (Ember.testing) {
         return;
       }

--- a/ui/lib/core/addon/components/replication-header.hbs
+++ b/ui/lib/core/addon/components/replication-header.hbs
@@ -37,12 +37,16 @@
       {{else}}
         <ul>
           <li>
-            <LinkTo @route="vault.cluster.replication-dr-promote.details">
+            <LinkTo @route="vault.cluster.replication-dr-promote.details" data-test-link-to="Details">
               Details
             </LinkTo>
           </li>
           <li>
-            <LinkTo @route="vault.cluster.replication-dr-promote" @current-when="vault.cluster.replication-dr-promote.index">
+            <LinkTo
+              @route="vault.cluster.replication-dr-promote"
+              @current-when="vault.cluster.replication-dr-promote.index"
+              data-test-link-to="Manage"
+            >
               Manage
             </LinkTo>
           </li>

--- a/ui/lib/core/addon/templates/components/replication-action-promote.hbs
+++ b/ui/lib/core/addon/templates/components/replication-action-promote.hbs
@@ -8,7 +8,7 @@
     <h3 class="title is-5 is-marginless">
       Promote cluster
     </h3>
-    <p class="has-top-padding-s">
+    <p class="has-top-padding-s" data-test-promote-description>
       Promote this cluster to a
       {{this.model.replicationModeForDisplay}}
       primary

--- a/ui/lib/replication/addon/templates/components/known-secondaries-card.hbs
+++ b/ui/lib/replication/addon/templates/components/known-secondaries-card.hbs
@@ -29,7 +29,12 @@
     {{/if}}
   </div>
   {{#if this.cluster.canAddSecondary}}
-    <LinkTo @route="mode.secondaries.add" @model={{this.cluster.replicationMode}} class="link add-secondaries">
+    <LinkTo
+      @route="mode.secondaries.add"
+      @model={{this.cluster.replicationMode}}
+      class="link add-secondaries"
+      data-test-link-to="Add secondary"
+    >
       Add secondary
     </LinkTo>
   {{/if}}

--- a/ui/lib/replication/addon/templates/mode/secondaries/add.hbs
+++ b/ui/lib/replication/addon/templates/mode/secondaries/add.hbs
@@ -47,7 +47,7 @@
   {{/if}}
   <hr class="has-background-gray-100" />
   <Hds::ButtonSet>
-    <Hds::Button @text="Generate token" type="submit" data-test-secondary-add />
+    <Hds::Button @text="Generate token" type="submit" data-test-submit />
     <Hds::Button @text="Cancel" @color="secondary" @route="mode.secondaries" @model={{this.model.replicationMode}} />
   </Hds::ButtonSet>
 </form>

--- a/ui/tests/acceptance/enterprise-replication-modes-test.js
+++ b/ui/tests/acceptance/enterprise-replication-modes-test.js
@@ -9,9 +9,9 @@ import { setupMirage } from 'ember-cli-mirage/test-support';
 import { click, currentURL, settled, visit, waitFor } from '@ember/test-helpers';
 import { login } from 'vault/tests/helpers/auth/auth-helpers';
 import { STATUS_DISABLED_RESPONSE, mockReplicationBlock } from 'vault/tests/helpers/replication';
+import { GENERAL } from 'vault/tests/helpers/general-selectors';
 
 const s = {
-  navLink: (title) => `[data-test-sidebar-nav-link="${title}"]`,
   title: (t) => `[data-test-replication-title="${t}"]`,
   detailLink: (mode) => `[data-test-replication-details-link="${mode}"]`,
   summaryCard: '[data-test-replication-summary-card]',
@@ -53,8 +53,8 @@ module('Acceptance | Enterprise | replication modes', function (hooks) {
     await assertTitle(assert, 'Replication unsupported');
 
     // Nav links
-    assert.dom(s.navLink('Performance')).doesNotExist('hides performance link');
-    assert.dom(s.navLink('Disaster Recovery')).doesNotExist('hides dr link');
+    assert.dom(GENERAL.navLink('Performance')).doesNotExist('hides performance link');
+    assert.dom(GENERAL.navLink('Disaster Recovery')).doesNotExist('hides dr link');
   });
 
   test('replication page when disabled', async function (assert) {
@@ -64,15 +64,15 @@ module('Acceptance | Enterprise | replication modes', function (hooks) {
     await assertTitle(assert, 'Enable Replication');
 
     // Nav links
-    assert.dom(s.navLink('Performance')).exists('shows performance link');
-    assert.dom(s.navLink('Disaster Recovery')).exists('shows dr link');
+    assert.dom(GENERAL.navLink('Performance')).exists('shows performance link');
+    assert.dom(GENERAL.navLink('Disaster Recovery')).exists('shows dr link');
 
-    await click(s.navLink('Performance'));
+    await click(GENERAL.navLink('Performance'));
     assert.strictEqual(currentURL(), '/vault/replication/performance', 'it navigates to the correct page');
     await settled();
     assert.dom(s.enableForm).exists();
 
-    await click(s.navLink('Disaster Recovery'));
+    await click(GENERAL.navLink('Disaster Recovery'));
 
     await assertTitle(assert, 'Enable Disaster Recovery Replication', 'dr');
   });
@@ -90,15 +90,15 @@ module('Acceptance | Enterprise | replication modes', function (hooks) {
       assert.dom(s.detailLink('dr')).hasText('Enable', 'CTA to enable dr');
 
       // Nav links
-      assert.dom(s.navLink('Performance')).exists('shows performance link');
-      assert.dom(s.navLink('Disaster Recovery')).exists('shows dr link');
+      assert.dom(GENERAL.navLink('Performance')).exists('shows performance link');
+      assert.dom(GENERAL.navLink('Disaster Recovery')).exists('shows dr link');
 
-      await click(s.navLink('Performance'));
+      await click(GENERAL.navLink('Performance'));
       assert.strictEqual(currentURL(), `/vault/replication/performance`, `goes to correct URL`);
       await waitFor(s.dashboard);
       assert.dom(s.dashboard).exists(`it shows the replication dashboard`);
 
-      await click(s.navLink('Disaster Recovery'));
+      await click(GENERAL.navLink('Disaster Recovery'));
       await assertTitle(assert, 'Enable Disaster Recovery Replication', 'dr');
       assert.dom(s.enableForm).exists('it shows the enable view for dr');
     });
@@ -115,15 +115,15 @@ module('Acceptance | Enterprise | replication modes', function (hooks) {
     assert.dom(s.detailLink('dr')).hasText('Details', 'CTA to see dr details');
 
     // Nav links
-    assert.dom(s.navLink('Performance')).exists('shows performance link');
-    assert.dom(s.navLink('Disaster Recovery')).exists('shows dr link');
+    assert.dom(GENERAL.navLink('Performance')).exists('shows performance link');
+    assert.dom(GENERAL.navLink('Disaster Recovery')).exists('shows dr link');
 
-    await click(s.navLink('Performance'));
+    await click(GENERAL.navLink('Performance'));
     assert.strictEqual(currentURL(), `/vault/replication/performance`, `goes to correct URL`);
     await waitFor(s.enableForm);
     assert.dom(s.enableForm).exists('it shows the enable view for performance');
 
-    await click(s.navLink('Disaster Recovery'));
+    await click(GENERAL.navLink('Disaster Recovery'));
     await assertTitle(assert, 'Disaster Recovery primary', 'Disaster Recovery');
     assert.dom(s.dashboard).exists(`it shows the replication dashboard`);
   });
@@ -137,11 +137,11 @@ module('Acceptance | Enterprise | replication modes', function (hooks) {
     await assertTitle(assert, 'Disaster Recovery & Performance primary', 'Disaster Recovery & Performance');
     assert.dom(s.summaryCard).exists({ count: 2 }, 'shows 2 summary cards');
 
-    await click(s.navLink('Performance'));
+    await click(GENERAL.navLink('Performance'));
     await assertTitle(assert, 'Performance primary', 'Performance');
     assert.dom(s.enableForm).doesNotExist();
 
-    await click(s.navLink('Disaster Recovery'));
+    await click(GENERAL.navLink('Disaster Recovery'));
     await assertTitle(assert, 'Disaster Recovery primary', 'Disaster Recovery');
     assert.dom(s.enableForm).doesNotExist();
   });

--- a/ui/tests/acceptance/replication-dr-secondaries-stub-test.js
+++ b/ui/tests/acceptance/replication-dr-secondaries-stub-test.js
@@ -1,0 +1,142 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import { click, visit, settled } from '@ember/test-helpers';
+import { module, test } from 'qunit';
+import { setupApplicationTest } from 'ember-qunit';
+import { login } from 'vault/tests/helpers/auth/auth-helpers';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { GENERAL } from 'vault/tests/helpers/general-selectors';
+import sinon from 'sinon';
+import { enableReplication } from 'vault/tests/helpers/replication';
+import { pollCluster } from 'vault/tests/helpers/poll-cluster';
+
+// This module can only have one test because once the cluster is demoted to DR secondary,
+// you cannot log in or perform admin actions. All DR secondary assertions must be done in one test.
+module('Acceptance | Enterprise | replication-secondaries', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  hooks.afterEach(function () {
+    this.server.shutdown();
+  });
+
+  test('DR secondary: manage tab, details tab, and analytics are not run', async function (assert) {
+    // Log in and set up Mirage stubs to simulate DR secondary state
+    await login();
+    await settled();
+    await enableReplication('dr', 'primary');
+    await pollCluster(this.owner);
+    await click('[data-test-replication-link="manage"]');
+
+    // Stub the demote action so it does not actually demote the cluster
+    this.server.post('/sys/replication/dr/demote', () => {
+      return { request_id: 'fake-demote', data: { success: true } };
+    });
+    // Stub endpoints for DR secondary state
+    this.server.post('/sys/capabilities-self', () => ({ capabilities: [] }));
+    this.server.get('/sys/replication/status', () => ({
+      request_id: '2f50313f-be70-493d-5883-c84c2d6f05ce',
+      lease_id: '',
+      renewable: false,
+      lease_duration: 0,
+      data: {
+        dr: {
+          cluster_id: '7222cbbf-3fb3-949b-8e03-cd5a15babde6',
+          corrupted_merkle_tree: false,
+          known_primary_cluster_addrs: null,
+          last_corruption_check_epoch: '-62135596800',
+          last_reindex_epoch: '0',
+          merkle_root: 'd3ae75bde029e05d435f92b9ecc5641c1b027cc4',
+          mode: 'secondary',
+          primaries: [],
+          primary_cluster_addr: '',
+          secondary_id: '',
+          ssct_generation_counter: 0,
+          state: 'idle',
+        },
+        performance: {
+          mode: 'disabled',
+        },
+      },
+      wrap_info: null,
+      warnings: null,
+      auth: null,
+      mount_type: '',
+    }));
+    this.server.get('/sys/replication/dr/status', () => ({
+      data: { mode: 'secondary', cluster_id: 'dr-cluster-id' },
+    }));
+    this.server.get('/sys/health', () => ({
+      initialized: true,
+      sealed: false,
+      standby: false,
+      performance_standby: false,
+      replication_performance_mode: 'disabled',
+      replication_dr_mode: 'secondary',
+      server_time_utc: 1754948244,
+      version: '1.21.0-beta1+ent',
+      enterprise: true,
+      cluster_name: 'vault-cluster-64853bcd',
+      cluster_id: '113a6c47-077f-bea7-0e8e-70a91821e85a',
+      last_wal: 82,
+      license: {
+        state: 'autoloaded',
+        expiry_time: '2029-01-27T00:00:00Z',
+        terminated: false,
+      },
+      echo_duration_ms: 0,
+      clock_skew_ms: 0,
+      replication_primary_canary_age_ms: 0,
+      removed_from_cluster: false,
+    }));
+    this.server.get('/sys/seal-status', () => ({
+      type: 'shamir',
+      initialized: true,
+      sealed: false,
+      t: 1,
+      n: 1,
+      progress: 0,
+      nonce: '',
+      version: '1.21.0-beta1+ent',
+      build_date: '2025-08-11T14:11:00Z',
+      migration: false,
+      cluster_name: 'vault-cluster-64853bcd',
+      cluster_id: '113a6c47-077f-bea7-0e8e-70a91821e85a',
+      recovery_seal: false,
+      storage_type: 'raft',
+      removed_from_cluster: false,
+    }));
+    await click(GENERAL.button('demote'));
+    await pollCluster(this.owner);
+    // Spy on the route's addAnalyticsService method
+    const clusterRoute = this.owner.lookup('route:vault.cluster');
+    const addAnalyticsSpy = sinon.spy(clusterRoute, 'addAnalyticsService');
+
+    // Visit the DR secondary promote view
+    await visit('/vault/replication-dr-promote');
+
+    assert
+      .dom('[data-test-promote-description]')
+      .hasText(
+        'Promote this cluster to a Disaster Recovery primary',
+        'shows the correct description for a DR secondary'
+      );
+    assert.dom('[data-test-mode]').includesText('secondary', 'shows the DR secondary mode badge');
+    await click(GENERAL.linkTo('Details'));
+    assert
+      .dom('[data-test-replication-secondary-card]')
+      .hasClass(
+        'has-error-border',
+        'shows error border on status because the DR secondary is not connected to a primary.'
+      );
+
+    // Assert addAnalyticsService was NOT called
+    assert.false(addAnalyticsSpy.called, 'addAnalyticsService should not be called on DR secondary');
+
+    // Restore spy
+    addAnalyticsSpy.restore();
+  });
+});

--- a/ui/tests/helpers/general-selectors.ts
+++ b/ui/tests/helpers/general-selectors.ts
@@ -27,7 +27,7 @@ export const GENERAL = {
   confirmButton: '[data-test-confirm-button]', // used most often on modal or confirm popups
   confirmTrigger: '[data-test-confirm-action-trigger]',
   copyButton: '[data-test-copy-button]',
-  // there should only be one save button per view (e.g. one per form) so this does not need to be dynamic
+  // there should only be one submit button per view (e.g. one per form) so this does not need to be dynamic
   // this button should be used for any kind of "submit" on a form or "save" action.
   submitButton: '[data-test-submit]',
   button: (label: string) => (label ? `[data-test-button="${label}"]` : '[data-test-button]'),

--- a/ui/tests/helpers/replication.js
+++ b/ui/tests/helpers/replication.js
@@ -38,7 +38,7 @@ export async function addSecondary(secondaryName, mountFilterMode = null) {
     await searchSelect.options.objectAt(0).click();
   }
 
-  await click('[data-test-secondary-add]');
+  await click(GENERAL.submitButton);
 }
 
 export const disableReplication = async (type, assert) => {


### PR DESCRIPTION
- [ ] Ent tests pass

### Description
The DR secondary view failed to load after PR #30425. The error occurred because of the addition of the `async` keyword to the `afterModel` hook. My best guess as to why this breaks the DR Secondary transition is that `async` causes Ember to wait for any awaited promises before completing the route transition. For most routes, this is fine, but DR secondary is sensitive to timing, and the transition hangs/fails silently, breaking the transition.

_Note: The addition of `async` on the `afterModel` hook does not cause a failure for Performance Secondaries._

To repro:
- Confirming it was the Posthog pr: checkout commit `d7bb0adfe0` (the commit right before the Posthog PR), create a DR secondary, and navigate to the UI view. Then, check out the Posthog commit `689ede2da5` and follow the same steps. It works on the commit before, and fails on the regression commit.
- To reproduce the fix: on this PR, add the `async` before the `afterModel` hook on the cluster route, and the DR secondary will fail to transition. Remove `async`, and it will transition. This shows that it's not the `this.analytics` service check that's breaking the flow, it's the `async` keyword added to the `afterModel` hook.

Failure:
<img width="1854" height="1485" alt="image" src="https://github.com/user-attachments/assets/226adfe4-1fac-45b5-a829-93da8ae16f93" />

After fix:
<img width="1854" height="1485" alt="image" src="https://github.com/user-attachments/assets/5ad2cf35-2e4f-482f-8d7e-da981292f31b" />
