### PR TITLE
transit: add associated_data support to rewrap endpoint

### DIFF
--- a/builtin/logical/transit/path_rewrap.go
+++ b/builtin/logical/transit/path_rewrap.go
@@ -101,6 +101,17 @@ Must be 0 (for latest) or a value greater than or equal
 to the min_encryption_version configured on the key.`,
 			},
 
+			"associated_data": {
+				Type: framework.TypeString,
+				Description: `
+When using an AEAD cipher mode, such as AES-GCM, this parameter allows
+passing associated data (AD/AAD) into the encryption function; this data
+must be passed on subsequent decryption requests but can be transited in
+plaintext. On successful decryption, both the ciphertext and the associated
+data are attested not to have been tampered with.
+				`,
+			},
+
 			"batch_input": {
 				Type: framework.TypeSlice,
 				Description: `
@@ -140,10 +151,11 @@ func (b *backend) pathRewrapWrite(ctx context.Context, req *logical.Request, d *
 
 		batchInputItems = make([]RewrapBatchRequestItem, 1)
 		batchInputItems[0] = RewrapBatchRequestItem{
-			Ciphertext: ciphertext,
-			Context:    d.Get("context").(string),
-			Nonce:      d.Get("nonce").(string),
-			KeyVersion: d.Get("key_version").(int),
+			Ciphertext:     ciphertext,
+			Context:        d.Get("context").(string),
+			Nonce:          d.Get("nonce").(string),
+			KeyVersion:     d.Get("key_version").(int),
+			AssociatedData: d.Get("associated_data").(string),
 		}
 		if ps, ok := d.GetOk("decrypt_padding_scheme"); ok {
 			batchInputItems[0].DecryptPaddingScheme = ps.(string)
@@ -217,6 +229,14 @@ func (b *backend) pathRewrapWrite(ctx context.Context, req *logical.Request, d *
 			}
 			factories = append(factories, paddingScheme)
 		}
+		if item.AssociatedData != "" {
+			if !p.Type.AssociatedDataSupported() {
+				batchResponseItems[i].Error = fmt.Sprintf("'[%d].associated_data' provided for non-AEAD cipher suite %v", i, p.Type.String())
+				continue
+			}
+
+			factories = append(factories, AssocDataFactory{item.AssociatedData})
+		}
 		if item.Nonce != "" && !nonceAllowed(p) {
 			batchResponseItems[i].Error = ErrNonceNotAllowed.Error()
 			continue
@@ -247,6 +267,9 @@ func (b *backend) pathRewrapWrite(ctx context.Context, req *logical.Request, d *
 			}
 			factories = append(factories, paddingScheme)
 			factories = append(factories, keysutil.PaddingScheme(item.EncryptPaddingScheme))
+		}
+		if item.AssociatedData != "" {
+			factories = append(factories, AssocDataFactory{item.AssociatedData})
 		}
 		if !warnAboutNonceUsage && shouldWarnAboutNonceUsage(p, item.DecodedNonce) {
 			warnAboutNonceUsage = true


### PR DESCRIPTION
## Description

The transit `rewrap` endpoint currently does not accept the `associated_data` parameter, even though both the `encrypt` and `decrypt` endpoints support it. This means that ciphertext encrypted with associated data (AD/AAD) using AEAD cipher modes like AES-GCM cannot be rewrapped — the only workaround is to decrypt and re-encrypt as separate API calls, which defeats the purpose of rewrap (avoiding exposure of plaintext to the client).

Fixes #31791

## Root Cause

The `associated_data` support was missing from `path_rewrap.go` in three places:

1. **Endpoint Fields map** — the `associated_data` parameter was not declared in the endpoint schema, so non-batch requests couldn't pass it at all
2. **Non-batch request construction** — when building a single-item request (non-batch), the `AssociatedData` field was never populated from the request data
3. **Decrypt/encrypt processing loop** — no `AssocDataFactory` was created or passed to `DecryptWithOptions` or `EncryptWithOptions`, so even batch requests that included `associated_data` via mapstructure had it silently ignored

The `RewrapBatchRequestItem` struct already had an `AssociatedData` field and the `AssocDataFactory` type already existed — they just weren't wired up.

## Changes

All changes are in `builtin/logical/transit/path_rewrap.go`:

- Added `associated_data` field to the endpoint's `Fields` map (matching the encrypt/decrypt endpoints)
- Populated `AssociatedData` from `d.Get("associated_data")` for non-batch requests
- Added `AssocDataFactory` to the decrypt factory slice (so decryption can verify the AAD)
- Added `AssocDataFactory` to the encrypt factory slice (so re-encryption preserves the AAD binding)
- Added proper validation that the key type supports associated data (same guard as encrypt/decrypt)

## How I verified

- `go build ./builtin/logical/transit/...` — compiles cleanly
- `go test ./builtin/logical/transit/... -run "TestTransit_.*"` — all existing tests pass
- Reviewed the pattern against `path_encrypt.go` and `path_decrypt.go` to ensure consistency