### PR TITLE
fix: false-positive Stackdriver error in diagnose

### DIFF
--- a/changelog/31616.txt
+++ b/changelog/31616.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+vault/diagnose: fix false-positive about missing Stackdriver keys when checking telemetry configuration
+```

--- a/command/operator_diagnose.go
+++ b/command/operator_diagnose.go
@@ -273,7 +273,7 @@ func (c *OperatorDiagnoseCommand) offlineDiagnostics(ctx context.Context) error 
 			}
 
 			// If any Stackdriver setting is present but we're missing the basic fields...
-			if coalesce(t.StackdriverNamespace, t.StackdriverLocation, t.StackdriverDebugLogs, t.StackdriverNamespace) != nil {
+			if coalesce(t.StackdriverNamespace, t.StackdriverLocation, t.StackdriverNamespace) != nil || t.StackdriverDebugLogs {
 				if t.StackdriverProjectID == "" {
 					return errors.New("incomplete Stackdriver telemetry configuration, missing stackdriver_project_id")
 				}

--- a/command/operator_diagnose_test.go
+++ b/command/operator_diagnose_test.go
@@ -628,6 +628,18 @@ func TestOperatorDiagnoseCommand_Run(t *testing.T) {
 			},
 		},
 		{
+			"diagnose_telemetry_ok_dogstatsd",
+			[]string{
+				"-config", "./server/test-fixtures/diagnose_ok_dogstatsd_telemetry.hcl",
+			},
+			[]*diagnose.Result{
+				{
+					Name:   "Check Telemetry",
+					Status: diagnose.OkStatus,
+				},
+			},
+		},
+		{
 			"diagnose_telemetry_partial_stackdriver",
 			[]string{
 				"-config", "./server/test-fixtures/diagnose_bad_telemetry3.hcl",

--- a/command/server/test-fixtures/diagnose_ok_dogstatsd_telemetry.hcl
+++ b/command/server/test-fixtures/diagnose_ok_dogstatsd_telemetry.hcl
@@ -1,0 +1,22 @@
+# Copyright IBM Corp. 2016, 2025
+# SPDX-License-Identifier: BUSL-1.1
+
+disable_cache = true
+disable_mlock = true
+ui = true
+
+listener "tcp" {
+	address = "127.0.0.1:8200"
+}
+
+backend "consul" {
+	advertise_addr = "foo"
+	token = "foo"
+}
+
+telemetry {
+	dogstatsd_tags = ["tag1:value"]
+	dogstatsd_addr = "127.0.0.1:8164"
+}
+
+cluster_addr = "127.0.0.1:8201"


### PR DESCRIPTION
### Description
Fixes the bug in `operator diagnose` as described in https://github.com/hashicorp/vault/issues/31615.

`operator diagnose` contains checks to validate your Telemetry configuration. However, due to a glitch in how the `coalesce` helper handles booleans, it always reports an error with missing Stackdriver configuration if you omit Stackdriver settings (even if you specify other telemetry backend values correctly).

This change simply pulls the boolean out of the coalesce call and checks it separately. An updated unit test is included to validate a dogstatsd-only configuration.

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.

### PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.

Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
