### PR TITLE
fix: typos in comments

### DIFF
--- a/builtin/credential/approle/path_role.go
+++ b/builtin/credential/approle/path_role.go
@@ -160,7 +160,7 @@ IP addresses which can perform the login operation.`,
 			"secret_id_num_uses": {
 				Type: framework.TypeInt,
 				Description: `Number of times a SecretID can access the role, after which the SecretID
-will expire. Defaults to 0 meaning that the the secret_id is of unlimited use.`,
+will expire. Defaults to 0 meaning that the secret_id is of unlimited use.`,
 			},
 
 			"secret_id_ttl": {

--- a/builtin/credential/cert/path_login.go
+++ b/builtin/credential/cert/path_login.go
@@ -817,7 +817,7 @@ func (b *backend) loadTrustedCerts(ctx context.Context, storage logical.Storage,
 			}
 
 			// Limits are arbitrary. Max of 2^55 backoff just so that delay
-			// and the the jitter fits into a double. Is that silly? Yes.
+			// and the jitter fits into a double. Is that silly? Yes.
 			// 2^55 seconds is more years than the computer will keep
 			// running.
 			if cache.retry.attempt < 55 {

--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -4255,7 +4255,7 @@ func TestBackend_RevokePlusTidy_Intermediate(t *testing.T) {
 		t.Fatal("expected certificate information from read operation")
 	}
 
-	// Issue a revoke on on /pki
+	// Issue a revoke on /pki
 	_, err = client.Logical().Write("pki/revoke", map[string]interface{}{
 		"serial_number": intermediateCertSerial,
 	})

--- a/builtin/logical/transit/path_datakey.go
+++ b/builtin/logical/transit/path_datakey.go
@@ -255,7 +255,7 @@ This path can be used to generate a data key: a random
 key of a certain length that can be used for encryption
 and decryption, protected by the named backend key. 128, 256,
 or 512 bits can be specified; if not specified, the default
-is 256 bits. Call with the the "wrapped" path to prevent the
+is 256 bits. Call with the "wrapped" path to prevent the
 (base64-encoded) plaintext key from being returned along with
 the encrypted key, the "plaintext" path returns both.
 `

--- a/tools/pipeline/internal/pkg/git/reset.go
+++ b/tools/pipeline/internal/pkg/git/reset.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 )
 
-// ResetMode is is mode to use when resetting the repository
+// ResetMode is the mode to use when resetting the repository
 type ResetMode string
 
 const (

--- a/vault/init.go
+++ b/vault/init.go
@@ -476,7 +476,7 @@ func (c *Core) UnsealWithStoredKeys(ctx context.Context) error {
 		return NewNonFatalError(fmt.Errorf("fetching stored unseal keys failed: %w", err))
 	}
 
-	// Check whether Vault initialization is still in progress. If it is is, then
+	// Check whether Vault initialization is still in progress. If it is, then
 	// bail out to give it a chance to complete.
 	isInitializing, err := c.seal.IsInitializationFlagSet(ctx)
 	if err != nil {

--- a/vault/logical_system_activity.go
+++ b/vault/logical_system_activity.go
@@ -37,7 +37,7 @@ const (
 	// ErrWaitingForClientIDsToLoadToMemory is an error string that is used to indicate that the clientIDs are currently being loaded to memory which is needed to compute the actual values for new clients in the current month.
 	ErrWaitingForClientIDsToLoadToMemory = "We are gathering the most up-to-date client usage information. Please try again later."
 
-	// WarningCurrentMonthDataNotIncluded is a warning string that is used to indicate the the current month's data will be included in the next billing period, and not the current
+	// WarningCurrentMonthDataNotIncluded is a warning string that is used to indicate the current month's data will be included in the next billing period, and not the current
 	WarningCurrentMonthDataNotIncluded = "The current month's data will not be included in the current billing period client count as this month is outside of the 12 month billing period. This data will be included in the next billing period"
 )
 

--- a/vault/logical_system_quotas.go
+++ b/vault/logical_system_quotas.go
@@ -19,7 +19,7 @@ import (
 )
 
 var (
-	ErrExemptRateLimitsOnChildNs            = errors.New("exempt paths can only be be configured in the root namespace")
+	ErrExemptRateLimitsOnChildNs            = errors.New("exempt paths can only be configured in the root namespace")
 	ErrInvalidExemptPathsFromChildNs        = errors.New("exempt paths cannot be added for parent namespaces")
 	ErrInvalidQuotaDeletion                 = "cannot delete quota configured for a parent namespace"
 	ErrInvalidQuotaUpdate                   = "quotas in parent namespaces cannot be updated"


### PR DESCRIPTION
Fix typos: doubled words (is is, the the, on on, be be)