### PR TITLE
UI: Always show lease pagination (backport #13973 to release/2.1.x)

### DIFF
--- a/ui/app/templates/vault/cluster/access/leases/list.hbs
+++ b/ui/app/templates/vault/cluster/access/leases/list.hbs
@@ -110,16 +110,14 @@
       />
     </Hds::ApplicationState>
   {{/each}}
-  {{#unless this.filter}}
-    <Hds::Pagination::Numbered
-      @currentPage={{this.model.meta.currentPage}}
-      @currentPageSize={{this.model.meta.pageSize}}
-      @route={{concat "vault.cluster.access.leases.list" (unless this.baseKey.id "-root")}}
-      @showSizeSelector={{false}}
-      @totalItems={{this.model.meta.total}}
-      @queryFunction={{this.paginationQueryParams}}
-    />
-  {{/unless}}
+  <Hds::Pagination::Numbered
+    @currentPage={{this.model.meta.currentPage}}
+    @currentPageSize={{this.model.meta.pageSize}}
+    @route={{concat "vault.cluster.access.leases.list" (unless this.baseKey.id "-root")}}
+    @showSizeSelector={{false}}
+    @totalItems={{this.model.meta.total}}
+    @queryFunction={{this.paginationQueryParams}}
+  />
 {{else}}
   <Hds::ApplicationState class="top-padding-32 is-marginless" as |A|>
     <A.Header @title={{this.emptyTitle}} @titleTag="h2" data-test-empty-state-title />


### PR DESCRIPTION
## Description

Manual backport of [vault-enterprise#13973](https://github.com/hashicorp/vault-enterprise/pull/13973) to `release/2.1.x`.

**Original change:** Fix Vault UI to always show lease pagination controls regardless of whether a filter is applied. Previously, pagination was hidden unless a filter was active.

**Cherry-picked commit:** `a0f74e193a` from `main`

**Related PRs:**
- Original: hashicorp/vault-enterprise#13973
- ce/main backport: hashicorp/vault-enterprise#13981

**Enterprise releases containing this fix:** v1.19.17+ent, v1.20.11+ent, v1.21.6+ent