### PR TITLE
Add new JSON max token limit and new tests

### DIFF
--- a/http/handler.go
+++ b/http/handler.go
@@ -93,6 +93,7 @@ const (
 	// recover from snapshot operation. This replaces the use of query parameters
 	// to pass the snapshot ID
 	VaultSnapshotRecoverHeader = "X-Vault-Recover-Snapshot-Id"
+
 	// CustomMaxJSONDepth specifies the maximum nesting depth of a JSON object.
 	// This limit is designed to prevent stack exhaustion attacks from deeply
 	// nested JSON payloads, which could otherwise lead to a denial-of-service
@@ -129,6 +130,15 @@ const (
 	// systems that require handling larger datasets, though pagination is the
 	// recommended practice for such cases.
 	CustomMaxJSONArrayElementCount = 10000
+
+	// CustomMaxJSONToken sets the maximum total number of tokens (e.g., keys, values,
+	// braces, brackets) permitted in a single JSON payload. This limit is a crucial
+	// defense against complexity-based denial-of-service (DoS) attacks, where a
+	// payload could exhaust CPU and memory with an enormous number of small elements,
+	// even while respecting all other individual limits. The default of 500,000
+	// tokens provides a robust safeguard against malicious inputs without interfering
+	// with legitimate, large-scale API operations. This value is configurable.
+	CustomMaxJSONToken = 500000
 )
 
 var (

--- a/http/util.go
+++ b/http/util.go
@@ -25,7 +25,7 @@ var nonVotersAllowed = false
 
 func wrapMaxRequestSizeHandler(handler http.Handler, props *vault.HandlerProperties) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var maxRequestSize, maxJSONDepth, maxStringValueLength, maxObjectEntryCount, maxArrayElementCount int64
+		var maxRequestSize, maxJSONDepth, maxStringValueLength, maxObjectEntryCount, maxArrayElementCount, maxToken int64
 
 		if props.ListenerConfig != nil {
 			maxRequestSize = props.ListenerConfig.MaxRequestSize
@@ -33,6 +33,7 @@ func wrapMaxRequestSizeHandler(handler http.Handler, props *vault.HandlerPropert
 			maxStringValueLength = props.ListenerConfig.CustomMaxJSONStringValueLength
 			maxObjectEntryCount = props.ListenerConfig.CustomMaxJSONObjectEntryCount
 			maxArrayElementCount = props.ListenerConfig.CustomMaxJSONArrayElementCount
+			maxToken = props.ListenerConfig.CustomMaxJSONToken
 		}
 
 		if maxRequestSize == 0 {
@@ -50,12 +51,16 @@ func wrapMaxRequestSizeHandler(handler http.Handler, props *vault.HandlerPropert
 		if maxArrayElementCount == 0 {
 			maxArrayElementCount = CustomMaxJSONArrayElementCount
 		}
+		if maxToken == 0 {
+			maxToken = CustomMaxJSONToken
+		}
 
 		jsonLimits := jsonutil.JSONLimits{
 			MaxDepth:             int(maxJSONDepth),
 			MaxStringValueLength: int(maxStringValueLength),
 			MaxObjectEntryCount:  int(maxObjectEntryCount),
 			MaxArrayElementCount: int(maxArrayElementCount),
+			MaxTokens:            int(maxToken),
 		}
 
 		// If the payload is JSON, the VerifyMaxDepthStreaming function will perform validations.

--- a/internalshared/configutil/listener.go
+++ b/internalshared/configutil/listener.go
@@ -167,6 +167,10 @@ type Listener struct {
 	// CustomMaxJSONArrayElementCount determines the maximum number of elements in a JSON array.
 	CustomMaxJSONArrayElementCountRaw interface{} `hcl:"max_json_array_element_count"`
 	CustomMaxJSONArrayElementCount    int64       `hcl:"-"`
+
+	// CustomMaxJSONToken determines the maximum number of tokens in a JSON.
+	CustomMaxJSONTokenRaw interface{} `hcl:"max_json_token"`
+	CustomMaxJSONToken    int64       `hcl:"-"`
 }
 
 // AgentAPI allows users to select which parts of the Agent API they want enabled.
@@ -760,6 +764,13 @@ func (l *Listener) parseJSONLimitsSettings() error {
 	}
 	if l.CustomMaxJSONArrayElementCount < 0 {
 		return fmt.Errorf("max_json_array_element_count cannot be negative")
+	}
+
+	if err := parseAndClearInt(&l.CustomMaxJSONTokenRaw, &l.CustomMaxJSONToken); err != nil {
+		return fmt.Errorf("error parsing max_json_token: %w", err)
+	}
+	if l.CustomMaxJSONToken < 0 {
+		return fmt.Errorf("max_json_token cannot be negative")
 	}
 
 	return nil

--- a/internalshared/configutil/listener_test.go
+++ b/internalshared/configutil/listener_test.go
@@ -230,6 +230,8 @@ func TestListener_parseRequestSettings(t *testing.T) {
 		expectedCustomMaxJSONObjectEntryCount  int64
 		rawCustomMaxJSONArrayElementCount      any
 		expectedCustomMaxJSONArrayElementCount int64
+		rawCustomMaxJSONToken                  any
+		expectedCustomMaxJSONToken             int64
 		isErrorExpected                        bool
 		errorMessage                           string
 	}{
@@ -306,6 +308,21 @@ func TestListener_parseRequestSettings(t *testing.T) {
 			expectedCustomMaxJSONArrayElementCount: 500,
 			isErrorExpected:                        false,
 		},
+		"max-json-token-bad": {
+			rawCustomMaxJSONToken: "badvalue",
+			isErrorExpected:       true,
+			errorMessage:          "error parsing max_json_token",
+		},
+		"max-json-token-negative": {
+			rawCustomMaxJSONToken: "-1",
+			isErrorExpected:       true,
+			errorMessage:          "max_json_token cannot be negative",
+		},
+		"max-json-token-good": {
+			rawCustomMaxJSONToken:      "500000",
+			expectedCustomMaxJSONToken: 500000,
+			isErrorExpected:            false,
+		},
 	}
 
 	for name, tc := range tests {
@@ -323,6 +340,7 @@ func TestListener_parseRequestSettings(t *testing.T) {
 				CustomMaxJSONStringValueLengthRaw: tc.rawCustomMaxJSONStringValueLength,
 				CustomMaxJSONObjectEntryCountRaw:  tc.rawCustomMaxJSONObjectEntryCount,
 				CustomMaxJSONArrayElementCountRaw: tc.rawCustomMaxJSONArrayElementCount,
+				CustomMaxJSONTokenRaw:             tc.rawCustomMaxJSONToken,
 			}
 
 			err := l.parseRequestSettings()
@@ -338,6 +356,7 @@ func TestListener_parseRequestSettings(t *testing.T) {
 				require.Equal(t, tc.expectedCustomMaxJSONStringValueLength, l.CustomMaxJSONStringValueLength)
 				require.Equal(t, tc.expectedCustomMaxJSONObjectEntryCount, l.CustomMaxJSONObjectEntryCount)
 				require.Equal(t, tc.expectedCustomMaxJSONArrayElementCount, l.CustomMaxJSONArrayElementCount)
+				require.Equal(t, tc.expectedCustomMaxJSONToken, l.CustomMaxJSONToken)
 				require.Equal(t, tc.expectedRequireRequestHeader, l.RequireRequestHeader)
 				require.Equal(t, tc.expectedDisableRequestLimiter, l.DisableRequestLimiter)
 				require.Equal(t, tc.expectedDuration, l.MaxRequestDuration)
@@ -347,6 +366,7 @@ func TestListener_parseRequestSettings(t *testing.T) {
 				require.Nil(t, l.CustomMaxJSONStringValueLengthRaw)
 				require.Nil(t, l.CustomMaxJSONObjectEntryCountRaw)
 				require.Nil(t, l.CustomMaxJSONArrayElementCountRaw)
+				require.Nil(t, l.CustomMaxJSONTokenRaw)
 				require.Nil(t, l.MaxRequestDurationRaw)
 				require.Nil(t, l.RequireRequestHeaderRaw)
 				require.Nil(t, l.DisableRequestLimiterRaw)

--- a/sdk/helper/jsonutil/json.go
+++ b/sdk/helper/jsonutil/json.go
@@ -10,6 +10,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"strconv"
+	"strings"
+	"unicode"
 
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/vault/sdk/helper/compressutil"
@@ -105,8 +108,18 @@ func DecodeJSONFromReader(r io.Reader, out interface{}) error {
 
 // containerState holds information about an open JSON container (object or array).
 type containerState struct {
-	Type  json.Delim // '{' or '['
-	Count int        // Number of entries (for objects) or elements for arrays)
+	// '{' or '['
+	Type json.Delim
+
+	// Number of entries (for objects) or elements for arrays)
+	Count int
+
+	// isKey is true if the next expected token in an object is a key.
+	isKey bool
+
+	// keys tracks the keys seen in an object to detect duplicates.
+	// It is only initialized for objects ('{').
+	keys map[string]struct{}
 }
 
 // JSONLimits defines the configurable limits for JSON validation.
@@ -115,127 +128,250 @@ type JSONLimits struct {
 	MaxStringValueLength int
 	MaxObjectEntryCount  int
 	MaxArrayElementCount int
+	MaxTokens            int
 }
 
 // isWhitespace checks if a byte is a JSON whitespace character.
 func isWhitespace(b byte) bool {
-	return b == ' ' || b == '\t' || b == '\n' || b == '\r'
+	// Standard JSON whitespace characters (RFC 8259)
+	if b == ' ' || b == '\t' || b == '\n' || b == '\r' {
+		return true
+	}
+	// Custom support for non-standard Unit Separator character (ASCII 31)
+	if b == 31 || b == 139 {
+		return true
+	}
+	return false
 }
 
-// VerifyMaxDepthStreaming scans the JSON stream to determine its maximum nesting depth
-// and enforce various limits. It first checks if the stream is likely JSON before proceeding.
+// VerifyMaxDepthStreaming scans the JSON stream to enforce nesting depth, counts,
+// and other limits without decoding the full structure into memory.
 func VerifyMaxDepthStreaming(jsonReader io.Reader, limits JSONLimits) (int, error) {
 	// Use a buffered reader to peek at the stream without consuming it from the original reader.
 	bufReader := bufio.NewReader(jsonReader)
 
-	// Find the first non-whitespace character.
-	var firstByte byte
-	var err error
-	for {
-		firstByte, err = bufReader.ReadByte()
-		if err != nil {
-			// If we hit EOF before finding a real character, it's an empty or whitespace-only payload.
-			if err == io.EOF {
-				return 0, nil
-			}
-			return 0, err // A different I/O error occurred.
-		}
-		if !isWhitespace(firstByte) {
-			break // Found the first significant character.
-		}
+	bom, err := bufReader.Peek(3)
+	if err == nil && bytes.Equal(bom, []byte{0xEF, 0xBB, 0xBF}) {
+		_, _ = bufReader.Discard(3)
 	}
 
-	// If the payload doesn't start with '{' or '[', assume it's not a JSON object or array
-	// and that our limits do not apply.
-	if firstByte != '{' && firstByte != '[' {
-		return 0, nil
-	}
-
-	fullStreamReader := io.MultiReader(bytes.NewReader([]byte{firstByte}), bufReader)
-	decoder := json.NewDecoder(fullStreamReader)
-	decoder.UseNumber()
-
+	// We use a manual token loop instead of json.Decoder to gain low-level
+	// control over the stream. This is necessary to fix a vulnerability where
+	// the raw byte length of strings with escape sequences was not correctly limited.
 	var (
-		maxDepth      = 0
-		currentDepth  = 0
-		isKeyExpected bool
+		maxDepth          int
+		currentDepth      int
+		tokenCount        int
+		lastTokenWasComma bool
 	)
 	containerInfoStack := make([]containerState, 0, limits.MaxDepth)
 
-	for {
-		t, err := decoder.Token()
+	// Prime the loop by finding the first non-whitespace character.
+	if err := skipWhitespace(bufReader); err != nil {
 		if err == io.EOF {
-			break
+			// An empty payload or one with only whitespace is valid. Skip verification.
+			return 0, nil
 		}
+		return 0, err
+	}
+
+	b, err := bufReader.Peek(1)
+	if err != nil {
+		// This can happen if there's an I/O error after skipping whitespace.
+		return 0, err
+	}
+
+	// If the payload doesn't start with a JSON container ('{' or '['), skip
+	// verification. The limits are intended for structured data, not primitives
+	// or other formats.
+	if b[0] != '{' && b[0] != '[' {
+		return 0, nil
+	}
+
+	for {
+		// Check for EOF before peeking.
+		b, err := bufReader.Peek(1)
+		// Any error from the decoder is now considered a real error.
 		if err != nil {
-			// Any error from the decoder is now considered a real error.
+			if err == io.EOF {
+				break
+			}
 			return 0, fmt.Errorf("error reading JSON token: %w", err)
 		}
 
-		switch v := t.(type) {
-		case json.Delim:
-			switch v {
-			case '{', '[':
-				currentDepth++
-				// Check against the limit directly.
-				if currentDepth > limits.MaxDepth {
-					return 0, fmt.Errorf("JSON input exceeds allowed nesting depth")
-				}
-				if currentDepth > maxDepth {
-					maxDepth = currentDepth
-				}
+		// If the last token was a comma, the next token cannot be a closing delimiter.
+		if lastTokenWasComma && (b[0] == '}' || b[0] == ']') {
+			if b[0] == '}' {
+				return 0, fmt.Errorf("invalid character '}' after object key-value pair")
+			}
+			return 0, fmt.Errorf("invalid character ']' after array element")
+		}
 
-				containerInfoStack = append(containerInfoStack, containerState{Type: v, Count: 0})
-				if v == '{' {
-					isKeyExpected = true
-				}
-			case '}', ']':
-				if len(containerInfoStack) == 0 {
-					return 0, fmt.Errorf("malformed JSON: unmatched closing delimiter '%c'", v)
-				}
-				top := containerInfoStack[len(containerInfoStack)-1]
-				containerInfoStack = containerInfoStack[:len(containerInfoStack)-1]
-				currentDepth--
-				if (v == '}' && top.Type != '{') || (v == ']' && top.Type != '[') {
-					return 0, fmt.Errorf("malformed JSON: mismatched closing delimiter '%c' for opening '%c'", v, top.Type)
-				}
-				if len(containerInfoStack) > 0 && containerInfoStack[len(containerInfoStack)-1].Type == '{' {
-					isKeyExpected = false
-				}
+		// After a top-level value, any other character is an error.
+		if len(containerInfoStack) == 0 && maxDepth > 0 {
+			return 0, fmt.Errorf("invalid character '%c' after top-level value", b[0])
+		}
+
+		// Increment and check the total token count limit.
+		if limits.MaxTokens > 0 {
+			tokenCount++
+			if tokenCount > limits.MaxTokens {
+				return 0, fmt.Errorf("JSON payload exceeds allowed token count")
 			}
-		case string:
-			if len(v) > limits.MaxStringValueLength {
-				return 0, fmt.Errorf("JSON string value exceeds allowed length")
-			}
-			if len(containerInfoStack) > 0 {
-				top := &containerInfoStack[len(containerInfoStack)-1]
-				if top.Type == '{' {
-					if isKeyExpected {
-						top.Count++
-						if top.Count > limits.MaxObjectEntryCount {
-							return 0, fmt.Errorf("JSON object exceeds allowed entry count")
-						}
-						isKeyExpected = false
-					}
-				} else if top.Type == '[' {
-					top.Count++
-					if top.Count > limits.MaxArrayElementCount {
+		}
+
+		var currentContainer *containerState
+		if len(containerInfoStack) > 0 {
+			currentContainer = &containerInfoStack[len(containerInfoStack)-1]
+		}
+
+		// Before processing the token, reset the comma flag. It will be set
+		// again below if the current token is a comma.
+		lastTokenWasComma = false
+
+		switch b[0] {
+		case '{', '[':
+			delim, _ := bufReader.ReadByte()
+			if currentContainer != nil {
+				if currentContainer.Type == '[' {
+					currentContainer.Count++
+					if currentContainer.Count > limits.MaxArrayElementCount {
 						return 0, fmt.Errorf("JSON array exceeds allowed element count")
 					}
+				} else {
+					currentContainer.isKey = true
 				}
 			}
-		default: // Handles numbers, booleans, and nulls
-			if len(containerInfoStack) > 0 {
-				top := &containerInfoStack[len(containerInfoStack)-1]
-				if top.Type == '[' {
-					top.Count++
-					if top.Count > limits.MaxArrayElementCount {
-						return 0, fmt.Errorf("JSON array exceeds allowed element count")
+
+			// Handle depth checks and tracking together for clarity.
+			currentDepth++
+			if currentDepth > maxDepth {
+				maxDepth = currentDepth
+			}
+			// Check depth limit immediately after incrementing.
+			if limits.MaxDepth > 0 && currentDepth > limits.MaxDepth {
+				return 0, fmt.Errorf("JSON input exceeds allowed nesting depth")
+			}
+
+			// For objects, initialize a map to track keys and prevent duplicates.
+			var keys map[string]struct{}
+			if delim == '{' {
+				keys = make(map[string]struct{})
+			}
+
+			containerInfoStack = append(containerInfoStack, containerState{Type: json.Delim(delim), isKey: delim == '{', keys: keys})
+
+		case '}', ']':
+			// A closing brace cannot follow a colon without a value.
+			if currentContainer != nil && currentContainer.Type == '{' && !currentContainer.isKey {
+				return 0, fmt.Errorf("invalid character '}' after object key")
+			}
+			delim, _ := bufReader.ReadByte()
+			if currentContainer == nil {
+				return 0, fmt.Errorf("malformed JSON: unmatched closing delimiter '%c'", delim)
+			}
+			if (delim == '}' && currentContainer.Type != '{') || (delim == ']' && currentContainer.Type != '[') {
+				return 0, fmt.Errorf("malformed JSON: mismatched closing delimiter '%c'", delim)
+			}
+			containerInfoStack = containerInfoStack[:len(containerInfoStack)-1]
+			currentDepth--
+			if len(containerInfoStack) > 0 && containerInfoStack[len(containerInfoStack)-1].Type == '{' {
+				containerInfoStack[len(containerInfoStack)-1].isKey = true
+			}
+
+		case '"':
+			// Manually scan the string to count its raw byte length and get the value.
+			val, err := scanString(bufReader, limits.MaxStringValueLength)
+			if err != nil {
+				return 0, err
+			}
+
+			if currentContainer == nil {
+				if maxDepth == 0 {
+					maxDepth = 1
+				}
+				break
+			}
+
+			if currentContainer.Type == '{' {
+				if currentContainer.isKey {
+					// Check for duplicate keys.
+					if _, ok := currentContainer.keys[val]; ok {
+						return 0, fmt.Errorf("duplicate key '%s' in object", val)
 					}
-				} else if top.Type == '{' {
-					isKeyExpected = true
+					currentContainer.keys[val] = struct{}{}
+
+					currentContainer.Count++
+					if currentContainer.Count > limits.MaxObjectEntryCount {
+						return 0, fmt.Errorf("JSON object exceeds allowed entry count")
+					}
+					currentContainer.isKey = false
+				} else {
+					currentContainer.isKey = true
+				}
+			} else {
+				currentContainer.Count++
+				if currentContainer.Count > limits.MaxArrayElementCount {
+					return 0, fmt.Errorf("JSON array exceeds allowed element count")
 				}
 			}
+
+		case 't', 'f', 'n': // true, false, null
+			if err := scanLiteral(bufReader); err != nil {
+				return 0, err
+			}
+			if currentContainer == nil {
+				if maxDepth == 0 {
+					maxDepth = 1
+				}
+				break
+			}
+			if currentContainer.Type == '[' {
+				currentContainer.Count++
+				if currentContainer.Count > limits.MaxArrayElementCount {
+					return 0, fmt.Errorf("JSON array exceeds allowed element count")
+				}
+			} else {
+				currentContainer.isKey = true
+			}
+		case '-', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9':
+			if err := scanNumber(bufReader, limits.MaxStringValueLength); err != nil {
+				return 0, err
+			}
+			if currentContainer == nil {
+				if maxDepth == 0 {
+					maxDepth = 1
+				}
+				break
+			}
+			if currentContainer.Type == '[' {
+				currentContainer.Count++
+				if currentContainer.Count > limits.MaxArrayElementCount {
+					return 0, fmt.Errorf("JSON array exceeds allowed element count")
+				}
+			} else {
+				currentContainer.isKey = true
+			}
+
+		case ',':
+			_, _ = bufReader.ReadByte()
+			lastTokenWasComma = true
+			if currentContainer != nil && currentContainer.Type == '{' {
+				currentContainer.isKey = true
+			}
+
+		case ':':
+			_, _ = bufReader.ReadByte()
+
+		default:
+			return 0, fmt.Errorf("invalid character '%c' looking for beginning of value", b[0])
+		}
+
+		if err := skipWhitespace(bufReader); err != nil {
+			if err == io.EOF {
+				break
+			}
+			return 0, err
 		}
 	}
 
@@ -244,4 +380,169 @@ func VerifyMaxDepthStreaming(jsonReader io.Reader, limits JSONLimits) (int, erro
 	}
 
 	return maxDepth, nil
+}
+
+func skipWhitespace(r *bufio.Reader) error {
+	for {
+		b, err := r.Peek(1)
+		if err != nil {
+			return err
+		}
+		if !isWhitespace(b[0]) {
+			return nil
+		}
+		_, _ = r.ReadByte()
+	}
+}
+
+// scanString consumes a JSON string from the reader, ensuring the raw byte
+// length of its content does not exceed the limit.
+func scanString(r *bufio.Reader, limit int) (string, error) {
+	if b, _ := r.ReadByte(); b != '"' {
+		return "", fmt.Errorf("expected string")
+	}
+
+	var builder strings.Builder
+	contentByteCount := 0
+	for {
+		b, err := r.ReadByte()
+		if err != nil {
+			if err == io.EOF {
+				return "", fmt.Errorf("malformed JSON, unclosed string")
+			}
+			return "", err
+		}
+
+		// End of string found.
+		if b == '"' {
+			return builder.String(), nil
+		}
+
+		contentByteCount++
+
+		if b == '\\' {
+			escaped, err := r.ReadByte()
+			if err != nil {
+				return "", fmt.Errorf("malformed JSON, unterminated escape sequence in string")
+			}
+			contentByteCount++
+
+			switch escaped {
+			case '"', '\\', '/':
+				builder.WriteByte(escaped)
+			case 'b':
+				builder.WriteByte('\b')
+			case 'f':
+				builder.WriteByte('\f')
+			case 'n':
+				builder.WriteByte('\n')
+			case 'r':
+				builder.WriteByte('\r')
+			case 't':
+				builder.WriteByte('\t')
+			case 'u':
+				// Unicode escape: read the next 4 hex digits.
+				hexChars := make([]byte, 4)
+				if _, err := io.ReadFull(r, hexChars); err != nil {
+					return "", fmt.Errorf("malformed JSON, unterminated unicode escape in string")
+				}
+				contentByteCount += 4
+
+				hexStr := string(hexChars)
+				for _, char := range hexStr {
+					if !((char >= '0' && char <= '9') || (char >= 'a' && char <= 'f') || (char >= 'A' && char <= 'F')) {
+						return "", fmt.Errorf("invalid character '%c' in string escape code", char)
+					}
+				}
+
+				code, _ := strconv.ParseUint(hexStr, 16, 32)
+				if code > unicode.MaxRune {
+					return "", fmt.Errorf("invalid unicode escape sequence: value out of range")
+				}
+				builder.WriteRune(rune(code))
+			default:
+				return "", fmt.Errorf("invalid character '%c' in string escape code", escaped)
+			}
+		} else {
+			builder.WriteByte(b)
+		}
+
+		if limit > 0 && contentByteCount > limit {
+			return "", fmt.Errorf("JSON string value exceeds allowed length")
+		}
+	}
+}
+
+func scanLiteral(r *bufio.Reader) error {
+	for {
+		b, err := r.Peek(1)
+		if err != nil {
+			// If we hit EOF after reading part of a literal, that's a clean end.
+			if err == io.EOF {
+				break
+			}
+			return err
+		}
+		if isWhitespace(b[0]) || b[0] == ',' || b[0] == '}' || b[0] == ']' {
+			return nil
+		}
+		_, _ = r.ReadByte()
+	}
+	return nil
+}
+
+func scanNumber(r *bufio.Reader, limit int) error {
+	var builder strings.Builder
+	byteCount := 0
+
+	// Peek at the first char to check for leading zero issues.
+	peeked, err := r.Peek(2)
+	if err == nil && len(peeked) > 1 {
+		if peeked[0] == '0' && peeked[1] >= '0' && peeked[1] <= '9' {
+			_, _ = r.ReadByte()
+			return fmt.Errorf("invalid character '%c' after top-level value", peeked[1])
+		}
+	}
+
+	for {
+		b, err := r.Peek(1)
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return err
+		}
+
+		char := b[0]
+		if isWhitespace(char) || char == ',' || char == '}' || char == ']' {
+			break
+		}
+
+		// A number token can contain only these characters.
+		isNumPart := (char >= '0' && char <= '9') || char == '.' || char == 'e' || char == 'E' || char == '+' || char == '-'
+		if !isNumPart {
+			// If it's not a valid number character, we stop scanning.
+			break
+		}
+
+		_, _ = r.ReadByte()
+		builder.WriteByte(char)
+		byteCount++
+		if limit > 0 && byteCount > limit {
+			return fmt.Errorf("JSON number value exceeds allowed length")
+		}
+	}
+
+	if byteCount == 0 {
+		return fmt.Errorf("malformed JSON, empty number")
+	}
+
+	// Use the standard library for a final, strict validation of the number's syntax.
+	// This correctly rejects malformed inputs like "-" or "123.".
+	numStr := builder.String()
+	if _, err := strconv.ParseFloat(numStr, 64); err != nil {
+		return fmt.Errorf("malformed JSON, invalid number syntax for '%s'", numStr)
+	}
+
+	return nil
 }


### PR DESCRIPTION
### Description
Add new JSON max token limit and new tests #31561

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.
- [ ] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.

### PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.

Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
