### PR TITLE
SECVULN-24009/replace AWS key

### DIFF
--- a/.github/workflows/test-ci-bootstrap.yml
+++ b/.github/workflows/test-ci-bootstrap.yml
@@ -35,8 +35,8 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_CI }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_CI }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_CI_09042025 }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_CI_09042025 }}
           aws-region: us-east-1
           role-to-assume: ${{ secrets.AWS_ROLE_ARN_CI }}
           role-skip-session-tagging: true

--- a/.github/workflows/test-ci-cleanup.yml
+++ b/.github/workflows/test-ci-cleanup.yml
@@ -13,8 +13,8 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_CI }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_CI }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_CI_09042025 }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_CI_09042025 }}
           aws-region: us-east-1
           role-to-assume: ${{ secrets.AWS_ROLE_ARN_CI }}
           role-skip-session-tagging: true
@@ -42,8 +42,8 @@ jobs:
         id: aws-configure
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_CI }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_CI }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_CI_09042025 }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_CI_09042025 }}
           aws-region: us-east-1
           role-to-assume: ${{ secrets.AWS_ROLE_ARN_CI }}
           role-skip-session-tagging: true
@@ -69,8 +69,8 @@ jobs:
     container:
       image: jantman/awslimitchecker
       env:
-        AWS_ACCESS_KEY_ID: ${{ env.AWS_ACCESS_KEY_ID_CI }}
-        AWS_SECRET_ACCESS_KEY: ${{ env.AWS_SECRET_ACCESS_KEY_CI }}
+        AWS_ACCESS_KEY_ID: ${{ env.AWS_ACCESS_KEY_ID_CI_09042025 }}
+        AWS_SECRET_ACCESS_KEY: ${{ env.AWS_SECRET_ACCESS_KEY_CI_09042025 }}
     strategy:
       matrix:
         region: ${{ fromJSON(needs.setup.outputs.regions) }}
@@ -78,8 +78,8 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_CI }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_CI }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_CI_09042025 }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_CI_09042025 }}
           aws-region: us-east-1
           role-to-assume: ${{ secrets.AWS_ROLE_ARN_CI }}
           role-skip-session-tagging: true

--- a/.github/workflows/test-enos-scenario-ui.yml
+++ b/.github/workflows/test-enos-scenario-ui.yml
@@ -115,8 +115,8 @@ jobs:
       - name: Configure AWS credentials from Test account
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_CI }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_CI }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_CI_09042025 }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_CI_09042025 }}
           aws-region: us-east-1
           role-to-assume: ${{ secrets.AWS_ROLE_ARN_CI }}
           role-skip-session-tagging: true

--- a/.github/workflows/test-run-enos-scenario-matrix.yml
+++ b/.github/workflows/test-run-enos-scenario-matrix.yml
@@ -132,7 +132,6 @@ jobs:
           token: ${{ steps.vault-auth.outputs.token }}
           secrets: |
             kv/data/github/${{ github.repository }}/artifactory token | ARTIFACTORY_TOKEN;
-            kv/data/github/${{ github.repository }}/artifactory username | ARTIFACTORY_USER;
             kv/data/github/${{ github.repository }}/aws access-key-id | AWS_ACCESS_KEY_ID_CI;
             kv/data/github/${{ github.repository }}/aws secret-access-key | AWS_SECRET_ACCESS_KEY_CI;
             kv/data/github/${{ github.repository }}/aws role-arn | AWS_ROLE_ARN_CI;
