### PR TITLE
UI: Security card component for new configuration page

### DIFF
--- a/ui/app/components/secret-engine/security-card.hbs
+++ b/ui/app/components/secret-engine/security-card.hbs
@@ -1,0 +1,14 @@
+<Hds::Card::Container @level="mid" @hasBorder={{true}} class="has-padding-s has-top-bottom-margin-12">
+  <Hds::Form::Toggle::Group as |G|>
+    {{! Title doesn't come from anywhere, so hardcoded? }}
+    <G.Legend>Security Card</G.Legend>
+    <G.ToggleField name="local" @id="local" as |F|>
+      <F.Label>Local</F.Label>
+      <F.HelperText>Secrets stay in one cluster and are not replicated.</F.HelperText>
+    </G.ToggleField>
+    <G.ToggleField name="seal-wrap" @id="seal-wrap" as |F|>
+      <F.Label>Seal wrap</F.Label>
+      <F.HelperText>Wrap secrets with an additional encryption layer using a seal.</F.HelperText>
+    </G.ToggleField>
+  </Hds::Form::Toggle::Group>
+</Hds::Card::Container>

--- a/ui/app/components/secret-engine/security-card.hbs
+++ b/ui/app/components/secret-engine/security-card.hbs
@@ -1,12 +1,19 @@
+{{!
+  Copyright (c) HashiCorp, Inc.
+  SPDX-License-Identifier: BUSL-1.1
+}}
 <Hds::Card::Container @level="mid" @hasBorder={{true}} class="has-padding-s has-top-bottom-margin-12">
   <Hds::Form::Toggle::Group as |G|>
-    {{! Title doesn't come from anywhere, so hardcoded? }}
-    <G.Legend>Security Card</G.Legend>
-    <G.ToggleField name="local" @id="local" as |F|>
+    <G.Legend>
+      <Hds::Text::Display @size="300">Security</Hds::Text::Display>
+    </G.Legend>
+
+    {{! TODO: Toggle fields here are currently hardcoded, will be replaced with actual data from model once wired into parent component }}
+    <G.ToggleField name="local" {{on "click" this.toggleLocal}} as |F|>
       <F.Label>Local</F.Label>
       <F.HelperText>Secrets stay in one cluster and are not replicated.</F.HelperText>
     </G.ToggleField>
-    <G.ToggleField name="seal-wrap" @id="seal-wrap" as |F|>
+    <G.ToggleField name="seal-wrap" {{on "click" this.toggleSealWrap}} as |F|>
       <F.Label>Seal wrap</F.Label>
       <F.HelperText>Wrap secrets with an additional encryption layer using a seal.</F.HelperText>
     </G.ToggleField>

--- a/ui/app/components/secret-engine/security-card.ts
+++ b/ui/app/components/secret-engine/security-card.ts
@@ -1,19 +1,25 @@
-import { service } from '@ember/service';
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import { action } from '@ember/object';
 import Component from '@glimmer/component';
-import type Router from '@ember/routing/router';
-import type FlashMessageService from 'vault/services/flash-messages';
-import type ApiService from 'vault/services/api';
 import SecretsEngineResource from 'vault/resources/secrets/engine';
 interface Args {
   model: SecretsEngineResource;
 }
 
 export default class SecurityCard extends Component<Args> {
-  @service declare readonly router: Router;
-  @service declare readonly api: ApiService;
-  @service declare readonly flashMessages: FlashMessageService;
-
   constructor(owner: unknown, args: Args) {
     super(owner, args);
+  }
+
+  @action toggleSealWrap() {
+    this.args.model.seal_wrap = !this.args.model.seal_wrap;
+  }
+
+  @action toggleLocal() {
+    this.args.model.local = !this.args.model.local;
   }
 }

--- a/ui/app/components/secret-engine/security-card.ts
+++ b/ui/app/components/secret-engine/security-card.ts
@@ -1,0 +1,19 @@
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
+import type Router from '@ember/routing/router';
+import type FlashMessageService from 'vault/services/flash-messages';
+import type ApiService from 'vault/services/api';
+import SecretsEngineResource from 'vault/resources/secrets/engine';
+interface Args {
+  model: SecretsEngineResource;
+}
+
+export default class SecurityCard extends Component<Args> {
+  @service declare readonly router: Router;
+  @service declare readonly api: ApiService;
+  @service declare readonly flashMessages: FlashMessageService;
+
+  constructor(owner: unknown, args: Args) {
+    super(owner, args);
+  }
+}

--- a/ui/app/templates/vault/cluster/secrets/backend/configuration/index.hbs
+++ b/ui/app/templates/vault/cluster/secrets/backend/configuration/index.hbs
@@ -36,8 +36,5 @@
         @value={{get this.model.secretsEngine field}}
       />
     {{/each}}
-
-    {{! testing only }}
-    <SecretEngine::SecurityCard @model={{this.model.secretsEngine}} />
   </div>
 {{/if}}

--- a/ui/app/templates/vault/cluster/secrets/backend/configuration/index.hbs
+++ b/ui/app/templates/vault/cluster/secrets/backend/configuration/index.hbs
@@ -36,5 +36,8 @@
         @value={{get this.model.secretsEngine field}}
       />
     {{/each}}
+
+    {{! testing only }}
+    <SecretEngine::SecurityCard @model={{this.model.secretsEngine}} />
   </div>
 {{/if}}


### PR DESCRIPTION
### Description
What does this PR do?

***Non customer facing until parent component is completed & wired up***

[Per new designs](https://www.figma.com/design/YVOfvCoypjzxr758OT6hvj/Plugin-management?node-id=786-58263&t=FKRmN1Z6XZ8eHUvZ-1) - Creating a new 'Security' card component with toggle buttons as part of secret engine configuration tuning

Will currently live in its own component, but could be merged into parent component if we decide to go that route


Usage ---> `<SecretEngine::SecurityCard @model={{this.model.secretsEngine}} />`

| Design | Current Implementation (can change once put into parent comp) |
|--------|--------|
| <img width="401" height="224" alt="image" src="https://github.com/user-attachments/assets/bd15fbd5-f490-4a02-b8c8-5fb0c25120c4" /> | <img width="563" height="172" alt="image" src="https://github.com/user-attachments/assets/97969684-6ae5-4c7c-9ee6-b077105d7737" /> | 



### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.

### PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.

Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
