### PR TITLE
Fix path traversal check rejecting paths with three or more consecutive dots

### DIFF
--- a/sdk/helper/consts/error.go
+++ b/sdk/helper/consts/error.go
@@ -3,7 +3,10 @@
 
 package consts
 
-import "errors"
+import (
+	"errors"
+	"strings"
+)
 
 var (
 	// ErrSealed is returned if an operation is performed on a sealed barrier.
@@ -29,3 +32,23 @@ var (
 	// ErrOverloaded indicates the Vault server is at capacity.
 	ErrOverloaded = errors.New("overloaded, try again later")
 )
+
+// PathContainsParentReferences checks whether a path contains ".." as an
+// actual parent directory reference (i.e., a complete path segment), as
+// opposed to ".." appearing as a substring of a longer segment like "...".
+//
+// For example:
+//   - "foo/../bar"  => true  (parent reference)
+//   - "foo/.."      => true  (parent reference)
+//   - "../foo"      => true  (parent reference)
+//   - ".."          => true  (parent reference)
+//   - "foo/.../bar" => false (three dots, not a parent reference)
+//   - "test_..."    => false (dots are part of a longer name)
+func PathContainsParentReferences(path string) bool {
+	for _, segment := range strings.Split(path, "/") {
+		if segment == ".." {
+			return true
+		}
+	}
+	return false
+}

--- a/sdk/helper/consts/error_test.go
+++ b/sdk/helper/consts/error_test.go
@@ -1,0 +1,45 @@
+// Copyright IBM Corp. 2016, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package consts
+
+import "testing"
+
+func TestPathContainsParentReferences(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want bool
+	}{
+		// True cases: actual parent references
+		{"bare double dot", "..", true},
+		{"leading parent ref", "../foo", true},
+		{"trailing parent ref", "foo/..", true},
+		{"middle parent ref", "foo/../bar", true},
+		{"multiple parent refs", "foo/../../bar", true},
+		{"only slashes and parent", "/../", true},
+
+		// False cases: dots that are NOT parent references
+		{"triple dots", "foo/.../bar", false},
+		{"triple dots trailing", "test_...", false},
+		{"quadruple dots", "foo/..../bar", false},
+		{"single dot", "foo/./bar", false},
+		{"dots in name", "foo/bar..baz", false},
+		{"double dots in name", "foo/bar..baz/qux", false},
+		{"empty string", "", false},
+		{"simple path", "foo/bar", false},
+		{"single segment", "foo", false},
+		{"trailing slash", "foo/bar/", false},
+		{"dots prefix in segment", "..foo/bar", false},
+		{"dots suffix in segment", "foo../bar", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := PathContainsParentReferences(tt.path)
+			if got != tt.want {
+				t.Errorf("PathContainsParentReferences(%q) = %v, want %v", tt.path, got, tt.want)
+			}
+		})
+	}
+}

--- a/sdk/logical/storage_view.go
+++ b/sdk/logical/storage_view.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"errors"
 	"strings"
