### PR TITLE
UI: Generalize Clients::Table component

### DIFF
--- a/ui/app/components/clients/counts-card.hbs
+++ b/ui/app/components/clients/counts-card.hbs
@@ -7,7 +7,7 @@
 Data visualizations render in in a flex row with a 1/3-width left element and a 2/3-width right element (with the @legend centered below, if present).
  }}
 
-<Hds::Card::Container class="counts-card-container" data-test-counts-card={{@title}} ...attributes>
+<Hds::Card::Container class="counts-card-container" data-test-card={{@title}} ...attributes>
   <div class="has-bottom-margin-xl">
     <Hds::Text::Display @tag="h2" @size="300" class="has-bottom-margin-xs">{{@title}}</Hds::Text::Display>
     {{#if @description}}

--- a/ui/app/components/clients/page/overview.hbs
+++ b/ui/app/components/clients/page/overview.hbs
@@ -35,7 +35,7 @@
     </:subheader>
 
     <:table>
-      <Clients::Table @data={{this.tableData}} />
+      <Clients::Table @data={{this.tableData}} data-test-table="attribution" />
     </:table>
   </Clients::CountsCard>
 

--- a/ui/app/components/clients/table.hbs
+++ b/ui/app/components/clients/table.hbs
@@ -15,10 +15,10 @@
     @sortBy="clients"
     @sortOrder="desc"
     @onSort={{this.updateSort}}
-    data-test-clients-attribution-table
+    ...attributes
   >
     <:body as |B|>
-      <B.Tr data-test-attribution-table-row>
+      <B.Tr data-test-table-row={{B.rowIndex}}>
         <B.Td>{{B.data.namespace}}</B.Td>
         <B.Td>{{B.data.label}}</B.Td>
         {{#if (eq B.data.mount_type "deleted mount")}}
@@ -26,7 +26,7 @@
         {{else}}
           <B.Td>{{B.data.mount_type}}</B.Td>
         {{/if}}
-        <B.Td data-test-attribution-table-counts={{B.rowIndex}}>{{B.data.clients}}</B.Td>
+        <B.Td data-test-table-data="clients">{{B.data.clients}}</B.Td>
       </B.Tr>
     </:body>
   </Hds::Table>
@@ -42,7 +42,7 @@
     class="has-top-margin-m"
   />
 {{else}}
-  <Hds::Card::Container @level="mid" @hasBorder={{true}} class="has-padding-l" data-test-card="attribution">
+  <Hds::Card::Container @level="mid" @hasBorder={{true}} class="has-padding-l" data-test-card="attribution empty state">
     <Hds::ApplicationState as |A|>
       <A.Header @title={{this.tableHeaderMessage}} />
       <A.Body @text={{this.tableBodyMessage}} />

--- a/ui/tests/acceptance/clients/counts/overview-test.js
+++ b/ui/tests/acceptance/clients/counts/overview-test.js
@@ -59,10 +59,10 @@ module('Acceptance | clients | overview', function (hooks) {
       .dom(CLIENT_COUNT.dateRange.dateDisplay('end'))
       .hasText('January 2024', 'billing start month is correctly parsed from license');
     assert
-      .dom(CHARTS.container('Client usage trends for selected billing period'))
+      .dom(CLIENT_COUNT.card('Client usage trends for selected billing period'))
       .exists('Shows running totals with monthly breakdown charts');
     assert
-      .dom(`${CHARTS.container('Client usage trends for selected billing period')} ${CHARTS.xAxisLabel}`)
+      .dom(`${CLIENT_COUNT.card('Client usage trends for selected billing period')} ${CHARTS.xAxisLabel}`)
       .hasText('7/23', 'x-axis labels start with billing start date');
     assert.dom(CHARTS.xAxisLabel).exists({ count: 7 }, 'chart months matches query');
   });
@@ -84,7 +84,7 @@ module('Acceptance | clients | overview', function (hooks) {
       .dom(CLIENT_COUNT.usageStats('Vault client counts'))
       .doesNotExist('running total single month stat boxes do not show');
     assert
-      .dom(CHARTS.container('Client usage trends for selected billing period'))
+      .dom(CLIENT_COUNT.card('Client usage trends for selected billing period'))
       .doesNotExist('running total month over month charts do not show');
 
     // change to start on month/year of upgrade to 1.10
@@ -96,10 +96,10 @@ module('Acceptance | clients | overview', function (hooks) {
       .dom(CLIENT_COUNT.dateRange.dateDisplay('start'))
       .hasText('September 2023', 'billing start month is correctly parsed from license');
     assert
-      .dom(CHARTS.container('Client usage trends for selected billing period'))
+      .dom(CLIENT_COUNT.card('Client usage trends for selected billing period'))
       .exists('Shows running totals with monthly breakdown charts');
     assert
-      .dom(`${CHARTS.container('Client usage trends for selected billing period')} ${CHARTS.xAxisLabel}`)
+      .dom(`${CLIENT_COUNT.card('Client usage trends for selected billing period')} ${CHARTS.xAxisLabel}`)
       .hasText('9/23', 'x-axis labels start with queried start month (upgrade date)');
     assert.dom(CHARTS.xAxisLabel).exists({ count: 4 }, 'chart months matches query');
 
@@ -113,7 +113,7 @@ module('Acceptance | clients | overview', function (hooks) {
       .dom(CLIENT_COUNT.usageStats('Vault client counts'))
       .exists('running total single month usage stats show');
     assert
-      .dom(CHARTS.container('Client usage trends for selected billing period'))
+      .dom(CLIENT_COUNT.card('Client usage trends for selected billing period'))
       .doesNotExist('running total month over month charts do not show');
 
     // query historical date range (from September 2023 to December 2023)
@@ -129,7 +129,7 @@ module('Acceptance | clients | overview', function (hooks) {
       .dom(CLIENT_COUNT.dateRange.dateDisplay('end'))
       .hasText('December 2023', 'billing start month is correctly parsed from license');
     assert
-      .dom(CHARTS.container('Client usage trends for selected billing period'))
+      .dom(CLIENT_COUNT.card('Client usage trends for selected billing period'))
       .exists('Shows running totals with monthly breakdown charts');
 
     assert.dom(CHARTS.xAxisLabel).exists({ count: 4 }, 'chart months matches query');
@@ -152,7 +152,7 @@ module('Acceptance | clients | overview', function (hooks) {
 
   test('totals filter correctly with full data', async function (assert) {
     assert
-      .dom(CHARTS.container('Client usage trends for selected billing period'))
+      .dom(CLIENT_COUNT.card('Client usage trends for selected billing period'))
       .exists('Shows running totals with monthly breakdown charts');
 
     const response = await this.store.peekRecord('clients/activity', 'some-activity-id');

--- a/ui/tests/acceptance/secret-engine-list-view-test.js
+++ b/ui/tests/acceptance/secret-engine-list-view-test.js
@@ -176,7 +176,7 @@ module('Acceptance | secret-engine list view', function (hooks) {
     }
 
     // navigate and check that details view is shown from non-nested secrets
-    await click(GENERAL.pagination.next);
+    await click(GENERAL.nextPage);
     assert.strictEqual(
       currentURL(),
       `/vault/secrets/${enginePath1}/list?page=2`,
@@ -217,7 +217,7 @@ module('Acceptance | secret-engine list view', function (hooks) {
       'After clicking a nested secret it navigates to the children list view.'
     );
 
-    await click(GENERAL.pagination.next);
+    await click(GENERAL.nextPage);
     assert.strictEqual(
       currentURL(),
       `/vault/secrets/${enginePath1}/list/${parentPath}/?page=2`,

--- a/ui/tests/helpers/clients/client-count-selectors.ts
+++ b/ui/tests/helpers/clients/client-count-selectors.ts
@@ -5,6 +5,7 @@
 
 // TODO: separate nested into distinct exported consts
 export const CLIENT_COUNT = {
+  card: (name: string) => `[data-test-card="${name}"]`,
   counts: {
     description: '[data-test-counts-description]',
     configDisabled: '[data-test-counts-disabled]',
@@ -26,14 +27,6 @@ export const CLIENT_COUNT = {
   statTextValue: (label: string) =>
     label ? `[data-test-stat-text="${label}"] .stat-value` : '[data-test-stat-text]',
   usageStats: (title: string) => `[data-test-usage-stats="${title}"]`,
-  attribution: {
-    card: '[data-test-card="attribution"]',
-    table: '[data-test-clients-attribution-table]',
-    row: '[data-test-attribution-table-row',
-    counts: (index: number) => `[data-test-attribution-table-counts="${index}"]`,
-    pagination: '[data-test-pagination',
-    paginationInfo: '.hds-pagination-info',
-  },
   filterBar: '[data-test-clients-filter-bar]',
   nsFilter: '#namespace-search-select',
   mountFilter: '#mounts-search-select',
@@ -45,8 +38,6 @@ export const CLIENT_COUNT = {
 
 export const CHARTS = {
   // container
-  container: (title: string) => `[data-test-counts-card="${title}"]`,
-  timestamp: '[data-test-counts-card-timestamp]',
   legend: '[data-test-counts-card-legend]',
   legendDot: (nth: number) => `.legend-item:nth-child(${nth}) > span`,
 

--- a/ui/tests/helpers/general-selectors.ts
+++ b/ui/tests/helpers/general-selectors.ts
@@ -39,6 +39,11 @@ export const GENERAL = {
   listItemLink: '[data-test-list-item-link]',
   linkedBlock: (item: string) => `[data-test-linked-block="${item}"]`,
 
+  /* ────── Tables ────── */
+  table: (title: string) => `[data-test-table="${title}"]`,
+  tableRow: (idx?: number) => (idx ? `[data-test-table-row="${idx}"]` : '[data-test-table-row]'),
+  tableData: (idx?: number, key?: string) => `[data-test-table-row="${idx}"] [data-test-table-data="${key}"]`,
+
   /* ────── Inputs / Form Fields ────── */
   checkboxByAttr: (attr: string) => `[data-test-checkbox="${attr}"]`,
   confirmModalInput: '[data-test-confirmation-modal-input]',
@@ -130,10 +135,10 @@ export const GENERAL = {
   },
 
   /* ────── Pagination ────── */
-  pagination: {
-    next: '.hds-pagination-nav__arrow--direction-next',
-    prev: '.hds-pagination-nav__arrow--direction-prev',
-  },
+  pagination: '[data-test-pagination]',
+  paginationInfo: '.hds-pagination-info',
+  nextPage: '.hds-pagination-nav__arrow--direction-next',
+  prevPage: '.hds-pagination-nav__arrow--direction-prev',
 
   /* ────── Overview Cards ────── */
   overviewCard: {

--- a/ui/tests/helpers/kv/kv-selectors.js
+++ b/ui/tests/helpers/kv/kv-selectors.js
@@ -62,8 +62,6 @@ export const PAGE = {
     listMenuDelete: `[data-test-popup-metadata-delete]`,
     overviewCard: '[data-test-overview-card-container="View secret"]',
     overviewInput: '[data-test-view-secret] input',
-    pagination: '[data-test-pagination]',
-    paginationInfo: '.hds-pagination-info',
     paginationNext: '.hds-pagination-nav__arrow--direction-next',
     paginationSelected: '.hds-pagination-nav__number--is-selected',
   },

--- a/ui/tests/integration/components/clients/page/overview-test.js
+++ b/ui/tests/integration/components/clients/page/overview-test.js
@@ -64,9 +64,9 @@ module('Integration | Component | clients/page/overview', function (hooks) {
 
     assert.dom(GENERAL.selectByAttr('attribution-month')).exists('shows month selection dropdown');
 
-    assert.dom(CLIENT_COUNT.attribution.card).exists('shows card for table state');
     assert
-      .dom(CLIENT_COUNT.attribution.card)
+      .dom(CLIENT_COUNT.card('attribution empty state'))
+      .exists('shows card for table state')
       .hasText(
         'Select a month to view client attribution View the namespace mount breakdown of clients by selecting a month. Client count documentation',
         'Show initial table state message'
@@ -80,7 +80,7 @@ module('Integration | Component | clients/page/overview', function (hooks) {
     await fillIn(GENERAL.selectByAttr('attribution-month'), '6/23');
 
     assert
-      .dom(CLIENT_COUNT.attribution.card)
+      .dom(CLIENT_COUNT.card('attribution empty state'))
       .hasText(
         'No data is available for the selected month View the namespace mount breakdown of clients by selecting another month. Client count documentation',
         'Shows correct message for a month selection with no data'
@@ -93,9 +93,11 @@ module('Integration | Component | clients/page/overview', function (hooks) {
     assert.dom(GENERAL.selectByAttr('attribution-month')).exists('shows month selection dropdown');
     await fillIn(GENERAL.selectByAttr('attribution-month'), '9/23');
 
-    assert.dom(CLIENT_COUNT.attribution.card).doesNotExist('does not show card when table has data');
-    assert.dom(CLIENT_COUNT.attribution.table).exists('shows table');
-    assert.dom(CLIENT_COUNT.attribution.paginationInfo).hasText('1–3 of 6', 'shows correct pagination info');
+    assert
+      .dom(CLIENT_COUNT.card('attribution empty state'))
+      .doesNotExist('does not show card when table has data');
+    assert.dom(GENERAL.table('attribution')).exists('shows table');
+    assert.dom(GENERAL.paginationInfo).hasText('1–3 of 6', 'shows correct pagination info');
   });
 
   test('it filters the table when a namespace filter is applied', async function (assert) {
@@ -107,9 +109,11 @@ module('Integration | Component | clients/page/overview', function (hooks) {
 
     await fillIn(GENERAL.selectByAttr('attribution-month'), '9/23');
 
-    assert.dom(CLIENT_COUNT.attribution.card).doesNotExist('does not show card when table has data');
-    assert.dom(CLIENT_COUNT.attribution.table).exists();
-    assert.dom(CLIENT_COUNT.attribution.paginationInfo).hasText('1–3 of 3', 'shows correct pagination info');
+    assert
+      .dom(CLIENT_COUNT.card('attribution empty state'))
+      .doesNotExist('does not show card when table has data');
+    assert.dom(GENERAL.table('attribution')).exists();
+    assert.dom(GENERAL.paginationInfo).hasText('1–3 of 3', 'shows correct pagination info');
   });
 
   test('it hides the table when a mount filter is applied', async function (assert) {
@@ -122,9 +126,11 @@ module('Integration | Component | clients/page/overview', function (hooks) {
     await render(
       hbs`<Clients::Page::Overview @activity={{this.activity}} @namespace={{this.namespace}} @mountPath={{this.mountPath}}/>`
     );
-    assert.dom(CLIENT_COUNT.attribution.card).doesNotExist('does not show card when table has data');
     assert
-      .dom(CLIENT_COUNT.attribution.table)
+      .dom(CLIENT_COUNT.card('attribution empty state'))
+      .doesNotExist('does not show card when table has data');
+    assert
+      .dom(GENERAL.table('attribution'))
       .doesNotExist('does not show table when a mount filter is applied');
   });
 
@@ -134,16 +140,16 @@ module('Integration | Component | clients/page/overview', function (hooks) {
     await fillIn(GENERAL.selectByAttr('attribution-month'), '9/23');
 
     assert
-      .dom(CLIENT_COUNT.attribution.row)
+      .dom(GENERAL.tableRow())
       .exists({ count: 3 }, 'Correct number of table rows render based on page size');
-    assert.dom(CLIENT_COUNT.attribution.counts(0)).hasText('96', 'First page shows data');
-    assert.dom(CLIENT_COUNT.attribution.pagination).exists('shows pagination');
-    assert.dom(CLIENT_COUNT.attribution.paginationInfo).hasText('1–3 of 6', 'shows correct pagination info');
+    assert.dom(GENERAL.tableData(0, 'clients')).hasText('96', 'First page shows data');
+    assert.dom(GENERAL.pagination).exists('shows pagination');
+    assert.dom(GENERAL.paginationInfo).hasText('1–3 of 6', 'shows correct pagination info');
 
-    await click(GENERAL.pagination.next);
+    await click(GENERAL.nextPage);
 
-    assert.dom(CLIENT_COUNT.attribution.counts(0)).hasText('53', 'Second page shows new data');
-    assert.dom(CLIENT_COUNT.attribution.paginationInfo).hasText('4–6 of 6', 'shows correct pagination info');
+    assert.dom(GENERAL.tableData(0, 'clients')).hasText('53', 'Second page shows new data');
+    assert.dom(GENERAL.paginationInfo).hasText('4–6 of 6', 'shows correct pagination info');
   });
 
   test('it shows correct month options for billing period', async function (assert) {

--- a/ui/tests/integration/components/clients/running-total-test.js
+++ b/ui/tests/integration/components/clients/running-total-test.js
@@ -62,7 +62,7 @@ module('Integration | Component | clients/running-total', function (hooks) {
     await this.renderComponent();
 
     assert
-      .dom(CHARTS.container('Client usage trends for selected billing period'))
+      .dom(CLIENT_COUNT.card('Client usage trends for selected billing period'))
       .exists('running total component renders');
     assert.dom(CHARTS.chart('Client usage by month')).exists('bar chart renders');
     assert.dom(CHARTS.legend).hasText('New clients');
@@ -105,7 +105,7 @@ module('Integration | Component | clients/running-total', function (hooks) {
     await click(GENERAL.inputByAttr('toggle view'));
 
     assert
-      .dom(CHARTS.container('Client usage trends for selected billing period'))
+      .dom(CLIENT_COUNT.card('Client usage trends for selected billing period'))
       .exists('running total component renders');
     assert.dom(CHARTS.chart('Client usage by month')).exists('bar chart renders');
     assert.dom(CHARTS.legend).hasText('Entity clients Non-entity clients Secret sync clients Acme clients');
@@ -174,7 +174,7 @@ module('Integration | Component | clients/running-total', function (hooks) {
     await this.renderComponent();
 
     assert
-      .dom(CHARTS.container('Client usage trends for selected billing period'))
+      .dom(CLIENT_COUNT.card('Client usage trends for selected billing period'))
       .exists('running total component renders');
     assert.dom(CHARTS.chart('Client usage by month')).exists('bar chart renders');
     assert.dom(CLIENT_COUNT.statTextValue('Entity')).exists();

--- a/ui/tests/integration/components/kv/page/kv-page-list-test.js
+++ b/ui/tests/integration/components/kv/page/kv-page-list-test.js
@@ -78,8 +78,8 @@ module('Integration | Component | kv | Page::List', function (hooks) {
       }
     );
 
-    assert.dom(PAGE.list.pagination).exists('shows hds pagination component');
-    assert.dom(PAGE.list.paginationInfo).hasText('1–15 of 16', 'shows correct page of pages');
+    assert.dom(GENERAL.pagination).exists('shows hds pagination component');
+    assert.dom(GENERAL.paginationInfo).hasText('1–15 of 16', 'shows correct page of pages');
     assert.dom(PAGE.title).includesText(this.backend, 'shows backend as title');
 
     this.model.forEach((record) => {


### PR DESCRIPTION
### Description
What does this PR do?

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.

### PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.

Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
