### PR TITLE
fix check invalidKeyUsages slice emptiness 

### DIFF
--- a/builtin/logical/pki/path_root.go
+++ b/builtin/logical/pki/path_root.go
@@ -693,7 +693,7 @@ func validateCaKeyUsages(keyUsages []string) error {
 			invalidKeyUsages = append(invalidKeyUsages, fmt.Sprintf("unrecognized key usage %s", usage))
 		}
 	}
-	if invalidKeyUsages != nil {
+	if len(invalidKeyUsages) > 0 {
 		return errors.New(strings.Join(invalidKeyUsages, "; "))
 	}
 	return nil

--- a/changelog/31597.txt
+++ b/changelog/31597.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+builtin/logical/pki: don't return error for valid CA Key Usages on validation
+```


### PR DESCRIPTION
### Description
When check for slice emptiness for empty slice, it's wrong to check for nil and correct  to check for len, so fix it in validating ca key usages


