### PR TITLE
storage/etcd: configure grpc keepalive timeouts to detect unresponsive members

### DIFF
--- a/changelog/32094.txt
+++ b/changelog/32094.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+storage/etcd: configure grpc keepalive timeouts to detect unresponsive etcd members
+```

--- a/physical/etcd/etcd3.go
+++ b/physical/etcd/etcd3.go
@@ -145,8 +145,8 @@ func newEtcd3Backend(conf map[string]string, logger log.Logger) (physical.Backen
 
 	sDialKeepaliveTimeout := conf["dial_keepalive_timeout"]
 	if sDialKeepaliveTimeout == "" {
-		// keeps detection inside the default 15s lock timeout.
-		sDialKeepaliveTimeout = "5s"
+		// keep unresponsive node detection window (dial_keepalive_time + dial_keepalive_timeout) inside the default 15s lock timeout.
+		sDialKeepaliveTimeout = "3s"
 	}
 	dialKeepaliveTimeout, err := parseutil.ParseDurationSecond(sDialKeepaliveTimeout)
 	if err != nil {

--- a/physical/etcd/etcd3.go
+++ b/physical/etcd/etcd3.go
@@ -132,6 +132,28 @@ func newEtcd3Backend(conf map[string]string, logger log.Logger) (physical.Backen
 		cfg.MaxCallSendMsgSize = int(val)
 	}
 
+	sDialKeepaliveTime := conf["dial_keepalive_time"]
+	if sDialKeepaliveTime == "" {
+		// minimum ping inteval permitted by grpc-go.
+		sDialKeepaliveTime = "10s"
+	}
+	dialKeepaliveTime, err := parseutil.ParseDurationSecond(sDialKeepaliveTime)
+	if err != nil {
+		return nil, fmt.Errorf("value [%v] of 'dial_keepalive_time' could not be understood: %w", sDialKeepaliveTime, err)
+	}
+	cfg.DialKeepAliveTime = dialKeepaliveTime
+
+	sDialKeepaliveTimeout := conf["dial_keepalive_timeout"]
+	if sDialKeepaliveTimeout == "" {
+		// keeps detection inside the default 15s lock timeout.
+		sDialKeepaliveTimeout = "5s"
+	}
+	dialKeepaliveTimeout, err := parseutil.ParseDurationSecond(sDialKeepaliveTimeout)
+	if err != nil {
+		return nil, fmt.Errorf("value [%v] of 'dial_keepalive_timeout' could not be understood: %w", sDialKeepaliveTimeout, err)
+	}
+	cfg.DialKeepAliveTimeout = dialKeepaliveTimeout
+
 	etcd, err := clientv3.New(cfg)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Add configurable gRPC keepalive timeouts to detect and cancel connection to unresponsive etcd members

Without these timeouts etcd client keeps waiting for an ACK from an unresponsive etcd node until kernel closes the connection.

This fixes vault downtime during long etcd defrags or non-graceful shutdown of etcd node.

Closes #32091,
see #23074, #4961, #9920

dialKeepaliveTime is a gRPC ping period
dialKeepaliveTimeout is an ACK deadline