### PR TITLE
Remove 40 dead CODEOWNERS rules

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,21 +18,15 @@
 
 # Secrets engines (pki, ssh, totp and transit omitted)
 /builtin/logical/aws/         @hashicorp/vault-ecosystem
-/builtin/logical/cassandra/   @hashicorp/vault-ecosystem
 /builtin/logical/consul/      @hashicorp/vault-ecosystem
 /builtin/logical/database/    @hashicorp/vault-ecosystem
-/builtin/logical/mongodb/     @hashicorp/vault-ecosystem
-/builtin/logical/mssql/       @hashicorp/vault-ecosystem
-/builtin/logical/mysql/       @hashicorp/vault-ecosystem
 /builtin/logical/nomad/       @hashicorp/vault-ecosystem
-/builtin/logical/postgresql/  @hashicorp/vault-ecosystem
 /builtin/logical/rabbitmq/    @hashicorp/vault-ecosystem
 
 # Identity Integrations (OIDC, tokens)
 /vault/identity_store_oidc*   @hashicorp/vault-ecosystem
 
 /plugins/                     @hashicorp/vault-ecosystem
-/vault/plugin_catalog.go      @hashicorp/vault-ecosystem
 
 # Content on developer.hashicorp.com
 # Web presence gets notified of, and can approve changes to web tooling, but not content.
@@ -41,15 +35,8 @@
 
 # Education gets notified of, and can approve changes to web content.
 # These more-specific patterns override the web-presence rule above for content subdirs.
-/website/data/          @hashicorp/vault-education-approvers
-/website/public/        @hashicorp/vault-education-approvers
-/website/content/       @hashicorp/vault-education-approvers
-/website/templates/     @hashicorp/vault-education-approvers
-/website/redirects.js   @hashicorp/vault-education-approvers
 
 # Plugin docs
-/website/content/docs/plugins/              @hashicorp/vault-ecosystem @hashicorp/vault-education-approvers
-/website/content/docs/upgrading/plugins.mdx @hashicorp/vault-ecosystem @hashicorp/vault-education-approvers
 
 # Automation/Quality engineering
 /.github/                         @hashicorp/team-vault-quality @hashicorp/team-vault-engineering-productivity-team
@@ -61,10 +48,6 @@
 # UI
 /.github/actions/build-ui/                  @hashicorp/vault-ui @hashicorp/vault-frontend
 /.github/actions/set-up-pnpm/               @hashicorp/vault-ui @hashicorp/vault-frontend
-/.github/workflows/gen-diff-spec/           @hashicorp/vault-ui @hashicorp/vault-frontend
-/.github/workflows/test-enos-scenarios-ui/  @hashicorp/vault-ui @hashicorp/vault-frontend
-/.github/workflows/test-ui/                 @hashicorp/vault-ui @hashicorp/vault-frontend
-/.github/workflows/ui-client-update/        @hashicorp/vault-ui @hashicorp/vault-frontend
 /ui/                                        @hashicorp/vault-ui @hashicorp/vault-frontend
 # UI code related to Vault's JWT/OIDC auth method and OIDC provider.
 # Changes to these files often require coordination with backend code,
@@ -74,9 +57,6 @@
 /ui/app/routes/vault/cluster/oidc-*.js   @hashicorp/vault-ui @hashicorp/vault-frontend @hashicorp/vault-ecosystem
 
 # AI assistant configuration
-/.bob/                            @hashicorp/vault
-/.opencode/                       @hashicorp/vault
-/opencode.json                    @hashicorp/vault
 /.github/copilot-instructions.md  @hashicorp/vault
 /.github/instructions/            @hashicorp/vault
 
@@ -84,18 +64,9 @@
 /api/auth/cert/                                      @hashicorp/vault-crypto
 /builtin/logical/pki/                                @hashicorp/vault-crypto
 /builtin/logical/pkiext/                             @hashicorp/vault-crypto
-/website/content/docs/secrets/pki/                   @hashicorp/vault-crypto @hashicorp/vault-education-approvers
-/website/content/api-docs/secret/pki/                @hashicorp/vault-crypto @hashicorp/vault-education-approvers
-/website/content/api-docs/secret/pki.mdx             @hashicorp/vault-crypto @hashicorp/vault-education-approvers
 /builtin/credential/cert/                            @hashicorp/vault-crypto
-/website/content/docs/auth/cert.mdx                  @hashicorp/vault-crypto @hashicorp/vault-education-approvers
-/website/content/api-docs/auth/cert.mdx              @hashicorp/vault-crypto @hashicorp/vault-education-approvers
 /builtin/logical/ssh/                                @hashicorp/vault-crypto
-/website/content/docs/secrets/ssh/                   @hashicorp/vault-crypto @hashicorp/vault-education-approvers
-/website/content/api-docs/secret/ssh.mdx             @hashicorp/vault-crypto @hashicorp/vault-education-approvers
 /builtin/logical/transit/                            @hashicorp/vault-crypto
-/website/content/docs/secrets/transit/               @hashicorp/vault-crypto @hashicorp/vault-education-approvers
-/website/content/api-docs/secret/transit.mdx         @hashicorp/vault-crypto @hashicorp/vault-education-approvers
 /helper/random/                                      @hashicorp/vault-crypto
 /sdk/helper/certutil/                                @hashicorp/vault-crypto
 /sdk/helper/cryptoutil/                              @hashicorp/vault-crypto
@@ -109,14 +80,3 @@
 /vault/managed_key*                                  @hashicorp/vault-crypto
 /vault/seal*                                         @hashicorp/vault-crypto
 /vault/seal/                                         @hashicorp/vault-crypto
-/website/content/docs/configuration/seal/            @hashicorp/vault-crypto @hashicorp/vault-education-approvers
-/website/content/docs/enterprise/sealwrap.mdx        @hashicorp/vault-crypto @hashicorp/vault-education-approvers
-/website/content/api-docs/system/sealwrap-rewrap.mdx @hashicorp/vault-crypto @hashicorp/vault-education-approvers
-/website/content/docs/secrets/transform/             @hashicorp/vault-crypto @hashicorp/vault-education-approvers
-/website/content/api-docs/secret/transform.mdx       @hashicorp/vault-crypto @hashicorp/vault-education-approvers
-/website/content/docs/secrets/kmip-profiles.mdx      @hashicorp/vault-crypto @hashicorp/vault-education-approvers
-/website/content/docs/secrets/kmip.mdx               @hashicorp/vault-crypto @hashicorp/vault-education-approvers
-/website/content/api-docs/secret/kmip.mdx            @hashicorp/vault-crypto @hashicorp/vault-education-approvers
-/website/content/docs/enterprise/fips/               @hashicorp/vault-crypto @hashicorp/vault-education-approvers
-/website/content/docs/platform/k8s                   @hashicorp/vault-ecosystem @hashicorp/vault-education-approvers
-/website/content/                                    @hashicorp/vault-customer-engineering @hashicorp/vault-education-approvers


### PR DESCRIPTION
### Description
Resolves 40 stale references in CODEOWNERS. The lines themselves were left unchanged while the paths they referenced disappeared from the tree.

```
# a stale line
sed -n '46p' .github/CODEOWNERS

# tracked files under the referenced paths
git ls-files -- 'website/' 'builtin/logical/cassandra/' | wc -l
```

I found this mismatch in your repo while analyzing public data with my tool: https://github.com/DanielSwift1992/gate. If you need more details, happy to share.

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch.
    - [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.

### PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.