### PR TITLE
VAULT-43873 return 431 for oversized token headers

### DIFF
--- a/http/token_header_size_test.go
+++ b/http/token_header_size_test.go
@@ -53,7 +53,7 @@ func newTestClusterForTokenHeader(t *testing.T, opts *vault.TestClusterOptions) 
 }
 
 // TestTokenHeader_ExceedsDefaultLimit_IsRejected verifies that tokens larger than
-// DefaultMaxTokenHeaderSize are rejected with 400 before token validation occurs.
+// DefaultMaxTokenHeaderSize are rejected with 431 before token validation occurs.
 func TestTokenHeader_ExceedsDefaultLimit_IsRejected(t *testing.T) {
 	t.Parallel()
 
@@ -98,8 +98,8 @@ func TestTokenHeader_ExceedsDefaultLimit_IsRejected(t *testing.T) {
 			require.NoError(t, err)
 			defer resp.Body.Close()
 
-			require.Equal(t, http.StatusBadRequest, resp.StatusCode,
-				"token of %d bytes must be rejected by Vault middleware (want 400, not 403)",
+			require.Equal(t, http.StatusRequestHeaderFieldsTooLarge, resp.StatusCode,
+				"token of %d bytes must be rejected by Vault middleware (want 431, not 403)",
 				tc.headerSize)
 		})
 	}
@@ -172,8 +172,8 @@ func TestTokenHeader_ConfigurableLimit_Enforced(t *testing.T) {
 	require.NoError(t, err)
 	defer resp.Body.Close()
 
-	require.Equal(t, http.StatusBadRequest, resp.StatusCode,
-		"token exceeding custom limit of %d bytes must be rejected with 400", customLimit)
+	require.Equal(t, http.StatusRequestHeaderFieldsTooLarge, resp.StatusCode,
+		"token exceeding custom limit of %d bytes must be rejected with 431", customLimit)
 
 	atLimit := strings.Repeat("x", customLimit)
 	resp2, err := sendTokenHeaderRequest(t, client, addr, consts.AuthHeaderName, atLimit)
@@ -203,7 +203,7 @@ func TestTokenHeader_MultipleAuthorizationHeaders_BypassPrevented(t *testing.T) 
 	require.NoError(t, err)
 	defer resp.Body.Close()
 
-	require.Equal(t, http.StatusBadRequest, resp.StatusCode,
+	require.Equal(t, http.StatusRequestHeaderFieldsTooLarge, resp.StatusCode,
 		"oversized Bearer token must be rejected even when a non-Bearer Authorization header precedes it")
 }
 
@@ -242,7 +242,7 @@ func TestTokenHeader_ErrorResponseFormat(t *testing.T) {
 	require.NoError(t, err)
 	defer resp.Body.Close()
 
-	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	require.Equal(t, http.StatusRequestHeaderFieldsTooLarge, resp.StatusCode)
 	require.Equal(t, "application/json", resp.Header.Get("Content-Type"))
 
 	body, err := io.ReadAll(resp.Body)
@@ -504,7 +504,7 @@ func TestTokenHeader_ClusterListener_SkipsCheck(t *testing.T) {
 		resp, err := cleanhttp.DefaultClient().Do(req)
 		require.NoError(t, err)
 		defer resp.Body.Close()
-		require.Equal(t, http.StatusBadRequest, resp.StatusCode,
+		require.Equal(t, http.StatusRequestHeaderFieldsTooLarge, resp.StatusCode,
 			"API listener must reject a token that exceeds the default size limit")
 	})
 }

--- a/http/util.go
+++ b/http/util.go
@@ -72,7 +72,7 @@ func wrapTokenHeaderSizeHandler(handler http.Handler, props *vault.HandlerProper
 			bearerPrefix := "Bearer "
 			tokenLen := int64(len(r.Header.Get(consts.AuthHeaderName)))
 			if tokenLen > maxTokenHeaderSize {
-				respondError(w, http.StatusBadRequest,
+				respondError(w, http.StatusRequestHeaderFieldsTooLarge,
 					fmt.Errorf("authentication token exceeds maximum allowed header size of %d bytes", maxTokenHeaderSize))
 				return
 			}
@@ -87,7 +87,7 @@ func wrapTokenHeaderSizeHandler(handler http.Handler, props *vault.HandlerProper
 				}
 				bearerTokenLen := int64(len(strings.TrimSpace(v[len(bearerPrefix):])))
 				if bearerTokenLen > maxTokenHeaderSize {
-					respondError(w, http.StatusBadRequest,
+					respondError(w, http.StatusRequestHeaderFieldsTooLarge,
 						fmt.Errorf("authentication token exceeds maximum allowed header size of %d bytes", maxTokenHeaderSize))
 					return
 				}


### PR DESCRIPTION
### Description
What does this PR do?

## Summary

Updates Vault’s token header size validation to return `431 Request Header Fields Too Large` instead of `400 Bad Request` when authentication token headers exceed the configured size limit.

This applies to oversized `X-Vault-Token` headers and oversized `Authorization: Bearer` token values.

## Test-first confirmation

I followed the bug test-first workflow for this change. I first ran the focused token-header test with the existing implementation and confirmed it passed with the old `400 Bad Request` expectation.

I then changed the focused oversized-token test expectation from `http.StatusBadRequest` to `http.StatusRequestHeaderFieldsTooLarge` and reran the test. It failed with `expected: 431` and `actual: 400`, confirming the implementation still returned the old status code before the fix.

## Implementation

After confirming the test failed for the expected reason, I updated `wrapTokenHeaderSizeHandler` in `http/util.go` so oversized authentication token headers return `http.StatusRequestHeaderFieldsTooLarge`.

Both oversized token paths were updated:

- `X-Vault-Token`
- `Authorization: Bearer`

## Test updates

After the implementation change, the focused oversized-token test passed. I then ran the broader token-header test group, which exposed other assertions still expecting `400` for the same oversized token/header validation path.

I updated only the related assertions that exercise oversized token/header validation, including the custom limit case, multiple authorization header case, error response format case, and the API listener enforcement case. The cluster listener skip behavior remains unchanged.

## Testing

- `go test ./http -run TestTokenHeader_ExceedsDefaultLimit_IsRejected -v`
- `go test ./http -run TokenHeader -v -count=1`
- `go test ./http -count=1`

All passed.

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [x] **Jira:** If this change has an associated Jira, it's referenced either in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.

### PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.

Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
