### PR TITLE
Telemetry: Fix handling of the disable_hostname option

### DIFF
--- a/internalshared/configutil/telemetry.go
+++ b/internalshared/configutil/telemetry.go
@@ -420,6 +420,7 @@ func SetupTelemetry(opts *SetupTelemetryOpts) (*metrics.InmemSink, *metricsutil.
 	}
 
 	// Initialize the global sink
+	fanout = append(fanout, inm)
 	if len(fanout) > 1 {
 		// Hostname enabled will create poor quality metrics name for prometheus
 		if !opts.Config.DisableHostname {
@@ -428,7 +429,6 @@ func SetupTelemetry(opts *SetupTelemetryOpts) (*metrics.InmemSink, *metricsutil.
 	} else {
 		metricsConf.EnableHostname = false
 	}
-	fanout = append(fanout, inm)
 	globalMetrics, err := metrics.NewGlobal(metricsConf, fanout)
 	if err != nil {
 		return nil, nil, false, err


### PR DESCRIPTION
### Description

This PR fixes the handling of the disable_hostname option in the telemetry section. Currently, this option is processed incorrectly, which differs from the behavior described in the documentation.

The problem is described in more detail in the Issue: #31747

The changes in this PR may affect metric names in existing installations. According to the documentation, the default value for the `disable_hostname` option is false, which means a hostname prefix should be added to metric names. And this is the correct behavior according to the documentation.

Currently, this does not happen when only a single telemetry output is configured.

If this PR is merged, installations that have not overridden the default value of disable_hostname and have only a single telemetry block configured will start seeing this hostname prefix added to their metric names.

Fixes #31747

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.

### PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.

Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
