### PR TITLE
api: fix WriteRawWithContext/PatchRawWithContext premature context cancel

### DIFF
--- a/api/logical.go
+++ b/api/logical.go
@@ -237,10 +237,22 @@ func (c *Logical) WriteWithContext(ctx context.Context, path string, data map[st
 	return c.write(ctx, path, r)
 }
 
+// WriteRaw attempts to write the given bytes to the given Vault path
+// (without '/v1/' prefix) and returns a raw *http.Response.
+//
+// Note: the raw-response functions do not respect the client-configured
+// request timeout; if a timeout is desired, please use WriteRawWithContext
+// instead and set the timeout through context.WithTimeout or context.WithDeadline.
 func (c *Logical) WriteRaw(path string, data []byte) (*Response, error) {
 	return c.WriteRawWithContext(context.Background(), path, data)
 }
 
+// WriteRawWithContext attempts to write the given bytes to the given Vault
+// path (without '/v1/' prefix) and returns a raw *http.Response.
+//
+// Note: the raw-response functions do not respect the client-configured
+// request timeout; if a timeout is desired, please set it through
+// context.WithTimeout or context.WithDeadline.
 func (c *Logical) WriteRawWithContext(ctx context.Context, path string, data []byte) (*Response, error) {
 	r := c.c.NewRequest(http.MethodPut, "/v1/"+path)
 	r.BodyBytes = data
@@ -300,10 +312,22 @@ func (c *Logical) addExtraHeaders(r *Request, headers http.Header) error {
 	return nil
 }
 
+// PatchRaw attempts to patch the given bytes to the given Vault path
+// (without '/v1/' prefix) and returns a raw *http.Response.
+//
+// Note: the raw-response functions do not respect the client-configured
+// request timeout; if a timeout is desired, please use PatchRawWithContext
+// instead and set the timeout through context.WithTimeout or context.WithDeadline.
 func (c *Logical) PatchRaw(path string, data []byte) (*Response, error) {
 	return c.PatchRawWithContext(context.Background(), path, data)
 }
 
+// PatchRawWithContext attempts to patch the given bytes to the given Vault
+// path (without '/v1/' prefix) and returns a raw *http.Response.
+//
+// Note: the raw-response functions do not respect the client-configured
+// request timeout; if a timeout is desired, please set it through
+// context.WithTimeout or context.WithDeadline.
 func (c *Logical) PatchRawWithContext(ctx context.Context, path string, data []byte) (*Response, error) {
 	r := c.c.NewRequest(http.MethodPatch, "/v1/"+path)
 	r.Headers.Set("Content-Type", "application/scim+json")
@@ -378,11 +402,7 @@ func (c *Logical) write(ctx context.Context, path string, request *Request) (*Se
 }
 
 func (c *Logical) writeRaw(ctx context.Context, request *Request) (*Response, error) {
-	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
-	defer cancelFunc()
-
-	resp, err := c.c.rawRequestWithContext(ctx, request)
-	return resp, err
+	return c.c.RawRequestWithContext(ctx, request)
 }
 
 func (c *Logical) Delete(path string) (*Secret, error) {

--- a/api/logical_test.go
+++ b/api/logical_test.go
@@ -4,8 +4,11 @@
 package api
 
 import (
+	"context"
 	"fmt"
+	"io"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -108,6 +111,64 @@ func TestLogical_addExtraHeaders(t *testing.T) {
 				return
 			}
 			assert.Equalf(t, tt.wantHeaders, tt.r.Headers, "Headers after addExtraHeaders(%v, %v)", tt.r, tt.headers)
+		})
+	}
+}
+
+// TestWriteRawWithContextBodyReadable verifies that WriteRawWithContext and
+// PatchRawWithContext return a *Response whose body remains readable after the
+// call returns. Previously, both methods routed through writeRaw which installed
+// a withConfiguredTimeout cancel and deferred it, cancelling the context (and
+// thus the response body) before the caller had a chance to read it.
+func TestWriteRawWithContextBodyReadable(t *testing.T) {
+	t.Parallel()
+
+	const responseBody = `{"data":"hello"}`
+
+	for _, tc := range []struct {
+		name   string
+		invoke func(l *Logical, path string, data []byte) (*Response, error)
+	}{
+		{
+			name: "WriteRawWithContext",
+			invoke: func(l *Logical, path string, data []byte) (*Response, error) {
+				return l.WriteRawWithContext(context.Background(), path, data)
+			},
+		},
+		{
+			name: "PatchRawWithContext",
+			invoke: func(l *Logical, path string, data []byte) (*Response, error) {
+				return l.PatchRawWithContext(context.Background(), path, data)
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(responseBody))
+			})
+
+			config, ln := testHTTPServer(t, handler)
+			defer ln.Close()
+
+			client, err := NewClient(config)
+			require.NoError(t, err)
+			client.SetToken("test-token")
+
+			resp, err := tc.invoke(client.Logical(), "secret/test", []byte(`{}`))
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+			defer resp.Body.Close()
+
+			// Body must be readable after the call returns — this was broken
+			// when writeRaw deferred cancelFunc() before the caller could read.
+			got, err := io.ReadAll(resp.Body)
+			require.NoError(t, err)
+			assert.True(t, strings.Contains(string(got), "hello"),
+				"expected response body to contain 'hello', got: %s", string(got))
 		})
 	}
 }


### PR DESCRIPTION
## Summary

`WriteRawWithContext` and `PatchRawWithContext` both route through `writeRaw`, which installed a `withConfiguredTimeout` cancel and deferred it:

```go
func (c *Logical) writeRaw(ctx context.Context, request *Request) (*Response, error) {
    ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
    defer cancelFunc()  // fires before caller reads resp.Body

    resp, err := c.c.rawRequestWithContext(ctx, request)
    return resp, err
}
```

The `defer` fires the moment `writeRaw` returns, cancelling the context the response body is bound to. For small responses the body is fully buffered before the cancel matters; for **large responses still streaming at read time**, the caller gets a spurious `context canceled` even though the request succeeded server-side.

This is the exact defect fixed for the **read** path in #18708 and is already absent from `readRawWithDataWithContext` and `DeleteRawWithContext`, both of which call `RawRequestWithContext` directly.

## Fix

Remove `withConfiguredTimeout`/`defer cancelFunc()` from `writeRaw` and delegate to `RawRequestWithContext` directly — identical to the pattern already used by the read/delete raw paths:

```go
func (c *Logical) writeRaw(ctx context.Context, request *Request) (*Response, error) {
    return c.c.RawRequestWithContext(ctx, request)
}
```

Callers who need a timeout can set one on the context they pass in (via `context.WithTimeout` or `context.WithDeadline`).

Also adds doc comments to `WriteRaw`, `WriteRawWithContext`, `PatchRaw`, and `PatchRawWithContext` noting that raw-response functions do not apply the client-configured timeout — consistent with existing comments on the read/delete raw variants.

## Testing

Added `TestWriteRawWithContextBodyReadable` covering both `WriteRawWithContext` and `PatchRawWithContext`: starts a real test HTTP server, calls each method, and verifies the response body is fully readable after the call returns.

Fixes #31986