### PR TITLE
Redact the token from the log

### DIFF
--- a/sdk/helper/testcluster/docker/environment.go
+++ b/sdk/helper/testcluster/docker/environment.go
@@ -168,7 +168,7 @@ func (dc *DockerCluster) GetRootToken() string {
 }
 
 func (dc *DockerCluster) SetRootToken(s string) {
-	dc.Logger.Trace("cluster root token changed", "helpful_env", fmt.Sprintf("VAULT_TOKEN=%s VAULT_CACERT=/vault/config/ca.pem", s))
+	dc.Logger.Trace("cluster root token changed", "helpful_env", "VAULT_TOKEN=<redacted> VAULT_CACERT=/vault/config/ca.pem")
 	dc.rootToken = s
 }
 
@@ -451,7 +451,7 @@ func NewTestDockerClusterWithErr(t *testing.T, opts *DockerClusterOptions) (*Doc
 
 	dc, err := NewDockerCluster(ctx, opts)
 	if err == nil {
-		dc.Logger.Trace("cluster started", "helpful_env", fmt.Sprintf("VAULT_TOKEN=%s VAULT_CACERT=/vault/config/ca.pem", dc.GetRootToken()))
+		dc.Logger.Trace("cluster started", "helpful_env", "VAULT_TOKEN=<redacted> VAULT_CACERT=/vault/config/ca.pem")
 		// Register cleanup with t.Cleanup so it's automatically called when the test ends
 		t.Cleanup(dc.Cleanup)
 	}


### PR DESCRIPTION
### Description

Fix #32036: a vault token is getting written to the log in plaintext. This PR changes the logging so that it writes `<redacted>` rather than the actual token.

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.

### PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.

Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
