### PR TITLE
Hackweek 2025 Policy Wizard

### DIFF
--- a/ui/app/styles/components/popup-menu.scss
+++ b/ui/app/styles/components/popup-menu.scss
@@ -9,8 +9,7 @@
  */
 
 // Popup menu no longer exists, but these styles are still used in some places
-.popup-menu-content,
-.ember-power-select-options {
+.popup-menu-content {
   border-radius: size_variables.$radius;
   margin: -2px 0 0 0;
 
@@ -38,8 +37,6 @@
 
   button.link,
   a,
-  .ember-power-select-option,
-  .ember-power-select-option[aria-current='true'],
   .menu-item {
     background: transparent;
     box-shadow: none;
@@ -69,8 +66,6 @@
   }
 
   button.link,
-  .ember-power-select-option,
-  .ember-power-select-option[aria-current='true'],
   a {
     background-color: color_variables.$white;
     color: color_variables.$grey-darkest;
@@ -152,34 +147,6 @@
     min-width: 0;
     padding: 0;
     width: 2.5rem;
-  }
-}
-
-.ember-basic-dropdown-content {
-  background-color: transparent;
-
-  &--left.popup-menu {
-    margin: 0px 0 0 -8px;
-  }
-
-  &--below {
-    &.ember-basic-dropdown--transitioning-in {
-      animation: drop-fade-above 0.15s;
-    }
-
-    &.ember-basic-dropdown--transitioning-out {
-      animation: drop-fade-above 0.15s reverse;
-    }
-  }
-
-  &--above {
-    &.ember-basic-dropdown--transitioning-in {
-      animation: drop-fade-below 0.15s;
-    }
-
-    &.ember-basic-dropdown--transitioning-out {
-      animation: drop-fade-below 0.15s reverse;
-    }
   }
 }
 

--- a/ui/app/styles/components/search-select.scss
+++ b/ui/app/styles/components/search-select.scss
@@ -8,97 +8,6 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-.ember-power-select-dropdown {
-  background: transparent;
-  box-shadow: none;
-  overflow: visible;
-
-  &.ember-power-select-dropdown.ember-basic-dropdown-content--below {
-    border: 0;
-  }
-}
-
-.ember-power-select-trigger {
-  border: 0;
-  border-radius: size_variables.$radius;
-  padding-right: 0;
-
-  &--active {
-    outline-width: 3px;
-    outline-offset: -2px;
-  }
-}
-
-.ember-power-select-trigger:focus,
-.ember-power-select-trigger--active {
-  border: 0;
-}
-
-.ember-power-select-status-icon {
-  display: none;
-}
-
-.ember-power-select-search {
-  left: 0;
-  padding: 0;
-  position: absolute;
-  top: 0;
-  right: 0;
-  transform: translateY(-100%);
-  z-index: -1;
-
-  &::after {
-    background: color_variables.$white;
-    bottom: size_variables.$spacing-4;
-    content: '';
-    left: size_variables.$spacing-4 + size_variables.$spacing-24;
-    position: absolute;
-    right: size_variables.$spacing-4;
-    top: size_variables.$spacing-4;
-    z-index: -1;
-  }
-}
-
-.ember-power-select-search-input {
-  background: transparent;
-  border: 0;
-  padding: size_variables.$spacing-4 size_variables.$spacing-12;
-  padding-left: size_variables.$spacing-4 + size_variables.$spacing-24;
-}
-
-div > .ember-power-select-options {
-  background: color_variables.$white;
-  border: box-shadow_variables.$base-border;
-  box-shadow: box-shadow_variables.$box-shadow-middle;
-  margin: -4px size_variables.$spacing-8 0;
-  padding: size_variables.$spacing-4 0;
-
-  .ember-power-select-option,
-  .ember-power-select-option[aria-current='true'] {
-    align-items: center;
-    display: flex;
-    justify-content: space-between;
-  }
-
-  .ember-power-select-option[aria-current='true'] {
-    background-color: color_variables.$ui-gray-050;
-    color: color_variables.$ui-gray-900;
-  }
-
-  .ember-power-select-option--no-matches-message {
-    color: color_variables.$grey;
-    font-size: size_variables.$size-8;
-    font-weight: font_variables.$font-weight-semibold;
-    text-transform: uppercase;
-
-    &:hover,
-    &:focus {
-      background: transparent;
-      color: color_variables.$grey;
-    }
-  }
-}
-
 .search-select-list-item {
   align-items: center;
   display: flex;
@@ -124,14 +33,6 @@ div > .ember-power-select-options {
 .search-select-list-key {
   color: var(--token-color-foreground-faint);
   font-size: size_variables.$size-8;
-}
-
-.ember-power-select-dropdown.ember-basic-dropdown-content {
-  animation: none;
-
-  .ember-power-select-options {
-    animation: drop-fade-above 0.15s;
-  }
 }
 
 .search-select .search-icon {

--- a/ui/app/styles/core/buttons.scss
+++ b/ui/app/styles/core/buttons.scss
@@ -390,3 +390,19 @@ a.button.disabled {
     }
   }
 }
+
+.policy-wizard {
+  background: linear-gradient(
+    135deg,
+    color_variables.$blue,
+    hsl(237, 100%, 71%)
+  ); // only use case for purple in the app. define here instead of utils/color_var
+  animation: env-banner-color-rotate 8s infinite linear alternate;
+  color: color_variables.$white;
+
+  .notification {
+    background-color: transparent;
+    line-height: 2;
+    padding: 0 size_variables.$spacing-12;
+  }
+}

--- a/ui/app/templates/vault/cluster.hbs
+++ b/ui/app/templates/vault/cluster.hbs
@@ -71,6 +71,12 @@
     />
   {{/if}}
 </div>
+
+{{! template-lint-disable no-inline-styles}}
+<div style="position: fixed; top: 5%; right: 15%; z-index: 1000;">
+  <PolicyBuilder />
+</div>
+
 <div class="global-flash">
   {{#each this.flashMessages.queue as |flash|}}
     <FlashMessage data-test-flash-message={{true}} @flash={{flash}} as |customComponent flash close|>

--- a/ui/app/templates/vault/cluster.hbs
+++ b/ui/app/templates/vault/cluster.hbs
@@ -72,8 +72,9 @@
   {{/if}}
 </div>
 
+{{! HACKWEEK }}
 {{! template-lint-disable no-inline-styles}}
-<div style="position: fixed; top: 5%; right: 15%; z-index: 1000;">
+<div style="position: fixed; top: 1%; right: 1%; z-index: 1000; ">
   <PolicyBuilder />
 </div>
 

--- a/ui/app/utils/policy-path-map.ts
+++ b/ui/app/utils/policy-path-map.ts
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import apiPath from './api-path';
+
+const API_PATHS = {
+  kvv2: [apiPath`${'backend'}/data/${'path'}`, apiPath`${'backend'}/metadata/${'path'}`],
+};
+
+// Regex-based route matching - more flexible for parent/child relationships
+const ROUTE_PATTERNS: Array<{ pattern: RegExp; paths: ReturnType<typeof apiPath>[] }> = [
+  // KV v2 routes - matches any kv secret route
+  {
+    pattern: /^vault\.cluster\.secrets\.backend\.kv/,
+    paths: API_PATHS.kvv2,
+  },
+];
+
+export default function mapApiPathToRoute(routeName: string): ReturnType<typeof apiPath>[] {
+  // Try pattern matching
+  for (const { pattern, paths } of ROUTE_PATTERNS) {
+    if (pattern.test(routeName)) {
+      return paths;
+    }
+  }
+
+  return [];
+}

--- a/ui/app/utils/policy-path-map.ts
+++ b/ui/app/utils/policy-path-map.ts
@@ -7,6 +7,7 @@ import apiPath from './api-path';
 
 const API_PATHS = {
   kvv2: [apiPath`${'backend'}/data/${'path'}`, apiPath`${'backend'}/metadata/${'path'}`],
+  secretsList: [apiPath`${'backend'}/`],
 };
 
 // Regex-based route matching - more flexible for parent/child relationships
@@ -15,6 +16,10 @@ const ROUTE_PATTERNS: Array<{ pattern: RegExp; paths: ReturnType<typeof apiPath>
   {
     pattern: /^vault\.cluster\.secrets\.backend\.kv/,
     paths: API_PATHS.kvv2,
+  },
+  {
+    pattern: /^vault\.cluster\.secrets\./,
+    paths: API_PATHS.secretsList,
   },
 ];
 

--- a/ui/app/utils/policy-path-map.ts
+++ b/ui/app/utils/policy-path-map.ts
@@ -6,7 +6,10 @@
 import apiPath from './api-path';
 
 const API_PATHS = {
-  kvv2: [apiPath`${'backend'}/data/${'path'}`, apiPath`${'backend'}/metadata/${'path'}`],
+  kvv2: {
+    overview: [apiPath`${'backend'}/data/${'path'}`, apiPath`${'backend'}/metadata/${'path'}`],
+    subkeys: [apiPath`${'backend'}/subkeys/${'path'}`, apiPath`${'backend'}/data/${'path'}`],
+  },
   secretsList: [apiPath`${'backend'}/`],
 };
 
@@ -14,8 +17,12 @@ const API_PATHS = {
 const ROUTE_PATTERNS: Array<{ pattern: RegExp; paths: ReturnType<typeof apiPath>[] }> = [
   // KV v2 routes - matches any kv secret route
   {
+    pattern: /^vault\.cluster\.secrets\.backend\.kv\.secret\.patch/,
+    paths: API_PATHS.kvv2.subkeys,
+  },
+  {
     pattern: /^vault\.cluster\.secrets\.backend\.kv/,
-    paths: API_PATHS.kvv2,
+    paths: API_PATHS.kvv2.overview,
   },
   {
     pattern: /^vault\.cluster\.secrets\./,

--- a/ui/lib/core/addon/components/policy-builder.hbs
+++ b/ui/lib/core/addon/components/policy-builder.hbs
@@ -143,51 +143,61 @@
       </Hds::Card::Container>
 
       <Hds::Card::Container class="has-padding-m has-top-margin-m has-bottom-margin-m" @level="base" @hasBorder={{true}}>
-        <Hds::Text::Display>Apply policy via</Hds::Text::Display>
-        <Hds::Tabs as |T|>
-          <T.Tab>
-            UI
-          </T.Tab>
-          <T.Tab>
-            CLI
-          </T.Tab>
-          <T.Tab>
-            TFVP
-          </T.Tab>
+        {{#if this.policyName}}
+          <Hds::Text::Display>Apply policy via</Hds::Text::Display>
+          <Hds::Tabs as |T|>
+            <T.Tab>
+              UI
+            </T.Tab>
+            <T.Tab>
+              CLI
+            </T.Tab>
+            <T.Tab>
+              TFVP
+            </T.Tab>
 
-          <T.Panel class="has-top-padding-m">
-            <Hds::Text::Body @tag="p" class="has-bottom-padding-s">Click "Apply policy" to
-              {{this.policyAction}}
-              the policy{{this.applySubtext}}.
-            </Hds::Text::Body>
-            <Hds::Button @text="Apply policy" @icon="wand" @isFullWidth={{true}} {{on "click" this.applyPolicy}} />
+            <T.Panel class="has-top-padding-m">
+              <Hds::Text::Body @tag="p" class="has-bottom-padding-s">Click "Apply policy" to
+                {{this.policyAction}}
+                the policy{{this.applySubtext}}.
+              </Hds::Text::Body>
+              <Hds::Button @text="Apply policy" @icon="wand" @isFullWidth={{true}} {{on "click" this.applyPolicy}} />
 
-            {{#if this.error}}
-              <Hds::Alert @type="inline" @color="critical" class="has-top-margin-m" as |A|>
-                <A.Title>Oops! It's hackweek give me a break! ¯\_(ツ)_/¯</A.Title>
-                <A.Description>
-                  {{this.error}}
-                </A.Description>
-              </Hds::Alert>
-            {{/if}}
-          </T.Panel>
-          <T.Panel class="has-top-padding-m">
-            <Hds::Text::Body @tag="p" class="has-bottom-padding-s">
-              A CLI snippet to
-              {{this.policyAction}}
-              the policy{{this.applySubtext}}.
-            </Hds::Text::Body>
-            <Hds::CodeBlock @value={{this.cliSnippet}} @language="ruby" @hasCopyButton={{true}} />
-          </T.Panel>
-          <T.Panel class="has-top-padding-m">
-            <Hds::Text::Body @tag="p" class="has-bottom-padding-s">
-              A TFVP (Terraform Vault Provider) snippet to
-              {{this.policyAction}}
-              the policy{{this.applySubtext}}.
-            </Hds::Text::Body>
-            <Hds::CodeBlock @value={{this.tfvpSnippet}} @language="hcl" @hasCopyButton={{true}} />
-          </T.Panel>
-        </Hds::Tabs>
+              {{#if this.error}}
+                <Hds::Alert @type="inline" @color="critical" class="has-top-margin-m" as |A|>
+                  <A.Title>Oops! It's hackweek give me a break! ¯\_(ツ)_/¯</A.Title>
+                  <A.Description>
+                    {{this.error}}
+                  </A.Description>
+                </Hds::Alert>
+              {{/if}}
+            </T.Panel>
+            <T.Panel class="has-top-padding-m">
+              <Hds::Text::Body @tag="p" class="has-bottom-padding-s">
+                A CLI snippet to
+                {{this.policyAction}}
+                the policy{{this.applySubtext}}.
+              </Hds::Text::Body>
+              <Hds::CodeBlock @value={{this.cliSnippet}} @language="ruby" @hasCopyButton={{true}} />
+            </T.Panel>
+            <T.Panel class="has-top-padding-m">
+              <Hds::Text::Body @tag="p" class="has-bottom-padding-s">
+                A TFVP (Terraform Vault Provider) snippet to
+                {{this.policyAction}}
+                the policy{{this.applySubtext}}.
+              </Hds::Text::Body>
+              <Hds::CodeBlock @value={{this.tfvpSnippet}} @language="hcl" @hasCopyButton={{true}} />
+            </T.Panel>
+          </Hds::Tabs>
+        {{else}}
+          <Hds::ApplicationState @align="center" as |A|>
+            <A.Header
+              @title="{{if (eq this.policyAction 'create') 'Create' 'Select'}} a policy to get started"
+              @icon="wand"
+            />
+            <A.Body @text="Select an existing policy above or create a new one to see options for applying the policy." />
+          </Hds::ApplicationState>
+        {{/if}}
       </Hds::Card::Container>
     </M.Body>
   </Hds::Flyout>

--- a/ui/lib/core/addon/components/policy-builder.hbs
+++ b/ui/lib/core/addon/components/policy-builder.hbs
@@ -2,12 +2,12 @@
   @text="Generate policy"
   @color="tertiary"
   @icon="shield-check"
-  {{on "click" this.openFlyout}}
+  {{on "click" (fn this.handleFlyout "open")}}
   class="policy-wizard"
 />
 
 {{#if this.showFlyout}}
-  <Hds::Flyout @size="large" @onClose={{fn (mut this.showFlyout) false}} as |M|>
+  <Hds::Flyout @size="large" @onClose={{fn this.handleFlyout "close"}} as |M|>
     <M.Header class="policy-wizard" @icon="wand">
       Policy Wizard
     </M.Header>

--- a/ui/lib/core/addon/components/policy-builder.hbs
+++ b/ui/lib/core/addon/components/policy-builder.hbs
@@ -1,8 +1,14 @@
-<Hds::Button @text="Generate policy" @color="tertiary" @icon="shield-check" {{on "click" this.openFlyout}} />
-{{#if this.showFlyout}}
+<Hds::Button
+  @text="Generate policy"
+  @color="tertiary"
+  @icon="shield-check"
+  {{on "click" this.openFlyout}}
+  class="policy-wizard"
+/>
 
-  <Hds::Flyout @size="large" id="policy-builder" @onClose={{fn (mut this.showFlyout) false}} as |M|>
-    <M.Header @icon="wand" @tagline="Policy builder for {{this.context}}">
+{{#if this.showFlyout}}
+  <Hds::Flyout @size="large" @onClose={{fn (mut this.showFlyout) false}} as |M|>
+    <M.Header class="policy-wizard" @icon="wand">
       Policy Wizard
     </M.Header>
     <M.Body>
@@ -115,19 +121,28 @@
       <Hds::Card::Container class="has-padding-m has-top-margin-m has-bottom-margin-m" @level="base" @hasBorder={{true}}>
         <Hds::Text::Display class="has-bottom-margin-xxs">Assign policy</Hds::Text::Display>
         <br />
-        <Hds::Text::Body class="has-bottom-margin-xxs">Select who this policy should be assigned to:</Hds::Text::Body>
-        <div class="flex space-between column-gap-16">
-          {{#each-in this.identityOptions as |type options|}}
-            <Hds::Dropdown class="is-flex-grow-1" as |D|>
-              <D.ToggleButton @isFullWidth={{true}} @color="secondary" @text={{type}} />
-              <D.Title @text={{get (this.dropdownText type) "title"}} />
-              <D.Description @text={{get (this.dropdownText type) "description"}} />
-              {{#each options as |opt|}}
-                <D.Checkbox>{{opt.id}}</D.Checkbox>
-              {{/each}}
-            </Hds::Dropdown>
-          {{/each-in}}
-        </div>
+        <Hds::Text::Body class="has-bottom-margin-xxs">Select who this policy should be assigned to.</Hds::Text::Body>
+        {{#each-in this.identityOptions as |type options|}}
+          <Hds::Form::SuperSelect::Multiple::Field
+            @onChange={{fn this.handleAssignment type}}
+            @selected={{get this.selectedAssignments type}}
+            @options={{options}}
+            @searchEnabled={{true}}
+            @searchField="name"
+            class="field"
+            as |F|
+          >
+            <F.Label class="has-top-margin-xs">{{get (this.displayText type) "title"}}</F.Label>
+            <F.HelperText>{{get (this.displayText type) "description"}}</F.HelperText>
+            <F.Options>
+              {{#let F.options as |option|}}
+                {{option.name}}
+              {{/let}}
+            </F.Options>
+
+          </Hds::Form::SuperSelect::Multiple::Field>
+        {{/each-in}}
+
       </Hds::Card::Container>
 
       <Hds::Card::Container class="has-padding-m has-top-margin-m has-bottom-margin-m" @level="base" @hasBorder={{true}}>

--- a/ui/lib/core/addon/components/policy-builder.hbs
+++ b/ui/lib/core/addon/components/policy-builder.hbs
@@ -14,9 +14,15 @@
     <M.Body>
 
       {{! CREATE OR EDIT A POLICY  }}
-      <Hds::Card::Container class="has-padding-m has-top-margin-m has-bottom-margin-m" @level="base" @hasBorder={{true}}>
+      <Hds::Card::Container class="has-padding-m has-bottom-margin-m" @level="base" @hasBorder={{true}}>
         <Hds::Text::Display class="has-bottom-margin-xxs">Create or edit a policy</Hds::Text::Display>
-        <Hds::Form::Radio::Group @layout="horizontal" {{on "change" this.selectPolicy}} class="has-bottom-margin-m" as |G|>
+        <Hds::Form::Radio::Group
+          @layout="horizontal"
+          @name="policyAction"
+          {{on "input" this.handlePolicySelection}}
+          class="has-bottom-margin-m"
+          as |G|
+        >
           <G.HelperText>Choose to create a new policy or edit existing one</G.HelperText>
           <G.RadioField checked={{eq this.policyAction "create"}} @value="create" as |F|>
             <F.Label>Create a new policy</F.Label>
@@ -27,16 +33,17 @@
         </Hds::Form::Radio::Group>
 
         {{#if (eq this.policyAction "create")}}
-          <Hds::Form::TextInput::Field class="field" as |F|>
+          <Hds::Form::TextInput::Field
+            class="field"
+            name="name"
+            autocomplete="off"
+            {{on "input" this.handlePolicySelection}}
+            as |F|
+          >
             <F.Label>Policy name</F.Label>
           </Hds::Form::TextInput::Field>
-          <Hds::Reveal class="is-fullwidth has-top-margin-xxs" @text="Add a description">
-            <Hds::Form::TextInput::Field class="field" as |F|>
-              <F.Label>Description</F.Label>
-            </Hds::Form::TextInput::Field>
-          </Hds::Reveal>
         {{else if (eq this.policyAction "edit")}}
-          <Hds::Form::Select::Field class="field" as |F|>
+          <Hds::Form::Select::Field class="field" name="policyName" {{on "input" this.handlePolicySelection}} as |F|>
             <F.Label>Select a policy</F.Label>
             <F.HelperText>The configured permissions will be added to the selected policy.</F.HelperText>
             <F.Options>
@@ -55,44 +62,35 @@
       <Hds::Card::Container class="has-padding-m has-top-margin-m has-bottom-margin-m" @level="base" @hasBorder={{true}}>
         <div class="is-flex-between">
           <Hds::Text::Display class="has-bottom-margin-xxs">Policy stanza</Hds::Text::Display>
-          <Hds::Form::Toggle::Field
-            name="toggle-view"
-            {{on "change" (fn (mut this.showAdvanced) (not this.showAdvanced))}}
-            as |F|
-          >
+          <Hds::Form::Toggle::Field {{on "input" (fn (mut this.showPreview) (not this.showPreview))}} as |F|>
             <F.Label>Preview policy</F.Label>
           </Hds::Form::Toggle::Field>
         </div>
 
-        {{#if this.showAdvanced}}
-          {{! POLICY SAMPLE }}
+        {{! POLICY SAMPLE }}
+        {{#if this.showPreview}}
           <div class="has-padding-m has-top-margin-m has-bottom-margin-m">
             <Hds::CodeBlock
               @value={{this.policySnippet}}
-              @language="yaml"
+              @language="hcl"
               @hasCopyButton={{true}}
               @hasLineNumbers={{false}}
             />
           </div>
         {{else}}
           {{! PATH CAPABILITIES CARD }}
-          {{#each this.capabilities as |capability|}}
-            <Hds::Card::Container @background="neutral-secondary" class="has-padding-m has-top-margin-m has-bottom-margin-m">
+          {{#each this.policyStanzas as |stanza|}}
+            <Hds::Card::Container @background="neutral-secondary" class="has-padding-s has-top-margin-m has-bottom-margin-m">
               <Hds::Button
                 @text="Remove path"
                 @icon="trash"
                 @isIconOnly={{true}}
                 @color="critical"
                 class="is-pulled-right"
-                {{on "click" (fn this.deletePath capability.path)}}
+                {{on "click" (fn this.deletePath stanza.path)}}
               />
               <div class="is-flex-between has-bottom-margin-xxs">
-                <Hds::Form::TextInput::Field
-                  @value={{capability.path}}
-                  class="field"
-                  {{on "change" capability.setPath}}
-                  as |F|
-                >
+                <Hds::Form::TextInput::Field @value={{stanza.path}} class="field" {{on "input" stanza.setPath}} as |F|>
                   <F.Label class="has-top-margin-m">API path:</F.Label>
                 </Hds::Form::TextInput::Field>
               </div>
@@ -101,9 +99,9 @@
                 <G.Legend class="has-top-padding-m">Capabilities</G.Legend>
                 {{#each this.permissions as |p|}}
                   <G.CheckboxField
-                    checked={{includes p capability.permissions}}
+                    checked={{includes p stanza.permissions}}
                     @value={{p}}
-                    {{on "change" capability.setPermissions}}
+                    {{on "input" stanza.setPermissions}}
                     as |F|
                   >
                     <F.Label>{{p}}</F.Label>
@@ -112,16 +110,15 @@
               </Hds::Form::Checkbox::Group>
             </Hds::Card::Container>
           {{/each}}
+          <Hds::Button @icon="plus" @text="Add new path" @size="small" @color="secondary" {{on "click" this.addPath}} />
         {{/if}}
 
-        <Hds::Button @icon="plus" @text="Add new path" @size="small" @color="secondary" {{on "click" this.addPath}} />
       </Hds::Card::Container>
 
       {{! POLICY ASSIGNMENT }}
       <Hds::Card::Container class="has-padding-m has-top-margin-m has-bottom-margin-m" @level="base" @hasBorder={{true}}>
-        <Hds::Text::Display class="has-bottom-margin-xxs">Assign policy</Hds::Text::Display>
-        <br />
-        <Hds::Text::Body class="has-bottom-margin-xxs">Select who this policy should be assigned to.</Hds::Text::Body>
+        <Hds::Text::Display @tag="p" class="has-bottom-margin-xxs">Assign policy</Hds::Text::Display>
+        <Hds::Text::Body @tag="p" class="has-bottom-padding-s">Select who this policy should be applied to.</Hds::Text::Body>
         {{#each-in this.identityOptions as |type options|}}
           <Hds::Form::SuperSelect::Multiple::Field
             @onChange={{fn this.handleAssignment type}}
@@ -132,14 +129,13 @@
             class="field"
             as |F|
           >
-            <F.Label class="has-top-margin-xs">{{get (this.displayText type) "title"}}</F.Label>
+            <F.Label>{{get (this.displayText type) "title"}}</F.Label>
             <F.HelperText>{{get (this.displayText type) "description"}}</F.HelperText>
             <F.Options>
               {{#let F.options as |option|}}
                 {{option.name}}
               {{/let}}
             </F.Options>
-
           </Hds::Form::SuperSelect::Multiple::Field>
         {{/each-in}}
 
@@ -159,13 +155,18 @@
           </T.Tab>
 
           <T.Panel class="has-top-padding-m">
-            <Hds::Button @text="Apply policy" @color="secondary" @icon="wand" @isFullWidth={{true}} />
+            <Hds::Text::Body @tag="p" class="has-bottom-padding-s">Click "Apply policy" to assigned
+              {{this.policyAction}}
+              the policy and assign it to the selected
+              {{this.assignmentText}}.
+            </Hds::Text::Body>
+            <Hds::Button @text="Apply policy" @icon="wand" @isFullWidth={{true}} {{on "click" this.applyPolicy}} />
           </T.Panel>
           <T.Panel>
-            <Hds::CodeBlock @value={{this.cli}} @language="ruby" @hasCopyButton={{true}} />
+            <Hds::CodeBlock @value={{this.cliSnippet}} @language="ruby" @hasCopyButton={{true}} />
           </T.Panel>
           <T.Panel class="has-top-padding-m">
-            <Hds::CodeBlock @value={{this.tfvp}} @language="ruby" @hasCopyButton={{true}} />
+            <Hds::CodeBlock @value={{this.tfvpSnippet}} @language="hcl" @hasCopyButton={{true}} />
           </T.Panel>
         </Hds::Tabs>
       </Hds::Card::Container>

--- a/ui/lib/core/addon/components/policy-builder.hbs
+++ b/ui/lib/core/addon/components/policy-builder.hbs
@@ -120,8 +120,8 @@
           {{#each-in this.identityOptions as |type options|}}
             <Hds::Dropdown class="is-flex-grow-1" as |D|>
               <D.ToggleButton @isFullWidth={{true}} @color="secondary" @text={{type}} />
-              <D.Title @text="Title Text" />
-              <D.Description @text="Descriptive text goes here." />
+              <D.Title @text={{get (this.dropdownText type) "title"}} />
+              <D.Description @text={{get (this.dropdownText type) "description"}} />
               {{#each options as |opt|}}
                 <D.Checkbox>{{opt.id}}</D.Checkbox>
               {{/each}}

--- a/ui/lib/core/addon/components/policy-builder.hbs
+++ b/ui/lib/core/addon/components/policy-builder.hbs
@@ -1,0 +1,99 @@
+<Hds::Button
+  @text="Generate policy"
+  @color="tertiary"
+  @icon="shield-check"
+  {{on "click" (fn (mut this.showFlyout) (not this.showFlyout))}}
+/>
+
+{{#if this.showFlyout}}
+  <Hds::Flyout @size="large" id="policy-builder" @onClose={{fn (mut this.showFlyout) false}} as |M|>
+    <M.Header @icon="shield-check" @tagline="Policy builder for {{this.context}}">
+      Policy Builder
+    </M.Header>
+    <M.Body>
+
+      <Hds::Card::Container class="has-padding-m has-top-margin-m has-bottom-margin-m" @level="base" @hasBorder={{true}}>
+        <Hds::Text::Display class="has-bottom-margin-xxs">Create or edit policy</Hds::Text::Display>
+
+        <Hds::Form::TextInput::Field class="field" name="policy_name" as |F|>
+          <F.Label>Policy name</F.Label>
+        </Hds::Form::TextInput::Field>
+      </Hds::Card::Container>
+
+      <Hds::Card::Container class="has-padding-m has-top-margin-m has-bottom-margin-m" @level="base" @hasBorder={{true}}>
+        <div class="has-bottom-margin-m">
+          <Hds::Text::Display class="has-bottom-margin-xxs">Configure policy</Hds::Text::Display>
+          <br />
+          <Hds::Text::Body>
+            Select permissions to grant for
+            {{if (gt this.paths.length 1) "each" "the"}}
+            API path.
+          </Hds::Text::Body>
+        </div>
+
+        {{#each this.paths as |path|}}
+          <Hds::Form::Checkbox::Group class="field" @layout="horizontal" @name={{path}} as |G|>
+            <G.Legend><Hds::Text::Code class="code-in-text">{{path}}</Hds::Text::Code></G.Legend>
+            {{#each this.permissions as |p|}}
+              <G.CheckboxField @value={{p}} {{on "change" this.updatePermissions}} as |F|>
+                <F.Label>{{p}}</F.Label>
+              </G.CheckboxField>
+            {{/each}}
+          </Hds::Form::Checkbox::Group>
+        {{/each}}
+
+        {{! POLICY STANZA }}
+        <Hds::CodeBlock @value={{this.policySnippet}} @language="yaml" @hasCopyButton={{true}} @hasLineNumbers={{false}} />
+      </Hds::Card::Container>
+
+      <Hds::Card::Container class="has-padding-m has-top-margin-m has-bottom-margin-m" @level="base" @hasBorder={{true}}>
+
+        <Hds::Text::Display>Apply policy via</Hds::Text::Display>
+        <Hds::Tabs as |T|>
+          <T.Tab Tab data-test-tab-example-policy>
+            UI
+          </T.Tab>
+          <T.Tab data-test-tab-your-policy>
+            CLI
+          </T.Tab>
+          <T.Tab Tab data-test-tab-example-policy>
+            TFVP
+          </T.Tab>
+
+          <T.Panel class="has-top-padding-m">
+            <Hds::Button @text="Apply policy" @color="secondary" @icon="wand" />
+          </T.Panel>
+          <T.Panel>
+            <Hds::CodeBlock @value={{this.cli}} @language="ruby" @hasCopyButton={{true}} />
+          </T.Panel>
+          <T.Panel class="has-top-padding-m">
+            <Hds::CodeBlock @value={{this.tfvp}} @language="ruby" @hasCopyButton={{true}} />
+          </T.Panel>
+        </Hds::Tabs>
+      </Hds::Card::Container>
+    </M.Body>
+  </Hds::Flyout>
+{{/if}}
+
+{{!-- <div style="background-color: #c1843e;padding: 24px">
+
+  <Hds::Form::TextInput::Field class="field" name="demo-cluster-name" as |F|>
+    <F.Label>Cluster name</F.Label>
+  </Hds::Form::TextInput::Field>
+
+  {{#each this.paths as |path|}}
+    <Hds::Form::Checkbox::Group class="field" @layout="horizontal" @name={{path}} as |G|>
+      <G.HelperText>Select permissions for the API path:
+        <Hds::Text::Code class="code-in-text">{{path}}</Hds::Text::Code>
+      </G.HelperText>
+      {{#each this.permissions as |p|}}
+        <G.CheckboxField @value={{p}} {{on "change" this.updatePermissions}} as |F|>
+          <F.Label>{{p}}</F.Label>
+        </G.CheckboxField>
+      {{/each}}
+    </Hds::Form::Checkbox::Group>
+  {{/each}}
+  {{! POLICY STANZA }}
+
+  <Hds::CodeBlock @value={{this.policySnippet}} @language="yaml" @hasCopyButton={{true}} @hasLineNumbers={{false}} />
+</div> --}}

--- a/ui/lib/core/addon/components/policy-builder.hbs
+++ b/ui/lib/core/addon/components/policy-builder.hbs
@@ -27,13 +27,7 @@
         </Hds::Form::Radio::Group>
 
         {{#if (eq this.policyAction "create")}}
-          <Hds::Form::TextInput::Field
-            class="field"
-            name="name"
-            autocomplete="off"
-            {{on "input" this.handleCreatePolicy}}
-            as |F|
-          >
+          <Hds::Form::TextInput::Field class="field" autocomplete="off" {{on "input" this.handleCreatePolicy}} as |F|>
             <F.Label>Policy name</F.Label>
           </Hds::Form::TextInput::Field>
         {{else if (eq this.policyAction "edit")}}
@@ -101,7 +95,7 @@
                 </Hds::Form::TextInput::Field>
               </div>
 
-              <Hds::Form::Checkbox::Group class="field" @layout="horizontal" @name="PATH NAME" as |G|>
+              <Hds::Form::Checkbox::Group class="field" @layout="horizontal" as |G|>
                 <G.Legend class="has-top-padding-m">Capabilities</G.Legend>
                 {{#each this.permissions as |p|}}
                   <G.CheckboxField
@@ -135,8 +129,9 @@
             class="field"
             as |F|
           >
-            <F.Label>{{get (this.displayText type) "title"}}</F.Label>
-            <F.HelperText>{{get (this.displayText type) "description"}}</F.HelperText>
+            <F.Label>{{pluralize (capitalize type)}}</F.Label>
+            <F.HelperText>Policy will apply to users who belong to the selected
+              {{pluralize (get (get this.selectedAssignments type) "length") type without-count=true}}.</F.HelperText>
             <F.Options>
               {{#let F.options as |option|}}
                 {{option.name}}
@@ -161,10 +156,9 @@
           </T.Tab>
 
           <T.Panel class="has-top-padding-m">
-            <Hds::Text::Body @tag="p" class="has-bottom-padding-s">Click "Apply policy" to assigned
+            <Hds::Text::Body @tag="p" class="has-bottom-padding-s">Click "Apply policy" to
               {{this.policyAction}}
-              the policy and assign it to the selected
-              {{this.applySubtext}}.
+              the policy{{this.applySubtext}}.
             </Hds::Text::Body>
             <Hds::Button @text="Apply policy" @icon="wand" @isFullWidth={{true}} {{on "click" this.applyPolicy}} />
 
@@ -177,10 +171,20 @@
               </Hds::Alert>
             {{/if}}
           </T.Panel>
-          <T.Panel>
+          <T.Panel class="has-top-padding-m">
+            <Hds::Text::Body @tag="p" class="has-bottom-padding-s">
+              A CLI snippet to
+              {{this.policyAction}}
+              the policy{{this.applySubtext}}.
+            </Hds::Text::Body>
             <Hds::CodeBlock @value={{this.cliSnippet}} @language="ruby" @hasCopyButton={{true}} />
           </T.Panel>
           <T.Panel class="has-top-padding-m">
+            <Hds::Text::Body @tag="p" class="has-bottom-padding-s">
+              A TFVP (Terraform Vault Provider) snippet to
+              {{this.policyAction}}
+              the policy{{this.applySubtext}}.
+            </Hds::Text::Body>
             <Hds::CodeBlock @value={{this.tfvpSnippet}} @language="hcl" @hasCopyButton={{true}} />
           </T.Panel>
         </Hds::Tabs>

--- a/ui/lib/core/addon/components/policy-builder.hbs
+++ b/ui/lib/core/addon/components/policy-builder.hbs
@@ -94,7 +94,12 @@
               <Hds::Form::Checkbox::Group class="field" @layout="horizontal" @name="PATH NAME" as |G|>
                 <G.Legend class="has-top-padding-m">Capabilities</G.Legend>
                 {{#each this.permissions as |p|}}
-                  <G.CheckboxField @value={{p}} {{on "change" capability.setPermissions}} as |F|>
+                  <G.CheckboxField
+                    checked={{includes p capability.permissions}}
+                    @value={{p}}
+                    {{on "change" capability.setPermissions}}
+                    as |F|
+                  >
                     <F.Label>{{p}}</F.Label>
                   </G.CheckboxField>
                 {{/each}}
@@ -107,17 +112,34 @@
       </Hds::Card::Container>
 
       {{! POLICY ASSIGNMENT }}
+      <Hds::Card::Container class="has-padding-m has-top-margin-m has-bottom-margin-m" @level="base" @hasBorder={{true}}>
+        <Hds::Text::Display class="has-bottom-margin-xxs">Assign policy</Hds::Text::Display>
+        <br />
+        <Hds::Text::Body class="has-bottom-margin-xxs">Select who this policy should be assigned to:</Hds::Text::Body>
+        <div class="flex space-between column-gap-16">
+          {{#each-in this.identityOptions as |type options|}}
+            <Hds::Dropdown class="is-flex-grow-1" as |D|>
+              <D.ToggleButton @isFullWidth={{true}} @color="secondary" @text={{type}} />
+              <D.Title @text="Title Text" />
+              <D.Description @text="Descriptive text goes here." />
+              {{#each options as |opt|}}
+                <D.Checkbox>{{opt.id}}</D.Checkbox>
+              {{/each}}
+            </Hds::Dropdown>
+          {{/each-in}}
+        </div>
+      </Hds::Card::Container>
 
       <Hds::Card::Container class="has-padding-m has-top-margin-m has-bottom-margin-m" @level="base" @hasBorder={{true}}>
         <Hds::Text::Display>Apply policy via</Hds::Text::Display>
         <Hds::Tabs as |T|>
-          <T.Tab Tab data-test-tab-example-policy>
+          <T.Tab>
             UI
           </T.Tab>
-          <T.Tab data-test-tab-your-policy>
+          <T.Tab>
             CLI
           </T.Tab>
-          <T.Tab Tab data-test-tab-example-policy>
+          <T.Tab>
             TFVP
           </T.Tab>
 

--- a/ui/lib/core/addon/components/policy-builder.hbs
+++ b/ui/lib/core/addon/components/policy-builder.hbs
@@ -1,53 +1,114 @@
-<Hds::Button
-  @text="Generate policy"
-  @color="tertiary"
-  @icon="shield-check"
-  {{on "click" (fn (mut this.showFlyout) (not this.showFlyout))}}
-/>
-
+<Hds::Button @text="Generate policy" @color="tertiary" @icon="shield-check" {{on "click" this.openFlyout}} />
 {{#if this.showFlyout}}
+
   <Hds::Flyout @size="large" id="policy-builder" @onClose={{fn (mut this.showFlyout) false}} as |M|>
-    <M.Header @icon="shield-check" @tagline="Policy builder for {{this.context}}">
-      Policy Builder
+    <M.Header @icon="wand" @tagline="Policy builder for {{this.context}}">
+      Policy Wizard
     </M.Header>
     <M.Body>
 
+      {{! CREATE OR EDIT A POLICY  }}
       <Hds::Card::Container class="has-padding-m has-top-margin-m has-bottom-margin-m" @level="base" @hasBorder={{true}}>
-        <Hds::Text::Display class="has-bottom-margin-xxs">Create or edit policy</Hds::Text::Display>
+        <Hds::Text::Display class="has-bottom-margin-xxs">Create or edit a policy</Hds::Text::Display>
+        <Hds::Form::Radio::Group @layout="horizontal" {{on "change" this.selectPolicy}} class="has-bottom-margin-m" as |G|>
+          <G.HelperText>Choose to create a new policy or edit existing one</G.HelperText>
+          <G.RadioField checked={{eq this.policyAction "create"}} @value="create" as |F|>
+            <F.Label>Create a new policy</F.Label>
+          </G.RadioField>
+          <G.RadioField checked={{eq this.policyAction "edit"}} @value="edit" as |F|>
+            <F.Label>Edit an existing policy</F.Label>
+          </G.RadioField>
+        </Hds::Form::Radio::Group>
 
-        <Hds::Form::TextInput::Field class="field" name="policy_name" as |F|>
-          <F.Label>Policy name</F.Label>
-        </Hds::Form::TextInput::Field>
+        {{#if (eq this.policyAction "create")}}
+          <Hds::Form::TextInput::Field class="field" as |F|>
+            <F.Label>Policy name</F.Label>
+          </Hds::Form::TextInput::Field>
+          <Hds::Reveal class="is-fullwidth has-top-margin-xxs" @text="Add a description">
+            <Hds::Form::TextInput::Field class="field" as |F|>
+              <F.Label>Description</F.Label>
+            </Hds::Form::TextInput::Field>
+          </Hds::Reveal>
+        {{else if (eq this.policyAction "edit")}}
+          <Hds::Form::Select::Field class="field" as |F|>
+            <F.Label>Select a policy</F.Label>
+            <F.HelperText>The configured permissions will be added to the selected policy.</F.HelperText>
+            <F.Options>
+              <option value=""></option>
+              {{#each this.existingPolicies as |policy|}}
+                <option selected={{eq this.policyName policy}} value={{policy}}>
+                  {{policy}}
+                </option>
+              {{/each}}
+            </F.Options>
+          </Hds::Form::Select::Field>
+        {{/if}}
       </Hds::Card::Container>
 
+      {{! POLICY PATHS }}
       <Hds::Card::Container class="has-padding-m has-top-margin-m has-bottom-margin-m" @level="base" @hasBorder={{true}}>
-        <div class="has-bottom-margin-m">
-          <Hds::Text::Display class="has-bottom-margin-xxs">Configure policy</Hds::Text::Display>
-          <br />
-          <Hds::Text::Body>
-            Select permissions to grant for
-            {{if (gt this.paths.length 1) "each" "the"}}
-            API path.
-          </Hds::Text::Body>
+        <div class="is-flex-between">
+          <Hds::Text::Display class="has-bottom-margin-xxs">Policy stanza</Hds::Text::Display>
+          <Hds::Form::Toggle::Field
+            name="toggle-view"
+            {{on "change" (fn (mut this.showAdvanced) (not this.showAdvanced))}}
+            as |F|
+          >
+            <F.Label>Preview policy</F.Label>
+          </Hds::Form::Toggle::Field>
         </div>
 
-        {{#each this.paths as |path|}}
-          <Hds::Form::Checkbox::Group class="field" @layout="horizontal" @name={{path}} as |G|>
-            <G.Legend><Hds::Text::Code class="code-in-text">{{path}}</Hds::Text::Code></G.Legend>
-            {{#each this.permissions as |p|}}
-              <G.CheckboxField @value={{p}} {{on "change" this.updatePermissions}} as |F|>
-                <F.Label>{{p}}</F.Label>
-              </G.CheckboxField>
-            {{/each}}
-          </Hds::Form::Checkbox::Group>
-        {{/each}}
+        {{#if this.showAdvanced}}
+          {{! POLICY SAMPLE }}
+          <div class="has-padding-m has-top-margin-m has-bottom-margin-m">
+            <Hds::CodeBlock
+              @value={{this.policySnippet}}
+              @language="yaml"
+              @hasCopyButton={{true}}
+              @hasLineNumbers={{false}}
+            />
+          </div>
+        {{else}}
+          {{! PATH CAPABILITIES CARD }}
+          {{#each this.capabilities as |capability|}}
+            <Hds::Card::Container @background="neutral-secondary" class="has-padding-m has-top-margin-m has-bottom-margin-m">
+              <Hds::Button
+                @text="Remove path"
+                @icon="trash"
+                @isIconOnly={{true}}
+                @color="critical"
+                class="is-pulled-right"
+                {{on "click" (fn this.deletePath capability.path)}}
+              />
+              <div class="is-flex-between has-bottom-margin-xxs">
+                <Hds::Form::TextInput::Field
+                  @value={{capability.path}}
+                  class="field"
+                  {{on "change" capability.setPath}}
+                  as |F|
+                >
+                  <F.Label class="has-top-margin-m">API path:</F.Label>
+                </Hds::Form::TextInput::Field>
+              </div>
 
-        {{! POLICY STANZA }}
-        <Hds::CodeBlock @value={{this.policySnippet}} @language="yaml" @hasCopyButton={{true}} @hasLineNumbers={{false}} />
+              <Hds::Form::Checkbox::Group class="field" @layout="horizontal" @name="PATH NAME" as |G|>
+                <G.Legend class="has-top-padding-m">Capabilities</G.Legend>
+                {{#each this.permissions as |p|}}
+                  <G.CheckboxField @value={{p}} {{on "change" capability.setPermissions}} as |F|>
+                    <F.Label>{{p}}</F.Label>
+                  </G.CheckboxField>
+                {{/each}}
+              </Hds::Form::Checkbox::Group>
+            </Hds::Card::Container>
+          {{/each}}
+        {{/if}}
+
+        <Hds::Button @icon="plus" @text="Add new path" @size="small" @color="secondary" {{on "click" this.addPath}} />
       </Hds::Card::Container>
 
-      <Hds::Card::Container class="has-padding-m has-top-margin-m has-bottom-margin-m" @level="base" @hasBorder={{true}}>
+      {{! POLICY ASSIGNMENT }}
 
+      <Hds::Card::Container class="has-padding-m has-top-margin-m has-bottom-margin-m" @level="base" @hasBorder={{true}}>
         <Hds::Text::Display>Apply policy via</Hds::Text::Display>
         <Hds::Tabs as |T|>
           <T.Tab Tab data-test-tab-example-policy>
@@ -61,7 +122,7 @@
           </T.Tab>
 
           <T.Panel class="has-top-padding-m">
-            <Hds::Button @text="Apply policy" @color="secondary" @icon="wand" />
+            <Hds::Button @text="Apply policy" @color="secondary" @icon="wand" @isFullWidth={{true}} />
           </T.Panel>
           <T.Panel>
             <Hds::CodeBlock @value={{this.cli}} @language="ruby" @hasCopyButton={{true}} />
@@ -74,26 +135,3 @@
     </M.Body>
   </Hds::Flyout>
 {{/if}}
-
-{{!-- <div style="background-color: #c1843e;padding: 24px">
-
-  <Hds::Form::TextInput::Field class="field" name="demo-cluster-name" as |F|>
-    <F.Label>Cluster name</F.Label>
-  </Hds::Form::TextInput::Field>
-
-  {{#each this.paths as |path|}}
-    <Hds::Form::Checkbox::Group class="field" @layout="horizontal" @name={{path}} as |G|>
-      <G.HelperText>Select permissions for the API path:
-        <Hds::Text::Code class="code-in-text">{{path}}</Hds::Text::Code>
-      </G.HelperText>
-      {{#each this.permissions as |p|}}
-        <G.CheckboxField @value={{p}} {{on "change" this.updatePermissions}} as |F|>
-          <F.Label>{{p}}</F.Label>
-        </G.CheckboxField>
-      {{/each}}
-    </Hds::Form::Checkbox::Group>
-  {{/each}}
-  {{! POLICY STANZA }}
-
-  <Hds::CodeBlock @value={{this.policySnippet}} @language="yaml" @hasCopyButton={{true}} @hasLineNumbers={{false}} />
-</div> --}}

--- a/ui/lib/core/addon/components/policy-builder.hbs
+++ b/ui/lib/core/addon/components/policy-builder.hbs
@@ -16,13 +16,7 @@
       {{! CREATE OR EDIT A POLICY  }}
       <Hds::Card::Container class="has-padding-m has-bottom-margin-m" @level="base" @hasBorder={{true}}>
         <Hds::Text::Display class="has-bottom-margin-xxs">Create or edit a policy</Hds::Text::Display>
-        <Hds::Form::Radio::Group
-          @layout="horizontal"
-          @name="policyAction"
-          {{on "input" this.handlePolicySelection}}
-          class="has-bottom-margin-m"
-          as |G|
-        >
+        <Hds::Form::Radio::Group @layout="horizontal" {{on "input" this.handleRadio}} class="has-bottom-margin-m" as |G|>
           <G.HelperText>Choose to create a new policy or edit existing one</G.HelperText>
           <G.RadioField checked={{eq this.policyAction "create"}} @value="create" as |F|>
             <F.Label>Create a new policy</F.Label>
@@ -37,28 +31,29 @@
             class="field"
             name="name"
             autocomplete="off"
-            {{on "input" this.handlePolicySelection}}
+            {{on "input" this.handleCreatePolicy}}
             as |F|
           >
             <F.Label>Policy name</F.Label>
           </Hds::Form::TextInput::Field>
         {{else if (eq this.policyAction "edit")}}
-          <Hds::Form::Select::Field class="field" name="policyName" {{on "input" this.handlePolicySelection}} as |F|>
+          <Hds::Form::SuperSelect::Single::Field
+            @onChange={{this.handleEditPolicy}}
+            @selected={{this.policyName}}
+            @options={{this.existingPolicies}}
+            @searchEnabled={{true}}
+            class="field"
+            autocomplete="off"
+            as |F|
+          >
             <F.Label>Select a policy</F.Label>
             <F.HelperText>The configured permissions will be added to the selected policy.</F.HelperText>
-            <F.Options>
-              <option value=""></option>
-              {{#each this.existingPolicies as |policy|}}
-                <option selected={{eq this.policyName policy}} value={{policy}}>
-                  {{policy}}
-                </option>
-              {{/each}}
-            </F.Options>
-          </Hds::Form::Select::Field>
+            <F.Options>{{F.options}}</F.Options>
+          </Hds::Form::SuperSelect::Single::Field>
         {{/if}}
       </Hds::Card::Container>
 
-      {{! POLICY PATHS }}
+      {{! POLICY STANZAS }}
       <Hds::Card::Container class="has-padding-m has-top-margin-m has-bottom-margin-m" @level="base" @hasBorder={{true}}>
         <div class="is-flex-between">
           <Hds::Text::Display class="has-bottom-margin-xxs">Policy stanza</Hds::Text::Display>
@@ -66,6 +61,11 @@
             <F.Label>Preview</F.Label>
           </Hds::Form::Toggle::Field>
         </div>
+        <Hds::Text::Body @color="faint" @tag="p" class="has-bottom-margin-xs" @size="100">
+          Use
+          <Hds::Text::Code class="code-in-text">*</Hds::Text::Code>
+          for wildcard matching.
+        </Hds::Text::Body>
 
         {{! POLICY SAMPLE }}
         {{#if this.showPreview}}
@@ -90,7 +90,13 @@
                 {{on "click" (fn this.deletePath stanza.path)}}
               />
               <div class="is-flex-between has-bottom-margin-xxs">
-                <Hds::Form::TextInput::Field @value={{stanza.path}} class="field" {{on "input" stanza.setPath}} as |F|>
+                <Hds::Form::TextInput::Field
+                  @value={{stanza.path}}
+                  class="field"
+                  {{on "input" stanza.setPath}}
+                  autocomplete="off"
+                  as |F|
+                >
                   <F.Label class="has-top-margin-m">API path:</F.Label>
                 </Hds::Form::TextInput::Field>
               </div>

--- a/ui/lib/core/addon/components/policy-builder.hbs
+++ b/ui/lib/core/addon/components/policy-builder.hbs
@@ -63,7 +63,7 @@
         <div class="is-flex-between">
           <Hds::Text::Display class="has-bottom-margin-xxs">Policy stanza</Hds::Text::Display>
           <Hds::Form::Toggle::Field {{on "input" (fn (mut this.showPreview) (not this.showPreview))}} as |F|>
-            <F.Label>Preview policy</F.Label>
+            <F.Label>Preview</F.Label>
           </Hds::Form::Toggle::Field>
         </div>
 
@@ -99,7 +99,7 @@
                 <G.Legend class="has-top-padding-m">Capabilities</G.Legend>
                 {{#each this.permissions as |p|}}
                   <G.CheckboxField
-                    checked={{includes p stanza.permissions}}
+                    checked={{includes p stanza.capabilities}}
                     @value={{p}}
                     {{on "input" stanza.setPermissions}}
                     as |F|
@@ -158,9 +158,18 @@
             <Hds::Text::Body @tag="p" class="has-bottom-padding-s">Click "Apply policy" to assigned
               {{this.policyAction}}
               the policy and assign it to the selected
-              {{this.assignmentText}}.
+              {{this.applySubtext}}.
             </Hds::Text::Body>
             <Hds::Button @text="Apply policy" @icon="wand" @isFullWidth={{true}} {{on "click" this.applyPolicy}} />
+
+            {{#if this.error}}
+              <Hds::Alert @type="inline" @color="critical" class="has-top-margin-m" as |A|>
+                <A.Title>Oops - something went wrong! It's hackweek give me a break!</A.Title>
+                <A.Description>
+                  {{this.error}}
+                </A.Description>
+              </Hds::Alert>
+            {{/if}}
           </T.Panel>
           <T.Panel>
             <Hds::CodeBlock @value={{this.cliSnippet}} @language="ruby" @hasCopyButton={{true}} />

--- a/ui/lib/core/addon/components/policy-builder.hbs
+++ b/ui/lib/core/addon/components/policy-builder.hbs
@@ -58,7 +58,7 @@
         <div class="is-flex-between">
           <Hds::Text::Display class="has-bottom-margin-xxs">Policy stanza</Hds::Text::Display>
           <Hds::Form::Toggle::Field {{on "input" (fn (mut this.showPreview) (not this.showPreview))}} as |F|>
-            <F.Label>Preview</F.Label>
+            <F.Label>{{if this.showPreview "Hide" "Show"}} preview</F.Label>
           </Hds::Form::Toggle::Field>
         </div>
         <Hds::Text::Body @color="faint" @tag="p" class="has-bottom-margin-xs" @size="100">

--- a/ui/lib/core/addon/components/policy-builder.hbs
+++ b/ui/lib/core/addon/components/policy-builder.hbs
@@ -164,7 +164,7 @@
 
             {{#if this.error}}
               <Hds::Alert @type="inline" @color="critical" class="has-top-margin-m" as |A|>
-                <A.Title>Oops - something went wrong! It's hackweek give me a break!</A.Title>
+                <A.Title>Oops! It's hackweek give me a break! ¯\_(ツ)_/¯</A.Title>
                 <A.Description>
                   {{this.error}}
                 </A.Description>

--- a/ui/lib/core/addon/components/policy-builder.ts
+++ b/ui/lib/core/addon/components/policy-builder.ts
@@ -75,6 +75,32 @@ export default class PolicyBuilder extends Component {
     Entity: [{ id: 'bob' }, { id: 'matilda' }, { id: 'lorraine' }],
   };
 
+  dropdownText = (type: string) => {
+    switch (type) {
+      case 'Authentication mount':
+        return {
+          title: 'Authentication mounts',
+          description: 'The policy will be applied to users who authenticate with the selected mounts.',
+        };
+      case 'Group':
+        return {
+          title: 'Groups',
+          description: 'The policy will be applied to users who belong to the selected groups.',
+        };
+      case 'Entity':
+        return {
+          title: 'Entities',
+          description: 'The policy will be applied to users who belong to the selected entities.',
+        };
+
+      default:
+        return {
+          title: `Select a ${type}`,
+          description: 'The policy will be applied the selected resource.',
+        };
+    }
+  };
+
   constructor(owner: unknown, args: Record<string, never>) {
     super(owner, args);
     this.fetchPolicies();

--- a/ui/lib/core/addon/components/policy-builder.ts
+++ b/ui/lib/core/addon/components/policy-builder.ts
@@ -1,0 +1,115 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { service } from '@ember/service';
+import { addToArray } from 'vault/helpers/add-to-array';
+import { removeFromArray } from 'vault/helpers/remove-from-array';
+
+import type { HTMLElementEvent } from 'vault/forms';
+import type RouterService from '@ember/routing/router-service';
+import mapApiPathToRoute from 'vault/utils/policy-path-map';
+
+class Capability {
+  @tracked permissions: string[] = [];
+  @tracked path: string;
+
+  constructor(path: string) {
+    this.path = path;
+  }
+
+  get policyStanza() {
+    return `path "${this.path}" {
+  permissions = [ ${this.permissions.map((c) => `"${c}"`).join(', ')} ]
+}`;
+  }
+
+  get hasPermissions() {
+    return this.permissions.length !== 0;
+  }
+
+  setPermissions(checked: boolean, value: string) {
+    if (checked) {
+      this.permissions = addToArray(this.permissions, value);
+    } else {
+      this.permissions = removeFromArray(this.permissions, value);
+    }
+  }
+}
+
+export default class PolicyBuilder extends Component {
+  @service declare readonly router: RouterService;
+
+  @tracked showFlyout = false;
+  @tracked capabilities: Capability[] = [];
+
+  permissions = ['create', 'read', 'update', 'delete', 'list', 'patch', 'sudo'];
+
+  get policySnippet() {
+    if (this.capabilities.length === 0) {
+      return `path " " {
+  permissions = [ ]
+}`;
+    }
+    return this.capabilities.map((c) => c.policyStanza).join('\n');
+  }
+
+  @action
+  updatePermissions(event: HTMLElementEvent<HTMLInputElement>) {
+    const { name, value, checked } = event.target;
+    let capability = this.capabilities.find((c) => c.path === name);
+    if (!capability) {
+      capability = new Capability(name);
+      this.capabilities.push(capability);
+    }
+    capability.setPermissions(checked, value);
+    // Trigger reactivity by reassigning the array
+    // Remove any stanzas with no permissions
+    this.capabilities = [...this.capabilities.filter((c) => c.hasPermissions)];
+  }
+
+  get paths() {
+    const { currentRoute, currentRouteName } = this.router;
+    if (currentRoute && !currentRouteName?.includes('loading') && 'attributes' in currentRoute) {
+      const { name, attributes } = currentRoute as { name: string; attributes: unknown };
+      const paths = mapApiPathToRoute(name);
+      return paths?.map((fn) => fn(attributes)) || [];
+    }
+    return [];
+  }
+
+  get context() {
+    return this.paths.join(', ');
+  }
+
+  tfvp = `
+resource "vault_auth_backend" "userpass" {
+  type = "userpass"
+}
+
+resource "vault_generic_endpoint" "danielle-user" {
+   path                 = "auth/path/users/danielle-vault-user"
+   ignore_absent_fields = true
+   data_json = <<EOT
+{
+   "token_policies": ["developer-vault-policy"],
+   "password": "Vividness Itinerary Mumbo Reassure"
+}
+EOT
+}
+`;
+  cli = `-
+vault policy write top-secret-policy - <<EOF
+path "sys/auth" {
+  capabilities = ["read"]
+}
+EOF
+path "/v2/admin/secret/data/top-secret" {
+  capabilities = [ "update" ]
+}
+`;
+}

--- a/ui/lib/core/addon/components/policy-builder.ts
+++ b/ui/lib/core/addon/components/policy-builder.ts
@@ -202,31 +202,36 @@ ${command}`;
   }
 
   @action
-  openFlyout() {
-    this.showFlyout = true;
+  handleFlyout(action: string) {
+    this.showFlyout = action === 'open' ? true : false;
 
-    const { currentRoute, currentRouteName } = this.router;
-    if (currentRoute && !currentRouteName?.includes('loading') && 'attributes' in currentRoute) {
-      const { name, attributes } = currentRoute as { name: string; attributes: unknown };
-      const apiPaths = mapApiPathToRoute(name);
-      // hardcoding the check for "backend" since this is hackweek and
-      // only secrets are supported
-      // try the parent if there are none at the current route
-      let params;
-      if (
-        attributes &&
-        typeof attributes === 'object' &&
-        !Array.isArray(attributes) &&
-        'backend' in attributes
-      ) {
-        params = attributes;
+    if (action === 'open') {
+      const { currentRoute, currentRouteName } = this.router;
+      if (currentRoute && !currentRouteName?.includes('loading') && 'attributes' in currentRoute) {
+        const { name, attributes } = currentRoute as { name: string; attributes: unknown };
+        const apiPaths = mapApiPathToRoute(name);
+        // hardcoding the check for "backend" since this is hackweek and
+        // only secrets are supported
+        // try the parent if there are none at the current route
+        let params;
+        if (
+          attributes &&
+          typeof attributes === 'object' &&
+          !Array.isArray(attributes) &&
+          'backend' in attributes
+        ) {
+          params = attributes;
+        } else {
+          params = currentRoute?.parent?.params;
+        }
+        this.policyStanzas = apiPaths?.map((fn) => new PolicyStanza(fn(params))) || [];
+        this.policyStanzas = [...this.policyStanzas];
       } else {
-        params = currentRoute?.parent?.params;
+        this.policyStanzas = [];
       }
-      this.policyStanzas = apiPaths?.map((fn) => new PolicyStanza(fn(params))) || [];
-      this.policyStanzas = [...this.policyStanzas];
+    } else {
+      this.resetState();
     }
-    return [];
   }
 
   @action

--- a/ui/lib/core/addon/components/policy-builder.ts
+++ b/ui/lib/core/addon/components/policy-builder.ts
@@ -34,11 +34,9 @@ interface IdentityResponse {
 interface Option {
   type: string;
   name: string;
-  authType?: string;
 }
 
 const IDENTITY_TYPES = {
-  // mount: 'Authentication mount',
   group: 'Group',
   entity: 'Entity',
 } as const;
@@ -85,7 +83,6 @@ export default class PolicyBuilder extends Component {
   existingPolicies: string[] | undefined = [];
   permissions = ['create', 'read', 'update', 'delete', 'list', 'patch', 'sudo'];
   identityOptions: Record<IdentitySelectionKey, Option[]> = {
-    // mount: [],
     group: [],
     entity: [],
   };
@@ -98,7 +95,6 @@ export default class PolicyBuilder extends Component {
   @tracked existingPolicy = ''; // if a policy is being edited
   @tracked policyStanzas: PolicyStanza[] = [];
   @tracked selectedAssignments: Record<IdentitySelectionKey, Option[]> = {
-    // mount: [],
     group: [],
     entity: [],
   };
@@ -285,17 +281,6 @@ ${command}`;
     } catch {
       // nope
     }
-
-    // try {
-    //   type = 'mount';
-    //   const { auth } = await this.api.sys.internalUiListEnabledVisibleMounts();
-    //   const mounts = this.api
-    //     .responseObjectToArray(auth, 'path')
-    //     .map((m) => ({ type, name: m.path, authType: m.type }));
-    //   setOptions(type, mounts);
-    // } catch {
-    //   // nope
-    // }
   }
 
   @action
@@ -364,7 +349,6 @@ ${command}`;
     this.policyAction = 'create';
     this.policyName = '';
     this.selectedAssignments = {
-      // mount: [],
       group: [],
       entity: [],
     };
@@ -380,12 +364,8 @@ ${command}`;
     if (this.filteredAssignments.length) {
       for (const [key, value] of Object.entries(this.selectedAssignments)) {
         if (!value?.length) continue;
-        if (key === 'mount') {
-          // do auth mount command
-        } else {
-          const commands = value.map((g) => commandTemplate(g, key as IdentitySelectionKey));
-          assignments = [...commands, ...assignments];
-        }
+        const commands = value.map((g) => commandTemplate(g, key as IdentitySelectionKey));
+        assignments = [...commands, ...assignments];
       }
       return assignments.length ? assignments.join('\n') : '';
     }

--- a/ui/lib/core/addon/components/policy-builder.ts
+++ b/ui/lib/core/addon/components/policy-builder.ts
@@ -148,40 +148,32 @@ export default class PolicyBuilder extends Component {
   }
 
   get cliSnippet() {
-    if (this.policyName) {
-      const cliCommand = (o: Option, type: IdentitySelectionKey) =>
-        `vault write identity/${type} name="${o.name}" policies="default, ${this.policyName}"`;
-      const command = this.buildAssignmentSnippet(cliCommand);
+    const cliCommand = (o: Option, type: IdentitySelectionKey) =>
+      `vault write identity/${type} name="${o.name}" policies="default, ${this.policyName}"`;
+    const command = this.buildAssignmentSnippet(cliCommand);
 
-      return `vault policy write ${this.policyName} - <<EOF
+    return `vault policy write ${this.policyName} - <<EOF
 ${this.actualPolicy}
 EOF
 ${command}`;
-    } else {
-      return '# Select a policy or fill in a name to preview commands!';
-    }
   }
 
   get tfvpSnippet() {
-    if (this.policyName) {
-      const tfvpCommand = (o: Option, type: IdentitySelectionKey) => {
-        return `resource "vault_identity_${type}" "${o.name}" {
+    const tfvpCommand = (o: Option, type: IdentitySelectionKey) => {
+      return `resource "vault_identity_${type}" "${o.name}" {
  name     = "${o.name}"
  policies = ["default", "${this.policyName}"]
 }`;
-      };
+    };
 
-      const command = this.buildAssignmentSnippet(tfvpCommand);
-      return `resource "vault_policy" "${this.policyName}" {
+    const command = this.buildAssignmentSnippet(tfvpCommand);
+    return `resource "vault_policy" "${this.policyName}" {
   name   = "${this.policyName}"
   policy = <<-EOT
 ${this.actualPolicy}
 EOT
 }
 ${command}`;
-    } else {
-      return '# Select a policy or fill in a name to preview commands!';
-    }
   }
 
   @action

--- a/ui/lib/core/addon/components/policy-builder.ts
+++ b/ui/lib/core/addon/components/policy-builder.ts
@@ -63,17 +63,17 @@ export default class PolicyBuilder extends Component {
   @tracked identities: string[] | undefined = [];
 
   permissions = ['create', 'read', 'update', 'delete', 'list', 'patch', 'sudo'];
-  identityTypes = [
-    { type: 'authMount', label: 'Authentication mount' },
-    { type: 'group', label: 'Group' },
-    { type: 'entity', label: 'Entity' },
-  ];
+  // identityTypes = [
+  //   { type: 'authMount', label: 'Authentication mount' },
+  //   { type: 'group', label: 'Group' },
+  //   { type: 'entity', label: 'Entity' },
+  // ];
 
-  identityOptions = [
-    { groupName: 'Authentication mount', options: [{ id: 'userpass/' }, { id: 'oidc/' }, { id: 'ldap/' }] },
-    { groupName: 'Group', options: [{ id: 'admins' }, { id: 'platform-engineers' }, { id: 'sales' }] },
-    { groupName: 'Entity', options: [{ id: 'bob' }, { id: 'matilda' }, { id: 'lorraine' }] },
-  ];
+  identityOptions = {
+    'Authentication mount': [{ id: 'userpass/' }, { id: 'oidc/' }, { id: 'ldap/' }],
+    Group: [{ id: 'admins' }, { id: 'platform-engineers' }, { id: 'sales' }],
+    Entity: [{ id: 'bob' }, { id: 'matilda' }, { id: 'lorraine' }],
+  };
 
   constructor(owner: unknown, args: Record<string, never>) {
     super(owner, args);

--- a/ui/lib/core/addon/components/policy-builder.ts
+++ b/ui/lib/core/addon/components/policy-builder.ts
@@ -168,7 +168,21 @@ EOT
     if (currentRoute && !currentRouteName?.includes('loading') && 'attributes' in currentRoute) {
       const { name, attributes } = currentRoute as { name: string; attributes: unknown };
       const apiPaths = mapApiPathToRoute(name);
-      this.policyStanzas = apiPaths?.map((fn) => new PolicyStanza(fn(attributes))) || [];
+      // hardcoding the check for "backend" since this is hackweek and
+      // only secrets are supported
+      // try the parent if there are none at the current route
+      let params;
+      if (
+        attributes &&
+        typeof attributes === 'object' &&
+        !Array.isArray(attributes) &&
+        'backend' in attributes
+      ) {
+        params = attributes;
+      } else {
+        params = currentRoute?.parent?.params;
+      }
+      this.policyStanzas = apiPaths?.map((fn) => new PolicyStanza(fn(params))) || [];
       this.policyStanzas = [...this.policyStanzas];
     }
     return [];

--- a/ui/lib/core/app/components/policy-builder.js
+++ b/ui/lib/core/app/components/policy-builder.js
@@ -1,0 +1,6 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+export { default } from 'core/components/policy-builder';


### PR DESCRIPTION
### Description
Policy wizard to help build a policy depending on the current context of the UI.

_The functionality of this POC is limited to just `secrets` but could be extended to support other routes._

For example, when a user navigates to view a KV v2 secret, the fly out pre-fills the relevant paths for that view. 
<img width="1446" height="798" alt="Screenshot 2025-07-25 at 9 50 54 AM" src="https://github.com/user-attachments/assets/3e839a6e-7d65-4e70-9890-8a30724fb7b4" />

When capabilities are selected, it builds the policy stanza for that path:
<img width="600" height="718" alt="Screenshot 2025-07-25 at 9 52 27 AM" src="https://github.com/user-attachments/assets/e0c514a2-438e-4372-ade5-bed6d7b36c47" />
<img width="600" height="310" alt="Screenshot 2025-07-25 at 9 52 36 AM" src="https://github.com/user-attachments/assets/6c461656-8ec6-462b-94ec-e85dc0f65ddc" />

The policy can also be assigned to various identity entities or groups:
<img width="685" height="464" alt="Screenshot 2025-07-25 at 9 54 04 AM" src="https://github.com/user-attachments/assets/84dcc81f-0cc6-43f7-b5e6-878e3f89623d" />


Once selections are made, the UI can manually apply the policy or a CLI and TFVP (Terraform Vault Provider) snippet are generated that can be used depending on the users workflow. 
<img width="691" height="195" alt="Screenshot 2025-07-25 at 10 08 41 AM" src="https://github.com/user-attachments/assets/fd038090-a967-4b6b-ac39-16d52d7b8413" />

<img width="692" height="401" alt="Screenshot 2025-07-25 at 10 08 54 AM" src="https://github.com/user-attachments/assets/b52f36d8-2965-468c-96db-7125d4d38d95" />

<img width="689" height="640" alt="Screenshot 2025-07-25 at 10 09 05 AM" src="https://github.com/user-attachments/assets/2806088a-926a-4587-97bd-5bdb8575c96e" />

