### PR TITLE
VAULT-38228 CE side of sighup for observations

### DIFF
--- a/command/server.go
+++ b/command/server.go
@@ -2304,6 +2304,15 @@ func (c *ServerCommand) Reload(lock *sync.RWMutex, reloadFuncs *map[string][]rel
 					}
 				}
 			}
+
+		case strings.HasPrefix(k, "observations|"):
+			for _, relFunc := range relFuncs {
+				if relFunc != nil {
+					if err := relFunc(); err != nil {
+						reloadErrors = multierror.Append(reloadErrors, fmt.Errorf("error encountered reloading observation system with ledger at path %q: %w", strings.TrimPrefix(k, "observations|"), err))
+					}
+				}
+			}
 		}
 	}
 

--- a/vault/core.go
+++ b/vault/core.go
@@ -1394,17 +1394,39 @@ func NewCore(conf *CoreConfig) (*Core, error) {
 				LocalNodeId:             nodeID,
 				Logger:                  observationsLogger,
 			}
-			observations, err := observations.NewObservationSystem(config)
+			err = c.AddObservationSystemToCore(config)
 			if err != nil {
 				return nil, err
 			}
-			c.observations = observations
-			c.observations.Start()
 		}
 	}
 
 	c.clusterAddrBridge = conf.ClusterAddrBridge
 	return c, nil
+}
+
+func (c *Core) AddObservationSystemToCore(config *observations.NewObservationSystemConfig) error {
+	observations, err := observations.NewObservationSystem(config)
+	if err != nil {
+		return err
+	}
+	c.observations = observations
+
+	c.reloadFuncsLock.Lock()
+
+	// While it's only possible to configure one observation system now, making the key
+	// include the path future-proofs us going forward.
+	key := "observations|" + config.LedgerPath
+	c.reloadFuncs[key] = append(c.reloadFuncs[key], func() error {
+		config.Logger.Info("reloading observation system", "path", config.LedgerPath)
+		return observations.Reload()
+	})
+
+	c.reloadFuncsLock.Unlock()
+
+	c.observations.Start()
+
+	return nil
 }
 
 // configureListeners configures the Core with the listeners from the CoreConfig.


### PR DESCRIPTION
### Description

CE Counterpart to https://github.com/hashicorp/vault-enterprise/pull/8540

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.

### PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.

Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
