### PR TITLE
fix: update Go version in go.mod and sdk/go.mod to 1.25.7

### DIFF
--- a/changelog/31641.txt
+++ b/changelog/31641.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+release/build: This fixes the incorrect Go version in go.mod and sdk/go.mod, updating them from 1.25.3 and 1.25.0 to 1.25.7 respectively, to match the minimum required version specified in .go-version.
+```

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ module github.com/hashicorp/vault
 // semantic related to Go module handling), this comment should be updated to explain that.
 //
 // Whenever this value gets updated, sdk/go.mod should be updated to the same value.
-go 1.25.3
+go 1.25.7
 
 replace github.com/hashicorp/vault/api => ./api
 

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -1,6 +1,6 @@
 module github.com/hashicorp/vault/sdk
 
-go 1.25.0
+go 1.25.7
 
 require (
 	cloud.google.com/go/cloudsqlconn v1.4.3


### PR DESCRIPTION
This fixes issue #31641 where go.mod had 1.25.3 and sdk/go.mod had 1.25.0, but the minimum required version in .go-version is 1.25.7.

### Description
This PR updates the Go version directive in both `go.mod` and `sdk/go.mod` to match the minimum required version specified in `.go-version`.

   Previously:
   - `.go-version`: 1.25.7 (minimum required)
   - `go.mod`: 1.25.3 (incorrect)
   - `sdk/go.mod`: 1.25.0 (incorrect)

   After this fix:
   - `.go-version`: 1.25.7
   - `go.mod`: 1.25.7 
   - `sdk/go.mod`: 1.25.7 

   This resolves the build error where users trying to build with Go 1.25.1 would encounter: "Vault requires go 1.25.2 to build; found 1.25.1" because the go.mod files were
   inconsistent with the actual minimum requirement.

   According to the comment in go.mod: "Whenever this value gets updated, sdk/go.mod should be updated to the same value."

   ### TODO only if you're a HashiCorp employee
   - [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch.
       - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to
   be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version)
   of Vault. To ensure this, use **all** available enterprise labels.
   - [ ] **Jira:** If this change has an associated Jira, it's referenced either in the PR description, commit message, or branch name.
   - [ ] **RFC:** If this change has an associated RFC, please link it in the description.

   ### PCI review checklist
   - [x] I have documented a clear reason for, and description of, the change I am making.
   - [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
   - [ ] If applicable, I've documented the impact of any changes to security controls.