### PR TITLE
Password policy consecutive chars

### DIFF
--- a/changelog/32111.txt
+++ b/changelog/32111.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+core/password-policies: Add an optional top-level `consecutive-chars-allowed` setting to password policies. When set to `false`, generated passwords will not contain the same character in adjacent positions. Defaults to `true`.
+```

--- a/helper/random/parser.go
+++ b/helper/random/parser.go
@@ -106,8 +106,9 @@ func (p PolicyParser) ParsePolicy(raw string) (sg StringGenerator, err error) {
 	}
 
 	gen = StringGenerator{
-		Length: gen.Length,
-		Rules:  rules,
+		Length:                  gen.Length,
+		Rules:                   rules,
+		ConsecutiveCharsAllowed: gen.ConsecutiveCharsAllowed,
 	}
 
 	err = gen.validateConfig()

--- a/helper/random/parser_test.go
+++ b/helper/random/parser_test.go
@@ -250,6 +250,21 @@ func TestParser_ParsePolicy(t *testing.T) {
 			expected:  StringGenerator{},
 			expectErr: true,
 		},
+		"consecutive chars disallowed with single character rule over half the length": {
+			registry: defaultRuleNameMapping,
+			rawConfig: `
+				length = 4
+				consecutive-chars-allowed = false
+				rule "charset" {
+					charset = "a"
+					min-chars = 3
+				}
+				rule "charset" {
+					charset = "b"
+				}`,
+			expected:  StringGenerator{},
+			expectErr: true,
+		},
 		"consecutive chars not a bool": {
 			registry: defaultRuleNameMapping,
 			rawConfig: `

--- a/helper/random/parser_test.go
+++ b/helper/random/parser_test.go
@@ -199,6 +199,68 @@ func TestParser_ParsePolicy(t *testing.T) {
 			expected:  StringGenerator{},
 			expectErr: true,
 		},
+		"consecutive chars explicitly allowed": {
+			registry: defaultRuleNameMapping,
+			rawConfig: `
+				length = 20
+				consecutive-chars-allowed = true
+				rule "charset" {
+					charset = "abcde"
+				}`,
+			expected: StringGenerator{
+				Length:                  20,
+				ConsecutiveCharsAllowed: boolPtr(true),
+				charset:                 []rune("abcde"),
+				Rules: []Rule{
+					CharsetRule{
+						Charset: []rune("abcde"),
+					},
+				},
+			},
+			expectErr: false,
+		},
+		"consecutive chars disallowed": {
+			registry: defaultRuleNameMapping,
+			rawConfig: `
+				length = 20
+				consecutive-chars-allowed = false
+				rule "charset" {
+					charset = "abcde"
+				}`,
+			expected: StringGenerator{
+				Length:                  20,
+				ConsecutiveCharsAllowed: boolPtr(false),
+				charset:                 []rune("abcde"),
+				Rules: []Rule{
+					CharsetRule{
+						Charset: []rune("abcde"),
+					},
+				},
+			},
+			expectErr: false,
+		},
+		"consecutive chars disallowed with single character": {
+			registry: defaultRuleNameMapping,
+			rawConfig: `
+				length = 20
+				consecutive-chars-allowed = false
+				rule "charset" {
+					charset = "a"
+				}`,
+			expected:  StringGenerator{},
+			expectErr: true,
+		},
+		"consecutive chars not a bool": {
+			registry: defaultRuleNameMapping,
+			rawConfig: `
+				length = 20
+				consecutive-chars-allowed = "nope"
+				rule "charset" {
+					charset = "abcde"
+				}`,
+			expected:  StringGenerator{},
+			expectErr: true,
+		},
 
 		// /////////////////////////////////////////////////
 		// JSON data
@@ -275,6 +337,29 @@ func TestParser_ParsePolicy(t *testing.T) {
 					CharsetRule{
 						Charset:  []rune("abcde"),
 						MinChars: 2,
+					},
+				},
+			},
+			expectErr: false,
+		},
+		"JSONified HCL with consecutive chars disallowed": {
+			registry: defaultRuleNameMapping,
+			rawConfig: toJSON(t, StringGenerator{
+				Length:                  20,
+				ConsecutiveCharsAllowed: boolPtr(false),
+				Rules: []Rule{
+					CharsetRule{
+						Charset: []rune("abcde"),
+					},
+				},
+			}),
+			expected: StringGenerator{
+				Length:                  20,
+				ConsecutiveCharsAllowed: boolPtr(false),
+				charset:                 []rune("abcde"),
+				Rules: []Rule{
+					CharsetRule{
+						Charset: []rune("abcde"),
 					},
 				},
 			},
@@ -587,4 +672,8 @@ func toJSON(t *testing.T, val interface{}) string {
 		t.Fatalf("unable to marshal to JSON: %s", err)
 	}
 	return string(b)
+}
+
+func boolPtr(b bool) *bool {
+	return &b
 }

