### PR TITLE
feat(gcp): support universe_domain for GCP kms wrappers and vault config

### DIFF
--- a/changelog/31554.txt
+++ b/changelog/31554.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+Add support for the `universe_domain` parameter in the KMS backend. This allows Vault to work with GCP sovereign cloud environments requiring custom API domains.
+```


### PR DESCRIPTION
**Description**
This PR adds support for the `universe_domain` parameter for GCP KMS usage in Vault. When set, Vault forwards the value to the GCP KMS wrapper so the client uses a custom API domain; if not set Vault keeps using `googleapis.com`.

**Related Issue**
Closes #31553 

**Changes Introduced**

* Forward `universe_domain` from Vault KMS config to the gcpckms wrapper (`internalshared/configutil/kms.go`).

**Backward Compatibility**
Default behavior unchanged: if `universe_domain` is not set, Vault continues to use `googleapis.com`.

**Dependency**
This PR depends on a change in `go-kms-wrapping` that adds `WithUniverseDomain`. Link: [go-kms-wrapping](https://github.com/hashicorp/go-kms-wrapping/pull/291).
I tested locally using a temporary `replace` in my `go.mod`. Once the wrapper PR is merged I will update `go.mod` in this branch to the released tag.

**Quick post-merge step (what I will do or maintainers can do):**

```bash
# after go-kms-wrapping PR merged -> bump dependency
go get github.com/hashicorp/go-kms-wrapping/v2@<commit-or-tag>
go mod tidy
git add go.mod go.sum
git commit -m "go: bump go-kms-wrapping for universe_domain support"
git push
```

**Additional Context**
Enables Vault to operate with GCP sovereign/custom endpoints by opt-in config only.

Signed-off-by: Houssein Mnaouar <houssein.mnaouar@gmail.com>