### PR TITLE
transit: warn when context is ignored on non-derived keys

### DIFF
--- a/builtin/logical/transit/path_decrypt.go
+++ b/builtin/logical/transit/path_decrypt.go
@@ -191,6 +191,7 @@ func (b *backend) pathDecryptWrite(ctx context.Context, req *logical.Request, d 
 	}
 	defer p.Unlock()
 
+	warnAboutUnusedContext := contextSet && !p.Derived
 	successesInBatch := false
 	successfulRequests := 0
 	for i, item := range batchInputItems {
@@ -271,6 +272,10 @@ func (b *backend) pathDecryptWrite(ctx context.Context, req *logical.Request, d 
 
 	if err = b.incrementBillingCounts(ctx, uint64(successfulRequests)); err != nil {
 		b.Logger().Error("failed to track transit decrypt request count", "error", err.Error())
+	}
+
+	if warnAboutUnusedContext {
+		resp.AddWarning("context was supplied but this key does not have derivation enabled; the supplied context was ignored")
 	}
 
 	return batchRequestResponse(d, resp, req, successesInBatch, userErrorInBatch, internalErrorInBatch)

--- a/builtin/logical/transit/path_encrypt.go
+++ b/builtin/logical/transit/path_encrypt.go
@@ -526,6 +526,7 @@ func (b *backend) pathEncryptWrite(ctx context.Context, req *logical.Request, d 
 	// item fails, respectively mark the error in the response
 	// collection and continue to process other items.
 	warnAboutNonceUsage := false
+	warnAboutUnusedContext := contextSet && !p.Derived
 	successesInBatch := false
 	successfulRequests := 0
 	for i, item := range batchInputItems {
@@ -635,6 +636,10 @@ func (b *backend) pathEncryptWrite(ctx context.Context, req *logical.Request, d 
 
 	if constants.IsFIPS() && warnAboutNonceUsage {
 		resp.AddWarning("A provided nonce value was used within FIPS mode, this violates FIPS 140 compliance.")
+	}
+
+	if warnAboutUnusedContext {
+		resp.AddWarning("context was supplied but this key does not have derivation enabled; the supplied context was ignored")
 	}
 
 	if req.Operation == logical.CreateOperation && !upserted {

--- a/builtin/logical/transit/path_encrypt_test.go
+++ b/builtin/logical/transit/path_encrypt_test.go
@@ -391,6 +391,176 @@ func TestTransit_BatchEncryptionCase5(t *testing.T) {
 	require.Equal(t, uint64(4), b.billingDataCounts.Transit.Load())
 }
 
+
+
+func TestTransit_EncryptNoWarnWhenDerivedUsesContext(t *testing.T) {
+	b, s := createBackendWithStorage(t)
+
+	req := &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "keys/derived",
+		Storage:   s,
+		Data: map[string]interface{}{
+			"type":    "aes256-gcm96",
+			"derived": true,
+		},
+	}
+	resp, err := b.HandleRequest(context.Background(), req)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("create key err:%v resp:%#v", err, resp)
+	}
+
+	encReq := &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "encrypt/derived",
+		Storage:   s,
+		Data: map[string]interface{}{
+			"plaintext": "dGhlIHF1aWNrIGJyb3duIGZveA==",
+			"context":   "Y29udGV4dC1h",
+		},
+	}
+	resp, err = b.HandleRequest(context.Background(), encReq)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("encrypt err:%v resp:%#v", err, resp)
+	}
+	for _, w := range resp.Warnings {
+		if strings.Contains(w, "context was supplied but this key does not have derivation") {
+			t.Fatalf("unexpected unused-context warning on derived key: %#v", resp.Warnings)
+		}
+	}
+}
+
+func TestTransit_EncryptWarnsOnUnusedContext(t *testing.T) {
+	b, s := createBackendWithStorage(t)
+
+	// Create a non-derived key explicitly.
+	req := &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "keys/plain",
+		Storage:   s,
+		Data: map[string]interface{}{
+			"type": "aes256-gcm96",
+		},
+	}
+	resp, err := b.HandleRequest(context.Background(), req)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("create key err:%v resp:%#v", err, resp)
+	}
+
+	plaintext := "dGhlIHF1aWNrIGJyb3duIGZveA=="
+	contextA := "Y29udGV4dC1h"
+	contextB := "Y29udGV4dC1i"
+
+	encReq := &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "encrypt/plain",
+		Storage:   s,
+		Data: map[string]interface{}{
+			"plaintext": plaintext,
+			"context":   contextA,
+		},
+	}
+	resp, err = b.HandleRequest(context.Background(), encReq)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("encrypt err:%v resp:%#v", err, resp)
+	}
+	ciphertext := resp.Data["ciphertext"].(string)
+
+	found := false
+	for _, w := range resp.Warnings {
+		if strings.Contains(w, "context") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected unused-context warning, got %#v", resp.Warnings)
+	}
+
+	// Decrypt without context must succeed (context was ignored at encrypt).
+	decReq := &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "decrypt/plain",
+		Storage:   s,
+		Data: map[string]interface{}{
+			"ciphertext": ciphertext,
+		},
+	}
+	resp, err = b.HandleRequest(context.Background(), decReq)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("decrypt without context err:%v resp:%#v", err, resp)
+	}
+	if resp.Data["plaintext"] != plaintext {
+		t.Fatalf("bad plaintext: got %q want %q", resp.Data["plaintext"], plaintext)
+	}
+
+	// Decrypt with a different context also succeeds (proves context was unused).
+	decReq.Data["context"] = contextB
+	resp, err = b.HandleRequest(context.Background(), decReq)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("decrypt with other context err:%v resp:%#v", err, resp)
+	}
+	if resp.Data["plaintext"] != plaintext {
+		t.Fatalf("bad plaintext with other context: got %q want %q", resp.Data["plaintext"], plaintext)
+	}
+}
+
+
+func TestTransit_DecryptWarnsOnUnusedContext(t *testing.T) {
+	b, s := createBackendWithStorage(t)
+
+	req := &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "keys/plain-dec",
+		Storage:   s,
+		Data: map[string]interface{}{
+			"type": "aes256-gcm96",
+		},
+	}
+	resp, err := b.HandleRequest(context.Background(), req)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("create key err:%v resp:%#v", err, resp)
+	}
+
+	encReq := &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "encrypt/plain-dec",
+		Storage:   s,
+		Data: map[string]interface{}{
+			"plaintext": "dGhlIHF1aWNrIGJyb3duIGZveA==",
+		},
+	}
+	resp, err = b.HandleRequest(context.Background(), encReq)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("encrypt err:%v resp:%#v", err, resp)
+	}
+	ciphertext := resp.Data["ciphertext"].(string)
+
+	decReq := &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "decrypt/plain-dec",
+		Storage:   s,
+		Data: map[string]interface{}{
+			"ciphertext": ciphertext,
+			"context":    "Y29udGV4dC1h",
+		},
+	}
+	resp, err = b.HandleRequest(context.Background(), decReq)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("decrypt err:%v resp:%#v", err, resp)
+	}
+	found := false
+	for _, w := range resp.Warnings {
+		if strings.Contains(w, "context was supplied but this key does not have derivation") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected unused-context warning on decrypt, got %#v", resp.Warnings)
+	}
+}
+
 // Case6: Test batch encryption with an upserted non-derived key
 func TestTransit_BatchEncryptionCase6(t *testing.T) {
 	var resp *logical.Response


### PR DESCRIPTION
### Description

Transit `encrypt` / `decrypt` accept a `context` parameter even when the key has derivation disabled. `GetKey` then takes the non-derived fast path and silently ignores that context, so operators can believe they have per-context isolation while ciphertext still decrypts without (or with a different) context.

This PR emits a **response warning** when `context` is supplied on a non-derived key for encrypt/decrypt. Cryptographic behavior is unchanged (still ignore context; no hard fail), so existing clients keep working while the warning makes the footgun visible.

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.

### PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [x] If applicable, I've documented the impact of any changes to security controls.

Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.

**Revert:** Revert this PR; no migration or data change.
**Security-control impact:** Adds an operator-visible warning only. No new authz path, no change to encrypt/decrypt success criteria, no logging pipeline change.