### PR TITLE
[UI] Hack Week Acceptance Tests POC

### DIFF
--- a/ui/mirage/factories/health.js
+++ b/ui/mirage/factories/health.js
@@ -1,0 +1,96 @@
+import { Factory, trait } from 'miragejs';
+import timestamp from 'core/utils/timestamp';
+import { addYears, subMonths } from 'date-fns';
+
+export default Factory.extend({
+  // Core health status fields
+  initialized: true,
+  sealed: false,
+  standby: false,
+  performance_standby: false,
+  replication_performance_mode: 'disabled',
+  replication_dr_mode: 'disabled',
+
+  // Server information
+  server_time_utc: () => Math.floor(timestamp.now() / 1000),
+  version: '1.15.0+ent',
+  cluster_name: 'vault-cluster-e779cd7c',
+  cluster_id: '5f20f5ab-acea-0481-787e-71ec2ff5a60b',
+
+  // Storage and WAL
+  last_wal: 121,
+
+  // Enterprise features
+  enterprise: true,
+  license: () => ({
+    expiry: addYears(timestamp.now(), 1).toISOString(),
+    state: 'autoloaded',
+  }),
+
+  // Migration status (when applicable)
+  migration: false,
+
+  // Echo request ID for debugging
+  echo_duration_ms: null,
+  clock_skew_ms: null,
+
+  // Traits for different health states
+  isSealed: trait({
+    sealed: true,
+    initialized: true,
+    standby: false,
+  }),
+
+  isUninitialized: trait({
+    initialized: false,
+    sealed: true,
+    standby: false,
+  }),
+
+  isStandby: trait({
+    standby: true,
+    performance_standby: false,
+    sealed: false,
+    initialized: true,
+  }),
+
+  isPerformanceStandby: trait({
+    standby: false,
+    performance_standby: true,
+    sealed: false,
+    initialized: true,
+  }),
+
+  isDrPrimary: trait({
+    replication_dr_mode: 'primary',
+    replication_performance_mode: 'disabled',
+  }),
+
+  isDrSecondary: trait({
+    replication_dr_mode: 'secondary',
+    replication_performance_mode: 'disabled',
+  }),
+
+  isPerformancePrimary: trait({
+    replication_performance_mode: 'primary',
+    replication_dr_mode: 'disabled',
+  }),
+
+  isPerformanceSecondary: trait({
+    replication_performance_mode: 'secondary',
+    replication_dr_mode: 'disabled',
+  }),
+
+  isCommunity: trait({
+    enterprise: false,
+    version: '1.15.0',
+    license: null,
+  }),
+
+  isExpired: trait({
+    license: () => ({
+      expiry: subMonths(timestamp.now(), 1).toISOString(),
+      state: 'expired',
+    }),
+  }),
+});

