### PR TITLE
Route statsd telemetry logs through Vault logger

### DIFF
--- a/command/agent.go
+++ b/command/agent.go
@@ -305,6 +305,7 @@ func (c *AgentCommand) Run(args []string) int {
 		DisplayName: "Vault",
 		UserAgent:   useragent.AgentString(),
 		ClusterName: config.ClusterName,
+		LogWriter:   c.logWriter,
 	})
 	if err != nil {
 		c.UI.Error(fmt.Sprintf("Error initializing telemetry: %s", err))

--- a/command/proxy.go
+++ b/command/proxy.go
@@ -280,6 +280,7 @@ func (c *ProxyCommand) Run(args []string) int {
 		DisplayName: "Vault",
 		UserAgent:   useragent.ProxyString(),
 		ClusterName: config.ClusterName,
+		LogWriter:   c.logWriter,
 	})
 	if err != nil {
 		c.UI.Error(fmt.Sprintf("Error initializing telemetry: %s", err))

--- a/command/server.go
+++ b/command/server.go
@@ -1272,6 +1272,10 @@ func (c *ServerCommand) Run(args []string) int {
 		DisplayName: "Vault",
 		UserAgent:   useragent.String(),
 		ClusterName: clusterName,
+		LogWriter: c.logger.StandardWriter(&hclog.StandardLoggerOptions{
+			InferLevels:              true,
+			InferLevelsWithTimestamp: true,
+		}),
 	})
 	if err != nil {
 		c.UI.Error(fmt.Sprintf("Error initializing telemetry: %s", err))

--- a/internalshared/configutil/telemetry.go
+++ b/internalshared/configutil/telemetry.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
+	"log"
 	"time"
 
 	monitoring "cloud.google.com/go/monitoring/apiv3"
@@ -280,6 +282,7 @@ type SetupTelemetryOpts struct {
 	DisplayName string
 	UserAgent   string
 	ClusterName string
+	LogWriter   io.Writer
 }
 
 // SetupTelemetry is used to setup the telemetry sub-systems and returns the
@@ -309,6 +312,10 @@ func SetupTelemetry(opts *SetupTelemetryOpts) (*metrics.InmemSink, *metricsutil.
 	metricsConf.EnableHostnameLabel = opts.Config.EnableHostnameLabel
 	if opts.Config.FilterDefault != nil {
 		metricsConf.FilterDefault = *opts.Config.FilterDefault
+	}
+	log.SetFlags(0)
+	if opts.LogWriter != nil {
+		log.SetOutput(opts.LogWriter)
 	}
 
 	// Configure the statsite sink

--- a/internalshared/configutil/telemetry_test.go
+++ b/internalshared/configutil/telemetry_test.go
@@ -4,6 +4,8 @@
 package configutil
 
 import (
+	"bytes"
+	"log"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -98,4 +100,33 @@ func TestNormalizeTelemetryAddresses(t *testing.T) {
 			require.EqualValues(t, tc.expected, tc.given)
 		})
 	}
+}
+
+func TestSetupTelemetryDisablesStandardLoggerFlags(t *testing.T) {
+	origFlags := log.Flags()
+	origWriter := log.Writer()
+	defer func() {
+		log.SetFlags(origFlags)
+		log.SetOutput(origWriter)
+	}()
+	log.SetFlags(log.LstdFlags)
+
+	_, _, _, err := SetupTelemetry(&SetupTelemetryOpts{
+		Config: &Telemetry{},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 0, log.Flags())
+}
+
+func TestSetupTelemetrySetsStandardLoggerOutput(t *testing.T) {
+	origWriter := log.Writer()
+	defer log.SetOutput(origWriter)
+
+	writer := &bytes.Buffer{}
+	_, _, _, err := SetupTelemetry(&SetupTelemetryOpts{
+		Config:    &Telemetry{},
+		LogWriter: writer,
+	})
+	require.NoError(t, err)
+	assert.Same(t, writer, log.Writer())
 }


### PR DESCRIPTION
Fix statsd/go-metrics telemetry error logs to use Vault's log/timestamp format

Problem

The statsd/go-metrics telemetry error path was emitting log lines in a non-Vault format on main, resulting in mixed log formats in the same output stream.

Before the fix:

2026-08-20 10:18:33.134229 I | [ERR] Error flushing to statsd! Err: ...
Normal Vault log:

2026-08-20T10:18:32.033-0500 [INFO]  core: Initializing version history cache for core
Fix

Route telemetry sink standard-library log output through Vault's logger-backed writer during telemetry setup, so statsd/statsite error lines are emitted using Vault's normal logging path.

Testing

Ran env -u AWS_ACCESS_KEY_ID -u AWS_SECRET_ACCESS_KEY -u AWS_SESSION_TOKEN -u AWS_SESSION_EXPIRATION go test ./internalshared/configutil

Reproduced the issue on main with statsd_address = "127.0.0.1:8125" and no listener on that port

Verified after the fix that statsd error lines use Vault-style formatting:

2026-08-20T13:21:53.558-0500 [ERROR] Error flushing to statsd! Err: ...
Fixes: VAULT-20733