### PR TITLE
sdk/ldaputil: fix malformed error messages from errwrap placeholder

### DIFF
--- a/changelog/32064.txt
+++ b/changelog/32064.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+sdk/ldaputil: Fix malformed error messages that embedded the literal `{{err}}` placeholder and a `%!(EXTRA ...)` marker, and wrap the underlying error so `errors.Is`/`errors.As` work.
+```

--- a/sdk/helper/ldaputil/client.go
+++ b/sdk/helper/ldaputil/client.go
@@ -37,7 +37,7 @@ func (c *Client) DialLDAP(cfg *ConfigEntry) (Connection, error) {
 	for _, uut := range urls {
 		u, err := url.Parse(uut)
 		if err != nil {
-			retErr = multierror.Append(retErr, fmt.Errorf(fmt.Sprintf("error parsing url %q: {{err}}", uut), err))
+			retErr = multierror.Append(retErr, fmt.Errorf("error parsing url %q: %w", uut, err))
 			continue
 		}
 		host, port, err := net.SplitHostPort(u.Host)
@@ -104,7 +104,7 @@ func (c *Client) DialLDAP(cfg *ConfigEntry) (Connection, error) {
 			retErr = nil
 			break
 		}
-		retErr = multierror.Append(retErr, fmt.Errorf(fmt.Sprintf("error connecting to host %q: {{err}}", uut), err))
+		retErr = multierror.Append(retErr, fmt.Errorf("error connecting to host %q: %w", uut, err))
 	}
 	if retErr != nil {
 		return nil, retErr
@@ -453,21 +453,21 @@ func sidBytesToString(b []byte) (string, error) {
 	var identifierAuthorityParts [3]uint16
 
 	if err := binary.Read(reader, binary.LittleEndian, &revision); err != nil {
-		return "", fmt.Errorf(fmt.Sprintf("SID %#v convert failed reading Revision: {{err}}", b), err)
+		return "", fmt.Errorf("SID %#v convert failed reading Revision: %w", b, err)
 	}
 
 	if err := binary.Read(reader, binary.LittleEndian, &subAuthorityCount); err != nil {
-		return "", fmt.Errorf(fmt.Sprintf("SID %#v convert failed reading SubAuthorityCount: {{err}}", b), err)
+		return "", fmt.Errorf("SID %#v convert failed reading SubAuthorityCount: %w", b, err)
 	}
 
 	if err := binary.Read(reader, binary.BigEndian, &identifierAuthorityParts); err != nil {
-		return "", fmt.Errorf(fmt.Sprintf("SID %#v convert failed reading IdentifierAuthority: {{err}}", b), err)
+		return "", fmt.Errorf("SID %#v convert failed reading IdentifierAuthority: %w", b, err)
 	}
 	identifierAuthority := (uint64(identifierAuthorityParts[0]) << 32) + (uint64(identifierAuthorityParts[1]) << 16) + uint64(identifierAuthorityParts[2])
 
 	subAuthority := make([]uint32, subAuthorityCount)
 	if err := binary.Read(reader, binary.LittleEndian, &subAuthority); err != nil {
-		return "", fmt.Errorf(fmt.Sprintf("SID %#v convert failed reading SubAuthority: {{err}}", b), err)
+		return "", fmt.Errorf("SID %#v convert failed reading SubAuthority: %w", b, err)
 	}
 
 	result := fmt.Sprintf("S-%d-%d", revision, identifierAuthority)

--- a/sdk/helper/ldaputil/client_test.go
+++ b/sdk/helper/ldaputil/client_test.go
@@ -4,6 +4,7 @@
 package ldaputil
 
 import (
+	"io"
 	"testing"
 
 	"github.com/hashicorp/go-hclog"
@@ -94,6 +95,29 @@ func TestSIDBytesToString(t *testing.T) {
 			t.Errorf("Failed to convert %#v: %s != %s", test, res, answer)
 		}
 	}
+}
+
+// TestSIDBytesToStringErrorFormatting confirms that a failure to convert a SID
+// produces a usable error. These messages previously embedded the errwrap
+// placeholder "{{err}}" in a format string passed to fmt.Errorf, which has no
+// verb to consume the error argument, so the rendered message contained both
+// the literal placeholder and Go's "%!(EXTRA ...)" marker and did not wrap the
+// underlying error.
+//
+// go vet does not catch the original form, because fmt.Sprintf makes the format
+// string non-constant and printf analysis is skipped.
+func TestSIDBytesToStringErrorFormatting(t *testing.T) {
+	// Truncated: too short to read the Revision field.
+	_, err := sidBytesToString([]byte{})
+	require.Error(t, err)
+
+	assert.NotContains(t, err.Error(), "{{err}}",
+		"errwrap placeholder leaked into the rendered message")
+	assert.NotContains(t, err.Error(), "%!(EXTRA",
+		"error argument was not consumed by a format verb")
+
+	assert.ErrorIs(t, err, io.EOF,
+		"underlying error should be wrapped with %w so errors.Is can reach it")
 }
 
 func TestClient_renderUserSearchFilter(t *testing.T) {


### PR DESCRIPTION
Fixes #32063

### What

Six call sites in `sdk/helper/ldaputil/client.go` built a format string containing the `errwrap` placeholder `{{err}}` and passed it to `fmt.Errorf` along with an `error`. `fmt.Errorf` does not interpret `{{err}}`, and the format string had no verb to consume the argument, so Go appended `%!(EXTRA ...)`.

Let me know if you want me to adjust the test to not hardcode old behavior. it was useful for validation purposes for this PR so i left it in.

Before:

```
error connecting to host "ldaps://dc.example.com:636": {{err}}%!(EXTRA *ldap.Error=LDAP Result Code 200 "Network Error": dial tcp 10.0.0.1:636: i/o timeout)
```

After:

```
error connecting to host "ldaps://dc.example.com:636": LDAP Result Code 200 "Network Error": dial tcp 10.0.0.1:636: i/o timeout
```

Switching to `%w` also wraps the underlying error, so `errors.Is` and `errors.As` reach it. They could not before.

### Why it went unnoticed

`go vet` does not flag the original form. `fmt.Sprintf` makes the format string non-constant, so the printf analyser skips it. Confirmed by running `go vet ./helper/ldaputil/` against the unfixed code: clean.

Elsewhere in the codebase `{{err}}` is used correctly with `errwrap.Wrapf`, which does interpret it. Only these six passed it to `fmt.Errorf`.

### Scope

All six call sites are in `sdk/helper/ldaputil/client.go`:

| Line | Message |
|------|---------|
| 40 | `error parsing url %q` |
| 107 | `error connecting to host %q` |
| 456 | `SID %#v convert failed reading Revision` |
| 460 | `SID %#v convert failed reading SubAuthorityCount` |
| 464 | `SID %#v convert failed reading IdentifierAuthority` |
| 470 | `SID %#v convert failed reading SubAuthority` |

`ldaputil` is used by the built-in LDAP auth method and, through `vault-plugin-secrets-openldap`, by the LDAP/AD secrets engines, so this affects both authentication and dynamic credential paths.

### Test

Added `TestSIDBytesToStringErrorFormatting`, which exercises the SID conversion path (no network required) and asserts the rendered error contains neither `{{err}}` nor `%!(EXTRA`, and that `errors.Is` reaches the wrapped `io.EOF`.

Verified the test fails against the unfixed code and passes with the change:

```
--- FAIL: TestSIDBytesToStringErrorFormatting
    Error: "SID []byte{} convert failed reading Revision: {{err}}%!(EXTRA *errors.errorString=EOF)" should not contain "{{err}}"
    Error: "SID []byte{} convert failed reading Revision: {{err}}%!(EXTRA *errors.errorString=EOF)" should not contain "%!(EXTRA"
    Error: Target error should be in err chain
```

`go build`, `go vet` and `go test ./helper/ldaputil/` all pass on the change.

### Impact on users

Error text changes. Anything matching on the literal `{{err}}` or `%!(EXTRA` strings would need updating, though such matching seems unlikely to be deliberate.

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.

### PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.

Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.

Co-authored: 🤖 Claude Code