--- a/ui/mirage/factories/mount.js
+++ b/ui/mirage/factories/mount.js
@@ -1,0 +1,164 @@
+import { Factory, trait } from 'miragejs';
+import uuid from 'core/utils/uuid';
+
+export default Factory.extend({
+  // Core mount information
+  type: 'cubbyhole',
+  path: 'cubbyhole/',
+  description: 'per-token private secret storage',
+  accessor: '', // set in afterCreate based on type
+
+  // Configuration
+  config: () => ({
+    default_lease_ttl: 2764800,
+    max_lease_ttl: 2764800,
+    force_no_cache: false,
+    listing_visibility: 'hidden',
+  }),
+
+  // Mount options
+  options: null,
+
+  // Seal wrapping
+  seal_wrap: false,
+  external_entropy_access: false,
+
+  // Plugin information
+  plugin_version: '',
+  running_plugin_version: '',
+  running_sha256: '',
+
+  // Additional metadata
+  local: false,
+  uuid: () => uuid(),
+
+  afterCreate(mount) {
+    mount.accessor = `${mount.type}_${uuid().split('-')[0]}`;
+  },
+
+  // Traits for different mount types
+  isKv: trait({
+    type: 'kv',
+    path: 'kv/',
+    description: 'key/value secret storage',
+    options: () => ({ version: '2' }),
+  }),
+
+  isKvV1: trait({
+    type: 'kv',
+    path: 'kv/',
+    description: 'key/value secret storage v1',
+    options: () => ({ version: '1' }),
+  }),
+
+  isPki: trait({
+    type: 'pki',
+    path: 'pki/',
+    description: 'PKI certificate authority',
+    config: () => ({
+      default_lease_ttl: 0,
+      max_lease_ttl: 315360000, // 10 years
+      force_no_cache: false,
+      listing_visibility: 'unauth',
+    }),
+  }),
+
+  isDatabase: trait({
+    type: 'database',
+    path: 'database/',
+    description: 'Database secrets engine',
+    config: () => ({
+      default_lease_ttl: 0,
+      max_lease_ttl: 0,
+      force_no_cache: false,
+      listing_visibility: 'unauth',
+    }),
+  }),
+
+  isAws: trait({
+    type: 'aws',
+    path: 'aws/',
+    description: 'AWS secrets engine',
+    config: () => ({
+      default_lease_ttl: 0,
+      max_lease_ttl: 0,
+      force_no_cache: false,
+      listing_visibility: 'unauth',
+      identity_token_key: null,
+      identity_token_ttl: 3600,
+    }),
+  }),
+
+  isTransit: trait({
+    type: 'transit',
+    path: 'transit/',
+    description: 'Transit encryption as a service',
+    config: () => ({
+      default_lease_ttl: 0,
+      max_lease_ttl: 0,
+      force_no_cache: false,
+      listing_visibility: 'unauth',
+    }),
+  }),
+
+  isLdap: trait({
+    type: 'ldap',
+    path: 'ldap/',
+    description: 'LDAP secrets engine',
+    config: () => ({
+      default_lease_ttl: 0,
+      max_lease_ttl: 0,
+      force_no_cache: false,
+      listing_visibility: 'unauth',
+    }),
+  }),
+
+  isSsh: trait({
+    type: 'ssh',
+    path: 'ssh/',
+    description: 'SSH secrets engine',
+    config: () => ({
+      default_lease_ttl: 0,
+      max_lease_ttl: 0,
+      force_no_cache: false,
+      listing_visibility: 'unauth',
+    }),
+  }),
+
+  withTtl: trait({
+    config: () => ({
+      default_lease_ttl: 3600, // 1 hour
+      max_lease_ttl: 86400, // 24 hours
+      force_no_cache: false,
+      listing_visibility: 'unauth',
+    }),
+  }),
+
+  isSealWrapped: trait({
+    seal_wrap: true,
+  }),
+
+  isLocal: trait({
+    local: true,
+  }),
+
+  withIdentityToken: trait({
+    config: () => ({
+      default_lease_ttl: 0,
+      max_lease_ttl: 0,
+      force_no_cache: false,
+      listing_visibility: 'unauth',
+      identity_token_key: 'test-key',
+      identity_token_ttl: 3600,
+    }),
+  }),
+
+  isHidden: trait({
+    config: () => ({
+      default_lease_ttl: 0,
+      max_lease_ttl: 0,
+      force_no_cache: false,
+      listing_visibility: 'hidden',
+    }),
+  }),
+});

