### PR TITLE
Add hooks for enterprise token auth metadata feature

### DIFF
--- a/builtin/credential/approle/path_role.go
+++ b/builtin/credential/approle/path_role.go
@@ -227,52 +227,6 @@ can only be set during role creation and once set, it can't be reset later.`,
 								Required:    true,
 								Description: "If true, the secret identifiers generated using this role will be cluster local. This can only be set during role creation and once set, it can't be reset later",
 							},
-							"token_bound_cidrs": {
-								Type:        framework.TypeCommaStringSlice,
-								Required:    true,
-								Description: `Comma separated string or JSON list of CIDR blocks. If set, specifies the blocks of IP addresses which are allowed to use the generated token.`,
-							},
-							"token_explicit_max_ttl": {
-								Type:        framework.TypeInt64,
-								Required:    true,
-								Description: "If set, tokens created via this role carry an explicit maximum TTL. During renewal, the current maximum TTL values of the role and the mount are not checked for changes, and any updates to these values will have no effect on the token being renewed.",
-							},
-							"token_max_ttl": {
-								Type:        framework.TypeInt64,
-								Required:    true,
-								Description: "The maximum lifetime of the generated token",
-							},
-							"token_no_default_policy": {
-								Type:        framework.TypeBool,
-								Required:    true,
-								Description: "If true, the 'default' policy will not automatically be added to generated tokens",
-							},
-							"token_period": {
-								Type:        framework.TypeInt64,
-								Required:    true,
-								Description: "If set, tokens created via this role will have no max lifetime; instead, their renewal period will be fixed to this value.",
-							},
-							"token_policies": {
-								Type:        framework.TypeCommaStringSlice,
-								Required:    true,
-								Description: "Comma-separated list of policies",
-							},
-							"token_type": {
-								Type:        framework.TypeString,
-								Required:    true,
-								Default:     "default-service",
-								Description: "The type of token to generate, service or batch",
-							},
-							"token_ttl": {
-								Type:        framework.TypeInt64,
-								Required:    true,
-								Description: "The initial ttl of the token to generate",
-							},
-							"token_num_uses": {
-								Type:        framework.TypeInt,
-								Required:    true,
-								Description: "The maximum number of times a token may be used, a value of zero means unlimited",
-							},
 							"period": {
 								Type:        framework.TypeInt64,
 								Required:    false,
@@ -299,6 +253,12 @@ can only be set during role creation and once set, it can't be reset later.`,
 	}
 
 	tokenutil.AddTokenFields(p.Fields)
+	{
+		// AppRole is coded differently from other Auth methods, it is the only one that
+		// populates the `Fields` field of the response
+		readOperation := p.Operations[logical.ReadOperation].(*framework.PathOperation)
+		tokenutil.AddTokenFields(readOperation.Responses[http.StatusOK][0].Fields)
+	}
 
 	return []*framework.Path{
 		p,

--- a/builtin/credential/aws/path_role_test.go
+++ b/builtin/credential/aws/path_role_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-secure-stdlib/awsutil"
 	"github.com/hashicorp/go-secure-stdlib/strutil"
+	"github.com/hashicorp/vault/helper/constants"
 	vlttesting "github.com/hashicorp/vault/helper/testhelpers/logical"
 	"github.com/hashicorp/vault/sdk/helper/logging"
 	"github.com/hashicorp/vault/sdk/helper/policyutil"
@@ -634,8 +635,12 @@ func TestAwsEc2_RoleCrud(t *testing.T) {
 		"token_type":                     "default",
 	}
 
+	if constants.IsEnterprise {
+		expected["token_auth_metadata"] = map[string]string{}
+	}
+
 	if resp.Data["role_id"] == nil {
-		t.Fatal("role_id not found in repsonse")
+		t.Fatal("role_id not found in response")
 	}
 	expected["role_id"] = resp.Data["role_id"]
 	if diff := deep.Equal(expected, resp.Data); diff != nil {

--- a/builtin/credential/ldap/backend_test.go
+++ b/builtin/credential/ldap/backend_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/go-test/deep"
 	hclog "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-secure-stdlib/strutil"
+	"github.com/hashicorp/vault/helper/constants"
 	"github.com/hashicorp/vault/helper/namespace"
 	"github.com/hashicorp/vault/helper/testhelpers/ldap"
 	logicaltest "github.com/hashicorp/vault/helper/testhelpers/logical"
@@ -1493,6 +1494,9 @@ func TestLdapAuthBackend_ConfigUpgrade(t *testing.T) {
 			DerefAliases:             "never",
 			MaximumPageSize:          1000,
 		},
+	}
+	if constants.IsEnterprise {
+		exp.TokenParams.TokenAuthMetadata = make(map[string]string)
 	}
 
 	configEntry, err := b.Config(ctx, configReq)

--- a/helper/testhelpers/pluginhelpers/pluginhelpers.go
+++ b/helper/testhelpers/pluginhelpers/pluginhelpers.go
@@ -16,6 +16,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/hashicorp/vault/helper/constants"
 	"github.com/hashicorp/vault/sdk/helper/consts"
 )
 
@@ -109,6 +110,12 @@ func CompilePlugin(t testing.TB, typ consts.PluginType, pluginVersion string, pl
 		line := []string{"build"}
 		if pluginVersion != "" {
 			line = append(line, "-ldflags", fmt.Sprintf("-X %s=%s", pluginVersionLocation, pluginVersion))
+		}
+		if constants.IsEnterprise {
+			// Under VAULT-38008, tokenutil.go got stubs, which means we now need to
+			// set the enterprise tag to avoid compiling both the _ent.go and the _stubs_oss.go
+			// files.
+			line = append(line, "-tags", "enterprise")
 		}
 		line = append(line, "-o", pluginPath, pluginMain)
 		cmd := exec.Command("go", line...)

--- a/sdk/helper/tokenutil/tokenutil_stubs_oss.go
+++ b/sdk/helper/tokenutil/tokenutil_stubs_oss.go
@@ -1,0 +1,21 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build !enterprise
+
+package tokenutil
+
+import (
+	"github.com/hashicorp/vault/sdk/framework"
+	"github.com/hashicorp/vault/sdk/logical"
+)
+
+func entTokenFields(fields map[string]*framework.FieldSchema) map[string]*framework.FieldSchema {
+	return fields
+}
+
+func (t *TokenParams) entParseTokenFields(d *framework.FieldData) {}
+
+func (t *TokenParams) entPopulateTokenData(m map[string]any) {}
+
+func (t *TokenParams) entPopulateTokenAuth(auth *logical.Auth) {}


### PR DESCRIPTION
### Description

Add hooks for the Vault Enterprise token auth metadata feature.

The corresponding ENT PR is https://github.com/hashicorp/vault-enterprise/pull/8470.

This PR supersedes #31327.

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.

### PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.

Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
