### PR TITLE
DEV: Update base docker image for build stage in dev ui dockerfile

### DIFF
--- a/scripts/docker/Dockerfile.ui
+++ b/scripts/docker/Dockerfile.ui
@@ -1,6 +1,6 @@
 # Multi-stage builder to avoid polluting users environment with wrong
 # architecture binaries. This file only currently works for linux/amd64.
-FROM debian:buster AS builder
+FROM debian:trixie AS builder
 
 ARG VERSION
 ARG CGO_ENABLED=0
@@ -20,16 +20,16 @@ RUN apt-get update -y && apt-get install --no-install-recommends -y -q \
                          libltdl7
 
 RUN curl -sL https://deb.nodesource.com/setup_20.x | bash -
-RUN curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
-RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
 
-RUN apt-get update -y && apt-get install -y -q nodejs yarn
+RUN apt-get update -y \
+    && apt-get install -y -q nodejs \
+    && corepack enable
 
 RUN rm -rf /var/lib/apt/lists/*
 
 RUN mkdir /goroot && mkdir /go
-RUN curl https://storage.googleapis.com/golang/go${VERSION}.linux-amd64.tar.gz \
-           | tar xvzf - -C /goroot --strip-components=1
+RUN curl https://dl.google.com/go/go${VERSION}.linux-amd64.tar.gz \
+    | tar xvzf - -C /goroot --strip-components=1
 ENV GOPATH /go
 ENV GOROOT /goroot
 ENV PATH $GOROOT/bin:$GOPATH/bin:$PATH


### PR DESCRIPTION
### Description
Debian 10 Buster, which is used as the base image for the build stage, reached its end of life (EOL) in 2024. When attempting to perform a dev build with the UI, we encounter the following errors:

```
#8 [builder  2/12] RUN apt-get update -y && apt-get install --no-install-recommends -y -q                          curl                          zip                          build-essential                          gcc-multilib                          g++-multilib                          ca-certificates                          git mercurial bzr                          gnupg                          libltdl-dev                          libltdl7
#8 0.584 Ign:1 http://deb.debian.org/debian buster InRelease
#8 0.682 Ign:2 http://deb.debian.org/debian-security buster/updates InRelease
#8 0.786 Ign:3 http://deb.debian.org/debian buster-updates InRelease
#8 0.885 Err:4 http://deb.debian.org/debian buster Release
#8 0.885   404  Not Found [IP: 151.101.66.132 80]
#8 0.994 Err:5 http://deb.debian.org/debian-security buster/updates Release
#8 0.994   404  Not Found [IP: 151.101.66.132 80]
#8 1.094 Err:6 http://deb.debian.org/debian buster-updates Release
#8 1.094   404  Not Found [IP: 151.101.66.132 80]
#8 1.102 Reading package lists...
#8 1.108 E: The repository 'http://deb.debian.org/debian buster Release' does not have a Release file.
#8 1.108 E: The repository 'http://deb.debian.org/debian-security buster/updates Release' does not have a Release file.
#8 1.108 E: The repository 'http://deb.debian.org/debian buster-updates Release' does not have a Release file.
#8 ERROR: process "/bin/sh -c apt-get update -y && apt-get install --no-install-recommends -y -q                          curl                          zip                          build-essential                          gcc-multilib                          g++-multilib                          ca-certificates                          git mercurial bzr                          gnupg                          libltdl-dev                          libltdl7" did not complete successfully: exit code: 100
------
 > [builder  2/12] RUN apt-get update -y && apt-get install --no-install-recommends -y -q                          curl                          zip                          build-essential                          gcc-multilib                          g++-multilib                          ca-certificates                          git mercurial bzr                          gnupg                          libltdl-dev                          libltdl7:
0.885 Err:4 http://deb.debian.org/debian buster Release
0.885   404  Not Found [IP: 151.101.66.132 80]
0.994 Err:5 http://deb.debian.org/debian-security buster/updates Release
0.994   404  Not Found [IP: 151.101.66.132 80]
1.094 Err:6 http://deb.debian.org/debian buster-updates Release
1.094   404  Not Found [IP: 151.101.66.132 80]
1.102 Reading package lists...
1.108 E: The repository 'http://deb.debian.org/debian buster Release' does not have a Release file.
1.108 E: The repository 'http://deb.debian.org/debian-security buster/updates Release' does not have a Release file.
1.108 E: The repository 'http://deb.debian.org/debian buster-updates Release' does not have a Release file.
```
This PR updates the base image for the build stage to Debian 13 Trixie.

pnpm is used to build the JavaScript code instead of yarn. The following directive is specified in `package.json`:
```
"packageManager": "pnpm@10.22.0+sha512.bf049efe995b28f527fd2b41ae0474ce29186f7edcb3bf545087bd61fbbebb2bf75362d1307fda09c2d288e1e499787ac12d4fcb617a974718a6051f2eee741c"
```
Therefore, to install pnpm, Corepack is enabled, which will automatically install the pnpm version specified in `package.json`.

I also changed the download URL for the Go distribution to the official address listed on the Go releases page: `https://go.dev/dl/`.

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.

### PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.

Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
