### PR TITLE
core/seal: Add Scaleway Key Manager (`scalewaykms`) auto-unseal seal …

### DIFF
--- a/changelog/scalewaykms-seal.txt
+++ b/changelog/scalewaykms-seal.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+core/seal: Add Scaleway Key Manager (`scalewaykms`) auto-unseal seal type.
+```

--- a/go.mod
+++ b/go.mod
@@ -106,13 +106,14 @@ require (
 	github.com/hashicorp/go-hmac-drbg v0.0.0-20210916214228-a6e5a68489f6
 	github.com/hashicorp/go-immutable-radix v1.3.1
 	github.com/hashicorp/go-kms-wrapping/entropy/v2 v2.0.1
-	github.com/hashicorp/go-kms-wrapping/v2 v2.0.23
+	github.com/hashicorp/go-kms-wrapping/v2 v2.0.24
 	github.com/hashicorp/go-kms-wrapping/wrappers/aead/v2 v2.0.10
 	github.com/hashicorp/go-kms-wrapping/wrappers/alicloudkms/v2 v2.0.5
 	github.com/hashicorp/go-kms-wrapping/wrappers/awskms/v4 v4.0.1
 	github.com/hashicorp/go-kms-wrapping/wrappers/azurekeyvault/v2 v2.0.15
 	github.com/hashicorp/go-kms-wrapping/wrappers/gcpckms/v2 v2.0.14
 	github.com/hashicorp/go-kms-wrapping/wrappers/ocikms/v2 v2.0.10
+	github.com/hashicorp/go-kms-wrapping/wrappers/scalewaykms/v2 v2.0.0
 	github.com/hashicorp/go-kms-wrapping/wrappers/transit/v2 v2.0.13
 	github.com/hashicorp/go-memdb v1.3.5
 	github.com/hashicorp/go-multierror v1.1.1
@@ -277,6 +278,7 @@ require (
 	github.com/google/pprof v0.0.0-20250630185457-6e76a2b096b5 // indirect
 	github.com/hashicorp/go-secure-stdlib/awsutil/v2 v2.1.1 // indirect
 	github.com/looplab/fsm v1.0.3 // indirect
+	github.com/scaleway/scaleway-sdk-go v1.0.0-beta.36 // indirect
 	github.com/softlayer/xmlrpc v0.0.0-20200409220501-5f089df7cb7e // indirect
 )
 
@@ -542,7 +544,7 @@ require (
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
-	github.com/rogpeppe/go-internal v1.14.1 // indirect
+	github.com/rogpeppe/go-internal v1.15.0 // indirect
 	github.com/segmentio/fasthash v1.0.3 // indirect
 	github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1295,6 +1295,7 @@ github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTE
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
+github.com/rogpeppe/go-internal v1.15.0/go.mod h1:DrUVZyrJU+txYW5/1kwtXQSMFio52ZOxX7yM1VHvnxs=
 github.com/rs/zerolog v1.4.0/go.mod h1:YbFCdg8HfsridGWAh22vktObvhZbQsZXe4/zB0OKkWU=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/ryancragun/triton-go/v2 v2.0.0-20260514164147-e8b61dd0652d h1:81yc/fWETAUZ8c3KHPiQQtTAb22AuK7u5BkwEf5Y4+M=
@@ -1308,6 +1309,8 @@ github.com/sasha-s/go-deadlock v0.3.5 h1:tNCOEEDG6tBqrNDOX35j/7hL5FcFViG6awUGROb
 github.com/sasha-s/go-deadlock v0.3.5/go.mod h1:bugP6EGbdGYObIlx7pUZtWqlvo8k9H6vCBBsiChJQ5U=
 github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
+github.com/scaleway/scaleway-sdk-go v1.0.0-beta.36 h1:ObX9hZmK+VmijreZO/8x9pQ8/P/ToHD/bdSb4Eg4tUo=
+github.com/scaleway/scaleway-sdk-go v1.0.0-beta.36/go.mod h1:LEsDu4BubxK7/cWhtlQWfuxwL4rf/2UEpxXz1o1EMtM=
 github.com/sean-/conswriter v0.0.0-20180208195008-f5ae3917a627/go.mod h1:7zjs06qF79/FKAJpBvFx3P8Ww4UTIMAe+lpNXDHziac=
 github.com/sean-/pager v0.0.0-20180208200047-666be9bf53b5/go.mod h1:BeybITEsBEg6qbIiqJ6/Bqeq25bCLbL7YFmpaFfJDuM=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529 h1:nn5Wsu0esKSJiIVhscUtVbo7ada43DJhG55ua/hjS5I=

--- a/internalshared/configutil/env_var_util.go
+++ b/internalshared/configutil/env_var_util.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/go-kms-wrapping/wrappers/azurekeyvault/v2"
 	"github.com/hashicorp/go-kms-wrapping/wrappers/gcpckms/v2"
 	"github.com/hashicorp/go-kms-wrapping/wrappers/ocikms/v2"
+	"github.com/hashicorp/go-kms-wrapping/wrappers/scalewaykms/v2"
 	"github.com/hashicorp/go-kms-wrapping/wrappers/transit/v2"
 )
 
@@ -63,6 +64,15 @@ var (
 		ocikms.EnvVaultOciKmsSealKeyId:              "key_id",
 		ocikms.EnvOciKmsWrapperManagementEndpoint:   "management_endpoint",
 		ocikms.EnvVaultOciKmsSealManagementEndpoint: "management_endpoint",
+	}
+
+	ScalewayKMSEnvVars = map[string]string{
+		scalewaykms.EnvScalewayRegion:            "region",
+		scalewaykms.EnvScalewayProjectId:         "project_id",
+		scalewaykms.EnvScalewayAccessKey:         "access_key",
+		scalewaykms.EnvScalewaySecretKey:         "secret_key",
+		scalewaykms.EnvVaultScalewayKmsSealKeyId: "key_id",
+		scalewaykms.EnvScalewayKmsWrapperKeyId:   "key_id",
 	}
 
 	TransitEnvVars = map[string]string{

--- a/internalshared/configutil/kms.go
+++ b/internalshared/configutil/kms.go
@@ -24,6 +24,7 @@ import (
 	"github.com/hashicorp/go-kms-wrapping/wrappers/azurekeyvault/v2"
 	"github.com/hashicorp/go-kms-wrapping/wrappers/gcpckms/v2"
 	"github.com/hashicorp/go-kms-wrapping/wrappers/ocikms/v2"
+	"github.com/hashicorp/go-kms-wrapping/wrappers/scalewaykms/v2"
 	"github.com/hashicorp/go-kms-wrapping/wrappers/transit/v2"
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/go-secure-stdlib/parseutil"
@@ -233,6 +234,7 @@ var kmsSealAddressKeys = map[string][]string{
 	wrapping.WrapperTypeGcpCkms.String():       {},
 	wrapping.WrapperTypeOciKms.String():        {"key_id", "crypto_endpoint", "management_endpoint"},
 	wrapping.WrapperTypePkcs11.String():        {},
+	wrapping.WrapperTypeScalewayKms.String():   {"api_url"},
 	wrapping.WrapperTypeTransit.String():       {"address"},
 }
 
@@ -312,6 +314,8 @@ func configureWrapper(configKMS *KMS, infoKeys *[]string, info *map[string]strin
 			opts = append(opts, wrapping.WithKeyId(keyId))
 		}
 		wrapper, kmsInfo, err = GetOCIKMSKMSFunc(configKMS, opts...)
+	case wrapping.WrapperTypeScalewayKms:
+		wrapper, kmsInfo, err = GetScalewayKMSFunc(configKMS, opts...)
 	case wrapping.WrapperTypeTransit:
 		wrapper, kmsInfo, err = GetTransitKMSFunc(configKMS, opts...)
 
@@ -446,6 +450,26 @@ func GetOCIKMSKMSFunc(kms *KMS, opts ...wrapping.Option) (wrapping.Wrapper, map[
 	return wrapper, info, nil
 }
 
+func GetScalewayKMSFunc(kms *KMS, opts ...wrapping.Option) (wrapping.Wrapper, map[string]string, error) {
+	wrapper := scalewaykms.NewWrapper()
+	wrapperInfo, err := wrapper.SetConfig(context.Background(), append(opts, scalewaykms.WithDisallowEnvVars(true), wrapping.WithConfigMap(kms.Config))...)
+	if err != nil {
+		return nil, nil, err
+	}
+	info := make(map[string]string)
+	if wrapperInfo != nil {
+		info["Scaleway KMS Region"] = wrapperInfo.Metadata["region"]
+		info["Scaleway KMS KeyID"] = wrapperInfo.Metadata["key_id"]
+		if projectId, ok := wrapperInfo.Metadata["project_id"]; ok && projectId != "" {
+			info["Scaleway KMS Project ID"] = projectId
+		}
+		if apiUrl, ok := wrapperInfo.Metadata["api_url"]; ok {
+			info["Scaleway KMS API URL"] = apiUrl
+		}
+	}
+	return wrapper, info, nil
+}
+
 var GetTransitKMSFunc = func(kms *KMS, opts ...wrapping.Option) (wrapping.Wrapper, map[string]string, error) {
 	wrapper := transit.NewWrapper()
 	var prefix string
@@ -496,6 +520,8 @@ func getEnvConfig(kms *KMS) map[string]string {
 		wrapperEnvVars = GCPCKMSEnvVars
 	case wrapping.WrapperTypeOciKms:
 		wrapperEnvVars = OCIKMSEnvVars
+	case wrapping.WrapperTypeScalewayKms:
+		wrapperEnvVars = ScalewayKMSEnvVars
 	case wrapping.WrapperTypeTransit:
 		wrapperEnvVars = TransitEnvVars
 	default:

--- a/internalshared/configutil/kms_test.go
+++ b/internalshared/configutil/kms_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-kms-wrapping/wrappers/ocikms/v2"
+	"github.com/hashicorp/go-kms-wrapping/wrappers/scalewaykms/v2"
 	"github.com/stretchr/testify/require"
 )
 
@@ -62,6 +63,27 @@ func Test_getEnvConfig(t *testing.T) {
 			},
 			map[string]string{"VAULT_OCIKMS_SEAL_KEY_ID": "test_key_id", "VAULT_OCIKMS_CRYPTO_ENDPOINT": "test_crypto_endpoint", "VAULT_OCIKMS_MANAGEMENT_ENDPOINT": "test_management_endpoint"},
 			map[string]string{"key_id": "test_key_id", "crypto_endpoint": "test_crypto_endpoint", "management_endpoint": "test_management_endpoint"},
+		},
+		{
+			"Scaleway KMS wrapper",
+			&KMS{
+				Type:     "scalewaykms",
+				Priority: 1,
+			},
+			map[string]string{
+				scalewaykms.EnvScalewayRegion:            "fr-par",
+				scalewaykms.EnvScalewayProjectId:         "test-project-id",
+				scalewaykms.EnvScalewayAccessKey:         "test-access-key",
+				scalewaykms.EnvScalewaySecretKey:         "test-secret-key",
+				scalewaykms.EnvVaultScalewayKmsSealKeyId: "test-key-id",
+			},
+			map[string]string{
+				"region":     "fr-par",
+				"project_id": "test-project-id",
+				"access_key": "test-access-key",
+				"secret_key": "test-secret-key",
+				"key_id":     "test-key-id",
+			},
 		},
 		{
 			"Transit wrapper",
@@ -243,6 +265,36 @@ seal "ocikms" {
 				"auth_type_api_key":   "true",
 			},
 		},
+		"scalewaykms ipv4": {
+			config: `
+seal "scalewaykms" {
+  region           = "fr-par"
+  key_id           = "11111111-1111-1111-1111-111111111111"
+  project_id       = "22222222-2222-2222-2222-222222222222"
+  credentials_file = "/etc/vault.d/scaleway-credentials.yaml"
+}`,
+			expected: map[string]string{
+				"region":           "fr-par",
+				"key_id":           "11111111-1111-1111-1111-111111111111",
+				"project_id":       "22222222-2222-2222-2222-222222222222",
+				"credentials_file": "/etc/vault.d/scaleway-credentials.yaml",
+			},
+		},
+		"scalewaykms ipv6": {
+			config: `
+seal "scalewaykms" {
+  region     = "fr-par"
+  key_id     = "11111111-1111-1111-1111-111111111111"
+  project_id = "22222222-2222-2222-2222-222222222222"
+  api_url    = "https://[2001:db8:0:0:0:0:2:1]:5984/api"
+}`,
+			expected: map[string]string{
+				"region":     "fr-par",
+				"key_id":     "11111111-1111-1111-1111-111111111111",
+				"project_id": "22222222-2222-2222-2222-222222222222",
+				"api_url":    "https://[2001:db8::2:1]:5984/api",
+			},
+		},
 		"transit ipv4": {
 			config: `
 seal "transit" {
@@ -396,6 +448,26 @@ func TestMergeKMSEnvConfigAddrConformance(t *testing.T) {
 				"crypto_endpoint":     "https://[2001:db8::2:1]/afnxza26aag4s-crypto",
 				"management_endpoint": "https://[2001:db8::2:1]/afnxza26aag4s-management",
 				"auth_type_api_key":   "true",
+			},
+		},
+		"scalewaykms": {
+			sealType: "scalewaykms",
+			kmsConfig: map[string]string{
+				"region":           "fr-par",
+				"key_id":           "11111111-1111-1111-1111-111111111111",
+				"project_id":       "22222222-2222-2222-2222-222222222222",
+				"credentials_file": "/etc/vault.d/scaleway-credentials.yaml",
+				"api_url":          "https://api.scaleway.com",
+			},
+			envVars: map[string]string{
+				scalewaykms.EnvScalewayRegion: "nl-ams",
+			},
+			expected: map[string]string{
+				"region":           "nl-ams",
+				"key_id":           "11111111-1111-1111-1111-111111111111",
+				"project_id":       "22222222-2222-2222-2222-222222222222",
+				"credentials_file": "/etc/vault.d/scaleway-credentials.yaml",
+				"api_url":          "https://api.scaleway.com",
 			},
 		},
 		"transit addr not in config": {


### PR DESCRIPTION
### Description

Adds Scaleway Key Manager (`scalewaykms`) as an auto-unseal seal type. Wires the `scalewaykms` wrapper into seal configuration, environment variable mapping, and config parsing tests.

**Depends on:** [go-kms-wrapping](https://github.com/hashicorp/go-kms-wrapping) release with `wrappers/scalewaykms/v2` v2.0.0 and `go-kms-wrapping/v2` v2.0.24.

```hcl
seal "scalewaykms" {
  region     = "fr-par"
  key_id     = "<uuid>"
  project_id = "<uuid>"
  access_key = "..."
  secret_key = "..."
}
```

```bash
go test ./internalshared/configutil/ -count=1
```

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.

### PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.

  Enables Vault auto-unseal via Scaleway Key Manager for Scaleway deployments. Optional new seal type; existing seal types unchanged.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

  Revert PR is sufficient. No schema or state migrations.

- [x] If applicable, I've documented the impact of any changes to security controls.

  New optional seal backend only. Master key wrapping via Scaleway KMS (go-kms-wrapping). Credentials from seal config or env vars. No new audit/logging pipelines.

