### PR TITLE
api: account for the HTTP Age header when renewing leases through a cache

### DIFF
--- a/api/auth_token.go
+++ b/api/auth_token.go
@@ -37,7 +37,7 @@ func (c *TokenAuth) CreateWithContext(ctx context.Context, opts *TokenCreateRequ
 	}
 	defer resp.Body.Close()
 
-	return ParseSecret(resp.Body)
+	return resp.toSecret()
 }
 
 func (c *TokenAuth) CreateOrphan(opts *TokenCreateRequest) (*Secret, error) {
@@ -59,7 +59,7 @@ func (c *TokenAuth) CreateOrphanWithContext(ctx context.Context, opts *TokenCrea
 	}
 	defer resp.Body.Close()
 
-	return ParseSecret(resp.Body)
+	return resp.toSecret()
 }
 
 func (c *TokenAuth) CreateWithRole(opts *TokenCreateRequest, roleName string) (*Secret, error) {
@@ -81,7 +81,7 @@ func (c *TokenAuth) CreateWithRoleWithContext(ctx context.Context, opts *TokenCr
 	}
 	defer resp.Body.Close()
 
-	return ParseSecret(resp.Body)
+	return resp.toSecret()
 }
 
 func (c *TokenAuth) Lookup(token string) (*Secret, error) {
@@ -105,7 +105,7 @@ func (c *TokenAuth) LookupWithContext(ctx context.Context, token string) (*Secre
 	}
 	defer resp.Body.Close()
 
-	return ParseSecret(resp.Body)
+	return resp.toSecret()
 }
 
 func (c *TokenAuth) LookupAccessor(accessor string) (*Secret, error) {
@@ -129,7 +129,7 @@ func (c *TokenAuth) LookupAccessorWithContext(ctx context.Context, accessor stri
 	}
 	defer resp.Body.Close()
 
-	return ParseSecret(resp.Body)
+	return resp.toSecret()
 }
 
 func (c *TokenAuth) LookupSelf() (*Secret, error) {
@@ -148,7 +148,7 @@ func (c *TokenAuth) LookupSelfWithContext(ctx context.Context) (*Secret, error) 
 	}
 	defer resp.Body.Close()
 
-	return ParseSecret(resp.Body)
+	return resp.toSecret()
 }
 
 func (c *TokenAuth) RenewAccessor(accessor string, increment int) (*Secret, error) {
@@ -173,7 +173,7 @@ func (c *TokenAuth) RenewAccessorWithContext(ctx context.Context, accessor strin
 	}
 	defer resp.Body.Close()
 
-	return ParseSecret(resp.Body)
+	return resp.toSecret()
 }
 
 func (c *TokenAuth) Renew(token string, increment int) (*Secret, error) {
@@ -198,7 +198,7 @@ func (c *TokenAuth) RenewWithContext(ctx context.Context, token string, incremen
 	}
 	defer resp.Body.Close()
 
-	return ParseSecret(resp.Body)
+	return resp.toSecret()
 }
 
 func (c *TokenAuth) RenewSelf(increment int) (*Secret, error) {
@@ -222,7 +222,7 @@ func (c *TokenAuth) RenewSelfWithContext(ctx context.Context, increment int) (*S
 	}
 	defer resp.Body.Close()
 
-	return ParseSecret(resp.Body)
+	return resp.toSecret()
 }
 
 // RenewTokenAsSelf wraps RenewTokenAsSelfWithContext using context.Background.
@@ -250,7 +250,7 @@ func (c *TokenAuth) RenewTokenAsSelfWithContext(ctx context.Context, token strin
 	}
 	defer resp.Body.Close()
 
-	return ParseSecret(resp.Body)
+	return resp.toSecret()
 }
 
 // RevokeAccessor wraps RevokeAccessorWithContext using context.Background.

--- a/api/lifetime_watcher.go
+++ b/api/lifetime_watcher.go
@@ -269,7 +269,9 @@ func (r *LifetimeWatcher) doRenewWithOptions(tokenMode bool, nonRenewable bool, 
 		return r.errLifetimeWatcherNotRenewable
 	}
 
-	initialTime := time.Now()
+	// A secret delivered from a cache describes a lease that began before the
+	// response arrived, so anchor the clock at issuance rather than at arrival.
+	initialTime := time.Now().Add(-r.secret.Age)
 	priorDuration := time.Duration(initLeaseDuration) * time.Second
 	r.calculateGrace(priorDuration, time.Duration(r.increment)*time.Second)
 	var errorBackoff backoff.BackOff
