### PR TITLE
fix: prevent premature context cancellation in writeRaw (WriteRawWithContext/PatchRawWithContext) [fj4WqyCCw3C5ShR1RfB7MoBPTpkRrBFYP1uT35g3MvT]

### DIFF
--- a/api/logical.go
+++ b/api/logical.go
@@ -378,11 +378,7 @@ func (c *Logical) write(ctx context.Context, path string, request *Request) (*Se
 }
 
 func (c *Logical) writeRaw(ctx context.Context, request *Request) (*Response, error) {
-	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
-	defer cancelFunc()
-
-	resp, err := c.c.rawRequestWithContext(ctx, request)
-	return resp, err
+	return c.c.RawRequestWithContext(ctx, request)
 }
 
 func (c *Logical) Delete(path string) (*Secret, error) {


### PR DESCRIPTION
### Description

`WriteRawWithContext` and `PatchRawWithContext` return a `*Response` whose body is bound to an already-cancelled context. Reading the body then fails with a spurious `context canceled`, even though the request succeeded server-side.

### Root Cause

Both methods route through `writeRaw`, which wraps the context with a timeout via `withConfiguredTimeout` and then `defer cancelFunc()` — the cancel fires before the caller can read `resp.Body`.

The read path (`readRawWithDataWithContext`) and delete path (`DeleteRawWithContext`) already fixed this (#18708) by routing through `Client.RawRequestWithContext`, which wraps the context with a timeout but **discards the cancel function** — the comment explains: "when canceled, the request.Body will EOF when reading due to the way it streams data in."

### Fix

Route `writeRaw` through `Client.RawRequestWithContext` instead of manually wrapping the context with `withConfiguredTimeout` + `defer cancelFunc()`. This matches the pattern used by `readRawWithDataWithContext`, `DeleteRawWithContext`, and all other raw methods.

### Testing

- `WriteRawWithContext` / `PatchRawWithContext` now return a body that remains readable after the function returns
- The client-configured timeout is still enforced by `RawRequestWithContext`'s internal `withConfiguredTimeout` call
- Small responses continue to work as before
- Large responses no longer fail with `context canceled`

Fixes #31986
