### PR TITLE
Fix duplicate headers in vault agent re-authentication

### DIFF
--- a/command/agentproxyshared/auth/auth.go
+++ b/command/agentproxyshared/auth/auth.go
@@ -338,11 +338,7 @@ func (ah *AuthHandler) Run(ctx context.Context, am AuthMethod) error {
 			})
 			clientToUse = wrapClient
 		}
-		for key, values := range header {
-			for _, value := range values {
-				clientToUse.AddHeader(key, value)
-			}
-		}
+		clientToUse.SetHeaders(header)
 
 		// This should only happen if there's no preloaded token (regular auto-auth login)
 		// or if a preloaded token has expired and is now switching to auto-auth.


### PR DESCRIPTION
Vault agent adds the headers to the client on every authentication run, this causes the Kerberos authentication method to fail due to a duplicated authentication header. Headers are also added on indefinitely leading to increasing memory usage on each re-authentication run