@@ -342,7 +344,7 @@ func (r *LifetimeWatcher) doRenewWithOptions(tokenMode bool, nonRenewable bool, 
 			}
 
 			// Reset initial time
-			initialTime = time.Now()
+			initialTime = time.Now().Add(-renewal.Age)
 
 			// Grab the lease duration
 			initLeaseDuration = renewal.LeaseDuration
@@ -350,7 +352,7 @@ func (r *LifetimeWatcher) doRenewWithOptions(tokenMode bool, nonRenewable bool, 
 				initLeaseDuration = renewal.Auth.LeaseDuration
 			}
 
-			remainingLeaseDuration = time.Duration(initLeaseDuration) * time.Second
+			remainingLeaseDuration = remainingLease(time.Duration(initLeaseDuration)*time.Second, renewal.Age)
 		}
 
 		var sleepDuration time.Duration
@@ -423,6 +425,21 @@ func (r *LifetimeWatcher) calculateGrace(leaseDuration, increment time.Duration)
 	// For a given lease duration, we want to allow 80-90% of that to elapse,
 	// so the remaining amount is the grace period
 	r.grace = time.Duration(jitterMax) + time.Duration(uint64(r.random.Int63())%uint64(jitterMax))
+}
+
+// remainingLease reports how much of a lease is left once the time its
+// response spent in an intermediate cache is discounted.
+//
+// A cached response reports the lease duration measured from when the lease was
+// issued rather than from when the client received it, so trusting that value
+// directly overestimates the remaining lifetime by the age of the response.
+func remainingLease(leaseDuration time.Duration, age time.Duration) time.Duration {
+	remaining := leaseDuration - age
+	if remaining < 0 {
+		return 0
+	}
+
+	return remaining
 }
 
 type (

--- a/api/lifetime_watcher_cache_age_test.go
+++ b/api/lifetime_watcher_cache_age_test.go
@@ -1,0 +1,85 @@
+// Copyright IBM Corp. 2016, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testCachedLeaseID              = "database/creds/readonly/abcd1234"
+	testCachedLeaseDurationSeconds = 6
+	testCachedLeaseAgeSeconds      = 5
+)
+
+// fakeCachedSecretServer stands in for a caching proxy serving a hit: it replays
+// a lease that was issued ageSeconds ago, with the body still reporting the
+// duration the lease had when it was issued.
+func fakeCachedSecretServer(t *testing.T, leaseDurationSeconds int, ageSeconds int) *httptest.Server {
+	t.Helper()
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Age", fmt.Sprintf("%d", ageSeconds))
+		w.Header().Set("X-Cache", "HIT")
+		w.Header().Set("Date", time.Now().Format(http.TimeFormat))
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"lease_id":%q,"lease_duration":%d,"renewable":true}`,
+			testCachedLeaseID, leaseDurationSeconds)
+	}))
+}
+
+// testWatchCachedLease starts a watcher over a lease whose renewals are served
+// by the given caching proxy.
+func testWatchCachedLease(t *testing.T, server *httptest.Server) *LifetimeWatcher {
+	t.Helper()
+
+	client, err := NewClient(&Config{Address: server.URL})
+	require.NoError(t, err)
+
+	watcher, err := client.NewLifetimeWatcher(&LifetimeWatcherInput{
+		Secret: &Secret{
+			LeaseID:       testCachedLeaseID,
+			LeaseDuration: testCachedLeaseDurationSeconds,
+			Renewable:     true,
+		},
+	})
+	require.NoError(t, err)
+
+	go watcher.Start()
+
+	return watcher
+}
+
+// TestLifetimeWatcher_SignalsReReadOfAgedLease asserts that the watcher gives up
+// and reports that the secret must be re-read, rather than renewing forever.
+//
+// A caching proxy reports how stale its response is in the HTTP Age header, but
+// the lease_duration in the body still reads from issuance. The watcher ignores
+// Age, so the remaining lifetime it computes never falls and the threshold at
+// which it gives up is never reached.
+//
+// See https://github.com/hashicorp/vault/issues/19227.
+func TestLifetimeWatcher_SignalsReReadOfAgedLease(t *testing.T) {
+	t.Parallel()
+
+	server := fakeCachedSecretServer(t, testCachedLeaseDurationSeconds, testCachedLeaseAgeSeconds)
+	defer server.Close()
+
+	watcher := testWatchCachedLease(t, server)
+	defer watcher.Stop()
+
+	select {
+	case err := <-watcher.DoneCh():
+		require.NoError(t, err)
+	case <-time.After(3 * time.Second):
+		t.Fatalf("watcher never signalled a re-read for a %ds lease already %ds old",
+			testCachedLeaseDurationSeconds, testCachedLeaseAgeSeconds)
+	}
+}

--- a/api/lifetime_watcher_cache_age_test.go
+++ b/api/lifetime_watcher_cache_age_test.go
@@ -83,9 +83,9 @@ func testWatchCachedLease(t *testing.T, server *httptest.Server) *LifetimeWatche
 // and reports that the secret must be re-read, rather than renewing forever.
 //
 // A caching proxy reports how stale its response is in the HTTP Age header, but
-// the lease_duration in the body still reads from issuance. The watcher ignores
-// Age, so the remaining lifetime it computes never falls and the threshold at
-// which it gives up is never reached.
+// the lease_duration in the body still reads from issuance. A watcher that
+// ignored Age would compute a remaining lifetime that never falls, so the
+// threshold at which it gives up would never be reached.
 //
 // See https://github.com/hashicorp/vault/issues/19227.
 func TestLifetimeWatcher_SignalsReReadOfAgedLease(t *testing.T) {
@@ -137,5 +137,43 @@ func TestLifetimeWatcher_DoesNotRenewExpiredLease(t *testing.T) {
 			t.Fatalf("renewed %s after the lease expired (renewal at %s, only %s of life left on arrival)",
 				at-remaining, at, remaining)
 		}
+	}
+}
+
+func TestRemainingLease(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name          string
+		leaseDuration time.Duration
+		age           time.Duration
+		want          time.Duration
+	}{
+		{
+			name:          "uncached response is unaffected",
+			leaseDuration: 30 * time.Second,
+			age:           0,
+			want:          30 * time.Second,
+		},
+		{
+			name:          "cached response discounts time spent in cache",
+			leaseDuration: 30 * time.Second,
+			age:           25 * time.Second,
+			want:          5 * time.Second,
+		},
+		{
+			name:          "age beyond the lease duration clamps to zero",
+			leaseDuration: 30 * time.Second,
+			age:           45 * time.Second,
+			want:          0,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, tc.want, remainingLease(tc.leaseDuration, tc.age))
+		})
 	}
 }

--- a/api/lifetime_watcher_cache_age_test.go
+++ b/api/lifetime_watcher_cache_age_test.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"slices"
+	"sync"
 	"testing"
 	"time"
 
@@ -22,10 +24,23 @@ const (
 // fakeCachedSecretServer stands in for a caching proxy serving a hit: it replays
 // a lease that was issued ageSeconds ago, with the body still reporting the
 // duration the lease had when it was issued.
-func fakeCachedSecretServer(t *testing.T, leaseDurationSeconds int, ageSeconds int) *httptest.Server {
+//
+// Renewals are timed from server start, so a test can tell whether one was
+// attempted after the lease it renews had already expired.
+func fakeCachedSecretServer(t *testing.T, leaseDurationSeconds int, ageSeconds int) (*httptest.Server, func() []time.Duration) {
 	t.Helper()
 
-	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	var (
+		mu       sync.Mutex
+		renewals []time.Duration
+	)
+	start := time.Now()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		mu.Lock()
+		renewals = append(renewals, time.Since(start))
+		mu.Unlock()
+
 		w.Header().Set("Age", fmt.Sprintf("%d", ageSeconds))
 		w.Header().Set("X-Cache", "HIT")
 		w.Header().Set("Date", time.Now().Format(http.TimeFormat))
@@ -33,10 +48,17 @@ func fakeCachedSecretServer(t *testing.T, leaseDurationSeconds int, ageSeconds i
 		fmt.Fprintf(w, `{"lease_id":%q,"lease_duration":%d,"renewable":true}`,
 			testCachedLeaseID, leaseDurationSeconds)
 	}))
+
+	return server, func() []time.Duration {
+		mu.Lock()
+		defer mu.Unlock()
+
+		return slices.Clone(renewals)
+	}
 }
 
-// testWatchCachedLease starts a watcher over a lease whose renewals are served
-// by the given caching proxy.
+// testWatchCachedLease starts a watcher over a lease whose renewals are served by
+// the given caching proxy.
 func testWatchCachedLease(t *testing.T, server *httptest.Server) *LifetimeWatcher {
 	t.Helper()
 
@@ -69,7 +91,7 @@ func testWatchCachedLease(t *testing.T, server *httptest.Server) *LifetimeWatche
 func TestLifetimeWatcher_SignalsReReadOfAgedLease(t *testing.T) {
 	t.Parallel()
 
-	server := fakeCachedSecretServer(t, testCachedLeaseDurationSeconds, testCachedLeaseAgeSeconds)
+	server, _ := fakeCachedSecretServer(t, testCachedLeaseDurationSeconds, testCachedLeaseAgeSeconds)
 	defer server.Close()
 
 	watcher := testWatchCachedLease(t, server)
@@ -81,5 +103,39 @@ func TestLifetimeWatcher_SignalsReReadOfAgedLease(t *testing.T) {
 	case <-time.After(3 * time.Second):
 		t.Fatalf("watcher never signalled a re-read for a %ds lease already %ds old",
 			testCachedLeaseDurationSeconds, testCachedLeaseAgeSeconds)
+	}
+}
+
+// TestLifetimeWatcher_DoesNotRenewExpiredLease asserts that the watcher stops
+// rather than going on renewing a lease that has already run out.
+//
+// The lease has only its duration less its age left when it arrives, but a
+// watcher that reads lease_duration alone sleeps for two thirds of the full
+// duration before renewing again, by which time the credential is long dead.
+// Each such renewal is a request Vault and its secrets backend must serve for a
+// lease that no longer exists.
+func TestLifetimeWatcher_DoesNotRenewExpiredLease(t *testing.T) {
+	t.Parallel()
+
+	remaining := time.Duration(testCachedLeaseDurationSeconds-testCachedLeaseAgeSeconds) * time.Second
+
+	server, renewals := fakeCachedSecretServer(t, testCachedLeaseDurationSeconds, testCachedLeaseAgeSeconds)
+	defer server.Close()
+
+	watcher := testWatchCachedLease(t, server)
+	defer watcher.Stop()
+
+	// Wait long enough to catch a second renewal, which a watcher that ignores
+	// Age schedules for roughly two thirds of the reported lease duration.
+	select {
+	case <-watcher.DoneCh():
+	case <-time.After(5 * time.Second):
+	}
+
+	for _, at := range renewals() {
+		if at > remaining {
+			t.Fatalf("renewed %s after the lease expired (renewal at %s, only %s of life left on arrival)",
+				at-remaining, at, remaining)
+		}
 	}
 }

--- a/api/logical.go
+++ b/api/logical.go
@@ -157,7 +157,7 @@ func (c *Logical) ParseRawResponseAndCloseBody(resp *Response, err error) (*Secr
 		return nil, err
 	}
 
-	return ParseSecret(resp.Body)
+	return resp.toSecret()
 }
 
 func (c *Logical) readRawWithDataWithContext(ctx context.Context, path string, values url.Values, extraHeaders http.Header) (*Response, error) {
@@ -374,7 +374,7 @@ func (c *Logical) write(ctx context.Context, path string, request *Request) (*Se
 		return nil, err
 	}
 
-	return ParseSecret(resp.Body)
+	return resp.toSecret()
 }
 
 func (c *Logical) writeRaw(ctx context.Context, request *Request) (*Response, error) {

--- a/api/response.go
+++ b/api/response.go
@@ -9,11 +9,39 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
+	"strings"
+	"time"
 )
 
 // Response is a raw response that wraps an HTTP response.
 type Response struct {
 	*http.Response
+}
+
+// cacheAge reports how long an intermediate cache held this response. It is
+// zero when no cache handled the response, or when the age it reported cannot
+// be understood, so that an unusable value is treated as a direct response
+// rather than failing the request that carried it.
+func (r *Response) cacheAge() time.Duration {
+	seconds, err := strconv.Atoi(strings.TrimSpace(r.Header.Get("Age")))
+	if err != nil || seconds < 0 {
+		return 0
+	}
+
+	return time.Duration(seconds) * time.Second
+}
+
+// toSecret reads the secret carried by this response, recording how long an
+// intermediate cache held it.
+func (r *Response) toSecret() (*Secret, error) {
+	secret, err := ParseSecret(r.Body)
+	if err != nil || secret == nil {
+		return secret, err
+	}
+	secret.Age = r.cacheAge()
+
+	return secret, nil
 }
 
 // DecodeJSON will decode the response body to a JSON structure. This

--- a/api/response_cache_age_test.go
+++ b/api/response_cache_age_test.go
@@ -1,0 +1,59 @@
+// Copyright IBM Corp. 2016, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestSysRenew_PopulatesAgeFromCachedResponse asserts that a lease renewed
+// through a caching proxy reports how long its response sat in that cache.
+func TestSysRenew_PopulatesAgeFromCachedResponse(t *testing.T) {
+	t.Parallel()
+
+	const (
+		leaseDurationSeconds = 30
+		ageSeconds           = 25
+	)
+
+	server, _ := fakeCachedSecretServer(t, leaseDurationSeconds, ageSeconds)
+	defer server.Close()
+
+	client, err := NewClient(&Config{Address: server.URL})
+	require.NoError(t, err)
+
+	secret, err := client.Sys().Renew(testCachedLeaseID, leaseDurationSeconds)
+	require.NoError(t, err)
+
+	require.Equal(t, leaseDurationSeconds, secret.LeaseDuration,
+		"lease_duration should be reported as the server sent it")
+	require.Equal(t, ageSeconds*time.Second, secret.Age,
+		"Age header should be surfaced to the caller")
+}
+
+// TestSysRenew_UncachedResponseHasNoAge asserts that a response served directly
+// by Vault, with no Age header, reports no age.
+func TestSysRenew_UncachedResponseHasNoAge(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"lease_id":%q,"lease_duration":30,"renewable":true}`, testCachedLeaseID)
+	}))
+	defer server.Close()
+
+	client, err := NewClient(&Config{Address: server.URL})
+	require.NoError(t, err)
+
+	secret, err := client.Sys().Renew(testCachedLeaseID, 30)
+	require.NoError(t, err)
+
+	require.Zero(t, secret.Age, "a response served directly by Vault has no age")
+}

