### PR TITLE
UI: Moving CTA buttons out of toolbars for keymgmt + add manage button

### DIFF
--- a/ui/app/controllers/vault/cluster/secrets/backend/list.js
+++ b/ui/app/controllers/vault/cluster/secrets/backend/list.js
@@ -10,12 +10,18 @@ import Controller from '@ember/controller';
 import BackendCrumbMixin from 'vault/mixins/backend-crumb';
 import ListController from 'core/mixins/list-controller';
 import { keyIsFolder } from 'core/utils/key-utils';
+import engineDisplayData from 'vault/helpers/engines-display-data';
 
 export default Controller.extend(ListController, BackendCrumbMixin, {
   flashMessages: service(),
   queryParams: ['page', 'pageFilter', 'tab'],
 
   tab: '',
+
+  // Check if the current engine is an old engine - for showing old UI designs
+  get isOldEngine() {
+    return engineDisplayData(this.backendType)?.isOldEngine;
+  },
 
   // callback from HDS pagination to set the queryParams page
   get paginationQueryParams() {

--- a/ui/app/templates/vault/cluster/secrets/backend/list.hbs
+++ b/ui/app/templates/vault/cluster/secrets/backend/list.hbs
@@ -40,7 +40,7 @@
       </ToolbarFilters>
 
       {{! Old Engines will keep the existing toolbar actions }}
-      {{#if (get (engines-display-data this.backendType) "isOldEngine")}}
+      {{#if this.isOldEngine}}
         <ToolbarActions>
           <ToolbarSecretLink
             @secret=""
@@ -58,7 +58,7 @@
   {{/if}}
 
   {{! Display CTA buttons if isOldEngine flag is not set }}
-  {{#if (not (get (engines-display-data this.backendType) "isOldEngine"))}}
+  {{#unless this.isOldEngine}}
     <div class="flex column-gap-16 top-right-absolute has-top-margin-s">
       {{! TODO: Hook dropdown actions to the appropriate routes & actions }}
       <Hds::Dropdown as |D|>
@@ -77,7 +77,7 @@
         data-test-create-secret-link
       />
     </div>
-  {{/if}}
+  {{/unless}}
 
   {{#if this.model.meta.total}}
     {{#each this.model as |item|}}


### PR DESCRIPTION
### Description
What does this PR do?

Continuing with removing actions out of the toolbar per HDS standards / incoming designs 
Adding separate buttons for engine actions like Create Key / Create Provider
Utilizing 'isOldEngine' flag, checks if it's set, if yes it'll show the old view with toolbar links
otherwise it'll display the separate button and new manage dropdown

The manage button will be updated in future PRs, for now the 'configure' option points to configuration page and the 'delete' option just closes the dropdown.

### Before (actions within toolbar): 

<img width="2122" height="806" alt="image" src="https://github.com/user-attachments/assets/9034b839-b0fb-4995-83a3-0a8e924e9b58" />



### After changes (CTA in separate buttons):

<img width="2122" height="806" alt="image" src="https://github.com/user-attachments/assets/203b1171-d7c9-4b8c-a283-e8d4f0ef6c26" />

<img width="2122" height="806" alt="image" src="https://github.com/user-attachments/assets/fd2118f6-e5b1-4229-ae5f-7bcdb9cb3258" />


### Other engines are unaffected (ie. Cubbyhole): 

<img width="2122" height="806" alt="image" src="https://github.com/user-attachments/assets/37f69024-17d3-4a8c-8740-57210a227502" />


### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.

### PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.

Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
