### PR TITLE
Add PkiCertificateCountSystemView to the PKI backend's SystemView

### DIFF
--- a/builtin/logical/pki/backend.go
+++ b/builtin/logical/pki/backend.go
@@ -311,9 +311,11 @@ func Backend(conf *logical.BackendConfig) *backend {
 	b.acmeState = NewACMEState()
 	b.certificateCounter = NewCertificateCounter(b.backendUUID)
 
+	b.pkiCertificateCounter = logical.NewNullPkiCertificateCounter()
+
 	// It is important that we call SetupEnt at the very end as
 	// some ENT backends need access to the member vars initialized above.
-	b.SetupEnt()
+	b.SetupEnt(conf)
 	return &b
 }
 
@@ -340,7 +342,12 @@ type backend struct {
 
 	unifiedTransferStatus *UnifiedTransferStatus
 
+	// certificateCounter emits metrics about the number of stored certificates.
 	certificateCounter *CertificateCounter
+
+	// pkiCertificateCounter keeps track of issued and stored certificate counts
+	// for the purposes of PKI-only billing.
+	pkiCertificateCounter logical.PkiCertificateCounter
 
 	pkiStorageVersion atomic.Value
 	crlBuilder        *CrlBuilder

--- a/builtin/logical/pki/backend_oss.go
+++ b/builtin/logical/pki/backend_oss.go
@@ -25,4 +25,4 @@ func (b *backend) periodicFuncEnt(_ *storageContext, _ *logical.Request) error {
 
 func (b *backend) cleanupEnt(_ *storageContext) {}
 
-func (b *backend) SetupEnt() {}
+func (b *backend) SetupEnt(conf *logical.BackendConfig) {}

--- a/sdk/logical/pki_cert_count_system_view.go
+++ b/sdk/logical/pki_cert_count_system_view.go
@@ -1,0 +1,25 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package logical
+
+// PkiCertificateCounter is an interface for incrementing the count of issued and stored
+// PKI certificates.
+type PkiCertificateCounter interface {
+	IncrementCount(issuedCerts, storedCerts uint64)
+}
+
+type PkiCertificateCountSystemView interface {
+	GetPkiCertificateCounter() PkiCertificateCounter
+}
+
+type nullPkiCertificateCounter struct{}
+
+func (n *nullPkiCertificateCounter) IncrementCount(_, _ uint64) {
+}
+
+var _ PkiCertificateCounter = (*nullPkiCertificateCounter)(nil)
+
+func NewNullPkiCertificateCounter() PkiCertificateCounter {
+	return &nullPkiCertificateCounter{}
+}

--- a/vault/acme_billing_system_view.go
+++ b/vault/acme_billing_system_view.go
@@ -69,10 +69,11 @@ type acmeBillingSystemViewImpl struct {
 }
 
 var (
-	_ logical.ACMEBillingSystemView = (*acmeBillingSystemViewImpl)(nil)
-	_ extendedSystemView            = (*acmeBillingSystemViewImpl)(nil)
-	_ logical.ManagedKeySystemView  = (*acmeBillingSystemViewImpl)(nil)
-	_ entropy.Sourcer               = (*acmeBillingSystemViewImpl)(nil)
+	_ logical.ACMEBillingSystemView         = (*acmeBillingSystemViewImpl)(nil)
+	_ extendedSystemView                    = (*acmeBillingSystemViewImpl)(nil)
+	_ logical.ManagedKeySystemView          = (*acmeBillingSystemViewImpl)(nil)
+	_ entropy.Sourcer                       = (*acmeBillingSystemViewImpl)(nil)
+	_ logical.PkiCertificateCountSystemView = (*acmeBillingSystemViewImpl)(nil)
 )
 
 // Scenario 2 above.
@@ -83,9 +84,10 @@ type acmeBillingSystemViewImplNoSourcer struct {
 }
 
 var (
-	_ logical.ACMEBillingSystemView = (*acmeBillingSystemViewImplNoSourcer)(nil)
-	_ extendedSystemView            = (*acmeBillingSystemViewImplNoSourcer)(nil)
-	_ logical.ManagedKeySystemView  = (*acmeBillingSystemViewImplNoSourcer)(nil)
+	_ logical.ACMEBillingSystemView         = (*acmeBillingSystemViewImplNoSourcer)(nil)
+	_ extendedSystemView                    = (*acmeBillingSystemViewImplNoSourcer)(nil)
+	_ logical.ManagedKeySystemView          = (*acmeBillingSystemViewImplNoSourcer)(nil)
+	_ logical.PkiCertificateCountSystemView = (*acmeBillingSystemViewImplNoSourcer)(nil)
 )
 
 // Scenario 3 above.
@@ -95,8 +97,9 @@ type acmeBillingSystemViewImplNoManagedKeys struct {
 }
 
 var (
-	_ logical.ACMEBillingSystemView = (*acmeBillingSystemViewImplNoManagedKeys)(nil)
-	_ extendedSystemView            = (*acmeBillingSystemViewImplNoManagedKeys)(nil)
+	_ logical.ACMEBillingSystemView         = (*acmeBillingSystemViewImplNoManagedKeys)(nil)
+	_ extendedSystemView                    = (*acmeBillingSystemViewImplNoManagedKeys)(nil)
+	_ logical.PkiCertificateCountSystemView = (*acmeBillingSystemViewImplNoManagedKeys)(nil)
 )
 
 // NewAcmeBillingSystemView creates the appropriate implementation based on
@@ -139,4 +142,8 @@ func (a *acmeBillingImpl) CreateActivityCountEventForIdentifiers(ctx context.Con
 	activityLog.AddActivityToFragment(clientID, a.entry.NamespaceID, time.Now().Unix(), ACMEActivityType, a.entry.Accessor, time.Now().Unix())
 
 	return nil
+}
+
+func (a *acmeBillingImpl) GetPkiCertificateCounter() logical.PkiCertificateCounter {
+	return a.core.GetPkiCertificateCounter()
 }

--- a/vault/core_stubs_oss.go
+++ b/vault/core_stubs_oss.go
@@ -8,6 +8,8 @@ package vault
 import (
 	"context"
 	"fmt"
+
+	"github.com/hashicorp/vault/sdk/logical"
 )
 
 //go:generate go run github.com/hashicorp/vault/tools/stubmaker
@@ -145,4 +147,8 @@ func (c *Core) entJoinPluginDir(_ string) (string, error) {
 // of that type should return an error on any routed external requests.
 func (c *Core) IsMountTypeAllowed(mountType string) bool {
 	return true
+}
+
+func (c *Core) GetPkiCertificateCounter() logical.PkiCertificateCounter {
+	return logical.NewNullPkiCertificateCounter()
 }


### PR DESCRIPTION
### Description

Add PkiCertificateCountSystemView to the PKI backend's SystemView.

This is part of the the PKI-only billing certificate counting project described in [RFC](https://hermes.hashicorp.services/document/1mglmZ69m7dsNBKJHhEi9MBsS_dyNt2GI-wjRsTUfKZg).

The ENT PR is https://github.com/hashicorp/vault-enterprise/pull/9573.
### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch. Note that in the CE repo, the latest release branch will look like `backport/x.x.x`, but older release branches will be `backport/ent/x.x.x+ent`.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **ENT Breakage:** If this PR either 1) removes a public function OR 2) changes the signature
  of a public function, even if that change is in a CE file, _double check_ that
  applying the patch for this PR to the ENT repo and running tests doesn't
  break any tests. Sometimes ENT only tests rely on public functions in CE
  files.
- [x] **Jira:** If this change has an associated Jira, it's referenced either
  in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.
- [x] **ENT PR:** If this change has an associated ENT PR, please link it in the
  description. Also, make sure the changelog is in this PR, _not_ in your ENT PR.

### PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.

Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
