### PR TITLE
http: allow empty request bodies in JSON parsing

### DIFF
--- a/changelog/31650.txt
+++ b/changelog/31650.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+http: allow empty request bodies in JSON parsing
+```

--- a/http/handler.go
+++ b/http/handler.go
@@ -896,7 +896,10 @@ func parseJSONRequest(perfStandby bool, r *http.Request, w http.ResponseWriter, 
 		reader = io.NopCloser(io.TeeReader(reader, origBody))
 	}
 	err := jsonutil.DecodeJSONFromReader(reader, out)
-	if err != nil && err != io.EOF {
+	if err == io.EOF {
+		// Empty body is not an error.
+		err = nil
+	} else if err != nil {
 		return nil, fmt.Errorf("failed to parse JSON input: %w", err)
 	}
 	if origBody != nil {


### PR DESCRIPTION
### Description
The JSON decoder returns `io.EOF` when the request body is empty, which was previously treated as an error.  This prevented API endpoints with optional request bodies from succeeding when called without a body.

After this change is applied, `io.EOF` is treated as an empty object and `nil` return value to support endpoints like DELETE `/sys/rekey/init` that accept either a body with `nonce` parameter or no body at all ([doc link](https://developer.hashicorp.com/vault/api-docs/system/rekey#cancel-rekey)).

Fixes #31649

### PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.

Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