--- a/ui/mirage/factories/replication-status.js
+++ b/ui/mirage/factories/replication-status.js
@@ -1,0 +1,143 @@
+import { Factory, trait } from 'miragejs';
+import timestamp from 'core/utils/timestamp';
+
+export default Factory.extend({
+  // Core replication status
+  mode: 'disabled',
+  dr: () => ({
+    mode: 'disabled',
+  }),
+  performance: () => ({
+    mode: 'disabled',
+  }),
+
+  // Traits for different replication states
+  drPrimary: trait({
+    mode: 'primary',
+    dr: () => ({
+      mode: 'primary',
+      cluster_id: 'dr-primary-cluster-id',
+      known_secondaries: ['dr-secondary-1', 'dr-secondary-2'],
+      last_wal: 1234,
+      last_remote_wal: 1230,
+      merkle_root: 'merkle-root-hash',
+      state: 'running',
+    }),
+    performance: () => ({ mode: 'disabled' }),
+  }),
+
+  drSecondary: trait({
+    mode: 'secondary',
+    dr: () => ({
+      mode: 'secondary',
+      cluster_id: 'dr-secondary-cluster-id',
+      known_primary_cluster_addr: 'https://primary.vault.com:8201',
+      primary_cluster_addr: 'https://primary.vault.com:8201',
+      last_wal: 1234,
+      last_remote_wal: 1235,
+      merkle_root: 'merkle-root-hash',
+      state: 'stream-wals',
+      connection_state: 'ready',
+      last_heartbeat: () => timestamp.now(),
+    }),
+    performance: () => ({ mode: 'disabled' }),
+  }),
+
+  performancePrimary: trait({
+    mode: 'primary',
+    dr: () => ({ mode: 'disabled' }),
+    performance: () => ({
+      mode: 'primary',
+      cluster_id: 'perf-primary-cluster-id',
+      known_secondaries: ['perf-secondary-1', 'perf-secondary-2'],
+      last_wal: 1234,
+      last_remote_wal: 1230,
+      merkle_root: 'merkle-root-hash',
+      state: 'running',
+    }),
+  }),
+
+  performanceSecondary: trait({
+    mode: 'secondary',
+    dr: () => ({ mode: 'disabled' }),
+    performance: () => ({
+      mode: 'secondary',
+      cluster_id: 'perf-secondary-cluster-id',
+      known_primary_cluster_addr: 'https://primary.vault.com:8201',
+      primary_cluster_addr: 'https://primary.vault.com:8201',
+      last_wal: 1234,
+      last_remote_wal: 1235,
+      merkle_root: 'merkle-root-hash',
+      state: 'stream-wals',
+      connection_state: 'ready',
+      last_heartbeat: () => timestamp.now(),
+    }),
+  }),
+
+  bothPrimary: trait({
+    mode: 'primary',
+    dr: () => ({
+      mode: 'primary',
+      cluster_id: 'dr-primary-cluster-id',
+      known_secondaries: ['dr-secondary-1'],
+      last_wal: 1234,
+      last_remote_wal: 1230,
+      merkle_root: 'merkle-root-hash',
+      state: 'running',
+    }),
+    performance: () => ({
+      mode: 'primary',
+      cluster_id: 'perf-primary-cluster-id',
+      known_secondaries: ['perf-secondary-1'],
+      last_wal: 1234,
+      last_remote_wal: 1230,
+      merkle_root: 'merkle-root-hash',
+      state: 'running',
+    }),
+  }),
+
+  bothSecondary: trait({
+    mode: 'secondary',
+    dr: () => ({
+      mode: 'secondary',
+      cluster_id: 'dr-secondary-cluster-id',
+      known_primary_cluster_addr: 'https://primary.vault.com:8201',
+      primary_cluster_addr: 'https://primary.vault.com:8201',
+      last_wal: 1234,
+      last_remote_wal: 1235,
+      merkle_root: 'merkle-root-hash',
+      state: 'stream-wals',
+      connection_state: 'ready',
+      last_heartbeat: () => timestamp.now(),
+    }),
+    performance: () => ({
+      mode: 'secondary',
+      cluster_id: 'perf-secondary-cluster-id',
+      known_primary_cluster_addr: 'https://primary.vault.com:8201',
+      primary_cluster_addr: 'https://primary.vault.com:8201',
+      last_wal: 1234,
+      last_remote_wal: 1235,
+      merkle_root: 'merkle-root-hash',
+      state: 'stream-wals',
+      connection_state: 'ready',
+      last_heartbeat: () => timestamp.now(),
+    }),
+  }),
+
+  withIssues: trait({
+    mode: 'secondary',
+    dr: () => ({
+      mode: 'secondary',
+      cluster_id: 'dr-secondary-cluster-id',
+      known_primary_cluster_addr: 'https://primary.vault.com:8201',
+      primary_cluster_addr: 'https://primary.vault.com:8201',
+      last_wal: 1200,
+      last_remote_wal: 1235,
+      merkle_root: 'merkle-root-hash',
+      state: 'idle',
+      connection_state: 'transient_failure',
+      last_heartbeat: () => timestamp.now() - 300000, // 5 minutes ago
+    }),
+    performance: () => ({ mode: 'disabled' }),
+  }),
+});

