### PR TITLE
Add prefix support to password policies

### DIFF
--- a/vault/dynamic_system_view.go
+++ b/vault/dynamic_system_view.go
@@ -326,7 +326,14 @@ func (d dynamicSystemView) GeneratePasswordFromPolicy(ctx context.Context, polic
 	if err != nil {
 		return "", fmt.Errorf("stored password policy is invalid: %w", err)
 	}
-	return passPolicy.Generate(ctx, rng)
+	password, err := passPolicy.Generate(ctx, rng)
+	if err != nil {
+		return "", fmt.Errorf("failed to generate password: %w", err)
+	}
+	if policyCfg.Prefix != "" {
+		password = policyCfg.Prefix + password
+	}
+	return password, nil
 }
 
 func (d dynamicSystemView) ClusterID(ctx context.Context) (string, error) {

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -4200,6 +4200,7 @@ func (b *SystemBackend) handlePoliciesDelete(policyType PolicyType) framework.Op
 type passwordPolicyConfig struct {
 	HCLPolicy     string `json:"policy"`
 	EntropySource string `json:"entropy_source,omitempty"`
+	Prefix        string `json:"prefix,omitempty"`
 }
 
 func getPasswordPolicyKey(policyName string) string {
@@ -4304,6 +4305,7 @@ func (*SystemBackend) handlePoliciesPasswordSet(ctx context.Context, req *logica
 	cfg := passwordPolicyConfig{
 		HCLPolicy:     rawPolicy,
 		EntropySource: entropySource,
+		Prefix:        data.Get("prefix").(string),
 	}
 	entry, err := logical.StorageEntryJSON(getPasswordPolicyKey(policyName), cfg)
 	if err != nil {
@@ -4342,6 +4344,9 @@ func (*SystemBackend) handlePoliciesPasswordGet(ctx context.Context, req *logica
 
 	if cfg.EntropySource != "" {
 		resp.Data["entropy_source"] = cfg.EntropySource
+	}
+	if cfg.Prefix != "" {
+		resp.Data["prefix"] = cfg.Prefix
 	}
 
 	return resp, nil
@@ -4411,6 +4416,10 @@ func (b *SystemBackend) handlePoliciesPasswordGenerate(ctx context.Context, req 
 	if err != nil {
 		return nil, logical.CodedError(http.StatusInternalServerError,
 			fmt.Sprintf("failed to generate password from policy: %s", err))
+	}
+
+	if cfg.Prefix != "" {
+		password = cfg.Prefix + password
 	}
 
 	resp := &logical.Response{

--- a/vault/logical_system_paths.go
+++ b/vault/logical_system_paths.go
@@ -37,6 +37,10 @@ var passwordPolicySchema = map[string]*framework.FieldSchema{
 		Type:        framework.TypeString,
 		Description: "The entropy source for generation",
 	},
+	"prefix": {
+		Type:        framework.TypeString,
+		Description: "The prefix to prepend to generated passwords",
+	},
 }
 
 func (b *SystemBackend) configPaths() []*framework.Path {

--- a/vault/logical_system_test.go
+++ b/vault/logical_system_test.go
@@ -5877,6 +5877,97 @@ func TestHandlePoliciesPasswordGenerate(t *testing.T) {
 			}
 		}
 	})
+
+	t.Run("success with prefix", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		policyEntry := storageEntryWithPrefix(t, "testprefix",
+			"length = 20\n"+
+				"rule \"charset\" {\n"+
+				"\tcharset=\"abcdefghij\"\n"+
+				"}", "", "vault.")
+		storage := makeStorage(t, policyEntry)
+
+		inputData := passwordPoliciesFieldData(map[string]interface{}{
+			"name": "testprefix",
+		})
+
+		for i := 0; i < 100; i++ {
+			req := &logical.Request{
+				Storage: storage,
+			}
+
+			b := &SystemBackend{}
+
+			actualResp, err := b.handlePoliciesPasswordGenerate(ctx, req, inputData)
+			if err != nil {
+				t.Fatalf("no error expected, got: %s", err)
+			}
+
+			assertTrue(t, actualResp != nil, "response is nil")
+			assertTrue(t, actualResp.Data != nil, "expected data, got nil")
+			assertHasKey(t, actualResp.Data, "password", "password key not found in data")
+			password := actualResp.Data["password"].(string)
+
+			if len(password) < 6 || password[:6] != "vault." {
+				t.Fatalf("password %s does not start with prefix 'vault.'", password)
+			}
+
+			passwordWithoutPrefix := password[6:]
+			passwordLength := len([]rune(passwordWithoutPrefix))
+			if passwordLength != 20 {
+				t.Fatalf("password without prefix is %d characters but should be 20", passwordLength)
+			}
+
+			rules := []random.Rule{
+				random.CharsetRule{
+					Charset:  []rune("abcdefghij"),
+					MinChars: 20,
+				},
+			}
+			for _, rule := range rules {
+				if !rule.Pass([]rune(passwordWithoutPrefix)) {
+					t.Fatalf("password %s does not have the correct characters after prefix", password)
+				}
+			}
+		}
+	})
+
+	t.Run("success empty prefix", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		policyEntry := storageEntryWithPrefix(t, "testemptyprefix",
+			"length = 20\n"+
+				"rule \"charset\" {\n"+
+				"\tcharset=\"abcdefghij\"\n"+
+				"}", "", "")
+		storage := makeStorage(t, policyEntry)
+
+		inputData := passwordPoliciesFieldData(map[string]interface{}{
+			"name": "testemptyprefix",
+		})
+
+		req := &logical.Request{
+			Storage: storage,
+		}
+
+		b := &SystemBackend{}
+
+		actualResp, err := b.handlePoliciesPasswordGenerate(ctx, req, inputData)
+		if err != nil {
+			t.Fatalf("no error expected, got: %s", err)
+		}
+
+		assertTrue(t, actualResp != nil, "response is nil")
+		password := actualResp.Data["password"].(string)
+
+		passwordLength := len([]rune(password))
+		if passwordLength != 20 {
+			t.Fatalf("password is %d characters but should be 20", passwordLength)
+		}
+	})
 }
 
 func assertTrue(t *testing.T, pass bool, f string, vals ...interface{}) {
@@ -5929,6 +6020,17 @@ func storageEntry(t *testing.T, key string, policy string, entropySource string)
 		Value: toJson(t, passwordPolicyConfig{
 			HCLPolicy:     policy,
 			EntropySource: entropySource,
+		}),
+	}
+}
+
+func storageEntryWithPrefix(t *testing.T, key string, policy string, entropySource string, prefix string) *logical.StorageEntry {
+	return &logical.StorageEntry{
+		Key: getPasswordPolicyKey(key),
+		Value: toJson(t, passwordPolicyConfig{
+			HCLPolicy:     policy,
+			EntropySource: entropySource,
+			Prefix:        prefix,
 		}),
 	}
 }


