### PR TITLE
[UI] - enable test server in dev

### DIFF
--- a/ui/ember-cli-build.js
+++ b/ui/ember-cli-build.js
@@ -35,7 +35,7 @@ const appConfig = {
     throwUnlessParallelizable: true,
   },
   hinting: isTest,
-  tests: isTest,
+  tests: !isProd,
   sourcemaps: {
     enabled: !isProd,
   },


### PR DESCRIPTION
### Description
This is more a quality of life improvement for UI developers. At some point the `tests` config in `ember-cli-build.js` was set to only be on when the environment was `'test'`. Unwittingly, this also removed a very useful feature in development: if you run `yarn start` (which runs `ember server`), you can then navigate to `http://localhost:4200/ui/tests` and get the QUnit UI with a fully running tests suite. This is really handy for TDD workflows, but also just generally nicer than having to run a test server in a separate terminal.

This PR enables `tests` in that config to re-enable QUnit as part of running the ember server.

<img width="1587" height="1237" alt="CleanShot 2025-08-08 at 17 01 42" src="https://github.com/user-attachments/assets/4087e31f-9516-41b7-868b-c45507eb3bd6" />

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.

### PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.

Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
