### PR TITLE
feat(auth ldap): enhance root credential rotation with schema and credential type to support AD and RACF

### DIFF
--- a/builtin/credential/ldap/backend_test.go
+++ b/builtin/credential/ldap/backend_test.go
@@ -1422,6 +1422,8 @@ func testAccStepUserList(t *testing.T, users []string) logicaltest.TestStep {
 	}
 }
 
+// TestLdapAuthBackend_ConfigUpgrade tests that older stored configurations are
+// properly upgraded to the latest configuration structure when read.
 func TestLdapAuthBackend_ConfigUpgrade(t *testing.T) {
 	var resp *logical.Response
 	var err error
@@ -1494,6 +1496,8 @@ func TestLdapAuthBackend_ConfigUpgrade(t *testing.T) {
 			DerefAliases:             "never",
 			MaximumPageSize:          1000,
 		},
+		RotationSchema:         schemaOpenLDAP,
+		RotationCredentialType: credentialTypePassword,
 	}
 	if constants.IsEnterprise {
 		exp.TokenParams.AliasMetadata = make(map[string]string)

--- a/builtin/credential/ldap/path_config.go
+++ b/builtin/credential/ldap/path_config.go
@@ -24,11 +24,11 @@ const (
 	rootRotationUrlKey            = "rotation_url"
 	rootRotationSchemaKey         = "rotation_schema"
 	rootRotationCredentialTypeKey = "rotation_credential_type"
-	SchemaOpenLDAP                = "openldap"
-	SchemaAD                      = "ad"
-	SchemaRACF                    = "racf"
-	CredentialTypePassword        = "password"
-	CredentialTypePhrase          = "phrase"
+	schemaOpenLDAP                = "openldap"
+	schemaAD                      = "ad"
+	schemaRACF                    = "racf"
+	credentialTypePassword        = "password"
+	credentialTypePhrase          = "phrase"
 )
 
 func pathConfig(b *backend) *framework.Path {
@@ -83,17 +83,17 @@ func pathConfig(b *backend) *framework.Path {
 	p.Fields[rootRotationSchemaKey] = &framework.FieldSchema{
 		Type:          framework.TypeString,
 		Description:   "The desired LDAP schema used when modifying user account passwords. Available options are 'openldap', 'ad', and 'racf'. If not specified, 'openldap' will be used.",
-		Default:       SchemaOpenLDAP,
+		Default:       schemaOpenLDAP,
 		Required:      false,
-		AllowedValues: []interface{}{SchemaOpenLDAP, SchemaAD, SchemaRACF},
+		AllowedValues: []interface{}{schemaOpenLDAP, schemaAD, schemaRACF},
 	}
 	p.Fields[rootRotationCredentialTypeKey] = &framework.FieldSchema{
 		Type: framework.TypeString,
 		Description: "The type of credential to manage. Options include: " +
 			"'password', 'phrase'. Defaults to 'password'. Will only affect RACF schema.",
-		Default:       CredentialTypePassword,
+		Default:       credentialTypePassword,
 		Required:      false,
-		AllowedValues: []interface{}{CredentialTypePassword, CredentialTypePhrase},
+		AllowedValues: []interface{}{credentialTypePassword, credentialTypePhrase},
 	}
 	return p
 }
@@ -265,9 +265,13 @@ func (b *backend) pathConfigWrite(ctx context.Context, req *logical.Request, d *
 	}
 	if rotationSchema, ok := d.GetOk(rootRotationSchemaKey); ok {
 		cfg.RotationSchema = rotationSchema.(string)
+	} else {
+		cfg.RotationSchema = schemaOpenLDAP
 	}
 	if rotationCredentialType, ok := d.GetOk(rootRotationCredentialTypeKey); ok {
 		cfg.RotationCredentialType = rotationCredentialType.(string)
+	} else {
+		cfg.RotationCredentialType = credentialTypePassword
 	}
 
 	var rotOp string

--- a/builtin/credential/ldap/path_config_rotate_root.go
+++ b/builtin/credential/ldap/path_config_rotate_root.go
@@ -6,12 +6,14 @@ package ldap
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/go-ldap/ldap/v3"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/helper/base62"
 	"github.com/hashicorp/vault/sdk/helper/ldaputil"
 	"github.com/hashicorp/vault/sdk/logical"
+	"golang.org/x/text/encoding/unicode"
 )
 
 func pathConfigRotateRoot(b *backend) *framework.Path {
@@ -103,11 +105,6 @@ func (b *backend) rotateRootCredential(ctx context.Context, req *logical.Request
 	if err != nil {
 		return err
 	}
-
-	lreq := &ldap.ModifyRequest{
-		DN: cfg.BindDN,
-	}
-
 	var newPassword string
 	if cfg.PasswordPolicy != "" {
 		newPassword, err = b.System().GeneratePasswordFromPolicy(ctx, cfg.PasswordPolicy)
@@ -117,9 +114,10 @@ func (b *backend) rotateRootCredential(ctx context.Context, req *logical.Request
 	if err != nil {
 		return err
 	}
-
-	lreq.Replace("userPassword", []string{newPassword})
-
+	lreq, err := b.getModifyRequest(cfg, newPassword)
+	if err != nil {
+		return err
+	}
 	err = conn.Modify(lreq)
 	if err != nil {
 		return err
@@ -136,6 +134,36 @@ func (b *backend) rotateRootCredential(ctx context.Context, req *logical.Request
 	}
 
 	return nil
+}
+
+func (b *backend) getModifyRequest(cfg *ldapConfigEntry, newPassword string) (*ldap.ModifyRequest, error) {
+	lreq := &ldap.ModifyRequest{
+		DN: cfg.BindDN,
+	}
+	switch cfg.RotationSchema {
+	case SchemaOpenLDAP:
+		lreq.Replace("userPassword", []string{newPassword})
+	case SchemaRACF:
+		// Password and password phrase management are mutually exclusive
+		// operations. When the system is configured to manage one, it will not
+		// modify the other.
+		if cfg.RotationCredentialType == CredentialTypePhrase {
+			lreq.Replace("racfPassPhrase", []string{newPassword})
+		} else {
+			lreq.Replace("racfPassword", []string{newPassword})
+		}
+		lreq.Replace("racfAttributes", []string{"noexpired"})
+	case SchemaAD:
+		utf16 := unicode.UTF16(unicode.LittleEndian, unicode.IgnoreBOM)
+		pwdEncoded, err := utf16.NewEncoder().String("\"" + newPassword + "\"")
+		if err != nil {
+			return nil, err
+		}
+		lreq.Replace("unicodePwd", []string{pwdEncoded})
+	default:
+		return nil, fmt.Errorf("configured schema %s not valid", cfg.RotationSchema)
+	}
+	return lreq, nil
 }
 
 const pathConfigRotateRootHelpSyn = `

--- a/builtin/credential/ldap/path_config_rotate_root_test.go
+++ b/builtin/credential/ldap/path_config_rotate_root_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/hashicorp/vault/helper/testhelpers/ldap"
 	logicaltest "github.com/hashicorp/vault/helper/testhelpers/logical"
+	"github.com/hashicorp/vault/sdk/helper/ldaputil"
 	"github.com/hashicorp/vault/sdk/logical"
 )
 
@@ -113,6 +114,9 @@ func TestRotateRootWithRotationUrl(t *testing.T) {
 	}
 
 	newCFG, err := b.Config(ctx, req)
+	if err != nil {
+		t.Fatalf("failed to read config after rotation: %s", err)
+	}
 	if newCFG.BindDN != cfg.BindDN {
 		t.Fatalf("BindDN %q changed unexpectedly, found new value %q", cfg.BindDN, newCFG.BindDN)
 	}
@@ -122,5 +126,100 @@ func TestRotateRootWithRotationUrl(t *testing.T) {
 	// expecting the newCFG url to be "ldap://example.com:389"
 	if newCFG.Url != mainDummyUrl {
 		t.Fatalf("URL %q changed unexpectedly, found new value %q", mainDummyUrl, newCFG.Url)
+	}
+}
+
+// TestGetModifyRequest tests that the correct LDAP modify requests are generated
+// for different rotation schemas and credential types.
+func TestGetModifyRequest(t *testing.T) {
+	b, _ := createBackendWithStorage(t)
+	cfgE := new(ldaputil.ConfigEntry)
+	cfgE.BindDN = "cn=admin,dc=planetexpress,dc=com"
+	cfg := &ldapConfigEntry{
+		ConfigEntry:            cfgE,
+		RotationSchema:         schemaOpenLDAP,
+		RotationCredentialType: credentialTypePassword,
+	}
+	dummyPassword := "newpassword123"
+	// Test OpenLDAP schema
+	lreq, err := b.getModifyRequest(cfg, dummyPassword)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if len(lreq.Changes) != 1 {
+		t.Fatalf("expected 1 change, got: %d", len(lreq.Changes))
+	}
+	if lreq.Changes[0].Modification.Type != "userPassword" {
+		t.Fatalf("expected userPassword attribute to be modified, got: %s", lreq.Changes[0].Modification.Type)
+	}
+	if lreq.Changes[0].Modification.Vals[0] != dummyPassword {
+		t.Fatalf("expected new password to be set to newpassword123, got: %s", lreq.Changes[0].Modification.Vals[0])
+	}
+	// Test Active Directory schema
+	cfg.RotationSchema = schemaAD
+	lreq, err = b.getModifyRequest(cfg, dummyPassword)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if len(lreq.Changes) != 1 {
+		t.Fatalf("expected 1 change, got: %d", len(lreq.Changes))
+	}
+	if lreq.Changes[0].Modification.Type != "unicodePwd" {
+		t.Fatalf("expected unicodePwd attribute to be modified, got: %s", lreq.Changes[0].Modification.Type)
+	}
+	pwdEncoded, err := formatPassword(dummyPassword)
+	if err != nil {
+		t.Fatalf("unexpected error encoding password: %s", err)
+	}
+	if lreq.Changes[0].Modification.Vals[0] != pwdEncoded {
+		t.Fatalf("expected new password to be encoded, got: %s", lreq.Changes[0].Modification.Vals[0])
+	}
+	// Test RACF schema with password type
+	cfg.RotationSchema = schemaRACF
+	lreq, err = b.getModifyRequest(cfg, dummyPassword)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if len(lreq.Changes) != 2 {
+		t.Fatalf("expected 2 change, got: %d", len(lreq.Changes))
+	}
+	if lreq.Changes[0].Modification.Type != "racfPassword" {
+		t.Fatalf("expected racfPassword attribute to be modified, got: %s", lreq.Changes[0].Modification.Type)
+	}
+	if lreq.Changes[0].Modification.Vals[0] != dummyPassword {
+		t.Fatalf("expected new password to be set to newpassword123, got: %s", lreq.Changes[0].Modification.Vals[0])
+	}
+	if lreq.Changes[1].Modification.Type != "racfAttributes" {
+		t.Fatalf("expected racfAttributes attribute to be modified, got: %s", lreq.Changes[1].Modification.Type)
+	}
+	if lreq.Changes[1].Modification.Vals[0] != "noexpired" {
+		t.Fatalf("expected racfAttributes to be set to noexpired, got: %s", lreq.Changes[1].Modification.Vals[0])
+	}
+	// Test RACF schema with passphrase type
+	cfg.RotationCredentialType = credentialTypePhrase
+	lreq, err = b.getModifyRequest(cfg, dummyPassword)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if len(lreq.Changes) != 2 {
+		t.Fatalf("expected 2 change, got: %d", len(lreq.Changes))
+	}
+	if lreq.Changes[0].Modification.Type != "racfPassPhrase" {
+		t.Fatalf("expected racfPassPhrase attribute to be modified, got: %s", lreq.Changes[0].Modification.Type)
+	}
+	if lreq.Changes[0].Modification.Vals[0] != dummyPassword {
+		t.Fatalf("expected new passphrase to be set to newpassword123, got: %s", lreq.Changes[0].Modification.Vals[0])
+	}
+	if lreq.Changes[1].Modification.Type != "racfAttributes" {
+		t.Fatalf("expected racfAttributes attribute to be modified, got: %s", lreq.Changes[1].Modification.Type)
+	}
+	if lreq.Changes[1].Modification.Vals[0] != "noexpired" {
+		t.Fatalf("expected racfAttributes to be set to noexpired, got: %s", lreq.Changes[1].Modification.Vals[0])
+	}
+	// Test invalid schema
+	cfg.RotationSchema = "invalidSchema"
+	_, err = b.getModifyRequest(cfg, dummyPassword)
+	if err == nil {
+		t.Fatalf("expected error due to invalid schema, got none")
 	}
 }

--- a/changelog/31626.txt
+++ b/changelog/31626.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+auth/ldap: Introduces options to do root password rotation for Active Directory and RACF rotation schemas
+```


### PR DESCRIPTION
### Description
Enable root password rotation for Active Directory and RACF rotation schemas.
Adds support for AD and RACF rotation schemas so the backend can rotate the root credential for those directory types (same behavior as in [hashicorp/vault-plugin-secrets-openldap](https://github.com/hashicorp/vault-plugin-secrets-openldap/blob/main/client/schema.go) ).
Includes unit tests that exercise the generated LDAP Modify requests for OpenLDAP, AD, and RACF, and validates rotate-root config options.

Notes:
Rather than importing the openldap plugin, a minimal, self-contained implementation was added in this repository to avoid pulling plugin code into the main Vault tree.
It would be cleaner to consolidate this logic under `github.com/hashicorp/vault/sdk/helper/ldaputil` so both repositories share the same implementation. Kept the smaller in-repo version here to preserve backward compatibility and limit scope of change — happy to refactor to ldaputil if preferred.
Testing:
Test coverage includes config validation, modify-request generation.

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.

### PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.

Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
