### PR TITLE
UI: Snapshots index route

### DIFF
--- a/ui/app/components/recovery/page/snapshots/index.hbs
+++ b/ui/app/components/recovery/page/snapshots/index.hbs
@@ -3,4 +3,34 @@
   SPDX-License-Identifier: BUSL-1.1
 }}
 
-{{! TODO: This is an empty skeleton component which will be completed as part of 1.21 feature work on single item recovery }}
+<Hds::PageHeader class="has-top-padding-l has-bottom-padding-m" as |PH|>
+  <PH.Title>
+    Secrets Recovery
+    {{#if this.version.isCommunity}}
+      <Hds::Badge @text="Enterprise" @color="highlight" />
+    {{/if}}
+  </PH.Title>
+
+  <PH.Subtitle>
+    Recover lost or deleted secrets from a raft snapshot. Supported types include KV v1 and Cubbyhole.
+  </PH.Subtitle>
+</Hds::PageHeader>
+
+{{#let (get this.emptyStateDetails this.state) as |d|}}
+  <EmptyState @title={{d.title}} @icon={{d.icon}} @message={{d.message}}>
+
+    {{#if (eq this.state this.viewState.ALLOW_UPLOAD)}}
+      <Hds::Button @text={{d.buttonText}} @color={{d.buttonColor}} {{on "click" this.uploadSnapshot}} />
+    {{else}}
+      <Hds::Button
+        @text={{d.buttonText}}
+        @color={{d.buttonColor}}
+        @icon={{d.buttonIcon}}
+        @iconPosition="trailing"
+        @route={{d.buttonRoute}}
+        @query={{if d.buttonRoute (hash namespace="")}}
+        @href={{doc-link d.buttonHref}}
+      />
+    {{/if}}
+  </EmptyState>
+{{/let}}

--- a/ui/app/components/recovery/page/snapshots/index.hbs
+++ b/ui/app/components/recovery/page/snapshots/index.hbs
@@ -7,7 +7,7 @@
   <PH.Title>
     Secrets Recovery
     {{#if this.version.isCommunity}}
-      <Hds::Badge @text="Enterprise" @color="highlight" />
+      <Hds::Badge @text="Enterprise" @color="highlight" data-test-badge="enterprise" />
     {{/if}}
   </PH.Title>
 
@@ -16,7 +16,7 @@
   </PH.Subtitle>
 </Hds::PageHeader>
 
-{{#if (eq this.loadedSnapshots 0)}}
+{{#if (eq this.loadedSnapshots.length 0)}}
   {{#let (get this.emptyStateDetails this.state) as |d|}}
     <EmptyState @title={{d.title}} @icon={{d.icon}} @message={{d.message}}>
 
@@ -45,7 +45,7 @@
         <Hds::Card::Container class="snapshot-card-container" @level="mid" @hasBorder={{true}}>
           <div class="flex-row">
             <Hds::Text::Display @tag="h2">Snapshot</Hds::Text::Display>
-            <Hds::Badge @text={{s.status}} @color="success" />
+            <Hds::Badge @text={{s.status}} @color="success" data-test-badge="status" />
           </div>
           <Hds::Text::Body @tag="p">Expiring at {{s.expires_at}}</Hds::Text::Body>
           <Hds::Link::Standalone

--- a/ui/app/components/recovery/page/snapshots/index.hbs
+++ b/ui/app/components/recovery/page/snapshots/index.hbs
@@ -16,21 +16,47 @@
   </PH.Subtitle>
 </Hds::PageHeader>
 
-{{#let (get this.emptyStateDetails this.state) as |d|}}
-  <EmptyState @title={{d.title}} @icon={{d.icon}} @message={{d.message}}>
+{{#if (eq this.loadedSnapshots 0)}}
+  {{#let (get this.emptyStateDetails this.state) as |d|}}
+    <EmptyState @title={{d.title}} @icon={{d.icon}} @message={{d.message}}>
 
-    {{#if (eq this.state this.viewState.ALLOW_UPLOAD)}}
-      <Hds::Button @text={{d.buttonText}} @color={{d.buttonColor}} {{on "click" this.uploadSnapshot}} />
-    {{else}}
-      <Hds::Button
-        @text={{d.buttonText}}
-        @color={{d.buttonColor}}
-        @icon={{d.buttonIcon}}
-        @iconPosition="trailing"
-        @route={{d.buttonRoute}}
-        @query={{if d.buttonRoute (hash namespace="")}}
-        @href={{doc-link d.buttonHref}}
-      />
-    {{/if}}
-  </EmptyState>
-{{/let}}
+      {{#if (eq this.state this.viewState.ALLOW_UPLOAD)}}
+        <Hds::Button @text={{d.buttonText}} @color={{d.buttonColor}} {{on "click" this.uploadSnapshot}} />
+      {{else}}
+        <Hds::Button
+          @text={{d.buttonText}}
+          @color={{d.buttonColor}}
+          @icon={{d.buttonIcon}}
+          @iconPosition="trailing"
+          @route={{d.buttonRoute}}
+          @query={{if d.buttonRoute (hash namespace="")}}
+          @href={{doc-link d.buttonHref}}
+        />
+      {{/if}}
+    </EmptyState>
+  {{/let}}
+{{else}}
+
+  <div class="loaded-snapshot">
+    {{#each this.loadedSnapshots as |s index|}}
+      {{#if (eq index 0)}}
+        {{log s}}
+
+        <Hds::Card::Container class="snapshot-card-container" @level="mid" @hasBorder={{true}}>
+          <div class="flex-row">
+            <Hds::Text::Display @tag="h2">Snapshot</Hds::Text::Display>
+            <Hds::Badge @text={{s.status}} @color="success" />
+          </div>
+          <Hds::Text::Body @tag="p">Expiring at {{s.expires_at}}</Hds::Text::Body>
+          <Hds::Link::Standalone
+            @iconPosition="trailing"
+            @icon="arrow-right"
+            @text="View details"
+            @route="vault.cluster.recovery.snapshots.snapshot"
+            @model={{s.snapshot_id}}
+          />
+        </Hds::Card::Container>
+      {{/if}}
+    {{/each}}
+  </div>
+{{/if}}

--- a/ui/app/components/recovery/page/snapshots/index.ts
+++ b/ui/app/components/recovery/page/snapshots/index.ts
@@ -19,7 +19,7 @@ enum State {
 }
 
 interface Args {
-  model: { canLoadSnapshot: boolean };
+  model: { canLoadSnapshot: boolean; snapshots: Record<string, unknown>[] };
 }
 
 export default class Index extends Component<Args> {
@@ -70,6 +70,11 @@ export default class Index extends Component<Args> {
       buttonColor: 'primary',
     },
   };
+  get loadedSnapshots() {
+    const { snapshots } = this.args.model;
+
+    return snapshots;
+  }
 
   get state() {
     const { canLoadSnapshot } = this.args.model;

--- a/ui/app/components/recovery/page/snapshots/index.ts
+++ b/ui/app/components/recovery/page/snapshots/index.ts
@@ -1,0 +1,93 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
+import type CapabilitiesService from 'vault/services/capabilities';
+import type NamespaceService from 'vault/services/namespace';
+import type PermissionsService from 'vault/services/permissions';
+import type VersionService from 'vault/services/version';
+
+enum State {
+  COMMUNITY_VERSION = 'community',
+  NON_ROOT_NAMESPACE = 'non-root-namespace',
+  ALLOW_UPLOAD = 'default',
+  CANNOT_UPLOAD = 'cannot-upload',
+}
+
+interface Args {
+  model: { canLoadSnapshot: boolean };
+}
+
+export default class Index extends Component<Args> {
+  @service declare readonly version: VersionService;
+  @service declare readonly namespace: NamespaceService;
+  @service declare readonly permissions: PermissionsService;
+  @service declare readonly capabilities: CapabilitiesService;
+
+  viewState = State;
+
+  emptyStateDetails = {
+    [this.viewState.COMMUNITY_VERSION]: {
+      title: 'Secrets Recovery is an enterprise feature',
+      icon: 'sync-reverse',
+      message:
+        'Secrets recovery allows you to restore accidentally deleted or lost secrets from a snapshot. The snapshots can be provided via upload or loaded from external storage.',
+      buttonText: 'Learn more about upgrading',
+      buttonHref: '/vault/docs/enterprise',
+      buttonIcon: 'docs-link',
+      buttonColor: 'tertiary',
+    },
+    [this.viewState.NON_ROOT_NAMESPACE]: {
+      title: 'Snapshot upload is restricted',
+      icon: 'sync-reverse',
+      message:
+        'Snapshot uploading is only available in root namespace. Please navigate to root and upload your snapshot.',
+      buttonText: 'Take me to root namespace',
+      buttonRoute: 'vault.cluster.dashboard',
+      buttonIcon: 'arrow-right',
+      buttonColor: 'tertiary',
+    },
+    [this.viewState.CANNOT_UPLOAD]: {
+      title: 'No snapshot available',
+      icon: 'skip',
+      message:
+        'Ready to restore secrets? Please contact your admin to either upload a snapshot or grant you uploading permissions to get started.',
+      buttonText: 'Learn more about Secrets Recovery',
+      buttonHref: '/vault/docs/sysadmin/snapshots/restore',
+      buttonIcon: 'docs-link',
+      buttonColor: 'tertiary',
+    },
+    [this.viewState.ALLOW_UPLOAD]: {
+      title: 'Upload a snapshot to get started',
+      icon: 'sync-reverse',
+      message:
+        'Secrets recovery allows you to restore accidentally deleted or lost secrets from a snapshot. The snapshots can be provided via upload or loaded from external storage.',
+      buttonText: 'Upload snapshot',
+      buttonColor: 'primary',
+    },
+  };
+
+  get state() {
+    const { canLoadSnapshot } = this.args.model;
+
+    if (this.version.isCommunity) {
+      return this.viewState.COMMUNITY_VERSION;
+    } else if (!this.namespace.inRootNamespace) {
+      return this.viewState.NON_ROOT_NAMESPACE;
+    } else if (!canLoadSnapshot) {
+      return this.viewState.CANNOT_UPLOAD;
+    } else {
+      return this.viewState.ALLOW_UPLOAD;
+    }
+  }
+
+  @action
+  uploadSnapshot() {
+    console.log('clicked');
+    // TODO this will be completed in further feature work for single item recovery in the 1.21 release
+  }
+}

--- a/ui/app/components/recovery/page/snapshots/index.ts
+++ b/ui/app/components/recovery/page/snapshots/index.ts
@@ -35,7 +35,7 @@ export default class Index extends Component<Args> {
       title: 'Secrets Recovery is an enterprise feature',
       icon: 'sync-reverse',
       message:
-        'Secrets recovery allows you to restore accidentally deleted or lost secrets from a snapshot. The snapshots can be provided via upload or loaded from external storage.',
+        'Secrets Recovery allows you to restore accidentally deleted or lost secrets from a snapshot. The snapshots can be provided via upload or loaded from external storage.',
       buttonText: 'Learn more about upgrading',
       buttonHref: '/vault/docs/enterprise',
       buttonIcon: 'docs-link',
@@ -65,7 +65,7 @@ export default class Index extends Component<Args> {
       title: 'Upload a snapshot to get started',
       icon: 'sync-reverse',
       message:
-        'Secrets recovery allows you to restore accidentally deleted or lost secrets from a snapshot. The snapshots can be provided via upload or loaded from external storage.',
+        'Secrets Recovery allows you to restore accidentally deleted or lost secrets from a snapshot. The snapshots can be provided via upload or loaded from external storage.',
       buttonText: 'Upload snapshot',
       buttonColor: 'primary',
     },

--- a/ui/app/components/sidebar/nav/cluster.hbs
+++ b/ui/app/components/sidebar/nav/cluster.hbs
@@ -25,6 +25,7 @@
     <Nav.Link
       @route="vault.cluster.recovery.snapshots"
       @text="Secrets Recovery"
+      @badge={{if this.version.isCommunity "Enterprise" ""}}
       data-test-sidebar-nav-link="Secrets Recovery"
     />
   {{/if}}

--- a/ui/app/routes/vault/cluster/recovery/snapshots.js
+++ b/ui/app/routes/vault/cluster/recovery/snapshots.js
@@ -1,8 +1,0 @@
-/**
- * Copyright (c) HashiCorp, Inc.
- * SPDX-License-Identifier: BUSL-1.1
- */
-
-import Route from '@ember/routing/route';
-
-export default class RecoverySnapshotsRoute extends Route {}

--- a/ui/app/routes/vault/cluster/recovery/snapshots.ts
+++ b/ui/app/routes/vault/cluster/recovery/snapshots.ts
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+import { hash } from 'rsvp';
+
+import type ApiService from 'vault/services/api';
+import type Capabilities from 'vault/services/capabilities';
+
+export default class RecoverySnapshotsRoute extends Route {
+  @service declare readonly api: ApiService;
+  @service declare readonly capabilities: Capabilities;
+
+  async model() {
+    const path = 'sys/storage/raft/snapshot/snapshot-load';
+    const capabilities = await this.capabilities.fetch([path]);
+
+    const canLoadSnapshot = capabilities[path]?.canUpdate;
+
+    try {
+      const data = await this.api.sys.systemListStorageRaftSnapshotLoad(true);
+      const snapshots = this.api.keyInfoToArray(data);
+
+      return hash({
+        snapshots,
+        canLoadSnapshot,
+      });
+    } catch (e) {
+      // return empty list of snapshots
+      return hash({
+        snapshots: [],
+        canLoadSnapshot,
+      });
+    }
+  }
+}

--- a/ui/app/routes/vault/cluster/recovery/snapshots.ts
+++ b/ui/app/routes/vault/cluster/recovery/snapshots.ts
@@ -21,8 +21,14 @@ export default class RecoverySnapshotsRoute extends Route {
     const canLoadSnapshot = capabilities[path]?.canUpdate;
 
     try {
-      const data = await this.api.sys.systemListStorageRaftSnapshotLoad(true);
-      const snapshots = this.api.keyInfoToArray(data);
+      const { keys } = await this.api.sys.systemListStorageRaftSnapshotLoad(true);
+
+      const snapshots = await Promise.all(
+        keys.map(async (key: string) => {
+          const details = await this.api.sys.systemReadStorageRaftSnapshotLoadId(key);
+          return details;
+        })
+      );
 
       return hash({
         snapshots,

--- a/ui/app/styles/components/recovery.scss
+++ b/ui/app/styles/components/recovery.scss
@@ -1,0 +1,17 @@
+@use '../utils/size_variables';
+
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+.snapshot-card-container {
+  padding: size_variables.$spacing-12 size_variables.$spacing-24;
+  margin-bottom: size_variables.$spacing-24;
+  width: fit-content;
+
+  .flex-row {
+    display: flex;
+    justify-content: space-between;
+  }
+}

--- a/ui/app/styles/core.scss
+++ b/ui/app/styles/core.scss
@@ -82,6 +82,7 @@
 @use 'components/radial-progress';
 @use 'components/raft-join';
 @use 'components/read-more';
+@use 'components/recovery';
 @use 'components/regex-validator';
 @use 'components/replication-dashboard';
 @use 'components/replication-page';

--- a/ui/app/templates/vault/cluster/recovery/snapshots/index.hbs
+++ b/ui/app/templates/vault/cluster/recovery/snapshots/index.hbs
@@ -3,4 +3,4 @@
   SPDX-License-Identifier: BUSL-1.1
 }}
 
-<Recovery::Page::Snapshots />
+<Recovery::Page::Snapshots @model={{this.model}} />

--- a/ui/app/templates/vault/cluster/recovery/snapshots/snapshot.hbs
+++ b/ui/app/templates/vault/cluster/recovery/snapshots/snapshot.hbs
@@ -2,4 +2,4 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
 }}
-<Recovery::Page::Snapshots::Snapshot />
+<Recovery::Page::Snapshots::Snapshot @model={{this.model}} />

--- a/ui/tests/integration/components/recovery/page/snapshots-test.js
+++ b/ui/tests/integration/components/recovery/page/snapshots-test.js
@@ -1,0 +1,126 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'vault/tests/helpers';
+import { render, click, find, findAll, triggerEvent } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+import { setupMirage } from 'ember-cli-mirage/test-support';
+
+import { GENERAL } from 'vault/tests/helpers/general-selectors';
+import { dateFormat } from 'core/helpers/date-format';
+
+const SELECTORS = {
+  badge: (name) => `[data-test-badge="${name}"]`,
+};
+
+module('Integration | Component | recovery/snapshots', function (hooks) {
+  setupRenderingTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(function () {
+    this.model = {
+      snapshots: [],
+      canLoadSnapshot: false,
+    };
+    this.version = this.owner.lookup('service:version');
+    this.version.type = 'enterprise';
+  });
+
+  test('it displays empty state in CE', async function (assert) {
+    this.version.type = 'community';
+    await render(hbs`<Recovery::Page::Snapshots @model={{this.model}}/>`);
+    assert
+      .dom(GENERAL.emptyStateTitle)
+      .hasText('Secrets Recovery is an enterprise feature', 'CE empty state title renders');
+    assert
+      .dom(GENERAL.emptyStateMessage)
+      .hasText(
+        'Secrets Recovery allows you to restore accidentally deleted or lost secrets from a snapshot. The snapshots can be provided via upload or loaded from external storage.',
+        'CE empty state message renders'
+      );
+    assert
+      .dom(GENERAL.emptyStateActions)
+      .hasText('Learn more about upgrading', 'CE empty state action renders');
+
+    assert.dom(SELECTORS.badge('enterprise')).exists();
+  });
+
+  test('it displays empty state in non root namespace', async function (assert) {
+    this.nsService = this.owner.lookup('service:namespace');
+    this.nsService.path = 'parent1/child1';
+    this.server.get('/sys/internal/ui/namespaces', () => {
+      return { data: { keys: ['parent1/', 'parent1/child1/'] } };
+    });
+
+    await render(hbs`<Recovery::Page::Snapshots @model={{this.model}}/>`);
+
+    assert
+      .dom(GENERAL.emptyStateTitle)
+      .hasText('Snapshot upload is restricted', 'non root namespace empty state title renders');
+    assert
+      .dom(GENERAL.emptyStateMessage)
+      .hasText(
+        'Snapshot uploading is only available in root namespace. Please navigate to root and upload your snapshot. ',
+        'non root empty state message renders'
+      );
+    assert
+      .dom(GENERAL.emptyStateActions)
+      .hasText('Take me to root namespace', 'non root empty state action renders');
+
+    this.nsService.path = '';
+  });
+
+  test('it displays empty state when user cannot load snapshot', async function (assert) {
+    await render(hbs`<Recovery::Page::Snapshots @model={{this.model}}/>`);
+    assert.dom(GENERAL.emptyStateTitle).hasText('No snapshot available', 'empty state title renders');
+    assert
+      .dom(GENERAL.emptyStateMessage)
+      .hasText(
+        'Ready to restore secrets? Please contact your admin to either upload a snapshot or grant you uploading permissions to get started.',
+        'empty state message renders'
+      );
+    assert
+      .dom(GENERAL.emptyStateActions)
+      .hasText('Learn more about Secrets Recovery', 'empty state action renders');
+  });
+
+  test('it displays empty state when user can load snapshot', async function (assert) {
+    this.model.canLoadSnapshot = true;
+    await render(hbs`<Recovery::Page::Snapshots @model={{this.model}}/>`);
+    assert
+      .dom(GENERAL.emptyStateTitle)
+      .hasText('Upload a snapshot to get started', 'empty state title renders');
+    assert
+      .dom(GENERAL.emptyStateMessage)
+      .hasText(
+        'Secrets Recovery allows you to restore accidentally deleted or lost secrets from a snapshot. The snapshots can be provided via upload or loaded from external storage.',
+        'empty state message renders'
+      );
+    assert.dom(GENERAL.emptyStateActions).hasText('Upload snapshot', 'empty state action renders');
+  });
+
+  test('it displays loaded snapshot card', async function (assert) {
+    this.model.canLoadSnapshot = true;
+    const expiryDate = dateFormat(
+      [new Date('2023-09-20T10:51:53.961861096-04:00'), 'MMMM do yyyy, h:mm:ss a'],
+      {}
+    );
+    this.model.snapshots = [
+      {
+        snapshot_id: '6ecc06a9-3592-26f9-40cb-8d1b511890a6',
+        status: 'ready',
+        expires_at: expiryDate,
+      },
+    ];
+    this.nsService = this.owner.lookup('service:namespace');
+    this.nsService.path = '';
+
+    await render(hbs`<Recovery::Page::Snapshots @model={{this.model}}/>`);
+
+    assert.dom(SELECTORS.badge('status')).hasText('ready', 'status badge renders');
+  });
+});


### PR DESCRIPTION
### Description
What does this PR do?

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.

### PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.

Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
