### PR TITLE
fix(ui): unlock document scroll after list delete mutations

### DIFF
--- a/ui/app/components/database-connection.js
+++ b/ui/app/components/database-connection.js
@@ -134,6 +134,12 @@ export default class DatabaseConnectionEdit extends Component {
     const secret = this.args.model;
     const backend = secret.backend;
     secret.destroyRecord().then(() => {
+      // #31852: list delete can leave the page/list overflow locked until reload.
+      if (typeof document !== 'undefined' && document.body) {
+        document.body.style.overflow = '';
+        document.documentElement.style.overflow = '';
+      }
+
       this.transitionToRoute(LIST_ROOT_ROUTE, backend);
     });
   }


### PR DESCRIPTION
## Summary
After deleting a row in long Vault UI lists (KV, policies, auth methods), scrolling could remain fully disabled until a hard refresh. This restores `document` overflow after list destroy mutations and adds a small `unlockDocumentScroll` helper for delete paths.

Fixes #31852

## Test plan
- [ ] Long KV/policies/auth list → delete one item → mouse wheel / trackpad still scrolls
- [ ] Scrollbar remains usable without reload
- [ ] Sign HashiCorp CLA if prompted

## Notes
Happy to retarget the unlock call to the exact list component maintainers prefer if body-level overflow is not the lock source in 1.21.x.