### PR TITLE
UI: wrap ember-power-select- overrides so Hds::SuperSelect is usable

### DIFF
--- a/ui/app/components/oidc/assignment-form.hbs
+++ b/ui/app/components/oidc/assignment-form.hbs
@@ -24,7 +24,6 @@
       @id="entities"
       @label="Entities"
       @placeholder="Search"
-      @renderInPlace={{true}}
       @models={{array "identity/entity"}}
       @inputValue={{@model.entityIds}}
       @shouldRenderName={{true}}
@@ -37,7 +36,6 @@
       @id="groups"
       @label="Groups"
       @placeholder="Search"
-      @renderInPlace={{true}}
       @models={{array "identity/group"}}
       @inputValue={{@model.groupIds}}
       @shouldRenderName={{true}}

--- a/ui/app/styles/components/popup-menu.scss
+++ b/ui/app/styles/components/popup-menu.scss
@@ -9,7 +9,7 @@
 
 // Popup menu no longer exists, but these styles are still used in some places
 .popup-menu-content,
-.ember-power-select-options {
+.search-select .ember-power-select-options {
   border-radius: size_variables.$radius;
   margin: -2px 0 0 0;
 
@@ -37,8 +37,8 @@
 
   button.link,
   a,
-  .ember-power-select-option,
-  .ember-power-select-option[aria-current='true'],
+  .search-select .ember-power-select-option,
+  .search-select .ember-power-select-option[aria-current='true'],
   .menu-item {
     background: transparent;
     box-shadow: none;
@@ -68,8 +68,8 @@
   }
 
   button.link,
-  .ember-power-select-option,
-  .ember-power-select-option[aria-current='true'],
+  .search-select .ember-power-select-option,
+  .search-select .ember-power-select-option[aria-current='true'],
   a {
     background-color: hsl(0, 0%, 100%);
     color: var(--token-color-palette-neutral-600);
@@ -154,30 +154,32 @@
   }
 }
 
-.ember-basic-dropdown-content {
-  background-color: transparent;
+.search-select {
+  .ember-basic-dropdown-content {
+    background-color: transparent;
 
-  &--left.popup-menu {
-    margin: 0px 0 0 -8px;
-  }
-
-  &--below {
-    &.ember-basic-dropdown--transitioning-in {
-      animation: drop-fade-above 0.15s;
+    &--left.popup-menu {
+      margin: 0px 0 0 -8px;
     }
 
-    &.ember-basic-dropdown--transitioning-out {
-      animation: drop-fade-above 0.15s reverse;
-    }
-  }
+    &--below {
+      &.ember-basic-dropdown--transitioning-in {
+        animation: drop-fade-above 0.15s;
+      }
 
-  &--above {
-    &.ember-basic-dropdown--transitioning-in {
-      animation: drop-fade-below 0.15s;
+      &.ember-basic-dropdown--transitioning-out {
+        animation: drop-fade-above 0.15s reverse;
+      }
     }
 
-    &.ember-basic-dropdown--transitioning-out {
-      animation: drop-fade-below 0.15s reverse;
+    &--above {
+      &.ember-basic-dropdown--transitioning-in {
+        animation: drop-fade-below 0.15s;
+      }
+
+      &.ember-basic-dropdown--transitioning-out {
+        animation: drop-fade-below 0.15s reverse;
+      }
     }
   }
 }

--- a/ui/app/styles/components/popup-menu.scss
+++ b/ui/app/styles/components/popup-menu.scss
@@ -37,8 +37,8 @@
 
   button.link,
   a,
-  .search-select .ember-power-select-option,
-  .search-select .ember-power-select-option[aria-current='true'],
+  .ember-power-select-option,
+  .ember-power-select-option[aria-current='true'],
   .menu-item {
     background: transparent;
     box-shadow: none;
@@ -68,8 +68,8 @@
   }
 
   button.link,
-  .search-select .ember-power-select-option,
-  .search-select .ember-power-select-option[aria-current='true'],
+  .ember-power-select-option,
+  .ember-power-select-option[aria-current='true'],
   a {
     background-color: hsl(0, 0%, 100%);
     color: var(--token-color-palette-neutral-600);

--- a/ui/app/styles/components/search-select.scss
+++ b/ui/app/styles/components/search-select.scss
@@ -7,142 +7,144 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-.ember-power-select-dropdown {
-  background: transparent;
-  box-shadow: none;
-  overflow: visible;
+.search-select {
+  .ember-power-select-dropdown {
+    background: transparent;
+    box-shadow: none;
+    overflow: visible;
 
-  &.ember-power-select-dropdown.ember-basic-dropdown-content--below {
+    &.ember-power-select-dropdown.ember-basic-dropdown-content--below {
+      border: 0;
+    }
+  }
+
+  .ember-power-select-trigger {
+    border: 0;
+    border-radius: size_variables.$radius;
+    padding-right: 0;
+
+    &--active {
+      outline-width: 3px;
+      outline-offset: -2px;
+    }
+  }
+
+  .ember-power-select-trigger:focus,
+  .ember-power-select-trigger--active {
     border: 0;
   }
-}
 
-.ember-power-select-trigger {
-  border: 0;
-  border-radius: size_variables.$radius;
-  padding-right: 0;
-
-  &--active {
-    outline-width: 3px;
-    outline-offset: -2px;
+  .ember-power-select-status-icon {
+    display: none;
   }
-}
 
-.ember-power-select-trigger:focus,
-.ember-power-select-trigger--active {
-  border: 0;
-}
-
-.ember-power-select-status-icon {
-  display: none;
-}
-
-.ember-power-select-search {
-  left: 0;
-  padding: 0;
-  position: absolute;
-  top: 0;
-  right: 0;
-  transform: translateY(-100%);
-  z-index: -1;
-
-  &::after {
-    background: hsl(0, 0%, 100%);
-    bottom: size_variables.$spacing-4;
-    content: '';
-    left: size_variables.$spacing-4 + size_variables.$spacing-24;
+  .ember-power-select-search {
+    left: 0;
+    padding: 0;
     position: absolute;
-    right: size_variables.$spacing-4;
-    top: size_variables.$spacing-4;
+    top: 0;
+    right: 0;
+    transform: translateY(-100%);
     z-index: -1;
+
+    &::after {
+      background: hsl(0, 0%, 100%);
+      bottom: size_variables.$spacing-4;
+      content: '';
+      left: size_variables.$spacing-4 + size_variables.$spacing-24;
+      position: absolute;
+      right: size_variables.$spacing-4;
+      top: size_variables.$spacing-4;
+      z-index: -1;
+    }
   }
-}
 
-.ember-power-select-search-input {
-  background: transparent;
-  border: 0;
-  padding: size_variables.$spacing-4 size_variables.$spacing-12;
-  padding-left: size_variables.$spacing-4 + size_variables.$spacing-24;
-}
+  .ember-power-select-search-input {
+    background: transparent;
+    border: 0;
+    padding: size_variables.$spacing-4 size_variables.$spacing-12;
+    padding-left: size_variables.$spacing-4 + size_variables.$spacing-24;
+  }
 
-div > .ember-power-select-options {
-  background: hsl(0, 0%, 100%);
-  border: box-shadow_variables.$base-border;
-  box-shadow: box-shadow_variables.$box-shadow-middle;
-  margin: -4px size_variables.$spacing-8 0;
-  padding: size_variables.$spacing-4 0;
+  div > .ember-power-select-options {
+    background: hsl(0, 0%, 100%);
+    border: box-shadow_variables.$base-border;
+    box-shadow: box-shadow_variables.$box-shadow-middle;
+    margin: -4px size_variables.$spacing-8 0;
+    padding: size_variables.$spacing-4 0;
 
-  .ember-power-select-option,
-  .ember-power-select-option[aria-current='true'] {
+    .ember-power-select-option,
+    .ember-power-select-option[aria-current='true'] {
+      align-items: center;
+      display: flex;
+      justify-content: space-between;
+    }
+
+    .ember-power-select-option[aria-current='true'] {
+      background-color: var(--token-color-palette-neutral-50);
+      color: var(--token-color-palette-neutral-600);
+    }
+
+    .ember-power-select-option--no-matches-message {
+      color: var(--token-color-palette-neutral-400);
+      font-size: size_variables.$size-8;
+      font-weight: font_variables.$font-weight-semibold;
+      text-transform: uppercase;
+
+      &:hover,
+      &:focus {
+        background: transparent;
+        color: var(--token-color-palette-neutral-400);
+      }
+    }
+  }
+
+  .search-select-list-item {
     align-items: center;
     display: flex;
+    padding: size_variables.$spacing-4;
     justify-content: space-between;
+    border-bottom: box-shadow_variables.$light-border;
+
+    .list-item-text {
+      max-width: 200px;
+    }
+
+    .control .button {
+      color: var(--token-color-palette-neutral-300);
+      min-width: auto;
+
+      &:hover,
+      &:focus {
+        color: var(--token-color-palette-blue-200);
+      }
+    }
   }
 
-  .ember-power-select-option[aria-current='true'] {
-    background-color: var(--token-color-palette-neutral-50);
-    color: var(--token-color-palette-neutral-600);
-  }
-
-  .ember-power-select-option--no-matches-message {
-    color: var(--token-color-palette-neutral-400);
+  .search-select-list-key {
+    color: var(--token-color-foreground-faint);
     font-size: size_variables.$size-8;
-    font-weight: font_variables.$font-weight-semibold;
-    text-transform: uppercase;
+  }
 
-    &:hover,
-    &:focus {
-      background: transparent;
-      color: var(--token-color-palette-neutral-400);
+  .ember-power-select-dropdown.ember-basic-dropdown-content {
+    animation: none;
+
+    .ember-power-select-options {
+      animation: drop-fade-above 0.15s;
     }
   }
-}
 
-.search-select-list-item {
-  align-items: center;
-  display: flex;
-  padding: size_variables.$spacing-4;
-  justify-content: space-between;
-  border-bottom: box-shadow_variables.$light-border;
-
-  .list-item-text {
-    max-width: 200px;
+  .search-select .search-icon {
+    position: absolute;
+    width: 20px;
+    top: 5px;
   }
 
-  .control .button {
-    color: var(--token-color-palette-neutral-300);
-    min-width: auto;
-
-    &:hover,
-    &:focus {
-      color: var(--token-color-palette-blue-200);
-    }
+  .search-icon {
+    margin-top: 4px;
   }
-}
 
-.search-select-list-key {
-  color: var(--token-color-foreground-faint);
-  font-size: size_variables.$size-8;
-}
-
-.ember-power-select-dropdown.ember-basic-dropdown-content {
-  animation: none;
-
-  .ember-power-select-options {
-    animation: drop-fade-above 0.15s;
+  .search-select.display-inherit {
+    display: inherit;
   }
-}
-
-.search-select .search-icon {
-  position: absolute;
-  width: 20px;
-  top: 5px;
-}
-
-.search-icon {
-  margin-top: 4px;
-}
-
-.search-select.display-inherit {
-  display: inherit;
 }

--- a/ui/app/styles/components/search-select.scss
+++ b/ui/app/styles/components/search-select.scss
@@ -120,12 +120,6 @@
       }
     }
   }
-
-  .search-select-list-key {
-    color: var(--token-color-foreground-faint);
-    font-size: size_variables.$size-8;
-  }
-
   .ember-power-select-dropdown.ember-basic-dropdown-content {
     animation: none;
 
@@ -133,18 +127,23 @@
       animation: drop-fade-above 0.15s;
     }
   }
+}
 
-  .search-select .search-icon {
-    position: absolute;
-    width: 20px;
-    top: 5px;
-  }
+.search-select-list-key {
+  color: var(--token-color-foreground-faint);
+  font-size: size_variables.$size-8;
+}
 
-  .search-icon {
-    margin-top: 4px;
-  }
+.search-select .search-icon {
+  position: absolute;
+  width: 20px;
+  top: 5px;
+}
 
-  .search-select.display-inherit {
-    display: inherit;
-  }
+.search-icon {
+  margin-top: 4px;
+}
+
+.search-select.display-inherit {
+  display: inherit;
 }

--- a/ui/lib/core/addon/components/search-select-with-modal.hbs
+++ b/ui/lib/core/addon/components/search-select-with-modal.hbs
@@ -42,6 +42,7 @@
         @search={{this.searchAndSuggest}}
         @options={{this.dropdownOptions}}
         @onChange={{this.selectOrCreate}}
+        @renderInPlace={{true}}
         @placeholderComponent={{component "search-select-placeholder"}}
         @verticalPosition="below"
         as |option|

--- a/ui/lib/core/addon/components/search-select.hbs
+++ b/ui/lib/core/addon/components/search-select.hbs
@@ -43,7 +43,7 @@
         @options={{this.dropdownOptions}}
         @onChange={{this.selectOrCreate}}
         @placeholderComponent={{component "search-select-placeholder"}}
-        @renderInPlace={{@renderInPlace}}
+        @renderInPlace={{true}}
         @verticalPosition="below"
         @disabled={{@disabled}}
         @ariaLabel={{or @ariaLabel @label (humanize @id)}}

--- a/ui/lib/core/addon/components/search-select.js
+++ b/ui/lib/core/addon/components/search-select.js
@@ -47,7 +47,6 @@ import { assert } from '@ember/debug';
  * @param {string} [wildcardLabel] - string (singular) for rendering label tag beside a wildcard selection (i.e. 'role*'), for the number of items it includes, e.g. @wildcardLabel="role" -> "includes 4 roles"
  * @param {string} [placeholder] - text you wish to replace the default "search" with
  * @param {boolean} [displayInherit=false] - if you need the search select component to display inherit instead of box.
- * @param {boolean} [renderInPlace] - pass `true` when power select renders in a modal
  * @param {function} [renderInfoTooltip] - receives each inputValue string and list of dropdownOptions as args, so parent can determine when to render a tooltip beside a selectedOption and the tooltip text. see 'oidc/provider-form.js'
  * @param {boolean} [disabled] - if true sets the disabled property on the ember-power-select component and makes it unusable.
  *

--- a/ui/lib/kubernetes/addon/components/page/overview.hbs
+++ b/ui/lib/kubernetes/addon/components/page/overview.hbs
@@ -39,7 +39,6 @@
             @selectLimit="1"
             @fallbackComponent="input-search"
             @onChange={{this.selectRole}}
-            @renderInPlace={{true}}
           />
           <Hds::Button
             @text="Generate"

--- a/ui/lib/ldap/addon/components/page/overview.hbs
+++ b/ui/lib/ldap/addon/components/page/overview.hbs
@@ -68,7 +68,6 @@
               @selectLimit="1"
               @fallbackComponent="input-search"
               @onChange={{this.selectRole}}
-              @renderInPlace={{true}}
               @passObject={{true}}
               @objectKeys={{array "id" "name" "type"}}
               @shouldRenderName={{true}}

--- a/ui/lib/pki/addon/components/page/pki-overview.hbs
+++ b/ui/lib/pki/addon/components/page/pki-overview.hbs
@@ -57,7 +57,6 @@
           @disallowNewItems={{true}}
           @onChange={{this.handleRolesInput}}
           @fallbackComponent="input-search"
-          @renderInPlace={{true}}
           data-test-issue-certificate-input
         />
         <Hds::Button
@@ -86,7 +85,6 @@
           @disallowNewItems={{true}}
           @onChange={{this.handleCertificateInput}}
           @fallbackComponent="input-search"
-          @renderInPlace={{true}}
           data-test-view-certificate-input
         />
         <Hds::Button
@@ -116,7 +114,6 @@
           @fallbackComponent="input-search"
           @shouldRenderName={{true}}
           @nameKey="issuerName"
-          @renderInPlace={{true}}
           data-test-issue-issuer-input
         />
         <Hds::Button

--- a/ui/lib/replication/addon/components/path-filter-config-list.hbs
+++ b/ui/lib/replication/addon/components/path-filter-config-list.hbs
@@ -89,7 +89,6 @@
     @label="Paths in this {{this.config.mode}}"
     @options={{this.autoCompleteOptions}}
     @search={{perform this.setAutoCompleteOptions}}
-    @renderInPlace={{true}}
   />
 {{/if}}
 {{#if (and (not this.config.mode) this.startedWithMode)}}

--- a/ui/lib/sync/addon/components/secrets/page/destinations.hbs
+++ b/ui/lib/sync/addon/components/secrets/page/destinations.hbs
@@ -26,7 +26,6 @@
       @ariaLabel="Filter by type"
       @inputValue={{if this.typeFilterName (array this.typeFilterName)}}
       @onChange={{fn this.onFilterChange "type"}}
-      @renderInPlace={{true}}
       class="is-marginless"
       data-test-filter="type"
     />

--- a/ui/lib/sync/addon/components/secrets/page/destinations/destination/sync.hbs
+++ b/ui/lib/sync/addon/components/secrets/page/destinations/destination/sync.hbs
@@ -53,7 +53,6 @@
           @selectLimit={{1}}
           @disallowNewItems={{true}}
           @onChange={{this.setMount}}
-          @renderInPlace={{true}}
           data-test-sync-mount-select
         />
       {{else}}


### PR DESCRIPTION
### Description
Using the [Hds::SuperSelect](https://helios.hashicorp.design/components/form/super-select) component is not possible right now because there are a lot of manual overrides for `.ember-power-select-` in our css. This PR is to unblock new features from using the HDS component by only applying those overrides to the custom `SearchSelect` component. 

## `Hds::SuperSelect` before
https://github.com/user-attachments/assets/5cf870ed-e5f6-4a1a-9e09-1c49332dd4b6



## `Hds::SuperSelect` after 
https://github.com/user-attachments/assets/858aefab-bf0d-4583-8fac-e436e7865181


<hr> 

## Custom search select components still render fine:
### befre | after
<img width="1000" alt="Screenshot 2025-08-13 at 4 49 31 PM" src="https://github.com/user-attachments/assets/bf6ed590-a4e2-47a9-8cc0-7b3739d8d8f2" />
<img width="1000" alt="Screenshot 2025-08-13 at 4 49 57 PM" src="https://github.com/user-attachments/assets/b8c236be-82bd-42bd-a461-d32e10423b41" />
<img width="1000" alt="Screenshot 2025-08-13 at 4 51 50 PM" src="https://github.com/user-attachments/assets/994f9e6c-37c3-4164-a7e6-500624f5d857" />



### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.

### PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.

Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