--- a/api/secret.go
+++ b/api/secret.go
@@ -47,6 +47,14 @@ type Secret struct {
 	// MountType, if non-empty, provides some information about what kind
 	// of mount this secret came from.
 	MountType string `json:"mount_type,omitempty"`
+
+	// Age reports how long this response was held by an intermediate cache
+	// before reaching the client. It is zero for a response served directly by
+	// Vault. The lifetime a lease has left is its LeaseDuration less its Age.
+	//
+	// It is never serialized, because it describes the delivery of a response
+	// rather than the secret that response carries.
+	Age time.Duration `json:"-"`
 }
 
 // TokenID returns the standardized token ID (token) for the given secret.

--- a/api/ssh.go
+++ b/api/ssh.go
@@ -49,7 +49,7 @@ func (c *SSH) CredentialWithContext(ctx context.Context, role string, data map[s
 	}
 	defer resp.Body.Close()
 
-	return ParseSecret(resp.Body)
+	return resp.toSecret()
 }
 
 // SignKey wraps SignKeyWithContext using context.Background.
@@ -74,5 +74,5 @@ func (c *SSH) SignKeyWithContext(ctx context.Context, role string, data map[stri
 	}
 	defer resp.Body.Close()
 
-	return ParseSecret(resp.Body)
+	return resp.toSecret()
 }

