### PR TITLE
Agent: replace existing auth headers during auto-auth re-authentication

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -1125,6 +1125,14 @@ func (c *Client) AddHeader(key, value string) {
 	c.headers.Add(key, value)
 }
 
+// SetHeader allows a single header key/value pair to be set
+// in a race-safe fashion.
+func (c *Client) SetHeader(key, value string) {
+	c.modifyLock.Lock()
+	defer c.modifyLock.Unlock()
+	c.headers.Set(key, value)
+}
+
 // SetHeaders clears all previous headers and uses only the given
 // ones going forward.
 func (c *Client) SetHeaders(headers http.Header) {

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -901,6 +901,33 @@ func TestSetHeadersRaceSafe(t *testing.T) {
 	}
 }
 
+func TestClientSetHeader(t *testing.T) {
+	client, err := NewClient(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	client.AddHeader("X-Test", "first")
+	client.AddHeader("X-Test", "second")
+
+	client.SetHeader("X-Test", "replacement")
+
+	headers := client.Headers()
+	if !reflect.DeepEqual(headers.Values("X-Test"), []string{"replacement"}) {
+		t.Fatalf("expected [replacement], got %v", headers.Values("X-Test"))
+	}
+
+	client.SetHeader("X-New", "value")
+	if !reflect.DeepEqual(headers.Values("X-New"), []string(nil)) {
+		t.Fatalf("stale header copy unexpectedly changed: %v", headers.Values("X-New"))
+	}
+
+	headers = client.Headers()
+	if !reflect.DeepEqual(headers.Values("X-New"), []string{"value"}) {
+		t.Fatalf("expected [value], got %v", headers.Values("X-New"))
+	}
+}
+
 func TestMergeReplicationStates(t *testing.T) {
 	type testCase struct {
 		name     string

--- a/changelog/32023.txt
+++ b/changelog/32023.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+agent: Fix auto-auth re-authentication header handling to replace existing header values instead of accumulating duplicates
+```

--- a/command/agentproxyshared/auth/auth.go
+++ b/command/agentproxyshared/auth/auth.go
@@ -361,12 +361,13 @@ func (ah *AuthHandler) Run(ctx context.Context, am AuthMethod) error {
 		}
 		for key, values := range header {
 			if existingValues := clientToUse.Headers().Values(key); len(existingValues) > 0 {
-				clientHeaders := clientToUse.Headers()
-				clientHeaders.Del(key)
-				for _, value := range values {
-					clientHeaders.Add(key, value)
+				for i, value := range values {
+					if i == 0 {
+						clientToUse.SetHeader(key, value)
+						continue
+					}
+					clientToUse.AddHeader(key, value)
 				}
-				clientToUse.SetHeaders(clientHeaders)
 				continue
 			}
 

--- a/command/agentproxyshared/auth/auth.go
+++ b/command/agentproxyshared/auth/auth.go
@@ -360,6 +360,16 @@ func (ah *AuthHandler) Run(ctx context.Context, am AuthMethod) error {
 			clientToUse = wrapClient
 		}
 		for key, values := range header {
+			if existingValues := clientToUse.Headers().Values(key); len(existingValues) > 0 {
+				clientHeaders := clientToUse.Headers()
+				clientHeaders.Del(key)
+				for _, value := range values {
+					clientHeaders.Add(key, value)
+				}
+				clientToUse.SetHeaders(clientHeaders)
+				continue
+			}
+
 			for _, value := range values {
 				clientToUse.AddHeader(key, value)
 			}

--- a/command/agentproxyshared/auth/auth_test.go
+++ b/command/agentproxyshared/auth/auth_test.go
@@ -530,3 +530,140 @@ func createMockToken(t *testing.T) string {
 	// The mock server will validate this token when lookup-self is called
 	return "test-token-123"
 }
+
+// headerReturningAuthMethod is an auth method that returns a header from its
+// Authenticate implementation. It is used to verify that the returned header is
+// not added to the client multiple times across re-authentications.
+type headerReturningAuthMethod struct {
+	headerKey  string
+	newCredsCh chan struct{}
+}
+
+func (m *headerReturningAuthMethod) Authenticate(_ context.Context, _ *api.Client) (string, http.Header, map[string]interface{}, error) {
+	header := http.Header{}
+	header.Set(m.headerKey, "custom-value")
+	return "auth/approle/login", header, map[string]interface{}{
+		"role_id":   "test-role-id",
+		"secret_id": "test-secret-id",
+	}, nil
+}
+
+func (m *headerReturningAuthMethod) NewCreds() chan struct{} {
+	return m.newCredsCh
+}
+
+func (m *headerReturningAuthMethod) CredSuccess() {}
+
+func (m *headerReturningAuthMethod) Shutdown() {}
+
+// TestAuthHandler_HeaderNotDuplicatedOnReauth verifies that a header returned by
+// an auth method's Authenticate implementation is sent exactly once per login,
+// even after the auth handler re-authenticates multiple times.
+//
+// This reproduces a bug where the header loop in AuthHandler.Run calls AddHeader
+// on the (reused) client on every iteration of the auth loop. Because AddHeader
+// appends rather than replaces, the header accumulates across re-authentications,
+// so each subsequent login request carries an additional copy of the header.
+func TestAuthHandler_HeaderNotDuplicatedOnReauth(t *testing.T) {
+	const customHeaderKey = "X-Custom-Auth-Header"
+
+	var mu sync.Mutex
+	// headerValueCounts records, per login request, how many values were sent
+	// for the custom header.
+	var headerValueCounts []int
+	loginCh := make(chan struct{}, 10)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/v1/auth/approle/login") {
+			http.Error(w, "endpoint not implemented in mock", http.StatusNotFound)
+			return
+		}
+
+		mu.Lock()
+		headerValueCounts = append(headerValueCounts, len(r.Header.Values(customHeaderKey)))
+		mu.Unlock()
+
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"auth": map[string]interface{}{
+				"client_token":   "test-token-123",
+				"policies":       []string{"default"},
+				"lease_duration": 3600,
+				"renewable":      true,
+			},
+		})
+		loginCh <- struct{}{}
+	}))
+	defer server.Close()
+
+	config := api.DefaultConfig()
+	config.Address = server.URL
+	client, err := api.NewClient(config)
+	require.NoError(t, err)
+
+	newCredsCh := make(chan struct{})
+	am := &headerReturningAuthMethod{
+		headerKey:  customHeaderKey,
+		newCredsCh: newCredsCh,
+	}
+
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+
+	ah := NewAuthHandler(&AuthHandlerConfig{
+		Logger:                       logging.NewVaultLogger(hclog.Trace).Named("auth.handler"),
+		Client:                       client,
+		EnableReauthOnNewCredentials: true,
+	})
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- ah.Run(ctx, am)
+	}()
+
+	// Drain tokens so the auth handler doesn't block writing to OutputCh.
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ah.OutputCh:
+			}
+		}
+	}()
+
+	const numAuths = 3
+	for i := 0; i < numAuths; i++ {
+		select {
+		case <-loginCh:
+		case <-time.After(10 * time.Second):
+			t.Fatalf("timeout waiting for login #%d", i+1)
+		}
+
+		// Trigger a re-authentication for every login except the last.
+		if i < numAuths-1 {
+			select {
+			case newCredsCh <- struct{}{}:
+			case <-time.After(10 * time.Second):
+				t.Fatalf("timeout triggering re-auth after login #%d", i+1)
+			}
+		}
+	}
+
+	cancelFunc()
+	select {
+	case <-errCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for auth handler to stop")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	require.GreaterOrEqual(t, len(headerValueCounts), numAuths)
+	for i, count := range headerValueCounts {
+		require.Equalf(t, 1, count,
+			"login #%d sent the custom header %d time(s); expected exactly 1 (header should not accumulate across re-authentications)",
+			i+1, count)
+	}
+}


### PR DESCRIPTION
### Description
This PR fixes a Vault Agent auto-auth bug where auth headers could accumulate on the shared API client across re-authentication cycles.

When an auth method returned headers (for example, Kerberos `Authorization`), re-authentication reused the same client and appended header values each cycle. Over time, requests could include duplicate/stale header values, causing authentication failures.

This change makes header handling explicit and safe:
- Added a new API client method to set a single header key/value using replacement semantics.
- Updated auto-auth header application to:
  - replace existing values when the header key is already present
  - add values only when the key is not present
- Added/updated tests to cover:
  - single-header replacement behavior on the API client
  - regression coverage ensuring headers do not duplicate across re-authentication

Issue reference:
- Fixes #32022

### Testing
- Ran targeted API client test for single-header replacement behavior.
- Ran targeted auth regression test:
  - `TestAuthHandler_HeaderNotDuplicatedOnReauth`
- Ran vault agent built from this branch against a local vault server instance per the testing instructions in #32022 and verified this resolved subsequent re-authentication attempts failing from `KRB_AP_ERR_SKEW `

### Risk / Impact
- Scope is limited to header mutation behavior in client/auth flows.
- No intended behavior change for unrelated auth flows.
- Low risk; covered by focused unit/regression tests.

### PCI review checklist
- [x] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [x] If applicable, I've documented the impact of any changes to security controls.

Security controls impact:
- No new access control mechanism was introduced.
- No logging pipeline changes were introduced.
- Change is limited to request header replacement semantics to prevent stale/duplicate auth header reuse.