--- a/ui/mirage/factories/seal-status.js
+++ b/ui/mirage/factories/seal-status.js
@@ -1,0 +1,54 @@
+import { Factory, trait } from 'miragejs';
+
+export default Factory.extend({
+  // Core seal status
+  type: 'shamir',
+  initialized: true,
+  sealed: false,
+  t: 3,
+  n: 5,
+  progress: 0,
+  nonce: '',
+  version: '1.15.0+ent',
+  build_date: '2023-09-01T10:00:00Z',
+  migration: false,
+  cluster_name: 'vault-cluster-e779cd7c',
+  cluster_id: '5f20f5ab-acea-0481-787e-71ec2ff5a60b',
+  recovery_seal: false,
+  storage_type: 'consul',
+
+  // Traits for different seal states
+  isSealed: trait({
+    sealed: true,
+    progress: 0,
+    nonce: '',
+  }),
+
+  isUnsealing: trait({
+    sealed: true,
+    progress: 1,
+    nonce: 'af9b5c9c-1c2a-4b3d-8e9f-0a1b2c3d4e5f',
+  }),
+
+  isAutoUnseal: trait({
+    type: 'awskms',
+    sealed: false,
+    recovery_seal: true,
+  }),
+
+  isTransitUnseal: trait({
+    type: 'transit',
+    sealed: false,
+    recovery_seal: true,
+  }),
+
+  isHsmUnseal: trait({
+    type: 'pkcs11',
+    sealed: false,
+    recovery_seal: true,
+  }),
+
+  isMigrating: trait({
+    migration: true,
+  }),
+});

