### PR TITLE
fix: guard nil core config in SIGHUP handler to prevent SIGSEGV

### DIFF
--- a/command/server.go
+++ b/command/server.go
@@ -1707,10 +1707,14 @@ func (c *ServerCommand) Run(args []string) int {
 			// See the call to Core.SetSealReloadFunc above.
 			if reloaded, err := c.reloadSealsOnSigHup(ctx, core, config); err != nil {
 				c.UI.Error(fmt.Errorf("error reloading seal config: %s", err).Error())
-				config.Seals = core.GetCoreConfigInternal().Seals
+				if coreConfig := core.GetCoreConfigInternal(); coreConfig != nil {
+					config.Seals = coreConfig.Seals
+				}
 				goto RUNRELOADFUNCS
 			} else if !reloaded {
-				config.Seals = core.GetCoreConfigInternal().Seals
+				if coreConfig := core.GetCoreConfigInternal(); coreConfig != nil {
+					config.Seals = coreConfig.Seals
+				}
 			}
 
 			core.SetConfig(config)


### PR DESCRIPTION
## Summary
- Add nil check for `GetCoreConfigInternal()` return value before accessing `.Seals` in the SIGHUP handler
- Prevents SIGSEGV when sending SIGHUP to vault dev server in Docker

## Root Cause
`GetCoreConfigInternal()` can return nil in dev mode. The SIGHUP handler at `command/server.go` accesses `.Seals` without checking for nil, causing a nil pointer dereference. Other paths in the same handler (e.g., ServiceRegistration) already guard against this.

## Testing
- Verified the nil check pattern matches existing guards in the same handler
- Existing test suite unaffected

Fixes #31800

Made with [Cursor](https://cursor.com)