--- a/helper/random/string_generator.go
+++ b/helper/random/string_generator.go
@@ -80,8 +80,7 @@ type StringGenerator struct {
 	Rules serializableRules `mapstructure:"-" json:"rule"` // This is "rule" in JSON so it matches the HCL property type
 
 	// ConsecutiveCharsAllowed controls whether the same character may appear in adjacent positions. The comparison is
-	// exact, so when this is false "aa" is rejected but "aA" is not. A nil value means true so that generators
-	// constructed directly (rather than parsed from HCL) keep the historical behavior.
+	// exact, so when this is false "aa" is rejected but "aA" is not. A nil value is treated as true.
 	ConsecutiveCharsAllowed *bool `mapstructure:"consecutive-chars-allowed" json:"consecutive-chars-allowed,omitempty"`
 
 	// CharsetRule to choose runes from. This is computed from the rules, not directly configurable
@@ -134,8 +133,6 @@ func (g *StringGenerator) generate(rng io.Reader) (str string, err error) {
 	if g.AllowsConsecutiveChars() {
 		candidate, err = randomRunes(rng, charset, g.Length)
 	} else {
-		// Built so that no two adjacent runes are identical, rather than drawing a full candidate and rejecting it.
-		// Rejection would time out on small charsets where almost every candidate contains a repeat.
 		candidate, err = randomRunesNoConsecutive(rng, charset, g.Length)
 	}
 	if err != nil {
@@ -339,8 +336,8 @@ func (g *StringGenerator) validateConfig() (err error) {
 		}
 	}
 
-	// A charset with a single character can never produce a string longer than 1 without repeating that character.
-	// The charset is already de-duplicated by getChars. Anything more subtle than this is left to the generation timeout.
+	// A single-character charset cannot produce a string longer than 1 without repeating that character. The charset
+	// has already been de-duplicated by getChars.
 	if !g.AllowsConsecutiveChars() && g.Length > 1 && len(g.charset) == 1 {
 		merr = multierror.Append(merr, fmt.Errorf("consecutive characters are not allowed but the charset contains only one character"))
 	}

--- a/helper/random/string_generator.go
+++ b/helper/random/string_generator.go
@@ -79,6 +79,11 @@ type StringGenerator struct {
 	// Rules the generated strings must adhere to.
 	Rules serializableRules `mapstructure:"-" json:"rule"` // This is "rule" in JSON so it matches the HCL property type
 
+	// ConsecutiveCharsAllowed controls whether the same character may appear in adjacent positions. The comparison is
+	// exact, so when this is false "aa" is rejected but "aA" is not. A nil value means true so that generators
+	// constructed directly (rather than parsed from HCL) keep the historical behavior.
+	ConsecutiveCharsAllowed *bool `mapstructure:"consecutive-chars-allowed" json:"consecutive-chars-allowed,omitempty"`
+
 	// CharsetRule to choose runes from. This is computed from the rules, not directly configurable
 	charset     runes
 	charsetLock sync.RWMutex
@@ -135,8 +140,27 @@ func (g *StringGenerator) generate(rng io.Reader) (str string, err error) {
 		}
 	}
 
+	if !g.AllowsConsecutiveChars() && hasConsecutiveChars(candidate) {
+		return "", nil
+	}
+
 	// Passed all rules
 	return string(candidate), nil
+}
+
+// AllowsConsecutiveChars returns the effective value of ConsecutiveCharsAllowed, defaulting to true when unset.
+func (g *StringGenerator) AllowsConsecutiveChars() bool {
+	return g.ConsecutiveCharsAllowed == nil || *g.ConsecutiveCharsAllowed
+}
+
+// hasConsecutiveChars returns true if any two adjacent runes are identical.
+func hasConsecutiveChars(value []rune) bool {
+	for i := 1; i < len(value); i++ {
+		if value[i] == value[i-1] {
+			return true
+		}
+	}
+	return false
 }
 
 const (
@@ -253,6 +277,12 @@ func (g *StringGenerator) validateConfig() (err error) {
 				break
 			}
 		}
+	}
+
+	// A charset with a single character can never produce a string longer than 1 without repeating that character.
+	// The charset is already de-duplicated by getChars. Anything more subtle than this is left to the generation timeout.
+	if !g.AllowsConsecutiveChars() && g.Length > 1 && len(g.charset) == 1 {
+		merr = multierror.Append(merr, fmt.Errorf("consecutive characters are not allowed but the charset contains only one character"))
 	}
 	return merr.ErrorOrNil()
 }

--- a/helper/random/string_generator.go
+++ b/helper/random/string_generator.go
@@ -336,12 +336,42 @@ func (g *StringGenerator) validateConfig() (err error) {
 		}
 	}
 
-	// A single-character charset cannot produce a string longer than 1 without repeating that character. The charset
-	// has already been de-duplicated by getChars.
-	if !g.AllowsConsecutiveChars() && g.Length > 1 && len(g.charset) == 1 {
-		merr = multierror.Append(merr, fmt.Errorf("consecutive characters are not allowed but the charset contains only one character"))
+	if !g.AllowsConsecutiveChars() && g.Length > 1 {
+		// A single-character charset cannot produce a string longer than 1 without repeating that character. The
+		// charset has already been de-duplicated by getChars.
+		if len(g.charset) == 1 {
+			merr = multierror.Append(merr, fmt.Errorf("consecutive characters are not allowed but the charset contains only one character"))
+		}
+
+		// A character that cannot be adjacent to itself fits in at most every other position, so a rule whose charset
+		// is a single character cannot require more than ceil(length / 2) of it.
+		maxSingleChar := (g.Length + 1) / 2
+		for _, r := range g.Rules {
+			if minChars, chars, ok := singleCharRequirement(r); ok && minChars > maxSingleChar {
+				merr = multierror.Append(merr, fmt.Errorf("consecutive characters are not allowed but rule requires %d of %q in %d characters (maximum %d)", minChars, string(chars), g.Length, maxSingleChar))
+			}
+		}
 	}
 	return merr.ErrorOrNil()
+}
+
+// singleCharRequirement returns the minimum count and charset of a rule whose charset is a single character, using the
+// optional interfaces `MinLength() int` and `Chars() []rune`. ok is false for any other rule.
+func singleCharRequirement(rule Rule) (minChars int, chars []rune, ok bool) {
+	type singleCharProvider interface {
+		MinLength() int
+		Chars() []rune
+	}
+
+	scp, isProvider := rule.(singleCharProvider)
+	if !isProvider {
+		return 0, nil, false
+	}
+	chars = deduplicateRunes(scp.Chars())
+	if len(chars) != 1 {
+		return 0, nil, false
+	}
+	return scp.MinLength(), chars, true
 }
 
 // getMinLength from the rules using the optional interface: `MinLength() int`

--- a/helper/random/string_generator.go
+++ b/helper/random/string_generator.go
@@ -129,7 +129,15 @@ func (g *StringGenerator) generate(rng io.Reader) (str string, err error) {
 	g.charsetLock.RLock()
 	charset := g.charset
 	g.charsetLock.RUnlock()
-	candidate, err := randomRunes(rng, charset, g.Length)
+
+	var candidate []rune
+	if g.AllowsConsecutiveChars() {
+		candidate, err = randomRunes(rng, charset, g.Length)
+	} else {
+		// Built so that no two adjacent runes are identical, rather than drawing a full candidate and rejecting it.
+		// Rejection would time out on small charsets where almost every candidate contains a repeat.
+		candidate, err = randomRunesNoConsecutive(rng, charset, g.Length)
+	}
 	if err != nil {
 		return "", fmt.Errorf("unable to generate random characters: %w", err)
 	}
@@ -140,10 +148,6 @@ func (g *StringGenerator) generate(rng io.Reader) (str string, err error) {
 		}
 	}
 
