### PR TITLE
Fix SSH billing count read for values beginning with '4'

### DIFF
--- a/vault/consumption_billing_util.go
+++ b/vault/consumption_billing_util.go
@@ -9,10 +9,10 @@ import (
 	"fmt"
 	"math"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/vault/helper/timeutil"
-	"github.com/hashicorp/vault/sdk/helper/jsonutil"
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/hashicorp/vault/vault/billing"
 )
@@ -942,8 +942,11 @@ func (c *Core) getStoredSSHDurationAdjustedCertCountLocked(ctx context.Context, 
 		return 0, err
 	}
 
-	var certCount float64
-	err = se.DecodeJSON(&certCount)
+	// The count is stored as a plain float64 string (matching the PKI and OIDC
+	// counters). TrimSpace tolerates values written by earlier versions that
+	// stored the count as JSON, which appended a trailing newline. See
+	// https://github.com/hashicorp/vault/issues/32013.
+	certCount, err := strconv.ParseFloat(strings.TrimSpace(string(se.Value)), 64)
 	if err != nil {
 		return 0, fmt.Errorf("error decoding current SSH duration adjusted cert count: %w", err)
 	}
@@ -977,14 +980,9 @@ func (c *Core) UpdateStoredSSHDurationAdjustedCertCount(ctx context.Context, cur
 func (c *Core) storeSSHDurationAdjustedCertCountLocked(ctx context.Context, localPathPrefix string, currentMonth time.Time, certCount float64) error {
 	billingPath := billing.GetMonthlyBillingMetricPath(localPathPrefix, currentMonth, billing.SSHCertificateMetric)
 
-	countBytes, err := jsonutil.EncodeJSON(certCount)
-	if err != nil {
-		return err
-	}
-
 	entry := &logical.StorageEntry{
 		Key:   billingPath,
-		Value: countBytes,
+		Value: []byte(strconv.FormatFloat(certCount, 'f', 4, 64)),
 	}
 
 	view, ok := c.GetBillingSubView()
@@ -1025,8 +1023,11 @@ func (c *Core) getStoredSSHOTPCountLocked(ctx context.Context, localPathPrefix s
 		return 0, err
 	}
 
-	var otpCount float64
-	err = se.DecodeJSON(&otpCount)
+	// The count is stored as a plain float64 string (matching the PKI and OIDC
+	// counters). TrimSpace tolerates values written by earlier versions that
+	// stored the count as JSON, which appended a trailing newline. See
+	// https://github.com/hashicorp/vault/issues/32013.
+	otpCount, err := strconv.ParseFloat(strings.TrimSpace(string(se.Value)), 64)
 	if err != nil {
 		return 0, fmt.Errorf("error decoding current OTP cert count: %w", err)
 	}
@@ -1060,14 +1061,9 @@ func (c *Core) UpdateStoredSSHOTPCount(ctx context.Context, currentMonth time.Ti
 func (c *Core) storeSSHOTPCountLocked(ctx context.Context, localPathPrefix string, currentMonth time.Time, otpCount float64) error {
 	billingPath := billing.GetMonthlyBillingMetricPath(localPathPrefix, currentMonth, billing.SSHOTPMetric)
 
-	countBytes, err := jsonutil.EncodeJSON(otpCount)
-	if err != nil {
-		return err
-	}
-
 	entry := &logical.StorageEntry{
 		Key:   billingPath,
-		Value: countBytes,
+		Value: []byte(strconv.FormatFloat(otpCount, 'f', 4, 64)),
 	}
 
 	view, ok := c.GetBillingSubView()

--- a/vault/consumption_billing_util_test.go
+++ b/vault/consumption_billing_util_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/hashicorp/vault/builtin/logical/transit"
 	"github.com/hashicorp/vault/helper/namespace"
 	"github.com/hashicorp/vault/helper/pluginconsts"
+	"github.com/hashicorp/vault/sdk/helper/jsonutil"
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/hashicorp/vault/vault/billing"
 	"github.com/stretchr/testify/require"
@@ -941,6 +942,67 @@ func TestSSHCertCounts(t *testing.T) {
 	require.NoError(t, err)
 	expectedSum += expectedCertUnit * 3
 	require.Equal(t, expectedSum, storedCounts)
+}
+
+// TestSSHBillingCounts_ValueBeginningWithCanaryDigit is a regression test for
+// https://github.com/hashicorp/vault/issues/32013. The SSH cert and OTP counts
+// must round-trip through storage even when the stored number's decimal
+// representation begins with the digit '4', which is the LZ4 compression canary
+// byte (0x34). Previously the read path treated the leading '4' as a
+// compression canary and failed with "lz4: bad magic number".
+func TestSSHBillingCounts_ValueBeginningWithCanaryDigit(t *testing.T) {
+	core, _, _ := TestCoreUnsealed(t)
+	ctx := namespace.RootContext(context.Background())
+	month := time.Now()
+
+	// Values whose decimal representation begins with '4'.
+	const certCount = 4.1096
+	const otpCount = 42.0
+
+	_, err := core.UpdateStoredSSHDurationAdjustedCertCount(ctx, month, certCount)
+	require.NoError(t, err)
+	gotCert, err := core.GetStoredSSHDurationAdjustedCertCount(ctx, month)
+	require.NoError(t, err)
+	require.Equal(t, certCount, gotCert)
+
+	_, err = core.UpdateStoredSSHOTPCount(ctx, month, otpCount)
+	require.NoError(t, err)
+	gotOTP, err := core.GetStoredSSHOTPCount(ctx, month)
+	require.NoError(t, err)
+	require.Equal(t, otpCount, gotOTP)
+}
+
+// TestSSHBillingCounts_ReadsLegacyJSONFormat verifies that SSH counts written
+// by earlier versions of Vault as JSON (via jsonutil.EncodeJSON, which appends a
+// trailing newline) are still readable. This includes values beginning with the
+// digit '4', which the previous reader could not decode at all
+// (https://github.com/hashicorp/vault/issues/32013).
+func TestSSHBillingCounts_ReadsLegacyJSONFormat(t *testing.T) {
+	core, _, _ := TestCoreUnsealed(t)
+	ctx := namespace.RootContext(context.Background())
+	month := time.Now()
+
+	view, ok := core.GetBillingSubView()
+	require.True(t, ok)
+
+	// 4.1096 begins with the LZ4 canary digit and was previously unreadable.
+	certBytes, err := jsonutil.EncodeJSON(4.1096)
+	require.NoError(t, err)
+	otpBytes, err := jsonutil.EncodeJSON(0.0658)
+	require.NoError(t, err)
+
+	certPath := billing.GetMonthlyBillingMetricPath(billing.LocalPrefix, month, billing.SSHCertificateMetric)
+	otpPath := billing.GetMonthlyBillingMetricPath(billing.LocalPrefix, month, billing.SSHOTPMetric)
+	require.NoError(t, view.Put(ctx, &logical.StorageEntry{Key: certPath, Value: certBytes}))
+	require.NoError(t, view.Put(ctx, &logical.StorageEntry{Key: otpPath, Value: otpBytes}))
+
+	gotCert, err := core.GetStoredSSHDurationAdjustedCertCount(ctx, month)
+	require.NoError(t, err)
+	require.Equal(t, 4.1096, gotCert)
+
+	gotOTP, err := core.GetStoredSSHOTPCount(ctx, month)
+	require.NoError(t, err)
+	require.Equal(t, 0.0658, gotOTP)
 }
 
 // TestSSHOTPCounts tests that we correctly store and track the SSH OTP counts


### PR DESCRIPTION
The monthly SSH duration-adjusted certificate count and SSH OTP count were written to storage as plain JSON (jsonutil.EncodeJSON) but read back via the canary-aware jsonutil.DecodeJSON. These are not inverses: DecodeJSON treats the first stored byte as a compression canary, and the LZ4 canary is the ASCII digit '4' (0x34). Any count whose decimal representation began with '4' (e.g. 4, 4.1096, 42) was misread as LZ4 data, failing with "lz4: bad magic number" and returning a 500 from sys/billing/overview.

Align the SSH counters with the existing PKI and OIDC counters, which store and read these scalar float64 values via strconv. Reads use strings.TrimSpace so values previously written as JSON (with a trailing newline) remain readable, including the '4'-leading values that the old reader could not decode.

Add regression tests for the new-format round-trip and for reading the legacy JSON format.

Fixes #32013

### Description
What does this PR do?

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.

### PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.

Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
