### PR TITLE
fix: respect disable_hostname config with single telemetry sink

### DIFF
--- a/internalshared/configutil/telemetry.go
+++ b/internalshared/configutil/telemetry.go
@@ -420,7 +420,7 @@ func SetupTelemetry(opts *SetupTelemetryOpts) (*metrics.InmemSink, *metricsutil.
 	}
 
 	// Initialize the global sink
-	if len(fanout) > 1 {
+	if len(fanout) > 0 {
 		// Hostname enabled will create poor quality metrics name for prometheus
 		if !opts.Config.DisableHostname {
 			opts.Ui.Warn("telemetry.disable_hostname has been set to false. Recommended setting is true for Prometheus to avoid poorly named metrics.")


### PR DESCRIPTION
## Problem

When only one external telemetry sink is configured (e.g., just Prometheus), the `disable_hostname` setting is ignored. Metric names never include the hostname prefix, regardless of the operator's configuration.

## Root Cause

In `internalshared/configutil/telemetry.go`, the hostname configuration check uses `len(fanout) > 1`:

```go
if len(fanout) > 1 {
    // warn about hostname if enabled
} else {
    metricsConf.EnableHostname = false  // forces hostname off
}
```

The `fanout` slice at this point contains only external sinks (statsite, statsd, dogstatsd, circonus, stackdriver, prometheus). The in-memory metrics sink (`inm`) is appended on the next line. So when exactly one external sink is configured, `len(fanout) == 1`, the condition is false, and `EnableHostname` is forced to `false` — ignoring the user's `disable_hostname = false` setting.

## Fix

Change the threshold from `> 1` to `> 0` so that the user's hostname configuration is respected whenever any external telemetry sink is present. The `EnableHostname = false` fallback now only applies when no external sinks are configured (i.e., only the in-memory sink is active).

Fixes #31747