### PR TITLE
fix: respect NO_PROXY CIDR notation in Vault CLI HTTP client

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -519,7 +519,34 @@ func (c *Config) ReadEnvironment() error {
 		}
 
 		transport := c.HttpClient.Transport.(*http.Transport)
-		transport.Proxy = http.ProxyURL(u)
+		transport.Proxy = func(r *http.Request) (*url.URL, error) {
+			host := r.URL.Hostname()
+			if noProxy := os.Getenv("NO_PROXY"); noProxy != "" {
+				for _, entry := range strings.Split(noProxy, ",") {
+					entry = strings.TrimSpace(entry)
+					if entry == "" {
+						continue
+					}
+					// Handle CIDR notation
+					if strings.Contains(entry, "/") {
+						ip := net.ParseIP(host)
+						if ip == nil {
+							continue
+						}
+						_, cidr, err := net.ParseCIDR(entry)
+						if err != nil {
+							continue
+						}
+						if cidr.Contains(ip) {
+							return nil, nil
+						}
+					} else if entry == host || strings.HasSuffix(host, "."+entry) {
+						return nil, nil
+					}
+				}
+			}
+			return u, nil
+		}
 	}
 
 	return nil


### PR DESCRIPTION
## What this does

Fixes #31954

When `VAULT_HTTP_PROXY` or `VAULT_PROXY_ADDR` is set, the Vault CLI uses `http.ProxyURL()` which always routes through the proxy regardless of `NO_PROXY` entries. This means CIDR notation in `NO_PROXY` (e.g., `10.66.0.0/16`) is ignored.

## Root cause

In `api/client.go`, the proxy is configured with:
```go
transport.Proxy = http.ProxyURL(u)
```

`http.ProxyURL` returns a function that always returns the given proxy URL, completely ignoring the `NO_PROXY` environment variable.

## Fix

Replace `http.ProxyURL()` with a custom proxy function that checks `NO_PROXY` entries before routing through the proxy, supporting:
- Exact hostname matching (`localhost`)
- Domain suffix matching (`.mycompany.tld`)
- CIDR subnet matching (`10.66.0.0/16`)

When a host matches a `NO_PROXY` entry, the proxy is bypassed (returns `nil, nil`).
