### PR TITLE
fix(command): add nil check for GetCoreConfigInternal during SIGHUP reload

### DIFF
--- a/command/server.go
+++ b/command/server.go
@@ -1715,10 +1715,18 @@ func (c *ServerCommand) Run(args []string) int {
 			// See the call to Core.SetSealReloadFunc above.
 			if reloaded, err := c.reloadSealsOnSigHup(ctx, core, config); err != nil {
 				c.UI.Error(fmt.Errorf("error reloading seal config: %s", err).Error())
-				config.Seals = core.GetCoreConfigInternal().Seals
+				if coreConfig := core.GetCoreConfigInternal(); coreConfig != nil {
+					config.Seals = coreConfig.Seals
+				} else {
+					c.logger.Warn("core config is nil, skipping seal reload")
+				}
 				goto RUNRELOADFUNCS
 			} else if !reloaded {
-				config.Seals = core.GetCoreConfigInternal().Seals
+				if coreConfig := core.GetCoreConfigInternal(); coreConfig != nil {
+					config.Seals = coreConfig.Seals
+				} else {
+					c.logger.Warn("core config is nil, skipping seal reload")
+				}
 			}
 
 			core.SetConfig(config)


### PR DESCRIPTION
Fixes #31800

## What did you do?

Started a vault dev server in docker and sent a HUP signal to trigger a config reload:
`docker run --rm --name vault hashicorp/vault:latest server -dev`
`docker kill --signal=HUP vault`

## What did you see instead?

Vault crashed with a panic:
`panic: runtime error: invalid memory address or nil pointer dereference [signal SIGSEGV: segmentation violation code=0x1 addr=0x38 pc=0x961ac56]`

Stack trace pointed to `command/server.go:1692` in `(*ServerCommand).Run`.

## Root Cause

`GetCoreConfigInternal()` returns nil in dev mode, but the SIGHUP reload handler does not check for nil before accessing `.Seals` on the returned config. This was working in 1.18 and lower but regressed in 1.19.

## Fix

Store the result of `GetCoreConfigInternal()` in a variable and check if it's not nil before accessing `.Seals`. If nil, log a warning and skip the seal reload gracefully.

## Changes

- `command/server.go`: Add nil check before accessing `GetCoreConfigInternal().Seals` in two places (lines 1718 and 1721)

Signed-off-by: wucm667 <stevenwucongmin@gmail.com>