### PR TITLE
fix: increase docker API version

### DIFF
--- a/sdk/helper/docker/testhelpers.go
+++ b/sdk/helper/docker/testhelpers.go
@@ -34,7 +34,7 @@ import (
 	"github.com/hashicorp/go-uuid"
 )
 
-const DockerAPIVersion = "1.40"
+const DockerAPIVersion = "1.44"
 
 type Runner struct {
 	DockerAPI  *client.Client


### PR DESCRIPTION
Recent docker releases are increasing the minimum required API version. This leads to failures to start testclusters. From running the tests it seems the version number increase is sufficient and there are no breaking changes in the API usages.

### Description

Fixes issue #31674

### PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.

Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
