### PR TITLE
fix: add request ID to audit entries for help requests (#32026)

### DIFF
--- a/http/help.go
+++ b/http/help.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/vault/helper/namespace"
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/hashicorp/vault/vault"
@@ -42,10 +43,17 @@ func handleHelp(core *vault.Core, w http.ResponseWriter, r *http.Request) {
 	}
 	path := trimPath(ns, r.URL.Path)
 
+	requestId, err := uuid.GenerateUUID()
+	if err != nil {
+		respondError(w, http.StatusInternalServerError, nil)
+		return
+	}
+
 	req := &logical.Request{
 		Operation:  logical.HelpOperation,
 		Path:       path,
 		Connection: getConnection(r),
+		ID:         requestId,
 	}
 	requestAuth(r, req)
 


### PR DESCRIPTION
Fixes #32026

**Problem:**
Audit entries for help requests (e.g. `vault path-help`) do not have a `request.id` set. This breaks code that tries to match responses to requests via the request ID.

**Root cause:**
`handleHelp()` in `http/help.go` creates a `logical.Request` without setting the `ID` field. By contrast, `buildLogicalRequestNoAuth()` in `http/logical.go` always generates a UUID and sets it as the request ID.

**Fix:**
Generate a UUID using `uuid.GenerateUUID()` and set it as `req.ID` in the help request, matching the pattern used by all other request handlers.

**Changes:**
- `http/help.go`: Added `go-uuid` import, generate UUID for help requests, set `ID` field on the `logical.Request` struct.