### PR TITLE
[UI] - Replace transform edit page tooltip with hds tooltip

### DIFF
--- a/ui/app/templates/components/transformation-edit.hbs
+++ b/ui/app/templates/components/transformation-edit.hbs
@@ -1,6 +1,6 @@
 {{!
-  Copyright (c) HashiCorp, Inc.
-  SPDX-License-Identifier: BUSL-1.1
+Copyright (c) HashiCorp, Inc.
+SPDX-License-Identifier: BUSL-1.1
 }}
 
 <PageHeader as |p|>
@@ -32,22 +32,15 @@
     <ToolbarActions>
       {{#if this.model.updatePath.canDelete}}
         {{#if (gt this.model.allowed_roles.length 0)}}
-          <ToolTip @verticalPosition="above" @horizontalPosition="center" as |T|>
-            <T.Trigger @tabindex="-1">
-              <Hds::Button
-                @text="Delete transformation"
-                @color="secondary"
-                class="toolbar-button"
-                aria-disabled="true"
-                disabled
-              />
-            </T.Trigger>
-            <T.Content @defaultClass="tool-tip">
-              <div class="box">
-                This transformation is in use by a role and can’t be deleted.
-              </div>
-            </T.Content>
-          </ToolTip>
+          <Hds::TooltipButton @text="This transformation is in use by a role and can't be deleted.">
+            <Hds::Button
+              @text="Delete transformation"
+              @color="secondary"
+              class="toolbar-button"
+              aria-disabled="true"
+              disabled
+            />
+          </Hds::TooltipButton>
         {{else}}
           <Hds::Button
             @text="Delete transformation"
@@ -109,7 +102,7 @@
     </M.Header>
     <M.Body>
       <p>
-        You’re editing a transformation that is in use by at least one role. Editing it may mean that encode and decode
+        You're editing a transformation that is in use by at least one role. Editing it may mean that encode and decode
         operations stop working. Are you sure?
       </p>
     </M.Body>


### PR DESCRIPTION
### Description
Replaces the internal tooltip on "delete transformation" with an HDS tooltip

### References
jira: https://hashicorp.atlassian.net/browse/VAULT-38496

before: 
<img width="538" height="183" alt="Screenshot 2025-07-30 at 2 56 20 PM" src="https://github.com/user-attachments/assets/afce2cf7-28a8-47ee-9d36-3ec65d42515c" />

after:
<img width="965" height="201" alt="Screenshot 2025-07-30 at 2 54 47 PM" src="https://github.com/user-attachments/assets/d2e641a0-d7ff-484d-ae42-0be50637b78f" />

### Testing instructions
Buckle up!

 - fire up a vault enterprise cluster
 - secrets engines -> enable -> `transform` -> create
 - create a transform
   - none of the details matter here, just remember the name
 - create a role
   - give it any name
   - assign the transformation above to this role
 - go back to your transformation
   - hover over delete
 -  See the new and _definitely_ different Hds Tooltip

### Enterprise tests
✅  - ent tests pass

<img width="546" height="158" alt="Screenshot 2025-07-30 at 2 27 36 PM" src="https://github.com/user-attachments/assets/9fa4b38c-cb94-40d3-89b4-ec5f007cc77e" />

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.

### PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.

Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
