### PR TITLE
cli: honor -no-print when token helper Store fails

### DIFF
--- a/command/login.go
+++ b/command/login.go
@@ -308,6 +308,12 @@ func (c *LoginCommand) Run(args []string) int {
 		// Store the token in the local client
 		if err := tokenHelper.Store(token); err != nil {
 			c.UI.Error(fmt.Sprintf("Error storing token: %s", err))
+			if c.flagNoPrint {
+				// -no-print exists specifically so the token never hits stdout
+				// (CI logs, Cloud Logging). Do not dump the secret as a
+				// consolation prize when persistence fails (#32089).
+				return 2
+			}
 			c.UI.Error(wrapAtLength(
 				"Authentication was successful, but the token was not persisted. The "+
 					"resulting token is shown below for your records.") + "\n")

--- a/command/login_test.go
+++ b/command/login_test.go
@@ -5,6 +5,7 @@ package command
 
 import (
 	"context"
+	"errors"
 	"os"
 	"regexp"
 	"strings"
@@ -95,6 +96,53 @@ func TestCustomPath(t *testing.T) {
 
 	if l, exp := len(storedToken), minTokenLengthExternal+vault.TokenPrefixLength; l < exp {
 		t.Errorf("expected token to be %d characters, was %d: %q", exp, l, storedToken)
+	}
+}
+
+type failStoreHelper struct {
+	*token.TestingTokenHelper
+}
+
+func (f *failStoreHelper) Store(string) error {
+	return errors.New("permission denied")
+}
+
+func TestNoPrintDoesNotDumpTokenWhenStoreFails(t *testing.T) {
+	t.Parallel()
+
+	client, closer := testVaultServer(t)
+	defer closer()
+
+	if err := client.Sys().EnableAuth("userpass-noprint", "userpass", ""); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.Logical().Write("auth/userpass-noprint/users/test", map[string]interface{}{
+		"password": "test",
+		"policies": "default",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	ui, cmd := testLoginCommand(t)
+	cmd.client = client
+	cmd.tokenHelper = &failStoreHelper{TestingTokenHelper: token.NewTestingTokenHelper()}
+
+	code := cmd.Run([]string{
+		"-no-print",
+		"-method", "userpass",
+		"-path", "userpass-noprint",
+		"username=test",
+		"password=test",
+	})
+	if exp := 2; code != exp {
+		t.Errorf("expected %d, got %d", exp, code)
+	}
+	combined := ui.OutputWriter.String() + ui.ErrorWriter.String()
+	if strings.Contains(combined, "token") && strings.Contains(combined, "hvs.") {
+		t.Fatalf("token leaked to UI despite -no-print: %q", combined)
+	}
+	if !strings.Contains(combined, "permission denied") {
+		t.Fatalf("expected store error, got %q", combined)
 	}
 }
 


### PR DESCRIPTION
If `vault login` succeeds but the token helper cannot persist the token (for example the home directory is not writable in CI), the CLI printed the full secret "for your records" even with `-no-print`. That leaked the token into Cloud Logging.

On a Store failure, `-no-print` now returns without dumping the secret.

Fixes #32089