--- a/api/sys_leases.go
+++ b/api/sys_leases.go
@@ -33,7 +33,7 @@ func (c *Sys) RenewWithContext(ctx context.Context, id string, increment int) (*
 	}
 	defer resp.Body.Close()
 
-	return ParseSecret(resp.Body)
+	return resp.toSecret()
 }
 
 func (c *Sys) Lookup(id string) (*Secret, error) {
@@ -59,7 +59,7 @@ func (c *Sys) LookupWithContext(ctx context.Context, id string) (*Secret, error)
 	}
 	defer resp.Body.Close()
 
-	return ParseSecret(resp.Body)
+	return resp.toSecret()
 }
 
 func (c *Sys) Revoke(id string) error {

--- a/changelog/32040.txt
+++ b/changelog/32040.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+api: Account for the HTTP Age header when calculating a lease's remaining lifetime, so that leases read or renewed through a caching proxy such as Vault Agent are renewed before they expire.
+```

--- a/command/agentproxyshared/cache/cache_test.go
+++ b/command/agentproxyshared/cache/cache_test.go
@@ -969,6 +969,15 @@ func TestCache_Caching_LeaseResponse(t *testing.T) {
 			t.Fatal(err)
 		}
 
+		// Only the cached response was held by the cache, so only it reports an
+		// age; the secret the two carry is otherwise identical. The age itself
+		// is reported in whole seconds, so it rounds to zero on a fast enough
+		// hit and cannot be asserted on here.
+		if proxiedResp.Age != 0 {
+			t.Fatalf("expected proxied response to report no age, got %s", proxiedResp.Age)
+		}
+		cachedResp.Age = 0
+
 		if diff := deep.Equal(proxiedResp, cachedResp); diff != nil {
 			t.Fatal(diff)
 		}


### PR DESCRIPTION
### Description

Vault Agent's cache stamps an `Age` header on cache hits but replays the stored response body verbatim, so the `lease_duration` inside it still reads from the moment the lease was issued. `ParseSecret` only ever sees that body, and `api.Secret` has no field for HTTP metadata, so `Age` was read off the wire and discarded. `LifetimeWatcher` therefore treats every lease as though it began the instant the response arrived.

For most of a lease's life this is harmless, which is what makes it easy to miss. While the lease is far from its `max_ttl`, Vault returns the full `lease_duration` on every renewal, so the cached body and the truth agree, and the watcher renews on schedule exactly as intended. This can run correctly for a very long time.

The failure appears as the lease approaches `max_ttl`. Vault then starts returning progressively smaller durations — whatever is left before the cap (`CalculateTTL`, `sdk/framework/lease.go`) — and that shrinking value is precisely how `LifetimeWatcher` knows to give up and tell its caller to re-read the secret. Served from cache, that signal never arrives: the replayed body still reports the original full duration, and the cache updates only `LastRenewed` on renewal, never the stored response. The remaining lifetime the watcher computes therefore never falls, the threshold at which it stops is never reached, and it goes on renewing and sleeping against a lease that has expired, while the template it feeds is never re-rendered. From the outside this looks like Agent running correctly for a long time and then quietly going to sleep.

Separately, once a response has been held long enough that its age exceeds roughly a third of the reported duration, the watcher's ~2/3 sleep also overshoots the true expiry, so the renewals it does make are requests Vault and its secrets backend must serve for a lease that no longer exists.

The fix is in two parts:

- `Secret` gains an `Age` field, populated for responses that carry a lease or token TTL a caller does arithmetic on. It is additive and never serialized, and `LeaseDuration` is still reported exactly as the server sent it, so existing callers are unaffected. Responses carrying only configuration are left alone.
- `LifetimeWatcher` anchors its clock at issuance rather than at arrival, so the existing duration arithmetic — including the error backoff window derived from it — accounts for the age of the response. Because a cached entry's age grows without bound, the remaining lifetime now falls even when the shrinking `lease_duration` never reaches the client, which restores the give-up threshold. `remainingLease` clamps at zero, because a response can outlive the lease it describes once a cache has held it long enough, and a negative duration would corrupt that backoff window.

The first two commits are failing tests, one per failure mode; the last two make them pass. They construct the end state directly — a renewal returned with `Age: 5` on a 6s lease — rather than waiting out a real `max_ttl`, so both are deterministic, use an `httptest` stub caching proxy, and need no Vault server. Reproducing this has historically been the blocker on the issue.

`TestCache_Caching_LeaseResponse` compared a proxied and a cached response for equality. A cache hit is now distinguishable from a fresh response by its age, so that comparison accounts for the field.

### Rationale

Refs #19227 (closed as filed against an unsupported release, not on the merits), #16439 (closed as not reproducible for want of a failing test), and #19684 (open, same failure).

Prior art, all self-withdrawn or abandoned by the author rather than rejected on technical grounds: #16887, #16924, #17921. #17919 is merged and was explicitly framed as groundwork for making the sleep-duration calculation `Age`-aware.

Note #32009 targets the same symptom from the cache side by not caching renewal responses. That only covers the renewal path; a first `Logical().Read()` served from cache still returns an unaged `lease_duration`, which is the gap #16887 was withdrawn over.

### PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [x] If applicable, I've documented the impact of any changes to security controls.
