### PR TITLE
Export api changes to add first used timestamp column in query period - CE changes

### DIFF
--- a/changelog/31422.txt
+++ b/changelog/31422.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-activity: The [activity export API](https://developer.hashicorp.com/vault/api-docs/system/internal-counters#activity-export) response now includes the client's first used timestamp within the specified query period.
+activity: The [activity export API](https://developer.hashicorp.com/vault/api-docs/system/internal-counters#activity-export) response now includes a new timestamp that denotes the first time the client was used within the specified query period.
 ```

--- a/changelog/31422.txt
+++ b/changelog/31422.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+activity: The [activity export API](https://developer.hashicorp.com/vault/api-docs/system/internal-counters#activity-export) response now includes the client's first used timestamp within the specified query period.
+```

--- a/vault/external_tests/activity_testonly/activity_testonly_test.go
+++ b/vault/external_tests/activity_testonly/activity_testonly_test.go
@@ -410,3 +410,70 @@ path "sys/internal/counters/activity/export" {
 	require.NoError(t, err)
 	require.Len(t, clients, 10)
 }
+
+// Test_ActivityLog_Export_FirstUsedTime ensures that the export API returns the timestamp the
+// clients were first seen in the query period for ClientFirstUsedTime field.
+func Test_ActivityLog_Export_FirstUsedTime(t *testing.T) {
+	timeutil.SkipAtEndOfMonth(t)
+	t.Parallel()
+
+	now := time.Now().UTC()
+
+	var err error
+
+	cluster := minimal.NewTestSoloCluster(t, nil)
+	client := cluster.Cores[0].Client
+	_, err = client.Logical().Write("sys/internal/counters/config", map[string]interface{}{
+		"enabled": "enable",
+	})
+	require.NoError(t, err)
+
+	// create new clients and repeated clients for every month.
+	// this is to verify that only the first used timestamp appears in the response
+	_, err = clientcountutil.NewActivityLogData(client).
+		NewPreviousMonthData(2).
+		NewClientsSeen(4).
+		NewPreviousMonthData(1).
+		NewClientsSeen(6).
+		RepeatedClientsSeen(4).
+		NewCurrentMonthData().
+		NewClientsSeen(10).
+		RepeatedClientsSeen(10).
+		Write(context.Background(), generation.WriteOptions_WRITE_ENTITIES)
+
+	require.NoError(t, err)
+
+	startTime := timeutil.StartOfMonth(timeutil.MonthsPreviousTo(3, now))
+
+	// Call export api
+	clients, err := getJSONExport(t, client, startTime, now)
+	require.NoError(t, err)
+
+	// total number of clients present in the query period
+	require.Len(t, clients, 20)
+
+	clientCountByFirstUsedMonth := make(map[time.Time]int)
+	currMonthStart := timeutil.StartOfMonth(now.UTC())
+	oneMonthAgoStart := timeutil.StartOfPreviousMonth(currMonthStart)
+	twoMonthsAgoStart := timeutil.StartOfPreviousMonth(oneMonthAgoStart)
+
+	// count number of clients by month the clients the first seen
+	// this actually corresponds to new clients added every month
+	// since clientcountutil assigns a random time for usage time we can check by month here as we do not know the exact expected usage time
+	for _, clientDetails := range clients {
+		require.NotEmpty(t, clientDetails.ClientFirstUsedTime)
+		parsedTime, err := time.Parse(time.RFC3339, clientDetails.ClientFirstUsedTime) // RFC3339 handles 'Z' for UTC
+		require.NoError(t, err)
+		startOfMonth := timeutil.StartOfMonth(parsedTime)
+		clientCountByFirstUsedMonth[startOfMonth]++
+	}
+
+	// 4 clients were first seen two months ago
+	require.Equal(t, clientCountByFirstUsedMonth[twoMonthsAgoStart], 4)
+
+	// 6 new clients were first seen one month ago
+	require.Equal(t, clientCountByFirstUsedMonth[oneMonthAgoStart], 6)
+
+	// 10 clients were first seen in the current month
+	require.Equal(t, clientCountByFirstUsedMonth[currMonthStart], 10)
+}

--- a/vault/logical_system_activity_write_testonly.go
+++ b/vault/logical_system_activity_write_testonly.go
@@ -357,8 +357,9 @@ func (m *multipleMonthsActivityClients) addRepeatedClients(monthsAgo int32, c *g
 
 	for _, client := range repeatedFrom.clients {
 		if c.ClientType == client.ClientType && mountAccessor == client.MountAccessor && c.Namespace == client.NamespaceID {
-			client.UsageTime = usageTime.Unix()
-			addingTo.addEntityRecord(client, segmentIndex)
+			repeatedClient := *client
+			repeatedClient.UsageTime = usageTime.Unix()
+			addingTo.addEntityRecord(&repeatedClient, segmentIndex)
 			numClients--
 			if numClients == 0 {
 				break

--- a/vault/logical_system_activity_write_testonly_test.go
+++ b/vault/logical_system_activity_write_testonly_test.go
@@ -352,26 +352,42 @@ func Test_multipleMonthsActivityClients_addRepeatedClients(t *testing.T) {
 	month2Clients := m.months[2].clients
 	month1Clients := m.months[1].clients
 
+	// checks if all the clients in "containsClients" array exists in "allClients" array
+	hasClients := func(allClients []*activity.EntityRecord, containsClients []*activity.EntityRecord) bool {
+		allClientsList := make(map[string]struct{})
+
+		for _, client := range allClients {
+			allClientsList[client.ClientID] = struct{}{}
+		}
+
+		for _, client := range containsClients {
+			if _, exists := allClientsList[client.ClientID]; !exists {
+				return false
+			}
+		}
+		return true
+	}
+
 	thisMonth := m.months[0]
 	// this will match the first client in month 1
 	require.NoError(t, m.addRepeatedClients(0, &generation.Client{Count: 1, Repeated: true}, defaultMount, nil, time.Now().UTC()))
-	require.Contains(t, month1Clients, thisMonth.clients[0])
+	require.True(t, hasClients(month1Clients, []*activity.EntityRecord{thisMonth.clients[0]}))
 
 	// this will match the 3rd client in month 1
 	require.NoError(t, m.addRepeatedClients(0, &generation.Client{Count: 1, Repeated: true, ClientType: "non-entity"}, defaultMount, nil, time.Now().UTC()))
-	require.Equal(t, month1Clients[2], thisMonth.clients[1])
+	require.True(t, hasClients([]*activity.EntityRecord{month1Clients[2]}, []*activity.EntityRecord{thisMonth.clients[1]}))
 
 	// this will match the first two clients in month 1
 	require.NoError(t, m.addRepeatedClients(0, &generation.Client{Count: 2, Repeated: true}, defaultMount, nil, time.Now().UTC()))
-	require.Equal(t, month1Clients[0:2], thisMonth.clients[2:4])
+	require.True(t, hasClients(month1Clients[0:2], thisMonth.clients[2:4]))
 
 	// this will match the first client in month 2
 	require.NoError(t, m.addRepeatedClients(0, &generation.Client{Count: 1, RepeatedFromMonth: 2}, "identity", nil, time.Now().UTC()))
-	require.Equal(t, month2Clients[0], thisMonth.clients[4])
+	require.True(t, hasClients([]*activity.EntityRecord{month2Clients[0]}, []*activity.EntityRecord{thisMonth.clients[4]}))
 
 	// this will match the 3rd client in month 2
 	require.NoError(t, m.addRepeatedClients(0, &generation.Client{Count: 1, RepeatedFromMonth: 2, Namespace: "other_ns"}, defaultMount, nil, time.Now().UTC()))
-	require.Equal(t, month2Clients[2], thisMonth.clients[5])
+	require.True(t, hasClients([]*activity.EntityRecord{month2Clients[2]}, []*activity.EntityRecord{thisMonth.clients[5]}))
 
 	require.Error(t, m.addRepeatedClients(0, &generation.Client{Count: 1, RepeatedFromMonth: 2, Namespace: "other_ns"}, "other_mount", nil, time.Now().UTC()))
 }


### PR DESCRIPTION
### Description
What does this PR do?
Jira: https://hashicorp.atlassian.net/browse/VAULT-37794

Approved ent: https://github.com/hashicorp/vault-enterprise/pull/8501

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.

### PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.

Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
