### PR TITLE
raft: scope join retry context to core shutdown lifecycle

### DIFF
--- a/http/sys_raft.go
+++ b/http/sys_raft.go
@@ -87,7 +87,7 @@ func handleSysRaftJoinPost(core *vault.Core, w http.ResponseWriter, r *http.Requ
 		},
 	}
 
-	joined, err := core.JoinRaftCluster(context.Background(), leaderInfos, req.NonVoter)
+	joined, err := core.JoinRaftCluster(core.ShutdownContext(), leaderInfos, req.NonVoter)
 	if err != nil {
 		respondError(w, http.StatusInternalServerError, err)
 		return

--- a/vault/core.go
+++ b/vault/core.go
@@ -309,6 +309,12 @@ type Core struct {
 	// that the join is complete
 	raftJoinDoneCh chan struct{}
 
+	// shutdownCtx is a context that is canceled when the Core is shut down.
+	// It is used to scope background operations (such as raft join retries)
+	// that must not outlive the server process.
+	shutdownCtx       context.Context
+	shutdownCtxCancel context.CancelFunc
+
 	// postUnsealStarted informs the raft retry join routine that unseal key
 	// validation is completed and post unseal has started so that it can complete
 	// the join process when Shamir seal is in use
@@ -1067,6 +1073,8 @@ func CreateCore(conf *CoreConfig) (*Core, error) {
 	mountsLock := locking.CreateConfigurableRWMutex(detectDeadlocks, "mountsLock")
 	authLock := locking.CreateConfigurableRWMutex(detectDeadlocks, "authLock")
 
+	shutdownCtx, shutdownCtxCancel := context.WithCancel(context.Background())
+
 	// Setup the core
 	c := &Core{
 		entCore:              entCore{},
@@ -1125,6 +1133,8 @@ func CreateCore(conf *CoreConfig) (*Core, error) {
 		postUnsealStarted:              new(uint32),
 		raftInfo:                       new(atomic.Value),
 		raftJoinDoneCh:                 make(chan struct{}),
+		shutdownCtx:                    shutdownCtx,
+		shutdownCtxCancel:              shutdownCtxCancel,
 		clusterHeartbeatInterval:       clusterHeartbeatInterval,
 		activityLogConfig:              conf.ActivityLogConfig,
 		billingConfig:                  conf.BillingConfig,
@@ -1651,6 +1661,9 @@ func (c *Core) ShutdownCoreError(err error) {
 // happens as quickly as possible.
 func (c *Core) Shutdown() error {
 	c.logger.Debug("shutdown called")
+	if c.shutdownCtxCancel != nil {
+		c.shutdownCtxCancel()
+	}
 	err := c.sealInternal()
 
 	c.stateLock.Lock()
@@ -1677,6 +1690,15 @@ func (c *Core) ShutdownWait() error {
 // ShutdownDone returns a channel that will be closed after Shutdown completes
 func (c *Core) ShutdownDone() <-chan struct{} {
 	return c.shutdownDoneCh.Load().(chan struct{})
+}
+
+// ShutdownContext returns a context that is canceled when the Core shuts down.
+// Use this for background operations that must not outlive the server process.
+func (c *Core) ShutdownContext() context.Context {
+	if c.shutdownCtx == nil {
+		return context.Background()
+	}
+	return c.shutdownCtx
 }
 
 // CORSConfig returns the current CORS configuration


### PR DESCRIPTION
## summary

- scope raft join retry goroutines to the core shutdown lifecycle by passing a shutdown-scoped context into `JoinRaftCluster`.

## background

`/v1/sys/storage/raft/join` currently passes `context.Background()` into `JoinRaftCluster`. when `retry=true`, `JoinRaftCluster` may spawn a retry loop that checks `ctx.Done()` but will never observe cancellation.

this change adds `Core.ShutdownContext()` (canceled in `Core.Shutdown()`) and uses it in the raft join http handler, so retries are stopped automatically when the core is shutting down.

## testing

- `go test ./http/... -run TestNonExistent`
- `go test ./vault/... -run TestNonExistent`