### PR DESCRIPTION
## Summary

This PR adds a `prefix` field to password policy configuration in HashiCorp Vault, allowing generated passwords to include a configurable prefix string.

### Problem

Currently, Vault-generated passwords have no prefix, making them impossible to identify with secret scanning tools. Vault already uses prefixes for its own tokens (e.g., `hvs.` for secrets), so this follows an existing pattern.

### Changes

- **`vault/logical_system.go`**: Added `Prefix` field to `passwordPolicyConfig` struct; updated `handlePoliciesPasswordSet` to accept and store prefix; updated `handlePoliciesPasswordGet` to return prefix; updated `handlePoliciesPasswordGenerate` to prepend prefix to generated passwords
- **`vault/dynamic_system_view.go`**: Updated `generatePassword` to prepend prefix when set
- **`vault/logical_system_paths.go`**: Added `prefix` field to `passwordPolicySchema`
- **`vault/logical_system_test.go`**: Added tests for prefix functionality (with prefix, empty prefix)

### Usage Example

```bash
# Create a policy with prefix
vault write sys/policies/password/my-policy \
  prefix="vault." \
  policy="length=20 rule \"charset\" { charset=\"abcdefghij\" }"

# Generate a password (e.g., "vault.ajdifbhoeigjhrfgc")
vault read sys/policies/password/my-policy/generate
```

### Files Changed
- `vault/logical_system.go` (+9 lines)
- `vault/dynamic_system_view.go` (+9 lines)
- `vault/logical_system_paths.go` (+4 lines)
- `vault/logical_system_test.go` (+102 lines)

---

Closes #31889