### PR TITLE
transit: warn when irreversible config flags cannot be disabled

### DIFF
--- a/builtin/logical/transit/path_keys_config.go
+++ b/builtin/logical/transit/path_keys_config.go
@@ -100,7 +100,7 @@ func (b *backend) pathKeysConfigWrite(ctx context.Context, req *logical.Request,
 	}
 	defer p.Unlock()
 
-	var warning string
+	var warnings []string
 
 	originalMinDecryptionVersion := p.MinDecryptionVersion
 	originalMinEncryptionVersion := p.MinEncryptionVersion
@@ -130,7 +130,7 @@ func (b *backend) pathKeysConfigWrite(ctx context.Context, req *logical.Request,
 
 		if minDecryptionVersion == 0 {
 			minDecryptionVersion = 1
-			warning = "since Vault 0.3, transit key numbering starts at 1; forcing minimum to 1"
+			warnings = append(warnings, "since Vault 0.3, transit key numbering starts at 1; forcing minimum to 1")
 		}
 
 		if minDecryptionVersion != p.MinDecryptionVersion {
@@ -193,6 +193,8 @@ func (b *backend) pathKeysConfigWrite(ctx context.Context, req *logical.Request,
 		if exportable && !p.Exportable {
 			p.Exportable = exportable
 			persistNeeded = true
+		} else if !exportable && p.Exportable {
+			warnings = append(warnings, "exportable cannot be disabled once set; the supplied value was ignored")
 		}
 	}
 
@@ -203,6 +205,8 @@ func (b *backend) pathKeysConfigWrite(ctx context.Context, req *logical.Request,
 		if allowPlaintextBackup && !p.AllowPlaintextBackup {
 			p.AllowPlaintextBackup = allowPlaintextBackup
 			persistNeeded = true
+		} else if !allowPlaintextBackup && p.AllowPlaintextBackup {
+			warnings = append(warnings, "allow_plaintext_backup cannot be disabled once set; the supplied value was ignored")
 		}
 	}
 
@@ -233,7 +237,7 @@ func (b *backend) pathKeysConfigWrite(ctx context.Context, req *logical.Request,
 			return nil, err
 		}
 		resp.Data["key_usages"] = p.Type.KeyUsages()
-		if warning != "" {
+		for _, warning := range warnings {
 			resp.AddWarning(warning)
 		}
 		return resp, nil
@@ -255,7 +259,7 @@ func (b *backend) pathKeysConfigWrite(ctx context.Context, req *logical.Request,
 		return nil, err
 	}
 	resp.Data["key_usages"] = p.Type.KeyUsages()
-	if warning != "" {
+	for _, warning := range warnings {
 		resp.AddWarning(warning)
 	}
 	return resp, nil

--- a/builtin/logical/transit/path_keys_config_test.go
+++ b/builtin/logical/transit/path_keys_config_test.go
@@ -477,3 +477,57 @@ func TestTransit_KeyUsagesInConfigResponse(t *testing.T) {
 		})
 	}
 }
+
+
+func TestTransit_ConfigWarnsOnIrreversibleFlagDisable(t *testing.T) {
+	b, storage := createBackendWithSysView(t)
+
+	doReq := func(op logical.Operation, path string, data map[string]interface{}) *logical.Response {
+		t.Helper()
+		resp, err := b.HandleRequest(context.Background(), &logical.Request{
+			Storage:   storage,
+			Operation: op,
+			Path:      path,
+			Data:      data,
+		})
+		if err != nil || (resp != nil && resp.IsError()) {
+			t.Fatalf("unexpected error for %s %s: err=%v resp=%v", op, path, err, resp)
+		}
+		return resp
+	}
+
+	hasWarning := func(resp *logical.Response, substr string) bool {
+		t.Helper()
+		for _, w := range resp.Warnings {
+			if strings.Contains(w, substr) {
+				return true
+			}
+		}
+		return false
+	}
+
+	// Create an exportable key with plaintext backup enabled.
+	doReq(logical.UpdateOperation, "keys/irrev", map[string]interface{}{
+		"exportable":             true,
+		"allow_plaintext_backup": true,
+	})
+
+	// Attempt to disable both irreversible flags. Policy must stay enabled,
+	// and the response must warn that the supplied values were ignored.
+	resp := doReq(logical.UpdateOperation, "keys/irrev/config", map[string]interface{}{
+		"exportable":             false,
+		"allow_plaintext_backup": false,
+	})
+	if resp.Data["exportable"] != true {
+		t.Fatalf("exportable should remain true after disable attempt, got %#v", resp.Data["exportable"])
+	}
+	if resp.Data["allow_plaintext_backup"] != true {
+		t.Fatalf("allow_plaintext_backup should remain true after disable attempt, got %#v", resp.Data["allow_plaintext_backup"])
+	}
+	if !hasWarning(resp, "exportable cannot be disabled once set") {
+		t.Fatalf("expected exportable disable warning, got %#v", resp.Warnings)
+	}
+	if !hasWarning(resp, "allow_plaintext_backup cannot be disabled once set") {
+		t.Fatalf("expected allow_plaintext_backup disable warning, got %#v", resp.Warnings)
+	}
+}


### PR DESCRIPTION
## Summary

`transit/keys/<name>/config` documents that `exportable` and `allow_plaintext_backup` cannot be disabled once set. The write handler already enforces that (it never clears the flags), but a client that POSTs `false` still gets a successful response with no warning while the policy stays enabled.

An operator can believe they revoked key export or plaintext backup when nothing changed. That is a silent failure on a security-relevant setting, in the same class as ignored `key_usages` on this endpoint.

## Fix

Emit warnings when a disable attempt is ignored:

```
exportable cannot be disabled once set; the supplied value was ignored
allow_plaintext_backup cannot be disabled once set; the supplied value was ignored
```

Behavior is unchanged: flags remain one-way. Only the response now surfaces the no-op.

## Test plan

- [x] New test: disable attempts leave flags enabled and return both warnings
- [x] `TestTransit_ConfigSettings`, `TestTransit_KeyUsagesInConfigResponse`, `TestTransit_UpdateKeyConfigWithAutorotation` pass


Made with [Cursor](https://cursor.com)