@@ -146,7 +145,6 @@ jobs:
         run: |
           if [[ "${{ needs.metadata.outputs.is-enterprise }}" != 'true' ]]; then
             {
-              echo "artifactory-user=${{ secrets.ARTIFACTORY_USER }}"
               echo "artifactory-token=${{ secrets.ARTIFACTORY_TOKEN }}"
               echo "aws-access-key-id=${{ secrets.AWS_ACCESS_KEY_ID_CI }}"
               echo "aws-secret-access-key=${{ secrets.AWS_SECRET_ACCESS_KEY_CI }}"
@@ -162,7 +160,6 @@ jobs:
            } | tee -a "$GITHUB_OUTPUT"
           else
             {
-              echo "artifactory-user=${{ steps.vault-secrets.outputs.ARTIFACTORY_USER }}"
               echo "artifactory-token=${{ steps.vault-secrets.outputs.ARTIFACTORY_TOKEN }}"
               echo "aws-access-key-id=${{ steps.vault-secrets.outputs.AWS_ACCESS_KEY_ID_CI }}"
               echo "aws-secret-access-key=${{ steps.vault-secrets.outputs.AWS_SECRET_ACCESS_KEY_CI }}"
@@ -183,7 +180,6 @@ jobs:
           {
             echo "GITHUB_TOKEN=${{ steps.secrets.outputs.github-token }}"
             echo "ENOS_DEBUG_DATA_ROOT_DIR=/tmp/enos-debug-data"
-            echo "ENOS_VAR_artifactory_username=${{ steps.secrets.outputs.artifactory-user }}"
             echo "ENOS_VAR_artifactory_token=${{ steps.secrets.outputs.artifactory-token }}"
             echo "ENOS_VAR_aws_region=${{ matrix.attributes.aws_region }}"
             echo "ENOS_VAR_aws_ssh_keypair_name=${{ inputs.ssh-key-name }}"

--- a/.github/workflows/test-run-enos-scenario-matrix.yml
+++ b/.github/workflows/test-run-enos-scenario-matrix.yml
@@ -131,7 +131,7 @@ jobs:
           caCertificate: ${{ steps.vault-auth.outputs.ca_certificate }}
           token: ${{ steps.vault-auth.outputs.token }}
           secrets: |
-            kv/data/github/${{ github.repository }}/artifactory token | ARTIFACTORY_TOKEN;
+            kv/data/github/${{ github.repository }}/artifactory bearer-token | ARTIFACTORY_BEARER_TOKEN;
             kv/data/github/${{ github.repository }}/aws access-key-id | AWS_ACCESS_KEY_ID_CI;
             kv/data/github/${{ github.repository }}/aws secret-access-key | AWS_SECRET_ACCESS_KEY_CI;
             kv/data/github/${{ github.repository }}/aws role-arn | AWS_ROLE_ARN_CI;
@@ -145,7 +145,7 @@ jobs:
         run: |
           if [[ "${{ needs.metadata.outputs.is-enterprise }}" != 'true' ]]; then
             {
-              echo "artifactory-token=${{ secrets.ARTIFACTORY_TOKEN }}"
+              echo "artifactory-token=${{ secrets.ARTIFACTORY_BEARER_TOKEN }}"
               echo "aws-access-key-id=${{ secrets.AWS_ACCESS_KEY_ID_CI }}"
               echo "aws-secret-access-key=${{ secrets.AWS_SECRET_ACCESS_KEY_CI }}"
               echo "aws-role-arn=${{ secrets.AWS_ROLE_ARN_CI }}"
@@ -160,7 +160,7 @@ jobs:
            } | tee -a "$GITHUB_OUTPUT"
           else
             {
-              echo "artifactory-token=${{ steps.vault-secrets.outputs.ARTIFACTORY_TOKEN }}"
+              echo "artifactory-token=${{ steps.vault-secrets.outputs.ARTIFACTORY_BEARER_TOKEN }}"
               echo "aws-access-key-id=${{ steps.vault-secrets.outputs.AWS_ACCESS_KEY_ID_CI }}"
               echo "aws-secret-access-key=${{ steps.vault-secrets.outputs.AWS_SECRET_ACCESS_KEY_CI }}"
               echo "aws-role-arn=${{ steps.vault-secrets.outputs.AWS_ROLE_ARN_CI }}"

--- a/.github/workflows/test-run-enos-scenario-matrix.yml
+++ b/.github/workflows/test-run-enos-scenario-matrix.yml
@@ -132,8 +132,8 @@ jobs:
           token: ${{ steps.vault-auth.outputs.token }}
           secrets: |
             kv/data/github/${{ github.repository }}/artifactory bearer-token | ARTIFACTORY_BEARER_TOKEN;
-            kv/data/github/${{ github.repository }}/aws access-key-id | AWS_ACCESS_KEY_ID_CI;
-            kv/data/github/${{ github.repository }}/aws secret-access-key | AWS_SECRET_ACCESS_KEY_CI;
+            kv/data/github/${{ github.repository }}/aws access-key-id | AWS_ACCESS_KEY_ID_CI_09042025;
+            kv/data/github/${{ github.repository }}/aws secret-access-key | AWS_SECRET_ACCESS_KEY_CI_09042025;
             kv/data/github/${{ github.repository }}/aws role-arn | AWS_ROLE_ARN_CI;
             kv/data/github/${{ github.repository }}/consul license | CONSUL_LICENSE;
             kv/data/github/${{ github.repository }}/vault-radar license | RADAR_LICENSE;
@@ -146,8 +146,8 @@ jobs:
           if [[ "${{ needs.metadata.outputs.is-enterprise }}" != 'true' ]]; then
             {
               echo "artifactory-token=${{ secrets.ARTIFACTORY_BEARER_TOKEN }}"
-              echo "aws-access-key-id=${{ secrets.AWS_ACCESS_KEY_ID_CI }}"
-              echo "aws-secret-access-key=${{ secrets.AWS_SECRET_ACCESS_KEY_CI }}"
+              echo "aws-access-key-id=${{ secrets.AWS_ACCESS_KEY_ID_CI_09042025 }}"
+              echo "aws-secret-access-key=${{ secrets.AWS_SECRET_ACCESS_KEY_CI_09042025 }}"
               echo "aws-role-arn=${{ secrets.AWS_ROLE_ARN_CI }}"
               echo "consul-license=${{ secrets.CONSUL_LICENSE }}"
               echo "github-token=${{ secrets.ELEVATED_GITHUB_TOKEN }}"
@@ -161,8 +161,8 @@ jobs:
           else
             {
               echo "artifactory-token=${{ steps.vault-secrets.outputs.ARTIFACTORY_BEARER_TOKEN }}"
-              echo "aws-access-key-id=${{ steps.vault-secrets.outputs.AWS_ACCESS_KEY_ID_CI }}"
-              echo "aws-secret-access-key=${{ steps.vault-secrets.outputs.AWS_SECRET_ACCESS_KEY_CI }}"
+              echo "aws-access-key-id=${{ steps.vault-secrets.outputs.AWS_ACCESS_KEY_ID_CI_09042025 }}"
+              echo "aws-secret-access-key=${{ steps.vault-secrets.outputs.AWS_SECRET_ACCESS_KEY_CI_09042025 }}"
               echo "aws-role-arn=${{ steps.vault-secrets.outputs.AWS_ROLE_ARN_CI }}"
               echo "consul-license=${{ steps.vault-secrets.outputs.CONSUL_LICENSE }}"
               echo "github-token=${{ steps.vault-secrets.outputs.ELEVATED_GITHUB_TOKEN }}"

--- a/.github/workflows/test-run-enos-scenario.yml
+++ b/.github/workflows/test-run-enos-scenario.yml
@@ -77,8 +77,8 @@ jobs:
           terraform_wrapper: false
       - uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_CI }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_CI }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_CI_09042025 }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_CI_09042025 }}
           aws-region: 'us-west-1'
           role-to-assume: ${{ secrets.AWS_ROLE_ARN_CI }}
           role-skip-session-tagging: true

--- a/enos/README.md
+++ b/enos/README.md
@@ -184,7 +184,6 @@ unzipped Vault binary at the `vault_local_binary_path`.
 
 ## `artifact_source:artifactory`
 This variant is for running the Enos scenario to test an artifact from Artifactory. It requires following Enos variables to be set:
-* `artifactory_username`
 * `artifactory_token`
 * `aws_ssh_keypair_name`
 * `aws_ssh_private_key_path`

--- a/enos/enos-dev-scenario-pr-replication.hcl
+++ b/enos/enos-dev-scenario-pr-replication.hcl
@@ -115,7 +115,7 @@ scenario "dev_pr_replication" {
           default value is where CRT will publish packages.
         artifactory_token:
           The artifactory identity token to use for authentication. You'll need this if you wish
-          to use deb or rpm artifacts! You can get a token joining the 'artifactory-users' Doormat
+          to use deb or rpm artifacts! You can get a token by joining the 'artifactory-users' Doormat
           group and using 'doormat artifactory create-token'.
         dev_build_local_ui:
           If you are not testing any changes in the UI, set to false. This will save time by not

--- a/enos/enos-dev-scenario-pr-replication.hcl
+++ b/enos/enos-dev-scenario-pr-replication.hcl
@@ -147,10 +147,10 @@ scenario "dev_pr_replication" {
       // Required when using a RPM or Deb package
       // Some of these variables don't have default values so we'll only set them if they are
       // required.
-      artifactory_host     = local.use_artifactory ? var.artifactory_host : null
-      artifactory_repo     = local.use_artifactory ? var.artifactory_repo : null
-      artifactory_token    = local.use_artifactory ? var.artifactory_token : null
-      distro               = matrix.distro
+      artifactory_host  = local.use_artifactory ? var.artifactory_host : null
+      artifactory_repo  = local.use_artifactory ? var.artifactory_repo : null
+      artifactory_token = local.use_artifactory ? var.artifactory_token : null
+      distro            = matrix.distro
     }
   }
 

