### PR TITLE
ui: fix secret engine description field truncation

### DIFF
--- a/ui/app/components/dashboard/secrets-engines-card.hbs
+++ b/ui/app/components/dashboard/secrets-engines-card.hbs
@@ -50,7 +50,7 @@
                   </code>
                 {{/if}}
                 {{#if backend.description}}
-                  <div data-test-description class="truncate-first-line overflow-wrap word-break">
+                  <div data-test-description class="overflow-wrap word-break">
                     {{backend.description}}
                   </div>
                 {{/if}}

--- a/ui/lib/core/addon/components/list-table.hbs
+++ b/ui/lib/core/addon/components/list-table.hbs
@@ -25,7 +25,10 @@
             {{yield B.data to="popupMenu"}}
           </B.Td>
         {{else}}
-          <B.Td data-test-table-data={{column.key}} class="is-inline text-overflow-ellipsis">
+          <B.Td
+            data-test-table-data={{column.key}}
+            class="is-inline {{if (eq column.key 'description') '' 'text-overflow-ellipsis'}}"
+          >
             {{#if column.customTableItem}}
               {{yield B.data to="customTableItem"}}
             {{else}}


### PR DESCRIPTION
### Description
Fixes the secret engine description field being truncated 
and non-expandable in the Vault 1.21+ UI 

Fixes #31739

## Testing
Ran `ember exam --launch=Chrome --filter="secret-engine"`
- 68/70 tests pass
- 2 failures are pre-existing enterprise-only namespace tests 
  unrelated to this change

### PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.