### PR TITLE
transit: warn when key_usages is supplied on key config writes

### DIFF
--- a/builtin/logical/transit/path_keys_config.go
+++ b/builtin/logical/transit/path_keys_config.go
@@ -206,6 +206,10 @@ func (b *backend) pathKeysConfigWrite(ctx context.Context, req *logical.Request,
 		}
 	}
 
+	if _, ok := d.GetOk("key_usages"); ok {
+		warning = "key_usages is derived from the key type and cannot be changed; the supplied value was ignored"
+	}
+
 	autoRotatePeriodRaw, ok, err := d.GetOkErr("auto_rotate_period")
 	if err != nil {
 		return nil, err

--- a/builtin/logical/transit/path_keys_config_test.go
+++ b/builtin/logical/transit/path_keys_config_test.go
@@ -405,6 +405,43 @@ func TestTransit_UpdateKeyConfigWithAutorotation(t *testing.T) {
 	}
 }
 
+func TestTransit_KeyUsagesWriteWarns(t *testing.T) {
+	b, storage := createBackendWithSysView(t)
+
+	doReq := func(op logical.Operation, path string, data map[string]interface{}) *logical.Response {
+		t.Helper()
+		resp, err := b.HandleRequest(context.Background(), &logical.Request{
+			Storage:   storage,
+			Operation: op,
+			Path:      path,
+			Data:      data,
+		})
+		if err != nil || (resp != nil && resp.IsError()) {
+			t.Fatalf("unexpected error for %s %s: err=%v resp=%v", op, path, err, resp)
+		}
+		return resp
+	}
+
+	doReq(logical.UpdateOperation, "keys/testkey", map[string]interface{}{"type": "ecdsa-p256"})
+
+	// Supplying key_usages on the config write path must produce a warning:
+	// the field is declared writable but is derived from the key type, so
+	// silently accepting it would let an operator believe they restricted a
+	// key's usages when nothing changed.
+	resp := doReq(logical.UpdateOperation, "keys/testkey/config", map[string]interface{}{
+		"key_usages": []string{"digital-signature"},
+	})
+	found := false
+	for _, w := range resp.Warnings {
+		if strings.Contains(w, "key_usages is derived from the key type") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected key_usages warning, got warnings=%v", resp.Warnings)
+	}
+}
+
 func TestTransit_KeyUsagesInConfigResponse(t *testing.T) {
 	b, storage := createBackendWithSysView(t)
 


### PR DESCRIPTION
## Summary

`transit/keys/<name>/config` declares `key_usages` as a writable field, but the write handler never reads it. Usages are derived from the key type (`p.Type.KeyUsages()`), which is also what the response returns.

Because the field is declared in the schema, Vault's unused/ignored-parameter warning never fires when a client supplies it. An operator can POST `key_usages=["digital-signature"]` to an encryption key's config, receive a successful response, and believe the key is now signature-only when nothing changed. That is a silent failure on a security-relevant setting.

## Fix

Emit a warning when `key_usages` is supplied on the write path, matching the existing warning pattern used for forced min-version adjustments:

```
key_usages is derived from the key type and cannot be changed; the supplied value was ignored
```

This keeps API compatibility (clients that send the field do not break) while surfacing the no-op.

## Test plan

- [x] New test: supplying `key_usages` on config write returns the warning
- [x] `TestTransit_KeyUsages*`, `TestTransit_ConfigSettings`, `TestTransit_UpdateKeyConfigWithAutorotation` pass

Made with [Cursor](https://cursor.com)