### PR TITLE
[UI] - Replace tooltip and tweak working on for replication dash card

### DIFF
--- a/ui/app/components/dashboard/replication-card.hbs
+++ b/ui/app/components/dashboard/replication-card.hbs
@@ -6,7 +6,7 @@
 
   <div class="is-flex-between">
     <h3 class="title is-4 has-bottom-margin-xxs" data-test-client-count-title>
-      Replication
+      Cluster replication status
     </h3>
 
     {{#if (or @replication.dr.clusterId @replication.performance.clusterId)}}

--- a/ui/app/components/dashboard/replication-state-text.hbs
+++ b/ui/app/components/dashboard/replication-state-text.hbs
@@ -1,9 +1,9 @@
 {{!
-  Copyright (c) HashiCorp, Inc.
-  SPDX-License-Identifier: BUSL-1.1
+Copyright (c) HashiCorp, Inc.
+SPDX-License-Identifier: BUSL-1.1
 }}
 
-<div>
+<div ...attributes>
   <h2 class="is-size-5 has-text-weight-semibold has-bottom-margin-xs" data-test-title={{@title}}>
     {{@title}}
   </h2>
@@ -14,25 +14,23 @@
     </div>
   {{/if}}
 
-  <ToolTip @verticalPosition="above" @horizontalPosition="center" as |T|>
-    <T.Trigger
-      data-test-tooltip-trigger
-      tabindex="-1"
-      class="title is-4 has-text-weight-semibold has-top-margin-xxs has-bottom-margin-xxs"
-      data-test-tooltip-title={{@title}}
-    >
-      {{or @state "not set up"}}
+  <Hds::TooltipButton @text="The cluster's current operating state" aria-label="The cluster's current operating state">
+    <div class="is-flex-v-centered">
+      <Hds::Text::Display
+        class="title is-4 has-text-weight-semibold has-top-margin-xxs has-bottom-margin-xxs has-right-padding-sm"
+        data-test-replication-status-title={{@title}}
+      >
+        {{or @state "not set up"}}
+      </Hds::Text::Display>
 
-      <Hds::Icon
-        @name={{or @clusterStates.glyph "x-circle"}}
-        @isInline={{true}}
-        class={{if @clusterStates.isOk "has-text-success" "has-text-danger"}}
-      />
-    </T.Trigger>
-    <T.Content @defaultClass="tool-tip smaller-font">
-      <div class="box" data-test-hover-copy-tooltip-text>
-        The cluster's current operating state
-      </div>
-    </T.Content>
-  </ToolTip>
+      {{#let (or @clusterStates.glyph "x-circle") as |icon|}}
+        <Hds::Icon
+          @isInline={{true}}
+          @name={{icon}}
+          class={{if @clusterStates.isOk "has-text-success" "has-text-danger"}}
+          data-test-replication-icon={{icon}}
+        />
+      {{/let}}
+    </div>
+  </Hds::TooltipButton>
 </div>

--- a/ui/tests/helpers/components/dashboard/dashboard-selectors.js
+++ b/ui/tests/helpers/components/dashboard/dashboard-selectors.js
@@ -17,9 +17,8 @@ export const DASHBOARD = {
   title: (name) => `[data-test-title="${name}"]`,
   subtitle: (name) => `[data-test-card-subtitle="${name}"]`,
   subtext: (name) => `[data-test-subtext="${name}"]`,
-  tooltipTitle: (name) => `[data-test-tooltip-title="${name}"]`,
-  tooltipIcon: (type, name, icon) =>
-    `[data-test-type="${type}"] [data-test-tooltip-title="${name}"] [data-test-icon="${icon}"]`,
+  tooltipTitle: (name) => `[data-test-replication-status-title="${name}"]`,
+  tooltipIcon: (type, name, icon) => `[data-test-type="${type}"] [data-test-replication-icon="${icon}"]`,
   statLabel: (name) => `[data-test-stat-text="${name}"] .stat-label`,
   statText: (name) => `[data-test-stat-text="${name}"] .stat-text`,
   statValue: (name) => `[data-test-stat-text="${name}"] .stat-value`,


### PR DESCRIPTION
### Description
This PR replaces the internal `ToolTip` component with the HDS Tooltip. We also do a small language tweak to make the card a bit more understandable.

NOTE: I think the _need_ for this tooltip is highly debatable. But I'm not here to change everything I don't need to change! I'm here to change the a subset of random things I don't need to change...

#### References
jira: https://hashicorp.atlassian.net/browse/VAULT-38495

Before:
<img width="447" height="237" alt="Screenshot 2025-07-30 at 2 36 48 PM" src="https://github.com/user-attachments/assets/4cb31dce-2872-403a-9ffe-cb438295a1d0" />

After:
<img width="459" height="208" alt="Screenshot 2025-07-30 at 2 39 09 PM" src="https://github.com/user-attachments/assets/2d11f5d2-5579-42ff-9ddb-11b85cf3477f" />

### Testing instruction
Thankfully, you can just lie about the primary cluster being in replication state:
 - launch the UI against an ent cluster locally
 - replication -> enable DR and/or PR
 - back to the dashboard page
 - BEHOLD!

#### Ent tests
✅  - ent tests pass
<img width="532" height="147" alt="Screenshot 2025-07-30 at 2 33 35 PM" src="https://github.com/user-attachments/assets/17a395ac-8532-4e99-868f-74142839f3e0" />


### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.

### PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.

Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
