### PR TITLE
Fix TSL host mismatch

### DIFF
--- a/plugins/database/cassandra/connection_producer_test.go
+++ b/plugins/database/cassandra/connection_producer_test.go
@@ -40,11 +40,9 @@ func TestSelfSignedCA(t *testing.T) {
 	tlsConfig := &tls.Config{
 		RootCAs: certBundle.CertPool,
 	}
-	// Note about CI behavior: when running these tests locally, they seem to pass without issue. However, if the
-	// ServerName is not set, the tests fail within CI. It's not entirely clear to me why they are failing in CI
-	// however by manually setting the ServerName we can get around the hostname/DNS issue and get them passing.
-	// Setting the ServerName isn't the ideal solution, but it was the only reliable one I was able to find
-	tlsConfig.ServerName = "cassandra"
+	// The test container is reached through a loopback port mapping, and the generated leaf cert is only valid
+	// for localhost and 127.0.0.1. Set ServerName explicitly so hostname verification matches the test cert.
+	tlsConfig.ServerName = "localhost"
 	sslOpts := &gocql.SslOptions{
 		Config:                 tlsConfig,
 		EnableHostVerification: true,
@@ -151,11 +149,8 @@ func TestSelfSignedCA(t *testing.T) {
 				"connect_timeout":  "30s",
 				"tls":              "true",
 
-				// Note about CI behavior: when running these tests locally, they seem to pass without issue. However, if the
-				// tls_server_name is not set, the tests fail within CI. It's not entirely clear to me why they are failing in CI
-				// however by manually setting the tls_server_name we can get around the hostname/DNS issue and get them passing.
-				// Setting the tls_server_name isn't the ideal solution, but it was the only reliable one I was able to find
-				"tls_server_name": "cassandra",
+				// Match the generated test certificate, which is valid for localhost and 127.0.0.1.
+				"tls_server_name": "localhost",
 			}
 
 			// Apply the generated & common fields to the config to be sent to the DB


### PR DESCRIPTION
This PR fixes the TSL host mismatch by manually setting the TSL server name in `TestSelfSignedCA` to match what is given by the new dynamic leaf cert generator.

In commit [c814860](https://github.com/hashicorp/vault/commit/c814860904d444bf418903aebbc60d039d5812f2#diff-7b6bc7e8b18b60a38e322303e01bc54e8355b850bf6eecf579082f459beb3764) we start using dynamic leaf certs, that have the server name of `local host` as opposed to the old cert this test would get which allowed for server name `local host` and `cassandra`.

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [x] **Jira:** If this change has an associated Jira, it's referenced either in the PR description, commit message, or branch name.
- [x] **RFC:** If this change has an associated RFC, please link it in the description.

### PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [x] If applicable, I've documented the impact of any changes to security controls.

Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
