### PR TITLE
VAULT-31369: Handle multiline statements in Postgres user updates.

### DIFF
--- a/changelog/31416.txt
+++ b/changelog/31416.txt
@@ -1,0 +1,5 @@
+```
+release-note:bug
+database/postgres: Handle multiline statements in Postgres user updates. [GH-31369]
+```
+

--- a/plugins/database/postgresql/postgresql_test.go
+++ b/plugins/database/postgresql/postgresql_test.go
@@ -1063,6 +1063,12 @@ func TestUpdateUser_Password(t *testing.T) {
 			expectErr:      false,
 			credsAssertion: assertCredsExist,
 		},
+		// https://github.com/hashicorp/vault/issues/31369
+		"multiline statement containing semicolons": {
+			statements:     []string{`DO $$ BEGIN IF NOT EXISTS (SELECT FROM pg_catalog.pg_roles WHERE rolname='{{name}}') THEN CREATE ROLE "{{name}}" WITH LOGIN PASSWORD '{{password}}'; ELSE ALTER ROLE "{{name}}" WITH LOGIN PASSWORD '{{password}}'; END IF; END $$;`},
+			expectErr:      false,
+			credsAssertion: assertCredsExist,
+		},
 		"bad statements": {
 			statements:     []string{`asdofyas8uf77asoiajv`},
 			expectErr:      true,


### PR DESCRIPTION
Fixes #31369
### Description
VAULT-31369: Handle multiline statements in Postgres user updates.

This MR applies the same logic that [PR 8512](https://github.com/hashicorp/vault/pull/8512) applied to PostgreSQL user creation statements, but to rotation statements on static users.

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.

### PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [X] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
