### PR TITLE
VAULT-34830 actions(plugin-update): update plugins from enterprise

### DIFF
--- a/.github/workflows/plugin-update.yml
+++ b/.github/workflows/plugin-update.yml
@@ -52,13 +52,13 @@ jobs:
           git config user.name hc-github-team-secure-vault-ecosystem
           git config user.email hc-github-team-secure-vault-ecosystem@users.noreply.github.com
 
-      - if: steps.metadata.outputs.is-ent-branch != 'true'
+      - if: ! contains(inputs.branch, '+ent')
         name: Update plugin
         run: |
           go get "github.com/hashicorp/${{ inputs.plugin }}@v${{ inputs.version }}"
           go mod tidy
 
-      - if: steps.metadata.outputs.is-ent-branch == 'true'
+      - if: contains(inputs.branch, '+ent')
         name: Update Enterprise-only plugin
         run: |
           (cd vault_ent && go get "github.com/hashicorp/${{ inputs.plugin }}@v${{ inputs.version }}" && go mod tidy)

--- a/.github/workflows/plugin-update.yml
+++ b/.github/workflows/plugin-update.yml
@@ -16,6 +16,10 @@ on:
         description: 'Version of the plugin with *NO* "v", e.g., 1.2.3'
         required: true
         type: string
+      ent-only:
+        description: Whether or not the plugin is enterprise only
+        required: true
+        type: boolean
       reviewer:
         description: 'Reviewer to tag on the PR'
         required: false
@@ -52,13 +56,13 @@ jobs:
           git config user.name hc-github-team-secure-vault-ecosystem
           git config user.email hc-github-team-secure-vault-ecosystem@users.noreply.github.com
 
-      - if: ! contains(inputs.branch, '+ent')
+      - if: ! inputs.ent-only
         name: Update plugin
         run: |
           go get "github.com/hashicorp/${{ inputs.plugin }}@v${{ inputs.version }}"
           go mod tidy
 
-      - if: contains(inputs.branch, '+ent')
+      - if: inputs.ent-only
         name: Update Enterprise-only plugin
         run: |
           (cd vault_ent && go get "github.com/hashicorp/${{ inputs.plugin }}@v${{ inputs.version }}" && go mod tidy)


### PR DESCRIPTION
### Description
Support updating both CE and Enterprise plugins when the plugin update workflow targets `vault-enterprise` instead of CE.

This needs to be merged in conjunction with https://github.com/hashicorp/vault-plugin-release/pull/62 right before we do the merge workflow cutover.

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [x] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.

### PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [x] If applicable, I've documented the impact of any changes to security controls.

Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
