### PR TITLE
 Backport: 1.20.x: fix(gcs): check storage errors correctly #31274

### DIFF
--- a/changelog/31274.txt
+++ b/changelog/31274.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+gcs: fix failed locking due to updated library error checks
+```

--- a/physical/gcs/gcs.go
+++ b/physical/gcs/gcs.go
@@ -221,7 +221,7 @@ func (b *Backend) Get(ctx context.Context, key string) (retEntry *physical.Entry
 
 	// Read
 	r, err := b.client.Bucket(b.bucket).Object(key).NewReader(ctx)
-	if err == storage.ErrObjectNotExist {
+	if errors.Is(err, storage.ErrObjectNotExist) {
 		return nil, nil
 	}
 	if err != nil {
@@ -258,7 +258,7 @@ func (b *Backend) Delete(ctx context.Context, key string) error {
 
 	// Delete
 	err := b.client.Bucket(b.bucket).Object(key).Delete(ctx)
-	if err != nil && err != storage.ErrObjectNotExist {
+	if err != nil && !errors.Is(err, storage.ErrObjectNotExist) {
 		return fmt.Errorf("failed to delete key %q: %w", key, err)
 	}
 	return nil

--- a/physical/gcs/gcs_ha.go
+++ b/physical/gcs/gcs_ha.go
@@ -398,7 +398,7 @@ func (l *Lock) writeLock() (bool, error) {
 func (l *Lock) get(ctx context.Context) (*LockRecord, error) {
 	// Read
 	attrs, err := l.backend.haClient.Bucket(l.backend.bucket).Object(l.key).Attrs(ctx)
-	if err == storage.ErrObjectNotExist {
+	if errors.Is(err, storage.ErrObjectNotExist) {
 		return nil, nil
 	}
 	if err != nil {


### PR DESCRIPTION
Manual backport of pr https://github.com/hashicorp/vault/pull/31274

Current latest 1.20.x block deployment in ha using a gcs bucket: https://github.com/hashicorp/vault/issues/31125