### PR TITLE
fix(database): use LastVaultRotation as reference for schedule-based TTL calculation

### DIFF
--- a/builtin/logical/database/path_roles.go
+++ b/builtin/logical/database/path_roles.go
@@ -1048,7 +1048,7 @@ func (s *staticAccount) NextRotationTime() time.Time {
 	if s.UsesRotationPeriod() {
 		return s.NextVaultRotation
 	}
-	return s.Schedule.Next(time.Now())
+	return s.Schedule.Next(s.LastVaultRotation)
 }
 
 // NextRotationTimeFromInput calculates the next rotation time for period and


### PR DESCRIPTION
## Description

When using database static roles with a cron-based `rotation_schedule`, the `/database/static-creds/<role>` endpoint returns a refreshed TTL at each cron boundary even though the password has not actually been rotated yet. This creates an inconsistent state where the TTL resets but the password remains the same.

## Root Cause

In `NextRotationTime()`, the schedule-based rotation branch uses `time.Now()` as the reference point for calculating the next cron occurrence. This means the TTL jumps back to the full interval at every cron boundary, regardless of whether the password was actually rotated.

## Fix

Changed `NextRotationTime()` to use `s.LastVaultRotation` as the reference point instead of `time.Now()`. This ensures the TTL accurately reflects the time remaining until the next rotation after the last actual password change.

## Related Issue

Fixes #31918