### PR TITLE
Add new decoder for multiline decoding

### DIFF
--- a/http/handler.go
+++ b/http/handler.go
@@ -698,6 +698,9 @@ func WrapForwardedForHandler(h http.Handler, l *configutil.Listener) http.Handle
 								return
 							}
 							v = string(decoded.Bytes[:])
+						case "MULTILINE":
+							v = strings.Replace(v, "-----BEGIN CERTIFICATE-----", "-----BEGIN CERTIFICATE-----\n", 1)
+							v = strings.Replace(v, "-----END CERTIFICATE-----", "\n-----END CERTIFICATE-----", 1)
 						default:
 							respondError(w, http.StatusBadRequest, fmt.Errorf("unknown decode option specified: %s", action))
 							return


### PR DESCRIPTION
Depending on the loadbalancer you need to decode the certificate in the header. there are currently three decoder with the setting "x_forwarded_for_client_cert_header_decoders". if you want to use Citrix Netscaler you are getting a certificate forwarded in the header that is a single line. it is not possible to rewrite the header in Citrix Netscaler.

I would like to request a ne decoder to convert a singleline to multiline.