### PR TITLE
Address CVE-2025-47913

### DIFF
--- a/api/auth/ldap/go.mod
+++ b/api/auth/ldap/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/ryanuber/go-glob v1.0.0 // indirect
-	golang.org/x/crypto v0.40.0 // indirect
+	golang.org/x/crypto v0.44.0 // indirect
 	golang.org/x/net v0.42.0 // indirect
 	golang.org/x/text v0.27.0 // indirect
 	golang.org/x/time v0.12.0 // indirect


### PR DESCRIPTION
https://github.com/hashicorp/vault/issues/31639

[CVE-2025-47913](https://security.snyk.io/vuln/SNYK-GOLANG-GOLANGORGXCRYPTOSSHAGENT-12668891):

How to fix?
Upgrade golang.org/x/crypto/ssh/agent to version 0.43.0 or higher.

### Description
Addresses CVE-2025-47913 by upgrading golang.org/x/crypto/ssh/agent to version 0.44.0.
 

### PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.

Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
