### PR TITLE
DRAFT - Correctly unescape client certificates in format passed by AWS ALB

### DIFF
--- a/http/handler.go
+++ b/http/handler.go
@@ -684,7 +684,7 @@ func WrapForwardedForHandler(h http.Handler, l *configutil.Listener) http.Handle
 					for _, action := range actions {
 						switch action {
 						case "URL":
-							decoded, err := url.QueryUnescape(v)
+							decoded, err := url.PathUnescape(v)
 							if err != nil {
 								respondError(w, http.StatusBadRequest, fmt.Errorf("failed to url unescape the client certificate: %w", err))
 								return


### PR DESCRIPTION
### Description
Demo solution to #31728 - use `url.PathUnescape` to correctly unescape client certificates in the format used by AWS ALBs.