--- a/ui/mirage/factories/token.js
+++ b/ui/mirage/factories/token.js
@@ -1,0 +1,130 @@
+import { Factory, trait } from 'miragejs';
+import timestamp from 'core/utils/timestamp';
+import { addHours, addDays } from 'date-fns';
+import uuid from 'core/utils/uuid';
+
+export default Factory.extend({
+  // Core token information
+  accessor: () => uuid(),
+  creation_time: () => Math.floor(timestamp.now() / 1000),
+  creation_ttl: 0,
+  display_name: 'root',
+  entity_id: '',
+  expire_time: null,
+  explicit_max_ttl: 0,
+  issue_time: () => new Date(timestamp.now()).toISOString(),
+  meta: () => ({}),
+  num_uses: 0,
+  orphan: true,
+  path: 'auth/token/root',
+  policies: () => ['root'],
+  renewable: false,
+  ttl: 0,
+  type: 'service',
+
+  // Additional fields
+  bound_cidrs: () => [],
+  external_namespace_policies: () => ({}),
+  identity_policies: () => [],
+  namespace_path: '',
+
+  // Traits for different token types
+  isService: trait({
+    entity_id: uuid(),
+    display_name: 'token',
+    policies: () => ['default'],
+    orphan: false,
+    renewable: true,
+    ttl: 2764800, // 32 days
+    creation_ttl: 2764800,
+    explicit_max_ttl: 0,
+    path: 'auth/token/create',
+  }),
+
+  isBatch: trait({
+    entity_id: uuid(),
+    type: 'batch',
+    display_name: 'batch-token',
+    policies: () => ['default'],
+    orphan: false,
+    renewable: false,
+    ttl: 600, // 10 minutes
+    creation_ttl: 600,
+    explicit_max_ttl: 0,
+    path: 'auth/token/create',
+  }),
+
+  isUserpass: trait({
+    entity_id: uuid(),
+    display_name: 'userpass-test-user',
+    path: 'auth/userpass/login/test-user',
+    policies: () => ['default', 'user-policy'],
+    orphan: false,
+    renewable: true,
+    ttl: 2764800,
+    creation_ttl: 2764800,
+    meta: () => ({ username: 'test-user' }),
+  }),
+
+  isLdap: trait({
+    entity_id: uuid(),
+    display_name: 'ldap-john.doe',
+    path: 'auth/ldap/login/john.doe',
+    policies: () => ['default', 'ldap-users'],
+    orphan: false,
+    renewable: true,
+    ttl: 2764800,
+    creation_ttl: 2764800,
+    meta: () => ({ username: 'john.doe' }),
+  }),
+
+  withExpiry: trait({
+    expire_time: () => addHours(timestamp.now(), 24).toISOString(),
+    ttl: 86400, // 24 hours
+    creation_ttl: 86400,
+    renewable: true,
+  }),
+
+  isShortLived: trait({
+    expire_time: () => addHours(timestamp.now(), 1).toISOString(),
+    ttl: 3600, // 1 hour
+    creation_ttl: 3600,
+    renewable: true,
+  }),
+
+  withUses: trait({
+    num_uses: 10,
+    ttl: 0,
+    creation_ttl: 0,
+    renewable: false,
+  }),
+
+  withEntity: trait({
+    entity_id: () => `entity_${Math.random().toString(36).substr(2, 16)}`,
+    identity_policies: () => ['entity-policy'],
+  }),
+
+  withBoundCidrs: trait({
+    bound_cidrs: () => ['192.168.1.0/24', '10.0.0.0/8'],
+  }),
+
+  isExpired: trait({
+    expire_time: () => addDays(timestamp.now(), -1).toISOString(),
+    ttl: 0,
+    renewable: false,
+  }),
+
+  isNearExpiry: trait({
+    expire_time: () => addHours(timestamp.now(), 1).toISOString(),
+    ttl: 3600,
+    renewable: true,
+  }),
+
+  withNamespace: trait({
+    namespace_path: 'admin/',
+    policies: () => ['admin-policy'],
+    external_namespace_policies: () => ({
+      'team-a/': ['team-a-policy'],
+    }),
+  }),
+});

--- a/ui/mirage/handlers/base.js
+++ b/ui/mirage/handlers/base.js
@@ -16,6 +16,10 @@ export default function (server) {
     };
   });
 