+
+	"github.com/hashicorp/vault/sdk/helper/consts"
 )
 
 type StorageView struct {
@@ -96,7 +98,7 @@ func (s *StorageView) SubView(prefix string) *StorageView {
 
 // SanityCheck is used to perform a sanity check on a key
 func (s *StorageView) SanityCheck(key string) error {
-	if strings.Contains(key, "..") {
+	if consts.PathContainsParentReferences(key) {
 		return ErrRelativePath
 	}
 	return nil

--- a/sdk/physical/file/file.go
+++ b/sdk/physical/file/file.go
@@ -377,7 +377,7 @@ func (b *FileBackend) expandPath(k string) (string, string) {
 
 func (b *FileBackend) validatePath(path string) error {
 	switch {
-	case strings.Contains(path, ".."):
+	case consts.PathContainsParentReferences(path):
 		return consts.ErrPathContainsParentReferences
 	}
 

--- a/sdk/physical/physical_view.go
+++ b/sdk/physical/physical_view.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"errors"
 	"strings"
+
+	"github.com/hashicorp/vault/sdk/helper/consts"
 )
 
 var ErrRelativePath = errors.New("relative paths not supported")
@@ -80,7 +82,7 @@ func (v *View) Delete(ctx context.Context, key string) error {
 
 // sanityCheck is used to perform a sanity check on a key
 func (v *View) sanityCheck(key string) error {
-	if strings.Contains(key, "..") {
+	if consts.PathContainsParentReferences(key) {
 		return ErrRelativePath
 	}
 	return nil

--- a/vault/expiration.go
+++ b/vault/expiration.go
@@ -1726,7 +1726,7 @@ func (m *ExpirationManager) RegisterAuth(ctx context.Context, te *logical.TokenE
 		return errors.New("cannot register an auth lease with an empty token")
 	}
 
-	if strings.Contains(te.Path, "..") {
+	if consts.PathContainsParentReferences(te.Path) {
 		return consts.ErrPathContainsParentReferences
 	}
 
@@ -2468,7 +2468,7 @@ func (m *ExpirationManager) CreateOrFetchRevocationLeaseByToken(ctx context.Cont
 			},
 		}
 
-		if strings.Contains(te.Path, "..") {
+		if consts.PathContainsParentReferences(te.Path) {
 			return "", consts.ErrPathContainsParentReferences
 		}
 

--- a/vault/plugincatalog/plugin_catalog.go
+++ b/vault/plugincatalog/plugin_catalog.go
@@ -992,9 +992,9 @@ func (c *PluginCatalog) Set(ctx context.Context, plugin pluginutil.SetPluginInpu
 	}
 
 	switch {
-	case strings.Contains(plugin.Name, ".."):
+	case consts.PathContainsParentReferences(plugin.Name):
 		fallthrough
-	case strings.Contains(plugin.Command, ".."):
+	case consts.PathContainsParentReferences(plugin.Command):
 		return consts.ErrPathContainsParentReferences
 	}
 

--- a/vault/token_store.go
+++ b/vault/token_store.go
@@ -3777,7 +3777,7 @@ func (ts *TokenStore) tokenStoreRoleCreateUpdate(ctx context.Context, req *logic
 			entry.PathSuffix = data.Get("path_suffix").(string)
 		}
 
-		if strings.Contains(entry.PathSuffix, "..") {
+		if consts.PathContainsParentReferences(entry.PathSuffix) {
 			return logical.ErrorResponse(fmt.Sprintf("error registering path suffix: %s", consts.ErrPathContainsParentReferences)), nil
 		}
 


### PR DESCRIPTION
## Description

Paths containing three or more consecutive dots (e.g., `test_.../`) are incorrectly rejected by vault's parent directory reference check. The current logic uses `strings.Contains(path, "..")` which matches `..` as a substring anywhere in the path, even when it's part of a longer segment like `...` or `....`.

This creates a situation where you can mount a secrets engine at a path like `test_.../`, but then can never disable, move, or operate on it because every subsequent operation triggers the path traversal protection:

```
vault secrets enable -path="test_.../" kv    # succeeds
vault secrets disable "test_.../"              # fails: "path cannot contain parent references"
```

## Fix

Added a `PathContainsParentReferences` helper to `sdk/helper/consts` that splits the path by `/` and checks whether any individual segment is exactly `..`, rather than checking for `..` as a substring. This properly distinguishes:

- `foo/../bar` -- actual parent reference, correctly rejected
- `foo/.../bar` -- three dots in a segment name, now allowed
- `test_...` -- dots at end of segment, now allowed

Updated all six call sites that performed this check:
- `sdk/physical/file/file.go` (file backend)
- `sdk/physical/physical_view.go` (physical view)
- `sdk/logical/storage_view.go` (logical storage view)
- `vault/expiration.go` (2 locations in expiration manager)
- `vault/token_store.go` (token path suffix validation)
- `vault/plugincatalog/plugin_catalog.go` (plugin name/command validation)

## Test plan

- Added comprehensive test cases in `sdk/helper/consts/error_test.go` covering:
  - True positives: `..`, `../foo`, `foo/..`, `foo/../bar`, `foo/../../bar`, `/../`
  - True negatives: `foo/.../bar`, `test_...`, `foo/..../bar`, `foo/./bar`, `foo/bar..baz`, `..foo/bar`, `foo../bar`
- All existing `sdk/physical/file` tests pass (including `TestFileBackend_ValidatePath`)
- All existing `sdk/physical` and `sdk/logical` tests pass

Fixes #31702