### PR TITLE
feat(gcs): support custom universe_domain via env/config

### DIFF
--- a/changelog/31550.txt
+++ b/changelog/31550.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+gcs: add support for the `universe_domain` parameter, allowing the backend to work with GCP sovereign cloud environments that require a custom API domain.
+```

--- a/physical/gcs/gcs_ha_test.go
+++ b/physical/gcs/gcs_ha_test.go
@@ -15,6 +15,7 @@ import (
 	log "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/vault/sdk/helper/logging"
 	"github.com/hashicorp/vault/sdk/physical"
+	"google.golang.org/api/option"
 )
 
 func TestHABackend(t *testing.T) {
@@ -23,27 +24,45 @@ func TestHABackend(t *testing.T) {
 		t.Skip("GOOGLE_PROJECT_ID not set")
 	}
 
+	universeDomain := os.Getenv("GOOGLE_UNIVERSE_DOMAIN")
+
 	r := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 	bucket := fmt.Sprintf("vault-gcs-testacc-%d", r)
 
 	ctx := context.Background()
-	client, err := storage.NewClient(ctx)
-	if err != nil {
-		t.Fatal(err)
+	// Build client options: if a custom universe domain is provided in env, use it.
+	clientOpts := []option.ClientOption{}
+	if universeDomain != "" {
+		clientOpts = append(clientOpts, option.WithUniverseDomain(universeDomain))
 	}
+	client, err := storage.NewClient(ctx, clientOpts...)
 
 	testCleanup(t, client, bucket)
 	defer testCleanup(t, client, bucket)
 
 	bh := client.Bucket(bucket)
-	if err := bh.Create(context.Background(), projectID, nil); err != nil {
-		t.Fatal(err)
+	// Support minimal for providers that require an explicit Location.
+	bucketLocation := os.Getenv("GOOGLE_BUCKET_LOCATION")
+
+	if bucketLocation != "" {
+		// Create the bucket with the explicit location required by some universe domains.
+		if err := bh.Create(ctx, projectID, &storage.BucketAttrs{
+			Location: bucketLocation,
+		}); err != nil {
+			t.Fatalf("failed to create bucket %q with location %q: %v", bucket, bucketLocation, err)
+		}
+	} else {
+		// Default behaviour (no explicit location).
+		if err := bh.Create(ctx, projectID, nil); err != nil {
+			t.Fatalf("failed to create bucket %q: %v", bucket, err)
+		}
 	}
 
 	logger := logging.NewVaultLogger(log.Trace)
 	config := map[string]string{
-		"bucket":     bucket,
-		"ha_enabled": "true",
+		"bucket":          bucket,
+		"ha_enabled":      "true",
+		"universe_domain": universeDomain,
 	}
 
 	b, err := NewBackend(config, logger)

--- a/physical/gcs/gcs_test.go
+++ b/physical/gcs/gcs_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/vault/sdk/helper/logging"
 	"github.com/hashicorp/vault/sdk/physical"
 	"google.golang.org/api/googleapi"
+	"google.golang.org/api/option"
 )
 
 func testCleanup(t testing.TB, client *storage.Client, bucket string) {
@@ -36,11 +37,18 @@ func TestBackend(t *testing.T) {
 		t.Skip("GOOGLE_PROJECT_ID not set")
 	}
 
+	universeDomain := os.Getenv("GOOGLE_UNIVERSE_DOMAIN")
+
 	r := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 	bucket := fmt.Sprintf("vault-gcs-testacc-%d", r)
 
 	ctx := context.Background()
-	client, err := storage.NewClient(ctx)
+	// Build client options: if a custom universe domain is provided in env, use it.
+	clientOpts := []option.ClientOption{}
+	if universeDomain != "" {
+		clientOpts = append(clientOpts, option.WithUniverseDomain(universeDomain))
+	}
+	client, err := storage.NewClient(ctx, clientOpts...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -49,13 +57,27 @@ func TestBackend(t *testing.T) {
 	defer testCleanup(t, client, bucket)
 
 	b := client.Bucket(bucket)
-	if err := b.Create(context.Background(), projectID, nil); err != nil {
-		t.Fatal(err)
+	// Support minimal for providers that require an explicit Location.
+	bucketLocation := os.Getenv("GOOGLE_BUCKET_LOCATION")
+
+	if bucketLocation != "" {
+		// Create the bucket with the explicit location required by some universe domains.
+		if err := b.Create(ctx, projectID, &storage.BucketAttrs{
+			Location: bucketLocation,
+		}); err != nil {
+			t.Fatalf("failed to create bucket %q with location %q: %v", bucket, bucketLocation, err)
+		}
+	} else {
+		// Default behaviour (no explicit location).
+		if err := b.Create(ctx, projectID, nil); err != nil {
+			t.Fatalf("failed to create bucket %q: %v", bucket, err)
+		}
 	}
 
 	backend, err := NewBackend(map[string]string{
-		"bucket":     bucket,
-		"ha_enabled": "false",
+		"bucket":          bucket,
+		"ha_enabled":      "false",
+		"universe_domain": universeDomain,
 	}, logging.NewVaultLogger(log.Trace))
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
**Description**
This PR adds support for the `universe_domain` parameter in the GCS backend.
By default, the backend uses the standard `googleapis.com`, but with this change, users can optionally configure a custom `universe_domain` to enable Vault to work in sovereign cloud environments.

**Related Issue**
Closes #31549 

**Changes Introduced**

* Added `universe_domain` as an optional configuration in the GCS backend
* Updated tests to allow specifying a custom universe domain and region

**Backward Compatibility**

* If `universe_domain` is not set, Vault continues to use `googleapis.com` by default

**Additional Context**
This enhancement enables the use of Vault with GCP sovereign clouds, where custom API domains are required.


Signed-off-by: Houssein Mnaouar <houssein.mnaouar@gmail.com>
