### PR TITLE
tools/pipeline: fix typo `seperate(d)` -> `separate(d)`

### DIFF
--- a/tools/pipeline/internal/cmd/hcp_show_image.go
+++ b/tools/pipeline/internal/cmd/hcp_show_image.go
@@ -29,7 +29,7 @@ func newHCPShowImageCmd() *cobra.Command {
 	}
 
 	showHCPImage.PersistentFlags().StringVarP(&showHCPImageReq.Req.ProductName, "product-name", "p", "vault", "The product or component of the image")
-	showHCPImage.PersistentFlags().StringVarP(&showHCPImageReq.Req.ProductVersionConstraint, "product-version-constraint", "v", "", "A comma seperated list of constraints. If left unset the latest will be returned")
+	showHCPImage.PersistentFlags().StringVarP(&showHCPImageReq.Req.ProductVersionConstraint, "product-version-constraint", "v", "", "A comma separated list of constraints. If left unset the latest will be returned")
 	showHCPImage.PersistentFlags().StringVarP(&showHCPImageReq.Req.HostManagerVersionConstraint, "host-manager-version-constraint", "m", "", "A semver string. If left unset the latest will be used")
 	showHCPImage.PersistentFlags().StringVarP(&showHCPImageReq.Req.CloudProvider, "cloud", "c", "aws", "The cloud provider you wish to search. E.g. aws, azure")
 	showHCPImage.PersistentFlags().StringVarP(&showHCPImageReq.Req.CloudRegion, "region", "r", "us-west-2", "The cloud region you wish to search")

--- a/tools/pipeline/internal/cmd/hcp_wait_image.go
+++ b/tools/pipeline/internal/cmd/hcp_wait_image.go
@@ -85,7 +85,7 @@ func newHCPWaitForImageCmd() *cobra.Command {
 	}
 
 	waitHCPImage.PersistentFlags().StringVarP(&waitForHCPImageReq.Req.ProductName, "product-name", "p", "vault", "The product or component of the image")
-	waitHCPImage.PersistentFlags().StringVarP(&waitForHCPImageReq.Req.ProductVersionConstraint, "product-version-constraint", "v", "", "A comma seperated list of constraints. If left unset the latest will be returned")
+	waitHCPImage.PersistentFlags().StringVarP(&waitForHCPImageReq.Req.ProductVersionConstraint, "product-version-constraint", "v", "", "A comma separated list of constraints. If left unset the latest will be returned")
 	waitHCPImage.PersistentFlags().StringVarP(&waitForHCPImageReq.Req.HostManagerVersionConstraint, "host-manager-version-constraint", "m", "", "A semver string. If left unset the latest will be used")
 	waitHCPImage.PersistentFlags().StringVarP(&waitForHCPImageReq.Req.CloudProvider, "cloud", "c", "aws", "The cloud provider you wish to search. E.g. aws, azure")
 	waitHCPImage.PersistentFlags().StringVarP(&waitForHCPImageReq.Req.CloudRegion, "region", "r", "us-west-2", "The cloud region you wish to search")

--- a/tools/pipeline/internal/pkg/releases/list_versions.go
+++ b/tools/pipeline/internal/pkg/releases/list_versions.go
@@ -310,7 +310,7 @@ func (req *ListVersionsReq) Run(ctx context.Context) (*ListVersionsRes, error) {
 			return nil, err
 		}
 
-		// The releases API will list all editions as seperate release versions, as it should. However,
+		// The releases API will list all editions as separate release versions, as it should. However,
 		// we don't make that distinction here. For our purposes we neeed a singular list of all versions
 		// on a license class basis. As such, we'll drop metadata and only focus on major, minor, patch,
 		// and prerelease.


### PR DESCRIPTION
Fix `seperate`/`seperated` -> `separate`/`separated` in three files under `tools/pipeline`:
- `internal/pkg/releases/list_versions.go:313` (comment)
- `internal/cmd/hcp_show_image.go:32` (CLI flag description)
- `internal/cmd/hcp_wait_image.go:88` (CLI flag description)