### PR TITLE
Fix vault binary capability in linux packages postinst

### DIFF
--- a/.release/linux/postinst
+++ b/.release/linux/postinst
@@ -1,36 +1,34 @@
 #!/bin/bash
 
-if [[ -f /opt/vault/tls/tls.crt ]] && [[ -f /opt/vault/tls/tls.key ]]; then
-  echo "Vault TLS key and certificate already exist. Exiting."
-  exit 0
+if [[ ! -f /opt/vault/tls/tls.crt ]] || [[ ! -f /opt/vault/tls/tls.key ]]; then
+
+  echo "Generating Vault TLS key and self-signed certificate..."
+
+  # Create TLS and Data directory
+  mkdir --parents /opt/vault/tls
+  mkdir --parents /opt/vault/data
+
+  # Generate TLS key and certificate
+  cd /opt/vault/tls
+  openssl req \
+    -out tls.crt \
+    -new \
+    -keyout tls.key \
+    -newkey rsa:4096 \
+    -nodes \
+    -sha256 \
+    -x509 \
+    -subj "/O=HashiCorp/CN=Vault" \
+    -days 1095 # 3 years
+
+  # Update file permissions
+  chown --recursive vault:vault /etc/vault.d
+  chown --recursive vault:vault /opt/vault
+  chmod 600 /opt/vault/tls/tls.crt /opt/vault/tls/tls.key
+  chmod 700 /opt/vault/tls
+
+  echo "Vault TLS key and self-signed certificate have been generated in '/opt/vault/tls'."
 fi
-
-echo "Generating Vault TLS key and self-signed certificate..."
-
-# Create TLS and Data directory
-mkdir --parents /opt/vault/tls
-mkdir --parents /opt/vault/data
-
-# Generate TLS key and certificate
-cd /opt/vault/tls
-openssl req \
-  -out tls.crt \
-  -new \
-  -keyout tls.key \
-  -newkey rsa:4096 \
-  -nodes \
-  -sha256 \
-  -x509 \
-  -subj "/O=HashiCorp/CN=Vault" \
-  -days 1095 # 3 years
-
-# Update file permissions
-chown --recursive vault:vault /etc/vault.d
-chown --recursive vault:vault /opt/vault
-chmod 600 /opt/vault/tls/tls.crt /opt/vault/tls/tls.key
-chmod 700 /opt/vault/tls
-
-echo "Vault TLS key and self-signed certificate have been generated in '/opt/vault/tls'."
 
 # Set IPC_LOCK capabilities on vault
 setcap cap_ipc_lock=+ep /usr/bin/vault


### PR DESCRIPTION
## Problem

When upgrading Vault via package managers (e.g., yum update or apt upgrade), the `cap_ipc_lock` capability is not applied to the vault binary. This causes Vault to lose its ability to lock memory, which is required for secure secret handling.

When vault package is purged (apt purge), the certificates are not removed. Any subsequent installation of the vault package will not regenerate certificates, but also not apply `cap_ipc_lock` capability on vault binary nor reload systemd daemon.

## Root Cause

The .release/linux/postinst script had an early exit 0 when TLS certificates already existed:

```bash
if [[ -f /opt/vault/tls/tls.crt ]] && [[ -f /opt/vault/tls/tls.key ]]; then
  echo "Vault TLS key and certificate already exist. Exiting."
  exit 0
fi
```

This was intended to avoid regenerating certificates on upgrade, but it also skipped the rest of the postinst script, including:

  - Setting cap_ipc_lock capability on /usr/bin/vault
  - Reloading the systemd daemon

Since the vault binary is replaced during an upgrade, the capability must be reapplied every time.

## Fix

Changed the logic from an early return to a conditional block. The TLS certificate generation is now wrapped in a conditional that only runs when certificates are missing, while the capability setting and other post-installation steps always execute.

```bash
if [[ ! -f /opt/vault/tls/tls.crt ]] || [[ ! -f /opt/vault/tls/tls.key ]]; then
  # Generate certificates...
fi

# Always run: set capabilities, etc.
setcap cap_ipc_lock=+ep /usr/bin/vault
```

This PR fixes https://github.com/hashicorp/vault/issues/13806