-	if !g.AllowsConsecutiveChars() && hasConsecutiveChars(candidate) {
-		return "", nil
-	}
-
 	// Passed all rules
 	return string(candidate), nil
 }
@@ -151,16 +155,6 @@ func (g *StringGenerator) generate(rng io.Reader) (str string, err error) {
 // AllowsConsecutiveChars returns the effective value of ConsecutiveCharsAllowed, defaulting to true when unset.
 func (g *StringGenerator) AllowsConsecutiveChars() bool {
 	return g.ConsecutiveCharsAllowed == nil || *g.ConsecutiveCharsAllowed
-}
-
-// hasConsecutiveChars returns true if any two adjacent runes are identical.
-func hasConsecutiveChars(value []rune) bool {
-	for i := 1; i < len(value); i++ {
-		if value[i] == value[i-1] {
-			return true
-		}
-	}
-	return false
 }
 
 const (
@@ -173,14 +167,80 @@ const (
 // could be expanded if needed. Expanding the maximum charset size will decrease performance because it will need to
 // combine bytes into a larger integer using binary.BigEndian.Uint16() function.
 func randomRunes(rng io.Reader, charset []rune, length int) (candidate []rune, err error) {
+	if err := validateCharsetAndLength(charset, length); err != nil {
+		return nil, err
+	}
+
+	indexes, err := randomIndexes(rng, len(charset), length)
+	if err != nil {
+		return nil, err
+	}
+
+	candidate = make([]rune, length)
+	for i, index := range indexes {
+		candidate[i] = charset[index]
+	}
+	return candidate, nil
+}
+
+// randomRunesNoConsecutive creates a random string based on the provided charset where no two adjacent runes are
+// identical. The first rune is chosen uniformly from the whole charset. Every later rune is chosen uniformly from the
+// charset with the previous rune removed: an index is drawn from [0, len(charset)-1) and shifted up by one if it lands
+// on or after the previous index, so each of the remaining runes is equally likely. The comparison is exact, so a
+// charset containing both "a" and "A" may produce "aA".
+func randomRunesNoConsecutive(rng io.Reader, charset []rune, length int) (candidate []rune, err error) {
+	if err := validateCharsetAndLength(charset, length); err != nil {
+		return nil, err
+	}
+	if length == 1 {
+		return randomRunes(rng, charset, length)
+	}
+	if len(charset) < 2 {
+		return nil, fmt.Errorf("charset must contain at least 2 characters when consecutive characters are not allowed")
+	}
+
+	first, err := randomIndexes(rng, len(charset), 1)
+	if err != nil {
+		return nil, err
+	}
+	rest, err := randomIndexes(rng, len(charset)-1, length-1)
+	if err != nil {
+		return nil, err
+	}
+
+	candidate = make([]rune, 0, length)
+	prev := first[0]
+	candidate = append(candidate, charset[prev])
+	for _, index := range rest {
+		if index >= prev {
+			index++
+		}
+		candidate = append(candidate, charset[index])
+		prev = index
+	}
+	return candidate, nil
+}
+
+func validateCharsetAndLength(charset []rune, length int) error {
 	if len(charset) == 0 {
-		return nil, fmt.Errorf("no charset specified")
+		return fmt.Errorf("no charset specified")
 	}
 	if len(charset) > maxCharsetLen {
-		return nil, fmt.Errorf("charset is too long: limited to %d characters", math.MaxUint8)
+		return fmt.Errorf("charset is too long: limited to %d characters", math.MaxUint8)
 	}
 	if length <= 0 {
-		return nil, fmt.Errorf("unable to generate a zero or negative length runeset")
+		return fmt.Errorf("unable to generate a zero or negative length runeset")
+	}
+	return nil
+}
+
+// randomIndexes draws count indexes uniformly from [0, n) using the provided RNG. n must be in [1, maxCharsetLen].
+func randomIndexes(rng io.Reader, n int, count int) (indexes []int, err error) {
+	if n <= 0 || n > maxCharsetLen {
+		return nil, fmt.Errorf("index range must be between 1 and %d", maxCharsetLen)
+	}
+	if count < 0 {
+		return nil, fmt.Errorf("unable to generate a negative number of indexes")
 	}
 
 	// This can't always select indexes from [0-maxCharsetLen) because it could introduce bias to the character selection.
@@ -196,7 +256,7 @@ func randomRunes(rng io.Reader, charset []rune, length int) (candidate []rune, e
 	//   Trunc(4.06) => 4
 	// Multiply by the charset length
 	// Subtract 1 to account for 0-based counting and you get the max index value: 251
-	maxAllowedRNGValue := (maxCharsetLen/len(charset))*len(charset) - 1
+	maxAllowedRNGValue := (maxCharsetLen/n)*n - 1
 
 	// rngBufferMultiplier increases the size of the RNG buffer to account for lost
 	// indexes due to the maxAllowedRNGValue
@@ -213,19 +273,20 @@ func randomRunes(rng io.Reader, charset []rune, length int) (candidate []rune, e
 		rng = rand.Reader
 	}
 
-	charsetLen := byte(len(charset))
+	// n == maxCharsetLen overflows a byte, which is why the modulo below is skipped in that case
+	nByte := byte(n)
 
-	runes := make([]rune, 0, length)
+	indexes = make([]int, 0, count)
 
-	for len(runes) < length {
+	for len(indexes) < count {
 		// Generate a bunch of indexes
-		data := make([]byte, int(float64(length)*rngBufferMultiplier))
+		data := make([]byte, int(float64(count)*rngBufferMultiplier))
 		numBytes, err := rng.Read(data)
 		if err != nil {
 			return nil, err
 		}
 
-		// Append characters until either we're out of indexes or the length is long enough
+		// Append indexes until either we're out of bytes or we have enough
 		for i := 0; i < numBytes; i++ {
 			// Be careful to ensure that maxAllowedRNGValue isn't >= 256 as it will overflow and this
 			// comparison will prevent characters from being selected from the charset
@@ -234,19 +295,18 @@ func randomRunes(rng io.Reader, charset []rune, length int) (candidate []rune, e
 			}
 
 			index := data[i]
-			if len(charset) != maxCharsetLen {
-				index = index % charsetLen
+			if n != maxCharsetLen {
+				index = index % nByte
 			}
-			r := charset[index]
-			runes = append(runes, r)
+			indexes = append(indexes, int(index))
 
-			if len(runes) == length {
+			if len(indexes) == count {
 				break
 			}
 		}
 	}
 
-	return runes, nil
+	return indexes, nil
 }
 
 // validateConfig of the generator to ensure that we can successfully generate a string.

--- a/helper/random/string_generator_test.go
+++ b/helper/random/string_generator_test.go
@@ -105,6 +105,128 @@ func TestStringGenerator_Generate_successful(t *testing.T) {
 	}
 }
 
+func TestStringGenerator_Generate_consecutiveChars(t *testing.T) {
+	type testCase struct {
+		generator *StringGenerator
+	}
+
+	// A small charset makes adjacent repeats very likely, so if the restriction wasn't being enforced these tests
+	// would fail almost immediately.
+	tests := map[string]testCase{
+		"disallowed": {
+			generator: &StringGenerator{
+				Length:                  20,
+				ConsecutiveCharsAllowed: boolPtr(false),
+				Rules: []Rule{
+					CharsetRule{
+						Charset: []rune("aAbBcC"),
+					},
+				},
+			},
+		},
+		"disallowed with charset rules": {
+			generator: &StringGenerator{
+				Length:                  20,
+				ConsecutiveCharsAllowed: boolPtr(false),
+				Rules: []Rule{
+					CharsetRule{
+						Charset:  []rune("abc"),
+						MinChars: 3,
+					},
+					CharsetRule{
+						Charset:  []rune("ABC"),
+						MinChars: 3,
+					},
+					CharsetRule{
+						Charset:  []rune("123"),
+						MinChars: 3,
+					},
+				},
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+
+			for i := 0; i < 100; i++ {
+				actual, err := test.generator.Generate(ctx, nil)
+				if err != nil {
+					t.Fatalf("no error expected, but got: %s", err)
+				}
+				if len([]rune(actual)) != test.generator.Length {
+					t.Fatalf("expected length %d, got %d: %q", test.generator.Length, len([]rune(actual)), actual)
+				}
+				if hasConsecutiveChars([]rune(actual)) {
+					t.Fatalf("generated string contains consecutive characters: %q", actual)
+				}
+				for _, rule := range test.generator.Rules {
+					if !rule.Pass([]rune(actual)) {
+						t.Fatalf("generated string failed rule %s: %q", rule.Type(), actual)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestStringGenerator_Generate_consecutiveCharsAllowedByDefault(t *testing.T) {
+	// With a single-character charset every generated string necessarily repeats that character, which proves the
+	// restriction is off unless explicitly disabled.
+	gen := &StringGenerator{
+		Length: 5,
+		Rules: []Rule{
+			CharsetRule{
+				Charset: []rune("a"),
+			},
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	actual, err := gen.Generate(ctx, nil)
+	if err != nil {
+		t.Fatalf("no error expected, but got: %s", err)
+	}
+	if actual != "aaaaa" {
+		t.Fatalf("expected %q, got %q", "aaaaa", actual)
+	}
+}
+
+func TestHasConsecutiveChars(t *testing.T) {
+	tests := map[string]struct {
+		value    string
+		expected bool
+	}{
+		"empty":                     {value: "", expected: false},
+		"single char":               {value: "a", expected: false},
+		"no repeats":                {value: "abcdef", expected: false},
+		"repeat separated":          {value: "aba", expected: false},
+		"lowercase repeat":          {value: "abccd", expected: true},
+		"uppercase repeat":          {value: "ABBC", expected: true},
+		"different case is allowed": {value: "abaAd", expected: false},
+		"repeat at start":           {value: "aab", expected: true},
+		"repeat at end":             {value: "baa", expected: true},
+		"digit repeat":              {value: "a11b", expected: true},
+		"symbol repeat":             {value: "a--b", expected: true},
+		"accented char is distinct": {value: "aá", expected: false},
+		"non-ascii repeat":          {value: "éé", expected: true},
+		"non-ascii different case":  {value: "éÉ", expected: false},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			actual := hasConsecutiveChars([]rune(test.value))
+			if actual != test.expected {
+				t.Fatalf("hasConsecutiveChars(%q) = %t, expected %t", test.value, actual, test.expected)
+			}
+		})
+	}
+}
+
 func TestStringGenerator_Generate_errors(t *testing.T) {
 	type testCase struct {
 		timeout   time.Duration
@@ -619,6 +741,46 @@ func TestValidate(t *testing.T) {
 				},
 			},
 			expectErr: true,
+		},
+		"consecutive chars disallowed with single character": {
+			generator: &StringGenerator{
+				Length:                  5,
+				ConsecutiveCharsAllowed: boolPtr(false),
+				charset:                 []rune("a"),
+			},
+			expectErr: true,
+		},
+		"consecutive chars disallowed with same letter in both cases": {
+			generator: &StringGenerator{
+				Length:                  5,
+				ConsecutiveCharsAllowed: boolPtr(false),
+				charset:                 []rune("aA"),
+			},
+			expectErr: false,
+		},
+		"consecutive chars disallowed with single character and length 1": {
+			generator: &StringGenerator{
+				Length:                  1,
+				ConsecutiveCharsAllowed: boolPtr(false),
+				charset:                 []rune("a"),
+			},
+			expectErr: false,
+		},
+		"consecutive chars disallowed with multiple characters": {
+			generator: &StringGenerator{
+				Length:                  5,
+				ConsecutiveCharsAllowed: boolPtr(false),
+				charset:                 []rune("ab"),
+			},
+			expectErr: false,
+		},
+		"consecutive chars allowed with single character": {
+			generator: &StringGenerator{
+				Length:                  5,
+				ConsecutiveCharsAllowed: boolPtr(true),
+				charset:                 []rune("a"),
+			},
+			expectErr: false,
 		},
 	}
 

--- a/helper/random/string_generator_test.go
+++ b/helper/random/string_generator_test.go
@@ -13,6 +13,7 @@ import (
 	MRAND "math/rand"
 	"reflect"
 	"sort"
+	"strings"
 	"testing"
 	"time"
 )
@@ -108,12 +109,49 @@ func TestStringGenerator_Generate_successful(t *testing.T) {
 func TestStringGenerator_Generate_consecutiveChars(t *testing.T) {
 	type testCase struct {
 		generator *StringGenerator
+		// mustContain is a substring that every generated string must include. Empty means no requirement.
+		mustContain string
 	}
 
-	// A small charset makes adjacent repeats very likely, so if the restriction wasn't being enforced these tests
-	// would fail almost immediately.
+	// Every case runs under a short budget. With rejection sampling the two-character charsets would time out, since
+	// almost every random candidate contains an adjacent repeat, so this also proves the string is built constructively.
 	tests := map[string]testCase{
-		"disallowed": {
+		"two character charset": {
+			generator: &StringGenerator{
+				Length:                  20,
+				ConsecutiveCharsAllowed: boolPtr(false),
+				Rules: []Rule{
+					CharsetRule{
+						Charset: []rune("ab"),
+					},
+				},
+			},
+		},
+		"two character charset long": {
+			generator: &StringGenerator{
+				Length:                  100,
+				ConsecutiveCharsAllowed: boolPtr(false),
+				Rules: []Rule{
+					CharsetRule{
+						Charset: []rune("ab"),
+					},
+				},
+			},
+		},
+		"same letter in both cases": {
+			// The comparison is exact, so "aA" is legal. With only these two characters the string must alternate.
+			generator: &StringGenerator{
+				Length:                  20,
+				ConsecutiveCharsAllowed: boolPtr(false),
+				Rules: []Rule{
+					CharsetRule{
+						Charset: []rune("aA"),
+					},
+				},
+			},
+			mustContain: "aA",
+		},
+		"mixed charset": {
 			generator: &StringGenerator{
 				Length:                  20,
 				ConsecutiveCharsAllowed: boolPtr(false),
@@ -124,7 +162,7 @@ func TestStringGenerator_Generate_consecutiveChars(t *testing.T) {
 				},
 			},
 		},
-		"disallowed with charset rules": {
+		"with charset rules": {
 			generator: &StringGenerator{
 				Length:                  20,
 				ConsecutiveCharsAllowed: boolPtr(false),
@@ -148,7 +186,7 @@ func TestStringGenerator_Generate_consecutiveChars(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 			defer cancel()
 
 			for i := 0; i < 100; i++ {
@@ -162,6 +200,9 @@ func TestStringGenerator_Generate_consecutiveChars(t *testing.T) {
 				if hasConsecutiveChars([]rune(actual)) {
 					t.Fatalf("generated string contains consecutive characters: %q", actual)
 				}
+				if test.mustContain != "" && !strings.Contains(actual, test.mustContain) {
+					t.Fatalf("generated string %q does not contain %q", actual, test.mustContain)
+				}
 				for _, rule := range test.generator.Rules {
 					if !rule.Pass([]rune(actual)) {
 						t.Fatalf("generated string failed rule %s: %q", rule.Type(), actual)
@@ -170,6 +211,162 @@ func TestStringGenerator_Generate_consecutiveChars(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRandomRunesNoConsecutive_successful(t *testing.T) {
+	type testCase struct {
+		charset []rune // Assumes no duplicate runes
+		length  int
+	}
+
+	tests := map[string]testCase{
+		"two characters": {
+			charset: []rune("ab"),
+			length:  20,
+		},
+		"small charset": {
+			charset: []rune("abcde"),
+			length:  20,
+		},
+		"common charset": {
+			charset: AlphaNumericShortSymbolRuneset,
+			length:  20,
+		},
+		"length 1 with single character": {
+			charset: []rune("a"),
+			length:  1,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			runeset := map[rune]bool{}
+			runesFound := []rune{}
+
+			for i := 0; i < 10000; i++ {
+				actual, err := randomRunesNoConsecutive(rand.Reader, test.charset, test.length)
+				if err != nil {
+					t.Fatalf("no error expected, but got: %s", err)
+				}
+				if len(actual) != test.length {
+					t.Fatalf("expected length %d, got %d: %q", test.length, len(actual), string(actual))
+				}
+				if hasConsecutiveChars(actual) {
+					t.Fatalf("string contains consecutive characters: %q", string(actual))
+				}
+				for _, r := range actual {
+					if runeset[r] {
+						continue
+					}
+					runeset[r] = true
+					runesFound = append(runesFound, r)
+				}
+			}
+
+			sort.Sort(runes(runesFound))
+
+			// Sort the input too just to ensure that they can be compared
+			sort.Sort(runes(test.charset))
+
+			// Every rune must be reachable, including the last one which is only selected via the index shift
+			if !reflect.DeepEqual(runesFound, test.charset) {
+				t.Fatalf("Didn't find all characters from the charset\nActual  : [%s]\nExpected: [%s]", string(runesFound), string(test.charset))
+			}
+		})
+	}
+}
+
+func TestRandomRunesNoConsecutive_deterministic(t *testing.T) {
+	// Pins the index shift: with charset "ab" every string must strictly alternate, and with a larger charset the
+	// seeded output proves the shifted index is applied relative to the previous rune.
+	type testCase struct {
+		rngSeed  int64
+		charset  string
+		length   int
+		expected string
+	}
+
+	tests := map[string]testCase{
+		"two characters": {
+			rngSeed:  1585593298447807000,
+			charset:  "ab",
+			length:   10,
+			expected: "babababababa"[:10],
+		},
+		"small charset": {
+			rngSeed:  1585593298447807000,
+			charset:  "abcde",
+			length:   20,
+			expected: "dadaebadbdbdaebdcecb",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			rng := MRAND.New(MRAND.NewSource(test.rngSeed))
+			actual, err := randomRunesNoConsecutive(rng, []rune(test.charset), test.length)
+			if err != nil {
+				t.Fatalf("Expected no error, but found: %s", err)
+			}
+			if string(actual) != test.expected {
+				t.Fatalf("Actual: %s  Expected: %s", string(actual), test.expected)
+			}
+		})
+	}
+}
+
+func TestRandomRunesNoConsecutive_errors(t *testing.T) {
+	type testCase struct {
+		charset []rune
+		length  int
+		rng     io.Reader
+	}
+
+	tests := map[string]testCase{
+		"nil charset": {
+			charset: nil,
+			length:  20,
+			rng:     rand.Reader,
+		},
+		"single character with length > 1": {
+			charset: []rune("a"),
+			length:  2,
+			rng:     rand.Reader,
+		},
+		"zero length": {
+			charset: []rune("ab"),
+			length:  0,
+			rng:     rand.Reader,
+		},
+		"bad RNG reader": {
+			charset: []rune("ab"),
+			length:  20,
+			rng:     badReader{},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			actual, err := randomRunesNoConsecutive(test.rng, test.charset, test.length)
+			if err == nil {
+				t.Fatalf("Expected error but none found")
+			}
+			if actual != nil {
+				t.Fatalf("Expected nil result but found: %q", string(actual))
+			}
+		})
+	}
+}
+
+// hasConsecutiveChars returns true if any two adjacent runes are identical. Test helper only: production code builds
+// strings so that this can never be true rather than checking after the fact.
+func hasConsecutiveChars(value []rune) bool {
+	for i := 1; i < len(value); i++ {
+		if value[i] == value[i-1] {
+			return true
+		}
+	}
+	return false
 }
 
 func TestStringGenerator_Generate_consecutiveCharsAllowedByDefault(t *testing.T) {

--- a/helper/random/string_generator_test.go
+++ b/helper/random/string_generator_test.go
@@ -113,8 +113,8 @@ func TestStringGenerator_Generate_consecutiveChars(t *testing.T) {
 		mustContain string
 	}
 
-	// Every case runs under a short budget. With rejection sampling the two-character charsets would time out, since
-	// almost every random candidate contains an adjacent repeat, so this also proves the string is built constructively.
+	// Two-character charsets have exactly one legal rune at every position after the first, so running them under a
+	// short budget proves generation does not rely on retries.
 	tests := map[string]testCase{
 		"two character charset": {
 			generator: &StringGenerator{
@@ -358,8 +358,7 @@ func TestRandomRunesNoConsecutive_errors(t *testing.T) {
 	}
 }
 
-// hasConsecutiveChars returns true if any two adjacent runes are identical. Test helper only: production code builds
-// strings so that this can never be true rather than checking after the fact.
+// hasConsecutiveChars returns true if any two adjacent runes are identical.
 func hasConsecutiveChars(value []rune) bool {
 	for i := 1; i < len(value); i++ {
 		if value[i] == value[i-1] {

--- a/helper/random/string_generator_test.go
+++ b/helper/random/string_generator_test.go
@@ -978,6 +978,105 @@ func TestValidate(t *testing.T) {
 			},
 			expectErr: false,
 		},
+		"consecutive chars disallowed with single character rule over half the length": {
+			generator: &StringGenerator{
+				Length:                  4,
+				ConsecutiveCharsAllowed: boolPtr(false),
+				charset:                 []rune("ab"),
+				Rules: []Rule{
+					CharsetRule{
+						Charset:  []rune("a"),
+						MinChars: 3,
+					},
+					CharsetRule{
+						Charset: []rune("b"),
+					},
+				},
+			},
+			expectErr: true,
+		},
+		"consecutive chars disallowed with single character rule at exactly half the length": {
+			generator: &StringGenerator{
+				Length:                  4,
+				ConsecutiveCharsAllowed: boolPtr(false),
+				charset:                 []rune("ab"),
+				Rules: []Rule{
+					CharsetRule{
+						Charset:  []rune("a"),
+						MinChars: 2,
+					},
+					CharsetRule{
+						Charset: []rune("b"),
+					},
+				},
+			},
+			expectErr: false,
+		},
+		"consecutive chars disallowed with single character rule at ceiling of odd length": {
+			generator: &StringGenerator{
+				Length:                  5,
+				ConsecutiveCharsAllowed: boolPtr(false),
+				charset:                 []rune("ab"),
+				Rules: []Rule{
+					CharsetRule{
+						Charset:  []rune("a"),
+						MinChars: 3,
+					},
+					CharsetRule{
+						Charset: []rune("b"),
+					},
+				},
+			},
+			expectErr: false,
+		},
+		"consecutive chars disallowed with duplicated single character rule over half the length": {
+			generator: &StringGenerator{
+				Length:                  4,
+				ConsecutiveCharsAllowed: boolPtr(false),
+				charset:                 []rune("ab"),
+				Rules: []Rule{
+					CharsetRule{
+						Charset:  []rune("aa"),
+						MinChars: 3,
+					},
+					CharsetRule{
+						Charset: []rune("b"),
+					},
+				},
+			},
+			expectErr: true,
+		},
+		"consecutive chars disallowed with multi character rule requiring full length": {
+			generator: &StringGenerator{
+				Length:                  4,
+				ConsecutiveCharsAllowed: boolPtr(false),
+				charset:                 []rune("ab"),
+				Rules: []Rule{
+					CharsetRule{
+						Charset:  []rune("ab"),
+						MinChars: 4,
+					},
+				},
+			},
+			expectErr: false,
+		},
+		"consecutive chars allowed with single character rule over half the length": {
+			generator: &StringGenerator{
+				Length:                  4,
+				ConsecutiveCharsAllowed: boolPtr(true),
+				charset:                 []rune("ab"),
+				Rules: []Rule{
+					CharsetRule{
+						Charset:  []rune("a"),
+						MinChars: 3,
+					},
+					CharsetRule{
+						Charset: []rune("b"),
+					},
+				},
+			},
+			expectErr: false,
+		},
 	}
 
 	for name, test := range tests {

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -4242,6 +4242,19 @@ func (*SystemBackend) handlePoliciesPasswordSet(ctx context.Context, req *logica
 		}
 	}
 
+	// The shuffled test password above may place identical characters next to each other even when the policy is
+	// satisfiable, so it can't be used to judge the consecutive character restriction. Run the real generator with a
+	// bounded timeout instead; it will fail if no valid password can be produced.
+	if !policy.AllowsConsecutiveChars() {
+		genCtx, cancel := context.WithTimeout(ctx, 1*time.Second)
+		defer cancel()
+
+		if _, err := policy.Generate(genCtx, nil); err != nil {
+			return nil, logical.CodedError(http.StatusBadRequest,
+				fmt.Sprintf("unable to generate a password from the provided policy with consecutive characters disallowed: are the rules impossible? (%s)", err))
+		}
+	}
+
 	cfg := passwordPolicyConfig{
 		HCLPolicy:     rawPolicy,
 		EntropySource: entropySource,

--- a/vault/logical_system_paths.go
+++ b/vault/logical_system_paths.go
@@ -30,8 +30,10 @@ var passwordPolicySchema = map[string]*framework.FieldSchema{
 		Description: "The name of the password policy.",
 	},
 	"policy": {
-		Type:        framework.TypeString,
-		Description: "The password policy",
+		Type: framework.TypeString,
+		Description: "The password policy in HCL or JSON, optionally base64 encoded. Supports a top-level " +
+			"'length', an optional top-level 'consecutive-chars-allowed' (defaults to true; when false the same " +
+			"character may not appear in adjacent positions), and one or more 'rule \"charset\"' blocks.",
 	},
 	"entropy_source": {
 		Type:        framework.TypeString,

--- a/vault/logical_system_test.go
+++ b/vault/logical_system_test.go
@@ -5331,9 +5331,7 @@ func TestHandlePoliciesPasswordSet(t *testing.T) {
 			expectedStore: map[string]*logical.StorageEntry{},
 		},
 		"consecutive chars disallowed with rules that force repeats": {
-			// Three 'a's in four characters cannot be arranged without two of them being adjacent, but the
-			// charset rules alone are satisfiable so only the generator can detect this. The handler gives
-			// generation up to a second before giving up, so this case needs a longer request context.
+			// Three 'a's in four characters cannot be arranged without two of them being adjacent.
 			inputData: passwordPoliciesFieldData(map[string]interface{}{
 				"name": "testpolicy",
 				"policy": "length = 4\n" +
@@ -5344,6 +5342,30 @@ func TestHandlePoliciesPasswordSet(t *testing.T) {
 					"}\n" +
 					"rule \"charset\" {\n" +
 					"	charset=\"b\"\n" +
+					"}",
+			}),
+
+			storage: new(logical.InmemStorage),
+
+			expectedResp:  nil,
+			expectErr:     true,
+			expectedStore: map[string]*logical.StorageEntry{},
+		},
+		"consecutive chars disallowed with rules that cannot be generated in time": {
+			// Ten 'a's in twenty characters is possible only in strictly alternating positions, which the generator
+			// will not produce from a large charset within its time bound. Static validation passes, so this
+			// exercises the generation check in the handler. The handler gives generation up to a second before
+			// giving up, so this case needs a longer request context.
+			inputData: passwordPoliciesFieldData(map[string]interface{}{
+				"name": "testpolicy",
+				"policy": "length = 20\n" +
+					"consecutive-chars-allowed = false\n" +
+					"rule \"charset\" {\n" +
+					"	charset=\"a\"\n" +
+					"	min-chars = 10\n" +
+					"}\n" +
+					"rule \"charset\" {\n" +
+					"	charset=\"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789\"\n" +
 					"}",
 			}),
 

--- a/vault/logical_system_test.go
+++ b/vault/logical_system_test.go
@@ -5124,6 +5124,9 @@ func TestHandlePoliciesPasswordSet(t *testing.T) {
 
 		storage *logical.InmemStorage
 
+		// timeout for the request context. Defaults to 100ms when unset.
+		timeout time.Duration
+
 		expectedResp  *logical.Response
 		expectErr     bool
 		expectedStore map[string]*logical.StorageEntry
@@ -5286,11 +5289,80 @@ func TestHandlePoliciesPasswordSet(t *testing.T) {
 					"	charset=\"abcdefghij\"\n"+
 					"}", "seal")),
 		},
+		"consecutive chars disallowed": {
+			inputData: passwordPoliciesFieldData(map[string]interface{}{
+				"name": "testpolicy",
+				"policy": "length = 20\n" +
+					"consecutive-chars-allowed = false\n" +
+					"rule \"charset\" {\n" +
+					"	charset=\"abcdefghij\"\n" +
+					"}",
+			}),
+
+			storage: new(logical.InmemStorage),
+
+			expectedResp: &logical.Response{
+				Data: map[string]interface{}{
+					logical.HTTPContentType: "application/json",
+					logical.HTTPStatusCode:  http.StatusNoContent,
+				},
+			},
+			expectedStore: makeStorageMap(storageEntry(t, "testpolicy",
+				"length = 20\n"+
+					"consecutive-chars-allowed = false\n"+
+					"rule \"charset\" {\n"+
+					"	charset=\"abcdefghij\"\n"+
+					"}", "")),
+		},
+		"consecutive chars disallowed with single character charset": {
+			inputData: passwordPoliciesFieldData(map[string]interface{}{
+				"name": "testpolicy",
+				"policy": "length = 20\n" +
+					"consecutive-chars-allowed = false\n" +
+					"rule \"charset\" {\n" +
+					"	charset=\"a\"\n" +
+					"}",
+			}),
+
+			storage: new(logical.InmemStorage),
+
+			expectedResp:  nil,
+			expectErr:     true,
+			expectedStore: map[string]*logical.StorageEntry{},
+		},
+		"consecutive chars disallowed with rules that force repeats": {
+			// Three 'a's in four characters cannot be arranged without two of them being adjacent, but the
+			// charset rules alone are satisfiable so only the generator can detect this. The handler gives
+			// generation up to a second before giving up, so this case needs a longer request context.
+			inputData: passwordPoliciesFieldData(map[string]interface{}{
+				"name": "testpolicy",
+				"policy": "length = 4\n" +
+					"consecutive-chars-allowed = false\n" +
+					"rule \"charset\" {\n" +
+					"	charset=\"a\"\n" +
+					"	min-chars = 3\n" +
+					"}\n" +
+					"rule \"charset\" {\n" +
+					"	charset=\"b\"\n" +
+					"}",
+			}),
+
+			storage: new(logical.InmemStorage),
+			timeout: 5 * time.Second,
+
+			expectedResp:  nil,
+			expectErr:     true,
+			expectedStore: map[string]*logical.StorageEntry{},
+		},
 	}
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+			timeout := test.timeout
+			if timeout == 0 {
+				timeout = 100 * time.Millisecond
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), timeout)
 			defer cancel()
 
 			req := &logical.Request{


### PR DESCRIPTION
Closes: https://github.com/hashicorp/vault/issues/32110

### Description

Adds an optional top-level `consecutive-chars-allowed` attribute to the password policy HCL. When set to `false`, generated passwords will not contain the same character in two adjacent positions. The comparison is an exact match, so `aa` is rejected while `aA` is allowed. Defaults to `true`, so existing stored policies and directly constructed generators behave exactly as before.

```hcl
length = 20
consecutive-chars-allowed = false

rule "charset" {
  charset = "abcdefghijklmnopqrstuvwxyz"
  min-chars = 1
}
```

**Implementation**

- `helper/random`: `StringGenerator` gains a `ConsecutiveCharsAllowed *bool` field decoded from the new HCL key. A nil value means `true`, which keeps every existing constructor and stored policy on the historical behavior. `validateConfig()` fails fast when the flag is off and the charset has only one character.
- `helper/random`: when the flag is set to `off`, the string is built constructively rather than by rejection. The first rune is drawn uniformly from the whole charset. Each later rune is drawn uniformly from the charset with the previous rune removed, by taking an index in `[0, k-1)` and shifting it up by one when it lands on or after the previous index. Rejection sampling would time out on small charsets such as `ab`, where almost every candidate contains a repeat. The index drawing was extracted from `randomRunes` into `randomIndexes` so both paths share the existing anti-bias logic, and the pre-existing seeded `randomRunes` test confirms the refactor consumes RNG bytes identically.
- `min-chars` requirements are not planted. Charset rules are still checked by rejection after the string is built.
- `vault/logical_system.go`: the existing feasibility check builds a shuffled synthetic password, which cannot judge adjacency without false rejections. When the flag is off, the write handler additionally runs the real generator with a one-second bound and rejects the policy if nothing valid can be produced.
- `vault/logical_system_paths.go`: the `policy` field description now documents the top-level attributes.

**Trade-offs**

- The adjacency constraint itself no longer costs retries. Charset `min-chars` rules are still satisfied by rejection, so a policy combining the flag with tight `min-chars` requirements can still generate slowly. The existing one-second generation timeout bounds this.
- An infeasible policy with the flag off costs the full one-second bound before the write is rejected. Feasible policies return in microseconds.

**Tests**

- Parser: absent, `true`, `false`, non-bool value, single-character rejection, and JSON round-trip.
- Generator: charset `ab` at length 20 and 100 succeed within a 100ms budget, charset `aA` at length 20 succeeds and contains `aA`, mixed charsets and charset rules hold with no adjacent repeats, and a default-behavior test proves repeats occur when unset.
- Constructive builder: every charset rune is reachable including the last one, a seeded deterministic case pins the index shift, and error cases cover a single-character charset with length > 1.
- Sys handler: accept, static rejection, and a policy whose charset rules force a repeat that only the generator can detect.

### TODO only if you're a HashiCorp employee
- [ ] **Backport Labels:** If this fix needs to be backported, use the appropriate `backport/` label that matches the desired release branch.
- [ ] **LTS**: If this fixes a critical security vulnerability or [severity 1](https://www.hashicorp.com/customer-success/enterprise-support) bug, it will also need to be backported to the current [LTS versions](https://developer.hashicorp.com/vault/docs/enterprise/lts#why-is-there-a-risk-to-updating-to-a-non-lts-vault-enterprise-version) of Vault. To ensure this, use **all** available enterprise labels.
- [ ] **Jira:** If this change has an associated Jira, it's referenced either in the PR description, commit message, or branch name.
- [ ] **RFC:** If this change has an associated RFC, please link it in the description.

### PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.

Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.

## Verification


```shell
go test ./helper/random/ -count=1 -v 2>&1 | grep -E '^--- (PASS|FAIL)|^(ok|FAIL)\s'
--- PASS: TestParsePolicy (0.00s)
--- PASS: TestParser_ParsePolicy (0.00s)
--- PASS: TestParseRules (0.00s)
--- PASS: TestGetMapSlice (0.00s)
--- PASS: TestGetRuleInfo (0.00s)
--- PASS: TestParseRule (0.00s)
--- PASS: TestDefaultRuleNameMapping (0.00s)
--- PASS: TestCharset (0.00s)
--- PASS: TestJSONMarshalling (0.00s)
--- PASS: TestRunes_UnmarshalJSON (0.00s)
--- PASS: TestStringGenerator_Generate_successful (0.00s)
--- PASS: TestStringGenerator_Generate_consecutiveChars (0.00s)
--- PASS: TestRandomRunesNoConsecutive_successful (0.02s)
--- PASS: TestRandomRunesNoConsecutive_deterministic (0.00s)
--- PASS: TestRandomRunesNoConsecutive_errors (0.00s)
--- PASS: TestStringGenerator_Generate_consecutiveCharsAllowedByDefault (0.00s)
--- PASS: TestHasConsecutiveChars (0.00s)
--- PASS: TestStringGenerator_Generate_errors (0.01s)
--- PASS: TestRandomRunes_deterministic (0.00s)
--- PASS: TestRandomRunes_successful (0.01s)
--- PASS: TestRandomRunes_errors (0.00s)
--- PASS: TestStringGenerator_JSON (0.00s)
--- PASS: TestValidate (0.00s)
--- PASS: TestGetChars (0.00s)
--- PASS: TestDeduplicateRunes (0.00s)
--- PASS: TestRandomRunes_Bias (0.42s)
ok  	github.com/hashicorp/vault/helper/random	0.815s
```

```shell
go test ./vault/ -run 'TestHandlePoliciesPassword|TestDynamicSystemView_GeneratePasswordFromPolicy' -count=1 -v 2>&1 | grep -E '^--- (PASS|FAIL)|^(ok|FAIL)\s'
--- PASS: TestDynamicSystemView_GeneratePasswordFromPolicy_successful (0.53s)
--- PASS: TestDynamicSystemView_GeneratePasswordFromPolicy_failed (0.00s)
--- PASS: TestHandlePoliciesPasswordSet (1.00s)
--- PASS: TestHandlePoliciesPasswordGet (0.00s)
--- PASS: TestHandlePoliciesPasswordDelete (0.00s)
--- PASS: TestHandlePoliciesPasswordList (0.00s)
--- PASS: TestHandlePoliciesPasswordGenerate (0.01s)
ok  	github.com/hashicorp/vault/vault	3.858s
