### PR TITLE
fix: close tmpFile on Chown error path to prevent file descriptor leak [fj4WqyCCw3C5ShR1RfB7MoBPTpkRrBFYP1uT35g3MvT]

### DIFF
--- a/command/agentproxyshared/sink/file/file_sink.go
+++ b/command/agentproxyshared/sink/file/file_sink.go
@@ -119,6 +119,9 @@ func (f *fileSink) WriteToken(token string) error {
 	}
 
 	if err := osutil.Chown(tmpFile, f.owner, f.group); err != nil {
+		// Attempt closing and deleting but ignore any error
+		tmpFile.Close()
+		os.Remove(tmpFile.Name())
 		return fmt.Errorf("error changing ownership of %s: %w", tmpFile.Name(), err)
 	}
 


### PR DESCRIPTION
## Description

Fix a file descriptor leak in `WriteToken` (`command/agentproxyshared/sink/file/file_sink.go`).

When `osutil.Chown` fails, the function returns without closing `tmpFile`, leaking a file descriptor. This is inconsistent with the other error paths in the same function (e.g., `WriteString` failure) which correctly close and remove the temp file.

## Fix

Added `tmpFile.Close()` and `os.Remove(tmpFile.Name())` before the Chown error return, matching the cleanup pattern used by the WriteString error path.

## Related Issue

Fixes #31801