### PR TITLE
vault: fix typo `recieved` -> `received` in inspectable_test

### DIFF
--- a/vault/inspectable_test.go
+++ b/vault/inspectable_test.go
@@ -120,7 +120,7 @@ func TestInspectAPIReload(t *testing.T) {
 		t.Fatal("expected invalid configuration error")
 	}
 	if !strings.Contains(resp.Error().Error(), ErrIntrospectionNotEnabled.Error()) {
-		t.Fatalf("expected invalid configuration error but recieved: %s", resp.Error())
+		t.Fatalf("expected invalid configuration error but received: %s", resp.Error())
 	}
 
 	originalConfig := core.rawConfig.Load().(*server.Config)


### PR DESCRIPTION
Minor typo fix in test failure message: `recieved` -> `received` at `vault/inspectable_test.go:123`. Test-only change, no behavior impact.