--- a/enos/enos-dev-scenario-pr-replication.hcl
+++ b/enos/enos-dev-scenario-pr-replication.hcl
@@ -113,9 +113,6 @@ scenario "dev_pr_replication" {
         artifactory_repo:
           The artifactory host to search. It's very unlikely that you'll want to change this. The
           default value is where CRT will publish packages.
-        artifactory_username:
-          The artifactory username associated with your token. You'll need this if you wish to use
-          deb or rpm artifacts! You can request access via Okta.
         artifactory_token:
           The artifactory token associated with your username. You'll need this if you wish to use
           deb or rpm artifacts! You can create a token by logging into Artifactory via Okta.
@@ -151,7 +148,6 @@ scenario "dev_pr_replication" {
       // required.
       artifactory_host     = local.use_artifactory ? var.artifactory_host : null
       artifactory_repo     = local.use_artifactory ? var.artifactory_repo : null
-      artifactory_username = local.use_artifactory ? var.artifactory_username : null
       artifactory_token    = local.use_artifactory ? var.artifactory_token : null
       distro               = matrix.distro
     }

--- a/enos/enos-dev-scenario-pr-replication.hcl
+++ b/enos/enos-dev-scenario-pr-replication.hcl
@@ -114,8 +114,9 @@ scenario "dev_pr_replication" {
           The artifactory host to search. It's very unlikely that you'll want to change this. The
           default value is where CRT will publish packages.
         artifactory_token:
-          The artifactory token associated with your username. You'll need this if you wish to use
-          deb or rpm artifacts! You can create a token by logging into Artifactory via Okta.
+          The artifactory identity token to use for authentication. You'll need this if you wish
+          to use deb or rpm artifacts! You can get a token joining the 'artifactory-users' Doormat
+          group and using 'doormat artifactory create-token'.
         dev_build_local_ui:
           If you are not testing any changes in the UI, set to false. This will save time by not
           building the entire UI. If you need to test the UI, set to true.

--- a/enos/enos-dev-scenario-single-cluster.hcl
+++ b/enos/enos-dev-scenario-single-cluster.hcl
@@ -107,9 +107,6 @@ scenario "dev_single_cluster" {
         artifactory_repo:
           The artifactory host to search. It's very unlikely that you'll want to change this. The
           default value is where CRT will publish packages.
-        artifactory_username:
-          The artifactory username associated with your token. You'll need this if you wish to use
-          deb or rpm artifacts! You can request access via Okta.
         artifactory_token:
           The artifactory token associated with your username. You'll need this if you wish to use
           deb or rpm artifacts! You can create a token by logging into Artifactory via Okta.
@@ -145,7 +142,6 @@ scenario "dev_single_cluster" {
       // required.
       artifactory_host     = local.use_artifactory ? var.artifactory_host : null
       artifactory_repo     = local.use_artifactory ? var.artifactory_repo : null
-      artifactory_username = local.use_artifactory ? var.artifactory_username : null
       artifactory_token    = local.use_artifactory ? var.artifactory_token : null
       distro               = matrix.distro
       distro_version       = global.distro_version[matrix.distro]

--- a/enos/enos-dev-scenario-single-cluster.hcl
+++ b/enos/enos-dev-scenario-single-cluster.hcl
@@ -109,7 +109,7 @@ scenario "dev_single_cluster" {
           default value is where CRT will publish packages.
         artifactory_token:
           The artifactory identity token to use for authentication. You'll need this if you wish
-          to use deb or rpm artifacts! You can get a token joining the 'artifactory-users' Doormat
+          to use deb or rpm artifacts! You can get a token by joining the 'artifactory-users' Doormat
           group and using 'doormat artifactory create-token'.
         dev_build_local_ui:
           If you are not testing any changes in the UI, set to false. This will save time by not

--- a/enos/enos-dev-scenario-single-cluster.hcl
+++ b/enos/enos-dev-scenario-single-cluster.hcl
@@ -141,11 +141,11 @@ scenario "dev_single_cluster" {
       // Required when using a RPM or Deb package
       // Some of these variables don't have default values so we'll only set them if they are
       // required.
-      artifactory_host     = local.use_artifactory ? var.artifactory_host : null
-      artifactory_repo     = local.use_artifactory ? var.artifactory_repo : null
-      artifactory_token    = local.use_artifactory ? var.artifactory_token : null
-      distro               = matrix.distro
-      distro_version       = global.distro_version[matrix.distro]
+      artifactory_host  = local.use_artifactory ? var.artifactory_host : null
+      artifactory_repo  = local.use_artifactory ? var.artifactory_repo : null
+      artifactory_token = local.use_artifactory ? var.artifactory_token : null
+      distro            = matrix.distro
+      distro_version    = global.distro_version[matrix.distro]
     }
   }
 

--- a/enos/enos-dev-scenario-single-cluster.hcl
+++ b/enos/enos-dev-scenario-single-cluster.hcl
@@ -108,8 +108,9 @@ scenario "dev_single_cluster" {
           The artifactory host to search. It's very unlikely that you'll want to change this. The
           default value is where CRT will publish packages.
         artifactory_token:
-          The artifactory token associated with your username. You'll need this if you wish to use
-          deb or rpm artifacts! You can create a token by logging into Artifactory via Okta.
+          The artifactory identity token to use for authentication. You'll need this if you wish
+          to use deb or rpm artifacts! You can get a token joining the 'artifactory-users' Doormat
+          group and using 'doormat artifactory create-token'.
         dev_build_local_ui:
           If you are not testing any changes in the UI, set to false. This will save time by not
           building the entire UI. If you need to test the UI, set to true.

--- a/enos/enos-scenario-agent.hcl
+++ b/enos/enos-scenario-agent.hcl
@@ -27,7 +27,6 @@ scenario "agent" {
     https://eng-handbook.hashicorp.services/internal-tools/enos/troubleshooting/#execution-error-expected-vs-got-for-vault-versioneditionrevisionbuild-date.
 
     Variables required for some scenario variants:
-      - artifactory_username (if using `artifact_source:artifactory` in your filter)
       - artifactory_token (if using `artifact_source:artifactory` in your filter)
       - aws_region (if different from the default value in enos-variables.hcl)
       - consul_license_path (if using an ENT edition of Consul)
@@ -108,7 +107,6 @@ scenario "agent" {
       goos                 = "linux"
       artifactory_host     = matrix.artifact_source == "artifactory" ? var.artifactory_host : null
       artifactory_repo     = matrix.artifact_source == "artifactory" ? var.artifactory_repo : null
-      artifactory_username = matrix.artifact_source == "artifactory" ? var.artifactory_username : null
       artifactory_token    = matrix.artifact_source == "artifactory" ? var.artifactory_token : null
       arch                 = matrix.artifact_source == "artifactory" ? matrix.arch : null
       product_version      = var.vault_product_version

--- a/enos/enos-scenario-agent.hcl
+++ b/enos/enos-scenario-agent.hcl
@@ -101,19 +101,19 @@ scenario "agent" {
     module      = "build_${matrix.artifact_source}"
 
     variables {
-      build_tags           = var.vault_local_build_tags != null ? var.vault_local_build_tags : global.build_tags[matrix.edition]
-      artifact_path        = local.artifact_path
-      goarch               = matrix.arch
-      goos                 = "linux"
-      artifactory_host     = matrix.artifact_source == "artifactory" ? var.artifactory_host : null
-      artifactory_repo     = matrix.artifact_source == "artifactory" ? var.artifactory_repo : null
-      artifactory_token    = matrix.artifact_source == "artifactory" ? var.artifactory_token : null
-      arch                 = matrix.artifact_source == "artifactory" ? matrix.arch : null
-      product_version      = var.vault_product_version
-      artifact_type        = matrix.artifact_type
-      distro               = matrix.artifact_source == "artifactory" ? matrix.distro : null
-      edition              = matrix.artifact_source == "artifactory" ? matrix.edition : null
-      revision             = var.vault_revision
+      build_tags        = var.vault_local_build_tags != null ? var.vault_local_build_tags : global.build_tags[matrix.edition]
+      artifact_path     = local.artifact_path
+      goarch            = matrix.arch
+      goos              = "linux"
+      artifactory_host  = matrix.artifact_source == "artifactory" ? var.artifactory_host : null
+      artifactory_repo  = matrix.artifact_source == "artifactory" ? var.artifactory_repo : null
+      artifactory_token = matrix.artifact_source == "artifactory" ? var.artifactory_token : null
+      arch              = matrix.artifact_source == "artifactory" ? matrix.arch : null
+      product_version   = var.vault_product_version
+      artifact_type     = matrix.artifact_type
+      distro            = matrix.artifact_source == "artifactory" ? matrix.distro : null
+      edition           = matrix.artifact_source == "artifactory" ? matrix.edition : null
+      revision          = var.vault_revision
     }
   }
 

--- a/enos/enos-scenario-autopilot.hcl
+++ b/enos/enos-scenario-autopilot.hcl
@@ -29,7 +29,6 @@ scenario "autopilot" {
     https://eng-handbook.hashicorp.services/internal-tools/enos/troubleshooting/#execution-error-expected-vs-got-for-vault-versioneditionrevisionbuild-date.
 
     Variables required for some scenario variants:
-      - artifactory_username (if using `artifact_source:artifactory` in your filter)
       - artifactory_token (if using `artifact_source:artifactory` in your filter)
       - aws_region (if different from the default value defined in enos-variables.hcl)
       - consul_license_path (if using an ENT edition of Consul)
@@ -118,7 +117,6 @@ scenario "autopilot" {
       goos                 = "linux"
       artifactory_host     = matrix.artifact_source == "artifactory" ? var.artifactory_host : null
       artifactory_repo     = matrix.artifact_source == "artifactory" ? var.artifactory_repo : null
-      artifactory_username = matrix.artifact_source == "artifactory" ? var.artifactory_username : null
       artifactory_token    = matrix.artifact_source == "artifactory" ? var.artifactory_token : null
       arch                 = matrix.artifact_source == "artifactory" ? matrix.arch : null
       product_version      = var.vault_product_version

--- a/enos/enos-scenario-autopilot.hcl
+++ b/enos/enos-scenario-autopilot.hcl
@@ -111,19 +111,19 @@ scenario "autopilot" {
     module      = "build_${matrix.artifact_source}"
 
     variables {
-      build_tags           = var.vault_local_build_tags != null ? var.vault_local_build_tags : global.build_tags[matrix.edition]
-      artifact_path        = local.artifact_path
-      goarch               = matrix.arch
-      goos                 = "linux"
-      artifactory_host     = matrix.artifact_source == "artifactory" ? var.artifactory_host : null
-      artifactory_repo     = matrix.artifact_source == "artifactory" ? var.artifactory_repo : null
-      artifactory_token    = matrix.artifact_source == "artifactory" ? var.artifactory_token : null
-      arch                 = matrix.artifact_source == "artifactory" ? matrix.arch : null
-      product_version      = var.vault_product_version
-      artifact_type        = matrix.artifact_type
-      distro               = matrix.artifact_source == "artifactory" ? matrix.distro : null
-      edition              = matrix.artifact_source == "artifactory" ? matrix.edition : null
-      revision             = var.vault_revision
+      build_tags        = var.vault_local_build_tags != null ? var.vault_local_build_tags : global.build_tags[matrix.edition]
+      artifact_path     = local.artifact_path
+      goarch            = matrix.arch
+      goos              = "linux"
+      artifactory_host  = matrix.artifact_source == "artifactory" ? var.artifactory_host : null
+      artifactory_repo  = matrix.artifact_source == "artifactory" ? var.artifactory_repo : null
+      artifactory_token = matrix.artifact_source == "artifactory" ? var.artifactory_token : null
+      arch              = matrix.artifact_source == "artifactory" ? matrix.arch : null
+      product_version   = var.vault_product_version
+      artifact_type     = matrix.artifact_type
+      distro            = matrix.artifact_source == "artifactory" ? matrix.distro : null
+      edition           = matrix.artifact_source == "artifactory" ? matrix.edition : null
+      revision          = var.vault_revision
     }
   }
 

--- a/enos/enos-scenario-benchmark.hcl
+++ b/enos/enos-scenario-benchmark.hcl
@@ -128,19 +128,19 @@ scenario "benchmark" {
     module      = "build_${matrix.artifact_source}"
 
     variables {
-      build_tags           = var.vault_local_build_tags != null ? var.vault_local_build_tags : global.build_tags[matrix.edition]
-      artifact_path        = local.artifact_path
-      goarch               = matrix.arch
-      goos                 = "linux"
-      artifactory_host     = matrix.artifact_source == "artifactory" ? var.artifactory_host : null
-      artifactory_repo     = matrix.artifact_source == "artifactory" ? var.artifactory_repo : null
-      artifactory_token    = matrix.artifact_source == "artifactory" ? var.artifactory_token : null
-      arch                 = matrix.artifact_source == "artifactory" ? matrix.arch : null
-      product_version      = var.vault_product_version
-      artifact_type        = matrix.artifact_type
-      distro               = matrix.artifact_source == "artifactory" ? matrix.distro : null
-      edition              = matrix.artifact_source == "artifactory" ? matrix.edition : null
-      revision             = var.vault_revision
+      build_tags        = var.vault_local_build_tags != null ? var.vault_local_build_tags : global.build_tags[matrix.edition]
+      artifact_path     = local.artifact_path
+      goarch            = matrix.arch
+      goos              = "linux"
+      artifactory_host  = matrix.artifact_source == "artifactory" ? var.artifactory_host : null
+      artifactory_repo  = matrix.artifact_source == "artifactory" ? var.artifactory_repo : null
+      artifactory_token = matrix.artifact_source == "artifactory" ? var.artifactory_token : null
+      arch              = matrix.artifact_source == "artifactory" ? matrix.arch : null
+      product_version   = var.vault_product_version
+      artifact_type     = matrix.artifact_type
+      distro            = matrix.artifact_source == "artifactory" ? matrix.distro : null
+      edition           = matrix.artifact_source == "artifactory" ? matrix.edition : null
+      revision          = var.vault_revision
     }
   }
 

--- a/enos/enos-scenario-benchmark.hcl
+++ b/enos/enos-scenario-benchmark.hcl
@@ -134,7 +134,6 @@ scenario "benchmark" {
       goos                 = "linux"
       artifactory_host     = matrix.artifact_source == "artifactory" ? var.artifactory_host : null
       artifactory_repo     = matrix.artifact_source == "artifactory" ? var.artifactory_repo : null
-      artifactory_username = matrix.artifact_source == "artifactory" ? var.artifactory_username : null
       artifactory_token    = matrix.artifact_source == "artifactory" ? var.artifactory_token : null
       arch                 = matrix.artifact_source == "artifactory" ? matrix.arch : null
       product_version      = var.vault_product_version

--- a/enos/enos-scenario-dr-replication.hcl
+++ b/enos/enos-scenario-dr-replication.hcl
@@ -32,7 +32,6 @@ scenario "dr_replication" {
     https://eng-handbook.hashicorp.services/internal-tools/enos/troubleshooting/#execution-error-expected-vs-got-for-vault-versioneditionrevisionbuild-date.
 
     Variables required for some scenario variants:
-      - artifactory_username (if using `artifact_source:artifactory` in your filter)
       - artifactory_token (if using `artifact_source:artifactory` in your filter)
       - aws_region (if different from the default value in enos-variables.hcl)
       - consul_license_path (if using an ENT edition of Consul)
@@ -131,7 +130,6 @@ scenario "dr_replication" {
       goos                 = "linux"
       artifactory_host     = matrix.artifact_source == "artifactory" ? var.artifactory_host : null
       artifactory_repo     = matrix.artifact_source == "artifactory" ? var.artifactory_repo : null
-      artifactory_username = matrix.artifact_source == "artifactory" ? var.artifactory_username : null
       artifactory_token    = matrix.artifact_source == "artifactory" ? var.artifactory_token : null
       arch                 = matrix.artifact_source == "artifactory" ? matrix.arch : null
       product_version      = var.vault_product_version

--- a/enos/enos-scenario-dr-replication.hcl
+++ b/enos/enos-scenario-dr-replication.hcl
@@ -124,19 +124,19 @@ scenario "dr_replication" {
     module      = "build_${matrix.artifact_source}"
 
     variables {
-      build_tags           = var.vault_local_build_tags != null ? var.vault_local_build_tags : global.build_tags[matrix.edition]
-      artifact_path        = local.artifact_path
-      goarch               = matrix.arch
-      goos                 = "linux"
-      artifactory_host     = matrix.artifact_source == "artifactory" ? var.artifactory_host : null
-      artifactory_repo     = matrix.artifact_source == "artifactory" ? var.artifactory_repo : null
-      artifactory_token    = matrix.artifact_source == "artifactory" ? var.artifactory_token : null
-      arch                 = matrix.artifact_source == "artifactory" ? matrix.arch : null
-      product_version      = var.vault_product_version
-      artifact_type        = matrix.artifact_type
-      distro               = matrix.artifact_source == "artifactory" ? matrix.distro : null
-      edition              = matrix.artifact_source == "artifactory" ? matrix.edition : null
-      revision             = var.vault_revision
+      build_tags        = var.vault_local_build_tags != null ? var.vault_local_build_tags : global.build_tags[matrix.edition]
+      artifact_path     = local.artifact_path
+      goarch            = matrix.arch
+      goos              = "linux"
+      artifactory_host  = matrix.artifact_source == "artifactory" ? var.artifactory_host : null
+      artifactory_repo  = matrix.artifact_source == "artifactory" ? var.artifactory_repo : null
+      artifactory_token = matrix.artifact_source == "artifactory" ? var.artifactory_token : null
+      arch              = matrix.artifact_source == "artifactory" ? matrix.arch : null
+      product_version   = var.vault_product_version
+      artifact_type     = matrix.artifact_type
+      distro            = matrix.artifact_source == "artifactory" ? matrix.distro : null
+      edition           = matrix.artifact_source == "artifactory" ? matrix.edition : null
+      revision          = var.vault_revision
     }
   }
 

--- a/enos/enos-scenario-pr-replication.hcl
+++ b/enos/enos-scenario-pr-replication.hcl
@@ -32,7 +32,6 @@ scenario "pr_replication" {
     https://eng-handbook.hashicorp.services/internal-tools/enos/troubleshooting/#execution-error-expected-vs-got-for-vault-versioneditionrevisionbuild-date.
 
     Variables required for some scenario variants:
-      - artifactory_username (if using `artifact_source:artifactory` in your filter)
       - artifactory_token (if using `artifact_source:artifactory` in your filter)
       - aws_region (if different from the default value in enos-variables.hcl)
       - consul_license_path (if using an ENT edition of Consul)
@@ -131,7 +130,6 @@ scenario "pr_replication" {
       goos                 = "linux"
       artifactory_host     = matrix.artifact_source == "artifactory" ? var.artifactory_host : null
       artifactory_repo     = matrix.artifact_source == "artifactory" ? var.artifactory_repo : null
-      artifactory_username = matrix.artifact_source == "artifactory" ? var.artifactory_username : null
       artifactory_token    = matrix.artifact_source == "artifactory" ? var.artifactory_token : null
       arch                 = matrix.artifact_source == "artifactory" ? matrix.arch : null
       product_version      = var.vault_product_version

--- a/enos/enos-scenario-pr-replication.hcl
+++ b/enos/enos-scenario-pr-replication.hcl
@@ -124,19 +124,19 @@ scenario "pr_replication" {
     module      = "build_${matrix.artifact_source}"
 
     variables {
-      build_tags           = var.vault_local_build_tags != null ? var.vault_local_build_tags : global.build_tags[matrix.edition]
-      artifact_path        = local.artifact_path
-      goarch               = matrix.arch
-      goos                 = "linux"
-      artifactory_host     = matrix.artifact_source == "artifactory" ? var.artifactory_host : null
-      artifactory_repo     = matrix.artifact_source == "artifactory" ? var.artifactory_repo : null
-      artifactory_token    = matrix.artifact_source == "artifactory" ? var.artifactory_token : null
-      arch                 = matrix.artifact_source == "artifactory" ? matrix.arch : null
-      product_version      = var.vault_product_version
-      artifact_type        = matrix.artifact_type
-      distro               = matrix.artifact_source == "artifactory" ? matrix.distro : null
-      edition              = matrix.artifact_source == "artifactory" ? matrix.edition : null
-      revision             = var.vault_revision
+      build_tags        = var.vault_local_build_tags != null ? var.vault_local_build_tags : global.build_tags[matrix.edition]
+      artifact_path     = local.artifact_path
+      goarch            = matrix.arch
+      goos              = "linux"
+      artifactory_host  = matrix.artifact_source == "artifactory" ? var.artifactory_host : null
+      artifactory_repo  = matrix.artifact_source == "artifactory" ? var.artifactory_repo : null
+      artifactory_token = matrix.artifact_source == "artifactory" ? var.artifactory_token : null
+      arch              = matrix.artifact_source == "artifactory" ? matrix.arch : null
+      product_version   = var.vault_product_version
+      artifact_type     = matrix.artifact_type
+      distro            = matrix.artifact_source == "artifactory" ? matrix.distro : null
+      edition           = matrix.artifact_source == "artifactory" ? matrix.edition : null
+      revision          = var.vault_revision
     }
   }
 

--- a/enos/enos-scenario-proxy.hcl
+++ b/enos/enos-scenario-proxy.hcl
@@ -27,7 +27,6 @@ scenario "proxy" {
   https://eng-handbook.hashicorp.services/internal-tools/enos/troubleshooting/#execution-error-expected-vs-got-for-vault-versioneditionrevisionbuild-date.
 
   Variables required for some scenario variants:
-    - artifactory_username (if using `artifact_source:artifactory` in your filter)
     - artifactory_token (if using `artifact_source:artifactory` in your filter)
     - aws_region (if different from the default value in enos-variables.hcl)
     - consul_license_path (if using an ENT edition of Consul)
@@ -115,7 +114,6 @@ scenario "proxy" {
       goos                 = "linux"
       artifactory_host     = matrix.artifact_source == "artifactory" ? var.artifactory_host : null
       artifactory_repo     = matrix.artifact_source == "artifactory" ? var.artifactory_repo : null
-      artifactory_username = matrix.artifact_source == "artifactory" ? var.artifactory_username : null
       artifactory_token    = matrix.artifact_source == "artifactory" ? var.artifactory_token : null
       arch                 = matrix.artifact_source == "artifactory" ? matrix.arch : null
       product_version      = var.vault_product_version

--- a/enos/enos-scenario-proxy.hcl
+++ b/enos/enos-scenario-proxy.hcl
@@ -108,19 +108,19 @@ scenario "proxy" {
     module      = "build_${matrix.artifact_source}"
 
     variables {
-      build_tags           = var.vault_local_build_tags != null ? var.vault_local_build_tags : global.build_tags[matrix.edition]
-      artifact_path        = local.artifact_path
-      goarch               = matrix.arch
-      goos                 = "linux"
-      artifactory_host     = matrix.artifact_source == "artifactory" ? var.artifactory_host : null
-      artifactory_repo     = matrix.artifact_source == "artifactory" ? var.artifactory_repo : null
-      artifactory_token    = matrix.artifact_source == "artifactory" ? var.artifactory_token : null
-      arch                 = matrix.artifact_source == "artifactory" ? matrix.arch : null
-      product_version      = var.vault_product_version
-      artifact_type        = matrix.artifact_type
-      distro               = matrix.artifact_source == "artifactory" ? matrix.distro : null
-      edition              = matrix.artifact_source == "artifactory" ? matrix.edition : null
-      revision             = var.vault_revision
+      build_tags        = var.vault_local_build_tags != null ? var.vault_local_build_tags : global.build_tags[matrix.edition]
+      artifact_path     = local.artifact_path
+      goarch            = matrix.arch
+      goos              = "linux"
+      artifactory_host  = matrix.artifact_source == "artifactory" ? var.artifactory_host : null
+      artifactory_repo  = matrix.artifact_source == "artifactory" ? var.artifactory_repo : null
+      artifactory_token = matrix.artifact_source == "artifactory" ? var.artifactory_token : null
+      arch              = matrix.artifact_source == "artifactory" ? matrix.arch : null
+      product_version   = var.vault_product_version
+      artifact_type     = matrix.artifact_type
+      distro            = matrix.artifact_source == "artifactory" ? matrix.distro : null
+      edition           = matrix.artifact_source == "artifactory" ? matrix.edition : null
+      revision          = var.vault_revision
     }
   }
 

--- a/enos/enos-scenario-seal-ha.hcl
+++ b/enos/enos-scenario-seal-ha.hcl
@@ -122,19 +122,19 @@ scenario "seal_ha" {
     module      = "build_${matrix.artifact_source}"
 
     variables {
-      build_tags           = var.vault_local_build_tags != null ? var.vault_local_build_tags : global.build_tags[matrix.edition]
-      artifact_path        = local.artifact_path
-      goarch               = matrix.arch
-      goos                 = "linux"
-      artifactory_host     = matrix.artifact_source == "artifactory" ? var.artifactory_host : null
-      artifactory_repo     = matrix.artifact_source == "artifactory" ? var.artifactory_repo : null
-      artifactory_token    = matrix.artifact_source == "artifactory" ? var.artifactory_token : null
-      arch                 = matrix.artifact_source == "artifactory" ? matrix.arch : null
-      product_version      = var.vault_product_version
-      artifact_type        = matrix.artifact_type
-      distro               = matrix.artifact_source == "artifactory" ? matrix.distro : null
-      edition              = matrix.artifact_source == "artifactory" ? matrix.edition : null
-      revision             = var.vault_revision
+      build_tags        = var.vault_local_build_tags != null ? var.vault_local_build_tags : global.build_tags[matrix.edition]
+      artifact_path     = local.artifact_path
+      goarch            = matrix.arch
+      goos              = "linux"
+      artifactory_host  = matrix.artifact_source == "artifactory" ? var.artifactory_host : null
+      artifactory_repo  = matrix.artifact_source == "artifactory" ? var.artifactory_repo : null
+      artifactory_token = matrix.artifact_source == "artifactory" ? var.artifactory_token : null
+      arch              = matrix.artifact_source == "artifactory" ? matrix.arch : null
+      product_version   = var.vault_product_version
+      artifact_type     = matrix.artifact_type
+      distro            = matrix.artifact_source == "artifactory" ? matrix.distro : null
+      edition           = matrix.artifact_source == "artifactory" ? matrix.edition : null
+      revision          = var.vault_revision
     }
   }
 

--- a/enos/enos-scenario-seal-ha.hcl
+++ b/enos/enos-scenario-seal-ha.hcl
@@ -30,7 +30,6 @@ scenario "seal_ha" {
     https://eng-handbook.hashicorp.services/internal-tools/enos/troubleshooting/#execution-error-expected-vs-got-for-vault-versioneditionrevisionbuild-date.
 
     Variables required for some scenario variants:
-      - artifactory_username (if using `artifact_source:artifactory` in your filter)
       - artifactory_token (if using `artifact_source:artifactory` in your filter)
       - aws_region (if different from the default value in enos-variables.hcl)
       - consul_license_path (if using an ENT edition of Consul)
@@ -129,7 +128,6 @@ scenario "seal_ha" {
       goos                 = "linux"
       artifactory_host     = matrix.artifact_source == "artifactory" ? var.artifactory_host : null
       artifactory_repo     = matrix.artifact_source == "artifactory" ? var.artifactory_repo : null
-      artifactory_username = matrix.artifact_source == "artifactory" ? var.artifactory_username : null
       artifactory_token    = matrix.artifact_source == "artifactory" ? var.artifactory_token : null
       arch                 = matrix.artifact_source == "artifactory" ? matrix.arch : null
       product_version      = var.vault_product_version

--- a/enos/enos-scenario-smoke.hcl
+++ b/enos/enos-scenario-smoke.hcl
@@ -100,19 +100,19 @@ scenario "smoke" {
     module      = "build_${matrix.artifact_source}"
 
     variables {
-      build_tags           = var.vault_local_build_tags != null ? var.vault_local_build_tags : global.build_tags[matrix.edition]
-      artifact_path        = local.artifact_path
-      goarch               = matrix.arch
-      goos                 = "linux"
-      artifactory_host     = matrix.artifact_source == "artifactory" ? var.artifactory_host : null
-      artifactory_repo     = matrix.artifact_source == "artifactory" ? var.artifactory_repo : null
-      artifactory_token    = matrix.artifact_source == "artifactory" ? var.artifactory_token : null
-      arch                 = matrix.artifact_source == "artifactory" ? matrix.arch : null
-      product_version      = var.vault_product_version
-      artifact_type        = matrix.artifact_type
-      distro               = matrix.artifact_source == "artifactory" ? matrix.distro : null
-      edition              = matrix.artifact_source == "artifactory" ? matrix.edition : null
-      revision             = var.vault_revision
+      build_tags        = var.vault_local_build_tags != null ? var.vault_local_build_tags : global.build_tags[matrix.edition]
+      artifact_path     = local.artifact_path
+      goarch            = matrix.arch
+      goos              = "linux"
+      artifactory_host  = matrix.artifact_source == "artifactory" ? var.artifactory_host : null
+      artifactory_repo  = matrix.artifact_source == "artifactory" ? var.artifactory_repo : null
+      artifactory_token = matrix.artifact_source == "artifactory" ? var.artifactory_token : null
+      arch              = matrix.artifact_source == "artifactory" ? matrix.arch : null
+      product_version   = var.vault_product_version
+      artifact_type     = matrix.artifact_type
+      distro            = matrix.artifact_source == "artifactory" ? matrix.distro : null
+      edition           = matrix.artifact_source == "artifactory" ? matrix.edition : null
+      revision          = var.vault_revision
     }
   }
 

--- a/enos/enos-scenario-smoke.hcl
+++ b/enos/enos-scenario-smoke.hcl
@@ -26,7 +26,6 @@ scenario "smoke" {
     https://eng-handbook.hashicorp.services/internal-tools/enos/troubleshooting/#execution-error-expected-vs-got-for-vault-versioneditionrevisionbuild-date.
 
     Variables required for some scenario variants:
-      - artifactory_username (if using `artifact_source:artifactory` in your filter)
       - artifactory_token (if using `artifact_source:artifactory` in your filter)
       - aws_region (if different from the default value in enos-variables.hcl)
       - consul_license_path (if using an ENT edition of Consul)
@@ -107,7 +106,6 @@ scenario "smoke" {
       goos                 = "linux"
       artifactory_host     = matrix.artifact_source == "artifactory" ? var.artifactory_host : null
       artifactory_repo     = matrix.artifact_source == "artifactory" ? var.artifactory_repo : null
-      artifactory_username = matrix.artifact_source == "artifactory" ? var.artifactory_username : null
       artifactory_token    = matrix.artifact_source == "artifactory" ? var.artifactory_token : null
       arch                 = matrix.artifact_source == "artifactory" ? matrix.arch : null
       product_version      = var.vault_product_version

--- a/enos/enos-scenario-upgrade.hcl
+++ b/enos/enos-scenario-upgrade.hcl
@@ -27,7 +27,6 @@ scenario "upgrade" {
     https://eng-handbook.hashicorp.services/internal-tools/enos/troubleshooting/#execution-error-expected-vs-got-for-vault-versioneditionrevisionbuild-date.
 
     Variables required for some scenario variants:
-      - artifactory_username (if using `artifact_source:artifactory` in your filter)
       - artifactory_token (if using `artifact_source:artifactory` in your filter)
       - aws_region (if different from the default value in enos-variables.hcl)
       - consul_license_path (if using an ENT edition of Consul)
@@ -117,7 +116,6 @@ scenario "upgrade" {
       goos                 = "linux"
       artifactory_host     = matrix.artifact_source == "artifactory" ? var.artifactory_host : null
       artifactory_repo     = matrix.artifact_source == "artifactory" ? var.artifactory_repo : null
-      artifactory_username = matrix.artifact_source == "artifactory" ? var.artifactory_username : null
       artifactory_token    = matrix.artifact_source == "artifactory" ? var.artifactory_token : null
       arch                 = matrix.artifact_source == "artifactory" ? matrix.arch : null
       product_version      = var.vault_product_version

--- a/enos/enos-scenario-upgrade.hcl
+++ b/enos/enos-scenario-upgrade.hcl
@@ -110,19 +110,19 @@ scenario "upgrade" {
     module      = "build_${matrix.artifact_source}"
 
     variables {
-      build_tags           = var.vault_local_build_tags != null ? var.vault_local_build_tags : global.build_tags[matrix.edition]
-      artifact_path        = local.artifact_path
-      goarch               = matrix.arch
-      goos                 = "linux"
-      artifactory_host     = matrix.artifact_source == "artifactory" ? var.artifactory_host : null
-      artifactory_repo     = matrix.artifact_source == "artifactory" ? var.artifactory_repo : null
-      artifactory_token    = matrix.artifact_source == "artifactory" ? var.artifactory_token : null
-      arch                 = matrix.artifact_source == "artifactory" ? matrix.arch : null
-      product_version      = var.vault_product_version
-      artifact_type        = matrix.artifact_type
-      distro               = matrix.artifact_source == "artifactory" ? matrix.distro : null
-      edition              = matrix.artifact_source == "artifactory" ? matrix.edition : null
-      revision             = var.vault_revision
+      build_tags        = var.vault_local_build_tags != null ? var.vault_local_build_tags : global.build_tags[matrix.edition]
+      artifact_path     = local.artifact_path
+      goarch            = matrix.arch
+      goos              = "linux"
+      artifactory_host  = matrix.artifact_source == "artifactory" ? var.artifactory_host : null
+      artifactory_repo  = matrix.artifact_source == "artifactory" ? var.artifactory_repo : null
+      artifactory_token = matrix.artifact_source == "artifactory" ? var.artifactory_token : null
+      arch              = matrix.artifact_source == "artifactory" ? matrix.arch : null
+      product_version   = var.vault_product_version
+      artifact_type     = matrix.artifact_type
+      distro            = matrix.artifact_source == "artifactory" ? matrix.distro : null
+      edition           = matrix.artifact_source == "artifactory" ? matrix.edition : null
+      revision          = var.vault_revision
     }
   }
 

--- a/enos/enos-variables.hcl
+++ b/enos/enos-variables.hcl
@@ -1,13 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: BUSL-1.1
 
-variable "artifactory_username" {
-  type        = string
-  description = "The username to use when testing an artifact from artifactory"
-  default     = null
-  sensitive   = true
-}
-
 variable "artifactory_token" {
   type        = string
   description = "The token to use when authenticating to artifactory"

--- a/enos/enos.vars.hcl
+++ b/enos/enos.vars.hcl
@@ -1,9 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: BUSL-1.1
 
-// artifactory_username is the username to use when testing an artifact stored in artfactory.
-// artifactory_username = "yourname@hashicorp.com"
-
 // artifactory_token is the token to use when authenticating to artifactory.
 // artifactory_token = "yourtoken"
 

--- a/enos/modules/build_artifactory_artifact/main.tf
+++ b/enos/modules/build_artifactory_artifact/main.tf
@@ -52,11 +52,11 @@ module "artifact_metadata" {
 }
 
 data "enos_artifactory_item" "vault" {
-  token    = var.artifactory_token
-  name     = module.artifact_metadata.artifact_name
-  host     = var.artifactory_host
-  repo     = var.artifactory_repo
-  path     = "${module.artifact_metadata.product_name}/*"
+  token = var.artifactory_token
+  name  = module.artifact_metadata.artifact_name
+  host  = var.artifactory_host
+  repo  = var.artifactory_repo
+  path  = "${module.artifact_metadata.product_name}/*"
   properties = tomap({
     "commit"          = var.revision,
     "product-name"    = module.artifact_metadata.product_name,
@@ -86,8 +86,8 @@ output "name" {
 
 output "vault_artifactory_release" {
   value = {
-    url      = data.enos_artifactory_item.vault.results[0].url
-    sha256   = data.enos_artifactory_item.vault.results[0].sha256
-    token    = var.artifactory_token
+    url    = data.enos_artifactory_item.vault.results[0].url
+    sha256 = data.enos_artifactory_item.vault.results[0].sha256
+    token  = var.artifactory_token
   }
 }

--- a/enos/modules/build_artifactory_artifact/main.tf
+++ b/enos/modules/build_artifactory_artifact/main.tf
@@ -10,12 +10,6 @@ terraform {
   }
 }
 
-variable "artifactory_username" {
-  type        = string
-  description = "The username to use when connecting to artifactory"
-  default     = null
-}
-
 variable "artifactory_token" {
   type        = string
   description = "The token to use when connecting to artifactory"
@@ -58,7 +52,6 @@ module "artifact_metadata" {
 }
 
 data "enos_artifactory_item" "vault" {
-  username = var.artifactory_username
   token    = var.artifactory_token
   name     = module.artifact_metadata.artifact_name
   host     = var.artifactory_host
@@ -95,7 +88,6 @@ output "vault_artifactory_release" {
   value = {
     url      = data.enos_artifactory_item.vault.results[0].url
     sha256   = data.enos_artifactory_item.vault.results[0].sha256
-    username = var.artifactory_username
     token    = var.artifactory_token
   }
 }

--- a/enos/modules/build_artifactory_artifact/main.tf
+++ b/enos/modules/build_artifactory_artifact/main.tf
@@ -86,8 +86,9 @@ output "name" {
 
 output "vault_artifactory_release" {
   value = {
-    url    = data.enos_artifactory_item.vault.results[0].url
-    sha256 = data.enos_artifactory_item.vault.results[0].sha256
-    token  = var.artifactory_token
+    url      = data.enos_artifactory_item.vault.results[0].url
+    sha256   = data.enos_artifactory_item.vault.results[0].sha256
+    token    = var.artifactory_token
+    username = null # username is not an optional value yet
   }
 }

--- a/enos/modules/build_artifactory_package/main.tf
+++ b/enos/modules/build_artifactory_package/main.tf
@@ -68,11 +68,11 @@ module "artifact_metadata" {
 }
 
 data "enos_artifactory_item" "vault" {
-  token    = var.artifactory_token
-  name     = module.artifact_metadata.artifact_name
-  host     = var.artifactory_host
-  repo     = module.artifact_metadata.release_repo
-  path     = module.artifact_metadata.release_paths[var.distro_version]
+  token = var.artifactory_token
+  name  = module.artifact_metadata.artifact_name
+  host  = var.artifactory_host
+  repo  = module.artifact_metadata.release_repo
+  path  = module.artifact_metadata.release_paths[var.distro_version]
 }
 
 output "results" {
@@ -101,8 +101,8 @@ output "name" {
 
 output "release" {
   value = {
-    url      = data.enos_artifactory_item.vault.results[0].url
-    sha256   = data.enos_artifactory_item.vault.results[0].sha256
-    token    = var.artifactory_token
+    url    = data.enos_artifactory_item.vault.results[0].url
+    sha256 = data.enos_artifactory_item.vault.results[0].sha256
+    token  = var.artifactory_token
   }
 }

--- a/enos/modules/build_artifactory_package/main.tf
+++ b/enos/modules/build_artifactory_package/main.tf
@@ -4,7 +4,8 @@
 terraform {
   required_providers {
     enos = {
-      source = "registry.terraform.io/hashicorp-forge/enos"
+      source  = "registry.terraform.io/hashicorp-forge/enos"
+      version = ">= 0.6.1"
     }
   }
 }
@@ -101,8 +102,9 @@ output "name" {
 
 output "release" {
   value = {
-    url    = data.enos_artifactory_item.vault.results[0].url
-    sha256 = data.enos_artifactory_item.vault.results[0].sha256
-    token  = var.artifactory_token
+    url      = data.enos_artifactory_item.vault.results[0].url
+    sha256   = data.enos_artifactory_item.vault.results[0].sha256
+    token    = var.artifactory_token
+    username = null # username is not optional yet
   }
 }

--- a/enos/modules/build_artifactory_package/main.tf
+++ b/enos/modules/build_artifactory_package/main.tf
@@ -14,11 +14,6 @@ variable "arch" {
   description = "The architecture for the desired artifact"
 }
 
-variable "artifactory_username" {
-  type        = string
-  description = "The username to use when connecting to Artifactory"
-}
-
 variable "artifactory_token" {
   type        = string
   description = "The token to use when connecting to Artifactory"
@@ -73,7 +68,6 @@ module "artifact_metadata" {
 }
 
 data "enos_artifactory_item" "vault" {
-  username = var.artifactory_username
   token    = var.artifactory_token
   name     = module.artifact_metadata.artifact_name
   host     = var.artifactory_host
@@ -109,7 +103,6 @@ output "release" {
   value = {
     url      = data.enos_artifactory_item.vault.results[0].url
     sha256   = data.enos_artifactory_item.vault.results[0].sha256
-    username = var.artifactory_username
     token    = var.artifactory_token
   }
 }

--- a/enos/modules/build_crt/main.tf
+++ b/enos/modules/build_crt/main.tf
@@ -24,7 +24,6 @@ variable "goos" {
 
 variable "artifactory_host" { default = null }
 variable "artifactory_repo" { default = null }
-variable "artifactory_username" { default = null }
 variable "artifactory_token" { default = null }
 variable "arch" { default = null }
 variable "artifact_path" { default = null }

--- a/enos/modules/build_local/main.tf
+++ b/enos/modules/build_local/main.tf
@@ -38,7 +38,6 @@ variable "goos" {
 
 variable "artifactory_host" { default = null }
 variable "artifactory_repo" { default = null }
-variable "artifactory_username" { default = null }
 variable "artifactory_token" { default = null }
 variable "arch" { default = null }
 variable "artifact_type" { default = null }


### PR DESCRIPTION
### Description
What does this PR do?
[SECVULN-24009](https://hashicorp.atlassian.net/browse/SECVULN-24009)
The github_actions-vault_ci access key that we're currently using was created over 90 days ago. I have created a new one and added it to this repo's GH Actions Secrets. This PR replaces the old key. Once we have confirmed that introducing the new key hasn't broken anything, the old key will be removed from GH Actions secrets and AWS keys.

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [X] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.

### PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.

Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.


[SECVULN-24009]: https://hashicorp.atlassian.net/browse/SECVULN-24009?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