### PR TITLE
Fix potential nil pointer dereference in RawRequestWithContext

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -1563,9 +1563,10 @@ START:
 		if c.config.ReadYourWrites {
 			c.replicationStateStore.recordState(result)
 		}
-	}
-	if err := result.Error(); err != nil {
-		return result, err
+
+		if err := result.Error(); err != nil {
+			return result, err
+		}
 	}
 
 	return result, nil


### PR DESCRIPTION
Fixes a potential nil pointer dereference where result.Error() is called without verifying result is non-nil first.

The code checks if result != nil for callbacks, but then calls result.Error() outside that block. This allows the Error() call when result is nil, causing a panic.

Fix: Move the result.Error() check inside the nil validation block.

Fixes #30209