+  server.get('/sys/health', function (schema) {
+    return schema.db.healths.firstOrCreate({}, server.create('health'));
+  });
+
   server.get('/sys/activation-flags', () => {
     return {
       data: {
@@ -25,24 +29,31 @@ export default function (server) {
     };
   });
 
-  server.get('/sys/health', function () {
+  server.get('/sys/license/features', function () {
     return {
-      enterprise: true,
-      initialized: true,
-      sealed: false,
-      standby: false,
-      license: {
-        expiry: '2021-05-12T23:20:50.52Z',
-        state: 'stored',
-      },
-      performance_standby: false,
-      replication_performance_mode: 'disabled',
-      replication_dr_mode: 'disabled',
-      server_time_utc: 1622562585,
-      version: '1.9.0+ent',
-      cluster_name: 'vault-cluster-e779cd7c',
-      cluster_id: '5f20f5ab-acea-0481-787e-71ec2ff5a60b',
-      last_wal: 121,
+      features: [
+        [
+          'HSM',
+          'Performance Replication',
+          'DR Replication',
+          'MFA',
+          'Sentinel',
+          'Seal Wrapping',
+          'Control Groups',
+          'Performance Standby',
+          'Namespaces',
+          'KMIP',
+          'Entropy Augmentation',
+          'Transform Secrets Engine',
+          'Lease Count Quotas',
+          'Key Management Secrets Engine',
+          'Automated Snapshots',
+          'Key Management Transparent Data Encryption',
+          'Secrets Sync',
+          'Secrets Import',
+          'Oracle Database Secrets Engine',
+        ],
+      ],
     };
   });
 
@@ -66,6 +77,14 @@ export default function (server) {
         },
       },
     };
+  });
+
+  server.get('/sys/seal-status', function (schema) {
+    return schema.db.sealStatuses.firstOrCreate({}, server.create('seal-status'));
+  });
+
+  server.get('/sys/replication/status', function (schema) {
+    return schema.db.replicationStatuses.firstOrCreate({}, server.create('replication-status'));
   });
 
   server.get('sys/namespaces', function () {
@@ -93,5 +112,47 @@ export default function (server) {
         ],
       },
     };
+  });
+
+  server.get('/sys/internal/ui/unauthenticated-messages', function () {
+    return { data: {} };
+  });
+
+  server.get('/sys/internal/ui/authenticated-messages', function () {
+    return { data: {} };
+  });
+
+  server.get('/sys/internal/ui/default-auth-methods', function () {
+    return { data: null };
+  });
+
+  // defaults to root token
+  server.get('/auth/token/lookup-self', function (schema) {
+    return schema.db.tokens.firstOrCreate({}, server.create('token'));
+  });
+
+  server.post('/sys/capabilities-self', function (schema, req) {
+    const { paths } = JSON.parse(req.requestBody);
+    const response = {
+      data: {
+        capabilities: ['root'],
+      },
+    };
+
+    paths.forEach((path) => {
+      response.data[path] = ['root'];
+    });
+
+    return response;
+  });
+
+  server.get('/sys/internal/ui/resultant-acl', function () {
+    return {
+      data: { chroot_namespace: '', root: true },
+    };
+  });
+
+  server.get('/sys/internal/ui/mounts', function () {
+    return { auth: {}, data: {} };
   });
 }

--- a/ui/package.json
+++ b/ui/package.json
@@ -39,6 +39,7 @@
     "test:filter": "node scripts/start-vault.js --server -f='!enterprise'",
     "test:server": "node scripts/start-vault.js --server",
     "test:dev": "node scripts/start-vault.js",
+    "test:mirage": "ember exam",
     "vault": "VAULT_REDIRECT_ADDR=http://127.0.0.1:8200 vault server -log-level=error -dev -dev-root-token-id=root -dev-ha -dev-transactional",
     "vault:cluster": "VAULT_REDIRECT_ADDR=http://127.0.0.1:8202 vault server -log-level=error -dev -dev-root-token-id=root -dev-listen-address=127.0.0.1:8202 -dev-ha -dev-transactional"
   },

--- a/ui/tests/helpers/auth/setup-auth.js
+++ b/ui/tests/helpers/auth/setup-auth.js
@@ -1,0 +1,8 @@
+import sinon from 'sinon';
+
+export function setupAuth(hooks) {
+  hooks.beforeEach(function () {
+    const auth = this.owner.lookup('service:auth');
+    sinon.stub(auth, 'currentToken').value('test-token');
+  });
+}


### PR DESCRIPTION
### Description
This is a proof of concept explored during hack week for discontinuing use of the Vault binary for acceptance tests.

- use a combination of mirage and sinon to intercept network requests and stub api service methods in acceptance tests
- copilot generated the mirage factories
- refactor a test module to remove any console commands to the Vault backend
- remove any backend specific setup (mounts, policies etc.) that could otherwise be stubbed or mocked


### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.

### PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.

Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
