### PR TITLE
audit: Fix missing request ID in audit log for help operations

### DIFF
--- a/changelog/32025.txt
+++ b/changelog/32025.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+audit: Include `request.id` for `path-help` audit entries
+```

--- a/http/help.go
+++ b/http/help.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/vault/helper/namespace"
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/hashicorp/vault/vault"
@@ -42,7 +43,14 @@ func handleHelp(core *vault.Core, w http.ResponseWriter, r *http.Request) {
 	}
 	path := trimPath(ns, r.URL.Path)
 
+	requestId, err := uuid.GenerateUUID()
+	if err != nil {
+		respondError(w, http.StatusInternalServerError, nil)
+		return
+	}
+
 	req := &logical.Request{
+		ID:         requestId,
 		Operation:  logical.HelpOperation,
 		Path:       path,
 		Connection: getConnection(r),

--- a/http/help.go
+++ b/http/help.go
@@ -5,6 +5,7 @@ package http
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"strings"
 
@@ -45,7 +46,7 @@ func handleHelp(core *vault.Core, w http.ResponseWriter, r *http.Request) {
 
 	requestId, err := uuid.GenerateUUID()
 	if err != nil {
-		respondError(w, http.StatusInternalServerError, nil)
+		respondError(w, http.StatusInternalServerError, fmt.Errorf("failed to generate identifier for the request: %w", err))
 		return
 	}
 

--- a/http/help_test.go
+++ b/http/help_test.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/hashicorp/vault/audit"
+	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/hashicorp/vault/vault"
 )
 
@@ -32,5 +34,62 @@ func TestHelp(t *testing.T) {
 	testResponseBody(t, resp, &actual)
 	if _, ok := actual["help"]; !ok {
 		t.Fatalf("bad: %#v", actual)
+	}
+}
+
+func TestHelp_AuditRequestID(t *testing.T) {
+	noop := audit.TestNoopAudit(t, "noop/", nil)
+	c, _, root := vault.TestCoreUnsealedWithConfig(t, &vault.CoreConfig{
+		AuditBackends: map[string]audit.Factory{
+			"noop": func(config *audit.BackendConfig, _ audit.HeaderFormatter) (audit.Backend, error) {
+				return noop, nil
+			},
+		},
+	})
+	ln, addr := TestServer(t, c)
+	defer ln.Close()
+	TestServerAuth(t, addr, root)
+
+	// Enable the audit backend
+	resp := testHttpPost(t, root, addr+"/v1/sys/audit/noop", map[string]interface{}{
+		"type": "noop",
+	})
+	testResponseStatus(t, resp, 204)
+
+	// Make a help request
+	resp = testHttpGet(t, root, addr+"/v1/sys/mounts?help=1")
+	testResponseStatus(t, resp, 200)
+
+	// Find the help request in the audit trail
+	var helpReq *logical.Request
+	for _, r := range noop.Req {
+		if r.Operation == logical.HelpOperation {
+			helpReq = r
+			break
+		}
+	}
+	if helpReq == nil {
+		t.Fatalf("no help request found in audit trail; got %d requests", len(noop.Req))
+	}
+	if helpReq.ID == "" {
+		t.Fatal("help request in audit trail has empty request ID")
+	}
+
+	// Find the matching response entry and verify it carries the same request ID
+	var helpRespReq *logical.Request
+	for _, r := range noop.RespReq {
+		if r.Operation == logical.HelpOperation {
+			helpRespReq = r
+			break
+		}
+	}
+	if helpRespReq == nil {
+		t.Fatalf("no help response found in audit trail; got %d responses", len(noop.RespReq))
+	}
+	if helpRespReq.ID == "" {
+		t.Fatal("help response in audit trail has empty request ID")
+	}
+	if helpRespReq.ID != helpReq.ID {
+		t.Fatalf("request ID mismatch: request has %q, response has %q", helpReq.ID, helpRespReq.ID)
 	}
 }


### PR DESCRIPTION
The handleHelp function in http/help.go didn't set an ID unlike all other handlers.
This caused the request.id field to be silently omitted from audit log entries for all
help operations (e.g. `vault path-help`), making it impossible to correlate request and response entries in the audit log.

Fix this by setting that ID

Fixes https://github.com/hashicorp/vault/issues/32026