### PR TITLE
Fix missing dependencies in enos workflow for raft node removal

### DIFF
--- a/enos/modules/vault_verify_removed_node/main.tf
+++ b/enos/modules/vault_verify_removed_node/main.tf
@@ -145,7 +145,7 @@ resource "enos_remote_exec" "verify_rejoin_fails" {
   }
 }
 module "restart" {
-  depends_on        = [
+  depends_on = [
     enos_remote_exec.verify_rejoin_fails,
     enos_remote_exec.verify_raft_peer_removed,
     enos_remote_exec.verify_unseal_fails


### PR DESCRIPTION
### Description

This PR fixes missing dependencies in the enos workflow during raft node removal operations. After removing a raft node, we run an unseal test that is expected to fail, but we were not requiring this test to complete before re-adding the node back to the cluster. This could cause race conditions where nodes are re-added before we've properly validated the expected unseal failure.

The fix adds the missing test dependency to ensure the unseal failure test runs and completes before proceeding with node re-addition. This dependency was previously missing but is necessary for reliable test sequencing and proper validation of the expected behavior.

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.

### PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.

Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
