### PR TITLE
UI: Fix download service

### DIFF
--- a/ui/app/services/download.ts
+++ b/ui/app/services/download.ts
@@ -28,25 +28,27 @@ const EXTENSION_TO_MIME: Extensions = {
 };
 
 export default class DownloadService extends Service {
-  download(filename: string, content: string, extension: string) {
-    // replace spaces with hyphens, append extension to filename
-    const formattedFilename =
-      `${filename?.replace(/\s+/g, '-')}.${extension}` ||
-      `vault-data-${timestamp.now().toISOString()}.${extension}`;
+  formatFilename(filename: string, extension: keyof Extensions = 'txt') {
+    const downloadTimestamp = timestamp.now().toISOString();
+    // replace spaces with underscores
+    const name = filename ? filename?.replace(/\s+/g, '_') : 'vault_data';
+    // appends extension to filename
+    return `${name}_${downloadTimestamp}.${extension}`;
+  }
+
+  download(filename: string, content: any, extension: keyof Extensions) {
+    const formattedFilename = this.formatFilename(filename, extension);
 
     // map extension to MIME type or use default
-    const mimetype = EXTENSION_TO_MIME[extension as keyof Extensions] || 'text/plain';
+    const mimetype = EXTENSION_TO_MIME[extension] || 'text/plain';
 
     // commence download
-    const { document, URL } = window;
     const downloadElement = document.createElement('a');
     const data = new File([content], formattedFilename, { type: mimetype });
     downloadElement.download = formattedFilename;
     downloadElement.href = URL.createObjectURL(data);
-    document.body.appendChild(downloadElement);
     downloadElement.click();
     URL.revokeObjectURL(downloadElement.href);
-    downloadElement.remove();
     return formattedFilename;
   }
 
@@ -63,7 +65,7 @@ export default class DownloadService extends Service {
     this.download(filename, content, 'pem');
   }
 
-  miscExtension(filename: string, content: string, extension: string) {
+  miscExtension(filename: string, content: string, extension: keyof Extensions) {
     this.download(filename, content, extension);
   }
 }


### PR DESCRIPTION
### Description
Not sure when - but at some point the "Export activity" button stopped working. I'm not really sure what caused it, but removing the appendage of DOM objects resolved the issue. The binary is working fine, so it could also just be an issue on :4200. 

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.

### PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.

Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
