### PR TITLE
fix: prevent duplicate member_entity_ids entries on OIDC login (#32057)

### DIFF
--- a/vault/identity_store_util.go
+++ b/vault/identity_store_util.go
@@ -3141,7 +3141,9 @@ func (i *IdentityStore) refreshExternalGroupMembershipsByEntityID(ctx context.Co
 
 			i.logger.Debug("adding member entity ID to external group", "member_entity_id", entityID, "group_id", group.ID)
 
-			group.MemberEntityIDs = append(group.MemberEntityIDs, entityID)
+			if !strutil.StrListContains(group.MemberEntityIDs, entityID) {
+				group.MemberEntityIDs = append(group.MemberEntityIDs, entityID)
+			}
 
 			err = i.UpsertGroupInTxn(ctx, txn, group, true)
 			if errors.Is(err, logical.ErrReadOnly) {


### PR DESCRIPTION
## Summary

Fixes #32057

Every OIDC login appends the authenticating entity's ID to the `member_entity_ids` list of each external identity group named in the user's groups claim — without checking whether the entity is already a member. The list grows by one entry per login per group, unbounded.

The LDAP auth path does not exhibit this issue. The `identity/group` API path also deduplicates. Only the OIDC login path in `refreshExternalGroupMembershipsByEntityID` skips this check.

## Root Cause

In `vault/identity_store_util.go`, the `refreshExternalGroupMembershipsByEntityID` function at line 3144 does:

```go
group.MemberEntityIDs = append(group.MemberEntityIDs, entityID)
```

This appends without checking if the entity ID is already present in the list. While the `diffGroups` function should prevent re-adding existing members, the fix adds an explicit defensive check to ensure deduplication regardless of the diff logic.

## Fix

Wrap the append with a `strutil.StrListContains` guard:

```go
if !strutil.StrListContains(group.MemberEntityIDs, entityID) {
    group.MemberEntityIDs = append(group.MemberEntityIDs, entityID)
}
```

The `strutil` package is already imported in this file.