### PR TITLE
Allow unsetting sys flags from sys command.

### DIFF
--- a/api/sys_mounts.go
+++ b/api/sys_mounts.go
@@ -222,11 +222,16 @@ func (c *Sys) RemountStatusWithContext(ctx context.Context, migrationID string) 
 	return &result, err
 }
 
+func (c *Sys) TuneMountAllowNil(path string, config map[string]interface{}) error {
+	return c.TuneMountAllowNilWithContext(context.Background(), path, config)
+}
+
+// Deprecated: newer functionality should use TuneMountAllowNil instead so that parameters can be set to the nil value
 func (c *Sys) TuneMount(path string, config MountConfigInput) error {
 	return c.TuneMountWithContext(context.Background(), path, config)
 }
 
-func (c *Sys) TuneMountWithContext(ctx context.Context, path string, config MountConfigInput) error {
+func (c *Sys) TuneMountAllowNilWithContext(ctx context.Context, path string, config map[string]interface{}) error {
 	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
 	defer cancelFunc()
 
@@ -240,6 +245,76 @@ func (c *Sys) TuneMountWithContext(ctx context.Context, path string, config Moun
 		defer resp.Body.Close()
 	}
 	return err
+}
+
+// Deprecated: newer functionality should use TuneMountAllowNilWithContext instead, so that configuration can be set to
+// a nil value.
+func (c *Sys) TuneMountWithContext(ctx context.Context, path string, config MountConfigInput) error {
+	mapConfig := map[string]interface{}{}
+
+	mapConfig["options"] = config.Options
+	mapConfig["default_lease_ttl"] = config.DefaultLeaseTTL
+
+	if config.Description != nil { // Because omitempty in the JSON
+		mapConfig["description"] = config.Description
+	}
+
+	mapConfig["max_lease_ttl"] = config.MaxLeaseTTL
+	mapConfig["force_no_cache"] = config.ForceNoCache
+
+	if len(config.AuditNonHMACRequestKeys) != 0 { // Because omitempty in the JSON
+		mapConfig["audit_non_hmac_request_keys"] = config.AuditNonHMACRequestKeys
+	}
+
+	if len(config.AuditNonHMACResponseKeys) != 0 { // Because omitempty in the JSON
+		mapConfig["audit_non_hmac_response_keys"] = config.AuditNonHMACResponseKeys
+	}
+
+	if config.ListingVisibility != "" { // Because omitempty in the JSON
+		mapConfig["listing_visibility"] = config.ListingVisibility
+	}
+
+	if len(config.PassthroughRequestHeaders) != 0 { // Because omitempty in the JSON
+		mapConfig["passthrough_request_headers"] = config.PassthroughRequestHeaders
+	}
+
+	if len(config.AllowedResponseHeaders) != 0 { // Because omitempty in the JSON
+		mapConfig["allowed_response_headers"] = config.AllowedResponseHeaders
+	}
+
+	if config.TokenType != "" { // Because omitempty in the JSON
+		mapConfig["token_type"] = config.TokenType
+	}
+
+	if len(config.AllowedManagedKeys) != 0 { // Because omitempty in the JSON
+		mapConfig["allowed_managed_keys"] = config.AllowedManagedKeys
+	}
+
+	if config.PluginVersion != "" { // Because omitempty in the JSON
+		mapConfig["plugin_version"] = config.PluginVersion
+	}
+
+	if config.UserLockoutConfig != nil { // Because omitempty in the JSON
+		mapConfig["user_lockout_config"] = config.UserLockoutConfig
+	}
+
+	if len(config.DelegatedAuthAccessors) != 0 { // Because omitempty in the JSON
+		mapConfig["delegated_auth_accessors"] = config.DelegatedAuthAccessors
+	}
+
+	if config.IdentityTokenKey != "" { // Because omitempty in the JSON
+		mapConfig["identity_token_key"] = config.IdentityTokenKey
+	}
+
+	if config.TrimRequestTrailingSlashes != nil { // Because omitempty in the JSON
+		mapConfig["trim_request_trailing_slashes"] = config.TrimRequestTrailingSlashes
+	}
+
+	if config.PluginName != "" { // Because omitempty in the JSON
+		mapConfig["plugin_name"] = config.PluginName
+	}
+
+	return c.TuneMountAllowNilWithContext(ctx, path, mapConfig)
 }
 
 func (c *Sys) MountConfig(path string) (*MountConfigOutput, error) {

--- a/changelog/31555.txt
+++ b/changelog/31555.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+sys/mounts: enable unsetting allowed_response_headers
+```

--- a/command/auth_tune.go
+++ b/command/auth_tune.go
@@ -311,7 +311,7 @@ func (c *AuthTuneCommand) Run(args []string) int {
 		}
 
 		if fl.Name == flagNameIdentityTokenKey {
-			mountConfigParamInput[transformFlagNameToParamName(fl.Name)] = c.flagPluginVersion
+			mountConfigParamInput[transformFlagNameToParamName(fl.Name)] = c.flagIdentityTokenKey
 		}
 
 		if fl.Name == flagNameTrimRequestTrailingSlashes && c.flagTrimRequestTrailingSlashes.IsSet() {


### PR DESCRIPTION
### Description
Fixes a bug in which sys fields once set to a non-empty value in the command line can never be set to an empty value again.

### TODO only if you're a HashiCorp employee
- [x] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
-- only one "backport" flag exists now - will be backported on ent
-- not a security vulnerability, just an annoying bug
- [x] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
-- This change has been made in such a way that the public function isn't change, just deprecated
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
-- Branch name
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
-- N/A
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.
-- N/A

### PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
-- reverting this pull-request would be sufficient
- [x] If applicable, I've documented the impact of any changes to security controls.
-- no security controls are touched by this change

Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
